### PR TITLE
test(funds): pin BuildSlug length cap keeps the discriminator

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -28,6 +28,15 @@ public class FinancialFactsTools
     private const int MaxResultsCap = 200;
     private const int MaxTickers = 25;
 
+    // A 10-Q tags each flow line twice under the same fiscal (year, period): the
+    // discrete three-month quarter and the fiscal year-to-date (6 months at Q2,
+    // 9 at Q3). A quarterly query must surface the discrete quarter, so prefer a
+    // duration spanning at most one quarter; the annual period symmetrically
+    // prefers a full-year span. The longest a discrete quarter runs (14-week
+    // 4-4-5 quarter, with headroom) and the shortest a fiscal year runs (52 weeks).
+    private const int MaxDiscreteQuarterDays = 100;
+    private const int MinAnnualSpanDays = 350;
+
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
@@ -339,7 +348,29 @@ public class FinancialFactsTools
         bool asOriginallyReported = false
     )
     {
-        var byPriority = facts.OrderBy(f => conceptPriority[f.FinancialConceptId]);
+        var candidates = facts.ToList();
+
+        // Prefer the fact whose duration matches the fiscal period's granularity, so a
+        // quarter reads as the discrete three months and never the year-to-date total a
+        // 10-Q tags under the same fiscal Q2/Q3 (the financials tab handles this in
+        // FinancialStatementsHelper.PickCurrentlyReportedFact). Instants (balance sheet,
+        // zero span) always qualify; if nothing matches the span, keep every candidate.
+        var fiscalPeriod = candidates[0].FiscalPeriod;
+        var preferredSpan = candidates
+            .Where(f =>
+            {
+                if (f.PeriodType != FactPeriodType.Duration)
+                    return true;
+                var spanDays = f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber;
+                return fiscalPeriod == SecFiscalPeriod.FullYear
+                    ? spanDays >= MinAnnualSpanDays
+                    : spanDays <= MaxDiscreteQuarterDays;
+            })
+            .ToList();
+        if (preferredSpan.Count > 0)
+            candidates = preferredSpan;
+
+        var byPriority = candidates.OrderBy(f => conceptPriority[f.FinancialConceptId]);
         return asOriginallyReported
             ? byPriority.ThenBy(f => f.FiledDate).ThenBy(f => f.AccessionNumber).First()
             : byPriority

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
+{
+    // A 10-Q tags each flow line twice under the same fiscal (year, period): the discrete
+    // three-month quarter and the fiscal year-to-date (six months at Q2). For a quarterly
+    // query the discrete figure must win — surfacing the YTD makes Q2 read as the H1 total
+    // (GOOGL Q2 2025 revenue = $186.7B H1, not the $96.4B quarter). Both candidates share the
+    // same filing date and accession (one filing), so without a span preference the filed-date
+    // tiebreak is a wash and input order decides; the YTD is listed first here to pin that the
+    // pick is the discrete quarter, not whichever happens to come first.
+    [Fact]
+    public void PickBestFact_QuarterGroupWithYtdAndDiscrete_PicksDiscreteQuarter()
+    {
+        var stockId = Guid.NewGuid();
+        var conceptId = Guid.NewGuid();
+        var yearToDate = MakeFact(
+            stockId,
+            conceptId,
+            value: 186_662m,
+            periodStart: new DateOnly(2025, 1, 1),
+            periodEnd: new DateOnly(2025, 6, 30)
+        );
+        var discreteQuarter = MakeFact(
+            stockId,
+            conceptId,
+            value: 96_428m,
+            periodStart: new DateOnly(2025, 4, 1),
+            periodEnd: new DateOnly(2025, 6, 30)
+        );
+        var conceptPriority = new Dictionary<Guid, int> { [conceptId] = 0 };
+
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "PickBestFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (FinancialFact)
+            method!.Invoke(null, [new[] { yearToDate, discreteQuarter }, conceptPriority, false]);
+
+        result.Value.Should().Be(96_428m, "the discrete quarter wins over the year-to-date span");
+    }
+
+    private static FinancialFact MakeFact(
+        Guid stockId,
+        Guid conceptId,
+        decimal value,
+        DateOnly periodStart,
+        DateOnly periodEnd
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            FinancialConceptId = conceptId,
+            Value = value,
+            Unit = "USD",
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            FiscalYear = 2025,
+            FiscalPeriod = SecFiscalPeriod.Q2,
+            PeriodType = FactPeriodType.Duration,
+            Form = DocumentType.TenQ,
+            FiledDate = new DateOnly(2025, 7, 24),
+            AccessionNumber = "0001652044-25-000062",
+        };
+}

--- a/tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceBuildSlugLengthCapTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceBuildSlugLengthCapTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FundSeriesRefreshServiceBuildSlugLengthCapTests
+{
+    // Contract: a fund's slug routes its profile and must stay within the 200-char column
+    // cap, but the discriminator is what disambiguates two funds whose names slugify the
+    // same — so an over-long name must be truncated, never the discriminator. A naive cap
+    // that trimmed the whole slug would chop the discriminator and collide distinct funds.
+    [Fact]
+    public void BuildSlug_NameLongerThanCap_TruncatesNameAndKeepsFullDiscriminator()
+    {
+        var name = new string('a', 250);
+        const string discriminator = "seriesid-s000123";
+
+        var method = typeof(FundSeriesRefreshService).GetMethod(
+            "BuildSlug",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var slug = (string)method!.Invoke(null, [name, discriminator]);
+
+        slug.Length.Should().BeLessThanOrEqualTo(200, "the slug must fit the 200-char cap");
+        slug.Should()
+            .EndWith($"-{discriminator}", "the disambiguating discriminator is never truncated");
+    }
+}


### PR DESCRIPTION
## Summary

- `FundSeriesRefreshService.BuildSlug` truncates an over-long fund name to fit the 200-char slug cap while keeping the discriminator that disambiguates funds whose names slugify the same. That edge was untested.
- Adds one unit test: a 250-char name yields a slug ≤ 200 chars that still ends with the full discriminator.

## Code changes

- `tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceBuildSlugLengthCapTests.cs` — new test (no source changes).