### PR TITLE
fix(holdings): serve latest-13f-filings feed from a composite index

### DIFF
--- a/src/Equibles.Holdings.Data/Models/InstitutionalFiling.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalFiling.cs
@@ -27,7 +27,13 @@ namespace Equibles.Holdings.Data.Models;
 /// </para>
 /// </summary>
 [Index(nameof(AccessionNumber), IsUnique = true)]
-[Index(nameof(FilingDate))]
+// Composite over (FilingDate, AccessionNumber) so the "latest filings" feed's
+// ORDER BY FilingDate DESC, AccessionNumber DESC + page is served by a backward
+// index scan instead of a full sort of the whole rollup, which exceeded the 30s
+// command timeout and 500'd the page on every load (#3565). FilingDate is the
+// leading column, so this also serves the FilingDate-only lookups the old
+// single-column index covered.
+[Index(nameof(FilingDate), nameof(AccessionNumber))]
 public class InstitutionalFiling
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]

--- a/src/Equibles.Migrations/Migrations/20260616183857_AddInstitutionalFilingSortIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260616183857_AddInstitutionalFilingSortIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616183857_AddInstitutionalFilingSortIndex")]
+    partial class AddInstitutionalFilingSortIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260616183857_AddInstitutionalFilingSortIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260616183857_AddInstitutionalFilingSortIndex.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstitutionalFilingSortIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalFiling_FilingDate",
+                table: "InstitutionalFiling");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalFiling_FilingDate_AccessionNumber",
+                table: "InstitutionalFiling",
+                columns: new[] { "FilingDate", "AccessionNumber" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalFiling_FilingDate_AccessionNumber",
+                table: "InstitutionalFiling");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalFiling_FilingDate",
+                table: "InstitutionalFiling",
+                column: "FilingDate");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalFilingSortIndexTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalFilingSortIndexTests.cs
@@ -1,0 +1,64 @@
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins the composite index that makes the "latest 13F filings" feed an
+/// index-served scan. <c>GetRecentFilings</c> orders by
+/// <c>FilingDate DESC, AccessionNumber DESC</c> and pages the
+/// <see cref="Equibles.Holdings.Data.Models.InstitutionalFiling"/> rollup; with no
+/// covering index Postgres full-sorts the whole rollup on every request, which
+/// exceeded the 30s command timeout and 500'd the page on every load (#3565). A
+/// composite over <c>(FilingDate, AccessionNumber)</c> turns that sort into a
+/// backward index scan over just the page's rows.
+///
+/// <para>
+/// The fix is pure timing, so it has no result-level contract — this instead pins
+/// the fix's mechanism: the migration must physically create the
+/// <c>(FilingDate, AccessionNumber)</c> index on the production schema. The fixture
+/// applies the real migrations, so the assertion fails on the pre-fix schema (only a
+/// single-column <c>FilingDate</c> index existed) and passes once the migration runs.
+/// </para>
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalFilingSortIndexTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+
+    public InstitutionalFilingSortIndexTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Schema_HasCompositeFilingDateThenAccessionNumberIndex()
+    {
+        await using var ctx = _fixture.CreateDbContext();
+
+        // pg_indexes.indexdef spells the index out, e.g.
+        //   CREATE INDEX "..." ON public."InstitutionalFiling"
+        //   USING btree ("FilingDate", "AccessionNumber")
+        // Scalar SqlQueryRaw requires the column to be named "Value".
+        var indexDefs = await ctx
+            .Database.SqlQueryRaw<string>(
+                """
+                SELECT indexdef AS "Value"
+                FROM pg_indexes
+                WHERE tablename = 'InstitutionalFiling'
+                """
+            )
+            .ToListAsync();
+
+        // FilingDate must be the leading column (so the backward scan satisfies the
+        // ORDER BY) with AccessionNumber as the tie-breaker; the single-column
+        // AccessionNumber unique index does not match this pair.
+        indexDefs
+            .Should()
+            .ContainSingle(def => def.Contains("\"FilingDate\", \"AccessionNumber\""));
+    }
+}


### PR DESCRIPTION
## Summary

The latest 13F filings feed (`GetRecentFilings` → `HoldingsActivityController.LatestFilings`) orders the `InstitutionalFiling` rollup by `FilingDate DESC, AccessionNumber DESC` and pages it. Only a single-column `FilingDate` index and the unique `AccessionNumber` index existed, so neither covered the two-column sort — Postgres full-sorted the entire rollup on every request, exceeding the 30s command timeout and returning a 500 on every load.

`COUNT(*)` is not the bottleneck: `InstitutionalHolderId` is a NOT-NULL FK, so the planner eliminates the holder join for the count. The full sort is the cost the index removes.

## Code changes

- **`InstitutionalFiling`** — replace `[Index(FilingDate)]` with a composite `[Index(FilingDate, AccessionNumber)]`. `FilingDate` stays the leading column (so the prior FilingDate-only lookups are still served), and the feed's `ORDER BY … DESC + page` becomes a backward index scan over just the page's rows instead of a full sort.
- **Migration `AddInstitutionalFilingSortIndex`** — drops the single-column index, creates the composite.
- **`InstitutionalFilingSortIndexTests`** — a timing fix has no result-level contract, so this pins the fix's mechanism: it asserts (against the real migrated schema) that the composite `(FilingDate, AccessionNumber)` index physically exists. Fails on the pre-fix schema, passes after the migration.