### PR TITLE
fix(ir-feeds): degrade stealth feed fetch failures to null so news/events scraping doesn't starve

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightFeedClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightFeedClient.cs
@@ -54,7 +54,25 @@ public class NasdaqIrInsightFeedClient
         // Pull the feed through the cleared stealth session when a sidecar is
         // configured; the parser sees the raw XML the server sent, not a rendered DOM.
         if (_stealthClient.IsEnabled)
-            return await _stealthClient.FetchRaw(feedUrl, cancellationToken);
+        {
+            try
+            {
+                return await _stealthClient.FetchRaw(feedUrl, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // FetchRaw is contracted to degrade to null, but a sidecar navigation
+                // timeout/error can still surface as an exception. Return null the same way the
+                // plain-HTTP path below does so one feed that throws never bubbles out of the
+                // content scrape and starves the rest of the cohort's news/events.
+                _logger.LogDebug(ex, "Investor relations feed fetch failed for {Url}", feedUrl);
+                return null;
+            }
+        }
 
         try
         {

--- a/src/Equibles.CommonStocks.HostedService/Services/Q4IncFeedClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/Q4IncFeedClient.cs
@@ -54,7 +54,25 @@ public class Q4IncFeedClient
         // Pull the feed through the cleared stealth session when a sidecar is
         // configured; the parser sees the raw XML the server sent, not a rendered DOM.
         if (_stealthClient.IsEnabled)
-            return await _stealthClient.FetchRaw(feedUrl, cancellationToken);
+        {
+            try
+            {
+                return await _stealthClient.FetchRaw(feedUrl, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // FetchRaw is contracted to degrade to null, but a sidecar navigation
+                // timeout/error can still surface as an exception. Return null the same way the
+                // plain-HTTP path below does so one feed that throws never bubbles out of the
+                // content scrape and starves the rest of the cohort's news/events.
+                _logger.LogDebug(ex, "Investor relations feed fetch failed for {Url}", feedUrl);
+                return null;
+            }
+        }
 
         try
         {

--- a/tests/Equibles.UnitTests/CommonStocks/NasdaqIrInsightFeedClientFetchTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/NasdaqIrInsightFeedClientFetchTests.cs
@@ -48,6 +48,36 @@ public class NasdaqIrInsightFeedClientFetchTests
     }
 
     [Fact]
+    public async Task Fetch_Sidecar_FetchRawThrows_DegradesToNull()
+    {
+        // A sidecar fetch can fail with an exception (e.g. a navigation timeout) instead of the
+        // contractual null. Fetch must degrade that to null, not let it bubble out — otherwise one
+        // throwing feed aborts the content scrape and starves the rest of the cohort's news/events.
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(true);
+        stealth
+            .FetchRaw(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string>(new TimeoutException("navigation timeout")));
+
+        var client = new NasdaqIrInsightFeedClient(
+            new HttpClient(new ThrowingHandler()),
+            stealth,
+            NullLogger<NasdaqIrInsightFeedClient>.Instance
+        );
+
+        string result = null;
+        var act = async () =>
+            result = await client.Fetch(
+                "https://investors.example.com/",
+                NasdaqIrInsightFeedClient.EventsFeedPath,
+                CancellationToken.None
+            );
+
+        await act.Should().NotThrowAsync();
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public async Task Fetch_NoSidecar_XmlFeed_ReturnsBodyViaPlainHttp()
     {
         // Standalone build with no sidecar: an XML feed is returned over plain HTTP.

--- a/tests/Equibles.UnitTests/CommonStocks/Q4IncFeedClientFetchTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/Q4IncFeedClientFetchTests.cs
@@ -45,6 +45,36 @@ public class Q4IncFeedClientFetchTests
     }
 
     [Fact]
+    public async Task Fetch_Sidecar_FetchRawThrows_DegradesToNull()
+    {
+        // A sidecar fetch can fail with an exception (e.g. a navigation timeout) instead of the
+        // contractual null. Fetch must degrade that to null, not let it bubble out — otherwise one
+        // throwing feed aborts the content scrape and starves the rest of the cohort's news/events.
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(true);
+        stealth
+            .FetchRaw(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string>(new TimeoutException("navigation timeout")));
+
+        var client = new Q4IncFeedClient(
+            new HttpClient(new ThrowingHandler()),
+            stealth,
+            NullLogger<Q4IncFeedClient>.Instance
+        );
+
+        string result = null;
+        var act = async () =>
+            result = await client.Fetch(
+                "https://ir.example.com/",
+                Q4IncFeedClient.NewsFeedPath,
+                CancellationToken.None
+            );
+
+        await act.Should().NotThrowAsync();
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public async Task Fetch_NoSidecar_XmlFeed_ReturnsBodyViaPlainHttp()
     {
         // Standalone build with no sidecar: an XML feed is returned over plain HTTP.


### PR DESCRIPTION
## Summary

IR news/events scraping stalled in production: `IrNewsItem` / `IrEvent` stopped growing on 2026-06-14, and the Q4 cohort (957 stocks, the largest with feeds) has news on only 47.

Same root pattern as #3744 / #3745, in the two IR feed clients. `Q4IncFeedClient.Fetch` and `NasdaqIrInsightFeedClient.Fetch` pull the feed through the stealth sidecar by default (since #3716), but the stealth branch wasn't wrapped in try/catch — unlike the plain-HTTP branch, which catches everything and returns `null`. Both methods are documented as returning null on a missing/errored feed, but `FetchRaw` can throw on a sidecar navigation timeout/error, so the exception bubbled out of `Fetch` into the content scrape instead of being the contractual null.

## Code changes

- `Q4IncFeedClient.Fetch` / `NasdaqIrInsightFeedClient.Fetch` — wrap the stealth feed fetch in the same `try/catch` as the plain-HTTP path: rethrow on cancellation, otherwise log at Debug and return `null`. A fetch failure now degrades to a feed miss.
- `Q4IncFeedClientFetchTests` / `NasdaqIrInsightFeedClientFetchTests` — add `Fetch_Sidecar_FetchRawThrows_DegradesToNull` to each: with a sidecar configured and `FetchRaw` throwing, `Fetch` must return null rather than throw. Fails on unfixed code, passes with the fix.

Completes the #3716 sidecar-first regression sweep across the discovery clients (IR probe #3744, website probe #3745, these two feed clients). The FDA calendar fetch is single-URL and tracked separately (#3718).
