### PR TITLE
fix(financial-facts): return the discrete quarter, not YTD, from GetFinancialFact

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -28,6 +28,15 @@ public class FinancialFactsTools
     private const int MaxResultsCap = 200;
     private const int MaxTickers = 25;
 
+    // A 10-Q tags each flow line twice under the same fiscal (year, period): the
+    // discrete three-month quarter and the fiscal year-to-date (6 months at Q2,
+    // 9 at Q3). A quarterly query must surface the discrete quarter, so prefer a
+    // duration spanning at most one quarter; the annual period symmetrically
+    // prefers a full-year span. The longest a discrete quarter runs (14-week
+    // 4-4-5 quarter, with headroom) and the shortest a fiscal year runs (52 weeks).
+    private const int MaxDiscreteQuarterDays = 100;
+    private const int MinAnnualSpanDays = 350;
+
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
@@ -339,7 +348,29 @@ public class FinancialFactsTools
         bool asOriginallyReported = false
     )
     {
-        var byPriority = facts.OrderBy(f => conceptPriority[f.FinancialConceptId]);
+        var candidates = facts.ToList();
+
+        // Prefer the fact whose duration matches the fiscal period's granularity, so a
+        // quarter reads as the discrete three months and never the year-to-date total a
+        // 10-Q tags under the same fiscal Q2/Q3 (the financials tab handles this in
+        // FinancialStatementsHelper.PickCurrentlyReportedFact). Instants (balance sheet,
+        // zero span) always qualify; if nothing matches the span, keep every candidate.
+        var fiscalPeriod = candidates[0].FiscalPeriod;
+        var preferredSpan = candidates
+            .Where(f =>
+            {
+                if (f.PeriodType != FactPeriodType.Duration)
+                    return true;
+                var spanDays = f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber;
+                return fiscalPeriod == SecFiscalPeriod.FullYear
+                    ? spanDays >= MinAnnualSpanDays
+                    : spanDays <= MaxDiscreteQuarterDays;
+            })
+            .ToList();
+        if (preferredSpan.Count > 0)
+            candidates = preferredSpan;
+
+        var byPriority = candidates.OrderBy(f => conceptPriority[f.FinancialConceptId]);
         return asOriginallyReported
             ? byPriority.ThenBy(f => f.FiledDate).ThenBy(f => f.AccessionNumber).First()
             : byPriority

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
+{
+    // A 10-Q tags each flow line twice under the same fiscal (year, period): the discrete
+    // three-month quarter and the fiscal year-to-date (six months at Q2). For a quarterly
+    // query the discrete figure must win — surfacing the YTD makes Q2 read as the H1 total
+    // (GOOGL Q2 2025 revenue = $186.7B H1, not the $96.4B quarter). Both candidates share the
+    // same filing date and accession (one filing), so without a span preference the filed-date
+    // tiebreak is a wash and input order decides; the YTD is listed first here to pin that the
+    // pick is the discrete quarter, not whichever happens to come first.
+    [Fact]
+    public void PickBestFact_QuarterGroupWithYtdAndDiscrete_PicksDiscreteQuarter()
+    {
+        var stockId = Guid.NewGuid();
+        var conceptId = Guid.NewGuid();
+        var yearToDate = MakeFact(
+            stockId,
+            conceptId,
+            value: 186_662m,
+            periodStart: new DateOnly(2025, 1, 1),
+            periodEnd: new DateOnly(2025, 6, 30)
+        );
+        var discreteQuarter = MakeFact(
+            stockId,
+            conceptId,
+            value: 96_428m,
+            periodStart: new DateOnly(2025, 4, 1),
+            periodEnd: new DateOnly(2025, 6, 30)
+        );
+        var conceptPriority = new Dictionary<Guid, int> { [conceptId] = 0 };
+
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "PickBestFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (FinancialFact)
+            method!.Invoke(null, [new[] { yearToDate, discreteQuarter }, conceptPriority, false]);
+
+        result.Value.Should().Be(96_428m, "the discrete quarter wins over the year-to-date span");
+    }
+
+    private static FinancialFact MakeFact(
+        Guid stockId,
+        Guid conceptId,
+        decimal value,
+        DateOnly periodStart,
+        DateOnly periodEnd
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            FinancialConceptId = conceptId,
+            Value = value,
+            Unit = "USD",
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            FiscalYear = 2025,
+            FiscalPeriod = SecFiscalPeriod.Q2,
+            PeriodType = FactPeriodType.Duration,
+            Form = DocumentType.TenQ,
+            FiledDate = new DateOnly(2025, 7, 24),
+            AccessionNumber = "0001652044-25-000062",
+        };
+}


### PR DESCRIPTION
## Summary

- `GetFinancialFact` grouped a concept's facts by `(FiscalYear, FiscalPeriod)` and picked by tag priority then filing date, with no preference for the duration span. A 10-Q tags each flow line twice under the same fiscal Q2/Q3 — the discrete three-month quarter and the fiscal year-to-date — so the year-to-date figure could win and a quarter read as the cumulative total.
- Confirmed on GOOGL: `GetFinancialFact(GOOGL, revenue, 10-Q)` returned Q2 2025 = $186,662M (= Q1 $90,234M + the $96,428M discrete quarter = the H1 total) and Q3 = $289,007M (nine months). The Financials tab shows the correct discrete $96,428M.
- Applies the same discrete-quarter / full-year span preference the tab already uses in `FinancialStatementsHelper.PickCurrentlyReportedFact` (the closed #1538) to `PickBestFact`. Instant (balance-sheet) concepts are unaffected; when no span matches, every candidate is kept (existing behaviour).

This is the open-source half of the fix for the commercial bug (Refs daniel3303/EquiblesCommercial#4038).

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — `PickBestFact` prefers the duration matching the fiscal period's granularity before the priority / filed-date tiebreak.
- `tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs` — a Q2 group with a discrete and a YTD fact (same filing) returns the discrete quarter.