### PR TITLE
fix(common-stocks): catch System.TimeoutException on the stealth network-idle wait

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
@@ -144,6 +144,10 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
     /// DOM is kept rather than discarding an otherwise successful render. A genuine
     /// navigation failure — refused connection, DNS, protocol error — is a different
     /// exception that still propagates, so the fetch degrades to a miss as before.
+    /// Playwright .NET surfaces the wait timeout as a <see cref="System.TimeoutException"/>
+    /// (not a <see cref="PlaywrightException"/>), so that is caught directly; the
+    /// message-matched <see cref="PlaywrightException"/> clause is kept as a belt-and-braces
+    /// guard for any path that reports the same timeout as a Playwright error.
     /// </summary>
     internal static async Task NavigateWaitingForNetworkIdle(
         IPage page,
@@ -162,6 +166,10 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
                     Timeout = timeoutMilliseconds,
                 }
             );
+        }
+        catch (System.TimeoutException)
+        {
+            logger.LogDebug("NetworkIdle wait timed out for {Url}; using the loaded DOM.", url);
         }
         catch (PlaywrightException ex) when (IsNetworkIdleTimeout(ex))
         {

--- a/tests/Equibles.UnitTests/CommonStocks/CloakBrowserStealthClientNavigateTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CloakBrowserStealthClientNavigateTests.cs
@@ -38,6 +38,27 @@ public class CloakBrowserStealthClientNavigateTests
     }
 
     [Fact]
+    public async Task NavigateWaitingForNetworkIdle_SwallowsSystemTimeoutException_SoTheLoadedDomIsKept()
+    {
+        // Playwright .NET surfaces a GotoAsync wait timeout as System.TimeoutException — NOT a
+        // PlaywrightException — which is what the FDA calendar actually throws in production. The
+        // idle-wait timeout must still be non-fatal regardless of the concrete timeout type.
+        var page = Substitute.For<IPage>();
+        page.GotoAsync(Arg.Any<string>(), Arg.Any<PageGotoOptions>())
+            .ThrowsAsync(new System.TimeoutException("Timeout 45000ms exceeded."));
+
+        var navigate = async () =>
+            await CloakBrowserStealthClient.NavigateWaitingForNetworkIdle(
+                page,
+                "https://www.fda.gov/advisory-committees/advisory-committee-calendar",
+                45000,
+                NullLogger.Instance
+            );
+
+        await navigate.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task NavigateWaitingForNetworkIdle_Rethrows_OnGenuineNavigationFailure()
     {
         var page = Substitute.For<IPage>();


### PR DESCRIPTION
## Summary

- The stealth navigation's network-idle graceful-degradation (keep the rendered DOM when a host never lets the network fall idle) caught `PlaywrightException`, but Playwright .NET actually throws **`System.TimeoutException`** on a `GotoAsync` wait timeout. The catch never fired, so the FDA advisory-committee calendar import threw `Timeout 45000ms exceeded.` out of every cycle in production (fda.gov streams telemetry that never lets the network idle). Verified against prod: the worker restarted onto the fixed pin and the import still errored 51s later, confirming the catch type was wrong.
- Catch `System.TimeoutException` directly; the existing message-matched `PlaywrightException` clause stays as a belt-and-braces guard. A genuine navigation failure (`net::ERR_CONNECTION_REFUSED`) is a `PlaywrightException` that still propagates, so the fetch degrades to a miss as before.

## Code changes

- `src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs` — add a `catch (System.TimeoutException)` clause to `NavigateWaitingForNetworkIdle`; update the doc comment to record that Playwright .NET reports the wait timeout as `System.TimeoutException`.
- `tests/Equibles.UnitTests/CommonStocks/CloakBrowserStealthClientNavigateTests.cs` — add `NavigateWaitingForNetworkIdle_SwallowsSystemTimeoutException_...` seeding the real `System.TimeoutException`. Fails on the pre-fix code (the original test only seeded a `PlaywrightException`, which is why the production case slipped through), passes after.