### PR TITLE
fix(revenue-breakdown): keep operating-segment-qualified facts on the segment axis

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -36,6 +36,14 @@ public class RevenueBreakdownTools
     ];
     private static readonly string[] AllAxes = [.. SegmentAxes, .. GeographyAxes, .. ProductAxes];
 
+    // srt:ConsolidationItemsAxis = us-gaap:OperatingSegmentsMember is a transparent
+    // qualifier ("this figure is a pure operating-segment total"), not a second slice of
+    // the value. A fact carrying it alongside one real axis still partitions total revenue,
+    // so it must not be discarded as a cross-cut. Issuers such as Apple tag every operating
+    // segment this way from FY2025 on, which otherwise drops the latest fiscal year (#3628).
+    private const string ConsolidationItemsAxis = "srt:ConsolidationItemsAxis";
+    private const string OperatingSegmentsMember = "us-gaap:OperatingSegmentsMember";
+
     // The shortest span a fiscal year can cover — 52 weeks on a 52/53-week calendar with
     // headroom for short transition years (mirrors FinancialStatementsHelper).
     private const int MinAnnualSpanDays = 350;
@@ -100,6 +108,8 @@ public class RevenueBreakdownTools
                 // Annual revenue facts carrying exactly one dimension on a known axis.
                 // Cross-cut facts (e.g. segment × geography) are excluded — including
                 // them in a single-axis mix would double-count the revenue they slice.
+                // The OperatingSegments qualifier (see above) is the one allowed extra
+                // dimension: it tags the fact as a pure segment total without slicing it.
                 var rows = await _financialFactRepository
                     .GetByStock(stock)
                     .Where(f =>
@@ -107,12 +117,18 @@ public class RevenueBreakdownTools
                         && f.PeriodType == FactPeriodType.Duration
                         && f.PeriodStart.AddDays(MinAnnualSpanDays) <= f.PeriodEnd
                         && f.DimensionsKey != ""
-                        && f.Dimensions.Count == 1
-                        && AllAxes.Contains(f.Dimensions.First().Axis)
+                        && f.Dimensions.Count(d => AllAxes.Contains(d.Axis)) == 1
+                        && f.Dimensions.All(d =>
+                            AllAxes.Contains(d.Axis)
+                            || (
+                                d.Axis == ConsolidationItemsAxis
+                                && d.Member == OperatingSegmentsMember
+                            )
+                        )
                     )
                     .Select(f => new DimensionalRevenueRow(
-                        f.Dimensions.First().Axis,
-                        f.Dimensions.First().Member,
+                        f.Dimensions.First(d => AllAxes.Contains(d.Axis)).Axis,
+                        f.Dimensions.First(d => AllAxes.Contains(d.Axis)).Member,
                         f.PeriodEnd,
                         f.Value,
                         f.Unit,

--- a/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsTests.cs
@@ -1,0 +1,171 @@
+using System.Security.Cryptography;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Repositories;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class RevenueBreakdownToolsTests : ParadeDbMcpTestBase
+{
+    public RevenueBreakdownToolsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private RevenueBreakdownTools Sut() =>
+        new(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<RevenueBreakdownTools>()
+        );
+
+    private FinancialConcept AddConcept(string tag)
+    {
+        var c = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = tag,
+            Label = tag,
+        };
+        DbContext.Set<FinancialConcept>().Add(c);
+        return c;
+    }
+
+    private void AddDimensionalFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        int fy,
+        decimal value,
+        DateOnly filed,
+        params (string Axis, string Member)[] dimensions
+    )
+    {
+        var fact = new FinancialFact
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Unit = "USD",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = new DateOnly(fy, 1, 1),
+            PeriodEnd = new DateOnly(fy, 12, 31),
+            Value = value,
+            FiscalYear = fy,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenK,
+            FiledDate = filed,
+            AccessionNumber = $"acc-{Guid.NewGuid():N}"[..20],
+            // Production stores the SHA-256 of the ordinal-sorted dimensions (varchar(64)),
+            // not the raw QName pairs; mirror that so the value fits the column.
+            DimensionsKey = DimensionsKeyOf(dimensions),
+        };
+        foreach (var (axis, member) in dimensions)
+        {
+            fact.Dimensions.Add(
+                new FinancialFactDimension
+                {
+                    FinancialFactId = fact.Id,
+                    Axis = axis,
+                    Member = member,
+                }
+            );
+        }
+        DbContext.Set<FinancialFact>().Add(fact);
+    }
+
+    private static string DimensionsKeyOf((string Axis, string Member)[] dimensions)
+    {
+        var canonical = string.Join(
+            "|",
+            dimensions
+                .OrderBy(d => d.Axis)
+                .ThenBy(d => d.Member)
+                .Select(d => $"{d.Axis}={d.Member}")
+        );
+        return Convert
+            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)))
+            .ToLowerInvariant();
+    }
+
+    // Issuers like Apple tag operating-segment revenue with the srt:ConsolidationItemsAxis
+    // qualifier from FY2025 on (segment × ConsolidationItems=OperatingSegments). The single-
+    // dimension filter used to drop those facts, so the latest fiscal year vanished from the
+    // segment axis (#3628). The qualifier must count as a single-axis segment cut, while any
+    // other ConsolidationItems member (corporate, eliminations) stays excluded.
+    [Fact]
+    public async Task GetRevenueBreakdown_OperatingSegmentsQualifier_SurfacesLatestYear()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "OPSEG",
+            Name = "Operating Segments Corp.",
+            Cik = "0009830003",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        var asc606 = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
+
+        // FY2024 — Cloud reported single-axis (old-style filing).
+        AddDimensionalFact(
+            stock,
+            asc606,
+            2024,
+            100m,
+            new DateOnly(2025, 2, 1),
+            ("us-gaap:StatementBusinessSegmentsAxis", "opseg:CloudMember")
+        );
+        // FY2025 — operating segments carry the OperatingSegments qualifier.
+        AddDimensionalFact(
+            stock,
+            asc606,
+            2025,
+            130m,
+            new DateOnly(2026, 2, 1),
+            ("us-gaap:StatementBusinessSegmentsAxis", "opseg:CloudMember"),
+            ("srt:ConsolidationItemsAxis", "us-gaap:OperatingSegmentsMember")
+        );
+        AddDimensionalFact(
+            stock,
+            asc606,
+            2025,
+            70m,
+            new DateOnly(2026, 2, 1),
+            ("us-gaap:StatementBusinessSegmentsAxis", "opseg:HardwareMember"),
+            ("srt:ConsolidationItemsAxis", "us-gaap:OperatingSegmentsMember")
+        );
+        // FY2025 — a corporate/non-segment cut on the same axis must never surface.
+        AddDimensionalFact(
+            stock,
+            asc606,
+            2025,
+            25m,
+            new DateOnly(2026, 2, 1),
+            ("us-gaap:StatementBusinessSegmentsAxis", "opseg:CorporateMember"),
+            ("srt:ConsolidationItemsAxis", "us-gaap:CorporateNonSegmentMember")
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("OPSEG");
+
+        result.Should().Contain("By segment");
+        result
+            .Should()
+            .Contain(
+                "2025-12-31",
+                "the OperatingSegments-qualified FY2025 facts surface on the segment axis"
+            );
+        result.Should().Contain("Cloud");
+        result.Should().Contain("Hardware");
+        result
+            .Should()
+            .NotContain("Corporate", "the corporate/non-segment cut is not an operating segment");
+    }
+}


### PR DESCRIPTION
## Summary

The dimensional revenue breakdown (`GetRevenueBreakdown` and the per-stock Revenue Breakdown surface) accepted only facts carrying **exactly one** dimension. Operating-segment revenue tagged as `(segment axis × srt:ConsolidationItemsAxis = us-gaap:OperatingSegmentsMember)` was therefore dropped as a cross-cut.

That `ConsolidationItemsAxis = OperatingSegmentsMember` is a transparent qualifier — it marks the figure as a pure operating-segment total without slicing the value, so the fact still partitions total revenue. Issuers such as Apple tag every operating segment this way from FY2025 on, so the latest fiscal year silently vanished from the **By segment** axis while geography/product (still single-axis) kept reaching it.

Verified against production data: under the new logic Apple's segment axis reconciles exactly to consolidated total revenue (FY2025 = 5 members = $416,161M, previously missing; FY2024 = 5 members = $391,035M).

## Code changes

- `RevenueBreakdownTools.GetRevenueBreakdown` — accept a fact when exactly one dimension is a tracked segment/geography/product axis and every other dimension is the OperatingSegments qualifier; project that substantive dimension. Cross-cut facts (two real axes) and other ConsolidationItems members (eliminations, corporate) stay excluded.
- New `RevenueBreakdownToolsTests` integration test (real ParadeDB) pinning that an OperatingSegments-qualified fact surfaces as a single-axis segment cut while a corporate/non-segment cut does not.