### PR TITLE
fix(holdings): exclude Schedule 13D/G from institution portfolio summaries

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -772,10 +772,12 @@ public class InstitutionalHoldingsTools
                 var previousDate = GetPriorReportDate(reportDates, targetDate);
 
                 var currentHoldings = await _holdingRepository
-                    .GetByHolder(holder, targetDate)
+                    .Get13FByHolder(holder, targetDate)
                     .ToListAsync();
                 var previousHoldings = previousDate.HasValue
-                    ? await _holdingRepository.GetByHolder(holder, previousDate.Value).ToListAsync()
+                    ? await _holdingRepository
+                        .Get13FByHolder(holder, previousDate.Value)
+                        .ToListAsync()
                     : [];
                 var summary = InstitutionPortfolioSummaryCalculator.Calculate(
                     currentHoldings,
@@ -879,7 +881,7 @@ public class InstitutionalHoldingsTools
                     return error;
 
                 var holdings = await _holdingRepository
-                    .GetByHolder(holder, targetDate)
+                    .Get13FByHolder(holder, targetDate)
                     .Include(h => h.CommonStock)
                         .ThenInclude(s => s.Industry)
                     .ToListAsync();

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -48,6 +48,18 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return GetByHolder(holder, reportDate).Include(h => h.CommonStock);
     }
 
+    // 13F-only holdings for one holder at a quarter end. A holder can file a Schedule 13D/G
+    // whose event ReportDate coincides with a 13F quarter end; that stake shares this table
+    // but is not part of the 13F portfolio, so a portfolio summary (reported AUM, sector
+    // allocation) must exclude it or the single disclosed position double-counts the AUM.
+    public IQueryable<InstitutionalHolding> Get13FByHolder(
+        InstitutionalHolder holder,
+        DateOnly reportDate
+    )
+    {
+        return GetByHolder(holder, reportDate).Where(h => h.FilingType == FilingType.Form13F);
+    }
+
     public IQueryable<InstitutionalHolding> GetLatestByStock(CommonStock stock)
     {
         var latestDates = GetAll()

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
@@ -142,6 +142,60 @@ public class InstitutionalHoldingsToolsGetInstitutionSummaryTests : ParadeDbMcpT
         output.Should().NotContain("BlackRock Advisors");
     }
 
+    [Fact]
+    public async Task GetInstitutionSummary_Schedule13GAtSame13FQuarter_ExcludesItFromReportedAum()
+    {
+        // A holder can file a Schedule 13G whose event date lands on a 13F quarter end. That
+        // single disclosed stake shares the holdings table but is not part of the 13F
+        // portfolio — reported AUM and position count must reflect the 13F holdings only,
+        // never the 13F + 13G sum that doubled cross-filing holders' AUM (GH-3929).
+        var apple = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var tesla = new CommonStock
+        {
+            Ticker = "TSLA",
+            Name = "Tesla Inc.",
+            Cik = "0001318605",
+        };
+        var holder = new InstitutionalHolder { Cik = "00090001", Name = "Crossfiling Capital" };
+        DbContext.AddRange(apple, tesla, holder);
+        var quarterEnd = new DateOnly(2026, 3, 31);
+        // The real 13F portfolio: one position worth $1,000,000.
+        DbContext.Add(MakeHolding(apple, holder, quarterEnd, shares: 1_000, value: 1_000_000));
+        // A Schedule 13G stake reported at the same quarter end and worth far more — summing
+        // it would inflate the AUM and add a phantom second position.
+        DbContext.Add(
+            new InstitutionalHolding
+            {
+                CommonStockId = tesla.Id,
+                InstitutionalHolderId = holder.Id,
+                FilingDate = quarterEnd.AddDays(45),
+                ReportDate = quarterEnd,
+                FilingType = FilingType.Schedule13G,
+                Shares = 5_000,
+                Value = 9_000_000,
+                ShareType = ShareType.Shares,
+                InvestmentDiscretion = InvestmentDiscretion.Sole,
+                AccessionNumber = "acc-13g-tsla",
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionSummary("Crossfiling Capital");
+
+        output.Should().Contain("| Reported AUM | $1,000,000 |");
+        output.Should().Contain("| # Positions | 1 |");
+        output.Should().NotContain("10,000,000");
+    }
+
     private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesFinancialDbContext ctx) =>
         new(
             new InstitutionalHoldingRepository(ctx),


### PR DESCRIPTION
## Summary

Follow-up to #3769. That change made the holder-portfolio report-date resolution 13F-only, but `GetInstitutionSummary` and `GetInstitutionSectorAllocation` still summed the holder's holdings across **all** filing types at the resolved date. A holder that files a Schedule 13G whose event `ReportDate` coincides with a 13F quarter end — e.g. Vanguard Capital Management LLC at 2026-03-31 — had that single disclosed stake added to its 13F portfolio, so the reported AUM roughly doubled (≈$8.1T vs the real ≈$3.9T) and the position count was inflated. The materialised quarterly snapshot and the Top-by-AUM list are already 13F-only, so the summary tool contradicted them.

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — add `Get13FByHolder(holder, reportDate)`, the 13F-only companion to `GetByHolder` (mirrors the existing `Get13FHistoryByHolder` / `Get13FReportDatesByHolder` pattern).
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — `GetInstitutionSummary` (current + prior quarter) and `GetInstitutionSectorAllocation` now pull holdings via `Get13FByHolder`, so a 13D/G stake sharing the quarter-end date no longer enters the portfolio aggregate.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs` — new regression test seeding a 13F position plus a Schedule 13G stake at the same quarter end; asserts the reported AUM and position count reflect the 13F holding only. Fails on the old code (renders `$10,000,000` / `2` positions), passes after the fix.

Two pre-existing failures in the integration suite (`CboeToolsTests.GetPutCallRatios_NullVolumes_RenderEmDash`, `RagSearchToolsTests.SearchDocuments_NegativeMaxResults_DoesNotSurfaceInternalError`) are unrelated to this change (different modules) and present on `main` before it.