### PR TITLE
fix(congress): normalise House member names so honorifics and doubled tokens don't split one person

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
@@ -51,7 +51,18 @@ public partial class HouseAnnualReportClient
     private const string ZipUrlTemplate = BaseUrl + "/public_disc/financial-pdfs/{0}FD.zip";
     private const string AnnualPdfUrlTemplate = BaseUrl + "/public_disc/financial-pdfs/{0}/{1}.pdf";
 
-    private static readonly string[] HonorificPrefixes = ["Hon. ", "Mr. ", "Mrs. ", "Ms. "];
+    // Honorific tokens some House filings inject into the disclosed name, with or
+    // without a trailing period ("Mr"/"Mr."/"Dr"). They are not part of the name;
+    // left in, they fragment one person into several CongressMember records keyed
+    // on the raw name string (e.g. "Mark Dr Green" vs "Mark Green").
+    private static readonly HashSet<string> HonorificTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Mr",
+        "Mrs",
+        "Ms",
+        "Dr",
+        "Hon",
+    };
 
     public HouseAnnualReportClient(HttpClient httpClient, ILogger<HouseAnnualReportClient> logger)
     {
@@ -609,11 +620,28 @@ public partial class HouseAnnualReportClient
         );
     }
 
+    // Normalises a House-disclosed member name so cosmetic variants resolve to one
+    // identity: drops honorific tokens in any position (period-agnostic) and
+    // collapses an immediately repeated token (the source occasionally doubles the
+    // first name, e.g. "Scott Scott Franklin"). Whole-token matching keeps real
+    // names such as "Mraz" intact.
     private static string StripHonorificPrefixes(string name)
     {
-        foreach (var prefix in HonorificPrefixes)
-            name = name.Replace(prefix, "");
-        return name;
+        var tokens = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var result = new List<string>(tokens.Length);
+        foreach (var token in tokens)
+        {
+            if (HonorificTokens.Contains(token.TrimEnd('.')))
+                continue;
+            if (
+                result.Count > 0
+                && string.Equals(result[^1], token, StringComparison.OrdinalIgnoreCase)
+            )
+                continue;
+            result.Add(token);
+        }
+
+        return string.Join(' ', result);
     }
 
     // Bracketed asset-type code such as [ST], [OP], [BA] — a code, not part of

--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -33,7 +33,18 @@ public partial class HouseDisclosureClient
     private const string ZipUrlTemplate = BaseUrl + "/public_disc/financial-pdfs/{0}FD.zip";
     private const string PtrPdfUrlTemplate = BaseUrl + "/public_disc/ptr-pdfs/{0}/{1}.pdf";
 
-    private static readonly string[] HonorificPrefixes = ["Hon. ", "Mr. ", "Mrs. ", "Ms. "];
+    // Honorific tokens some House filings inject into the disclosed name, with or
+    // without a trailing period ("Mr"/"Mr."/"Dr"). They are not part of the name;
+    // left in, they fragment one person into several CongressMember records keyed
+    // on the raw name string (e.g. "Matt Mr Rosendale" vs "Matt Rosendale").
+    private static readonly HashSet<string> HonorificTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Mr",
+        "Mrs",
+        "Ms",
+        "Dr",
+        "Hon",
+    };
 
     public HouseDisclosureClient(HttpClient httpClient, ILogger<HouseDisclosureClient> logger)
     {
@@ -479,10 +490,27 @@ public partial class HouseDisclosureClient
         string StateDst
     );
 
+    // Normalises a House-disclosed member name so cosmetic variants resolve to one
+    // identity: drops honorific tokens in any position (period-agnostic) and
+    // collapses an immediately repeated token (the source occasionally doubles the
+    // first name, e.g. "Scott Scott Franklin"). Whole-token matching keeps real
+    // names such as "Mraz" intact.
     private static string StripHonorificPrefixes(string name)
     {
-        foreach (var prefix in HonorificPrefixes)
-            name = name.Replace(prefix, "");
-        return name;
+        var tokens = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var result = new List<string>(tokens.Length);
+        foreach (var token in tokens)
+        {
+            if (HonorificTokens.Contains(token.TrimEnd('.')))
+                continue;
+            if (
+                result.Count > 0
+                && string.Equals(result[^1], token, StringComparison.OrdinalIgnoreCase)
+            )
+                continue;
+            result.Add(token);
+        }
+
+        return string.Join(' ', result);
     }
 }

--- a/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientStripHonorificPrefixesVariantTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientStripHonorificPrefixesVariantTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Pins the member-name normalisation in <c>HouseAnnualReportClient</c> (the
+/// annual Form A / net-worth path that feeds the richest ranking) for the
+/// duplicate sets reported in #3374. The annual path shares the same honorific
+/// and doubled-token defects as the PTR path, so it must collapse the same
+/// variants to one canonical name — otherwise a member is listed twice on
+/// <c>/congress/richest</c>.
+/// </summary>
+public class HouseAnnualReportClientStripHonorificPrefixesVariantTests
+{
+    private static readonly MethodInfo StripHonorificPrefixesMethod =
+        typeof(HouseAnnualReportClient).GetMethod(
+            "StripHonorificPrefixes",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    [Theory]
+    [InlineData("Mr Matt Rosendale", "Matt Rosendale")]
+    [InlineData("Matt Mr Rosendale", "Matt Rosendale")]
+    [InlineData("Mark Dr Green", "Mark Green")]
+    [InlineData("Marjorie Taylor Mrs Greene", "Marjorie Taylor Greene")]
+    [InlineData("Scott Scott Franklin", "Scott Franklin")]
+    [InlineData("Hon. Mr. Smith", "Smith")]
+    [InlineData("Scott Franklin", "Scott Franklin")]
+    [InlineData("C. Scott Franklin", "C. Scott Franklin")]
+    public void StripHonorificPrefixes_NameVariant_NormalisesToCanonical(
+        string input,
+        string expected
+    )
+    {
+        var result = (string)StripHonorificPrefixesMethod.Invoke(null, [input]);
+
+        result.Should().Be(expected);
+    }
+}

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientStripHonorificPrefixesVariantTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientStripHonorificPrefixesVariantTests.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Pins the member-name normalisation in <c>HouseDisclosureClient</c> (the PTR /
+/// trades path) for the duplicate sets reported in #3374. House filings inject
+/// honorific tokens into the disclosed name — often without the trailing period
+/// the old <c>"Mr. "</c> replace looked for, and "Dr" was never handled at all —
+/// and occasionally double the first name ("Scott Scott Franklin"). Each variant
+/// must collapse to the same canonical name so one member maps to one
+/// <c>CongressMember</c> record instead of two-to-four.
+/// </summary>
+public class HouseDisclosureClientStripHonorificPrefixesVariantTests
+{
+    private static readonly MethodInfo StripHonorificPrefixesMethod =
+        typeof(HouseDisclosureClient).GetMethod(
+            "StripHonorificPrefixes",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    [Theory]
+    // Period-less honorific, leading and mid-name (was never stripped).
+    [InlineData("Mr Matt Rosendale", "Matt Rosendale")]
+    [InlineData("Matt Mr Rosendale", "Matt Rosendale")]
+    // "Dr" was absent from the honorific list entirely.
+    [InlineData("Mark Dr Green", "Mark Green")]
+    [InlineData("Kim Dr Schrier", "Kim Schrier")]
+    [InlineData("Marjorie Taylor Mrs Greene", "Marjorie Taylor Greene")]
+    [InlineData("Scott Mr Franklin", "Scott Franklin")]
+    // Doubled first name from the parser.
+    [InlineData("Scott Scott Franklin", "Scott Franklin")]
+    // Existing stacked-prefix contract (#1422) still holds.
+    [InlineData("Hon. Mr. Smith", "Smith")]
+    // Clean names and genuine initials are left untouched (no over-merging).
+    [InlineData("Scott Franklin", "Scott Franklin")]
+    [InlineData("C. Scott Franklin", "C. Scott Franklin")]
+    public void StripHonorificPrefixes_NameVariant_NormalisesToCanonical(
+        string input,
+        string expected
+    )
+    {
+        var result = (string)StripHonorificPrefixesMethod.Invoke(null, [input]);
+
+        result.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

- House disclosure filings inject honorific tokens into the disclosed member name — often without the trailing period the old `Replace("Mr. ", "")` looked for, and "Dr" was never handled at all — and occasionally double the first name ("Scott Scott Franklin"). Member identity is keyed on the raw name string, so each cosmetic variant created a separate `CongressMember` record: one person's trade history splits across up to four profiles, and they double-list on the richest ranking.
- Normalise the assembled name so cosmetic variants resolve to one identity, removing the parser's role in fragmenting members.

## Code changes

- `src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs` — replace the period-bearing prefix list + `Replace` loop with token-wise normalisation: drop honorific tokens (Mr/Mrs/Ms/Dr/Hon, with or without a trailing period) in any position and collapse an immediately repeated token. Whole-token matching keeps real names like "Mraz" intact; genuine initials ("C. Scott Franklin") are left untouched.
- `src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs` — same normalisation for the annual Form A / net-worth path that feeds the richest ranking.
- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientStripHonorificPrefixesVariantTests.cs` — new theory pinning the production duplicate sets (Rosendale, Green, Schrier, Greene, Franklin) to their canonical names; preserves the existing stacked-prefix contract; asserts clean names and genuine initials are unchanged.
- `tests/Equibles.UnitTests/Congress/HouseAnnualReportClientStripHonorificPrefixesVariantTests.cs` — same coverage for the annual path.