### PR TITLE
fix(tests): repair the four failing checks on main

### DIFF
--- a/src/Equibles.Data/EquiblesDbContextBase.cs
+++ b/src/Equibles.Data/EquiblesDbContextBase.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Equibles.Data;
 
@@ -22,6 +23,24 @@ public abstract class EquiblesDbContextBase : DbContext
         : base(options)
     {
         _modules = modules;
+    }
+
+    /// <summary>
+    /// Stable identity of this context's module composition, used by
+    /// <see cref="ModuleAwareModelCacheKeyFactory"/> so contexts of the same type
+    /// built from different module sets cache distinct models. Constant per
+    /// context type in production.
+    /// </summary>
+    internal string ModuleCacheKey =>
+        string.Join(
+            ",",
+            _modules.Select(m => m.GetType().FullName).OrderBy(name => name, StringComparer.Ordinal)
+        );
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        base.OnConfiguring(optionsBuilder);
+        optionsBuilder.ReplaceService<IModelCacheKeyFactory, ModuleAwareModelCacheKeyFactory>();
     }
 
     protected override void OnModelCreating(ModelBuilder builder)

--- a/src/Equibles.Data/ModuleAwareModelCacheKeyFactory.cs
+++ b/src/Equibles.Data/ModuleAwareModelCacheKeyFactory.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Equibles.Data;
+
+/// <summary>
+/// Model-cache key that folds the context's module set into the key. EF Core
+/// caches the built model per context type by default; that is correct in
+/// production, where each context type resolves exactly one module set, but tests
+/// build the same context type with different module subsets. With a type-only
+/// key whichever model builds first serves every later context of that type,
+/// dropping entities the later context expected (its <c>FindEntityType</c> then
+/// returns null). Folding the module set into the key gives each distinct
+/// composition its own cached model. In production the set is constant per
+/// context type, so this collapses back to a single cache entry — same behaviour
+/// as the default factory.
+/// </summary>
+public sealed class ModuleAwareModelCacheKeyFactory : IModelCacheKeyFactory
+{
+    public object Create(DbContext context, bool designTime) =>
+        context is EquiblesDbContextBase equiblesContext
+            ? (context.GetType(), equiblesContext.ModuleCacheKey, designTime)
+            : (context.GetType(), designTime);
+}

--- a/tests/Equibles.IntegrationTests/Mcp/CboeToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CboeToolsTests.cs
@@ -123,8 +123,12 @@ public class CboeToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task GetPutCallRatios_NullVolumes_RenderEmDash()
+    public async Task GetPutCallRatios_NullPutVolume_RendersEmDash()
     {
+        // OnlyReconcilable (#3760) requires a positive call denominator and a ratio below total
+        // volume, so a fully-null row is dropped from the served series. PutVolume is the one
+        // optional column that can be null on an otherwise-reconcilable row, and it must still
+        // render as an em-dash rather than a blank or a zero.
         DbContext
             .Set<CboePutCallRatio>()
             .Add(
@@ -132,10 +136,10 @@ public class CboeToolsTests : ParadeDbMcpTestBase
                 {
                     RatioType = CboePutCallRatioType.Vix,
                     Date = new DateOnly(2026, 4, 1),
-                    CallVolume = null,
+                    CallVolume = 1_000_000,
                     PutVolume = null,
-                    TotalVolume = null,
-                    PutCallRatio = null,
+                    TotalVolume = 2_000_000,
+                    PutCallRatio = 0.5m,
                 }
             );
         await DbContext.SaveChangesAsync();
@@ -144,7 +148,7 @@ public class CboeToolsTests : ParadeDbMcpTestBase
             .GetPutCallRatios(type: "Vix", startDate: "2026-03-01", endDate: "2026-04-30");
 
         result.Should().Contain("2026-04-01");
-        result.Should().Contain("| — | — | — | — |");
+        result.Should().Contain("| 1,000,000 | — | 2,000,000 | 0.50 |");
     }
 
     // ── GetVixHistory ────────────────────────────────────────────────────

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
@@ -237,8 +237,10 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
         var result = await Sut().SearchDocuments("services segment revenue", maxResults: -1);
 
         result.Should().NotContain("An error occurred while executing");
-        // Clamped to zero rows → the standard empty-result message.
-        result.Should().Be("No relevant financial documents found.");
+        // McpLimit.Clamp floors a non-positive cap at 1 (never turns "has data" into "no data"),
+        // so the seeded document is still returned rather than a false empty-result message.
+        result.Should().NotBe("No relevant financial documents found.");
+        result.Should().Contain("services segment");
     }
 
     // ── SearchCompanyDocuments ──────────────────────────────────────────

--- a/tests/Equibles.UnitTests/Models/InsiderTradingEnumTests.cs
+++ b/tests/Equibles.UnitTests/Models/InsiderTradingEnumTests.cs
@@ -31,6 +31,7 @@ public class InsiderTradingEnumTests
     [InlineData(TransactionCode.Inheritance, "Inheritance")]
     [InlineData(TransactionCode.Discretionary, "Discretionary")]
     [InlineData(TransactionCode.Other, "Other")]
+    [InlineData(TransactionCode.Holding, "Holding")]
     public void TransactionCode_AllValues_HaveCorrectDisplayName(
         TransactionCode code,
         string expected
@@ -67,7 +68,7 @@ public class InsiderTradingEnumTests
     public void TransactionCode_AllValues_HaveDisplayAttribute()
     {
         var values = Enum.GetValues<TransactionCode>();
-        values.Should().HaveCount(11);
+        values.Should().HaveCount(12);
 
         foreach (var value in values)
         {


### PR DESCRIPTION
## Summary

The default branch's CI was red on four tests. This makes it green by fixing the actual causes — three were stale assertions left behind by deliberate, documented production changes, and one was a flaky EF model-cache race fixed at the source. No production behavior changes (the model-cache key is a no-op where each context type has a single module set).

Verified locally: unit suite 2963/2963 green; full integration suite green except a pre-existing, unrelated local timing flake (`AumSnapshotRebuildWorkerTests…BackfillsDespiteFullAumCoverage`, whose 500 ms worker window is too short on a cold container — passes at 5 s and on CI; left untouched).

## Code changes

- **`Equibles.Data` — new `ModuleAwareModelCacheKeyFactory` + `EquiblesDbContextBase.OnConfiguring`**: EF caches the built model per context type only. Tests build `EquiblesFinancialDbContext` with different module subsets, so a type-only key let whichever model built first serve later contexts of that type, dropping entities the later context expected (`FindEntityType` returned null → the per-holder covering-index test flaked). The new `IModelCacheKeyFactory` folds the module set into the key. In production each context type resolves exactly one module set, so this collapses to one cache entry per type — behavior-preserving, including at design time / migrations.
- **`InsiderTradingEnumTests`**: a 12th `TransactionCode.Holding` value was added (with a `[Display]`); the count assertion (11→12) and the per-value display theory now include it.
- **`CboeToolsTests`**: `OnlyReconcilable` (#3760) drops fully-null rows from the served series, so the null-volume test now uses a reconcilable row with a null put volume — still exercising the em-dash render path (the only column that can legitimately be null after reconciliation).
- **`RagSearchToolsTests`**: `McpLimit.Clamp` floors a non-positive cap at 1 ("never turn has-data into no-data"), so `maxResults: -1` returns the seeded document; the assertion now tracks that, keeping the negative-LIMIT regression guard.

## Note

`OnConfiguring` lives on the shared base, so the commercial `EquiblesCustomerDbContext` inherits it too — behavior-preserving there (single module set), but its suite should be confirmed green when this lands downstream.