### PR TITLE
fix(congress): drop incomplete annual-report range cells instead of fabricating (0, X)

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
@@ -732,6 +732,14 @@ public partial class HouseAnnualReportClient
             if (_rangeText == null)
                 return null;
 
+            // A range cell still ending in the opening bound's dash ("$X -")
+            // never received its wrapped upper bound (truncated/dropped line):
+            // it is not a bracket the filer checked. Drop the row rather than
+            // let the single-amount fallback fabricate a (0, X) range from the
+            // lone opening bound.
+            if (_rangeText.TrimEnd().EndsWith('-'))
+                return null;
+
             var (minimum, maximum) = ParseAmountRange(_rangeText);
             if (minimum == 0 && maximum == 0)
                 return null;

--- a/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientIncompleteRangeTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientIncompleteRangeTests.cs
@@ -8,9 +8,7 @@ public class HouseAnnualReportClientIncompleteRangeTests
     private static List<ScheduleToken> Tokens(params (string text, double left)[] words) =>
         words.Select(w => new ScheduleToken(w.text, w.left)).ToList();
 
-    [Fact(
-        Skip = "GH-3656 — incomplete range cell is emitted as a fabricated (0, X) bracket instead of being dropped"
-    )]
+    [Fact]
     public void ParseScheduleLines_RangeUpperBoundNeverArrives_DropsTheRow()
     {
         // Line items must carry "the form's own brackets". A range cell that


### PR DESCRIPTION
## Summary

- A House Schedule A/D range cell that opens with `$X -` whose wrapped upper bound never arrives (truncated document, dropped line) was stored as a line item with `RangeMinimum 0, RangeMaximum X`. `(0, X)` is not a bracket the filer checked and it understates both bounds of the real range.
- Drop any pending row whose range text still ends in the opening bound's dash, consistent with how `None`/`Undetermined` rows are never materialized.

## Code changes

- `src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs` — guard `PendingLine.ToLineItem` to return null when `_rangeText` still ends in `-` (incomplete range), before the single-amount fallback runs. The shared `ParseAmountRange` helper is left untouched so PTR "Under $X" amounts keep their `(0, X)` semantics.
- `tests/Equibles.UnitTests/Congress/HouseAnnualReportClientIncompleteRangeTests.cs` — un-skipped the regression test (`ParseScheduleLines_RangeUpperBoundNeverArrives_DropsTheRow`); fails before the fix, passes after.

closes #3656