### PR TITLE
feat(funds): materialise FundSeries directory from NPORT-P

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260616225839_AddFundSeries.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260616225839_AddFundSeries.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616225839_AddFundSeries")]
+    partial class AddFundSeries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260616225839_AddFundSeries.cs
+++ b/src/Equibles.Migrations/Migrations/20260616225839_AddFundSeries.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFundSeries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FundSeries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    IdentityKey = table.Column<string>(type: "character varying(80)", maxLength: 80, nullable: false),
+                    Slug = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: true),
+                    RegistrantCik = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: true),
+                    SeriesId = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    SeriesName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    RegistrantName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Ticker = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: true),
+                    LatestReportPeriodDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    LatestFilingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    NetAssets = table.Column<decimal>(type: "numeric", nullable: false),
+                    TotalAssets = table.Column<decimal>(type: "numeric", nullable: false),
+                    PositionCount = table.Column<int>(type: "integer", nullable: false),
+                    FundType = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: true),
+                    ComputedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FundSeries", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FundSeries_CommonStockId",
+                table: "FundSeries",
+                column: "CommonStockId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FundSeries_IdentityKey",
+                table: "FundSeries",
+                column: "IdentityKey",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FundSeries_RegistrantCik_SeriesId",
+                table: "FundSeries",
+                columns: new[] { "RegistrantCik", "SeriesId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FundSeries_Slug",
+                table: "FundSeries",
+                column: "Slug",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FundSeries");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/FundSeries.cs
+++ b/src/Equibles.Sec.Data/Models/FundSeries.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// One materialised row per registered-fund series, derived from the latest NPORT-P report of
+/// each series. Funds have no first-class entity of their own — identity is implicit across
+/// <see cref="NportFiling"/> rows — so deriving the fund directory live would mean running the
+/// correlated "latest report per series" scan (<c>NportFilingRepository.GetLatestPerSeries</c>)
+/// on every browse request. This table holds one indexed row per series so the <c>/funds</c>
+/// index and per-fund profile become plain lookups, the same way
+/// <c>HolderQuarterlySnapshot</c> backs the institutions browse.
+///
+/// Rebuilt wholesale by <c>FundSeriesRefreshService</c>: every series' latest report is upserted
+/// keyed by <see cref="IdentityKey"/> and rows left untouched by a run (stale series) are pruned
+/// by the <see cref="ComputedAt"/> watermark.
+///
+/// Series identity never compares name text. Exactly one of the two populations applies per row:
+/// a tracked fund (listed closed-end fund / standalone ETF trust crawled through its own feed) is
+/// scoped by <see cref="CommonStockId"/>; a fund-family trust series discovered by the daily-index
+/// sweep is scoped by <see cref="RegistrantCik"/> + <see cref="SeriesId"/>. For the sweep-discovered
+/// trusts only the holdings carrying a tracked stock's CUSIP are stored, so <see cref="PositionCount"/>
+/// counts the fund's positions in tracked stocks, not its whole portfolio; <see cref="NetAssets"/>
+/// and <see cref="TotalAssets"/> are the fund's real totals from the report header regardless.
+/// </summary>
+[Index(nameof(IdentityKey), IsUnique = true)]
+[Index(nameof(Slug), IsUnique = true)]
+[Index(nameof(CommonStockId))]
+[Index(nameof(RegistrantCik), nameof(SeriesId))]
+public class FundSeries
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Stable canonical identity and upsert conflict target. Derived from whichever identity
+    /// population applies, never from name text: <c>cs:{CommonStockId}</c> for a tracked fund,
+    /// <c>rc:{RegistrantCik}:{SeriesId}</c> for a sweep-discovered trust series (an id-less
+    /// registrant collapses to <c>rc:{RegistrantCik}:</c>).
+    /// </summary>
+    [Required]
+    [MaxLength(80)]
+    public string IdentityKey { get; set; }
+
+    /// <summary>
+    /// URL slug for the per-fund profile route, <c>{name-slug}-{discriminator}</c>. The
+    /// discriminator (series id / ticker / registrant CIK) is unique per series, so the slug is
+    /// unique even when two funds share a name. Regenerated each refresh from the latest name.
+    /// </summary>
+    [Required]
+    [MaxLength(256)]
+    public string Slug { get; set; }
+
+    /// <summary>The tracked stock the fund is itself, when crawled through its own feed; null for trusts.</summary>
+    public Guid? CommonStockId { get; set; }
+
+    /// <summary>The sweep-discovered trust's registrant CIK; null for tracked funds.</summary>
+    [MaxLength(16)]
+    public string RegistrantCik { get; set; }
+
+    /// <summary>The SEC series id (e.g. "S000002277"); empty string for a registrant's single id-less fund.</summary>
+    [Required]
+    [MaxLength(32)]
+    public string SeriesId { get; set; }
+
+    [MaxLength(512)]
+    public string SeriesName { get; set; }
+
+    [MaxLength(512)]
+    public string RegistrantName { get; set; }
+
+    /// <summary>The fund's own ticker, denormalised from the tracked stock; null for trusts.</summary>
+    [MaxLength(16)]
+    public string Ticker { get; set; }
+
+    public DateOnly LatestReportPeriodDate { get; set; }
+
+    public DateOnly LatestFilingDate { get; set; }
+
+    /// <summary>Net assets in USD, from the latest report header.</summary>
+    public decimal NetAssets { get; set; }
+
+    /// <summary>Total assets in USD, from the latest report header.</summary>
+    public decimal TotalAssets { get; set; }
+
+    /// <summary>Stored holding rows on the latest report (tracked-stock positions only for trusts).</summary>
+    public int PositionCount { get; set; }
+
+    /// <summary>
+    /// The N-CEN registration type of the fund (e.g. "N-1A" open-end/ETF, "N-2" closed-end), when
+    /// an N-CEN filing is on record. Null for trusts and newly-launched funds with no N-CEN yet.
+    /// </summary>
+    [MaxLength(16)]
+    public string FundType { get; set; }
+
+    public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -27,6 +27,7 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<FormAdvAdviser>();
         builder.Entity<FormDFiling>();
         builder.Entity<FormDRelatedPerson>();
+        builder.Entity<FundSeries>();
         builder.Entity<NCenFiling>();
         builder.Entity<NCenServiceProvider>();
         builder.Entity<NportFiling>();

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<InsiderFilingReprocessWorker>();
         services.AddHostedService<NportFilingReprocessWorker>();
         services.AddHostedService<NportRealtimeWorker>();
+        services.AddHostedService<FundSeriesRefreshWorker>();
 
         return services;
     }

--- a/src/Equibles.Sec.HostedService/FundSeriesRefreshWorker.cs
+++ b/src/Equibles.Sec.HostedService/FundSeriesRefreshWorker.cs
@@ -1,0 +1,78 @@
+using Equibles.Sec.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService;
+
+/// <summary>
+/// Keeps the materialised <see cref="Sec.Data.Models.FundSeries"/> directory current. After a
+/// startup delay it rebuilds the whole directory, then again every <see cref="SleepInterval"/>.
+/// Funds report monthly, so a daily full rebuild from <see cref="FundSeriesRefreshService"/> is
+/// ample — there is no per-filing dirty signal to drain. The first rebuild runs with an extended
+/// command timeout because the cold "latest report per series" scan over the whole NPORT table is
+/// the heaviest one.
+/// </summary>
+public class FundSeriesRefreshWorker : BackgroundService
+{
+    private readonly FundSeriesRefreshService _refreshService;
+    private readonly ILogger<FundSeriesRefreshWorker> _logger;
+
+    // Virtual seams so tests can collapse the waits without changing production behaviour.
+    protected virtual TimeSpan StartupDelay => TimeSpan.FromMinutes(2);
+    protected virtual TimeSpan SleepInterval => TimeSpan.FromHours(24);
+    protected virtual TimeSpan RebuildCommandTimeout => TimeSpan.FromMinutes(30);
+
+    public FundSeriesRefreshWorker(
+        FundSeriesRefreshService refreshService,
+        ILogger<FundSeriesRefreshWorker> logger
+    )
+    {
+        _refreshService = refreshService;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (StartupDelay > TimeSpan.Zero)
+        {
+            try
+            {
+                await Task.Delay(StartupDelay, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                _logger.LogInformation("Rebuilding fund-series directory");
+                await _refreshService.RebuildAllAsync(RebuildCommandTimeout, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                // A throw out of ExecuteAsync is fatal to a BackgroundService. Catch everything
+                // except cancellation so a transient DB hiccup doesn't kill the worker for the
+                // process lifetime — the next cycle reconciles.
+                _logger.LogError(ex, "Fund-series directory rebuild failed; will retry next cycle");
+            }
+
+            try
+            {
+                await Task.Delay(SleepInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
@@ -1,0 +1,262 @@
+using System.Text;
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using FlexLabs.EntityFrameworkCore.Upsert;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Rebuilds the materialised <see cref="FundSeries"/> directory from NPORT-P data: one row per
+/// registered-fund series, taken from each series' latest report
+/// (<see cref="NportFilingRepository.GetLatestPerSeries"/>). The whole directory is recomputed in
+/// one pass — funds report monthly and the set of series is small relative to the holdings table,
+/// so a periodic full rebuild is simpler than a per-filing dirty-flag drain and never leaves the
+/// index stale.
+///
+/// The rebuild is floor-agnostic: every series ever seen is materialised with its latest report
+/// date, and the read side (the commercial /funds index) applies its own data-sync floor by
+/// filtering <see cref="FundSeries.LatestReportPeriodDate"/>. Writes go through a single FlexLabs
+/// <c>UpsertRange</c> (INSERT … ON CONFLICT (IdentityKey)) and stale rows are pruned by the
+/// <see cref="FundSeries.ComputedAt"/> watermark — every row touched this run carries the run's
+/// timestamp, so anything older is a series that no longer resolves and is deleted.
+/// </summary>
+[Service]
+public class FundSeriesRefreshService
+{
+    private const int MaxSlugLength = 200;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FundSeriesRefreshService> _logger;
+
+    public FundSeriesRefreshService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<FundSeriesRefreshService> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public virtual Task RebuildAllAsync(CancellationToken cancellationToken) =>
+        RebuildAllAsync(commandTimeout: null, cancellationToken);
+
+    public virtual async Task RebuildAllAsync(
+        TimeSpan? commandTimeout,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        var nportRepository = scope.ServiceProvider.GetRequiredService<NportFilingRepository>();
+        if (commandTimeout is not null)
+        {
+            dbContext.Database.SetCommandTimeout(commandTimeout.Value);
+        }
+
+        // Latest report per series, with the report-header totals and the count of stored holding
+        // rows. The fund's ticker is denormalised from the tracked stock (null for trusts, whose
+        // CommonStockId is null — a LEFT JOIN yields null).
+        var aggregates = await nportRepository
+            .GetLatestPerSeries(DateOnly.MinValue)
+            .Select(f => new FundSeriesAggregate
+            {
+                CommonStockId = f.CommonStockId,
+                RegistrantCik = f.RegistrantCik,
+                SeriesId = f.SeriesId,
+                SeriesName = f.SeriesName,
+                RegistrantName = f.RegistrantName,
+                Ticker = f.CommonStock.Ticker,
+                LatestReportPeriodDate = f.ReportPeriodDate,
+                LatestFilingDate = f.FilingDate,
+                NetAssets = f.NetAssets,
+                TotalAssets = f.TotalAssets,
+                PositionCount = f.Holdings.Count(),
+            })
+            .ToListAsync(cancellationToken);
+
+        var fundTypeByStock = await LoadFundTypesByStock(dbContext, cancellationToken);
+
+        var computedAt = DateTime.UtcNow;
+        var rows = aggregates
+            .Where(a => a.CommonStockId != null || !string.IsNullOrEmpty(a.RegistrantCik))
+            .Select(a => BuildRow(a, fundTypeByStock, computedAt))
+            .ToList();
+
+        _logger.LogInformation("Rebuilding fund-series directory: {Count} series", rows.Count);
+
+        if (rows.Count > 0)
+        {
+            await dbContext
+                .Set<FundSeries>()
+                .UpsertRange(rows)
+                .On(s => s.IdentityKey)
+                .WhenMatched(
+                    (_, incoming) =>
+                        new FundSeries
+                        {
+                            Slug = incoming.Slug,
+                            CommonStockId = incoming.CommonStockId,
+                            RegistrantCik = incoming.RegistrantCik,
+                            SeriesId = incoming.SeriesId,
+                            SeriesName = incoming.SeriesName,
+                            RegistrantName = incoming.RegistrantName,
+                            Ticker = incoming.Ticker,
+                            LatestReportPeriodDate = incoming.LatestReportPeriodDate,
+                            LatestFilingDate = incoming.LatestFilingDate,
+                            NetAssets = incoming.NetAssets,
+                            TotalAssets = incoming.TotalAssets,
+                            PositionCount = incoming.PositionCount,
+                            FundType = incoming.FundType,
+                            ComputedAt = incoming.ComputedAt,
+                        }
+                )
+                .RunAsync(cancellationToken);
+        }
+
+        // Series no longer present (renamed away, dropped from the floor, deleted) keep their older
+        // ComputedAt and are pruned. With no series at all this deletes the whole table.
+        var deleted = await dbContext
+            .Set<FundSeries>()
+            .Where(s => s.ComputedAt < computedAt)
+            .ExecuteDeleteAsync(cancellationToken);
+        if (deleted > 0)
+        {
+            _logger.LogInformation("Pruned {Count} stale fund-series rows", deleted);
+        }
+    }
+
+    // Latest N-CEN registration type per tracked fund. N-CEN is filed only by tracked funds
+    // (keyed by CommonStockId), so trusts get no type. The table is small (annual filings), so it
+    // is read whole and folded in memory.
+    private static async Task<Dictionary<Guid, string>> LoadFundTypesByStock(
+        EquiblesFinancialDbContext dbContext,
+        CancellationToken cancellationToken
+    )
+    {
+        var ncen = await dbContext
+            .Set<NCenFiling>()
+            .Select(n => new
+            {
+                n.CommonStockId,
+                n.FilingDate,
+                n.InvestmentCompanyType,
+            })
+            .ToListAsync(cancellationToken);
+
+        return ncen.GroupBy(n => n.CommonStockId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderByDescending(n => n.FilingDate).First().InvestmentCompanyType
+            );
+    }
+
+    private static FundSeries BuildRow(
+        FundSeriesAggregate a,
+        Dictionary<Guid, string> fundTypeByStock,
+        DateTime computedAt
+    )
+    {
+        var seriesId = a.SeriesId ?? string.Empty;
+        var isTracked = a.CommonStockId != null;
+
+        var identityKey = isTracked ? $"cs:{a.CommonStockId}" : $"rc:{a.RegistrantCik}:{seriesId}";
+
+        var displayName = !string.IsNullOrWhiteSpace(a.SeriesName)
+            ? a.SeriesName
+            : a.RegistrantName;
+
+        var discriminator = isTracked
+            ? (!string.IsNullOrEmpty(a.Ticker) ? a.Ticker : a.CommonStockId.ToString())
+            : (!string.IsNullOrEmpty(seriesId) ? seriesId : $"cik{a.RegistrantCik}");
+
+        string fundType = null;
+        if (isTracked)
+        {
+            fundTypeByStock.TryGetValue(a.CommonStockId.Value, out fundType);
+        }
+
+        return new FundSeries
+        {
+            IdentityKey = identityKey,
+            Slug = BuildSlug(displayName, discriminator),
+            CommonStockId = a.CommonStockId,
+            RegistrantCik = a.RegistrantCik,
+            SeriesId = seriesId,
+            SeriesName = a.SeriesName,
+            RegistrantName = a.RegistrantName,
+            Ticker = a.Ticker,
+            LatestReportPeriodDate = a.LatestReportPeriodDate,
+            LatestFilingDate = a.LatestFilingDate,
+            NetAssets = a.NetAssets,
+            TotalAssets = a.TotalAssets,
+            PositionCount = a.PositionCount,
+            FundType = fundType,
+            ComputedAt = computedAt,
+        };
+    }
+
+    // "{name-slug}-{discriminator}". The discriminator (unique per series) is preserved whole; only
+    // the name part is trimmed to fit, so the slug stays unique under truncation.
+    private static string BuildSlug(string name, string discriminator)
+    {
+        var disc = Slugify(discriminator);
+        var baseSlug = Slugify(name);
+
+        var room = MaxSlugLength - disc.Length - 1;
+        if (room <= 0)
+        {
+            return disc.Length > MaxSlugLength ? disc[..MaxSlugLength] : disc;
+        }
+        if (baseSlug.Length > room)
+        {
+            baseSlug = baseSlug[..room].TrimEnd('-');
+        }
+        return string.IsNullOrEmpty(baseSlug) ? disc : $"{baseSlug}-{disc}";
+    }
+
+    private static string Slugify(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        var pendingDash = false;
+        foreach (var ch in value.ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                builder.Append(ch);
+                pendingDash = false;
+            }
+            else if (!pendingDash && builder.Length > 0)
+            {
+                builder.Append('-');
+                pendingDash = true;
+            }
+        }
+
+        return builder.ToString().TrimEnd('-');
+    }
+
+    private class FundSeriesAggregate
+    {
+        public Guid? CommonStockId { get; set; }
+        public string RegistrantCik { get; set; }
+        public string SeriesId { get; set; }
+        public string SeriesName { get; set; }
+        public string RegistrantName { get; set; }
+        public string Ticker { get; set; }
+        public DateOnly LatestReportPeriodDate { get; set; }
+        public DateOnly LatestFilingDate { get; set; }
+        public decimal NetAssets { get; set; }
+        public decimal TotalAssets { get; set; }
+        public int PositionCount { get; set; }
+    }
+}

--- a/src/Equibles.Sec.Repositories/FundSeriesRepository.cs
+++ b/src/Equibles.Sec.Repositories/FundSeriesRepository.cs
@@ -1,0 +1,21 @@
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Repositories;
+
+/// <summary>
+/// Reads the materialised fund directory (<see cref="FundSeries"/>). One row per registered-fund
+/// series, rebuilt by the refresh worker — these queries are plain indexed lookups, never the live
+/// "latest report per series" scan over <see cref="NportFiling"/>.
+/// </summary>
+public class FundSeriesRepository : BaseRepository<FundSeries>
+{
+    public FundSeriesRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    /// <summary>The series with the given route slug (empty result when unknown).</summary>
+    public IQueryable<FundSeries> GetBySlug(string slug)
+    {
+        return GetAll().Where(s => s.Slug == slug);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
@@ -1,0 +1,332 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Contract for <see cref="FundSeriesRefreshService"/>: after <c>RebuildAllAsync</c> the
+/// <see cref="FundSeries"/> directory holds one row per series taken from that series' latest NPORT
+/// report — tracked funds keyed by stock, sweep-discovered trusts keyed by registrant CIK + series
+/// id — with the report-header totals, the stored-holdings count, the N-CEN type when on record,
+/// and a unique route slug. Superseded reports never linger; rows the run doesn't touch are pruned.
+/// Exercised against ParadeDB because the service writes through FlexLabs <c>UpsertRange</c> and
+/// <c>ExecuteDeleteAsync</c>, neither of which the in-memory provider supports.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FundSeriesRefreshServiceTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public FundSeriesRefreshServiceTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private FundSeriesRefreshService BuildService()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(_ => CreateScopeFromFixture());
+        return new FundSeriesRefreshService(
+            scopeFactory,
+            NullLogger<FundSeriesRefreshService>.Instance
+        );
+    }
+
+    // Each scope hands out a fresh context plus a repository bound to the same context, mirroring
+    // how the worker resolves both from its request scope.
+    private IServiceScope CreateScopeFromFixture()
+    {
+        var ctx = FreshContext();
+        var scope = Substitute.For<IServiceScope>();
+        var provider = Substitute.For<IServiceProvider>();
+        provider.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+        provider.GetService(typeof(NportFilingRepository)).Returns(new NportFilingRepository(ctx));
+        scope.ServiceProvider.Returns(provider);
+        return scope;
+    }
+
+    [Fact]
+    public async Task RebuildAll_MaterialisesTrackedAndTrustSeries_WithIdentityStatsAndSlug()
+    {
+        await using var seed = FreshContext();
+        var cef = await SeedStock(seed, "GAB", "0000038777");
+        var trackedFiling = MakeFiling(
+            commonStockId: cef.Id,
+            registrantCik: null,
+            accession: "0000038777-25-000001",
+            seriesId: "",
+            seriesName: null,
+            registrantName: "Gabelli Equity Trust",
+            reportPeriod: new DateOnly(2025, 3, 31),
+            netAssets: 1_000m,
+            totalAssets: 1_100m
+        );
+        AddHolding(trackedFiling, "037833100", 600m);
+        AddHolding(trackedFiling, "594918104", 400m);
+
+        var trustFiling = MakeFiling(
+            commonStockId: null,
+            registrantCik: "0001100663",
+            accession: "0001100663-25-000002",
+            seriesId: "S000002277",
+            seriesName: "iShares Russell 2000 ETF",
+            registrantName: "iShares Trust",
+            reportPeriod: new DateOnly(2025, 3, 31),
+            netAssets: 2_000m,
+            totalAssets: 2_050m
+        );
+        AddHolding(trustFiling, "037833100", 1_500m);
+
+        seed.AddRange(trackedFiling, trustFiling);
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildAllAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var tracked = await read.Set<FundSeries>().SingleAsync(s => s.CommonStockId == cef.Id);
+        tracked.IdentityKey.Should().Be($"cs:{cef.Id}");
+        tracked.Ticker.Should().Be("GAB");
+        tracked.Slug.Should().Be("gabelli-equity-trust-gab");
+        tracked.NetAssets.Should().Be(1_000m);
+        tracked.TotalAssets.Should().Be(1_100m);
+        tracked.PositionCount.Should().Be(2);
+        tracked.LatestReportPeriodDate.Should().Be(new DateOnly(2025, 3, 31));
+
+        var trust = await read.Set<FundSeries>().SingleAsync(s => s.RegistrantCik == "0001100663");
+        trust.IdentityKey.Should().Be("rc:0001100663:S000002277");
+        trust.SeriesId.Should().Be("S000002277");
+        trust.Ticker.Should().BeNull();
+        trust.Slug.Should().Be("ishares-russell-2000-etf-s000002277");
+        trust.NetAssets.Should().Be(2_000m);
+        trust.PositionCount.Should().Be(1, "only the tracked-CUSIP holding is stored for a trust");
+    }
+
+    [Fact]
+    public async Task RebuildAll_KeepsOnlyTheLatestReportPerSeries()
+    {
+        await using var seed = FreshContext();
+        var cef = await SeedStock(seed, "ECF", "0000123456");
+        var older = MakeFiling(
+            cef.Id,
+            null,
+            "0000123456-24-000001",
+            "",
+            null,
+            "Ellsworth Fund",
+            new DateOnly(2024, 12, 31),
+            netAssets: 500m,
+            totalAssets: 550m
+        );
+        AddHolding(older, "037833100", 500m);
+        var newer = MakeFiling(
+            cef.Id,
+            null,
+            "0000123456-25-000002",
+            "",
+            null,
+            "Ellsworth Fund",
+            new DateOnly(2025, 3, 31),
+            netAssets: 900m,
+            totalAssets: 950m
+        );
+        AddHolding(newer, "037833100", 450m);
+        AddHolding(newer, "594918104", 450m);
+        seed.AddRange(older, newer);
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildAllAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var row = await read.Set<FundSeries>().SingleAsync(s => s.CommonStockId == cef.Id);
+        row.NetAssets.Should().Be(900m, "the newest report wins");
+        row.PositionCount.Should().Be(2);
+        row.LatestReportPeriodDate.Should().Be(new DateOnly(2025, 3, 31));
+    }
+
+    [Fact]
+    public async Task RebuildAll_PopulatesFundType_FromLatestNCen()
+    {
+        await using var seed = FreshContext();
+        var cef = await SeedStock(seed, "GAB", "0000038777");
+        var filing = MakeFiling(
+            cef.Id,
+            null,
+            "0000038777-25-000001",
+            "",
+            null,
+            "Gabelli Equity Trust",
+            new DateOnly(2025, 3, 31),
+            netAssets: 1_000m,
+            totalAssets: 1_100m
+        );
+        AddHolding(filing, "037833100", 1_000m);
+        seed.Add(filing);
+        seed.Add(
+            new NCenFiling
+            {
+                Id = Guid.NewGuid(),
+                CommonStockId = cef.Id,
+                AccessionNumber = "0000038777-25-000099",
+                FilingDate = new DateOnly(2025, 2, 1),
+                RegistrantName = "Gabelli Equity Trust",
+                InvestmentCompanyType = "N-2",
+                ReportEndingPeriod = new DateOnly(2024, 12, 31),
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildAllAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var row = await read.Set<FundSeries>().SingleAsync(s => s.CommonStockId == cef.Id);
+        row.FundType.Should().Be("N-2");
+    }
+
+    [Fact]
+    public async Task RebuildAll_PrunesStaleRowsAndUpdatesExistingInPlace()
+    {
+        await using var seed = FreshContext();
+        var cef = await SeedStock(seed, "GAB", "0000038777");
+        var filing = MakeFiling(
+            cef.Id,
+            null,
+            "0000038777-25-000001",
+            "",
+            null,
+            "Gabelli Equity Trust",
+            new DateOnly(2025, 3, 31),
+            netAssets: 1_000m,
+            totalAssets: 1_100m
+        );
+        AddHolding(filing, "037833100", 1_000m);
+        seed.Add(filing);
+        // A stale directory row no NPORT filing resolves to, plus an outdated row for the series
+        // that still exists — the run must drop the first and overwrite the second.
+        seed.AddRange(
+            new FundSeries
+            {
+                IdentityKey = "rc:9999999999:S000099999",
+                Slug = "ghost-fund-s000099999",
+                RegistrantCik = "9999999999",
+                SeriesId = "S000099999",
+                SeriesName = "Ghost Fund",
+                RegistrantName = "Ghost Trust",
+                LatestReportPeriodDate = new DateOnly(2020, 1, 1),
+                LatestFilingDate = new DateOnly(2020, 1, 15),
+                NetAssets = 42m,
+                PositionCount = 1,
+                ComputedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            },
+            new FundSeries
+            {
+                IdentityKey = $"cs:{cef.Id}",
+                Slug = "stale-slug",
+                CommonStockId = cef.Id,
+                SeriesId = "",
+                SeriesName = "Gabelli Equity Trust",
+                RegistrantName = "Gabelli Equity Trust",
+                Ticker = "GAB",
+                LatestReportPeriodDate = new DateOnly(2024, 1, 1),
+                LatestFilingDate = new DateOnly(2024, 1, 15),
+                NetAssets = 1m,
+                PositionCount = 99,
+                ComputedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildAllAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var rows = await read.Set<FundSeries>().ToListAsync();
+        rows.Should().ContainSingle("the ghost row with no current filing is pruned");
+        rows[0].CommonStockId.Should().Be(cef.Id);
+        rows[0].NetAssets.Should().Be(1_000m, "the surviving row is overwritten with fresh stats");
+        rows[0].PositionCount.Should().Be(1);
+        rows[0].Slug.Should().Be("gabelli-equity-trust-gab");
+    }
+
+    private static async Task<CommonStock> SeedStock(
+        EquiblesFinancialDbContext ctx,
+        string ticker,
+        string cik
+    )
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = $"{ticker} Fund",
+            Cik = cik,
+        };
+        ctx.Add(stock);
+        await ctx.SaveChangesAsync();
+        return stock;
+    }
+
+    private static NportFiling MakeFiling(
+        Guid? commonStockId,
+        string registrantCik,
+        string accession,
+        string seriesId,
+        string seriesName,
+        string registrantName,
+        DateOnly reportPeriod,
+        decimal netAssets,
+        decimal totalAssets
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = commonStockId,
+            RegistrantCik = registrantCik,
+            AccessionNumber = accession,
+            FilingDate = reportPeriod.AddDays(30),
+            RegistrantName = registrantName,
+            SeriesName = seriesName,
+            SeriesId = seriesId,
+            ReportPeriodDate = reportPeriod,
+            ReportPeriodEnd = reportPeriod.AddMonths(9),
+            TotalAssets = totalAssets,
+            NetAssets = netAssets,
+        };
+
+    private static void AddHolding(NportFiling filing, string cusip, decimal valueUsd) =>
+        filing.Holdings.Add(
+            new NportHolding
+            {
+                Id = Guid.NewGuid(),
+                Cusip = cusip,
+                Name = cusip,
+                Balance = valueUsd,
+                Units = "NS",
+                Currency = "USD",
+                ValueUsd = valueUsd,
+                PayoffProfile = "Long",
+                AssetCategory = "EC",
+                IssuerCategory = "CORP",
+            }
+        );
+}


### PR DESCRIPTION
## Summary

Funds have no first-class entity — identity is implicit across `NportFiling` rows — so deriving a fund directory live would mean running the correlated "latest report per series" scan (`NportFilingRepository.GetLatestPerSeries`) on every request. This materialises one row per registered-fund series into a new `FundSeries` table, the same way `HolderQuarterlySnapshot` backs the institutions browse.

First slice of the commercial Funds & ETFs epic (daniel3303/EquiblesCommercial#4017 / #4019); the `/funds` index and per-fund profile that read this table land in later commercial slices.

## Code changes

- **`Equibles.Sec.Data/Models/FundSeries.cs`** — new entity: one row per series, keyed by a canonical `IdentityKey` (`cs:{CommonStockId}` for tracked funds, `rc:{RegistrantCik}:{SeriesId}` for sweep-discovered trusts) with a unique route `Slug`, the report-header totals, stored-holdings count, and N-CEN registration type. Registered in `SecModuleConfiguration`.
- **`Equibles.Sec.Repositories/FundSeriesRepository.cs`** — read access (`GetBySlug`).
- **`Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs`** — rebuilds the whole directory from `GetLatestPerSeries`: FlexLabs `UpsertRange` on `IdentityKey`, stale rows pruned by a `ComputedAt` watermark. Floor-agnostic — the read side applies its own data-sync floor.
- **`Equibles.Sec.HostedService/FundSeriesRefreshWorker.cs`** — daily full rebuild (funds report monthly, no per-filing dirty signal needed). Registered in `AddSecWorker`.
- **`Equibles.Migrations`** — `AddFundSeries` (financial context): the table + unique indexes on `IdentityKey` and `Slug`.
- **Tests** — `FundSeriesRefreshServiceTests` (ParadeDB): tracked + trust materialisation, latest-report-per-series, N-CEN type, stale-prune. 4/4 green.

For trust series the sweep stores only tracked-CUSIP holdings, so `PositionCount` counts positions in tracked stocks; `NetAssets`/`TotalAssets` are the fund's real totals from the report header regardless.
