### PR TITLE
fix: keep the rendered DOM when a stealth navigation never reaches network-idle

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
@@ -133,14 +133,51 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
     }
 
     private Task Navigate(IPage page, string url) =>
-        page.GotoAsync(
-            url,
-            new PageGotoOptions
-            {
-                WaitUntil = WaitUntilState.NetworkIdle,
-                Timeout = _options.RenderTimeoutSeconds * 1000,
-            }
-        );
+        NavigateWaitingForNetworkIdle(page, url, _options.RenderTimeoutSeconds * 1000, _logger);
+
+    /// <summary>
+    /// Navigates to <paramref name="url"/> waiting for the network to fall idle, but
+    /// treats an idle-wait timeout as non-fatal. Some hosts (e.g. the FDA advisory-
+    /// committee calendar) stream background telemetry that never lets the network go
+    /// idle, so <see cref="WaitUntilState.NetworkIdle"/> times out even though the
+    /// document has fully rendered within the budget. On that timeout the already-loaded
+    /// DOM is kept rather than discarding an otherwise successful render. A genuine
+    /// navigation failure — refused connection, DNS, protocol error — is a different
+    /// exception that still propagates, so the fetch degrades to a miss as before.
+    /// </summary>
+    internal static async Task NavigateWaitingForNetworkIdle(
+        IPage page,
+        string url,
+        int timeoutMilliseconds,
+        ILogger logger
+    )
+    {
+        try
+        {
+            await page.GotoAsync(
+                url,
+                new PageGotoOptions
+                {
+                    WaitUntil = WaitUntilState.NetworkIdle,
+                    Timeout = timeoutMilliseconds,
+                }
+            );
+        }
+        catch (PlaywrightException ex) when (IsNetworkIdleTimeout(ex))
+        {
+            logger.LogDebug("NetworkIdle wait timed out for {Url}; using the loaded DOM.", url);
+        }
+    }
+
+    /// <summary>
+    /// A navigation that loads but never reaches network-idle throws a
+    /// <see cref="PlaywrightException"/> whose message is the idle-wait timeout
+    /// ("Timeout &lt;n&gt;ms exceeded"). This Playwright version has no dedicated timeout
+    /// type, so the timeout is matched by message; every other navigation failure
+    /// (refused connection, DNS, protocol error) does not match and still propagates.
+    /// </summary>
+    private static bool IsNetworkIdleTimeout(PlaywrightException ex) =>
+        ex.Message.Contains("Timeout", StringComparison.OrdinalIgnoreCase);
 
     private async Task<IPlaywright> EnsureDriver(CancellationToken cancellationToken)
     {

--- a/tests/Equibles.UnitTests/CommonStocks/CloakBrowserStealthClientNavigateTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CloakBrowserStealthClientNavigateTests.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using Equibles.CommonStocks.HostedService.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Playwright;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Contract: the stealth navigation waits for the network to fall idle, but a host that
+/// streams background telemetry (e.g. the FDA advisory-committee calendar) never lets the
+/// network go idle, so the idle wait times out even though the document is fully rendered.
+/// That timeout must be non-fatal — the loaded DOM is kept — while a genuine navigation
+/// failure still propagates so the fetch degrades to a miss rather than returning a
+/// half-broken page.
+/// </summary>
+public class CloakBrowserStealthClientNavigateTests
+{
+    [Fact]
+    public async Task NavigateWaitingForNetworkIdle_SwallowsIdleTimeout_SoTheLoadedDomIsKept()
+    {
+        var page = Substitute.For<IPage>();
+        page.GotoAsync(Arg.Any<string>(), Arg.Any<PageGotoOptions>())
+            .ThrowsAsync(new PlaywrightException("Timeout 45000ms exceeded."));
+
+        var navigate = async () =>
+            await CloakBrowserStealthClient.NavigateWaitingForNetworkIdle(
+                page,
+                "https://www.fda.gov/advisory-committees/advisory-committee-calendar",
+                45000,
+                NullLogger.Instance
+            );
+
+        await navigate.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task NavigateWaitingForNetworkIdle_Rethrows_OnGenuineNavigationFailure()
+    {
+        var page = Substitute.For<IPage>();
+        page.GotoAsync(Arg.Any<string>(), Arg.Any<PageGotoOptions>())
+            .ThrowsAsync(new PlaywrightException("net::ERR_CONNECTION_REFUSED"));
+
+        var navigate = async () =>
+            await CloakBrowserStealthClient.NavigateWaitingForNetworkIdle(
+                page,
+                "https://unreachable.example",
+                45000,
+                NullLogger.Instance
+            );
+
+        await navigate.Should().ThrowAsync<PlaywrightException>();
+    }
+}


### PR DESCRIPTION
## Summary

The stealth browser navigates every page with a `NetworkIdle` wait. Some hosts — notably the FDA advisory-committee calendar — stream background telemetry (analytics beacons, polling) that never lets the network fall idle, so the wait runs to the full render budget and times out even though the document has already rendered. The timeout was fatal: the whole fetch was discarded, so the importer received nothing on every cycle and the FDA catalyst table never populated.

This treats a network-idle timeout as non-fatal — the already-loaded DOM is kept instead of throwing the fetch away. A genuine navigation failure (refused connection, DNS, protocol error) is a different `PlaywrightException` that still propagates, so a truly unreachable host continues to degrade to a miss exactly as before. The default wait is unchanged, so client-rendered pages that do reach idle behave identically.

## Code changes

- `CloakBrowserStealthClient`: extracted the navigation into `NavigateWaitingForNetworkIdle`, which catches the idle-wait timeout (matched by message, since this Playwright version has no dedicated timeout type) and keeps the loaded DOM; all other navigation failures still propagate.
- Added `CloakBrowserStealthClientNavigateTests` pinning both halves of the contract: an idle-wait timeout is swallowed, a genuine navigation failure rethrows.