### PR TITLE
fix(cboe): exclude corrupt historical put/call ratios from served series

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
+using Equibles.Cboe.Repositories.Extensions;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
@@ -63,6 +64,7 @@ public class CboeTools
 
                 var records = await _putCallRepository
                     .GetByType(ratioType, start, end)
+                    .OnlyReconcilable()
                     .OrderByDescending(r => r.Date)
                     .Take(maxResults)
                     .ToListAsync();

--- a/src/Equibles.Cboe.Repositories/Extensions/CboePutCallRatioQueryableExtensions.cs
+++ b/src/Equibles.Cboe.Repositories/Extensions/CboePutCallRatioQueryableExtensions.cs
@@ -1,0 +1,28 @@
+using Equibles.Cboe.Data.Models;
+
+namespace Equibles.Cboe.Repositories.Extensions;
+
+public static class CboePutCallRatioQueryableExtensions
+{
+    /// <summary>
+    /// Keeps only rows whose put/call ratio reconciles with its own volumes.
+    /// A put/call ratio is puts ÷ calls, so a genuine row needs a positive call
+    /// denominator and can never reach total volume (puts/calls ≤ puts &lt; total).
+    /// A batch of historical VIX rows (all on or before 2019-10-04) was loaded
+    /// with the ratio set to puts + total and the call volume either missing or a
+    /// 1 sentinel; those values run into the millions and are not real ratios, so
+    /// they must never be served on the historical series.
+    /// </summary>
+    public static IQueryable<CboePutCallRatio> OnlyReconcilable(
+        this IQueryable<CboePutCallRatio> source
+    )
+    {
+        return source.Where(r =>
+            r.CallVolume != null
+            && r.CallVolume > 0
+            && r.PutCallRatio != null
+            && r.TotalVolume != null
+            && r.PutCallRatio < r.TotalVolume
+        );
+    }
+}

--- a/src/Equibles.Web/Controllers/MarketController.cs
+++ b/src/Equibles.Web/Controllers/MarketController.cs
@@ -1,5 +1,6 @@
 using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
+using Equibles.Cboe.Repositories.Extensions;
 using Equibles.Core.Extensions;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.Extensions;
@@ -87,6 +88,7 @@ public class MarketController : BaseController
 
         var records = await _putCallRepository
             .GetByType(ratioType)
+            .OnlyReconcilable()
             .OrderByDescending(r => r.Date)
             .Select(r => new PutCallRatioItem
             {

--- a/tests/Equibles.UnitTests/Cboe/CboePutCallRatioReconciliationTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboePutCallRatioReconciliationTests.cs
@@ -1,0 +1,91 @@
+using Equibles.Cboe.Data.Models;
+using Equibles.Cboe.Repositories.Extensions;
+
+namespace Equibles.UnitTests.Cboe;
+
+// A put/call ratio is puts ÷ calls: a genuine row needs a positive call
+// denominator and its ratio can never reach total volume (puts/calls ≤ puts <
+// total). A historical VIX backfill (all dates on or before 2019-10-04) stored
+// the ratio as puts + total — values into the millions — with the call volume
+// either missing or set to a 1 sentinel. OnlyReconcilable must drop exactly
+// those rows from a served series and keep every genuine row. Issue #3391.
+public class CboePutCallRatioReconciliationTests
+{
+    private static CboePutCallRatio Row(
+        CboePutCallRatioType type,
+        DateOnly date,
+        long? callVolume,
+        long? putVolume,
+        long? totalVolume,
+        decimal? putCallRatio
+    ) =>
+        new()
+        {
+            RatioType = type,
+            Date = date,
+            CallVolume = callVolume,
+            PutVolume = putVolume,
+            TotalVolume = totalVolume,
+            PutCallRatio = putCallRatio,
+        };
+
+    [Fact]
+    public void OnlyReconcilable_DropsCorruptVixRows_KeepsGenuineRows()
+    {
+        var rows = new[]
+        {
+            // Corrupt: call volume missing, ratio stored as puts + total.
+            Row(
+                CboePutCallRatioType.Vix,
+                new DateOnly(2018, 5, 1),
+                null,
+                200_000,
+                300_000,
+                500_000m
+            ),
+            // Corrupt: call volume is a 1 sentinel, ratio = puts + total (117973).
+            Row(CboePutCallRatioType.Vix, new DateOnly(2011, 11, 25), 1, 59_059, 58_914, 117_973m),
+            // Genuine VIX row (0.67 ≈ 350284 / 523819).
+            Row(
+                CboePutCallRatioType.Vix,
+                new DateOnly(2025, 6, 12),
+                523_819,
+                350_284,
+                874_103,
+                0.67m
+            ),
+            // Genuine Total row, unaffected by the VIX corruption.
+            Row(
+                CboePutCallRatioType.Total,
+                new DateOnly(2025, 6, 12),
+                2_000_000,
+                1_500_000,
+                3_500_000,
+                0.75m
+            ),
+        };
+
+        var kept = rows.AsQueryable().OnlyReconcilable().ToList();
+
+        kept.Should().HaveCount(2);
+        kept.Should().NotContain(r => r.CallVolume == null);
+        kept.Should().NotContain(r => r.PutCallRatio >= r.TotalVolume);
+        kept.Select(r => r.RatioType)
+            .Should()
+            .BeEquivalentTo(new[] { CboePutCallRatioType.Vix, CboePutCallRatioType.Total });
+    }
+
+    [Fact]
+    public void OnlyReconcilable_KeepsZeroRatioRow_WhenCallVolumePresent()
+    {
+        // A quiet day with no put volume is a genuine 0.0 ratio, not corruption.
+        var rows = new[]
+        {
+            Row(CboePutCallRatioType.Vix, new DateOnly(2025, 6, 12), 100_000, 0, 100_000, 0m),
+        };
+
+        var kept = rows.AsQueryable().OnlyReconcilable().ToList();
+
+        kept.Should().ContainSingle();
+    }
+}


### PR DESCRIPTION
## Summary

A batch of historical VIX put/call ratio rows (all dated on or before 2019-10-04) was loaded with the ratio set to **puts + total volume** — values running into the millions (max 4,336,057) — and the call volume either missing or set to a `1` sentinel. These rows carry no valid put/call ratio and rendered as garbage on the market put/call history page and through the put/call ratios data tool. Post-2019 rows ingested by the current importer are correct.

A put/call ratio is puts ÷ calls, so a genuine row needs a positive call denominator and can never reach total volume (puts/calls ≤ puts < total). This adds an authoritative reconciliation filter and applies it to the two surfaces that serve the historical series. Verified against production: the filter drops exactly the 2,081 corrupt rows (2,079 null-call + 2 sentinel-call) with zero false positives across 16,776 genuine rows.

## Code changes

- **`Equibles.Cboe.Repositories/Extensions/CboePutCallRatioQueryableExtensions.cs`** (new) — `OnlyReconcilable()` keeps only rows with a positive call volume and a ratio below total volume. Single source of the invariant.
- **`Equibles.Cboe.Mcp/Tools/CboeTools.cs`** — `GetPutCallRatios` applies `OnlyReconcilable()` to the historical query.
- **`Equibles.Web/Controllers/MarketController.cs`** — the put/call history action applies `OnlyReconcilable()`. The latest-per-type tile and row counts are unchanged (always-valid recent rows).
- **`Equibles.UnitTests/Cboe/CboePutCallRatioReconciliationTests.cs`** (new) — pins that both corruption signatures (missing call volume, ratio ≥ total) are dropped while genuine rows, including a legitimate zero-put-volume day, are kept.