### PR TITLE
fix(insider-trading): isolate reprocess filing cache insert from the batch

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -150,14 +150,25 @@ public class InsiderFilingReprocessManager
             }
             catch (DbUpdateException ex)
             {
-                // A concurrent ingest insert of the same filing (unique accession) or a
-                // similar conflict — drop the batch's changes and retry these next run.
-                _logger.LogWarning(
-                    ex,
-                    "Insider filing reprocess batch save failed; retrying next run"
-                );
-                foreach (var accession in accessions)
-                    failedThisRun.Add(accession);
+                // A concurrent ingest or reprocess run inserted one of these filings' cache
+                // rows first, so this batch's duplicate-accession insert is rejected by the
+                // unique index. That cache write is best-effort, but the batch's transaction
+                // updates (parser-version advances, reclassifications, price repairs) are
+                // not — detaching the pending filing/file inserts and re-saving lets the
+                // transaction work commit instead of being discarded with the conflict (#2454).
+                if (await TryCommitWithoutPendingCacheInserts())
+                {
+                    result.Processed += attempted;
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Insider filing reprocess batch save failed; retrying next run"
+                    );
+                    foreach (var accession in accessions)
+                        failedThisRun.Add(accession);
+                }
             }
             finally
             {
@@ -178,6 +189,37 @@ public class InsiderFilingReprocessManager
         }
 
         return result;
+    }
+
+    // Re-saves the batch after detaching the best-effort filing/file cache inserts that a
+    // concurrent run beat us to (the unique-accession conflict). Those cache rows are
+    // regenerable — re-fetched on a later pass — but the batch's transaction updates are the
+    // run's real work and must survive a duplicate filing insert. The only rows this manager
+    // ever stages as inserts are the cached InsiderFiling and its File; the transaction
+    // updates are tracked as modifications, so detaching the inserts leaves them intact.
+    // Returns false when there is nothing pending to drop (an unrelated failure) or the
+    // retry still fails, leaving the original discard-and-retry-next-run behaviour in place.
+    private async Task<bool> TryCommitWithoutPendingCacheInserts()
+    {
+        var pendingInserts = _dbContext
+            .ChangeTracker.Entries()
+            .Where(e => e.State == EntityState.Added)
+            .ToList();
+        if (pendingInserts.Count == 0)
+            return false;
+
+        foreach (var entry in pendingInserts)
+            entry.State = EntityState.Detached;
+
+        try
+        {
+            await _transactionRepository.SaveChanges();
+            return true;
+        }
+        catch (DbUpdateException)
+        {
+            return false;
+        }
     }
 
     private async Task ReprocessFiling(string accession, InsiderFilingReprocessResult result)

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerConcurrentInsertTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerConcurrentInsertTests.cs
@@ -1,0 +1,164 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+/// <summary>
+/// Concurrency pin for the reprocess loop. A stale row with no cached blob re-fetches the
+/// ownership XML from EDGAR and stages a fresh <see cref="InsiderFiling"/> cache row, which is
+/// committed in the batch save alongside the transaction updates. When a concurrent ingest or
+/// reprocess run inserts the same accession's filing first, the duplicate insert is rejected by
+/// the unique <c>IX_InsiderFiling_AccessionNumber</c> index — and that conflict must not discard
+/// the batch's transaction work (parser-version advance, security-kind reclassification, price
+/// repair), which is exactly what happened in production (every ~10s) before the fix (#2454).
+/// The cache write is best-effort; the transaction updates are not.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InsiderFilingReprocessManagerConcurrentInsertTests : ParadeDbMcpTestBase
+{
+    public InsiderFilingReprocessManagerConcurrentInsertTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Run_ConcurrentRunInsertsSameFilingDuringFetch_StillCommitsTransactionUpdates()
+    {
+        var date = new DateOnly(2024, 6, 14);
+        var accession = "0000320193-24-000088";
+
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0001",
+            Name = "Jane Insider",
+            City = "Cupertino",
+            StateOrCountry = "CA",
+            IsDirector = true,
+        };
+        // Stored as Derivative at the legacy version; the fetched XML places it in the
+        // non-derivative table, so the run must flip it and stamp the current version.
+        var stale = new InsiderTransaction
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            InsiderOwnerId = owner.Id,
+            AccessionNumber = accession,
+            TransactionOrder = 0,
+            FilingDate = date,
+            TransactionDate = date,
+            TransactionCode = TransactionCode.Purchase,
+            Shares = 1000,
+            PricePerShare = 55m,
+            ReportedPricePerShare = 55m,
+            AcquiredDisposed = AcquiredDisposed.Acquired,
+            SharesOwnedAfter = 5000,
+            OwnershipNature = OwnershipNature.Direct,
+            SecurityTitle = "Common Stock",
+            SecurityKind = InsiderSecurityKind.Derivative,
+            ParserVersion = 0,
+        };
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        DbContext.Add(
+            new DailyStockPrice
+            {
+                CommonStockId = stock.Id,
+                Date = date,
+                Close = 55m,
+            }
+        );
+        DbContext.Add(stale);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var ownershipXml =
+            "<ownershipDocument>"
+            + "<nonDerivativeTable><nonDerivativeTransaction>"
+            + "<securityTitle><value>Common Stock</value></securityTitle>"
+            + "<transactionDate><value>2024-06-14</value></transactionDate>"
+            + "<transactionCoding><transactionCode>P</transactionCode></transactionCoding>"
+            + "<transactionAmounts>"
+            + "<transactionShares><value>1000</value></transactionShares>"
+            + "<transactionPricePerShare><value>55</value></transactionPricePerShare>"
+            + "</transactionAmounts>"
+            + "</nonDerivativeTransaction></nonDerivativeTable>"
+            + "</ownershipDocument>";
+
+        // The cache misses, so the manager reaches EDGAR. The fetch is the race window: a
+        // concurrent run commits the same accession's InsiderFiling before this run's batch
+        // save, so this run's own insert collides with the unique accession index.
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar
+            .GetDocumentContent(accession, Arg.Any<string>())
+            .Returns(_ =>
+            {
+                using var concurrent = Fixture.CreateDbContext();
+                if (!concurrent.Set<InsiderFiling>().Any(f => f.AccessionNumber == accession))
+                {
+                    concurrent.Add(
+                        new InsiderFiling
+                        {
+                            AccessionNumber = accession,
+                            CaptureStatus = InsiderFilingCaptureStatus.Captured,
+                        }
+                    );
+                    concurrent.SaveChanges();
+                }
+                return ownershipXml;
+            });
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager
+            .SaveInternalFile(
+                Arg.Any<byte[]>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            )
+            .Returns(_ => new File
+            {
+                Name = accession,
+                Extension = "gz",
+                ContentType = "application/gzip",
+            });
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runCtx),
+            new InsiderFilingRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            edgar,
+            fileManager,
+            runCtx,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Failed.Should().Be(0, "the duplicate filing insert is recoverable, not a failure");
+
+        // The batch's transaction work must have committed despite the filing conflict.
+        await using var verify = Fixture.CreateDbContext();
+        var row = await verify.Set<InsiderTransaction>().FindAsync(stale.Id);
+        row!.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
+        row.SecurityKind.Should().Be(InsiderSecurityKind.NonDerivative);
+    }
+}


### PR DESCRIPTION
## Summary

The insider-filing reprocess sweep (`InsiderFilingReprocessManager.Run`) fails its batch `SaveChanges` continuously in production with `23505 duplicate key value violates constraint IX_InsiderFiling_AccessionNumber`. On a cache miss the manager re-fetches the ownership XML from EDGAR and stages a new `InsiderFiling` cache row that is committed in the batch save **alongside the transaction updates**. When a concurrent ingest or reprocess run inserts the same accession first, the duplicate insert is rejected and the **entire batch** — every parser-version advance, security-kind reclassification and price repair — is discarded and retried next run. In production both a backoffice-triggered run and the background worker drained the same queue at once, so the conflict fired on essentially every batch (~every 10s) and the backfill made little forward progress.

## Code changes

- `InsiderFilingReprocessManager`: the cached filing/file rows are best-effort (re-fetched on a later pass), but the transaction updates are the run's real work. On the duplicate-accession conflict, detach the pending filing/file inserts and re-save so the transaction updates commit instead of being lost with the conflict. Any other conflict falls back to the prior discard-and-retry-next-run behaviour.
- New integration test reproduces the race deterministically by having the EDGAR fetch mock commit the same filing from a second context mid-run; the transaction's parser version and security kind now persist despite the collision (fails before the fix, passes after).

Fixes the defect tracked in the commercial repo (insider reprocess batch saves failing on duplicate accession).