### PR TITLE
feat(sec): drain the XBRL backfill backlog with an adaptive cadence

### DIFF
--- a/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
@@ -22,5 +22,13 @@ public class XbrlCaptureOptions
     public bool BackfillEnabled { get; set; } = false;
 
     /// <summary>How many pending documents the backfill processes per cycle.</summary>
-    public int BackfillBatchSize { get; set; } = 32;
+    public int BackfillBatchSize { get; set; } = 128;
+
+    /// <summary>
+    /// Seconds to wait between back-to-back cycles while a backlog is still draining (a
+    /// cycle that filled its batch). Short so a large historical sweep clears in days, not
+    /// weeks; the gap still yields the shared EDGAR budget to the live scrapers between
+    /// bursts. Once the queue is drained a cycle falls back to the full 5-minute idle.
+    /// </summary>
+    public int BackfillDrainIntervalSeconds { get; set; } = 30;
 }

--- a/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
@@ -29,6 +29,13 @@ public class XbrlBackfillWorker : BaseScraperWorker
     // re-querying and re-spending the shared EDGAR budget when the queue is drained or stuck
     // on exhausted documents.
     protected override TimeSpan SleepInterval => TimeSpan.FromMinutes(5);
+
+    // While a backlog is still draining (a cycle that filled its batch) the loop uses this
+    // shorter interval instead of SleepInterval, so a large historical sweep clears in days
+    // rather than ~50 days of one batch every 5 minutes.
+    protected override TimeSpan ContinuationInterval =>
+        TimeSpan.FromSeconds(_captureOptions.BackfillDrainIntervalSeconds);
+
     protected override ErrorSource ErrorSource => ErrorSource.DocumentScraper;
 
     // Yield to the live SEC scrapers at deploy time before spending the shared EDGAR budget
@@ -65,13 +72,22 @@ public class XbrlBackfillWorker : BaseScraperWorker
             ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
             : (DateOnly?)null;
 
+        var batchSize = _captureOptions.BackfillBatchSize;
         await using var scope = ScopeFactory.CreateAsyncScope();
         var backfillService = scope.ServiceProvider.GetRequiredService<XbrlBackfillService>();
-        var result = await backfillService.Backfill(
-            _captureOptions.BackfillBatchSize,
-            minReportingDate,
-            stoppingToken
-        );
+        var result = await backfillService.Backfill(batchSize, minReportingDate, stoppingToken);
+
+        // A full batch that made forward progress means the newest-first queue still has
+        // selectable documents, so drain the next batch after the short ContinuationInterval
+        // instead of the full SleepInterval. Fall back to the 5-minute idle when the batch came
+        // up short (backlog drained, or only retry-exhausted rows remain) OR when every document
+        // failed — an all-failed full batch signals an EDGAR outage or an unfetchable head block,
+        // exactly when bursting requests faster would hurt rather than help.
+        var madeProgress = result.Failed < result.Processed;
+        if (batchSize > 0 && result.Processed >= batchSize && madeProgress)
+        {
+            RequestImmediateContinuation();
+        }
 
         Logger.LogInformation(
             "XBRL backfill cycle complete. Processed: {Processed}, Captured: {Captured}, "

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -17,6 +17,7 @@ public abstract class BaseScraperWorker : BackgroundService
     protected readonly ErrorReporter ErrorReporter;
 
     private bool _retrySoonRequested;
+    private bool _continuationRequested;
 
     protected abstract string WorkerName { get; }
     protected abstract TimeSpan SleepInterval { get; }
@@ -86,6 +87,23 @@ public abstract class BaseScraperWorker : BackgroundService
     /// </summary>
     protected void RequestRetrySoon() => _retrySoonRequested = true;
 
+    /// <summary>
+    /// Wait used after a cycle that called <see cref="RequestImmediateContinuation"/> —
+    /// e.g. a backfill that filled its batch and still has a backlog queued. Short by
+    /// design so a large backlog drains in successive bursts instead of one batch every
+    /// <see cref="SleepInterval"/>, while a brief gap between cycles still yields the
+    /// shared upstream budget to latency-sensitive workers.
+    /// </summary>
+    protected virtual TimeSpan ContinuationInterval => TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Marks the just-finished cycle as having more work immediately available, so the
+    /// loop waits <see cref="ContinuationInterval"/> instead of <see cref="SleepInterval"/>.
+    /// Reset at the start of each cycle, and outranked by <see cref="RequestRetrySoon"/> —
+    /// a not-yet-ready dependency is a reason to back off, not to press on.
+    /// </summary>
+    protected void RequestImmediateContinuation() => _continuationRequested = true;
+
     protected BaseScraperWorker(
         ILogger logger,
         IServiceScopeFactory scopeFactory,
@@ -134,6 +152,7 @@ public abstract class BaseScraperWorker : BackgroundService
         {
             Logger.LogInformation("{Worker} running at: {Time}", WorkerName, DateTimeOffset.Now);
             _retrySoonRequested = false;
+            _continuationRequested = false;
 
             await PublishActivity(ScraperActivitySeverity.Info, "cycle started", stoppingToken);
 
@@ -177,6 +196,20 @@ public abstract class BaseScraperWorker : BackgroundService
                 await PublishActivity(
                     ScraperActivitySeverity.Warn,
                     $"not ready, retrying in {FormatInterval(interval)}",
+                    stoppingToken
+                );
+            }
+            else if (_continuationRequested)
+            {
+                interval = ContinuationInterval;
+                Logger.LogInformation(
+                    "{Worker} has more work queued; continuing in {Interval}",
+                    WorkerName,
+                    interval
+                );
+                await PublishActivity(
+                    ScraperActivitySeverity.Info,
+                    $"more work queued, continuing in {FormatInterval(interval)}",
                     stoppingToken
                 );
             }

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerImmediateContinuationTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerImmediateContinuationTests.cs
@@ -1,0 +1,129 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Worker;
+
+public class BaseScraperWorkerImmediateContinuationTests
+{
+    // A cycle that calls RequestImmediateContinuation (e.g. an XBRL backfill that filled
+    // its batch and still has a backlog queued) must wait the short ContinuationInterval,
+    // NOT the full SleepInterval — so the backlog drains in successive bursts instead of one
+    // batch every SleepInterval. SleepInterval is 1h here: if the continuation path didn't
+    // apply, the second cycle would never arrive and the test would time out.
+    [Fact]
+    public async Task RequestImmediateContinuation_UsesShortInterval_SoNextCycleRunsPromptly()
+    {
+        var secondCycle = new TaskCompletionSource();
+        var cycles = 0;
+        var sut = new TestWorker(
+            sleepInterval: TimeSpan.FromHours(1),
+            retryInterval: TimeSpan.FromHours(1),
+            continuationInterval: TimeSpan.FromMilliseconds(20),
+            doWork: (worker, _) =>
+            {
+                cycles++;
+                if (cycles == 1)
+                {
+                    worker.CallRequestImmediateContinuation();
+                }
+                else
+                {
+                    secondCycle.TrySetResult();
+                }
+                return Task.CompletedTask;
+            }
+        );
+
+        await sut.StartAsync(CancellationToken.None);
+        var reached = await Task.WhenAny(secondCycle.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        await sut.StopAsync(CancellationToken.None);
+
+        reached
+            .Should()
+            .Be(secondCycle.Task, "the continuation interval should trigger a prompt second cycle");
+        cycles.Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    // A not-yet-ready dependency is a reason to back off, not to press on: when a cycle
+    // signals BOTH retry-soon and immediate-continuation, retry-soon must win. Here the
+    // retry interval is short (20ms) and the continuation interval is 1h, so a prompt second
+    // cycle proves the retry path was chosen; if continuation had won the test would time out.
+    [Fact]
+    public async Task RequestRetrySoon_OutranksImmediateContinuation()
+    {
+        var secondCycle = new TaskCompletionSource();
+        var cycles = 0;
+        var sut = new TestWorker(
+            sleepInterval: TimeSpan.FromHours(1),
+            retryInterval: TimeSpan.FromMilliseconds(20),
+            continuationInterval: TimeSpan.FromHours(1),
+            doWork: (worker, _) =>
+            {
+                cycles++;
+                if (cycles == 1)
+                {
+                    worker.CallRequestRetrySoon();
+                    worker.CallRequestImmediateContinuation();
+                }
+                else
+                {
+                    secondCycle.TrySetResult();
+                }
+                return Task.CompletedTask;
+            }
+        );
+
+        await sut.StartAsync(CancellationToken.None);
+        var reached = await Task.WhenAny(secondCycle.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        await sut.StopAsync(CancellationToken.None);
+
+        reached.Should().Be(secondCycle.Task, "retry-soon must outrank immediate-continuation");
+        cycles.Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    private sealed class TestWorker : BaseScraperWorker
+    {
+        private readonly TimeSpan _sleep;
+        private readonly TimeSpan _retry;
+        private readonly TimeSpan _continuation;
+        private readonly Func<TestWorker, CancellationToken, Task> _doWork;
+
+        public TestWorker(
+            TimeSpan sleepInterval,
+            TimeSpan retryInterval,
+            TimeSpan continuationInterval,
+            Func<TestWorker, CancellationToken, Task> doWork
+        )
+            : base(
+                NullLogger.Instance,
+                Substitute.For<IServiceScopeFactory>(),
+                new ErrorReporter(
+                    Substitute.For<IServiceScopeFactory>(),
+                    NullLogger<ErrorReporter>.Instance
+                )
+            )
+        {
+            _sleep = sleepInterval;
+            _retry = retryInterval;
+            _continuation = continuationInterval;
+            _doWork = doWork;
+        }
+
+        protected override string WorkerName => "Test";
+        protected override TimeSpan SleepInterval => _sleep;
+        protected override TimeSpan NotReadyRetryInterval => _retry;
+        protected override TimeSpan ContinuationInterval => _continuation;
+        protected override ErrorSource ErrorSource => ErrorSource.FtdScraper;
+
+        public void CallRequestRetrySoon() => RequestRetrySoon();
+
+        public void CallRequestImmediateContinuation() => RequestImmediateContinuation();
+
+        protected override Task DoWork(CancellationToken stoppingToken) =>
+            _doWork(this, stoppingToken);
+    }
+}


### PR DESCRIPTION
## Summary

The XBRL backfill walks documents ingested before envelope capture existed and fills in their raw XBRL. It processed one batch of 32 documents per cycle, then slept the full 5-minute `SleepInterval` no matter how much work remained — a hard ceiling of ~9,200 documents/day (~50 days to clear a 465k backlog) with the worker idle ~98% of each cycle. In production the backlog (465k+ `NotChecked`, nearly all at 0 capture attempts) never drains.

This keeps the conservative, opt-in design — yield to the live scrapers, never exceed the shared EDGAR budget — but lets an enabled sweep actually clear the backlog.

## Code changes

- **`src/Equibles.Worker/BaseScraperWorker.cs`** — adds a default-off continuation fast-path that mirrors the existing `RequestRetrySoon` / `NotReadyRetryInterval` pattern: `RequestImmediateContinuation()` sets a per-cycle flag, and a new `else if` branch waits the shorter `ContinuationInterval` (virtual, 30s default) instead of `SleepInterval`. Precedence is `retry-soon → continuation → sleep`. Both flags reset at the top of each cycle. No other worker calls it, so their behavior is unchanged.
- **`src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs`** — requests continuation when a cycle fills its batch **and** made forward progress. A short batch (drained / only retry-exhausted rows) or a full batch where every document failed (EDGAR outage / unfetchable head block) falls back to the 5-minute idle rather than bursting requests when it would hurt. Overrides `ContinuationInterval` from the new option.
- **`src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs`** — `BackfillBatchSize` 32 → 128; adds `BackfillDrainIntervalSeconds` (default 30) so the burst gap is tunable per environment.
- **`tests/Equibles.UnitTests/Worker/BaseScraperWorkerImmediateContinuationTests.cs`** — pins that continuation uses the short interval (prompt second cycle) and that retry-soon outranks continuation. All 24 `BaseScraperWorker` + `XbrlBackfillWorker` unit tests pass.

Activation stays operator-controlled: `XbrlCapture__BackfillEnabled=true` (plus optional `XbrlCapture__BackfillBatchSize` / `XbrlCapture__BackfillDrainIntervalSeconds`).

Closes #3735
