### PR TITLE
fix(holdings): cover FilingDate in the per-holder covering index to stop 30s-timeout 500s

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -50,6 +50,15 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
         // Mirrors the per-stock covering index above so the rollups are
         // index-only scans. EF merges this with the entity's
         // `[Index(InstitutionalHolderId, ReportDate)]` attribute into one btree.
+        //
+        // FilingDate rides along too so the per-holder latest-filing-date probe
+        // (`SELECT max(FilingDate) WHERE InstitutionalHolderId = @h AND ReportDate
+        // = @d`) on the institution-profile / valuation path runs index-only. Without
+        // it Postgres had no index that could seek that holder+quarter and read
+        // FilingDate, so it fell back to a backward scan of the FilingDate index that
+        // filtered out millions of rows before finding the match and hit the 30s
+        // command timeout — a hard 500 on /institutions/{id} and
+        // /stocks/{ticker}/holders/{cik} (#3605).
         builder
             .Entity<InstitutionalHolding>()
             .HasIndex(h => new { h.InstitutionalHolderId, h.ReportDate })
@@ -58,6 +67,7 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
                 h.CommonStockId,
                 h.Value,
                 h.Shares,
+                h.FilingDate,
             });
 
         // Covering index for the per-stock 13F ranking pages (Most-Held Stocks,

--- a/src/Equibles.Migrations/Migrations/20260616195326_AddFilingDateToHolderCoveringIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260616195326_AddFilingDateToHolderCoveringIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616195326_AddFilingDateToHolderCoveringIndex")]
+    partial class AddFilingDateToHolderCoveringIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260616195326_AddFilingDateToHolderCoveringIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260616195326_AddFilingDateToHolderCoveringIndex.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFilingDateToHolderCoveringIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding",
+                columns: new[] { "InstitutionalHolderId", "ReportDate" })
+                .Annotation("Npgsql:IndexInclude", new[] { "CommonStockId", "Value", "Shares", "FilingDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding",
+                columns: new[] { "InstitutionalHolderId", "ReportDate" })
+                .Annotation("Npgsql:IndexInclude", new[] { "CommonStockId", "Value", "Shares" });
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsModuleHolderCoveringIndexIncludesFilingDateTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsModuleHolderCoveringIndexIncludesFilingDateTests.cs
@@ -1,0 +1,73 @@
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Pins the per-holder covering index shape that keeps the institution-profile and
+// per-stock-holder pages off the 30s command timeout (#3605). The holder pages issue
+// `SELECT max("FilingDate") WHERE "InstitutionalHolderId" = @h AND "ReportDate" = @d`;
+// unless FilingDate rides along in the (InstitutionalHolderId, ReportDate) covering
+// index's INCLUDE list, Postgres can't seek that holder+quarter and aggregate FilingDate
+// index-only, so it falls back to a backward scan of the FilingDate index that filters
+// out millions of rows and 500s. This pins FilingDate into the INCLUDE list so the regression
+// can't silently come back.
+public class HoldingsModuleHolderCoveringIndexIncludesFilingDateTests
+{
+    // The Npgsql provider stores a covering index's INCLUDE columns under this annotation;
+    // reading it directly keeps the assertion provider-agnostic (the model builds under the
+    // in-memory provider but the annotation is set at model-build time regardless).
+    private const string IndexIncludeAnnotation = "Npgsql:IndexInclude";
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[] { new HoldingsModuleConfiguration() }
+        );
+    }
+
+    [Fact]
+    public void HolderReportDateIndex_CoversFilingDate_SoTheLatestFilingProbeIsIndexOnly()
+    {
+        using var db = NewDb();
+
+        var entity = db.Model.FindEntityType(typeof(InstitutionalHolding));
+        entity.Should().NotBeNull();
+
+        var holderReportDateIndex = entity
+            .GetIndexes()
+            .Single(i =>
+                i.Properties.Select(p => p.Name)
+                    .SequenceEqual(
+                        new[]
+                        {
+                            nameof(InstitutionalHolding.InstitutionalHolderId),
+                            nameof(InstitutionalHolding.ReportDate),
+                        }
+                    )
+            );
+
+        var includedColumns =
+            holderReportDateIndex.FindAnnotation(IndexIncludeAnnotation)?.Value
+            as IReadOnlyList<string>;
+
+        includedColumns
+            .Should()
+            .NotBeNull("the holder page rollups rely on a covering index, not a heap scan")
+            .And.Contain(
+                nameof(InstitutionalHolding.FilingDate),
+                "max(FilingDate) for a holder+quarter must be served index-only (#3605)"
+            )
+            .And.Contain(
+                nameof(InstitutionalHolding.Value),
+                "the existing portfolio-rollup INCLUDE columns must stay"
+            )
+            .And.Contain(nameof(InstitutionalHolding.Shares))
+            .And.Contain(nameof(InstitutionalHolding.CommonStockId));
+    }
+}


### PR DESCRIPTION
## Summary

The institution-profile (`/institutions/{id}`) and per-stock-holder (`/stocks/{ticker}/holders/{cik}`) pages routinely 500 because the per-holder latest-filing probe times out at the 30s command limit:

```sql
SELECT max("FilingDate") FROM "InstitutionalHolding"
WHERE "InstitutionalHolderId" = @h AND "ReportDate" = @d
```

`EXPLAIN ANALYZE` against production shows the planner has no index that can seek the holder+quarter and aggregate `FilingDate`, so it falls back to an `Index Scan Backward` on `IX_InstitutionalHolding_FilingDate`, walking the FilingDate index newest-first and **removing ~2,000,000 rows** before it finds the one match. For a holder whose latest filing sits deep in that ordering the scan blows past 30s and the page hard-500s.

## Code changes

- **`HoldingsModuleConfiguration`** — add `FilingDate` to the INCLUDE list of the existing `(InstitutionalHolderId, ReportDate)` covering index. The probe now runs as an index-only scan over just that holder's quarter rows instead of the 2M-row backward scan.
- **Migration** `AddFilingDateToHolderCoveringIndex` — drops and recreates the covering index with the extra INCLUDE column (index-only change, no data touched).
- **Test** `HoldingsModuleHolderCoveringIndexIncludesFilingDateTests` — pins `FilingDate` (and the existing INCLUDE columns) into the index so the regression can't silently come back.

Fixes the holder-page timeouts tracked in the commercial repo's #3605.