### PR TITLE
feat(sec): discover NPORT-P filings from multi-series fund trusts

### DIFF
--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -22,6 +22,7 @@ public sealed class ErrorSource
     public static readonly ErrorSource TranscriptScraper = new("TranscriptScraper");
     public static readonly ErrorSource InsiderTradingReprocess = new("InsiderTradingReprocess");
     public static readonly ErrorSource NportReprocess = new("NportReprocess");
+    public static readonly ErrorSource NportSweep = new("NportSweep");
     public static readonly ErrorSource WebsiteDiscovery = new("WebsiteDiscovery");
     public static readonly ErrorSource InvestorRelationsDiscovery = new(
         "InvestorRelationsDiscovery"
@@ -48,6 +49,7 @@ public sealed class ErrorSource
             TranscriptScraper,
             InsiderTradingReprocess,
             NportReprocess,
+            NportSweep,
             WebsiteDiscovery,
             InvestorRelationsDiscovery,
             InvestorRelationsScraper,

--- a/src/Equibles.Migrations/Migrations/20260616010229_AddNportTrustSweepCoverage.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260616010229_AddNportTrustSweepCoverage.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616010229_AddNportTrustSweepCoverage")]
+    partial class AddNportTrustSweepCoverage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260616010229_AddNportTrustSweepCoverage.cs
+++ b/src/Equibles.Migrations/Migrations/20260616010229_AddNportTrustSweepCoverage.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNportTrustSweepCoverage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_NportFiling_CommonStock_CommonStockId",
+                table: "NportFiling");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "CommonStockId",
+                table: "NportFiling",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RegistrantCik",
+                table: "NportFiling",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ProcessedNportFiling",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProcessedNportFiling", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NportFiling_RegistrantCik",
+                table: "NportFiling",
+                column: "RegistrantCik");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProcessedNportFiling_AccessionNumber",
+                table: "ProcessedNportFiling",
+                column: "AccessionNumber",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_NportFiling_CommonStock_CommonStockId",
+                table: "NportFiling",
+                column: "CommonStockId",
+                principalTable: "CommonStock",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_NportFiling_CommonStock_CommonStockId",
+                table: "NportFiling");
+
+            migrationBuilder.DropTable(
+                name: "ProcessedNportFiling");
+
+            migrationBuilder.DropIndex(
+                name: "IX_NportFiling_RegistrantCik",
+                table: "NportFiling");
+
+            migrationBuilder.DropColumn(
+                name: "RegistrantCik",
+                table: "NportFiling");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "CommonStockId",
+                table: "NportFiling",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_NportFiling_CommonStock_CommonStockId",
+                table: "NportFiling",
+                column: "CommonStockId",
+                principalTable: "CommonStock",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/NportFiling.cs
+++ b/src/Equibles.Sec.Data/Models/NportFiling.cs
@@ -1,15 +1,23 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Equibles.CommonStocks.Data.Models;
-using Equibles.Sec.Data.Contracts;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.Data.Models;
 
 /// <summary>
 /// A SEC Form NPORT-P monthly portfolio report filed by a registered investment company (mutual
-/// fund, ETF or closed-end fund) for one of its series. NPORT-P appears in the registrant's EDGAR
-/// submissions feed, so each report is attributed to the registrant's <see cref="CommonStock"/>.
+/// fund, ETF or closed-end fund) for one of its series.
+///
+/// A filing reaches the database two ways. Funds that are themselves tracked issuers (listed
+/// closed-end funds, standalone ETF trusts) are crawled through their EDGAR submissions feed and
+/// the report is attributed to the registrant's <see cref="CommonStock"/> — <see cref="CommonStockId"/>
+/// is set, <see cref="RegistrantCik"/> is null. The giant multi-series fund-family trusts
+/// ("Vanguard Index Funds", "Fidelity Concord Street Trust", "iShares Trust") are not tracked
+/// issuers, so they are instead discovered by the daily-index NPORT-P sweep — <see cref="CommonStockId"/>
+/// is null and the registrant is identified by <see cref="RegistrantCik"/>. Exactly one of the two
+/// is set, so the two populations never share a series.
+///
 /// The record captures the series' header facts — name, identifier, reporting period, total assets
 /// and liabilities, net assets — plus the schedule of portfolio investments in
 /// <see cref="Holdings"/>. Both the original report ("NPORT-P") and its amendments ("NPORT-P/A")
@@ -19,7 +27,8 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(AccessionNumber), IsUnique = true)]
 [Index(nameof(FilingDate))]
 [Index(nameof(ParserVersion))]
-public class NportFiling : IStockFiling
+[Index(nameof(RegistrantCik))]
+public class NportFiling
 {
     /// <summary>
     /// Current holdings-parsing algorithm version. Bump this whenever the NPORT-P parse changes so
@@ -31,8 +40,23 @@ public class NportFiling : IStockFiling
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid Id { get; set; } = Guid.NewGuid();
 
-    public Guid CommonStockId { get; set; }
+    /// <summary>
+    /// The tracked stock the report is attributed to, when the fund is itself a tracked issuer
+    /// (listed closed-end fund or standalone ETF trust). Null for filings discovered by the
+    /// daily-index sweep, whose registrant is a fund-family trust that is not a tracked stock —
+    /// those are identified by <see cref="RegistrantCik"/> instead.
+    /// </summary>
+    public Guid? CommonStockId { get; set; }
     public virtual CommonStock CommonStock { get; set; }
+
+    /// <summary>
+    /// The registrant's SEC CIK, set on filings discovered by the daily-index NPORT-P sweep (where
+    /// the registrant is not a tracked stock). Null on filings crawled through a tracked issuer's
+    /// submissions feed, whose registrant is identified by <see cref="CommonStockId"/>. Used both to
+    /// re-fetch the submission during reprocess and to scope a series to its registrant.
+    /// </summary>
+    [MaxLength(16)]
+    public string RegistrantCik { get; set; }
 
     [MaxLength(32)]
     public string AccessionNumber { get; set; }

--- a/src/Equibles.Sec.Data/Models/ProcessedNportFiling.cs
+++ b/src/Equibles.Sec.Data/Models/ProcessedNportFiling.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// Records an NPORT-P submission the daily-index sweep examined and deliberately did NOT store as a
+/// <see cref="NportFiling"/>, keyed by accession number. Two cases reach here: the registrant is a
+/// tracked stock (its filings are crawled at full fidelity through the issuer feed instead), or the
+/// report carries no position in any stock we track and the series has never been seen before.
+///
+/// This is the dedup ledger that keeps the sweep cheap: without it, every Vanguard bond fund and
+/// money-market series in the trailing window would be re-downloaded and re-parsed each cycle.
+/// Stored filings need no entry here — their accession already exists in <see cref="NportFiling"/>,
+/// which the sweep checks first.
+/// </summary>
+[Index(nameof(AccessionNumber), IsUnique = true)]
+public class ProcessedNportFiling
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -31,6 +31,7 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<NCenServiceProvider>();
         builder.Entity<NportFiling>();
         builder.Entity<NportHolding>();
+        builder.Entity<ProcessedNportFiling>();
         builder.Entity<TranscriptCheckStatus>();
     }
 }

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<FilingItemsBackfillWorker>();
         services.AddHostedService<InsiderFilingReprocessWorker>();
         services.AddHostedService<NportFilingReprocessWorker>();
+        services.AddHostedService<NportRealtimeWorker>();
 
         return services;
     }

--- a/src/Equibles.Sec.HostedService/Models/NportRealtimeResult.cs
+++ b/src/Equibles.Sec.HostedService/Models/NportRealtimeResult.cs
@@ -1,0 +1,16 @@
+namespace Equibles.Sec.HostedService.Models;
+
+/// <summary>
+/// Outcome of one NPORT-P daily-index sweep cycle.
+/// </summary>
+/// <param name="Stored">Trust-only filings stored this cycle (with or without tracked holdings).</param>
+/// <param name="Examined">Candidate filings fetched and classified this cycle.</param>
+/// <param name="MoreWorkQueued">
+/// True when the cycle hit its per-cycle candidate cap and unprocessed candidates remain, so the
+/// worker should continue promptly instead of sleeping the full interval.
+/// </param>
+/// <param name="NotReady">
+/// True when the tracked-stock universe is not populated yet (cold start), so there is nothing to
+/// match holdings against and the worker should retry soon rather than record progress.
+/// </param>
+public record NportRealtimeResult(int Stored, int Examined, bool MoreWorkQueued, bool NotReady);

--- a/src/Equibles.Sec.HostedService/NportRealtimeWorker.cs
+++ b/src/Equibles.Sec.HostedService/NportRealtimeWorker.cs
@@ -1,0 +1,107 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Worker;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService;
+
+/// <summary>
+/// Sweeps EDGAR's daily index for freshly accepted NPORT-P portfolio reports across all filers and
+/// ingests the ones filed by fund-family trusts that are not tracked stocks — the source of the
+/// "held by funds" coverage gap, where the largest index funds (Vanguard, Fidelity, iShares) never
+/// appeared because their multi-series trusts are not crawled through the issuer feed.
+///
+/// The full trailing window is re-swept each cycle and progress is deduped by accession number
+/// (against both stored and skip-recorded filings), so no watermark is needed and a transient
+/// daily-index failure self-heals next cycle. Runs in the worker process so it shares the single SEC
+/// rate-limiter with the other EDGAR scrapers, and staggers past deploy so its initial burst doesn't
+/// crowd the time-sensitive scrapers.
+/// </summary>
+public class NportRealtimeWorker : BaseScraperWorker
+{
+    // The fund universe files NPORT-P monthly but discloses quarterly, with up to 60 days after a
+    // quarter end to file — so the window must span a full filing cluster. Re-sweeping these days is
+    // cheap (one small index file each); only genuinely new submissions are downloaded.
+    private const int DefaultLookbackDays = 70;
+
+    // Caps submissions downloaded per cycle so a cold-start backlog drains in bursts through the
+    // shared SEC budget instead of one long run that starves the other scrapers.
+    private const int DefaultMaxFetchesPerCycle = 500;
+
+    private readonly IConfiguration _configuration;
+
+    protected override string WorkerName => "NPORT-P real-time ingestion";
+    protected override TimeSpan SleepInterval => TimeSpan.FromHours(6);
+    protected override ErrorSource ErrorSource => ErrorSource.NportSweep;
+
+    // Stagger past deploy so the initial daily-index burst doesn't collide with the other SEC
+    // scrapers (and after the reprocess worker, which staggers by 5 minutes).
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(7);
+
+    public NportRealtimeWorker(
+        ILogger<NportRealtimeWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration()
+    {
+        if (!_configuration.GetValue("NportSweep:Enabled", true))
+        {
+            Logger.LogInformation(
+                "NPORT-P real-time ingestion disabled (NportSweep:Enabled=false)"
+            );
+            return false;
+        }
+
+        return ValidateSecContactEmail(
+            _configuration,
+            "NPORT-P real-time ingestion",
+            treatWhitespaceAsAbsent: true
+        );
+    }
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        var lookbackDays = Math.Max(
+            1,
+            _configuration.GetValue("NportSweep:LookbackDays", DefaultLookbackDays)
+        );
+        var maxFetches = Math.Max(
+            1,
+            _configuration.GetValue("NportSweep:MaxFetchesPerCycle", DefaultMaxFetchesPerCycle)
+        );
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var service = scope.ServiceProvider.GetRequiredService<NportRealtimeIngestionService>();
+
+        var result = await service.IngestRecentFilings(
+            today,
+            lookbackDays,
+            maxFetches,
+            stoppingToken
+        );
+
+        // Cold start before the tracked-stock universe is populated — back off briefly and retry,
+        // don't sleep the full interval.
+        if (result.NotReady)
+        {
+            RequestRetrySoon();
+            return;
+        }
+
+        // A capped cycle left candidates behind — drain them promptly rather than waiting the full
+        // interval, while a brief gap still yields the shared SEC budget to the other scrapers.
+        if (result.MoreWorkQueued)
+            RequestImmediateContinuation();
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -65,10 +65,13 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
     /// <summary>
     /// Parses an NPORT-P submission root into a <see cref="NportFiling"/> with its schedule of
     /// holdings, stamped at <see cref="NportFiling.CurrentParserVersion"/>. Shared by the ingest
-    /// pipeline (<see cref="ParseFiling"/>) and the version-driven reprocess pass, so both derive
-    /// holdings identically. Returns null when the submission lacks the required genInfo section.
+    /// pipeline (<see cref="ParseFiling"/>), the daily-index sweep and the version-driven reprocess
+    /// pass, so all three derive holdings identically. <paramref name="companyId"/> is null for the
+    /// sweep, whose registrant is not a tracked stock (the caller sets
+    /// <see cref="NportFiling.RegistrantCik"/> instead). Returns null when the submission lacks the
+    /// required genInfo section.
     /// </summary>
-    internal static NportFiling ParseEntity(XElement root, Guid companyId, FilingData filing)
+    internal static NportFiling ParseEntity(XElement root, Guid? companyId, FilingData filing)
     {
         var headerData = El(root, "headerData");
         var formData = El(root, "formData");

--- a/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
@@ -38,13 +39,20 @@ public class NportFilingReprocessManager
     internal const int MaxReprocessAttempts = 3;
 
     private readonly NportFilingRepository _filingRepository;
+    private readonly CommonStockRepository _commonStockRepository;
     private readonly ISecEdgarClient _secEdgarClient;
     private readonly EquiblesFinancialDbContext _dbContext;
     private readonly ErrorReporter _errorReporter;
     private readonly ILogger<NportFilingReprocessManager> _logger;
 
+    // The tracked-stock CUSIP set, loaded on first need within a run. Only sweep-discovered
+    // (registrant-only) filings store a CUSIP-filtered schedule, so the set is consulted only when
+    // one is re-derived — most runs never touch it.
+    private HashSet<string> _trackedCusips;
+
     public NportFilingReprocessManager(
         NportFilingRepository filingRepository,
+        CommonStockRepository commonStockRepository,
         ISecEdgarClient secEdgarClient,
         EquiblesFinancialDbContext dbContext,
         ErrorReporter errorReporter,
@@ -52,6 +60,7 @@ public class NportFilingReprocessManager
     )
     {
         _filingRepository = filingRepository;
+        _commonStockRepository = commonStockRepository;
         _secEdgarClient = secEdgarClient;
         _dbContext = dbContext;
         _errorReporter = errorReporter;
@@ -174,7 +183,9 @@ public class NportFilingReprocessManager
     // the caller can record the attempt and retry the filing on a later run.
     private async Task<int> ReprocessFiling(NportFiling filing)
     {
-        var cik = filing.CommonStock?.Cik;
+        // A sweep-discovered filing has no tracked stock; its registrant CIK is the one to re-fetch
+        // from. A feed-crawled filing carries no registrant CIK and re-fetches via its stock's.
+        var cik = filing.RegistrantCik ?? filing.CommonStock?.Cik;
         if (string.IsNullOrEmpty(cik))
             throw new InvalidOperationException(
                 $"NPORT-P filing {filing.AccessionNumber} has no issuer CIK to re-fetch from EDGAR."
@@ -214,12 +225,27 @@ public class NportFilingReprocessManager
                 $"NPORT-P {filing.AccessionNumber} is missing its genInfo section."
             );
 
+        // Sweep-discovered (registrant-only) filings keep only positions in stocks we track — they
+        // exist solely to answer the reverse "who holds this stock" lookup. Re-derive that same
+        // filtered schedule so reprocess doesn't re-inflate the filing with the fund's full
+        // portfolio of bonds, derivatives and untracked equities.
+        var reparsedHoldings = parsed.Holdings;
+        if (filing.CommonStockId == null)
+        {
+            var trackedCusips = await GetTrackedCusips();
+            reparsedHoldings = parsed
+                .Holdings.Where(h =>
+                    !string.IsNullOrEmpty(h.Cusip) && trackedCusips.Contains(h.Cusip)
+                )
+                .ToList();
+        }
+
         // Replace the schedule of holdings and refresh the header facts, then stamp the version so
         // the filing drops out of the work-set.
         _dbContext.Set<NportHolding>().RemoveRange(filing.Holdings);
-        foreach (var holding in parsed.Holdings)
+        foreach (var holding in reparsedHoldings)
             holding.NportFilingId = filing.Id;
-        _dbContext.Set<NportHolding>().AddRange(parsed.Holdings);
+        _dbContext.Set<NportHolding>().AddRange(reparsedHoldings);
 
         filing.RegistrantName = parsed.RegistrantName;
         filing.SeriesName = parsed.SeriesName;
@@ -234,6 +260,23 @@ public class NportFilingReprocessManager
         filing.ParserVersion = NportFiling.CurrentParserVersion;
         filing.ReprocessAttempts = 0;
 
-        return parsed.Holdings.Count;
+        return reparsedHoldings.Count;
+    }
+
+    // The set of CUSIPs we track, loaded once per run and cached. Only consulted when a
+    // sweep-discovered filing is re-derived, so it stays unloaded on runs without one.
+    private async Task<HashSet<string>> GetTrackedCusips()
+    {
+        if (_trackedCusips != null)
+            return _trackedCusips;
+
+        var cusips = await _commonStockRepository
+            .GetAll()
+            .Where(c => c.Cusip != null && c.Cusip != "")
+            .Select(c => c.Cusip)
+            .ToListAsync();
+
+        _trackedCusips = new HashSet<string>(cusips, StringComparer.OrdinalIgnoreCase);
+        return _trackedCusips;
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/NportRealtimeIngestionService.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportRealtimeIngestionService.cs
@@ -1,0 +1,403 @@
+using System.Globalization;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Helpers;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Discovers NPORT-P portfolio reports across <em>all</em> EDGAR filers — not just tracked issuers —
+/// by sweeping the daily index, so the giant multi-series fund-family trusts ("Vanguard Index
+/// Funds", "Fidelity Concord Street Trust", "iShares Trust") that file one report per series under a
+/// single non-listed registrant are no longer missed. These trusts are not tracked stocks, so the
+/// issuer-feed crawler never reaches them; without this sweep their funds — the largest holders of
+/// the most widely held stocks — never appear under "held by funds".
+///
+/// Each swept filing keeps only the positions in stocks we already track (matched by CUSIP, the
+/// authoritative identifier — never name text); the rest of the fund's portfolio is dropped because
+/// the only consumer is the reverse "who holds this stock" lookup. A registrant that is itself a
+/// tracked stock is left to the issuer-feed crawler, which stores its reports at full fidelity, so
+/// the two paths never produce the same series twice.
+/// </summary>
+[Service]
+public class NportRealtimeIngestionService
+{
+    // Commit progress often so a throttled or interrupted cycle keeps what it managed to fetch.
+    private const int BatchSize = 50;
+
+    private readonly ISecEdgarClient _edgarClient;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly NportFilingRepository _nportFilingRepository;
+    private readonly ProcessedNportFilingRepository _processedRepository;
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly ErrorReporter _errorReporter;
+    private readonly ILogger<NportRealtimeIngestionService> _logger;
+
+    // NPORT-P and NPORT-P/A both start with this prefix in the daily index.
+    private static readonly string[] NportFormPrefixes = ["NPORT-P"];
+
+    public NportRealtimeIngestionService(
+        ISecEdgarClient edgarClient,
+        CommonStockRepository commonStockRepository,
+        NportFilingRepository nportFilingRepository,
+        ProcessedNportFilingRepository processedRepository,
+        EquiblesFinancialDbContext dbContext,
+        ErrorReporter errorReporter,
+        ILogger<NportRealtimeIngestionService> logger
+    )
+    {
+        _edgarClient = edgarClient;
+        _commonStockRepository = commonStockRepository;
+        _nportFilingRepository = nportFilingRepository;
+        _processedRepository = processedRepository;
+        _dbContext = dbContext;
+        _errorReporter = errorReporter;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Sweeps the last <paramref name="lookbackDays"/> days of EDGAR's daily index (inclusive of
+    /// <paramref name="today"/>) for NPORT-P submissions, ingesting the trust-only ones that hold a
+    /// stock we track. At most <paramref name="maxFetchesPerCycle"/> submissions are downloaded per
+    /// cycle; when more remain the result flags it so the worker drains the rest promptly.
+    /// </summary>
+    public async Task<NportRealtimeResult> IngestRecentFilings(
+        DateOnly today,
+        int lookbackDays,
+        int maxFetchesPerCycle,
+        CancellationToken cancellationToken
+    )
+    {
+        var trackedCusips = await LoadTrackedCusips(cancellationToken);
+        if (trackedCusips.Count == 0)
+        {
+            _logger.LogInformation(
+                "NPORT-P sweep: no tracked stock CUSIPs yet; nothing to match. Retrying soon."
+            );
+            return new NportRealtimeResult(0, 0, MoreWorkQueued: false, NotReady: true);
+        }
+
+        var trackedCiks = await LoadTrackedCiks(cancellationToken);
+
+        var entries = await DiscoverEntries(today, lookbackDays, cancellationToken);
+        if (entries.Count == 0)
+        {
+            _logger.LogInformation("NPORT-P sweep: no submissions in the daily-index window");
+            return new NportRealtimeResult(0, 0, MoreWorkQueued: false, NotReady: false);
+        }
+
+        var candidates = await SelectCandidates(entries, cancellationToken);
+        if (candidates.Count == 0)
+            return new NportRealtimeResult(0, 0, MoreWorkQueued: false, NotReady: false);
+
+        var stored = 0;
+        var fetched = 0;
+        var moreWorkQueued = false;
+        var pending = 0;
+
+        foreach (var entry in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // A registrant that is itself a tracked stock is crawled at full fidelity through the
+            // issuer feed; record it so the sweep doesn't re-examine it, and never download it.
+            if (trackedCiks.Contains(NormalizeCik(entry.Cik)))
+            {
+                RecordSkipped(entry.AccessionNumber);
+                pending++;
+            }
+            else
+            {
+                if (fetched >= maxFetchesPerCycle)
+                {
+                    moreWorkQueued = true;
+                    break;
+                }
+
+                fetched++;
+                var outcome = await ProcessTrustFiling(entry, trackedCusips, cancellationToken);
+                if (outcome == FilingOutcome.Stored)
+                    stored++;
+                if (outcome != FilingOutcome.TransientFailure)
+                    pending++;
+            }
+
+            if (pending >= BatchSize)
+            {
+                await FlushBatch(cancellationToken);
+                pending = 0;
+            }
+        }
+
+        await FlushBatch(cancellationToken);
+
+        _logger.LogInformation(
+            "NPORT-P sweep cycle complete: {Stored} trust filings stored, {Fetched} submissions examined{More}",
+            stored,
+            fetched,
+            moreWorkQueued ? " (more queued)" : string.Empty
+        );
+
+        return new NportRealtimeResult(stored, fetched, moreWorkQueued, NotReady: false);
+    }
+
+    private enum FilingOutcome
+    {
+        // Parsed and stored as a trust-only filing (with or without tracked holdings).
+        Stored,
+
+        // Examined and deliberately not stored (no tracked holdings, unseen series, or malformed) —
+        // recorded so it is not re-downloaded.
+        SkippedRecorded,
+
+        // Fetch returned nothing / threw after the client's own retries — left unrecorded so a later
+        // cycle retries it until it ages out of the sweep window.
+        TransientFailure,
+    }
+
+    private async Task<FilingOutcome> ProcessTrustFiling(
+        EdgarDailyIndexEntry entry,
+        HashSet<string> trackedCusips,
+        CancellationToken cancellationToken
+    )
+    {
+        string content;
+        try
+        {
+            content = await _edgarClient.GetDocumentContent(entry.AccessionNumber, entry.Cik);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // One submission failing must not abort the sweep; leave it unrecorded so it retries.
+            _logger.LogWarning(
+                ex,
+                "NPORT-P sweep: failed to fetch {Accession} (CIK {Cik}); will retry",
+                entry.AccessionNumber,
+                entry.Cik
+            );
+            return FilingOutcome.TransientFailure;
+        }
+
+        if (string.IsNullOrWhiteSpace(content))
+            return FilingOutcome.TransientFailure;
+
+        var filingData = new FilingData
+        {
+            Cik = entry.Cik,
+            AccessionNumber = entry.AccessionNumber,
+            FilingDate = entry.DateFiled,
+            ReportDate = entry.DateFiled,
+            Form = entry.FormType,
+        };
+
+        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
+            content,
+            filingData,
+            companyTicker: null,
+            "NPORT-P",
+            "Nport.Sweep",
+            _logger,
+            _errorReporter
+        );
+        if (root == null)
+        {
+            // Non-empty content that is not parseable XML is deterministic — record it so the sweep
+            // does not re-download it every cycle.
+            RecordSkipped(entry.AccessionNumber);
+            return FilingOutcome.SkippedRecorded;
+        }
+
+        var filing = NportFilingProcessor.ParseEntity(root, companyId: null, filingData);
+        if (filing == null)
+        {
+            RecordSkipped(entry.AccessionNumber);
+            return FilingOutcome.SkippedRecorded;
+        }
+
+        filing.RegistrantCik = Truncate(entry.Cik, 16);
+
+        var trackedHoldings = filing
+            .Holdings.Where(h => !string.IsNullOrEmpty(h.Cusip) && trackedCusips.Contains(h.Cusip))
+            .ToList();
+
+        // Store the report when it holds one of our stocks, or when this series has been stored
+        // before — so a later report that exited every tracked position still advances the series'
+        // latest report and the exited position stops reading as current. Otherwise the registrant
+        // holds nothing we track and never has: record it and move on.
+        if (trackedHoldings.Count == 0 && !await IsSeriesKnown(filing, cancellationToken))
+        {
+            RecordSkipped(entry.AccessionNumber);
+            return FilingOutcome.SkippedRecorded;
+        }
+
+        filing.Holdings = trackedHoldings;
+        _nportFilingRepository.Add(filing);
+        return FilingOutcome.Stored;
+    }
+
+    private Task<bool> IsSeriesKnown(NportFiling filing, CancellationToken cancellationToken) =>
+        _nportFilingRepository
+            .GetByRegistrantCikAndSeries(filing.RegistrantCik, filing.SeriesId)
+            .AnyAsync(cancellationToken);
+
+    private void RecordSkipped(string accessionNumber) =>
+        _processedRepository.Add(new ProcessedNportFiling { AccessionNumber = accessionNumber });
+
+    // Commits the staged filings/skip-records and clears the tracker so the cycle's memory stays
+    // flat. A batch conflict (e.g. a concurrent issuer-feed insert of the same accession) drops only
+    // that batch — those candidates are simply re-examined next cycle.
+    private async Task FlushBatch(CancellationToken cancellationToken)
+    {
+        if (!_dbContext.ChangeTracker.HasChanges())
+            return;
+
+        try
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex)
+        {
+            _logger.LogWarning(ex, "NPORT-P sweep: batch save failed; re-examining next cycle");
+        }
+        finally
+        {
+            _dbContext.ChangeTracker.Clear();
+        }
+    }
+
+    // The distinct candidate set: daily-index NPORT-P entries we have neither stored nor skipped
+    // before, oldest first so a capped cycle drains the backlog in filing order.
+    private async Task<List<EdgarDailyIndexEntry>> SelectCandidates(
+        List<EdgarDailyIndexEntry> entries,
+        CancellationToken cancellationToken
+    )
+    {
+        var accessions = entries.Select(e => e.AccessionNumber).ToList();
+
+        var stored = await _nportFilingRepository
+            .GetByAccessionNumbers(accessions)
+            .Select(f => f.AccessionNumber)
+            .ToListAsync(cancellationToken);
+        var skipped = await _processedRepository
+            .GetByAccessionNumbers(accessions)
+            .Select(p => p.AccessionNumber)
+            .ToListAsync(cancellationToken);
+
+        var known = new HashSet<string>(stored, StringComparer.OrdinalIgnoreCase);
+        known.UnionWith(skipped);
+
+        return entries
+            .Where(e => !known.Contains(e.AccessionNumber))
+            .OrderBy(e => e.DateFiled)
+            .ThenBy(e => e.AccessionNumber, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    // Walks the trailing window of daily indexes, deduping by accession across overlapping days. A
+    // day that fails to fetch is logged and skipped — the full window is re-swept each cycle, so a
+    // transient failure self-heals next time without a watermark.
+    private async Task<List<EdgarDailyIndexEntry>> DiscoverEntries(
+        DateOnly today,
+        int lookbackDays,
+        CancellationToken cancellationToken
+    )
+    {
+        var byAccession = new Dictionary<string, EdgarDailyIndexEntry>(
+            StringComparer.OrdinalIgnoreCase
+        );
+
+        for (var offset = 0; offset < lookbackDays; offset++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var date = today.AddDays(-offset);
+
+            List<EdgarDailyIndexEntry> dayEntries;
+            try
+            {
+                dayEntries = await _edgarClient.GetDailyIndexForForms(
+                    date,
+                    NportFormPrefixes,
+                    cancellationToken
+                );
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "NPORT-P sweep: failed to fetch the {Date:yyyy-MM-dd} daily index; skipping this day",
+                    date
+                );
+                continue;
+            }
+
+            foreach (var entry in dayEntries)
+            {
+                if (!string.IsNullOrEmpty(entry.AccessionNumber))
+                    byAccession[entry.AccessionNumber] = entry;
+            }
+        }
+
+        return byAccession.Values.ToList();
+    }
+
+    private async Task<HashSet<string>> LoadTrackedCusips(CancellationToken cancellationToken)
+    {
+        var cusips = await _commonStockRepository
+            .GetAll()
+            .Where(c => c.Cusip != null && c.Cusip != "")
+            .Select(c => c.Cusip)
+            .ToListAsync(cancellationToken);
+
+        return new HashSet<string>(cusips, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private async Task<HashSet<string>> LoadTrackedCiks(CancellationToken cancellationToken)
+    {
+        var rows = await _commonStockRepository
+            .GetAll()
+            .Select(c => new { c.Cik, c.SecondaryCiks })
+            .ToListAsync(cancellationToken);
+
+        var ciks = new HashSet<string>();
+        foreach (var row in rows)
+        {
+            if (!string.IsNullOrEmpty(row.Cik))
+                ciks.Add(NormalizeCik(row.Cik));
+
+            foreach (var secondary in row.SecondaryCiks)
+            {
+                if (!string.IsNullOrEmpty(secondary))
+                    ciks.Add(NormalizeCik(secondary));
+            }
+        }
+
+        return ciks;
+    }
+
+    // EDGAR's daily index reports CIKs without leading zeros; CommonStock may store them padded.
+    // Normalise both sides to the unpadded numeric form so the membership test never misses.
+    private static string NormalizeCik(string cik)
+    {
+        if (string.IsNullOrEmpty(cik))
+            return cik;
+        return long.TryParse(cik, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n)
+            ? n.ToString(CultureInfo.InvariantCulture)
+            : cik.TrimStart('0');
+    }
+
+    private static string Truncate(string value, int maxLength) =>
+        value != null && value.Length > maxLength ? value[..maxLength] : value;
+}

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -1,12 +1,39 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
 
 namespace Equibles.Sec.Repositories;
 
-public class NportFilingRepository : SecFilingRepositoryBase<NportFiling>
+/// <summary>
+/// Reads and writes NPORT-P portfolio reports. Unlike the other SEC filing repositories this one
+/// does not derive from <c>SecFilingRepositoryBase</c>: an NPORT-P filing is not necessarily
+/// attributed to a tracked stock (multi-series fund-family trusts discovered by the daily-index
+/// sweep carry a <see cref="NportFiling.RegistrantCik"/> instead of a <see cref="NportFiling.CommonStockId"/>),
+/// so its registrant identity is optional.
+/// </summary>
+public class NportFilingRepository : BaseRepository<NportFiling>
 {
     public NportFilingRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
+
+    /// <summary>The filings attributed to a tracked stock (the fund crawled through its own feed).</summary>
+    public IQueryable<NportFiling> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(f => f.CommonStockId == stock.Id);
+    }
+
+    public IQueryable<NportFiling> GetByAccessionNumber(string accessionNumber)
+    {
+        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
+    }
+
+    /// <summary>The filings whose accession number is in the set — the sweep's batch dedup lookup.</summary>
+    public IQueryable<NportFiling> GetByAccessionNumbers(
+        IReadOnlyCollection<string> accessionNumbers
+    )
+    {
+        return GetAll().Where(f => accessionNumbers.Contains(f.AccessionNumber));
+    }
 
     public IQueryable<NportHolding> GetHoldings(NportFiling filing)
     {
@@ -20,23 +47,59 @@ public class NportFilingRepository : SecFilingRepositoryBase<NportFiling>
     }
 
     /// <summary>
+    /// Filings of a sweep-discovered series, identified by registrant CIK and series id (an id-less
+    /// registrant collapses to its single fund). Lets the sweep tell whether it has stored this
+    /// series before, so a later report holding none of our tracked stocks is still recorded as the
+    /// series' latest — otherwise an earlier report would linger and an exited position would read as
+    /// current.
+    /// </summary>
+    public IQueryable<NportFiling> GetByRegistrantCikAndSeries(
+        string registrantCik,
+        string seriesId
+    )
+    {
+        return GetAll()
+            .Where(f =>
+                f.RegistrantCik == registrantCik
+                && (
+                    f.SeriesId == seriesId
+                    || (string.IsNullOrEmpty(f.SeriesId) && string.IsNullOrEmpty(seriesId))
+                )
+            );
+    }
+
+    /// <summary>
     /// Each fund series' most recent NPORT report whose portfolio is as of the floor date or
     /// later. Series identity never compares name text — the same fund's name varies across
     /// filings ("and"/"&amp;", "Inc"/"Inc.", stray spaces, legal renames), which would freeze a
-    /// stale "latest" report under every spelling. Within a stock, filings carrying the same
-    /// non-empty <see cref="NportFiling.SeriesId"/> are the same series; filings carrying
-    /// different non-empty ids are genuinely different series and never supersede each other;
-    /// and an id-less filing belongs to the registrant's single fund (listed closed-end funds
-    /// file with no series id at all), so it shares identity with every filing of its stock.
-    /// The latest report is the one with the greatest report period, breaking ties by filing
-    /// date and then accession number so amendments and re-filings of the same period win.
+    /// stale "latest" report under every spelling.
+    ///
+    /// A series is scoped to its registrant: a filing crawled through a tracked stock's feed is
+    /// scoped by <see cref="NportFiling.CommonStockId"/>; a filing discovered by the daily-index
+    /// sweep (whose registrant is a fund-family trust that is not a tracked stock) is scoped by
+    /// <see cref="NportFiling.RegistrantCik"/>. Exactly one is set per filing, so the two
+    /// populations never collide. Within a registrant, filings carrying the same non-empty
+    /// <see cref="NportFiling.SeriesId"/> are the same series; filings carrying different non-empty
+    /// ids are genuinely different series and never supersede each other; and an id-less filing
+    /// belongs to the registrant's single fund (listed closed-end funds file with no series id at
+    /// all), so it shares identity with every filing of its registrant.
+    ///
+    /// The latest report is the one with the greatest report period, breaking ties by filing date
+    /// and then accession number so amendments and re-filings of the same period win.
     /// </summary>
     public IQueryable<NportFiling> GetLatestPerSeries(DateOnly floor)
     {
         var filings = GetAll().Where(f => f.ReportPeriodDate >= floor);
         return filings.Where(f =>
             !filings.Any(f2 =>
-                f2.CommonStockId == f.CommonStockId
+                (
+                    (f.CommonStockId != null && f2.CommonStockId == f.CommonStockId)
+                    || (
+                        f.CommonStockId == null
+                        && f2.CommonStockId == null
+                        && f2.RegistrantCik == f.RegistrantCik
+                    )
+                )
                 && (
                     f2.SeriesId == f.SeriesId
                     || string.IsNullOrEmpty(f.SeriesId)

--- a/src/Equibles.Sec.Repositories/ProcessedNportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/ProcessedNportFilingRepository.cs
@@ -1,0 +1,17 @@
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Repositories;
+
+public class ProcessedNportFilingRepository : BaseRepository<ProcessedNportFiling>
+{
+    public ProcessedNportFilingRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<ProcessedNportFiling> GetByAccessionNumbers(
+        IReadOnlyCollection<string> accessionNumbers
+    )
+    {
+        return GetAll().Where(p => accessionNumbers.Contains(p.AccessionNumber));
+    }
+}

--- a/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
@@ -34,6 +34,7 @@ public class SecTestModuleConfiguration : Equibles.Data.IModuleConfiguration
         builder.Entity<NCenServiceProvider>();
         builder.Entity<NportFiling>();
         builder.Entity<NportHolding>();
+        builder.Entity<ProcessedNportFiling>();
         builder.Ignore<Chunk>();
         builder.Ignore<Embedding>();
     }

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
@@ -66,6 +66,27 @@ public class NportFilingRepositoryTests : IDisposable
         };
     }
 
+    // A sweep-discovered filing: no tracked stock, registrant identified by CIK.
+    private static NportFiling CreateTrustFiling(
+        string registrantCik,
+        string accessionNumber,
+        DateOnly? filingDate = null,
+        string seriesName = "Vanguard 500 Index Fund",
+        string seriesId = "S000002277"
+    )
+    {
+        var filing = CreateFiling(
+            commonStockId: Guid.Empty,
+            accessionNumber,
+            filingDate,
+            seriesName,
+            seriesId
+        );
+        filing.CommonStockId = null;
+        filing.RegistrantCik = registrantCik;
+        return filing;
+    }
+
     [Fact]
     public async Task GetByStock_ReturnsOnlyFilingsForThatStock()
     {
@@ -114,23 +135,6 @@ public class NportFilingRepositoryTests : IDisposable
         var any = await _repository.GetByAccessionNumber("9999999999-99-999999").AnyAsync();
 
         any.Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task GetRecent_ReturnsOnlyFilingsOnOrAfterCutoff()
-    {
-        var stock = CreateStock();
-        _dbContext.Set<CommonStock>().Add(stock);
-        await _dbContext.SaveChangesAsync();
-
-        _repository.Add(CreateFiling(stock.Id, "old", filingDate: new DateOnly(2024, 1, 1)));
-        _repository.Add(CreateFiling(stock.Id, "new", filingDate: new DateOnly(2025, 1, 15)));
-        await _repository.SaveChanges();
-
-        var result = await _repository.GetRecent(new DateOnly(2025, 1, 1)).ToListAsync();
-
-        result.Should().ContainSingle();
-        result[0].AccessionNumber.Should().Be("new");
     }
 
     [Fact]
@@ -386,5 +390,74 @@ public class NportFilingRepositoryTests : IDisposable
         var result = await _repository.GetHoldingsByCusip("037833100").ToListAsync();
 
         result.Should().ContainSingle().Which.Name.Should().Be("APPLE INC");
+    }
+
+    // Sweep-discovered filings carry no CommonStockId; their series is scoped by registrant CIK.
+    // Only the newest report of a trust series may surface, exactly as for tracked stocks.
+    [Fact]
+    public async Task GetLatestPerSeries_TrustOnlyFilings_ScopedByRegistrantCikNewestWins()
+    {
+        var older = CreateTrustFiling("36405", "0000036405-24-000001", new DateOnly(2024, 11, 20));
+        older.ReportPeriodDate = new DateOnly(2024, 10, 31);
+        var newest = CreateTrustFiling("36405", "0000036405-25-000002", new DateOnly(2025, 1, 15));
+        newest.ReportPeriodDate = new DateOnly(2024, 12, 31);
+        _repository.Add(older);
+        _repository.Add(newest);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetLatestPerSeries(DateOnly.MinValue).ToListAsync();
+
+        result.Should().ContainSingle().Which.Id.Should().Be(newest.Id);
+    }
+
+    // Two id-less trust filings from different registrants are different funds — registrant CIK,
+    // not a shared null CommonStockId, must keep them apart (otherwise every trust-only id-less
+    // filing would collapse into one).
+    [Fact]
+    public async Task GetLatestPerSeries_IdlessTrustFilingsDifferentRegistrants_BothSurvive()
+    {
+        var fundA = CreateTrustFiling(
+            "111111",
+            "0001111111-26-000001",
+            new DateOnly(2026, 1, 15),
+            "Cohen Closed-End Fund",
+            seriesId: null
+        );
+        fundA.ReportPeriodDate = new DateOnly(2025, 12, 31);
+        var fundB = CreateTrustFiling(
+            "222222",
+            "0002222222-26-000002",
+            new DateOnly(2026, 2, 15),
+            "Clough Closed-End Fund",
+            seriesId: null
+        );
+        fundB.ReportPeriodDate = new DateOnly(2026, 1, 31);
+        _repository.Add(fundA);
+        _repository.Add(fundB);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetLatestPerSeries(DateOnly.MinValue).ToListAsync();
+
+        result.Should().HaveCount(2);
+        result.Select(f => f.Id).Should().BeEquivalentTo([fundA.Id, fundB.Id]);
+    }
+
+    [Fact]
+    public async Task GetByRegistrantCikAndSeries_KnownSeries_ReturnsIt()
+    {
+        _repository.Add(CreateTrustFiling("36405", "0000036405-25-000002"));
+        await _repository.SaveChanges();
+
+        var known = await _repository.GetByRegistrantCikAndSeries("36405", "S000002277").AnyAsync();
+        var unknownSeries = await _repository
+            .GetByRegistrantCikAndSeries("36405", "S999999999")
+            .AnyAsync();
+        var unknownRegistrant = await _repository
+            .GetByRegistrantCikAndSeries("99999", "S000002277")
+            .AnyAsync();
+
+        known.Should().BeTrue();
+        unknownSeries.Should().BeFalse();
+        unknownRegistrant.Should().BeFalse();
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
@@ -122,6 +123,7 @@ public class NportFilingReprocessManagerTests
         );
 
         var repo = new NportFilingRepository(dbContext);
+        var commonStockRepo = new CommonStockRepository(dbContext);
         var secClient = Substitute.For<ISecEdgarClient>();
 
         // The error reporter is only reached when a submission fails to parse; the valid-XML paths
@@ -135,6 +137,7 @@ public class NportFilingReprocessManagerTests
 
         var manager = new NportFilingReprocessManager(
             repo,
+            commonStockRepo,
             secClient,
             dbContext,
             errorReporter,

--- a/tests/Equibles.IntegrationTests/Sec/NportRealtimeIngestionServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportRealtimeIngestionServiceTests.cs
@@ -1,0 +1,314 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// The daily-index NPORT-P sweep: it must surface fund-family trusts that are not tracked stocks
+/// (the held-by-funds coverage gap), keep only their positions in stocks we track, leave tracked-
+/// stock registrants to the issuer-feed crawler, and never re-download a filing it has already
+/// handled.
+/// </summary>
+public class NportRealtimeIngestionServiceTests
+{
+    private const string AppleCusip = "037833100";
+    private const string BondCusip = "912828YK0";
+
+    [Fact]
+    public async Task IngestRecentFilings_TrustHoldingTrackedStock_StoresFilteredToTrackedHoldings()
+    {
+        var (service, dbContext, secClient) = CreateServiceWithDeps();
+        SeedStock(dbContext, "AAPL", cik: "0000320193", cusip: AppleCusip);
+
+        var entry = Entry("0000036405-26-000001", cik: "36405");
+        StubDailyIndex(secClient, entry);
+        StubContent(
+            secClient,
+            entry,
+            NportXml(
+                "VANGUARD INDEX FUNDS",
+                "S000002277",
+                (AppleCusip, "APPLE INC", 170_000_000m),
+                (BondCusip, "US TREASURY NOTE", 5_000_000m)
+            )
+        );
+
+        var result = await service.IngestRecentFilings(
+            new DateOnly(2026, 3, 1),
+            lookbackDays: 1,
+            maxFetchesPerCycle: 100,
+            CancellationToken.None
+        );
+
+        result.Stored.Should().Be(1);
+
+        var stored = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        stored.CommonStockId.Should().BeNull();
+        stored.RegistrantCik.Should().Be("36405");
+        stored.RegistrantName.Should().Be("VANGUARD INDEX FUNDS");
+        // The bond is dropped; only the tracked-stock position is kept.
+        stored.Holdings.Should().ContainSingle().Which.Cusip.Should().Be(AppleCusip);
+    }
+
+    [Fact]
+    public async Task IngestRecentFilings_RegistrantIsTrackedStock_SkipsWithoutDownloading()
+    {
+        var (service, dbContext, secClient) = CreateServiceWithDeps();
+        SeedStock(dbContext, "AAPL", cik: "0000320193", cusip: AppleCusip);
+        // A standalone ETF trust we track — its CIK appears padded in CommonStock, unpadded in the
+        // daily index; normalisation must still match so the issuer feed keeps ownership.
+        SeedStock(dbContext, "SPY", cik: "0000884394", cusip: "78462F103");
+
+        var entry = Entry("0000884394-26-000005", cik: "884394");
+        StubDailyIndex(secClient, entry);
+
+        var result = await service.IngestRecentFilings(
+            new DateOnly(2026, 3, 1),
+            lookbackDays: 1,
+            maxFetchesPerCycle: 100,
+            CancellationToken.None
+        );
+
+        result.Stored.Should().Be(0);
+        (await dbContext.Set<NportFiling>().AnyAsync()).Should().BeFalse();
+        // The submission is never downloaded — the registrant is recognised as a tracked stock first.
+        await secClient
+            .DidNotReceive()
+            .GetDocumentContent(entry.AccessionNumber, Arg.Any<string>());
+        (
+            await dbContext
+                .Set<ProcessedNportFiling>()
+                .AnyAsync(p => p.AccessionNumber == entry.AccessionNumber)
+        )
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public async Task IngestRecentFilings_TrustHoldingNothingTracked_RecordsSkipDoesNotStore()
+    {
+        var (service, dbContext, secClient) = CreateServiceWithDeps();
+        SeedStock(dbContext, "AAPL", cik: "0000320193", cusip: AppleCusip);
+
+        var entry = Entry("0000999999-26-000007", cik: "999999");
+        StubDailyIndex(secClient, entry);
+        StubContent(
+            secClient,
+            entry,
+            NportXml("SOME BOND TRUST", "S000099999", (BondCusip, "US TREASURY NOTE", 9_000_000m))
+        );
+
+        var result = await service.IngestRecentFilings(
+            new DateOnly(2026, 3, 1),
+            lookbackDays: 1,
+            maxFetchesPerCycle: 100,
+            CancellationToken.None
+        );
+
+        result.Stored.Should().Be(0);
+        (await dbContext.Set<NportFiling>().AnyAsync()).Should().BeFalse();
+        (
+            await dbContext
+                .Set<ProcessedNportFiling>()
+                .AnyAsync(p => p.AccessionNumber == entry.AccessionNumber)
+        )
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public async Task IngestRecentFilings_AlreadyHandled_NotReDownloadedOnNextCycle()
+    {
+        var (service, dbContext, secClient) = CreateServiceWithDeps();
+        SeedStock(dbContext, "AAPL", cik: "0000320193", cusip: AppleCusip);
+
+        var stored = Entry("0000036405-26-000001", cik: "36405");
+        var skipped = Entry("0000999999-26-000007", cik: "999999");
+        StubDailyIndex(secClient, stored, skipped);
+        StubContent(
+            secClient,
+            stored,
+            NportXml("VANGUARD INDEX FUNDS", "S000002277", (AppleCusip, "APPLE INC", 1m))
+        );
+        StubContent(
+            secClient,
+            skipped,
+            NportXml("SOME BOND TRUST", "S000099999", (BondCusip, "US TREASURY NOTE", 1m))
+        );
+
+        await service.IngestRecentFilings(new DateOnly(2026, 3, 1), 1, 100, CancellationToken.None);
+        dbContext.ChangeTracker.Clear();
+        var second = await service.IngestRecentFilings(
+            new DateOnly(2026, 3, 1),
+            1,
+            100,
+            CancellationToken.None
+        );
+
+        second.Stored.Should().Be(0);
+        // Each submission was fetched exactly once across both cycles — the dedup ledger holds.
+        await secClient.Received(1).GetDocumentContent(stored.AccessionNumber, Arg.Any<string>());
+        await secClient.Received(1).GetDocumentContent(skipped.AccessionNumber, Arg.Any<string>());
+    }
+
+    // ── Helpers ──
+
+    private static (
+        NportRealtimeIngestionService service,
+        Equibles.Data.EquiblesFinancialDbContext dbContext,
+        ISecEdgarClient secClient
+    ) CreateServiceWithDeps()
+    {
+        var dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new ErrorsModuleConfiguration()
+        );
+
+        var secClient = Substitute.For<ISecEdgarClient>();
+        var errorManager = new ErrorManager(new ErrorRepository(dbContext));
+        var scopeFactory = ServiceScopeSubstitute.Create((typeof(ErrorManager), errorManager));
+        var errorReporter = new ErrorReporter(
+            scopeFactory,
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+
+        var service = new NportRealtimeIngestionService(
+            secClient,
+            new CommonStockRepository(dbContext),
+            new NportFilingRepository(dbContext),
+            new ProcessedNportFilingRepository(dbContext),
+            dbContext,
+            errorReporter,
+            Substitute.For<ILogger<NportRealtimeIngestionService>>()
+        );
+
+        return (service, dbContext, secClient);
+    }
+
+    private static void SeedStock(
+        Equibles.Data.EquiblesFinancialDbContext dbContext,
+        string ticker,
+        string cik,
+        string cusip
+    )
+    {
+        dbContext.Add(
+            new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = ticker,
+                Name = ticker,
+                Cik = cik,
+                Cusip = cusip,
+            }
+        );
+        dbContext.SaveChanges();
+        dbContext.ChangeTracker.Clear();
+    }
+
+    private static EdgarDailyIndexEntry Entry(string accession, string cik) =>
+        new()
+        {
+            FormType = "NPORT-P",
+            CompanyName = "FUND",
+            Cik = cik,
+            DateFiled = new DateOnly(2026, 3, 1),
+            AccessionNumber = accession,
+        };
+
+    private static void StubDailyIndex(
+        ISecEdgarClient secClient,
+        params EdgarDailyIndexEntry[] entries
+    ) =>
+        secClient
+            .GetDailyIndexForForms(
+                Arg.Any<DateOnly>(),
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(entries.ToList());
+
+    private static void StubContent(
+        ISecEdgarClient secClient,
+        EdgarDailyIndexEntry entry,
+        string content
+    ) => secClient.GetDocumentContent(entry.AccessionNumber, entry.Cik).Returns(content);
+
+    private static string NportXml(
+        string regName,
+        string seriesId,
+        params (string cusip, string name, decimal valueUsd)[] holdings
+    )
+    {
+        var rows = string.Join(
+            "\n",
+            holdings.Select(h =>
+                $"""
+                  <invstOrSec>
+                    <name>{h.name}</name>
+                    <cusip>{h.cusip}</cusip>
+                    <balance>1.00</balance>
+                    <units>NS</units>
+                    <curCd>USD</curCd>
+                    <valUSD>{h.valueUsd}</valUSD>
+                    <pctVal>1.00</pctVal>
+                    <payoffProfile>Long</payoffProfile>
+                    <assetCat>EC</assetCat>
+                    <issuerCat>CORP</issuerCat>
+                    <invCountry>US</invCountry>
+                  </invstOrSec>
+                """
+            )
+        );
+
+        return $"""
+            <SEC-DOCUMENT>
+            <DOCUMENT>
+            <TYPE>NPORT-P
+            <TEXT>
+            <XML>
+            <?xml version="1.0" encoding="UTF-8"?>
+            <edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
+              <headerData>
+                <submissionType>NPORT-P</submissionType>
+              </headerData>
+              <formData>
+                <genInfo>
+                  <regName>{regName}</regName>
+                  <seriesName>{regName} Fund</seriesName>
+                  <seriesId>{seriesId}</seriesId>
+                  <repPdEnd>2026-08-31</repPdEnd>
+                  <repPdDate>2026-02-28</repPdDate>
+                  <isFinalFiling>N</isFinalFiling>
+                </genInfo>
+                <fundInfo>
+                  <totAssets>1000</totAssets>
+                  <totLiabs>0</totLiabs>
+                  <netAssets>1000</netAssets>
+                </fundInfo>
+                <invstOrSecs>
+            {rows}
+                </invstOrSecs>
+              </formData>
+            </edgarSubmission>
+            </XML>
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+    }
+}


### PR DESCRIPTION
## Summary

The "held by funds" reverse lookup (and the `GetFundsHoldingStock` MCP tool) only surfaced funds whose own registrant is a tracked stock — listed closed-end funds and standalone ETF trusts. NPORT-P was ingested solely through tracked issuers' EDGAR submission feeds, so the giant multi-series fund-family trusts ("Vanguard Index Funds", Fidelity's trusts, "iShares Trust"), which are not tracked stocks, were never discovered. As a result the largest holders of the most widely held stocks (VOO, FXAIX, IVV) never appeared, while small slivers from tracked closed-end funds did.

This adds a daily-index NPORT-P sweep — mirroring the existing 13F real-time sweep — that finds reports from **all** filers, not just tracked issuers.

## Code changes

- **`NportFiling`** — `CommonStockId` is now optional; new `RegistrantCik` identifies the registrant for sweep-discovered filings. Exactly one of the two is set per filing, so the two populations never collide. (No longer implements `IStockFiling`.)
- **`NportFilingRepository`** — `GetLatestPerSeries` scopes a series by `CommonStockId` when set, else by `RegistrantCik`; new `GetByAccessionNumbers` / `GetByRegistrantCikAndSeries` helpers.
- **`NportRealtimeIngestionService` + `NportRealtimeWorker`** — sweep the trailing window of EDGAR's daily index for NPORT-P. A registrant that is itself a tracked stock is left to the issuer feed; every other filing is stored against its registrant CIK with holdings filtered to tracked-stock CUSIPs (authoritative match, never name text). A series header is kept even when it holds nothing tracked but has been seen before, so an exited position stops reading as current. On by default; configurable via `NportSweep:Enabled` / `LookbackDays` / `MaxFetchesPerCycle`.
- **`ProcessedNportFiling`** — dedup ledger so skipped submissions are not re-downloaded each cycle.
- **`NportFilingReprocessManager`** — re-fetches sweep filings via `RegistrantCik` and re-applies the tracked-CUSIP filter.
- **Migration** `AddNportTrustSweepCoverage` — additive: nullable `CommonStockId`, new `RegistrantCik` column + index, `ProcessedNportFiling` table.

## Tests

- New `NportRealtimeIngestionServiceTests` (store-filtered-to-tracked, skip tracked registrant without download, record-skip when nothing tracked, no re-download across cycles).
- New `GetLatestPerSeries` registrant-CIK scoping tests + `GetByRegistrantCikAndSeries`.
- Full integration suite green (1967 passed / 1 skipped); Sec unit tests green (1013).

Closes the held-by-funds coverage gap reported in EquiblesCommercial#3899.