### PR TITLE
fix(yahoo): skip non-positive OHLC bars from the price feed

### DIFF
--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -126,10 +126,12 @@ public class YahooFinanceClient : IYahooFinanceClient
     // incomplete and should be skipped like a holiday gap.
     //
     // Yahoo occasionally returns a ragged payload — a timestamp array longer than the
-    // OHLC/volume columns, or a column with a null hole on a holiday / early-close row.
-    // Bound every column access and require the full OHLC quartet: an incomplete row is
-    // skipped rather than emitted as an OHLC-impossible bar (e.g. High=0 while Close>0)
-    // or aborting the whole import.
+    // OHLC/volume columns, a column with a null hole on a holiday / early-close row, or a
+    // zeroed OHLC quartet for a delisted / halted ticker. Bound every column access and
+    // require a strictly-positive OHLC quartet: an incomplete or non-positive row is
+    // skipped rather than emitted as an impossible bar (e.g. Close=0 on a day with
+    // Volume>0, which corrupts market cap and price-derived rankings) or aborting the
+    // whole import.
     private static HistoricalPrice TryBuildPrice(
         ChartQuote quote,
         List<decimal?> adjCloseList,
@@ -144,7 +146,9 @@ public class YahooFinanceClient : IYahooFinanceClient
         var high = At(quote.High);
         var low = At(quote.Low);
         var close = At(quote.Close);
-        if (open == null || high == null || low == null || close == null)
+        // A real trading bar has every OHLC value present and strictly positive; a null
+        // hole or a $0/negative price (delisted/halted ticker) is not a tradeable price.
+        if (open is not > 0 || high is not > 0 || low is not > 0 || close is not > 0)
             return null;
 
         return new HistoricalPrice

--- a/tests/Equibles.UnitTests/Yahoo/YahooFinanceClientGetHistoricalPricesZeroPriceTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooFinanceClientGetHistoricalPricesZeroPriceTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Equibles.Integrations.Yahoo;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Yahoo;
+
+public class YahooFinanceClientGetHistoricalPricesZeroPriceTests
+{
+    // Contract: Yahoo returns a zeroed OHLC quartet (open/high/low/close all 0) for a
+    // delisted or trading-halted ticker, sometimes still carrying non-zero volume. A listed
+    // equity never trades at $0, so such a row is not a tradeable price and must be skipped
+    // like a holiday gap rather than emitted as an impossible bar (Close=0 on a day with
+    // Volume>0), which would corrupt market cap and price-derived rankings. Here bar 1 is
+    // all-zero with volume 1396, so only the valid bar 0 must survive.
+    [Fact]
+    public async Task GetHistoricalPrices_ZeroOhlcRowWithVolume_SkipsRowNotEmitsImpossibleBar()
+    {
+        // UTC exchange (gmtoffset 0) so each midnight timestamp maps to its own
+        // calendar date: 1704153600 -> 2024-01-02, 1704240000 -> 2024-01-03.
+        const string cassette = """
+            {
+              "chart": {
+                "result": [
+                  {
+                    "meta": { "gmtoffset": 0, "exchangeTimezoneName": "UTC" },
+                    "timestamp": [1704153600, 1704240000],
+                    "indicators": {
+                      "quote": [
+                        {
+                          "open": [100.0, 0.0],
+                          "high": [101.0, 0.0],
+                          "low": [99.0, 0.0],
+                          "close": [100.5, 0.0],
+                          "volume": [555, 1396]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "error": null
+              }
+            }
+            """;
+
+        var client = new SessionStubbedYahooClient(new HttpClient(new CassetteHandler(cassette)));
+
+        var prices = await client.GetHistoricalPrices(
+            "TEST",
+            new DateOnly(2024, 1, 2),
+            new DateOnly(2024, 1, 3)
+        );
+
+        prices.Should().ContainSingle();
+        var price = prices[0];
+        price.Date.Should().Be(new DateOnly(2024, 1, 2));
+        price.Close.Should().Be(100.5m);
+        prices.Should().NotContain(p => p.Date == new DateOnly(2024, 1, 3));
+    }
+
+    // Overrides the documented protected-virtual session seam so the data fetch
+    // skips the live cookie/crumb bootstrap and runs entirely against the stub.
+    private sealed class SessionStubbedYahooClient(HttpClient httpClient)
+        : YahooFinanceClient(httpClient, NullLogger<YahooFinanceClient>.Instance)
+    {
+        protected override Task<(string Crumb, string CookieHeader)> EnsureSession() =>
+            Task.FromResult<(string Crumb, string CookieHeader)>(("test-crumb", "A=1"));
+    }
+
+    private sealed class CassetteHandler(string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Yahoo returns a zeroed OHLC quartet (open/high/low/close all 0) for a delisted or trading-halted ticker, sometimes still carrying non-zero volume. The chart parser already skipped rows with a null OHLC hole, but a $0 quartet is a valid decimal and slipped through, getting stored as an impossible bar — a $0 price on a day with real volume. That collapses the stock's market cap to near zero and pollutes price-derived rankings (a buyback yield over 100%, etc.).
- A listed equity never trades at zero, so require a strictly-positive OHLC quartet: such bars are now skipped like a holiday gap instead of emitted.

## Code changes

- `src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs` — in `TryBuildPrice`, widen the existing null-hole guard to reject any non-positive OHLC value (`open/high/low/close is not > 0`), with an updated comment explaining the delisted/halted zero-price case.
- `tests/Equibles.UnitTests/Yahoo/YahooFinanceClientGetHistoricalPricesZeroPriceTests.cs` — new regression test: a cassette whose second bar is an all-zero OHLC quartet with volume 1396 must be skipped, leaving only the valid bar. Fails before the fix (emits the impossible $0 bar), passes after.

Refs daniel3303/EquiblesCommercial#3940