### PR TITLE
fix(holdings): resolve market-wide activity window off 13F-only report dates

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -559,7 +559,10 @@ public class InstitutionalHoldingsTools
         string Error
     )> ResolveMarketActivityDates(string reportDate)
     {
-        var reportDates = await _holdingRepository.GetAvailableReportDates().ToListAsync();
+        // 13F-only: the prior entry must be the prior QUARTER. The all-filings list now
+        // carries daily 13D/G event dates, which would make "previous" the prior day and
+        // compare a quarter-end portfolio against a single-day stake.
+        var reportDates = await _holdingRepository.Get13FAvailableReportDates().ToListAsync();
         if (reportDates.Count == 0)
             return (default, default, "No 13F holdings data available.");
 

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -89,6 +89,14 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     public IQueryable<DateOnly> GetAvailableReportDates() =>
         GetAll().DistinctReportDatesDescending();
 
+    // Market-wide 13F-only report dates, newest first. Schedule 13D/G rows carry a daily
+    // event date, not a quarter end (see Get13FHistoryByHolder); including them makes the
+    // "prior" entry the prior day, so a quarter-over-quarter comparison silently degrades
+    // into quarter-vs-single-day. Market-wide activity pages resolve their comparison
+    // window off this list, so it must stay 13F-only.
+    public IQueryable<DateOnly> Get13FAvailableReportDates() =>
+        GetAll().Where(h => h.FilingType == FilingType.Form13F).DistinctReportDatesDescending();
+
     // Latest dates first — see GetAvailableReportDates for the ordering contract.
     public IQueryable<DateOnly> GetReportDatesByStock(CommonStock stock) =>
         GetHistoryByStock(stock).DistinctReportDatesDescending();

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
@@ -1,0 +1,98 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly InstitutionalHoldingRepository _repository;
+
+    public InstitutionalHoldingRepository13FAvailableReportDatesTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new HoldingsModuleConfiguration()
+        );
+        _repository = new InstitutionalHoldingRepository(_dbContext);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // Contract: the market-wide report-date list must be 13F-only and newest-first.
+    // Schedule 13D/G rows carry a daily event date, not a quarter end; if a later 13D/G
+    // date leaked in, callers that treat index 0 as "latest" and index 1 as "prior
+    // quarter" would compare a quarter-end portfolio against the prior DAY — the regression
+    // behind the market-wide activity boards (double-down) showing zero positions.
+    [Fact]
+    public async Task Get13FAvailableReportDates_ExcludesLater13DGEventDates_NewestFirst()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Cik = "0000000001",
+            Name = "Holder A",
+        };
+
+        var q1 = new DateOnly(2024, 3, 31);
+        var q2 = new DateOnly(2024, 6, 30);
+        var q3 = new DateOnly(2024, 9, 30);
+        // A 13D/G stake filed AFTER the latest 13F quarter — exactly the row that
+        // pollutes the all-filings list and makes "prior" the prior day.
+        var event13G = new DateOnly(2024, 11, 14);
+
+        _dbContext.Set<CommonStock>().Add(stock);
+        _dbContext.Set<InstitutionalHolder>().Add(holder);
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .AddRange(
+                Holding(stock.Id, holder.Id, q2, FilingType.Form13F, "13F-Q2"),
+                Holding(stock.Id, holder.Id, q1, FilingType.Form13F, "13F-Q1"),
+                Holding(stock.Id, holder.Id, q3, FilingType.Form13F, "13F-Q3"),
+                Holding(stock.Id, holder.Id, event13G, FilingType.Schedule13G, "13G-EVENT"),
+                Holding(stock.Id, holder.Id, event13G, FilingType.Schedule13D, "13D-EVENT")
+            );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository
+            .Get13FAvailableReportDates()
+            .ToListAsync(CancellationToken.None);
+
+        // Only the 13F quarter ends, newest-first; the 2024-11-14 event date is gone, so
+        // index 0 is the latest quarter and index 1 is the genuine prior quarter.
+        dates.Should().Equal(q3, q2, q1);
+    }
+
+    private static InstitutionalHolding Holding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        FilingType filingType,
+        string accession
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate,
+            FilingType = filingType,
+            Shares = 100,
+            Value = 1000,
+            AccessionNumber = accession,
+        };
+}


### PR DESCRIPTION
## Summary

- The market-wide report-date list came from `GetAvailableReportDates()`, which is `GetAll().DistinctReportDatesDescending()` over every filing type. Since the holdings table began carrying daily Schedule 13D/13G event-date rows alongside quarterly 13F rows, that list turned daily — so the "prior" entry the quarter-over-quarter pages resolve became the prior **day**, collapsing every comparison (double-down, AUM movers, last-quarter movers, most-held) to a quarter-vs-single-day match that returns nothing.
- Adds `Get13FAvailableReportDates()` (mirrors the per-holder `Get13FReportDatesByHolder`) and switches the MCP market-activity resolver to it, so the comparison window is the prior quarter again.

This is the open-source half of the fix for the commercial Double-Down report bug (Refs daniel3303/EquiblesCommercial#3910); the commercial market-wide pages consume the same new method.

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — add `Get13FAvailableReportDates()`, a 13F-only, newest-first market-wide report-date list.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — `ResolveMarketActivityDates` reads the 13F-only list so `GetMarketWide13FActivity` / `GetMostHeldStocks` / `GetTopBuyersSellers` compare quarter-over-quarter.
- `tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs` — seeds 13F quarter ends plus a later 13D/G event date and asserts the new method excludes the event date.