### PR TITLE
feat(finra): poll for short volume each minute after market close on trading days

### DIFF
--- a/src/Equibles.Finra.HostedService/Configuration/FinraScraperOptions.cs
+++ b/src/Equibles.Finra.HostedService/Configuration/FinraScraperOptions.cs
@@ -2,4 +2,25 @@ using Equibles.Worker;
 
 namespace Equibles.Finra.HostedService.Configuration;
 
-public class FinraScraperOptions : ScraperOptions { }
+public class FinraScraperOptions : ScraperOptions
+{
+    /// <summary>
+    /// When true (default), the worker minute-polls for the daily short-volume file during
+    /// the post-close ET window on NYSE trading days so it syncs the moment FINRA publishes
+    /// it, instead of waiting the full <see cref="ScraperOptions.SleepIntervalHours"/> cycle.
+    /// Set false to fall back to the plain fixed-interval cycle.
+    /// </summary>
+    public bool EveningPollEnabled { get; set; } = true;
+
+    /// <summary>How often to re-check for the file while inside the post-close poll window.</summary>
+    public int ShortVolumePollIntervalMinutes { get; set; } = 1;
+
+    /// <summary>Poll-window start, ET hour (16 = 16:00, regular market close).</summary>
+    public int WindowStartHourEt { get; set; } = 16;
+
+    /// <summary>
+    /// Poll-window end, ET hour (22 = 22:00). If the file still hasn't published by this
+    /// hour the minute-poll stops for the day; the next idle cycle's import still backfills it.
+    /// </summary>
+    public int WindowEndHourEt { get; set; } = 22;
+}

--- a/src/Equibles.Finra.HostedService/FinraScraperWorker.cs
+++ b/src/Equibles.Finra.HostedService/FinraScraperWorker.cs
@@ -2,17 +2,29 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Finra.HostedService.Configuration;
 using Equibles.Finra.HostedService.Services;
+using Equibles.Finra.Repositories;
 using Equibles.Integrations.Finra.Contracts;
 using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
 namespace Equibles.Finra.HostedService;
 
 public class FinraScraperWorker : BaseScraperWorker
 {
+    private readonly FinraScraperOptions _options;
+
+    // True when the cycle just polled for an unpublished short-volume file, so the next
+    // wait uses the short poll interval rather than the idle wait-until-next-window. Reset
+    // at the top of every DoWork, mirroring the base class resetting its own retry flag.
+    private bool _pollWaitRequested;
+
     protected override string WorkerName => "FINRA scraper";
     protected override TimeSpan SleepInterval { get; }
     protected override ErrorSource ErrorSource => ErrorSource.FinraScraper;
+
+    protected override TimeSpan NotReadyRetryInterval =>
+        TimeSpan.FromMinutes(_options.ShortVolumePollIntervalMinutes);
 
     public FinraScraperWorker(
         ILogger<FinraScraperWorker> logger,
@@ -22,8 +34,12 @@ public class FinraScraperWorker : BaseScraperWorker
     )
         : base(logger, scopeFactory, errorReporter)
     {
-        SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+        _options = options.Value;
+        SleepInterval = TimeSpan.FromHours(_options.SleepIntervalHours);
     }
+
+    /// <summary>Current instant; a protected seam so tests can pin "now" deterministically.</summary>
+    protected virtual DateTimeOffset UtcNow() => DateTimeOffset.UtcNow;
 
     protected override bool ValidateConfiguration()
     {
@@ -39,28 +55,96 @@ public class FinraScraperWorker : BaseScraperWorker
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
+        _pollWaitRequested = false;
+
+        // Short volume is always attempted first — its importer scans [floor, today] and
+        // stores nothing for a day FINRA hasn't published, so an unpublished day leaves the
+        // DB short of today's session and ShouldPollForToday stays true.
+        await RunShortVolumeImport(stoppingToken);
+
+        if (await ShouldPollForToday(stoppingToken))
+        {
+            Logger.LogInformation(
+                "Short volume for today's session is not published yet; polling again in {Minutes} min",
+                _options.ShortVolumePollIntervalMinutes
+            );
+            _pollWaitRequested = true;
+            RequestRetrySoon();
+            // Skip the slow-cadence imports while minute-polling so we don't hammer them.
+            return;
+        }
+
+        await RunShortInterestImport(stoppingToken);
+        await RunOffExchangeVolumeImport(stoppingToken);
+    }
+
+    private async Task RunShortVolumeImport(CancellationToken stoppingToken)
+    {
         Logger.LogInformation("Starting daily short volume import");
-        await using (var scope = ScopeFactory.CreateAsyncScope())
-        {
-            var shortVolumeService =
-                scope.ServiceProvider.GetRequiredService<ShortVolumeImportService>();
-            await shortVolumeService.Import(stoppingToken);
-        }
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var service = scope.ServiceProvider.GetRequiredService<ShortVolumeImportService>();
+        await service.Import(stoppingToken);
+    }
 
+    private async Task RunShortInterestImport(CancellationToken stoppingToken)
+    {
         Logger.LogInformation("Starting short interest import");
-        await using (var scope = ScopeFactory.CreateAsyncScope())
-        {
-            var shortInterestService =
-                scope.ServiceProvider.GetRequiredService<ShortInterestImportService>();
-            await shortInterestService.Import(stoppingToken);
-        }
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var service = scope.ServiceProvider.GetRequiredService<ShortInterestImportService>();
+        await service.Import(stoppingToken);
+    }
 
+    private async Task RunOffExchangeVolumeImport(CancellationToken stoppingToken)
+    {
         Logger.LogInformation("Starting off-exchange volume import");
-        await using (var scope = ScopeFactory.CreateAsyncScope())
-        {
-            var offExchangeService =
-                scope.ServiceProvider.GetRequiredService<OffExchangeVolumeImportService>();
-            await offExchangeService.Import(stoppingToken);
-        }
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var service = scope.ServiceProvider.GetRequiredService<OffExchangeVolumeImportService>();
+        await service.Import(stoppingToken);
+    }
+
+    // True while we should keep minute-polling for today's file: evening polling enabled,
+    // ET-now is on an NYSE trading day inside the post-close window, and today's session row
+    // is not yet stored.
+    private async Task<bool> ShouldPollForToday(CancellationToken stoppingToken)
+    {
+        if (!_options.EveningPollEnabled)
+            return false;
+
+        var nowEt = UsMarketCalendar.ToEastern(UtcNow());
+        var etDate = DateOnly.FromDateTime(nowEt.DateTime);
+
+        if (!UsMarketCalendar.IsTradingDay(etDate))
+            return false;
+
+        var timeOfDay = nowEt.TimeOfDay;
+        if (
+            timeOfDay < TimeSpan.FromHours(_options.WindowStartHourEt)
+            || timeOfDay >= TimeSpan.FromHours(_options.WindowEndHourEt)
+        )
+            return false;
+
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
+        var alreadyStored = await repo.GetByDate(etDate).AnyAsync(stoppingToken);
+        return !alreadyStored;
+    }
+
+    protected override Task WaitForNextCycle(TimeSpan interval, CancellationToken stoppingToken) =>
+        base.WaitForNextCycle(EffectiveWait(interval), stoppingToken);
+
+    // The wait the worker actually uses. While polling, the short retry interval passes
+    // through unchanged. On an idle cycle (and only when evening polling is enabled) it is
+    // capped at the time until the next trading-day poll window, so a long SleepInterval
+    // never sleeps past the evening the file publishes. Protected so tests can pin it.
+    protected TimeSpan EffectiveWait(TimeSpan interval)
+    {
+        if (_pollWaitRequested || !_options.EveningPollEnabled)
+            return interval;
+
+        var untilWindow = UsMarketCalendar.TimeUntilNextWindowStart(
+            UtcNow(),
+            TimeSpan.FromHours(_options.WindowStartHourEt)
+        );
+        return untilWindow < interval ? untilWindow : interval;
     }
 }

--- a/src/Equibles.Worker/UsMarketCalendar.cs
+++ b/src/Equibles.Worker/UsMarketCalendar.cs
@@ -1,0 +1,150 @@
+namespace Equibles.Worker;
+
+/// <summary>
+/// NYSE trading-day calendar plus US Eastern time helpers. Pure and deterministic so the
+/// FINRA evening poller can decide "is the market open today, and is it past the close"
+/// without any external dependency or stored calendar. Models the regular full-day NYSE
+/// holiday closures; early-close half-days (e.g. the day after Thanksgiving) remain trading
+/// days because short-sale volume is still published for them.
+/// </summary>
+public static class UsMarketCalendar
+{
+    // IANA id; .NET resolves it cross-platform via ICU, so it works in the UTC Docker image.
+    public static readonly TimeZoneInfo EasternTimeZone = TimeZoneInfo.FindSystemTimeZoneById(
+        "America/New_York"
+    );
+
+    // NYSE began observing Juneteenth as a market holiday in 2022.
+    private const int JuneteenthFirstObservedYear = 2022;
+
+    public static DateTimeOffset ToEastern(DateTimeOffset instant) =>
+        TimeZoneInfo.ConvertTime(instant, EasternTimeZone);
+
+    /// <summary>True for any weekday that is not an observed NYSE holiday.</summary>
+    public static bool IsTradingDay(DateOnly date)
+    {
+        if (date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+            return false;
+        return !IsNyseHoliday(date);
+    }
+
+    public static bool IsNyseHoliday(DateOnly date)
+    {
+        var year = date.Year;
+
+        // New Year's Day: observed the following Monday when it falls on a Sunday. When it
+        // falls on a Saturday the NYSE does NOT close the preceding Friday (Dec 31 stays a
+        // normal trading day) — this is the one holiday that breaks the Sat -> Fri rule.
+        if (date == NewYearsObserved(year))
+            return true;
+
+        // Fixed-date holidays observed with the full weekend shift (Sat -> prior Fri,
+        // Sun -> following Mon).
+        if (year >= JuneteenthFirstObservedYear && date == ObservedDate(new DateOnly(year, 6, 19)))
+            return true; // Juneteenth National Independence Day
+        if (date == ObservedDate(new DateOnly(year, 7, 4)))
+            return true; // Independence Day
+        if (date == ObservedDate(new DateOnly(year, 12, 25)))
+            return true; // Christmas Day
+
+        // Floating Monday/Thursday holidays (never weekend-shifted).
+        if (date == NthWeekdayOfMonth(year, 1, DayOfWeek.Monday, 3))
+            return true; // Martin Luther King Jr. Day
+        if (date == NthWeekdayOfMonth(year, 2, DayOfWeek.Monday, 3))
+            return true; // Washington's Birthday
+        if (date == LastWeekdayOfMonth(year, 5, DayOfWeek.Monday))
+            return true; // Memorial Day
+        if (date == NthWeekdayOfMonth(year, 9, DayOfWeek.Monday, 1))
+            return true; // Labor Day
+        if (date == NthWeekdayOfMonth(year, 11, DayOfWeek.Thursday, 4))
+            return true; // Thanksgiving Day
+
+        // Good Friday — two days before Easter Sunday; always a Friday, no weekend shift.
+        if (date == EasterSunday(year).AddDays(-2))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Time from <paramref name="now"/> until the next trading-day poll window start
+    /// (<paramref name="windowStart"/> ET). Used as an idle-cycle cap so a long
+    /// <c>SleepInterval</c> never sleeps past the next evening window. Floored at zero.
+    /// </summary>
+    public static TimeSpan TimeUntilNextWindowStart(DateTimeOffset now, TimeSpan windowStart)
+    {
+        var nowEt = ToEastern(now);
+        var etDate = DateOnly.FromDateTime(nowEt.DateTime);
+
+        DateOnly candidate;
+        if (IsTradingDay(etDate) && nowEt.TimeOfDay < windowStart)
+        {
+            candidate = etDate;
+        }
+        else
+        {
+            candidate = etDate.AddDays(1);
+            while (!IsTradingDay(candidate))
+                candidate = candidate.AddDays(1);
+        }
+
+        var startEt = candidate.ToDateTime(
+            TimeOnly.FromTimeSpan(windowStart),
+            DateTimeKind.Unspecified
+        );
+        var startUtc = TimeZoneInfo.ConvertTimeToUtc(startEt, EasternTimeZone);
+        var delta = startUtc - now.UtcDateTime;
+        // The chosen candidate is always strictly in the future, so Zero is only a benign
+        // sub-second-rounding degenerate (the caller treats it as "run again now").
+        return delta > TimeSpan.Zero ? delta : TimeSpan.Zero;
+    }
+
+    private static DateOnly NewYearsObserved(int year)
+    {
+        var jan1 = new DateOnly(year, 1, 1);
+        return jan1.DayOfWeek == DayOfWeek.Sunday ? jan1.AddDays(1) : jan1;
+    }
+
+    // Sat -> preceding Fri, Sun -> following Mon; otherwise the date itself.
+    private static DateOnly ObservedDate(DateOnly fixedDate) =>
+        fixedDate.DayOfWeek switch
+        {
+            DayOfWeek.Saturday => fixedDate.AddDays(-1),
+            DayOfWeek.Sunday => fixedDate.AddDays(1),
+            _ => fixedDate,
+        };
+
+    private static DateOnly NthWeekdayOfMonth(int year, int month, DayOfWeek weekday, int n)
+    {
+        var first = new DateOnly(year, month, 1);
+        var offset = ((int)weekday - (int)first.DayOfWeek + 7) % 7;
+        return first.AddDays(offset + 7 * (n - 1));
+    }
+
+    private static DateOnly LastWeekdayOfMonth(int year, int month, DayOfWeek weekday)
+    {
+        var last = new DateOnly(year, month, DateTime.DaysInMonth(year, month));
+        var offset = ((int)last.DayOfWeek - (int)weekday + 7) % 7;
+        return last.AddDays(-offset);
+    }
+
+    // Anonymous Gregorian algorithm (Meeus/Jones/Butcher) for Easter Sunday.
+    private static DateOnly EasterSunday(int year)
+    {
+        var a = year % 19;
+        var b = year / 100;
+        var c = year % 100;
+        var d = b / 4;
+        var e = b % 4;
+        var f = (b + 8) / 25;
+        var g = (b - f + 1) / 3;
+        var h = (19 * a + b - d - g + 15) % 30;
+        var i = c / 4;
+        var k = c % 4;
+        var l = (32 + 2 * e + 2 * i - h - k) % 7;
+        var m = (a + 11 * h + 22 * l) / 451;
+        var month = (h + l - 7 * m + 114) / 31;
+        var day = ((h + l - 7 * m + 114) % 31) + 1;
+        return new DateOnly(year, month, day);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Finra/FinraScraperWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraScraperWorkerDoWorkTests.cs
@@ -86,11 +86,13 @@ public class FinraScraperWorkerDoWorkTests : ParadeDbMcpTestBase
             (typeof(OffExchangeVolumeImportService), offExchangeVolume)
         );
 
+        // EveningPollEnabled off so DoWork deterministically runs all three imports (the
+        // orchestration under test) rather than taking the time-of-day-dependent poll path.
         var worker = new FinraScraperWorker(
             Substitute.For<ILogger<FinraScraperWorker>>(),
             workerScopeFactory,
             errorReporter,
-            Options.Create(new FinraScraperOptions())
+            Options.Create(new FinraScraperOptions { EveningPollEnabled = false })
         );
 
         var doWork = typeof(FinraScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Finra/FinraScraperWorkerPollingTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraScraperWorkerPollingTests.cs
@@ -1,0 +1,286 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Finra.Data;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.HostedService;
+using Equibles.Finra.HostedService.Configuration;
+using Equibles.Finra.HostedService.Services;
+using Equibles.Finra.Repositories;
+using Equibles.Integrations.Finra.Contracts;
+using Equibles.Integrations.Finra.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Finra;
+
+/// <summary>
+/// Pins the evening-poll orchestration in <see cref="FinraScraperWorker"/>: during the
+/// post-close ET window on a trading day, while today's short-volume file is still
+/// unpublished, the worker re-runs only the short-volume import (and requests a fast retry)
+/// while skipping the slow-cadence short-interest and off-exchange imports. Outside that
+/// condition all three run. Which imports ran is observed through the shared FINRA client.
+/// </summary>
+public class FinraScraperWorkerPollingTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly IFinraClient _finraClient;
+    private readonly CommonStockRepository _stockRepo;
+
+    public FinraScraperWorkerPollingTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new FinraModuleConfiguration()
+        );
+        _stockRepo = new CommonStockRepository(_dbContext);
+        _finraClient = Substitute.For<IFinraClient>();
+        _finraClient
+            .GetDailyShortVolume(Arg.Any<DateOnly>())
+            .Returns(new List<ShortVolumeRecord>());
+        _finraClient.GetShortInterestSettlementDates().Returns(new List<DateOnly>());
+        _finraClient
+            .GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>())
+            .Returns(new List<OffExchangeWeeklyRecord>());
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // Wednesday 2025-03-12 16:30 ET — a trading day inside the default 16:00–22:00 window.
+    private static DateTimeOffset InWindowTradingDay() => Et(2025, 3, 12, 16, 30);
+
+    private static DateTimeOffset Et(int year, int month, int day, int hour, int minute)
+    {
+        var unspecified = new DateTime(year, month, day, hour, minute, 0, DateTimeKind.Unspecified);
+        var utc = TimeZoneInfo.ConvertTimeToUtc(unspecified, UsMarketCalendar.EasternTimeZone);
+        return new DateTimeOffset(utc, TimeSpan.Zero);
+    }
+
+    private async Task SeedStock()
+    {
+        _stockRepo.AddRange([
+            new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = "AAPL",
+                Name = "Apple Inc.",
+                Cik = "CIK-AAPL",
+            },
+        ]);
+        await _stockRepo.SaveChanges();
+    }
+
+    private async Task SeedShortVolume(DateOnly date)
+    {
+        var stockId = _stockRepo.GetAll().Select(s => s.Id).First();
+        _dbContext
+            .Set<DailyShortVolume>()
+            .Add(
+                new DailyShortVolume
+                {
+                    CommonStockId = stockId,
+                    Date = date,
+                    ShortVolume = 1,
+                    TotalVolume = 1,
+                }
+            );
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+    }
+
+    private TestableFinraScraperWorker BuildWorker(
+        DateTimeOffset now,
+        FinraScraperOptions options = null
+    )
+    {
+        // The importers resolve repositories from this scope factory.
+        var importScopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(CommonStockRepository), new CommonStockRepository(_dbContext)),
+            (typeof(DailyShortVolumeRepository), new DailyShortVolumeRepository(_dbContext)),
+            (typeof(ShortInterestRepository), new ShortInterestRepository(_dbContext)),
+            (typeof(OffExchangeVolumeRepository), new OffExchangeVolumeRepository(_dbContext))
+        );
+        var tickerMapService = new TickerMapService(importScopeFactory);
+        var errorReporter = new ErrorReporter(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+        // Bound the short-volume backfill scan to a few days so the loop stays tiny.
+        var workerOptions = Options.Create(
+            new WorkerOptions { TickersToSync = [], MinSyncDate = DateTime.UtcNow.AddDays(-3) }
+        );
+
+        var shortVolume = new ShortVolumeImportService(
+            importScopeFactory,
+            Substitute.For<ILogger<ShortVolumeImportService>>(),
+            _finraClient,
+            tickerMapService,
+            errorReporter,
+            workerOptions
+        );
+        var shortInterest = new ShortInterestImportService(
+            importScopeFactory,
+            Substitute.For<ILogger<ShortInterestImportService>>(),
+            _finraClient,
+            tickerMapService,
+            errorReporter,
+            workerOptions
+        );
+        var offExchange = new OffExchangeVolumeImportService(
+            importScopeFactory,
+            Substitute.For<ILogger<OffExchangeVolumeImportService>>(),
+            _finraClient,
+            tickerMapService,
+            errorReporter,
+            workerOptions
+        );
+
+        // The worker resolves the three import services + the repo used by ShouldPollForToday.
+        var workerScopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ShortVolumeImportService), shortVolume),
+            (typeof(ShortInterestImportService), shortInterest),
+            (typeof(OffExchangeVolumeImportService), offExchange),
+            (typeof(DailyShortVolumeRepository), new DailyShortVolumeRepository(_dbContext))
+        );
+
+        return new TestableFinraScraperWorker(
+            workerScopeFactory,
+            errorReporter,
+            Options.Create(options ?? new FinraScraperOptions()),
+            now
+        );
+    }
+
+    [Fact]
+    public async Task DoWork_InWindowTradingDayWithTodayMissing_RunsOnlyShortVolume()
+    {
+        await SeedStock();
+
+        await BuildWorker(InWindowTradingDay()).RunCycle(CancellationToken.None);
+
+        await _finraClient.Received().GetDailyShortVolume(Arg.Any<DateOnly>());
+        await _finraClient.DidNotReceive().GetShortInterestSettlementDates();
+        await _finraClient.DidNotReceive().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task DoWork_InWindowTradingDayWithTodayStored_RunsAllThree()
+    {
+        await SeedStock();
+        await SeedShortVolume(new DateOnly(2025, 3, 12)); // the ET date of InWindowTradingDay()
+
+        await BuildWorker(InWindowTradingDay()).RunCycle(CancellationToken.None);
+
+        await _finraClient.Received().GetDailyShortVolume(Arg.Any<DateOnly>());
+        await _finraClient.Received().GetShortInterestSettlementDates();
+        await _finraClient.Received().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task DoWork_WeekendInWindow_RunsAllThree()
+    {
+        await SeedStock();
+
+        // Saturday 2025-03-15 16:30 ET — not a trading day, so no polling.
+        await BuildWorker(Et(2025, 3, 15, 16, 30)).RunCycle(CancellationToken.None);
+
+        await _finraClient.Received().GetShortInterestSettlementDates();
+        await _finraClient.Received().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task DoWork_TradingDayBeforeWindow_RunsAllThree()
+    {
+        await SeedStock();
+
+        // Wednesday 10:00 ET — before the 16:00 window start, so no polling.
+        await BuildWorker(Et(2025, 3, 12, 10, 0)).RunCycle(CancellationToken.None);
+
+        await _finraClient.Received().GetShortInterestSettlementDates();
+        await _finraClient.Received().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task DoWork_TradingDayAfterWindowEnd_RunsAllThree()
+    {
+        await SeedStock();
+
+        // Wednesday 22:30 ET — past the 22:00 window end, so the minute-poll has stopped.
+        await BuildWorker(Et(2025, 3, 12, 22, 30)).RunCycle(CancellationToken.None);
+
+        await _finraClient.Received().GetShortInterestSettlementDates();
+        await _finraClient.Received().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task DoWork_EveningPollDisabled_RunsAllThreeEvenInWindow()
+    {
+        await SeedStock();
+
+        var options = new FinraScraperOptions { EveningPollEnabled = false };
+        await BuildWorker(InWindowTradingDay(), options).RunCycle(CancellationToken.None);
+
+        await _finraClient.Received().GetShortInterestSettlementDates();
+        await _finraClient.Received().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public void EffectiveWait_IdleTradingDayBeforeWindow_CapsToNextWindowStart()
+    {
+        var now = Et(2025, 3, 12, 10, 0); // Wednesday, before the 16:00 window
+        var worker = BuildWorker(now);
+
+        // Idle cycle (DoWork not run, so not polling): a 24h sleep is capped to the time
+        // remaining until today's 16:00 ET window start (~6h).
+        var wait = worker.ComputeWait(TimeSpan.FromHours(24));
+
+        wait.Should().Be(UsMarketCalendar.TimeUntilNextWindowStart(now, TimeSpan.FromHours(16)));
+        wait.Should().BeLessThan(TimeSpan.FromHours(24));
+    }
+
+    [Fact]
+    public async Task EffectiveWait_WhilePolling_PassesIntervalThrough()
+    {
+        await SeedStock();
+
+        var worker = BuildWorker(InWindowTradingDay());
+        await worker.RunCycle(CancellationToken.None); // in-window + missing -> polling armed
+
+        // The poll path must not be capped to the next window — it keeps its short interval.
+        worker.ComputeWait(TimeSpan.FromHours(24)).Should().Be(TimeSpan.FromHours(24));
+    }
+
+    private sealed class TestableFinraScraperWorker : FinraScraperWorker
+    {
+        private readonly DateTimeOffset _now;
+
+        public TestableFinraScraperWorker(
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IOptions<FinraScraperOptions> options,
+            DateTimeOffset now
+        )
+            : base(
+                Substitute.For<ILogger<FinraScraperWorker>>(),
+                scopeFactory,
+                errorReporter,
+                options
+            )
+        {
+            _now = now;
+        }
+
+        protected override DateTimeOffset UtcNow() => _now;
+
+        public Task RunCycle(CancellationToken stoppingToken) => DoWork(stoppingToken);
+
+        public TimeSpan ComputeWait(TimeSpan interval) => EffectiveWait(interval);
+    }
+}

--- a/tests/Equibles.UnitTests/Worker/UsMarketCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Worker/UsMarketCalendarTests.cs
@@ -1,0 +1,115 @@
+using Equibles.Worker;
+
+namespace Equibles.UnitTests.Worker;
+
+public class UsMarketCalendarTests
+{
+    // Builds a UTC instant from an Eastern wall-clock time, DST handled by the zone.
+    private static DateTimeOffset Et(int year, int month, int day, int hour, int minute)
+    {
+        var unspecified = new DateTime(year, month, day, hour, minute, 0, DateTimeKind.Unspecified);
+        var utc = TimeZoneInfo.ConvertTimeToUtc(unspecified, UsMarketCalendar.EasternTimeZone);
+        return new DateTimeOffset(utc, TimeSpan.Zero);
+    }
+
+    [Theory]
+    // Weekends.
+    [InlineData(2025, 3, 15, false)] // Saturday
+    [InlineData(2025, 3, 16, false)] // Sunday
+    // Ordinary trading days.
+    [InlineData(2025, 3, 12, true)] // Wednesday
+    [InlineData(2021, 12, 31, true)] // Fri Dec 31 2021 — NYSE open (New Year's Sat is NOT observed)
+    // Federal holidays the NYSE still trades on.
+    [InlineData(2024, 10, 14, true)] // Columbus Day — open
+    [InlineData(2024, 11, 11, true)] // Veterans Day — open
+    // Good Friday (no weekend shift).
+    [InlineData(2024, 3, 29, false)] // Good Friday 2024 — closed
+    [InlineData(2024, 4, 1, true)] // Easter Monday — open
+    // Fixed-date holidays + weekend observance.
+    [InlineData(2025, 1, 1, false)] // New Year's Day (Wed) — closed
+    [InlineData(2023, 1, 2, false)] // New Year's 2023 falls Sun -> observed Mon Jan 2 — closed
+    [InlineData(2026, 7, 3, false)] // July 4 2026 is Sat -> observed Fri Jul 3 — closed
+    [InlineData(2021, 7, 5, false)] // July 4 2021 is Sun -> observed Mon Jul 5 — closed
+    [InlineData(2021, 12, 24, false)] // Christmas 2021 is Sat -> observed Fri Dec 24 — closed
+    // Juneteenth (observed from 2022 only).
+    [InlineData(2021, 6, 18, true)] // pre-adoption Friday — open
+    [InlineData(2022, 6, 20, false)] // Jun 19 2022 is Sun -> observed Mon Jun 20 — closed
+    [InlineData(2023, 6, 19, false)] // Jun 19 2023 (Mon) — closed
+    // Floating Monday/Thursday holidays.
+    [InlineData(2025, 1, 20, false)] // MLK Day (3rd Mon Jan)
+    [InlineData(2025, 2, 17, false)] // Washington's Birthday (3rd Mon Feb)
+    [InlineData(2025, 5, 26, false)] // Memorial Day (last Mon May)
+    [InlineData(2025, 9, 1, false)] // Labor Day (1st Mon Sep)
+    [InlineData(2025, 11, 27, false)] // Thanksgiving (4th Thu Nov)
+    public void IsTradingDay_KnownDates_MatchesNyseSchedule(
+        int year,
+        int month,
+        int day,
+        bool expectedOpen
+    )
+    {
+        UsMarketCalendar.IsTradingDay(new DateOnly(year, month, day)).Should().Be(expectedOpen);
+    }
+
+    [Fact]
+    public void ToEastern_SummerInstant_IsEdtMinusFour()
+    {
+        var et = UsMarketCalendar.ToEastern(
+            new DateTimeOffset(2025, 7, 15, 20, 0, 0, TimeSpan.Zero)
+        );
+        et.TimeOfDay.Should().Be(TimeSpan.FromHours(16));
+        et.Offset.Should().Be(TimeSpan.FromHours(-4));
+    }
+
+    [Fact]
+    public void ToEastern_WinterInstant_IsEstMinusFive()
+    {
+        var et = UsMarketCalendar.ToEastern(
+            new DateTimeOffset(2025, 1, 15, 21, 0, 0, TimeSpan.Zero)
+        );
+        et.TimeOfDay.Should().Be(TimeSpan.FromHours(16));
+        et.Offset.Should().Be(TimeSpan.FromHours(-5));
+    }
+
+    [Fact]
+    public void TimeUntilNextWindowStart_BeforeStartOnTradingDay_TargetsSameDay()
+    {
+        AssertNextWindow(from: Et(2025, 3, 12, 10, 0), expected: new DateOnly(2025, 3, 12));
+    }
+
+    [Fact]
+    public void TimeUntilNextWindowStart_AfterStartOnTradingDay_TargetsNextTradingDay()
+    {
+        AssertNextWindow(from: Et(2025, 3, 12, 18, 0), expected: new DateOnly(2025, 3, 13));
+    }
+
+    [Fact]
+    public void TimeUntilNextWindowStart_FridayEvening_SkipsWeekendToMonday()
+    {
+        AssertNextWindow(from: Et(2025, 3, 14, 18, 0), expected: new DateOnly(2025, 3, 17));
+    }
+
+    [Fact]
+    public void TimeUntilNextWindowStart_FridayBeforeMondayHoliday_SkipsToTuesday()
+    {
+        // MLK Day 2025 = Mon Jan 20, so the next open window after Fri Jan 17 is Tue Jan 21.
+        AssertNextWindow(from: Et(2025, 1, 17, 18, 0), expected: new DateOnly(2025, 1, 21));
+    }
+
+    [Fact]
+    public void TimeUntilNextWindowStart_WeekendDay_TargetsNextTradingDay()
+    {
+        AssertNextWindow(from: Et(2025, 3, 15, 12, 0), expected: new DateOnly(2025, 3, 17));
+    }
+
+    private static void AssertNextWindow(DateTimeOffset from, DateOnly expected)
+    {
+        var windowStart = TimeSpan.FromHours(16);
+        var delta = UsMarketCalendar.TimeUntilNextWindowStart(from, windowStart);
+        delta.Should().BeGreaterThan(TimeSpan.Zero);
+
+        var landed = UsMarketCalendar.ToEastern(from + delta);
+        DateOnly.FromDateTime(landed.DateTime).Should().Be(expected);
+        landed.TimeOfDay.Should().Be(windowStart);
+    }
+}


### PR DESCRIPTION
## Summary

The FINRA scraper ran on a fixed 24h cycle, so the daily short-volume file could sit unsynced for up to a day after FINRA publishes it (evening ET, after market close). On NYSE trading days the worker now **minute-polls during the post-close ET window and stops the moment that day's file is stored**, so it syncs almost immediately on publish. Short interest (bi-monthly) and off-exchange volume (weekly) keep their daily cadence — they're skipped while polling so they aren't hammered every minute.

Builds on the recent backfill fix: the short-volume importer stores nothing for a day FINRA hasn't published, so an unpublished day leaves the DB short of today's session — exactly the signal the poller checks.

## Code changes

- **`UsMarketCalendar`** (new, pure, `Equibles.Worker`): NYSE trading-day detection (holidays incl. Good Friday via Easter computus and Juneteenth from 2022, with Sat→Fri/Sun→Mon observance — and the New-Year's-on-Saturday exception, which the NYSE does *not* observe), Eastern Time via the IANA `America/New_York` zone, and `TimeUntilNextWindowStart` for the idle-wait cap.
- **`FinraScraperWorker`**: always imports short volume first; if it's a trading day inside the post-close window and today's row is still absent (`DailyShortVolumeRepository.GetByDate(etDate)`), it calls `RequestRetrySoon()` and skips the other two imports. Overrides `NotReadyRetryInterval` (= poll interval) and `WaitForNextCycle` (caps the idle wait at the next window start so a 24h sleep never misses the evening). Time is a `protected virtual UtcNow()` seam for tests.
- **`FinraScraperOptions`**: `EveningPollEnabled` (default true), `ShortVolumePollIntervalMinutes` (1), `WindowStartHourEt` (16), `WindowEndHourEt` (22). Bind from the existing `FinraScraper` config section.
- **Tests**: `UsMarketCalendarTests` (holiday/observance/DST/next-window matrix) and `FinraScraperWorkerPollingTests` (which imports run, observed via the FINRA-client substitute; in-window-missing → only short volume; stored / weekend / pre-window / post-cutoff / disabled → all three; `EffectiveWait` cap vs poll pass-through). 85 unit + 97 integration FINRA tests pass; csharpier-clean.

## Notes

- On-by-default; no config required. Tunable via `FinraScraper__EveningPollEnabled` / `__ShortVolumePollIntervalMinutes` / `__WindowStartHourEt` / `__WindowEndHourEt`.
- If FINRA publishes unusually late (after the window) the minute-poll stops; the next idle cycle's import (and its `[floor, today]` backfill scan) still picks it up — no data loss.
- Early-close half-days remain trading days, so polling still runs.