### PR TITLE
test(holdings): wait for the AUM rebuild instead of a fixed sleep

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
@@ -82,6 +82,30 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
         protected override TimeSpan SleepInterval => TimeSpan.FromMilliseconds(1);
     }
 
+    // The worker backfills on a 1ms loop, so snapshot rows land asynchronously
+    // after StartAsync. Poll a fresh context until the expected state appears
+    // rather than sleeping a fixed interval — the old 500ms wait flaked when the
+    // backfill outlasted it on a slow host or a cold test container (#3780).
+    private async Task WaitForSnapshots(
+        Func<Equibles.Data.EquiblesFinancialDbContext, Task<bool>> ready
+    )
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        while (true)
+        {
+            await using (var ctx = _fixture.CreateDbContext())
+            {
+                if (await ready(ctx))
+                    return;
+            }
+
+            if (DateTime.UtcNow > deadline)
+                return; // let the assertion report the shortfall with detail
+
+            await Task.Delay(25);
+        }
+    }
+
     [Fact]
     public async Task ExecuteAsync_EmptySnapshotsButHoldingsExist_BackfillsEveryQuarter()
     {
@@ -101,7 +125,9 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
         // awaits ExecuteAsync, so contexts created by the loop are guaranteed
         // to be idle by the time DisposeAsync disposes them.
         await worker.StartAsync(cts.Token);
-        await Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
+        await WaitForSnapshots(async ctx =>
+            await ctx.Set<AumQuarterlySnapshot>().CountAsync() >= 2
+        );
         await worker.StopAsync(CancellationToken.None);
 
         await using var read = FreshContext();
@@ -150,7 +176,13 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await worker.StartAsync(cts.Token);
-        await Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
+        // Wait for both quarters present AND the Q4 sentinel overwritten — the
+        // upsert lands both in one backfill pass, so this is satisfied together.
+        await WaitForSnapshots(async ctx =>
+            await ctx.Set<AumQuarterlySnapshot>().CountAsync() >= 2
+            && await ctx.Set<AumQuarterlySnapshot>()
+                .AnyAsync(s => s.ReportDate == Q4 && s.TotalValue == 200_000)
+        );
         await worker.StopAsync(CancellationToken.None);
 
         await using var read = FreshContext();
@@ -238,7 +270,10 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await worker.StartAsync(cts.Token);
-        await Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
+        await WaitForSnapshots(async ctx =>
+            await ctx.Set<HolderQuarterlySnapshot>()
+                .CountAsync(s => s.InstitutionalHolderId == holder.Id) >= quarters.Count
+        );
         await worker.StopAsync(CancellationToken.None);
 
         await using var read = FreshContext();


### PR DESCRIPTION
## Summary

Fixes the timing flake in `AumSnapshotRebuildWorkerTests` (#3780). The three positive backfill tests started the worker, slept a fixed 500 ms, then asserted the snapshots had landed. On a slow host or a cold test container the multi-quarter backfill outlasted that wait, so `StopAsync` cancelled it mid-run and the assertion found an empty collection — a false failure. The production worker is correct; only the test was timing-dependent.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs`: add a `WaitForSnapshots` helper that polls a fresh context until the expected rows appear (25 ms interval, 30 s ceiling), and use it in the three positive tests in place of the fixed 500 ms sleep. The worker stops only once the backfill is observed. The negative "no holdings → no rows" test keeps its short delay (an empty result can't flake to a false failure).

Verified: all four `AumSnapshotRebuildWorkerTests` pass; the poll returns as soon as the rows land (~1 s).

Closes #3780