### PR TITLE
fix(mcp): floor the result-cap clamp at 1 so a 0 limit never claims no data

### DIFF
--- a/src/Equibles.Mcp/Helpers/McpLimit.cs
+++ b/src/Equibles.Mcp/Helpers/McpLimit.cs
@@ -7,10 +7,13 @@ public static class McpLimit
     // set, exhausting memory and database time.
     public const int MaxResults = 500;
 
-    // Clamps the client-supplied result cap to [0, MaxResults]. A negative cap would flow into
-    // .Take(...) as a negative SQL LIMIT, which PostgreSQL rejects and surfaces as the
-    // internal-error sentinel; clamping to non-negative makes a non-positive cap yield zero rows
-    // and the existing no-results message instead. The upper bound guards against resource
+    // Clamps the client-supplied result cap to [1, MaxResults]. A non-positive cap is nonsensical:
+    // a negative value would flow into .Take(...) as a negative SQL LIMIT (PostgreSQL rejects it as
+    // an internal error), and a cap of zero yields zero rows, which makes a tool render its factual
+    // empty-state message (e.g. "no annual disclosure found") even for a subject that has data — a
+    // false claim served to the caller. Flooring at 1 keeps at least one row so a nonsensical limit
+    // never turns "has data" into "has no data". No tool defaults maxResults to 0, so the floor only
+    // ever affects an explicit non-positive request. The upper bound guards against resource
     // exhaustion from an oversized request.
-    public static int Clamp(int maxResults) => Math.Clamp(maxResults, 0, MaxResults);
+    public static int Clamp(int maxResults) => Math.Clamp(maxResults, 1, MaxResults);
 }

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberNetWorthZeroMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberNetWorthZeroMaxResultsTests.cs
@@ -17,9 +17,7 @@ public class CongressToolsGetMemberNetWorthZeroMaxResultsTests : ParadeDbMcpTest
     // factual claim about the member. A caller passing a nonsensical
     // maxResults (0) must never turn a member WITH disclosures into that
     // false claim — the limit clamp has to keep at least one row.
-    [Fact(
-        Skip = "GH-3666 — maxResults 0 passes the clamp and renders the false no-disclosure message"
-    )]
+    [Fact]
     public async Task GetMemberNetWorth_ZeroMaxResults_DoesNotClaimNoDisclosures()
     {
         var member = new CongressMember

--- a/tests/Equibles.UnitTests/Mcp/McpLimitClampNegativeCapTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpLimitClampNegativeCapTests.cs
@@ -4,18 +4,18 @@ namespace Equibles.UnitTests.Mcp;
 
 public class McpLimitClampNegativeCapTests
 {
-    // Contract: McpLimit.Clamp exists so a negative result cap never reaches
+    // Contract: McpLimit.Clamp exists so a non-positive result cap never reaches
     // .Take(...) as a negative SQL LIMIT (PostgreSQL rejects it as an internal
-    // error). The documented promise is that a non-positive cap yields zero
-    // rows, i.e. the clamp returns a non-negative value — 0 for any negative
-    // input. int.MinValue is the extreme boundary: it must still clamp to 0,
-    // not overflow or pass a negative value through.
+    // error) and never yields zero rows (zero rows make a tool render a factual
+    // empty-state message even when the subject has data). A non-positive cap
+    // clamps to the floor of 1. int.MinValue is the extreme boundary: it must
+    // still clamp to 1, not overflow or pass a negative value through.
     [Fact]
-    public void Clamp_IntMinValue_ReturnsZeroNotNegative()
+    public void Clamp_IntMinValue_ReturnsFloorNotNegative()
     {
         var result = McpLimit.Clamp(int.MinValue);
 
-        result.Should().Be(0);
+        result.Should().Be(1);
     }
 
     // Contract: an oversized cap (e.g. int.MaxValue) must be bounded so it never flows
@@ -29,9 +29,11 @@ public class McpLimitClampNegativeCapTests
         result.Should().Be(McpLimit.MaxResults);
     }
 
-    // Values within [0, MaxResults] must pass through unchanged.
+    // A non-positive cap clamps up to the floor of 1; values within
+    // [1, MaxResults] pass through unchanged.
     [Theory]
-    [InlineData(0, 0)]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
     [InlineData(10, 10)]
     [InlineData(McpLimit.MaxResults, McpLimit.MaxResults)]
     public void Clamp_WithinRange_ReturnsInput(int input, int expected)


### PR DESCRIPTION
## Summary

- `McpLimit.Clamp` floored the client-supplied `maxResults` at 0, so a caller passing `maxResults: 0` took zero rows and the tool rendered its factual empty-state message — e.g. `GetMemberNetWorth` telling a client "No electronically filed annual disclosure found" for a member who actually has a disclosure. A false factual claim served to an AI caller that may repeat it.
- A non-positive cap is nonsensical (negative → invalid SQL `LIMIT`; zero → fabricated "no data"), and no MCP tool defaults `maxResults` to 0, so flooring the clamp at 1 is safe and closes the exposure across every tool (all feed `Clamp` into `.Take(...)`).

## Code changes

- `src/Equibles.Mcp/Helpers/McpLimit.cs` — `Clamp` now floors at 1 instead of 0; comment updated to document the corrected contract.
- `tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberNetWorthZeroMaxResultsTests.cs` — un-skipped the regression test; `GetMemberNetWorth(name, maxResults: 0)` no longer returns the no-disclosure message and surfaces the 2024 row. Fails before the fix, passes after.
- `tests/Equibles.UnitTests/Mcp/McpLimitClampNegativeCapTests.cs` — updated the clamp contract assertions to the new floor of 1 (`Clamp(0)` and `Clamp(int.MinValue)` now return 1).

closes #3666