### PR TITLE
fix(holdings): dedup 13F submissions by parsed filing date, not ordinal string

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -216,14 +216,21 @@ public class HoldingsImportService
 
         foreach (var group in byCikAndPeriod)
         {
-            // FilingDate is day-granular (and, on the real-time path, derived
-            // from the daily-index date), so an original and its same-day
-            // amendment can tie. Break ties by accession number — SEC assigns
-            // these monotonically per filer agent, so the lexicographically
-            // greatest accession is the later submission. Without this the
-            // winner is nondeterministic and an amendment can be dropped.
+            // FilingDate must be compared as a parsed date, not as a string: the
+            // bulk datasets carry SEC `dd-MMM-yyyy` values ("14-FEB-2025"), so an
+            // ordinal string sort compares the day-of-month first and orders
+            // "29-JAN-2025" after "14-FEB-2025", dropping the genuinely later
+            // amendment in favour of its original whenever the pair spans a month.
+            // FilingDate is day-granular, so an original and its same-day amendment
+            // can still tie on the parsed date; break those ties by accession
+            // number — SEC assigns these monotonically per filer agent, so the
+            // lexicographically greatest accession is the later submission.
             var latest = group
-                .OrderByDescending(s => s.FilingDate, StringComparer.Ordinal)
+                .OrderByDescending(s =>
+                    TryParseDateOnly(s.FilingDate, out var filingDate)
+                        ? filingDate
+                        : DateOnly.MinValue
+                )
                 .ThenByDescending(s => s.AccessionNumber, StringComparer.Ordinal)
                 .First();
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateSubmissionsSecDateMonthBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateSubmissionsSecDateMonthBoundaryTests.cs
@@ -1,0 +1,55 @@
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceDeduplicateSubmissionsSecDateMonthBoundaryTests
+{
+    // Contract: DeduplicateSubmissions orders survivors by FilingDate chronologically,
+    // so the genuinely later filing wins regardless of the calendar-string layout.
+    //
+    // The bulk SEC datasets carry FilingDate as `dd-MMM-yyyy` ("29-JAN-2025"). An
+    // ordinal string sort compares the day-of-month first, so "29-JAN-2025" sorts
+    // AFTER "14-FEB-2025" even though it is chronologically EARLIER. When an original
+    // (29-JAN) and its later amendment (14-FEB) share (Cik, PeriodOfReport) and span a
+    // month boundary, an ordinal sort keeps the original and silently drops the
+    // amendment — reverting amended holdings to their pre-correction values.
+    //
+    // This pins the chronological comparison: the FEB amendment must win over the JAN
+    // original. Sibling to the ISO-date FilingDatePrimary test (where ordinal happens
+    // to coincide with chronological order) and the same-day accession-tiebreaker test.
+    [Fact]
+    public void DeduplicateSubmissions_SecDatesSpanningMonthBoundary_LaterFilingWins()
+    {
+        var context = new ImportContext
+        {
+            Submissions = new Dictionary<string, SubmissionRow>(StringComparer.OrdinalIgnoreCase)
+            {
+                // Original — filed earlier (29 Jan) but ordinally GREATER than 14 Feb.
+                ["0001234567-25-000100"] = new()
+                {
+                    AccessionNumber = "0001234567-25-000100",
+                    Cik = "1234567",
+                    PeriodOfReport = "2024-12-31",
+                    FilingDate = "29-JAN-2025",
+                    FormType = "13F-HR",
+                },
+                // Amendment — filed later (14 Feb), the genuine correction that must win.
+                ["0001234567-25-000200"] = new()
+                {
+                    AccessionNumber = "0001234567-25-000200",
+                    Cik = "1234567",
+                    PeriodOfReport = "2024-12-31",
+                    FilingDate = "14-FEB-2025",
+                    FormType = "13F-HR/A",
+                },
+            },
+        };
+
+        HoldingsImportService.DeduplicateSubmissions(context);
+
+        context.Submissions.Should().HaveCount(1);
+        context.Submissions.Should().ContainKey("0001234567-25-000200");
+        context.Submissions.Should().NotContainKey("0001234567-25-000100");
+    }
+}


### PR DESCRIPTION
## Summary

`DeduplicateSubmissions` picks the surviving filing per `(Cik, PeriodOfReport)` group by ordering on `FilingDate` descending. It compared `FilingDate` as an **ordinal string**, but the bulk SEC datasets carry it as `dd-MMM-yyyy` ("29-JAN-2025"). Ordinal comparison sorts the day-of-month first, so "29-JAN-2025" orders *after* "14-FEB-2025". When an original and its later amendment share a group and span a month boundary, the **original wrongly wins and the amendment is discarded**, reverting amended holdings to pre-correction values for that quarter.

## Code changes

- `HoldingsImportService.DeduplicateSubmissions` — order survivors by the **parsed** `DateOnly` (`TryParseDateOnly` already handles both ISO and SEC formats) instead of an ordinal string sort. The accession-number tiebreaker is unchanged and still decides genuine same-day ties.
- Added `HoldingsImportServiceDeduplicateSubmissionsSecDateMonthBoundaryTests` — pins the chronological comparison with SEC-format dates spanning a month boundary (fails on the old ordinal sort, passes now). Sibling to the existing ISO-date FilingDatePrimary test and the same-day accession-tiebreaker test, which both still pass.

Surfaced while investigating the commercial Q4-2024 13F coverage hole; this is the confirmed dedup sub-defect from that report.