### PR TITLE
fix(sec): guard null SecondaryCiks in NPORT-P sweep LoadTrackedCiks

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/NportRealtimeIngestionService.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportRealtimeIngestionService.cs
@@ -377,7 +377,9 @@ public class NportRealtimeIngestionService
             if (!string.IsNullOrEmpty(row.Cik))
                 ciks.Add(NormalizeCik(row.Cik));
 
-            foreach (var secondary in row.SecondaryCiks)
+            // The projection reads the SecondaryCiks column directly, bypassing the entity getter
+            // that coalesces null to []; almost every stored row has a NULL column, so guard it.
+            foreach (var secondary in row.SecondaryCiks ?? [])
             {
                 if (!string.IsNullOrEmpty(secondary))
                     ciks.Add(NormalizeCik(secondary));

--- a/tests/Equibles.IntegrationTests/Sec/NportRealtimeIngestionServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportRealtimeIngestionServiceTests.cs
@@ -164,6 +164,50 @@ public class NportRealtimeIngestionServiceTests
         await secClient.Received(1).GetDocumentContent(skipped.AccessionNumber, Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task IngestRecentFilings_TrackedStockWithNullSecondaryCiks_StillIngests()
+    {
+        var (service, dbContext, secClient) = CreateServiceWithDeps();
+        // Almost every production CommonStock row has a NULL SecondaryCiks column (it predates the
+        // column), and the LoadTrackedCiks projection reads the column directly, bypassing the
+        // entity getter that coalesces null to []. Iterating it without a null guard threw and
+        // aborted the entire sweep cycle, so a tracked stock with no secondary CIKs must not stop
+        // ingestion. The other seeds in this file default SecondaryCiks to [], which is why this
+        // case slipped through.
+        dbContext.Add(
+            new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = "AAPL",
+                Name = "AAPL",
+                Cik = "0000320193",
+                Cusip = AppleCusip,
+                SecondaryCiks = null,
+            }
+        );
+        dbContext.SaveChanges();
+        dbContext.ChangeTracker.Clear();
+
+        var entry = Entry("0000036405-26-000001", cik: "36405");
+        StubDailyIndex(secClient, entry);
+        StubContent(
+            secClient,
+            entry,
+            NportXml("VANGUARD INDEX FUNDS", "S000002277", (AppleCusip, "APPLE INC", 170_000_000m))
+        );
+
+        var result = await service.IngestRecentFilings(
+            new DateOnly(2026, 3, 1),
+            lookbackDays: 1,
+            maxFetchesPerCycle: 100,
+            CancellationToken.None
+        );
+
+        result.Stored.Should().Be(1);
+        var stored = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        stored.Holdings.Should().ContainSingle().Which.Cusip.Should().Be(AppleCusip);
+    }
+
     // ── Helpers ──
 
     private static (


### PR DESCRIPTION
## Summary

The daily-index NPORT-P sweep (`NportRealtimeIngestionService.LoadTrackedCiks`) crashes its work cycle with a `NullReferenceException`, so the worker ingests nothing in production.

`LoadTrackedCiks` builds the tracked-CIK set from a projection:

```csharp
.Select(c => new { c.Cik, c.SecondaryCiks })
```

The projection reads the `SecondaryCiks` column directly, bypassing the `CommonStock.SecondaryCiks` entity getter that coalesces null to `[]`. Almost every stored row has a NULL `SecondaryCiks` column (it predates the column), so `foreach (var secondary in row.SecondaryCiks)` throws on the first such row and aborts the whole cycle.

## Code changes

- `NportRealtimeIngestionService.LoadTrackedCiks` — guard the iterated collection with `?? []`.
- `NportRealtimeIngestionServiceTests` — regression test seeding a tracked stock with a null `SecondaryCiks` column; fails (NRE) before the fix, passes after. The existing tests seed `SecondaryCiks` as `[]`, which is why the case slipped through.

Fixes the production NPORT-P real-time worker crash.