### PR TITLE
fix(insider-trading): tag Form 3/4/5 holdings as Holding, drop from transaction lists

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -261,7 +261,9 @@ public static class InsiderFilingParser
             CommonStockId = companyId,
             FilingDate = filing.FilingDate,
             TransactionDate = filing.ReportDate,
-            TransactionCode = TransactionCode.Other,
+            // A holding element reports a position, not a trade: tag it Holding so
+            // transaction lists can drop it while ownership summaries keep it.
+            TransactionCode = TransactionCode.Holding,
             Shares = ParseLong(sharesStr),
             PricePerShare = 0,
             AcquiredDisposed = AcquiredDisposed.Acquired,

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -243,6 +243,14 @@ public class InsiderFilingReprocessManager
                     row.SecurityKind = reparsed.SecurityKind;
                     result.Reclassified++;
                 }
+                // Re-tag the transaction code (v5 moved holding-only rows from Other
+                // to Holding). The parser is deterministic, so a real trade's code is
+                // unchanged; only mislabelled holding snapshots flip.
+                if (row.TransactionCode != reparsed.TransactionCode)
+                {
+                    row.TransactionCode = reparsed.TransactionCode;
+                    result.Reclassified++;
+                }
                 // Re-derive footnotes (added in parser v2); cheap to always copy.
                 row.Notes = reparsed.Notes;
             }

--- a/src/Equibles.InsiderTrading.Data/Extensions/InsiderTransactionQueryableExtensions.cs
+++ b/src/Equibles.InsiderTrading.Data/Extensions/InsiderTransactionQueryableExtensions.cs
@@ -1,0 +1,23 @@
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.InsiderTrading.Data.Extensions;
+
+public static class InsiderTransactionQueryableExtensions
+{
+    /// <summary>
+    /// Drops position-snapshot rows (<see cref="TransactionCode.Holding"/>) from a
+    /// transaction query. Holdings are parsed from Form 3/4/5 holding elements and
+    /// carry the insider's whole position in <see cref="InsiderTransaction.Shares"/>
+    /// with no price, so listing them next to trades reads as a phantom acquisition
+    /// of the entire stake. Apply on transaction lists and dollar-volume boards;
+    /// never on ownership summaries (which read the position) or the reprocess
+    /// (which re-tags the rows). Aggregates already filtered to Purchase/Sale don't
+    /// need it — a Holding row is neither.
+    /// </summary>
+    public static IQueryable<InsiderTransaction> ExcludeHoldings(
+        this IQueryable<InsiderTransaction> query
+    )
+    {
+        return query.Where(t => t.TransactionCode != TransactionCode.Holding);
+    }
+}

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -25,9 +25,13 @@ public class InsiderTransaction
     /// v3 restates per-ADS prices on ADS/ADR rows to per-ordinary so Shares ×
     /// PricePerShare is a real value (re-evaluated from the footnotes — see
     /// <see cref="ReportedPricePerShare"/>); v4 captures the Rule 10b5-1
-    /// affirmative-defense checkbox into <see cref="IsRule10b5One"/>.
+    /// affirmative-defense checkbox into <see cref="IsRule10b5One"/>; v5 tags
+    /// holding-only rows (parsed from a <c>nonDerivativeHolding</c>/
+    /// <c>derivativeHolding</c> element) as <see cref="TransactionCode.Holding"/>
+    /// instead of <see cref="TransactionCode.Other"/>, so the reprocess re-tags
+    /// every historical holding row and transaction lists can exclude them.
     /// </summary>
-    public const int CurrentParserVersion = 4;
+    public const int CurrentParserVersion = 5;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 

--- a/src/Equibles.InsiderTrading.Data/Models/TransactionCode.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/TransactionCode.cs
@@ -36,4 +36,16 @@ public enum TransactionCode
 
     [Display(Name = "Other")]
     Other,
+
+    /// <summary>
+    /// Not a transaction: a position snapshot parsed from a Form 3/4/5
+    /// <c>nonDerivativeHolding</c>/<c>derivativeHolding</c> element. The filing
+    /// reports the holding with no trade, so <see cref="InsiderTransaction.Shares"/>
+    /// carries the whole position (equal to
+    /// <see cref="InsiderTransaction.SharesOwnedAfter"/>) and the price is 0.
+    /// Kept so ownership summaries can read the position, but excluded from
+    /// transaction lists — see <c>ExcludeHoldings</c>.
+    /// </summary>
+    [Display(Name = "Holding")]
+    Holding,
 }

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -6,6 +6,7 @@ using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
+using Equibles.InsiderTrading.Data.Extensions;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Mcp;
@@ -61,6 +62,7 @@ public class InsiderTradingTools
 
                 var transactions = await _transactionRepository
                     .GetByStockWithOwner(stock)
+                    .ExcludeHoldings()
                     .OrderByDescending(t => t.TransactionDate)
                     .Take(maxResults)
                     .ToListAsync();

--- a/src/Equibles.Web/Controllers/InsiderActivityController.cs
+++ b/src/Equibles.Web/Controllers/InsiderActivityController.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Equibles.InsiderTrading.Data.Extensions;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Web.Controllers.Abstract;
@@ -75,7 +76,7 @@ public class InsiderActivityController : BaseController
         );
 
         var biggest = await LoadTopRows(
-            _transactionRepository.GetRecent(since),
+            _transactionRepository.GetRecent(since).ExcludeHoldings(),
             t => new InsiderDashboardRow
             {
                 OwnerName = t.InsiderOwner.Name,

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -3,6 +3,7 @@ using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
+using Equibles.InsiderTrading.Data.Extensions;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.Extensions;
@@ -333,6 +334,7 @@ public class ProfilesController : BaseController
 
         var transactions = await _insiderTransactionRepository
             .GetByOwner(owner)
+            .ExcludeHoldings()
             .TakeMostRecent(transaction => transaction.TransactionDate, RecentRowLimit)
             .Select(transaction => new InsiderTradeRowViewModel
             {

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -9,6 +9,7 @@ using Equibles.Data.Extensions;
 using Equibles.Finra.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
+using Equibles.InsiderTrading.Data.Extensions;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Statements;
@@ -315,7 +316,9 @@ public class StockTabService
 
     public async Task<InsiderTradingTabViewModel> LoadInsiderTradingTab(CommonStock stock)
     {
-        var transactionQuery = _insiderTransactionRepository.GetByStockWithOwner(stock);
+        var transactionQuery = _insiderTransactionRepository
+            .GetByStockWithOwner(stock)
+            .ExcludeHoldings();
         if (_minSyncDate is { } minDate)
         {
             transactionQuery = transactionQuery.Where(t => t.TransactionDate >= minDate);

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRetagHoldingTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRetagHoldingTests.cs
@@ -1,0 +1,151 @@
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+using FileContent = Equibles.Media.Data.Models.FileContent;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+/// <summary>
+/// Pins the v5 holding re-tag: historical rows stored before v5 carry a Form 3/4/5
+/// holding (a position snapshot) as <see cref="TransactionCode.Other"/>, which read
+/// as a phantom acquisition of the insider's whole stake in transaction lists. The
+/// reprocess re-parses from the cached ownership XML — where the source element is a
+/// <c>nonDerivativeHolding</c> — and re-tags the row to <see cref="TransactionCode.Holding"/>,
+/// authoritatively (from the element, never a DB heuristic), then stamps the version.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InsiderFilingReprocessManagerRetagHoldingTests : ParadeDbMcpTestBase
+{
+    public InsiderFilingReprocessManagerRetagHoldingTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Run_StaleHoldingTaggedOther_RetagsToHoldingFromSourceElement()
+    {
+        var date = new DateOnly(2024, 6, 14);
+        var accession = "0000320193-24-000099";
+
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0099",
+            Name = "Jane Holder",
+            City = "Cupertino",
+            StateOrCountry = "CA",
+            IsDirector = true,
+        };
+
+        // Legacy holding row: the whole position dumped into Shares (== SharesOwnedAfter),
+        // no price, mis-tagged Other, stuck at the pre-v5 version. SecurityKind already
+        // matches the source table so only the transaction code flips.
+        var stale = new InsiderTransaction
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            InsiderOwnerId = owner.Id,
+            AccessionNumber = accession,
+            TransactionOrder = 0,
+            FilingDate = date,
+            TransactionDate = date,
+            TransactionCode = TransactionCode.Other,
+            Shares = 5000,
+            PricePerShare = 0m,
+            ReportedPricePerShare = 0m,
+            AcquiredDisposed = AcquiredDisposed.Acquired,
+            SharesOwnedAfter = 5000,
+            OwnershipNature = OwnershipNature.Direct,
+            SecurityTitle = "Common Stock",
+            SecurityKind = InsiderSecurityKind.NonDerivative,
+            ParserVersion = 4,
+        };
+
+        // Source is a holding element (no transaction), so the re-parse routes through
+        // ParseHolding and tags the row Holding.
+        var ownershipXml =
+            "<ownershipDocument>"
+            + "<nonDerivativeTable><nonDerivativeHolding>"
+            + "<securityTitle><value>Common Stock</value></securityTitle>"
+            + "<postTransactionAmounts>"
+            + "<sharesOwnedFollowingTransaction><value>5000</value></sharesOwnedFollowingTransaction>"
+            + "</postTransactionAmounts>"
+            + "</nonDerivativeHolding></nonDerivativeTable>"
+            + "</ownershipDocument>";
+        var rawBytes = Encoding.UTF8.GetBytes(ownershipXml);
+        var filing = new InsiderFiling
+        {
+            AccessionNumber = accession,
+            CaptureStatus = InsiderFilingCaptureStatus.Captured,
+            UncompressedSize = rawBytes.Length,
+            Content = new File
+            {
+                Name = accession,
+                Extension = "gz",
+                ContentType = "application/gzip",
+                FileContent = new FileContent { Bytes = GzipCompressor.Compress(rawBytes) },
+            },
+        };
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        DbContext.Add(
+            new DailyStockPrice
+            {
+                CommonStockId = stock.Id,
+                Date = date,
+                Close = 55m,
+            }
+        );
+        DbContext.Add(stale);
+        DbContext.Add(filing);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var edgar = Substitute.For<ISecEdgarClient>();
+        var fileManager = Substitute.For<IFileManager>();
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runCtx),
+            new InsiderFilingRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            edgar,
+            fileManager,
+            runCtx,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Total.Should().Be(1);
+        result.Processed.Should().Be(1);
+        result.Reclassified.Should().Be(1);
+        result.Failed.Should().Be(0);
+        // Served from the cached blob — no EDGAR round-trip.
+        result.Fetched.Should().Be(0);
+        await edgar.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
+
+        await using var verify = Fixture.CreateDbContext();
+        var reprocessed = await verify.Set<InsiderTransaction>().FindAsync(stale.Id);
+        reprocessed!.TransactionCode.Should().Be(TransactionCode.Holding);
+        reprocessed.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -502,7 +502,7 @@ public class InsiderTradingFilingProcessorTests
         result.Should().BeTrue();
         var transactions = txRepo.GetAll().ToList();
         transactions.Should().HaveCount(1);
-        transactions[0].TransactionCode.Should().Be(TransactionCode.Other);
+        transactions[0].TransactionCode.Should().Be(TransactionCode.Holding);
         transactions[0].Shares.Should().Be(10000);
         transactions[0].SharesOwnedAfter.Should().Be(10000);
     }
@@ -733,7 +733,7 @@ public class InsiderTradingFilingProcessorTests
         // rely on: a newly-onboarding executive who already owns stock options reports them
         // as derivativeHoldings (no transactionDate, no acquired/disposed code — just "this
         // is what I currently hold"). `ParseHolding` synthesises a record using
-        // `filing.ReportDate` as the TransactionDate, hard-codes TransactionCode.Other and
+        // `filing.ReportDate` as the TransactionDate, tags TransactionCode.Holding and
         // AcquiredDisposed.Acquired, and lifts Shares from `postTransactionAmounts`.
         //
         // A regression that dropped this branch — or accidentally narrowed the inner foreach
@@ -777,8 +777,8 @@ public class InsiderTradingFilingProcessorTests
         transactions.Should().ContainSingle();
         transactions[0].SecurityTitle.Should().Be("Stock Option (Right to Buy)");
         transactions[0].Shares.Should().Be(5000);
-        // ParseHolding hard-codes TransactionCode = Other (no transaction, just a held position).
-        transactions[0].TransactionCode.Should().Be(TransactionCode.Other);
+        // ParseHolding tags a held position as TransactionCode = Holding (no transaction).
+        transactions[0].TransactionCode.Should().Be(TransactionCode.Holding);
         // TransactionDate falls back to filing.ReportDate because <derivativeHolding> has no
         // <transactionDate> element of its own.
         transactions[0].TransactionDate.Should().Be(filing.ReportDate);
@@ -1171,7 +1171,7 @@ public class InsiderTradingFilingProcessorTests
         //
         // Result: one persisted holding-as-transaction with SecurityTitle=null, Shares=0,
         // SharesOwnedAfter=0 (both derived from the same null sharesStr), OwnershipNature=Direct
-        // (`!= "I"` falls to Direct), TransactionCode=Other (hardcoded), TransactionDate
+        // (`!= "I"` falls to Direct), TransactionCode=Holding (tagged), TransactionDate
         // pulled from the filing's ReportDate. The transactions-count==0 fallback (which would
         // synthesize a "No Securities Owned" row) must NOT fire because ParseHolding does
         // return a row even when every optional element is null.
@@ -1204,7 +1204,7 @@ public class InsiderTradingFilingProcessorTests
         var transactions = txRepo.GetAll().ToList();
         transactions.Should().ContainSingle();
         transactions[0].SecurityTitle.Should().BeNull();
-        transactions[0].TransactionCode.Should().Be(TransactionCode.Other);
+        transactions[0].TransactionCode.Should().Be(TransactionCode.Holding);
         transactions[0].Shares.Should().Be(0);
         transactions[0].SharesOwnedAfter.Should().Be(0);
         transactions[0].OwnershipNature.Should().Be(OwnershipNature.Direct);

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseHoldingTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseHoldingTests.cs
@@ -11,9 +11,9 @@ public class InsiderFilingParserParseHoldingTests
     public void ParseTransactions_NonDerivativeHolding_ProducesHoldingSnapshotRow()
     {
         // Contract: a Form 3/4/5 *holding* (a position reported with no transaction) parses into an
-        // InsiderTransaction snapshot — TransactionCode.Other, no price, Acquired, and
-        // Shares == SharesOwnedAfter == the post-transaction holding amount. Only transaction rows
-        // are covered today; the holding path (nonDerivativeHolding) was entirely untested.
+        // InsiderTransaction snapshot — TransactionCode.Holding (a position, not a trade), no price,
+        // Acquired, and Shares == SharesOwnedAfter == the post-transaction holding amount. The
+        // Holding tag is what lets transaction lists drop these while ownership summaries keep them.
         var root = XElement.Parse(
             """
             <ownershipDocument>
@@ -44,7 +44,7 @@ public class InsiderFilingParserParseHoldingTests
         );
 
         var holding = result.Should().ContainSingle().Subject;
-        holding.TransactionCode.Should().Be(TransactionCode.Other);
+        holding.TransactionCode.Should().Be(TransactionCode.Holding);
         holding.PricePerShare.Should().Be(0);
         holding.AcquiredDisposed.Should().Be(AcquiredDisposed.Acquired);
         holding.Shares.Should().Be(5000);


### PR DESCRIPTION
## Summary

Form 3/4/5 *holding* elements (`nonDerivativeHolding`/`derivativeHolding`) report a **position**, not a trade. The parser stored each as a `TransactionCode.Other` row with the insider's whole position in `Shares` (equal to `SharesOwnedAfter`) and no price. Rendered alongside real trades on the per-stock insider tab, that reads as a phantom acquisition of the insider's entire stake — e.g. Elon Musk showing an "Other" row of **413,152,109** shares on the Tesla tab, which is his position, not an award.

The fix distinguishes holdings from trades with a dedicated code so transaction lists can drop them, while ownership summaries (which legitimately read the position) keep them.

## Code changes

- **`TransactionCode.cs`** — add `Holding` (a position snapshot, not a trade).
- **`InsiderFilingParser.ParseHolding`** — tag holding-only rows `Holding` instead of `Other`.
- **`InsiderTransaction.cs`** — bump `CurrentParserVersion` 4 → 5.
- **`InsiderFilingReprocessManager`** — copy `TransactionCode` from the re-parsed row, so the existing version-driven reprocess worker re-tags every historical holding row **authoritatively from the source element** (no DB heuristic — real `Other`/code-J trades are untouched).
- **`InsiderTransactionQueryableExtensions.ExcludeHoldings()`** (new) — applied at the transaction-list surfaces only: per-stock insider tab (`StockTabService`), per-insider profile (`ProfilesController`), biggest-transactions board (`InsiderActivityController`), and the `GetInsiderTransactions` MCP tool. Ownership summaries (`GetInsiderOwnership`), the Purchase/Sale-only aggregates (sentiment, screener net-buy) and the reprocess deliberately keep reading every row.

## Tests

- Parser tags `Holding` for non-derivative, derivative, and empty holding elements (updated existing pins; unknown-transaction-code → `Other` left intact).
- New: the reprocess re-tags a legacy `Other` holding row to `Holding` from cached XML, stamping the current version, with no EDGAR round-trip.

Build green; unit + holding/reprocess integration tests pass.