### PR TITLE
fix(investor-relations): drain the whole news/events cohort instead of re-scraping the alphabetical head

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -61,6 +61,16 @@ public class CommonStock
     /// </summary>
     public DateTime? InvestorRelationsCheckedAt { get; set; }
 
+    /// <summary>
+    /// When an IR content scraper (news/events) last worked through this stock (UTC),
+    /// stamped on every cycle the stock is scraped — whether or not new rows were
+    /// found. Null until first scraped. Scrapers order their cohort least-recently
+    /// -scraped first (never-scraped stocks lead), so each bounded cycle advances
+    /// through the whole platform cohort and then refreshes it oldest-first, instead
+    /// of re-scraping the same alphabetical head every cycle.
+    /// </summary>
+    public DateTime? IrContentScrapedAt { get; set; }
+
     public double MarketCapitalization { get; set; }
     public long SharesOutStanding { get; set; }
 

--- a/src/Equibles.CommonStocks.HostedService/Services/IrContentScrapeCandidates.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IrContentScrapeCandidates.cs
@@ -1,0 +1,29 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Selects and orders the stocks an IR content scraper (news/events) should work
+/// through. Stocks classified on a given <see cref="IrPlatformType"/> with a
+/// discovered IR URL are returned least-recently-scraped first — never-scraped
+/// stocks lead, then the oldest <see cref="CommonStock.IrContentScrapedAt"/>. Each
+/// scraper takes a bounded batch off the front and stamps every stock it scrapes, so
+/// successive cycles advance through the whole cohort and then refresh it oldest
+/// -first, rather than re-scraping the same alphabetical head every cycle.
+/// </summary>
+public static class IrContentScrapeCandidates
+{
+    public static IQueryable<CommonStock> ForPlatform(
+        IQueryable<CommonStock> stocks,
+        IrPlatformType platform
+    )
+    {
+        return stocks
+            .Where(s => s.IrPlatformType == platform && s.InvestorRelationsUrl != null)
+            // Postgres sorts NULLs last by default; ordering on the null-check first
+            // forces never-scraped stocks (false) ahead of already-scraped ones (true).
+            .OrderBy(s => s.IrContentScrapedAt != null)
+            .ThenBy(s => s.IrContentScrapedAt)
+            .ThenBy(s => s.Ticker);
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightScraperService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightScraperService.cs
@@ -88,8 +88,6 @@ public class NasdaqIrInsightScraperService : IImporter
         CancellationToken cancellationToken
     )
     {
-        var stock = new CommonStock { Id = candidate.Id };
-
         var newsXml = await _feedClient.Fetch(
             candidate.IrUrl,
             NasdaqIrInsightFeedClient.NewsFeedPath,
@@ -103,12 +101,16 @@ public class NasdaqIrInsightScraperService : IImporter
 
         var news = newsXml == null ? [] : NasdaqIrInsightFeedParser.ParseNews(newsXml);
         var events = eventsXml == null ? [] : NasdaqIrInsightFeedParser.ParseEvents(eventsXml);
-        if (news.Count == 0 && events.Count == 0)
-            return 0;
 
         using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var newsRepo = scope.ServiceProvider.GetRequiredService<IrNewsItemRepository>();
         var eventRepo = scope.ServiceProvider.GetRequiredService<IrEventRepository>();
+
+        var stock = await stockRepo.Get(candidate.Id);
+        // The stock may have been deleted between loading the batch and scraping.
+        if (stock == null)
+            return 0;
 
         var existingUrls = (
             await newsRepo.GetByStock(stock).Select(n => n.Url).ToListAsync(cancellationToken)
@@ -159,8 +161,10 @@ public class NasdaqIrInsightScraperService : IImporter
             added++;
         }
 
-        if (added > 0)
-            await newsRepo.SaveChanges();
+        // Stamp the scrape on every cycle — new rows or not — so the next cycle
+        // advances past this stock instead of re-scraping the same head forever.
+        stock.IrContentScrapedAt = DateTime.UtcNow;
+        await stockRepo.SaveChanges();
 
         return added;
     }
@@ -170,11 +174,8 @@ public class NasdaqIrInsightScraperService : IImporter
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
-        var rows = await repo.GetAll()
-            .Where(s =>
-                s.IrPlatformType == IrPlatformType.NasdaqIrInsight && s.InvestorRelationsUrl != null
-            )
-            .OrderBy(s => s.Ticker)
+        var rows = await IrContentScrapeCandidates
+            .ForPlatform(repo.GetAll(), IrPlatformType.NasdaqIrInsight)
             .Take(_options.BatchSize)
             .Select(s => new
             {

--- a/src/Equibles.CommonStocks.HostedService/Services/Q4IncScraperService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/Q4IncScraperService.cs
@@ -85,8 +85,6 @@ public class Q4IncScraperService : IImporter
         CancellationToken cancellationToken
     )
     {
-        var stock = new CommonStock { Id = candidate.Id };
-
         var newsXml = await _feedClient.Fetch(
             candidate.IrUrl,
             Q4IncFeedClient.NewsFeedPath,
@@ -100,12 +98,16 @@ public class Q4IncScraperService : IImporter
 
         var news = newsXml == null ? [] : Q4IncFeedParser.ParseNews(newsXml);
         var events = eventsXml == null ? [] : Q4IncFeedParser.ParseEvents(eventsXml);
-        if (news.Count == 0 && events.Count == 0)
-            return 0;
 
         using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var newsRepo = scope.ServiceProvider.GetRequiredService<IrNewsItemRepository>();
         var eventRepo = scope.ServiceProvider.GetRequiredService<IrEventRepository>();
+
+        var stock = await stockRepo.Get(candidate.Id);
+        // The stock may have been deleted between loading the batch and scraping.
+        if (stock == null)
+            return 0;
 
         var existingUrls = (
             await newsRepo.GetByStock(stock).Select(n => n.Url).ToListAsync(cancellationToken)
@@ -156,8 +158,10 @@ public class Q4IncScraperService : IImporter
             added++;
         }
 
-        if (added > 0)
-            await newsRepo.SaveChanges();
+        // Stamp the scrape on every cycle — new rows or not — so the next cycle
+        // advances past this stock instead of re-scraping the same head forever.
+        stock.IrContentScrapedAt = DateTime.UtcNow;
+        await stockRepo.SaveChanges();
 
         return added;
     }
@@ -167,9 +171,8 @@ public class Q4IncScraperService : IImporter
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
-        var rows = await repo.GetAll()
-            .Where(s => s.IrPlatformType == IrPlatformType.Q4Inc && s.InvestorRelationsUrl != null)
-            .OrderBy(s => s.Ticker)
+        var rows = await IrContentScrapeCandidates
+            .ForPlatform(repo.GetAll(), IrPlatformType.Q4Inc)
             .Take(_options.BatchSize)
             .Select(s => new
             {

--- a/src/Equibles.Migrations/Migrations/20260615023958_AddCommonStockIrContentScrapedAt.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260615023958_AddCommonStockIrContentScrapedAt.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615023958_AddCommonStockIrContentScrapedAt")]
+    partial class AddCommonStockIrContentScrapedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260615023958_AddCommonStockIrContentScrapedAt.cs
+++ b/src/Equibles.Migrations/Migrations/20260615023958_AddCommonStockIrContentScrapedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommonStockIrContentScrapedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "IrContentScrapedAt",
+                table: "CommonStock",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IrContentScrapedAt",
+                table: "CommonStock");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/IrContentScrapeCandidatesTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/IrContentScrapeCandidatesTests.cs
@@ -1,0 +1,82 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class IrContentScrapeCandidatesTests
+{
+    [Fact]
+    public void ForPlatform_OrdersNeverScrapedFirstThenLeastRecentlyScraped()
+    {
+        // Contract: each bounded cycle must advance through the cohort, not re-scrape the
+        // same head. Never-scraped stocks lead, then the oldest scrape — so the backlog
+        // drains first and the cohort then refreshes oldest-first.
+        var recent = Stock(
+            "AAA",
+            IrPlatformType.Q4Inc,
+            new DateTime(2026, 6, 14, 0, 0, 0, DateTimeKind.Utc)
+        );
+        var old = Stock(
+            "BBB",
+            IrPlatformType.Q4Inc,
+            new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+        );
+        var never = Stock("CCC", IrPlatformType.Q4Inc, null);
+
+        var ordered = IrContentScrapeCandidates
+            .ForPlatform(new[] { recent, old, never }.AsQueryable(), IrPlatformType.Q4Inc)
+            .Select(s => s.Ticker)
+            .ToList();
+
+        ordered.Should().Equal("CCC", "BBB", "AAA");
+    }
+
+    [Fact]
+    public void ForPlatform_ExcludesOtherPlatformsAndStocksWithoutIrUrl()
+    {
+        var match = Stock("AAA", IrPlatformType.Q4Inc, null);
+        var otherPlatform = Stock("BBB", IrPlatformType.NasdaqIrInsight, null);
+        var noIrUrl = Stock("CCC", IrPlatformType.Q4Inc, null, irUrl: null);
+
+        var tickers = IrContentScrapeCandidates
+            .ForPlatform(
+                new[] { match, otherPlatform, noIrUrl }.AsQueryable(),
+                IrPlatformType.Q4Inc
+            )
+            .Select(s => s.Ticker)
+            .ToList();
+
+        tickers.Should().Equal("AAA");
+    }
+
+    [Fact]
+    public void ForPlatform_TieBreaksByTickerWhenScrapedAtIsEqual()
+    {
+        var sameTime = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var z = Stock("ZZZ", IrPlatformType.Q4Inc, sameTime);
+        var a = Stock("AAA", IrPlatformType.Q4Inc, sameTime);
+
+        var tickers = IrContentScrapeCandidates
+            .ForPlatform(new[] { z, a }.AsQueryable(), IrPlatformType.Q4Inc)
+            .Select(s => s.Ticker)
+            .ToList();
+
+        tickers.Should().Equal("AAA", "ZZZ");
+    }
+
+    private static CommonStock Stock(
+        string ticker,
+        IrPlatformType platform,
+        DateTime? scrapedAt,
+        string irUrl = "https://ir.example.com"
+    )
+    {
+        return new CommonStock
+        {
+            Ticker = ticker,
+            IrPlatformType = platform,
+            InvestorRelationsUrl = irUrl,
+            IrContentScrapedAt = scrapedAt,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

The Q4 Inc and Nasdaq IR Insight news/event scrapers only ever covered the alphabetical head of their platform cohort. `LoadCandidates` selected stocks with `OrderBy(Ticker).Take(BatchSize)` and nothing recorded that a stock had already been scraped, so every cycle re-fetched the same first `BatchSize` stocks and never advanced to the rest. With the default batch of 50 against roughly 950 Q4-classified stocks, only about 50 of them ever received any news or events — the other ~95% of the cohort was never reached.

This is the same starvation class as the in-memory webcast sweep cursor (#3582): a bounded batch with no progress marker plus a stable head ordering can never drain a cohort larger than one batch.

## Fix

- Add `CommonStock.IrContentScrapedAt` (nullable UTC) — when an IR content scraper last worked through the stock.
- Add a shared `IrContentScrapeCandidates.ForPlatform` selector that returns a platform's stocks **least-recently-scraped first** (never-scraped lead, then oldest `IrContentScrapedAt`, then ticker). Postgres sorts NULLs last by default, so the ordering keys on the null-check first to put never-scraped stocks ahead.
- Both scrapers now stamp `IrContentScrapedAt` on **every** stock they work through — new rows found or not — so successive cycles advance past it. The backlog drains first, then the cohort refreshes oldest-first.
- The selector is reused by both scrapers and is ready for the upcoming Business Wire / Notified scraper.

## Code changes

- `Equibles.CommonStocks.Data/Models/CommonStock.cs` — new `IrContentScrapedAt` column.
- `Equibles.CommonStocks.HostedService/Services/IrContentScrapeCandidates.cs` — new shared, cursor-ordered candidate selector.
- `Equibles.CommonStocks.HostedService/Services/Q4IncScraperService.cs`, `NasdaqIrInsightScraperService.cs` — use the selector; load the tracked stock and stamp the cursor on every scrape with a single `SaveChanges`.
- `Equibles.Migrations` — migration `AddCommonStockIrContentScrapedAt` (single nullable column).
- `tests/Equibles.UnitTests/CommonStocks/IrContentScrapeCandidatesTests.cs` — ordering (never-scraped → oldest → ticker), platform/IR-URL filtering, ticker tie-break.

## Testing

- New cursor tests pass; full CommonStocks unit bucket green (164 tests); full solution builds clean; csharpier formatted.

## Deploy note

Behavioral uplift is deploy-gated — the worker must run cycles for the backlog to drain. Once deployed, the Q4 and Nasdaq cohorts (~970 stocks) fill in over successive cycles instead of staying pinned to the first batch.