### PR TITLE
feat(funds): series-scoped NPORT queries + fund-directory MCP tools

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
@@ -1,0 +1,174 @@
+using System.ComponentModel;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Sec.Mcp.Tools;
+
+/// <summary>
+/// Browse the registered-fund directory built from SEC Form NPORT-P reports. Unlike
+/// <c>GetFundHoldings</c> (which is keyed by a fund's own ticker), these tools reach every fund
+/// series we ingest — including the big multi-series fund-family trusts (iShares, Vanguard,
+/// Fidelity) that have no ticker of their own — via the materialised fund directory.
+/// </summary>
+[McpServerToolType]
+public class FundDirectoryTools
+{
+    private readonly FundSeriesRepository _fundSeriesRepository;
+    private readonly NportFilingRepository _nportRepository;
+    private readonly McpToolRunner _runner;
+
+    public FundDirectoryTools(
+        FundSeriesRepository fundSeriesRepository,
+        NportFilingRepository nportRepository,
+        ErrorManager errorManager,
+        ILogger<FundDirectoryTools> logger
+    )
+    {
+        _fundSeriesRepository = fundSeriesRepository;
+        _nportRepository = nportRepository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "SearchFunds")]
+    [Description(
+        "Search the directory of registered investment companies (mutual funds and ETFs) that file SEC Form NPORT-P, by fund name, ticker or registrant. Returns each matching fund series with its profile id (use it with GetFundProfile), ticker (when the fund is itself listed), net assets, number of reported holdings and latest report date, largest funds first. Covers the large multi-series trusts (iShares, Vanguard, Fidelity) that have no ticker of their own."
+    )]
+    public Task<string> SearchFunds(
+        [Description(
+            "Fund name, ticker or registrant to search for (e.g., 'Russell 2000', 'iShares', 'VOO')"
+        )]
+            string query,
+        [Description(
+            "Maximum number of funds to return, largest by net assets first (default: 20)"
+        )]
+            int maxResults = 20
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                if (string.IsNullOrWhiteSpace(query))
+                    return "Provide a fund name, ticker or registrant to search for.";
+
+                var term = query.Trim().ToLower();
+                var matches = await _fundSeriesRepository
+                    .GetAll()
+                    .Where(f =>
+                        (f.SeriesName != null && f.SeriesName.ToLower().Contains(term))
+                        || (f.RegistrantName != null && f.RegistrantName.ToLower().Contains(term))
+                        || (f.Ticker != null && f.Ticker.ToLower().Contains(term))
+                    )
+                    .OrderByDescending(f => f.NetAssets)
+                    .Take(Math.Max(1, maxResults))
+                    .ToListAsync();
+
+                if (matches.Count == 0)
+                    return $"No registered funds match '{query}'.";
+
+                var result = MarkdownTable.Start(
+                    $"Registered funds matching '{query}', largest by net assets first ({matches.Count}):",
+                    "| Fund | Profile id | Ticker | Type | Net Assets (USD) | Holdings | Latest Report |",
+                    "|------|-----------|--------|------|------------------|----------|---------------|"
+                );
+
+                result.AppendRows(
+                    matches,
+                    f =>
+                        $"| {f.SeriesName ?? f.RegistrantName ?? "-"} | {f.Slug} | {f.Ticker ?? "-"} | {f.FundType ?? "-"} | ${FormatAmount(f.NetAssets)} | {f.PositionCount} | {f.LatestReportPeriodDate:yyyy-MM-dd} |"
+                );
+
+                return result.ToString();
+            },
+            "SearchFunds",
+            $"query: {query}"
+        );
+    }
+
+    [McpServerTool(Name = "GetFundProfile")]
+    [Description(
+        "Get a registered fund's profile and largest holdings from its most recent SEC Form NPORT-P report. Accepts a fund profile id from SearchFunds or a fund's own ticker. Returns the fund's registrant and series, reporting period, net and total assets, then its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value, share of net assets and asset category. For the large multi-series trusts only positions in tracked stocks are stored, so the holdings shown are the fund's tracked-stock positions; the net-asset totals are the fund's real totals."
+    )]
+    public Task<string> GetFundProfile(
+        [Description(
+            "Fund profile id from SearchFunds (e.g., 'ishares-russell-2000-etf-s000002277') or a fund ticker (e.g., 'VOO')"
+        )]
+            string fund,
+        [Description("Maximum number of holdings to return, largest first (default: 20)")]
+            int maxResults = 20
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                if (string.IsNullOrWhiteSpace(fund))
+                    return "Provide a fund profile id or ticker.";
+
+                var key = fund.Trim();
+                var lowerKey = key.ToLower();
+                var series = await _fundSeriesRepository
+                    .GetAll()
+                    .Where(f =>
+                        f.Slug == key || (f.Ticker != null && f.Ticker.ToLower() == lowerKey)
+                    )
+                    .OrderByDescending(f => f.NetAssets)
+                    .FirstOrDefaultAsync();
+
+                if (series == null)
+                    return $"No registered fund found for '{fund}'. Use SearchFunds to find a fund's profile id.";
+
+                var latest = await _nportRepository
+                    .GetSeriesReportsByPeriod(
+                        series.CommonStockId,
+                        series.RegistrantCik,
+                        series.SeriesId,
+                        DateOnly.MinValue
+                    )
+                    .Include(f => f.Holdings)
+                    .OrderByDescending(f => f.ReportPeriodDate)
+                    .FirstOrDefaultAsync();
+
+                if (latest == null)
+                    return $"No Form NPORT-P report is on record for {series.SeriesName ?? series.RegistrantName}.";
+
+                var holdings = latest
+                    .Holdings.OrderByDescending(h => h.ValueUsd)
+                    .Take(Math.Max(1, maxResults))
+                    .ToList();
+
+                var header =
+                    $"{series.SeriesName ?? series.RegistrantName}"
+                    + (series.Ticker != null ? $" ({series.Ticker})" : "")
+                    + $" — registrant {series.RegistrantName ?? "-"}, "
+                    + $"reported {latest.ReportPeriodDate:yyyy-MM-dd}, "
+                    + $"net assets ${FormatAmount(latest.NetAssets)}, total assets ${FormatAmount(latest.TotalAssets)}, "
+                    + $"{latest.Holdings.Count} holdings on record, showing the largest {holdings.Count}:";
+
+                var result = MarkdownTable.Start(
+                    header,
+                    "| Holding | CUSIP | Balance | Units | Value (USD) | % Net Assets | Category | Country |",
+                    "|---------|-------|---------|-------|-------------|--------------|----------|---------|"
+                );
+
+                result.AppendRows(
+                    holdings,
+                    h =>
+                        $"| {h.Name ?? "-"} | {h.Cusip ?? "-"} | {FormatAmount(h.Balance)} | {h.Units ?? "-"} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {h.AssetCategory ?? "-"} | {h.InvestmentCountry ?? "-"} |"
+                );
+
+                return result.ToString();
+            },
+            "GetFundProfile",
+            $"fund: {fund}"
+        );
+    }
+
+    private static string FormatAmount(decimal value) => McpFormat.Invariant(value, "N2");
+
+    private static string FormatPercent(decimal value) => McpFormat.Invariant(value, "N2") + "%";
+}

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -117,4 +117,64 @@ public class NportFilingRepository : BaseRepository<NportFiling>
             )
         );
     }
+
+    /// <summary>
+    /// All filings of a single fund series, identified the same way as <see cref="GetLatestPerSeries"/>
+    /// — a tracked fund by its <see cref="NportFiling.CommonStockId"/>, a sweep-discovered trust by
+    /// its <see cref="NportFiling.RegistrantCik"/>, never name text; an id-less filing belongs to the
+    /// registrant's single fund, so an empty <paramref name="seriesId"/> matches the id-less reports.
+    /// Pass the series' own <c>CommonStockId</c> (or null for a trust) and its <c>RegistrantCik</c>.
+    /// </summary>
+    public IQueryable<NportFiling> GetSeriesFilings(
+        Guid? commonStockId,
+        string registrantCik,
+        string seriesId
+    )
+    {
+        return GetAll()
+            .Where(f =>
+                (
+                    (commonStockId != null && f.CommonStockId == commonStockId)
+                    || (
+                        commonStockId == null
+                        && f.CommonStockId == null
+                        && f.RegistrantCik == registrantCik
+                    )
+                )
+                && (
+                    f.SeriesId == seriesId
+                    || (string.IsNullOrEmpty(f.SeriesId) && string.IsNullOrEmpty(seriesId))
+                )
+            );
+    }
+
+    /// <summary>
+    /// One report per reporting period for a single series: the latest filing of each
+    /// <see cref="NportFiling.ReportPeriodDate"/> on or after <paramref name="floor"/>, so an
+    /// amendment or re-file of a period collapses to the newest by filing date then accession
+    /// number. This is the per-period spine of a fund's history and current portfolio — order by
+    /// <c>ReportPeriodDate</c> for the time series, or take the greatest for the latest report.
+    /// </summary>
+    public IQueryable<NportFiling> GetSeriesReportsByPeriod(
+        Guid? commonStockId,
+        string registrantCik,
+        string seriesId,
+        DateOnly floor
+    )
+    {
+        var filings = GetSeriesFilings(commonStockId, registrantCik, seriesId)
+            .Where(f => f.ReportPeriodDate >= floor);
+        return filings.Where(f =>
+            !filings.Any(f2 =>
+                f2.ReportPeriodDate == f.ReportPeriodDate
+                && (
+                    f2.FilingDate > f.FilingDate
+                    || (
+                        f2.FilingDate == f.FilingDate
+                        && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+                    )
+                )
+            )
+        );
+    }
 }

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
@@ -460,4 +460,75 @@ public class NportFilingRepositoryTests : IDisposable
         unknownSeries.Should().BeFalse();
         unknownRegistrant.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task GetSeriesFilings_TrackedFund_ReturnsOnlyThatStocksSeries()
+    {
+        var voo = CreateStock("VOO", "0000036405");
+        var spy = CreateStock("SPY", "0000884394");
+        _dbContext.Set<CommonStock>().AddRange(voo, spy);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateFiling(voo.Id, "0000036405-24-000001"));
+        _repository.Add(CreateFiling(voo.Id, "0000036405-25-000002"));
+        _repository.Add(CreateFiling(spy.Id, "0000884394-24-000001"));
+        await _repository.SaveChanges();
+
+        var result = await _repository
+            .GetSeriesFilings(voo.Id, registrantCik: null, "S000002277")
+            .ToListAsync();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(f => f.CommonStockId == voo.Id);
+    }
+
+    [Fact]
+    public async Task GetSeriesFilings_TrustSeries_ScopedByRegistrantAndSeries()
+    {
+        _repository.Add(CreateTrustFiling("36405", "0000036405-25-000001", seriesId: "S000002277"));
+        _repository.Add(CreateTrustFiling("36405", "0000036405-25-000002", seriesId: "S000009999"));
+        await _repository.SaveChanges();
+
+        var result = await _repository
+            .GetSeriesFilings(commonStockId: null, "36405", "S000002277")
+            .ToListAsync();
+
+        result.Should().ContainSingle().Which.SeriesId.Should().Be("S000002277");
+    }
+
+    // A period's amendment or re-file must collapse to the single newest filing, so a fund's
+    // history and current portfolio never double-count a restated month.
+    [Fact]
+    public async Task GetSeriesReportsByPeriod_CollapsesAmendmentsToTheLatestFilingPerPeriod()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var q1Original = CreateFiling(stock.Id, "0000036405-25-000001", new DateOnly(2025, 2, 10));
+        q1Original.ReportPeriodDate = new DateOnly(2025, 1, 31);
+        var q1Amendment = CreateFiling(stock.Id, "0000036405-25-000002", new DateOnly(2025, 3, 15));
+        q1Amendment.ReportPeriodDate = new DateOnly(2025, 1, 31);
+        var q2 = CreateFiling(stock.Id, "0000036405-25-000003", new DateOnly(2025, 3, 12));
+        q2.ReportPeriodDate = new DateOnly(2025, 2, 28);
+        var belowFloor = CreateFiling(stock.Id, "0000036405-24-000004", new DateOnly(2024, 12, 10));
+        belowFloor.ReportPeriodDate = new DateOnly(2024, 11, 30);
+        _repository.Add(q1Original);
+        _repository.Add(q1Amendment);
+        _repository.Add(q2);
+        _repository.Add(belowFloor);
+        await _repository.SaveChanges();
+
+        var result = await _repository
+            .GetSeriesReportsByPeriod(stock.Id, null, "S000002277", new DateOnly(2025, 1, 1))
+            .ToListAsync();
+
+        result.Should().HaveCount(2, "one report per period above the floor");
+        result
+            .Should()
+            .ContainSingle(f => f.ReportPeriodDate == new DateOnly(2025, 1, 31))
+            .Which.Id.Should()
+            .Be(q1Amendment.Id, "the later-filed amendment wins its period");
+        result.Select(f => f.Id).Should().NotContain(belowFloor.Id);
+    }
 }

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -409,6 +409,8 @@ public class McpModuleToolDiscoveryTests
                     "GetFundOperations",
                     "GetFundHoldings",
                     "GetFundsHoldingStock",
+                    "SearchFunds",
+                    "GetFundProfile",
                     "SearchInvestmentAdvisers",
                     "GetInvestmentAdviser",
                 }


### PR DESCRIPTION
## Summary

Second OSS slice of the Funds & ETFs epic (daniel3303/EquiblesCommercial#4017). Adds the series-scoped NPORT query spine that the per-fund profile and per-stock position history read, and exposes the fund directory over MCP. Builds on the `FundSeries` table from #3770.

## Code changes

- **`NportFilingRepository`** — two query methods, identified the same way as `GetLatestPerSeries` (tracked stock or registrant+series, never name):
  - `GetSeriesFilings(commonStockId, registrantCik, seriesId)` — all filings of one series.
  - `GetSeriesReportsByPeriod(...)` — one report per period, the newest filing of each `ReportPeriodDate` (amendments/re-files collapse), the spine of a fund's history and current portfolio.
- **`FundDirectoryTools`** (new MCP tool type, auto-discovered by the Sec assembly scan):
  - `SearchFunds(query, maxResults)` — search the `FundSeries` directory by name/ticker/registrant.
  - `GetFundProfile(fund, maxResults)` — a fund's profile + largest holdings from its latest report, accepts a profile slug or a ticker.
- **Tests** — `NportFilingRepositoryTests` (+3): series scoping for tracked + trust, and amendment-collapse-per-period above the floor (15/15 green). `McpModuleTests` tool-list pin updated with the two new tools (10/10 green).
