### PR TITLE
chore(holdings): re-import 13F history through the cross-type amendment fix

### DIFF
--- a/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
@@ -20,8 +20,11 @@ public class ProcessedDataSet
     /// it on the next cycle (oldest first, so amendments re-apply after their
     /// originals). Mirrors <c>NportFiling.CurrentParserVersion</c>.
     /// Version 1: duplicated share-count column repair (#3499).
+    /// Version 2: scope restatement-amendment deletes to the amendment's own
+    /// filing type (#3738) — re-import all 13F history so a Schedule 13D/G
+    /// amendment that previously wiped a same-quarter 13F-HR portfolio is healed.
     /// </summary>
-    public const int CurrentParserVersion = 1;
+    public const int CurrentParserVersion = 2;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 


### PR DESCRIPTION
## Summary

Triggers the one-time, non-destructive re-import of all historical 13F data through the cross-type amendment fix (#3738), so any quarter previously wiped by a same-quarter Schedule 13D/13G restatement is healed.

Bumps `ProcessedDataSet.CurrentParserVersion` 1 → 2. `HoldingsScraperWorker.IsAlreadyProcessed` treats any data set stored below the current version as unprocessed, so on the next cycle the worker re-imports every quarterly 13F data set (oldest first, amendments after originals) through the fixed pipeline. The import is an idempotent upsert, so this refreshes/back-fills holdings without deleting anything, and `BackfillProcessedDataSets` is a no-op once the table is non-empty.

This is the codebase's designed self-heal path for parser fixes that must re-apply to already-imported filings — no production write or manual data-set wipe required (a manual `ProcessedDataSet` delete would in fact be re-seeded by the backfill guard).

## Notes

- Deploy-gated by construction: the re-import only runs once the v2 worker is deployed, so it cannot re-corrupt on the old (pre-#3738) code.
- Covers published quarters only; the most recent unpublished quarters are healed by the reconciliation worker (#3740).
- One-time elevated worker/DB load on the first post-deploy cycle while history re-imports.

A.L.V.I.S.
