### PR TITLE
fix(holdings): reconstruct holder portfolios from 13F quarters only

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/HoldingsCloneBacktestProvider.cs
+++ b/src/Equibles.Holdings.BusinessLogic/HoldingsCloneBacktestProvider.cs
@@ -80,8 +80,10 @@ public class HoldingsCloneBacktestProvider
         }
         outcome.BenchmarkName = benchmarkStock.Name;
 
-        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
-        // GetReportDatesByHolder returns latest first; the backtest iterates earliest first.
+        var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
+        // Get13FReportDatesByHolder returns latest first; the backtest iterates earliest first.
+        // 13D/G event dates are excluded so a single disclosed stake never rotates the whole
+        // simulation into one stock at the event date.
         reportDates.Reverse();
         if (reportDates.Count == 0)
         {
@@ -104,7 +106,7 @@ public class HoldingsCloneBacktestProvider
         }
 
         var holdings = await _holdingRepository
-            .GetHistoryByHolder(holder)
+            .Get13FHistoryByHolder(holder)
             .Where(h => relevant.Contains(h.ReportDate))
             .Select(h => new BacktestHoldingRow(
                 h.ReportDate,

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -242,7 +242,7 @@ public class InstitutionalHoldingsTools
 
                 var (targetDate, found) = await TryResolveLatestReportDate(
                     reportDate,
-                    _holdingRepository.GetReportDatesByHolder(holder)
+                    _holdingRepository.Get13FReportDatesByHolder(holder)
                 );
                 if (!found)
                     return $"No holdings data for {holder.Name}.";
@@ -924,7 +924,7 @@ public class InstitutionalHoldingsTools
                     return holderError;
 
                 var reportDates = await _holdingRepository
-                    .GetReportDatesByHolder(holder)
+                    .Get13FReportDatesByHolder(holder)
                     .ToListAsync();
                 if (reportDates.Count < 2)
                     return $"{holder.Name} has fewer than two reported quarters — no diff available.";
@@ -1082,7 +1082,7 @@ public class InstitutionalHoldingsTools
     {
         var perHolder = new List<List<DateOnly>>(holders.Count);
         foreach (var holder in holders)
-            perHolder.Add(await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync());
+            perHolder.Add(await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync());
 
         return perHolder
             .Skip(1)
@@ -1319,7 +1319,7 @@ public class InstitutionalHoldingsTools
         if (holderError != null)
             return (null, null, default, holderError);
 
-        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
+        var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
         if (reportDates.Count == 0)
             return (holder, null, default, $"No 13F holdings reported by {holder.Name}.");
 

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -108,7 +108,7 @@ public class HoldingsExportController : BaseController
         if (holder == null)
             return NotFound();
 
-        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
+        var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
         if (reportDates.Count == 0)
             return NotFound();
 

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -65,7 +65,7 @@ public class ProfilesController : BaseController
             return NotFound();
 
         var holdings = await _institutionalHoldingRepository
-            .GetHistoryByHolder(holder)
+            .Get13FHistoryByHolder(holder)
             .TakeMostRecent(holding => holding.ReportDate, RecentRowLimit)
             .Select(holding => new HoldingRowViewModel
             {
@@ -80,7 +80,7 @@ public class ProfilesController : BaseController
         // Header strip + industry allocation — pulled with extra per-quarter
         // materializations so the existing recent-rows list keeps its top-50 shape.
         var distinctDates = await _institutionalHoldingRepository
-            .GetReportDatesByHolder(holder)
+            .Get13FReportDatesByHolder(holder)
             .ToListAsync();
         var (summary, industryAllocation) = await BuildSummaryAndAllocation(holder, distinctDates);
         var (quarterlyActivity, activityResolved, activityPrior) = await BuildQuarterlyActivity(
@@ -464,7 +464,7 @@ public class ProfilesController : BaseController
         foreach (var holder in holders)
         {
             var dates = await _institutionalHoldingRepository
-                .GetReportDatesByHolder(holder)
+                .Get13FReportDatesByHolder(holder)
                 .ToListAsync();
             perHolderDates.Add(dates);
         }

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests.cs
@@ -1,0 +1,108 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins that <c>GetInstitutionPortfolio</c> resolves its default report date from 13F
+/// quarters only. A Schedule 13D/G filed AFTER the last 13F quarter carries a daily
+/// event date, not a quarter end, and describes a single disclosed stake — if the tool
+/// resolved "latest" from all filing types, the served portfolio would collapse into that
+/// one stock at the event date instead of the real 13F holdings. Same root cause as
+/// GH-3685 (fund scoring / smart-money index), fixed for the remaining holder-portfolio
+/// surfaces in GH-3690.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests
+    : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests(
+        ParadeDbFixture fixture
+    )
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetInstitutionPortfolio_Later13DGEventDate_ServesLatest13FQuarterNotTheStake()
+    {
+        var holder = new InstitutionalHolder { Cik = "1", Name = "Pinnacle Capital Management" };
+        var apple = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var microsoft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var tesla = new CommonStock
+        {
+            Ticker = "TSLA",
+            Name = "Tesla Inc.",
+            Cik = "0001318605",
+        };
+        DbContext.AddRange(holder, apple, microsoft, tesla);
+
+        var quarterEnd = new DateOnly(2026, 3, 31);
+        // A single-stock Schedule 13D filed AFTER the latest 13F quarter — exactly the row
+        // that would hijack "latest" and replace the real portfolio with one stake.
+        var event13D = new DateOnly(2026, 5, 20);
+        DbContext.Add(MakeHolding(holder, apple, quarterEnd, FilingType.Form13F, 1_000, 200_000));
+        DbContext.Add(
+            MakeHolding(holder, microsoft, quarterEnd, FilingType.Form13F, 2_000, 300_000)
+        );
+        DbContext.Add(MakeHolding(holder, tesla, event13D, FilingType.Schedule13D, 5_000, 900_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetInstitutionPortfolio("Pinnacle");
+
+        // The default date must be the 2026-03-31 13F quarter (AAPL + MSFT), never the
+        // 2026-05-20 13D event date (TSLA stake at 100%).
+        output.Should().Contain("2026-03-31");
+        output.Should().Contain("AAPL");
+        output.Should().Contain("MSFT");
+        output.Should().NotContain("TSLA");
+        output.Should().NotContain("2026-05-20");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        InstitutionalHolder holder,
+        CommonStock stock,
+        DateOnly reportDate,
+        FilingType filingType,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            FilingType = filingType,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stock.Ticker}",
+        };
+}


### PR DESCRIPTION
## Summary

- #3685/#3686 fixed Schedule 13D/G event dates polluting fund scoring and the smart-money index, but the same unfiltered `GetReportDatesByHolder` / `GetHistoryByHolder` pattern remained on the other holder-portfolio surfaces. A 13D/G filed after the last 13F quarter carries a daily event date (not a quarter end) describing a single stake, so "latest report date" resolved that date and collapsed the holder's portfolio into one stock at 100% weight.
- Switch every portfolio-reconstruction / quarter-selector call site to the 13F-only `Get13FReportDatesByHolder` / `Get13FHistoryByHolder` variants added in #3686. Surfaces that deliberately list all filing types (filing-history views) are unchanged.

## Code changes

- `src/Equibles.Holdings.BusinessLogic/HoldingsCloneBacktestProvider.cs` — the on-demand institution backtest resolves its snapshot dates and reconstructs holdings from 13F only.
- `src/Equibles.Web/Controllers/ProfilesController.cs` (3 sites) — the institution profile's holdings list, default quarter / summary / activity dates, and the multi-holder compare intersection are 13F only.
- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — the institution CSV export defaults to the latest 13F quarter, not the latest filing of any type.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` (4 sites) — the MCP portfolio / quarterly-activity / overlap / target-date resolvers serve 13F quarters to API clients.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests.cs` — regression test: a holder with a 13F at 2026-03-31 and a 13D at 2026-05-20 serves the 2026-03-31 portfolio (AAPL+MSFT), never the 2026-05-20 stake (TSLA). Fails before the fix, passes after.

closes #3690