### PR TITLE
feat(web): frosted-glass sticky navbar

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -19,7 +19,8 @@
     </a>
 
     <!-- Navbar -->
-    <header class="navbar bg-base-100 border-b border-base-200 min-h-0 h-14 sticky top-0 z-40">
+    @* Frosted-glass navbar: translucent base-100 (color-mix keeps the alpha — a plain `/70` opacity modifier is dropped on DaisyUI theme colors) over a backdrop blur. *@
+    <header class="navbar bg-[color-mix(in_oklab,var(--color-base-100)_72%,transparent)] backdrop-blur-lg backdrop-saturate-150 border-b border-base-200 min-h-0 h-14 sticky top-0 z-40">
         <div class="max-w-6xl mx-auto w-full px-6 flex items-center">
             <div class="flex-1 flex items-center gap-6">
                 <a asp-action="Index" asp-controller="Home" class="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Gives the site's sticky top navigation bar a frosted-glass treatment — content now blurs softly behind a translucent bar as it scrolls under, while the nav stays crisp and readable.

## Code changes

- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — the `<header>` navbar background goes from solid `bg-base-100` to a translucent `color-mix` of base-100 over `backdrop-blur-lg` + `backdrop-saturate-150`.
  - Used an explicit `color-mix(in oklab, var(--color-base-100) 72%, transparent)` rather than a `bg-base-100/70` opacity modifier: in this Tailwind v4 + DaisyUI v5 setup the `/opacity` modifier is dropped on theme colors (it compiles to the bare, fully-opaque `var(--color-base-100)`), which would defeat the glass.
  - No bundle changes — `wwwroot/dist` is rebuilt during the Docker image build (`npm ci` + `npm run build`); verified the new utilities compile and render correctly.