### PR TITLE
fix(website-discovery): degrade stealth reachability probe failures to a miss so discovery doesn't starve

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/WebsiteProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/WebsiteProbeClient.cs
@@ -76,7 +76,26 @@ public class WebsiteProbeClient
         // wall and returns the page, so a walled-but-live company site reads as
         // reachable instead of being discarded. A dead host fails to render -> null.
         if (_stealthClient.IsEnabled)
-            return await _stealthClient.FetchHtml(url, cancellationToken) != null;
+        {
+            try
+            {
+                return await _stealthClient.FetchHtml(url, cancellationToken) != null;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // FetchHtml is contracted to degrade to null, but a sidecar navigation
+                // timeout/error can still surface as an exception. Treat it as a reachability
+                // miss the same way the plain-HTTP path below does: a host that throws must not
+                // bubble out of the discovery cycle and skip the definitive-miss back-off, which
+                // would re-occupy the batch and starve the rest of the universe.
+                _logger.LogDebug(ex, "Website stealth probe failed for {Url}", url);
+                return false;
+            }
+        }
 
         try
         {

--- a/tests/Equibles.UnitTests/CommonStocks/WebsiteProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/WebsiteProbeClientTests.cs
@@ -1,0 +1,49 @@
+using Equibles.CommonStocks.HostedService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class WebsiteProbeClientTests
+{
+    [Fact]
+    public async Task Validate_Sidecar_FetchThrows_DegradesToMiss()
+    {
+        // A sidecar render can fail with an exception (e.g. a navigation timeout) instead of the
+        // contractual null. The reachability probe must degrade that to a miss, not let it bubble
+        // out of the discovery cycle — otherwise the cycle's definitive-miss back-off never runs,
+        // the stock is never stamped, and it re-occupies every batch, starving the rest of the
+        // website-discovery universe (which in turn feeds IR-URL discovery).
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(true);
+        stealth
+            .FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string>(new TimeoutException("navigation timeout")));
+
+        var client = new WebsiteProbeClient(
+            new HttpClient(new ThrowingHandler()),
+            stealth,
+            NullLogger<WebsiteProbeClient>.Instance
+        );
+
+        string result = null;
+        var act = async () => result = await client.Validate("acme.com", CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        result.Should().BeNull();
+        await stealth.Received().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    // Fails the test if plain HTTP is used — proves the sidecar path never falls through to the
+    // HttpClient when a sidecar is configured.
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            throw new InvalidOperationException(
+                "plain HTTP must not be used when a sidecar is configured"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

Website discovery — the upstream feeder for IR-URL discovery (no website → no IR page) — stopped making progress in production: `MAX(CommonStock.WebsiteCheckedAt)` froze on 2026-06-13 with ~2,400 stocks still missing a website.

Same root pattern as #3744, in the sibling `WebsiteProbeClient`. `Probe` routes reachability checks through the stealth sidecar by default (since #3716), but the stealth branch wasn't wrapped in try/catch — unlike the plain-HTTP branch, which catches everything and returns `false`. `IStealthBrowserClient.FetchHtml` is contracted to degrade to null, but a sidecar navigation timeout/error can still throw. When it did, the exception bubbled out of `Probe` → `Validate` → out of `WebsiteDiscoveryService`'s per-stock loop (the `Validate` call is not guarded), out of `DoWork`, where `BaseScraperWorker` logs it and continues — but the cycle's `MarkChecked` loop never ran. No stock was stamped, none backed off, and with `OrderBy(Ticker).Take(BatchSize)` the same alphabetically-first stocks re-occupied every batch and starved the rest of the universe.

## Code changes

- `WebsiteProbeClient.Probe` — wrap the stealth reachability probe in the same `try/catch` as the plain-HTTP path: rethrow on cancellation, otherwise log at Debug and return `false`. A render failure now degrades to a reachability miss, so the cycle records the definitive-miss back-off and keeps draining the universe.
- `WebsiteProbeClientTests` (new) — `Validate_Sidecar_FetchThrows_DegradesToMiss`: with a sidecar configured and `FetchHtml` throwing, `Validate` must return null rather than throw. Fails on unfixed code (throws `TimeoutException`), passes with the fix.

Companion to #3744 (IR probe); both stem from #3716 making discovery sidecar-first without symmetric error handling on the stealth path.
