### PR TITLE
fix(ir-discovery): degrade stealth probe failures to a miss so discovery doesn't starve

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -92,10 +92,27 @@ public class InvestorRelationsProbeClient
     {
         if (_stealthClient.IsEnabled)
         {
-            // The stealth fetch follows redirects internally, so the requested URL is the best
-            // one we have for the rendered page.
-            var rendered = await _stealthClient.FetchHtml(url, cancellationToken);
-            return (rendered, url);
+            try
+            {
+                // The stealth fetch follows redirects internally, so the requested URL is the
+                // best one we have for the rendered page.
+                var rendered = await _stealthClient.FetchHtml(url, cancellationToken);
+                return (rendered, url);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // FetchHtml is contracted to degrade to null, but a sidecar navigation
+                // timeout/error can still surface as an exception. Swallow it the same way the
+                // plain-HTTP path below does: a single host that throws must not bubble out of
+                // the probe, or the caller skips the definitive-miss back-off and the stock
+                // re-occupies every batch, starving the rest of the universe.
+                _logger.LogDebug(ex, "Investor relations stealth probe failed for {Url}", url);
+                return (null, url);
+            }
         }
 
         try

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -47,6 +47,34 @@ public class InvestorRelationsProbeClientTests
     }
 
     [Fact]
+    public async Task Discover_Sidecar_FetchThrows_DegradesToMiss()
+    {
+        // A sidecar render can fail with an exception (e.g. a navigation timeout) instead of the
+        // contractual null. The probe must degrade that to a miss — if it bubbles out of Discover,
+        // the caller skips the definitive-miss back-off, so the stock is never stamped, re-occupies
+        // every batch, and starves the rest of the IR-discovery universe.
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(true);
+        stealth
+            .FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string>(new TimeoutException("navigation timeout")));
+
+        var client = new InvestorRelationsProbeClient(
+            new HttpClient(new ThrowingHandler()),
+            stealth,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        IrDiscoveryResult result = null;
+        var act = async () =>
+            result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        result.Should().BeNull();
+        await stealth.Received().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Discover_NoSidecar_DirectIrPage_ResolvesViaPlainHttp()
     {
         // Standalone build with no sidecar: a reachable IR page resolves over plain HTTP


### PR DESCRIPTION
## Summary

IR-URL discovery flat-lined in production: new discoveries collapsed from ~2,000/day to near zero, with thousands of website-bearing stocks left unprocessed and zero stocks ever recording the definitive-miss back-off.

Root cause: `InvestorRelationsProbeClient.Fetch` routes every probe through the stealth sidecar by default (since #3716), but the stealth branch was not wrapped in try/catch — unlike the plain-HTTP branch, which catches everything and returns `(null, url)`. `IStealthBrowserClient.FetchHtml` is contracted to degrade to null, but a sidecar navigation timeout/error can still throw. When it did, the exception bubbled out of `Discover` into the discovery service's per-candidate `catch`, which logs and continues **without** stamping `InvestorRelationsCheckedAt`. The stock was never marked a definitive miss, never backed off, and — because candidates are selected `OrderBy(Ticker).Take(BatchSize)` — the same alphabetically-first failing stocks re-occupied every batch and starved the rest of the universe.

## Code changes

- `InvestorRelationsProbeClient.Fetch` — wrap the stealth fetch in the same `try/catch` as the plain-HTTP path: rethrow on cancellation, otherwise log at Debug and return `(null, url)`. A render failure now degrades to a miss, so the caller records the definitive-miss back-off and discovery keeps draining the universe.
- `InvestorRelationsProbeClientTests` — add `Discover_Sidecar_FetchThrows_DegradesToMiss`: with a sidecar configured and `FetchHtml` throwing, `Discover` must return null rather than throw. Fails on the unfixed code (throws `TimeoutException`), passes with the fix.

Distinct from #3718 (the cloakbrowser `networkidle` wait condition in the shared stealth client); this is the IR probe not degrading gracefully when the stealth fetch throws.
