### PR TITLE
fix(holdings): stop cross-type amendments wiping 13F holdings and self-heal gaps

### DIFF
--- a/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<HoldingsScraperWorker>();
         services.AddHostedService<Holdings13FRealtimeWorker>();
         services.AddHostedService<Holdings13DGRealtimeWorker>();
+        services.AddHostedService<Holdings13FReconciliationWorker>();
         services.AddHostedService<AumSnapshotDrainWorker>();
         services.AddHostedService<AumSnapshotRebuildWorker>();
         services.AddHostedService<FundScoringWorker>();

--- a/src/Equibles.Holdings.HostedService/Holdings13FReconciliationWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13FReconciliationWorker.cs
@@ -1,0 +1,240 @@
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+namespace Equibles.Holdings.HostedService;
+
+/// <summary>
+/// Self-healing backstop for the 13F-HR ingestion pipeline. The real-time sweep
+/// and the quarterly bulk import can both leave a filer silently missing a
+/// quarter — a poisoned import, a filing recorded "processed" yet wiped by a
+/// same-quarter Schedule 13D/G restatement, or one that simply aged out of the
+/// trailing re-sweep window before it ever imported. When that filer is large
+/// (BlackRock, ~$5T) it vanishes from the AUM rankings entirely, because the
+/// Top-by-AUM page only ranks filers at the single global latest report date.
+///
+/// This worker reconciles the largest lagging filers against EDGAR's
+/// authoritative submission history: for each filer whose latest materialised
+/// quarter trails the global latest, it asks EDGAR which 13F-HRs that filer has
+/// actually filed and re-ingests any whose holdings we are missing. It only acts
+/// when EDGAR genuinely lists a 13F-HR we lack, so a filer that legitimately
+/// filed a 13F-NT notice (e.g. Vanguard Group Inc) or simply stopped filing is
+/// left alone. Re-ingestion runs through the shared import path, which republishes
+/// the per-quarter snapshot rebuild, so a healed filer reappears in the rankings.
+/// </summary>
+public class Holdings13FReconciliationWorker : BaseScraperWorker
+{
+    // Reconcile only the largest lagging filers each cycle. They are the ones
+    // that move the rankings, and the cap bounds the per-cycle EDGAR request
+    // budget (one submissions lookup per candidate, plus artifact fetches only
+    // for the filers actually missing a quarter).
+    private const int MaxLaggingFilersPerCycle = 200;
+
+    private readonly WorkerOptions _workerOptions;
+    private readonly IConfiguration _configuration;
+
+    protected override string WorkerName => "13F reconciliation";
+    protected override TimeSpan SleepInterval => TimeSpan.FromHours(24);
+    protected override ErrorSource ErrorSource => ErrorSource.HoldingsScraper;
+
+    // Let the real-time sweep and bulk import take the SEC request budget first
+    // after a deploy; this backstop is not time-sensitive.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(15);
+
+    public Holdings13FReconciliationWorker(
+        ILogger<Holdings13FReconciliationWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<WorkerOptions> workerOptions,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        _workerOptions = workerOptions.Value;
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(
+            _configuration,
+            "13F reconciliation",
+            treatWhitespaceAsAbsent: true
+        );
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        var startDate = _workerOptions.MinSyncDate ?? new DateTime(2020, 1, 1);
+        var minReportDate = DateOnly.FromDateTime(startDate);
+
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var snapshotRepo =
+            scope.ServiceProvider.GetRequiredService<HolderQuarterlySnapshotRepository>();
+        var holderRepo = scope.ServiceProvider.GetRequiredService<InstitutionalHolderRepository>();
+        var holdingRepo =
+            scope.ServiceProvider.GetRequiredService<InstitutionalHoldingRepository>();
+        var edgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
+        var ingestionService =
+            scope.ServiceProvider.GetRequiredService<Realtime13FIngestionService>();
+
+        // The latest quarter any filer has materialised — the date the Top-by-AUM
+        // ranking pins to. A filer trailing this is a reconciliation candidate.
+        var globalLatest = await snapshotRepo
+            .GetAll()
+            .MaxAsync(s => (DateOnly?)s.ReportDate, stoppingToken);
+        if (globalLatest == null)
+        {
+            Logger.LogInformation("13F reconciliation: no snapshots yet; nothing to reconcile");
+            return;
+        }
+
+        // Largest filers (by peak materialised AUM) whose newest quarter trails
+        // the global latest. Peak AUM keeps dead micro-filers out of the budget
+        // and puts the rankings-moving names (BlackRock, Vanguard) first.
+        var laggards = await snapshotRepo
+            .GetAll()
+            .GroupBy(s => s.InstitutionalHolderId)
+            .Select(g => new
+            {
+                HolderId = g.Key,
+                LatestReportDate = g.Max(s => s.ReportDate),
+                PeakAum = g.Max(s => s.Aum),
+            })
+            .Where(x => x.LatestReportDate < globalLatest.Value)
+            .OrderByDescending(x => x.PeakAum)
+            .Take(MaxLaggingFilersPerCycle)
+            .ToListAsync(stoppingToken);
+
+        if (laggards.Count == 0)
+        {
+            Logger.LogInformation(
+                "13F reconciliation: every materialised filer is current at {GlobalLatest:yyyy-MM-dd}",
+                globalLatest.Value
+            );
+            return;
+        }
+
+        var holderIds = laggards.Select(l => l.HolderId).ToList();
+        var holders = await holderRepo
+            .GetAll()
+            .Where(h => holderIds.Contains(h.Id))
+            .ToDictionaryAsync(h => h.Id, stoppingToken);
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var totalHealed = 0;
+        var filersHealed = 0;
+
+        foreach (var laggard in laggards)
+        {
+            stoppingToken.ThrowIfCancellationRequested();
+
+            if (
+                !holders.TryGetValue(laggard.HolderId, out var holder)
+                || string.IsNullOrWhiteSpace(holder.Cik)
+            )
+                continue;
+
+            List<FilingData> edgarFilings;
+            try
+            {
+                // FilingDate-floored at the filer's latest materialised quarter:
+                // any 13F-HR for a newer quarter is filed after it, so this stays
+                // a cheap recent-block lookup instead of paging the full archive.
+                edgarFilings = await edgarClient.GetCompanyFilings(
+                    holder.Cik,
+                    documentType: null,
+                    fromDate: laggard.LatestReportDate,
+                    toDate: today
+                );
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "13F reconciliation: EDGAR submissions lookup failed for {Name} (CIK {Cik}); skipping",
+                    holder.Name,
+                    holder.Cik
+                );
+                continue;
+            }
+
+            var ingestedDates = await holdingRepo
+                .Get13FReportDatesByHolder(holder)
+                .ToListAsync(stoppingToken);
+            var ingestedSet = ingestedDates.ToHashSet();
+
+            var toReingest = SelectFilingsToReingest(
+                edgarFilings,
+                ingestedSet,
+                minReportDate,
+                globalLatest.Value
+            );
+            if (toReingest.Count == 0)
+                continue;
+
+            var entries = toReingest
+                .Select(f => new EdgarDailyIndexEntry
+                {
+                    Cik = holder.Cik,
+                    AccessionNumber = f.AccessionNumber,
+                    DateFiled = f.FilingDate,
+                    FormType = f.Form,
+                })
+                .ToList();
+
+            Logger.LogInformation(
+                "13F reconciliation: {Name} (CIK {Cik}) is missing {Count} 13F-HR quarter(s) EDGAR lists; re-ingesting {Periods}",
+                holder.Name,
+                holder.Cik,
+                toReingest.Count,
+                string.Join(", ", toReingest.Select(f => f.ReportDate.ToString("yyyy-MM-dd")))
+            );
+
+            var healed = await ingestionService.IngestSpecificFilings(
+                entries,
+                minReportDate,
+                stoppingToken
+            );
+            totalHealed += healed;
+            if (healed > 0)
+                filersHealed++;
+        }
+
+        Logger.LogInformation(
+            "13F reconciliation cycle complete: re-ingested {Filings} filing(s) across {Filers} filer(s) (scanned {Scanned} lagging filer(s))",
+            totalHealed,
+            filersHealed,
+            laggards.Count
+        );
+    }
+
+    /// <summary>
+    /// The 13F-HR filings (originals and amendments, never 13F-NT notices) that
+    /// EDGAR lists for a filer but whose holdings we hold none of — the gaps to
+    /// heal. Ordered oldest-filed first so an original always re-imports before
+    /// its amendment.
+    /// </summary>
+    internal static List<FilingData> SelectFilingsToReingest(
+        IReadOnlyCollection<FilingData> edgarFilings,
+        ISet<DateOnly> ingestedReportDates,
+        DateOnly minReportDate,
+        DateOnly globalLatest
+    ) =>
+        edgarFilings
+            .Where(f =>
+                f.Form != null
+                && f.Form.StartsWith("13F-HR", StringComparison.OrdinalIgnoreCase)
+                && f.ReportDate >= minReportDate
+                && f.ReportDate <= globalLatest
+                && !ingestedReportDates.Contains(f.ReportDate)
+            )
+            .OrderBy(f => f.FilingDate)
+            .ThenBy(f => f.AccessionNumber, StringComparer.Ordinal)
+            .ToList();
+}

--- a/src/Equibles.Holdings.HostedService/Models/ImportResult.cs
+++ b/src/Equibles.Holdings.HostedService/Models/ImportResult.cs
@@ -1,3 +1,11 @@
 namespace Equibles.Holdings.HostedService.Models;
 
-public record ImportResult(int SubmissionCount, bool IsComplete);
+/// <summary>
+/// Outcome of one <see cref="Services.HoldingsImportService.ImportDataSet"/> call.
+/// <paramref name="InsertedHoldings"/> is the number of holding rows the import
+/// actually upserted — the real-time path treats a non-amendment original that
+/// imported as "complete" yet inserted zero holdings as suspect (it does NOT
+/// record it processed, so a later cycle retries) rather than silently
+/// consuming the filing forever.
+/// </summary>
+public record ImportResult(int SubmissionCount, bool IsComplete, int InsertedHoldings = 0);

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -82,10 +82,14 @@ public class HoldingsImportService
         await ParseOtherManagers(context, cancellationToken);
         await UpsertInstitutionalHolders(context, cancellationToken);
         await HandleAmendments(context, cancellationToken);
-        await StreamAndInsertHoldings(context, cancellationToken);
+        var insertedHoldings = await StreamAndInsertHoldings(context, cancellationToken);
         await SyncFilingSummaries(context, cancellationToken);
         await PublishAffectedQuartersAsync(context, cancellationToken);
-        return new ImportResult(submissionCount, IsComplete: true);
+        return new ImportResult(
+            submissionCount,
+            IsComplete: true,
+            InsertedHoldings: insertedHoldings
+        );
     }
 
     // Bulk data sets routinely import many quarters at once, so group submissions
@@ -573,7 +577,8 @@ public class HoldingsImportService
                     submission,
                     context,
                     out var holderId,
-                    out var reportDate
+                    out var reportDate,
+                    out var filingType
                 )
             )
                 continue;
@@ -590,17 +595,30 @@ public class HoldingsImportService
                 continue;
             }
 
+            // Scope the delete to the amendment's OWN filing type. A holder can
+            // file a 13F-HR and a Schedule 13D/G whose report dates collide on the
+            // same quarter end (BlackRock's monthly 13G/A amendments land on
+            // 31 Mar / 31 Dec — exactly the 13F quarter ends), and the upsert key
+            // keeps them as distinct rows. Deleting by (holder, reportDate) alone
+            // let a 13G/A restatement wipe the entire 13F-HR portfolio at that
+            // quarter (#3738), so a $5T filer vanished from the AUM rankings.
+            // Restatements only ever replace their own form's rows.
             var existingHoldings = await holdingRepo
                 .GetAll()
-                .Where(h => h.InstitutionalHolderId == holderId && h.ReportDate == reportDate)
+                .Where(h =>
+                    h.InstitutionalHolderId == holderId
+                    && h.ReportDate == reportDate
+                    && h.FilingType == filingType
+                )
                 .ToListAsync(cancellationToken);
 
             if (existingHoldings.Count > 0)
             {
                 holdingRepo.Delete(existingHoldings);
                 _logger.LogInformation(
-                    "Deleted {Count} holdings for RESTATEMENT amendment {Accession}",
+                    "Deleted {Count} {FilingType} holdings for RESTATEMENT amendment {Accession}",
                     existingHoldings.Count,
+                    filingType,
                     accession
                 );
             }
@@ -624,11 +642,17 @@ public class HoldingsImportService
         SubmissionRow submission,
         ImportContext context,
         out Guid holderId,
-        out DateOnly reportDate
+        out DateOnly reportDate,
+        out FilingType filingType
     )
     {
         holderId = default;
         reportDate = default;
+        // The form the amendment restates — the delete is scoped to this so a
+        // Schedule 13D/G amendment never deletes a 13F-HR portfolio (or vice
+        // versa) sharing the same (holder, quarter). Defaults to 13F for an
+        // unrecognised form so behaviour matches the historical 13F-only path.
+        filingType = FilingType.Form13F;
 
         if (!context.CoverPages.TryGetValue(accession, out var coverPage))
             return false;
@@ -641,10 +665,11 @@ public class HoldingsImportService
         if (!TryParseDateOnly(submission.PeriodOfReport, out reportDate))
             return false;
 
+        filingType = submission.FormType.ToHoldingsFilingType() ?? FilingType.Form13F;
         return true;
     }
 
-    private async Task StreamAndInsertHoldings(
+    private async Task<int> StreamAndInsertHoldings(
         ImportContext context,
         CancellationToken cancellationToken
     )
@@ -747,6 +772,8 @@ public class HoldingsImportService
             totalDuplicates,
             totalPending
         );
+
+        return totalInserted;
     }
 
     // Runs the per-filing share-count repair over one accession's buffered rows,

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
@@ -98,56 +98,17 @@ public class Realtime13FIngestionService
                 continue;
             }
 
-            var filing = await TryParseAndValidateEntry(entry, minReportDate, cancellationToken);
-            if (filing == null)
-                continue;
-
-            _logger.LogInformation(
-                "Importing 13F-HR {Accession} (CIK {Cik}, period {Period})",
-                entry.AccessionNumber,
-                entry.Cik,
-                filing.PeriodOfReport
-            );
-
-            ImportResult importResult;
-            try
+            var outcome = await ImportEntry(entry, minReportDate, cancellationToken);
+            if (outcome == EntryImportOutcome.Failed)
             {
-                using var archive = _archiveBuilder.Build([filing]);
-                importResult = await _importService.ImportDataSet(
-                    archive,
-                    minReportDate,
-                    cancellationToken
-                );
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                // A poisoned filing must cost only its own rows, never the sweep
-                // (EquiblesCommercial#2510): skip it and leave it unrecorded so a
-                // later cycle retries it. Holding the watermark back keeps the
-                // filing re-discoverable even after it ages out of the trailing
-                // window (EquiblesCommercial#2850).
-                _logger.LogError(
-                    ex,
-                    "Failed to import 13F-HR {Accession} (CIK {Cik}); skipping filing",
-                    entry.AccessionNumber,
-                    entry.Cik
-                );
+                // Hold the watermark back to this day so the filing is re-swept
+                // next cycle even after it ages out of the trailing window
+                // (EquiblesCommercial#2850).
                 if (earliestRetryDate == null || entry.DateFiled < earliestRetryDate)
                     earliestRetryDate = entry.DateFiled;
                 continue;
             }
-
-            // IsComplete=false is the import service's "retry later" contract (e.g.
-            // NoTrackedStocks until CUSIPs seed) — recording it here would consume
-            // the filing forever (EquiblesCommercial#2850). It deliberately does
-            // NOT hold the watermark back: a filing whose issuers never seed a
-            // CUSIP would wedge the sweep, so its retry is bounded by the trailing
-            // window instead — and the quarterly bulk import reconciles it anyway.
-            if (!importResult.IsComplete)
+            if (outcome != EntryImportOutcome.Imported)
                 continue;
 
             await RecordProcessed([entry.AccessionNumber], cancellationToken);
@@ -160,6 +121,140 @@ public class Realtime13FIngestionService
         );
 
         return new RealtimeIngestionResult(totalImported, earliestRetryDate);
+    }
+
+    /// <summary>
+    /// Force-imports a specific set of filings discovered out of band — the
+    /// reconciliation worker re-feeding 13F-HRs that EDGAR lists but our holdings
+    /// are missing. Unlike <see cref="IngestRecentFilings"/> this does NOT consult
+    /// the processed-accession set: a filing recorded "processed" yet holding no
+    /// rows (e.g. one a cross-type amendment wiped) must stay re-importable. The
+    /// shared import path is idempotent on its upsert key, so re-importing a
+    /// filing whose rows are already present is a no-op. Returns the number of
+    /// filings that imported with holdings.
+    /// </summary>
+    public async Task<int> IngestSpecificFilings(
+        IReadOnlyCollection<EdgarDailyIndexEntry> entries,
+        DateOnly minReportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        // Originals before amendments — same ordering contract as the sweep.
+        var sorted = entries
+            .OrderBy(e => e.DateFiled)
+            .ThenBy(e => e.AccessionNumber, StringComparer.Ordinal)
+            .ToList();
+
+        var imported = 0;
+        foreach (var entry in sorted)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var outcome = await ImportEntry(entry, minReportDate, cancellationToken);
+            if (outcome != EntryImportOutcome.Imported)
+                continue;
+
+            await RecordProcessed([entry.AccessionNumber], cancellationToken);
+            imported++;
+        }
+
+        return imported;
+    }
+
+    private enum EntryImportOutcome
+    {
+        // Parse/validation rejected it (wrong period, no parseable holdings) —
+        // nothing to record and nothing to retry.
+        Skipped,
+
+        // Imported but the service flagged it incomplete (retry-later, e.g. CUSIPs
+        // not seeded). Bounded by the trailing re-sweep window; not watermark-held.
+        Incomplete,
+
+        // The import threw, or a non-amendment original imported "complete" yet
+        // inserted zero holdings — treat as transient and retry.
+        Failed,
+
+        // Imported successfully with holdings (or a holdings-removing amendment).
+        Imported,
+    }
+
+    /// <summary>
+    /// Parses, validates and imports one daily-index entry through the shared
+    /// bulk-dataset pipeline, free of the caller's bookkeeping (processed-set,
+    /// watermark) so the sweep and the reconciliation re-feed share one path.
+    /// </summary>
+    private async Task<EntryImportOutcome> ImportEntry(
+        EdgarDailyIndexEntry entry,
+        DateOnly minReportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        var filing = await TryParseAndValidateEntry(entry, minReportDate, cancellationToken);
+        if (filing == null)
+            return EntryImportOutcome.Skipped;
+
+        _logger.LogInformation(
+            "Importing 13F-HR {Accession} (CIK {Cik}, period {Period})",
+            entry.AccessionNumber,
+            entry.Cik,
+            filing.PeriodOfReport
+        );
+
+        ImportResult importResult;
+        try
+        {
+            using var archive = _archiveBuilder.Build([filing]);
+            importResult = await _importService.ImportDataSet(
+                archive,
+                minReportDate,
+                cancellationToken
+            );
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A poisoned filing must cost only its own rows, never the sweep
+            // (EquiblesCommercial#2510): skip it and leave it unrecorded so a
+            // later cycle retries it.
+            _logger.LogError(
+                ex,
+                "Failed to import 13F-HR {Accession} (CIK {Cik}); skipping filing",
+                entry.AccessionNumber,
+                entry.Cik
+            );
+            return EntryImportOutcome.Failed;
+        }
+
+        // IsComplete=false is the import service's "retry later" contract (e.g.
+        // NoTrackedStocks until CUSIPs seed) — recording it here would consume
+        // the filing forever (EquiblesCommercial#2850). It deliberately does
+        // NOT hold the watermark back: a filing whose issuers never seed a
+        // CUSIP would wedge the sweep, so its retry is bounded by the trailing
+        // window instead — and the quarterly bulk import reconciles it anyway.
+        if (!importResult.IsComplete)
+            return EntryImportOutcome.Incomplete;
+
+        // A non-amendment original that imported "complete" yet inserted zero
+        // holdings is suspect: recording it would consume the filing forever even
+        // though we hold none of its positions (the silent permanent loss behind
+        // the missing-BlackRock gap). Treat it as transient so the sweep retries
+        // and holds the watermark back. Amendments legitimately remove holdings,
+        // so they are exempt.
+        if (!filing.IsAmendment && importResult.InsertedHoldings == 0)
+        {
+            _logger.LogWarning(
+                "13F-HR {Accession} (CIK {Cik}) imported as complete but inserted no holdings; not recording so a later cycle retries",
+                entry.AccessionNumber,
+                entry.Cik
+            );
+            return EntryImportOutcome.Failed;
+        }
+
+        return EntryImportOutcome.Imported;
     }
 
     private async Task<Parsed13FFiling> TryParseAndValidateEntry(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCrossFilingTypeAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCrossFilingTypeAmendmentTests.cs
@@ -1,0 +1,216 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Regression for the missing-BlackRock gap: a Schedule 13D/13G restatement
+/// amendment must NOT delete a 13F-HR portfolio that shares the same
+/// (holder, report date). BlackRock files monthly 13G/A amendments whose report
+/// dates land on quarter ends — exactly the 13F-HR quarter ends — and the old
+/// delete-by-(holder, period) wiped the entire 13F portfolio, dropping a ~$5T
+/// filer out of the AUM rankings. The delete must be scoped to the amendment's
+/// own filing type, so the two forms coexist at the same quarter.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServiceCrossFilingTypeAmendmentTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public HoldingsImportServiceCrossFilingTypeAmendmentTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private HoldingsImportService CreateImporter(IStockPriceProvider priceProvider) =>
+        new(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            priceProvider,
+            Substitute.For<MassTransit.IBus>()
+        );
+
+    private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)
+    {
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, body) in entries)
+            {
+                var entry = writer.CreateEntry(name);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(body);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    private static IStockPriceProvider PriceProviderReturning(
+        Dictionary<(Guid, DateOnly), decimal> prices
+    )
+    {
+        var provider = Substitute.For<IStockPriceProvider>();
+        provider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(prices));
+        return provider;
+    }
+
+    [Fact]
+    public async Task ImportDataSet_Schedule13GRestatement_DoesNotDeleteForm13FAtSameReportDate()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        // Quarter end shared by the 13F-HR portfolio and the 13G/A stake — the
+        // exact collision BlackRock hits every December and March.
+        var reportDate = new DateOnly(2024, 9, 30);
+        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 100m };
+
+        const string cover = "ACCESSION_NUMBER\tISAMENDMENT\tAMENDMENTTYPE\tFILINGMANAGER_NAME\n";
+        const string infoHeader =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n";
+
+        // 1) The filer's full 13F-HR portfolio for the quarter (AAPL, 1000 shares).
+        using (
+            var thirteenF = BuildArchive(
+                (
+                    "SUBMISSION.tsv",
+                    "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+                        + "13F-HR\tACC-13F\t2024-11-12\t2024-09-30\t0001067983\n"
+                ),
+                ("COVERPAGE.tsv", cover + "ACC-13F\tN\t\tGiant Asset Manager\n"),
+                (
+                    "INFOTABLE.tsv",
+                    infoHeader + "ACC-13F\t037833100\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t\n"
+                )
+            )
+        )
+        {
+            var sut = CreateImporter(PriceProviderReturning(prices));
+            await sut.ImportDataSet(thirteenF, new DateOnly(2020, 1, 1), CancellationToken.None);
+        }
+
+        // 2) A Schedule 13G/A RESTATEMENT for the SAME (CIK, period). Pre-fix this
+        //    deleted every holding at (holder, 2024-09-30) — including the 13F-HR.
+        using (
+            var thirteenG = BuildArchive(
+                (
+                    "SUBMISSION.tsv",
+                    "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+                        + "SCHEDULE 13G/A\tACC-13G\t2024-11-14\t2024-09-30\t0001067983\n"
+                ),
+                ("COVERPAGE.tsv", cover + "ACC-13G\tY\t\tGiant Asset Manager\n"),
+                (
+                    "INFOTABLE.tsv",
+                    infoHeader + "ACC-13G\t037833100\t500\tSH\t\tSOLE\t500\t0\t0\tCOM\t\n"
+                )
+            )
+        )
+        {
+            var sut = CreateImporter(PriceProviderReturning(prices));
+            await sut.ImportDataSet(thirteenG, new DateOnly(2020, 1, 1), CancellationToken.None);
+        }
+
+        using var verify = FreshContext();
+        var holdings = await verify
+            .Set<InstitutionalHolding>()
+            .Where(h => h.CommonStockId == stock.Id && h.ReportDate == reportDate)
+            .OrderBy(h => h.FilingType)
+            .ToListAsync();
+
+        // Both forms coexist: the 13F-HR portfolio survived the 13G/A restatement.
+        holdings.Should().HaveCount(2);
+
+        var form13F = holdings
+            .Should()
+            .ContainSingle(h => h.FilingType == FilingType.Form13F)
+            .Subject;
+        form13F.Shares.Should().Be(1000);
+        form13F.AccessionNumber.Should().Be("ACC-13F");
+
+        var schedule13G = holdings
+            .Should()
+            .ContainSingle(h => h.FilingType == FilingType.Schedule13G)
+            .Subject;
+        schedule13G.Shares.Should().Be(500);
+        schedule13G.AccessionNumber.Should().Be("ACC-13G");
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/Holdings13FReconciliationWorkerSelectFilingsToReingestTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FReconciliationWorkerSelectFilingsToReingestTests.cs
@@ -1,0 +1,103 @@
+using Equibles.Holdings.HostedService;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Holdings13FReconciliationWorkerSelectFilingsToReingestTests
+{
+    private static readonly DateOnly MinReportDate = new(2020, 1, 1);
+    private static readonly DateOnly GlobalLatest = new(2026, 3, 31);
+
+    private static FilingData Filing(
+        string form,
+        DateOnly reportDate,
+        DateOnly filingDate,
+        string accession
+    ) =>
+        new()
+        {
+            Form = form,
+            ReportDate = reportDate,
+            FilingDate = filingDate,
+            AccessionNumber = accession,
+        };
+
+    // The BlackRock case: two 13F-HR quarters EDGAR lists but we hold none of —
+    // both selected, in filing-date order; the quarter we already hold and the
+    // 13F-NT notice are left out.
+    [Fact]
+    public void SelectFilingsToReingest_PicksMissing13FHRQuartersOnly()
+    {
+        var edgar = new[]
+        {
+            Filing("13F-HR", new(2025, 9, 30), new(2025, 11, 12), "ACC-SEP"), // already held
+            Filing("13F-HR", new(2025, 12, 31), new(2026, 2, 12), "ACC-DEC"), // missing
+            Filing("13F-HR", new(2026, 3, 31), new(2026, 5, 13), "ACC-MAR"), // missing
+        };
+        var ingested = new HashSet<DateOnly> { new(2025, 9, 30) };
+
+        var result = Holdings13FReconciliationWorker.SelectFilingsToReingest(
+            edgar,
+            ingested,
+            MinReportDate,
+            GlobalLatest
+        );
+
+        result.Select(f => f.AccessionNumber).Should().Equal("ACC-DEC", "ACC-MAR");
+    }
+
+    // A 13F-NT notice (the filer reports through another manager — e.g. Vanguard
+    // Group Inc for Q1 2026) is not a holdings report; never re-ingest it.
+    [Fact]
+    public void SelectFilingsToReingest_ExcludesNoticeFilings()
+    {
+        var edgar = new[] { Filing("13F-NT", new(2026, 3, 31), new(2026, 5, 8), "ACC-NT") };
+
+        var result = Holdings13FReconciliationWorker.SelectFilingsToReingest(
+            edgar,
+            new HashSet<DateOnly>(),
+            MinReportDate,
+            GlobalLatest
+        );
+
+        result.Should().BeEmpty();
+    }
+
+    // Amendments are holdings reports too and must be picked up — ordered after
+    // the original they restate so the import replays them in submission order.
+    [Fact]
+    public void SelectFilingsToReingest_IncludesAmendmentsOrderedByFilingDate()
+    {
+        var edgar = new[]
+        {
+            Filing("13F-HR/A", new(2026, 3, 31), new(2026, 6, 1), "ACC-AMEND"),
+            Filing("13F-HR", new(2026, 3, 31), new(2026, 5, 13), "ACC-ORIG"),
+        };
+
+        var result = Holdings13FReconciliationWorker.SelectFilingsToReingest(
+            edgar,
+            new HashSet<DateOnly>(),
+            MinReportDate,
+            GlobalLatest
+        );
+
+        result.Select(f => f.AccessionNumber).Should().Equal("ACC-ORIG", "ACC-AMEND");
+    }
+
+    // A future-dated quarter past the global latest (a stray/erroneous report
+    // date) must not drag the worker into ingesting beyond the ranking horizon.
+    [Fact]
+    public void SelectFilingsToReingest_ExcludesQuartersBeyondGlobalLatest()
+    {
+        var edgar = new[] { Filing("13F-HR", new(2026, 6, 30), new(2026, 8, 12), "ACC-FUTURE") };
+
+        var result = Holdings13FReconciliationWorker.SelectFilingsToReingest(
+            edgar,
+            new HashSet<DateOnly>(),
+            MinReportDate,
+            GlobalLatest
+        );
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetFilingTypeTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetFilingTypeTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceTryResolveAmendmentTargetFilingTypeTests
+{
+    private static readonly MethodInfo TryResolveAmendmentTargetMethod =
+        typeof(HoldingsImportService).GetMethod(
+            "TryResolveAmendmentTarget",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // The resolved FilingType is what scopes the restatement delete: a Schedule
+    // 13G/A amendment must resolve to Schedule13G so HandleAmendments only deletes
+    // 13G rows, never the 13F-HR portfolio sharing the same (holder, quarter).
+    // A 13F-HR/A resolves to Form13F, and an unrecognised form falls back to
+    // Form13F (matching the historical 13F-only delete).
+    [Theory]
+    [InlineData("13F-HR/A", FilingType.Form13F)]
+    [InlineData("SCHEDULE 13G/A", FilingType.Schedule13G)]
+    [InlineData("SCHEDULE 13D/A", FilingType.Schedule13D)]
+    [InlineData("SOMETHING-ELSE", FilingType.Form13F)]
+    public void TryResolveAmendmentTarget_ResolvesFilingTypeFromSubmissionForm(
+        string formType,
+        FilingType expected
+    )
+    {
+        var accession = "0000950123-24-006477";
+        var cik = "1067983";
+        var submission = new SubmissionRow
+        {
+            AccessionNumber = accession,
+            Cik = cik,
+            PeriodOfReport = "2024-09-30",
+            FormType = formType,
+        };
+        var context = new ImportContext
+        {
+            CoverPages = new Dictionary<string, CoverPageRow>
+            {
+                [accession] = new() { AccessionNumber = accession, IsAmendment = "Y" },
+            },
+            CikToHolderId = new Dictionary<string, Guid> { [cik] = Guid.NewGuid() },
+        };
+        // Out params: holderId, reportDate, filingType.
+        var args = new object[] { accession, submission, context, null, null, null };
+
+        var resolved = (bool)TryResolveAmendmentTargetMethod.Invoke(null, args);
+
+        resolved.Should().BeTrue();
+        args[5].Should().Be(expected);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetLowercaseYTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetLowercaseYTests.cs
@@ -41,7 +41,8 @@ public class HoldingsImportServiceTryResolveAmendmentTargetLowercaseYTests
             },
             CikToHolderId = new Dictionary<string, Guid> { [cik] = holderGuid },
         };
-        var args = new object[] { accession, submission, context, null, null };
+        // Out params: holderId, reportDate, filingType.
+        var args = new object[] { accession, submission, context, null, null, null };
 
         var resolved = (bool)TryResolveAmendmentTargetMethod.Invoke(null, args);
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetMalformedPeriodOfReportTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetMalformedPeriodOfReportTests.cs
@@ -55,7 +55,8 @@ public class HoldingsImportServiceTryResolveAmendmentTargetMalformedPeriodOfRepo
             },
             CikToHolderId = new Dictionary<string, Guid> { ["1067983"] = holderId },
         };
-        var args = new object[] { accession, submission, context, null, null };
+        // Out params: holderId, reportDate, filingType.
+        var args = new object[] { accession, submission, context, null, null, null };
 
         var resolved = (bool)TryResolveAmendmentTargetMethod!.Invoke(null, args);
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetMissingCoverPageTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetMissingCoverPageTests.cs
@@ -40,7 +40,8 @@ public class HoldingsImportServiceTryResolveAmendmentTargetMissingCoverPageTests
             CoverPages = new Dictionary<string, CoverPageRow>(), // accession NOT here
             CikToHolderId = new Dictionary<string, Guid> { ["1067983"] = Guid.NewGuid() },
         };
-        var args = new object[] { accession, submission, context, null, null };
+        // Out params: holderId, reportDate, filingType.
+        var args = new object[] { accession, submission, context, null, null, null };
 
         var resolved = (bool)TryResolveAmendmentTargetMethod!.Invoke(null, args);
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetNullCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetNullCikTests.cs
@@ -40,7 +40,8 @@ public class HoldingsImportServiceTryResolveAmendmentTargetNullCikTests
             },
             CikToHolderId = new Dictionary<string, Guid>(),
         };
-        var args = new object[] { accession, submission, context, null, null };
+        // Out params: holderId, reportDate, filingType.
+        var args = new object[] { accession, submission, context, null, null, null };
 
         // MethodInfo.Invoke wraps a thrown inner exception in
         // TargetInvocationException, so `.NotThrow()` catches the NRE case.

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetUnknownCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetUnknownCikTests.cs
@@ -42,7 +42,8 @@ public class HoldingsImportServiceTryResolveAmendmentTargetUnknownCikTests
                 ["0001067983"] = Guid.NewGuid(),
             },
         };
-        var args = new object[] { accession, submission, context, null, null };
+        // Out params: holderId, reportDate, filingType.
+        var args = new object[] { accession, submission, context, null, null, null };
 
         bool resolved = false;
         var act = () => resolved = (bool)TryResolveAmendmentTargetMethod.Invoke(null, args);


### PR DESCRIPTION
## Summary

A Schedule 13D/13G restatement amendment was deleting holdings by `(holder, report date)` without filtering `FilingType`, so it wiped the 13F-HR portfolio that shares the same quarter end. BlackRock, Inc. (CIK 2012383) files monthly 13G/A amendments dated on 31 Dec and 31 Mar — exactly the 13F-HR quarter ends — so its 13F-HR holdings for those quarters were deleted. Since the Top-by-AUM ranking only shows filers at the single global latest report date, a wiped quarter dropped a ~$5T filer out of the rankings entirely. Closes #3738.

This also adds a self-healing backstop so such a gap recovers on its own instead of persisting until the quarterly bulk import lands.

## Code changes

- **`HoldingsImportService`** — `HandleAmendments` now scopes the restatement delete to the amendment's own `FilingType` (resolved in `TryResolveAmendmentTarget`). A 13D/13G amendment only ever deletes 13D/13G rows; a 13F-HR/A only deletes 13F-HR rows. The two forms coexist at a shared report date.
- **`Realtime13FIngestionService`** — extracted the per-filing import into a shared `ImportEntry`; a non-amendment 13F-HR that imports "complete" yet inserts zero holdings is no longer recorded processed (it retries instead of being consumed forever). Added `IngestSpecificFilings`, a force-reimport path that replays specific accessions regardless of the processed set. `ImportResult` now carries `InsertedHoldings`.
- **`Holdings13FReconciliationWorker`** (new) — daily backstop that reconciles the largest lagging filers (those trailing the global latest quarter) against EDGAR's authoritative 13F-HR submission list and re-ingests any quarter whose holdings are missing. Skips 13F-NT notices, so a filer reporting through another manager is left alone. Re-ingestion runs through the shared import path, which republishes the per-quarter snapshot rebuild, so a healed filer reappears in the rankings.

## Tests

- Integration: a `SCHEDULE 13G/A` restatement no longer deletes a 13F-HR portfolio at the same report date (both forms survive).
- Unit: `TryResolveAmendmentTarget` resolves the correct `FilingType` per form; `SelectFilingsToReingest` picks only missing 13F-HR quarters, includes amendments in filing-date order, and excludes 13F-NT notices and quarters beyond the global latest.
- Updated the existing `TryResolveAmendmentTarget` reflection tests for the new out-parameter.

All Holdings unit tests (469) and the affected import/realtime integration tests (54) pass; csharpier clean.

A.L.V.I.S.
