### PR TITLE
feat(common-stocks): persist SEC SIC code and entity type on CommonStock

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -94,6 +94,32 @@ public class CommonStockManager
         await _commonStockRepository.SaveChanges();
     }
 
+    /// <summary>
+    /// Sets the company's SEC classification — the submissions <c>sic</c> code and
+    /// <c>entityType</c> — used to tell operating companies apart from pooled
+    /// investment vehicles. Blank values are normalised to null so a missing SIC
+    /// stays eligible for a later refill rather than masquerading as classified. A
+    /// no-op change persists nothing. Saves directly via the repository — like
+    /// <see cref="SetFiscalYearEnd"/>, this mutates non-key fields and must not
+    /// re-run the full ticker/CIK uniqueness validation.
+    /// </summary>
+    public async Task SetSecClassification(CommonStock commonStock, string sic, string entityType)
+    {
+        ArgumentNullException.ThrowIfNull(commonStock);
+
+        var normalizedSic = string.IsNullOrWhiteSpace(sic) ? null : sic.Trim();
+        var normalizedEntityType = string.IsNullOrWhiteSpace(entityType) ? null : entityType.Trim();
+
+        if (commonStock.Sic == normalizedSic && commonStock.EntityType == normalizedEntityType)
+        {
+            return;
+        }
+
+        commonStock.Sic = normalizedSic;
+        commonStock.EntityType = normalizedEntityType;
+        await _commonStockRepository.SaveChanges();
+    }
+
     public async Task<CommonStock> Create(CommonStock commonStock)
     {
         await ValidateCommonStock(commonStock, true);

--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -105,6 +105,26 @@ public class CommonStock
     /// </summary>
     public int? FiscalYearEndDay { get; set; }
 
+    /// <summary>
+    /// SEC EDGAR's 4-digit Standard Industrial Classification code from the
+    /// submissions metadata, or null until detected. Identifies pooled
+    /// investment vehicles (e.g. 6221 commodity pools, 6722/6726 investment
+    /// offices, 6189 asset-backed) authoritatively, so they can be told apart
+    /// from operating companies without relying on ticker or name patterns.
+    /// </summary>
+    [MaxLength(8)]
+    public string Sic { get; set; }
+
+    /// <summary>
+    /// SEC EDGAR's <c>entityType</c> from the submissions metadata — "operating"
+    /// for operating companies, "other" for non-operating registrants such as
+    /// unit investment trusts that carry no SIC code. Null until detected.
+    /// Complements <see cref="Sic"/> when distinguishing operating companies
+    /// from investment vehicles.
+    /// </summary>
+    [MaxLength(32)]
+    public string EntityType { get; set; }
+
     public Guid? IndustryId { get; set; }
     public virtual Industry Industry { get; set; }
 }

--- a/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
+++ b/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
@@ -6,6 +6,15 @@ public class CompanyMetadata
 {
     public string Cik { get; set; }
     public string EntityType { get; set; }
+
+    /// <summary>
+    /// SEC's 4-digit Standard Industrial Classification code, or null/blank for
+    /// filers SEC never classified. Distinguishes pooled investment vehicles
+    /// (commodity pools 6221, investment offices 6722/6726, asset-backed 6189)
+    /// from operating companies.
+    /// </summary>
+    public string Sic { get; set; }
+
     public List<string> Exchanges { get; set; } = [];
 
     /// <summary>

--- a/src/Equibles.Integrations.Sec/Models/Responses/SecApiResponse.cs
+++ b/src/Equibles.Integrations.Sec/Models/Responses/SecApiResponse.cs
@@ -13,6 +13,14 @@ internal class SecApiResponse
     [JsonProperty("entityType")]
     public string EntityType { get; set; }
 
+    /// <summary>
+    /// SEC's 4-digit Standard Industrial Classification code (e.g. "3571" for
+    /// Apple, "6221" for commodity-pool ETPs, "6726" for investment offices).
+    /// Null/blank for filers SEC never classified.
+    /// </summary>
+    [JsonProperty("sic")]
+    public string Sic { get; set; }
+
     [JsonProperty("exchanges")]
     public List<string> Exchanges { get; set; } = [];
 

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -136,6 +136,7 @@ public class SecEdgarClient : ISecEdgarClient
             {
                 Cik = cik,
                 EntityType = apiResponse.EntityType,
+                Sic = apiResponse.Sic,
                 Exchanges = apiResponse.Exchanges ?? [],
                 FiscalYearEnd = apiResponse.FiscalYearEnd,
                 Website = apiResponse.Website,

--- a/src/Equibles.Migrations/Migrations/20260615213838_AddCommonStockSicAndEntityType.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260615213838_AddCommonStockSicAndEntityType.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615213838_AddCommonStockSicAndEntityType")]
+    partial class AddCommonStockSicAndEntityType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260615213838_AddCommonStockSicAndEntityType.cs
+++ b/src/Equibles.Migrations/Migrations/20260615213838_AddCommonStockSicAndEntityType.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommonStockSicAndEntityType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EntityType",
+                table: "CommonStock",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Sic",
+                table: "CommonStock",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EntityType",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "Sic",
+                table: "CommonStock");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -156,10 +156,11 @@ public class DocumentScraper : IDocumentScraper
                 company.Name
             );
 
-            // Detect the fiscal year-end before fetching filings: the metadata
-            // call primes the SEC client's submissions cache so the first
-            // GetCompanyFilings hits the same URL and adds no extra request.
-            await UpdateFiscalYearEnd(
+            // Capture SEC submissions metadata (fiscal year-end, SIC, entity type)
+            // before fetching filings: the metadata call primes the SEC client's
+            // submissions cache so the first GetCompanyFilings hits the same URL and
+            // adds no extra request.
+            await UpdateCompanyMetadata(
                 company,
                 secEdgarClient,
                 commonStockManager,
@@ -208,13 +209,15 @@ public class DocumentScraper : IDocumentScraper
     }
 
     /// <summary>
-    /// Reads SEC EDGAR's submissions <c>fiscalYearEnd</c> for the company and
-    /// persists it when it changed. Fallback chain when the metadata API returns
-    /// null: most recent 10-K period-end → 20-F report date → 40-F report date.
-    /// Best-effort: a failure is logged and reported but never blocks document
-    /// scraping, since fiscal-year metadata is a nice-to-have enrichment.
+    /// Reads SEC EDGAR's submissions metadata for the company and persists the
+    /// fields it derives: the SIC code and entity type (which tell operating
+    /// companies apart from pooled investment vehicles), and the fiscal year-end.
+    /// Fallback chain when the metadata API has no fiscal year-end: most recent
+    /// 10-K period-end → 20-F report date → 40-F report date. Best-effort: a
+    /// failure is logged and reported but never blocks document scraping, since
+    /// this metadata is a nice-to-have enrichment.
     /// </summary>
-    private async Task UpdateFiscalYearEnd(
+    private async Task UpdateCompanyMetadata(
         CommonStock company,
         ISecEdgarClient secEdgarClient,
         CommonStockManager commonStockManager,
@@ -224,6 +227,16 @@ public class DocumentScraper : IDocumentScraper
         try
         {
             var metadata = await secEdgarClient.GetCompanyMetadata(company.Cik);
+
+            // Persist the SEC classification first — unlike the fiscal year-end it
+            // has no fallback chain, so it must not be skipped by the early returns
+            // below. Blank values normalise to null and stay eligible for a refill.
+            await commonStockManager.SetSecClassification(
+                company,
+                metadata?.Sic,
+                metadata?.EntityType
+            );
+
             if (metadata?.FiscalYearEndMonth is { } month)
             {
                 await commonStockManager.SetFiscalYearEnd(
@@ -290,13 +303,13 @@ public class DocumentScraper : IDocumentScraper
         {
             _logger.LogWarning(
                 ex,
-                "Could not update fiscal year-end for {Ticker} (CIK: {Cik}): {Message}",
+                "Could not update SEC metadata for {Ticker} (CIK: {Cik}): {Message}",
                 company.Ticker,
                 company.Cik,
                 ex.Message
             );
             await ReportError(
-                "UpdateFiscalYearEnd",
+                "UpdateCompanyMetadata",
                 ex,
                 $"ticker: {company.Ticker}, cik: {company.Cik}"
             );

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperUpdateCompanyMetadataErrorIsolationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperUpdateCompanyMetadataErrorIsolationTests.cs
@@ -25,14 +25,14 @@ namespace Equibles.UnitTests.Sec;
 /// <summary>
 /// Adversarial sibling to <see cref="DocumentScraperTests"/>, which only pins
 /// the fiscal happy path (SEC returns a value / returns nothing). The
-/// UpdateFiscalYearEnd docstring is explicit: it is best-effort — a metadata
+/// UpdateCompanyMetadata docstring is explicit: it is best-effort — a metadata
 /// failure "is logged and reported but never blocks document scraping". So a
 /// throwing GetCompanyMetadata must be isolated: the company is still
 /// processed and the fault must NOT count as a scraping error (it is reported
 /// out-of-band). If the catch were mis-scoped the exception would reach the
 /// per-company catch and increment result.Errors.
 /// </summary>
-public class DocumentScraperUpdateFiscalYearEndErrorIsolationTests
+public class DocumentScraperUpdateCompanyMetadataErrorIsolationTests
 {
     [Fact]
     public async Task ScrapeDocuments_GetCompanyMetadataThrows_IsolatedAndDoesNotCountAsError()


### PR DESCRIPTION
## Summary

Persists SEC EDGAR's submissions `sic` code and `entityType` on `CommonStock` so consumers can tell operating companies apart from pooled investment vehicles (commodity pools, ETFs, mutual/closed-end funds, unit investment trusts, grantor/securitization trusts) using **authoritative SEC classification** rather than ticker or name patterns.

This is the data-layer half of a fix for funds appearing in the commercial Largest Buybacks ranking: a fund's `PaymentsForRepurchaseOfCommonStock` is a share/unit redemption, not a capital-return buyback, so those vehicles must be excluded from operating-company rankings. SIC alone is insufficient (commodity-pool ETPs are `entityType == "operating"` but SIC 6221; some trusts carry a blank SIC but `entityType == "other"`), so both fields are captured.

## Code changes

- **`SecApiResponse` / `CompanyMetadata`** — deserialize and surface the submissions `sic` field; mapped in `SecEdgarClient.GetCompanyMetadata`.
- **`CommonStock`** — new nullable `Sic` (≤8) and `EntityType` (≤32) columns, with a migration.
- **`CommonStockManager.SetSecClassification`** — persists both, normalising blank values to null (so a missing SIC stays eligible for a refill) and no-op-skipping unchanged values; saves directly like `SetFiscalYearEnd`.
- **`DocumentScraper`** — `UpdateFiscalYearEnd` renamed to `UpdateCompanyMetadata`; it now persists SIC + entity type from the submissions metadata it already fetches per company, so the fields backfill with **zero extra SEC requests**. The SEC-classification write happens before the fiscal-year fallback chain's early returns. Renamed the matching error-isolation test.

## Verification

- `dotnet build Equibles.sln` — green.
- 36 affected unit tests pass (`*DocumentScraper*`, `*CommonStockManagerSetFiscalYearEnd*`), including the best-effort error-isolation test (a throwing `GetCompanyMetadata` is still isolated and leaves the new columns null).