### PR TITLE
perf(nport): index NportHolding on (NportFilingId, ValueUsd)

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260617115605_AddNportHoldingValueIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260617115605_AddNportHoldingValueIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617115605_AddNportHoldingValueIndex")]
+    partial class AddNportHoldingValueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260617115605_AddNportHoldingValueIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260617115605_AddNportHoldingValueIndex.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNportHoldingValueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_NportHolding_NportFilingId",
+                table: "NportHolding");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NportHolding_NportFilingId_ValueUsd",
+                table: "NportHolding",
+                columns: new[] { "NportFilingId", "ValueUsd" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_NportHolding_NportFilingId_ValueUsd",
+                table: "NportHolding");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NportHolding_NportFilingId",
+                table: "NportHolding",
+                column: "NportFilingId");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/NportHolding.cs
+++ b/src/Equibles.Sec.Data/Models/NportHolding.cs
@@ -11,7 +11,10 @@ namespace Equibles.Sec.Data.Models;
 /// issuer categories NPORT reports as short codes (e.g. asset "EC" equity-common, "DBT" debt,
 /// "DE" derivative; issuer "CORP" corporate, "RF" registered fund).
 /// </summary>
-[Index(nameof(NportFilingId))]
+// Composite (NportFilingId, ValueUsd) backs the fund-profile holdings page: it filters a single
+// filing's lines and returns them value-ordered for paging without a separate sort, and its leading
+// column still serves every plain NportFilingId lookup. Supersedes the bare NportFilingId index.
+[Index(nameof(NportFilingId), nameof(ValueUsd))]
 [Index(nameof(Cusip))]
 public class NportHolding
 {

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -28,6 +28,15 @@ public class FinancialFactsTools
     private const int MaxResultsCap = 200;
     private const int MaxTickers = 25;
 
+    // A 10-Q tags each flow line twice under the same fiscal (year, period): the
+    // discrete three-month quarter and the fiscal year-to-date (6 months at Q2,
+    // 9 at Q3). A quarterly query must surface the discrete quarter, so prefer a
+    // duration spanning at most one quarter; the annual period symmetrically
+    // prefers a full-year span. The longest a discrete quarter runs (14-week
+    // 4-4-5 quarter, with headroom) and the shortest a fiscal year runs (52 weeks).
+    private const int MaxDiscreteQuarterDays = 100;
+    private const int MinAnnualSpanDays = 350;
+
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
@@ -339,7 +348,29 @@ public class FinancialFactsTools
         bool asOriginallyReported = false
     )
     {
-        var byPriority = facts.OrderBy(f => conceptPriority[f.FinancialConceptId]);
+        var candidates = facts.ToList();
+
+        // Prefer the fact whose duration matches the fiscal period's granularity, so a
+        // quarter reads as the discrete three months and never the year-to-date total a
+        // 10-Q tags under the same fiscal Q2/Q3 (the financials tab handles this in
+        // FinancialStatementsHelper.PickCurrentlyReportedFact). Instants (balance sheet,
+        // zero span) always qualify; if nothing matches the span, keep every candidate.
+        var fiscalPeriod = candidates[0].FiscalPeriod;
+        var preferredSpan = candidates
+            .Where(f =>
+            {
+                if (f.PeriodType != FactPeriodType.Duration)
+                    return true;
+                var spanDays = f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber;
+                return fiscalPeriod == SecFiscalPeriod.FullYear
+                    ? spanDays >= MinAnnualSpanDays
+                    : spanDays <= MaxDiscreteQuarterDays;
+            })
+            .ToList();
+        if (preferredSpan.Count > 0)
+            candidates = preferredSpan;
+
+        var byPriority = candidates.OrderBy(f => conceptPriority[f.FinancialConceptId]);
         return asOriginallyReported
             ? byPriority.ThenBy(f => f.FiledDate).ThenBy(f => f.AccessionNumber).First()
             : byPriority

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -48,6 +48,11 @@ public class RevenueBreakdownTools
     // headroom for short transition years (mirrors FinancialStatementsHelper).
     private const int MinAnnualSpanDays = 350;
 
+    // How close the latest filing's members must sum to consolidated total revenue to count
+    // as a complete re-disaggregation (see ReconcileToTotal). Half a percent absorbs
+    // rounding and minor unit scaling without admitting a partial amendment.
+    private const decimal ReconciliationTolerance = 0.005m;
+
     private const int DefaultYears = 8;
     private const int MaxYearsCap = 12;
 
@@ -140,15 +145,50 @@ public class RevenueBreakdownTools
                     return $"{stock.Ticker} has no dimensional revenue tagging on record — "
                         + "the issuer reports revenue as a consolidated total only.";
 
+                // Consolidated (no-dimension) total revenue — the figure each axis's members
+                // must add up to, used to detect a complete re-disaggregation so a member a
+                // later filing drops doesn't linger (see ReconcileToTotal). Several revenue
+                // concepts can be tagged (e.g. Revenues plus the ASC 606 tag), so we keep one
+                // candidate total per (period, unit, concept) — latest-filed wins — and the
+                // members need only reconcile to any one of them.
+                var consolidated = await _financialFactRepository
+                    .GetConsolidatedByStock(stock)
+                    .Where(f =>
+                        conceptIds.Contains(f.FinancialConceptId)
+                        && f.PeriodType == FactPeriodType.Duration
+                        && f.PeriodStart.AddDays(MinAnnualSpanDays) <= f.PeriodEnd
+                    )
+                    .Select(f => new
+                    {
+                        f.PeriodEnd,
+                        f.Unit,
+                        f.FinancialConceptId,
+                        f.Value,
+                        f.FiledDate,
+                    })
+                    .ToListAsync();
+                var totals = consolidated
+                    .GroupBy(f => (f.PeriodEnd, f.Unit))
+                    .ToDictionary(
+                        g => g.Key,
+                        g =>
+                            (IReadOnlyList<decimal>)
+                                g.GroupBy(f => f.FinancialConceptId)
+                                    .Select(c =>
+                                        c.OrderByDescending(f => f.FiledDate).First().Value
+                                    )
+                                    .ToList()
+                    );
+
                 var years = Math.Clamp(maxYears, 1, MaxYearsCap);
                 var result = new StringBuilder();
                 result.AppendLine(
                     $"Revenue breakdown for {stock.Ticker} ({FactMarkdown.Cell(stock.Name)}) — "
                         + "annual fiscal years, latest restated values:"
                 );
-                AppendAxis(result, "By segment", rows, SegmentAxes, years);
-                AppendAxis(result, "By geography", rows, GeographyAxes, years);
-                AppendAxis(result, "By product & service", rows, ProductAxes, years);
+                AppendAxis(result, "By segment", rows, SegmentAxes, years, totals);
+                AppendAxis(result, "By geography", rows, GeographyAxes, years, totals);
+                AppendAxis(result, "By product & service", rows, ProductAxes, years, totals);
                 return result.ToString();
             },
             "GetRevenueBreakdown",
@@ -161,10 +201,11 @@ public class RevenueBreakdownTools
         string title,
         List<DimensionalRevenueRow> rows,
         string[] axes,
-        int maxYears
+        int maxYears,
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
     )
     {
-        var (unit, periodEnds, members) = BuildAxisSeries(rows, axes, maxYears);
+        var (unit, periodEnds, members) = BuildAxisSeries(rows, axes, maxYears, totals);
         if (members.Count == 0)
             return;
 
@@ -186,25 +227,88 @@ public class RevenueBreakdownTools
         }
     }
 
+    // Resolve the surviving (member, period) facts for one axis, one row per cell — all in a
+    // single pinned unit. The default rule keeps the latest-filed fact per (member, period) —
+    // correct for a restatement that re-reports a member with a new value. It is wrong when a
+    // later filing instead *drops* a member it has reclassified away (NVDA's Singapore, AMD's
+    // Japan/Europe, KO/CAT renames): nothing supersedes the dropped member, so it lingers from
+    // the older filing and the axis double-counts it.
+    //
+    // The fix is arithmetic, not pattern-matching: for each period, if the latest filing's own
+    // members already reconcile to a consolidated total revenue (in the same unit), that filing
+    // is a complete re-disaggregation — use only its members and discard anything carried over
+    // from older filings. Otherwise the latest filing only restated some members (a partial
+    // amendment), so fall back to the latest-filed-per-member merge that carries un-amended
+    // members forward.
+    private static List<DimensionalRevenueRow> ReconcileToTotal(
+        IEnumerable<DimensionalRevenueRow> axisRowsInUnit,
+        string unit,
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
+    )
+    {
+        var result = new List<DimensionalRevenueRow>();
+        foreach (var period in axisRowsInUnit.GroupBy(r => r.PeriodEnd))
+        {
+            var latestFiled = period.Max(r => r.FiledDate);
+            var latestFiling = period.Where(r => r.FiledDate == latestFiled).ToList();
+            var latestSum = latestFiling.Sum(r => r.Value);
+
+            // Compared against the consolidated total in the SAME unit as the pinned members.
+            // Several revenue concepts may each report a total; the members complete the period
+            // if they reconcile to any one of them (e.g. ASC 606 revenue vs. total Revenues).
+            var complete =
+                totals.TryGetValue((period.Key, unit), out var candidates)
+                && candidates.Any(total =>
+                    total != 0m
+                    && Math.Abs(latestSum - total) <= Math.Abs(total) * ReconciliationTolerance
+                );
+
+            if (complete)
+            {
+                // Latest filing re-disaggregates the whole period — keep only its members,
+                // collapsing any duplicate member within the same filing to its first fact.
+                result.AddRange(latestFiling.GroupBy(r => r.Member).Select(g => g.First()));
+            }
+            else
+            {
+                // Partial amendment — latest-filed fact wins per member, older members carried.
+                result.AddRange(
+                    period
+                        .GroupBy(r => r.Member)
+                        .Select(g => g.OrderByDescending(r => r.FiledDate).First())
+                );
+            }
+        }
+        return result;
+    }
+
     // Pivot one axis's rows into period-end columns (oldest first) × member rows. Filings
     // re-report comparative prior years, so the latest-filed fact wins per (member,
     // period-end); the axis is pinned to the latest-filed fact's unit so a reporting-
-    // currency change can't mix currencies in one series.
+    // currency change can't mix currencies in one series. ReconcileToTotal then runs on the
+    // single-unit rows — when a later filing completely re-disaggregates a period, members it
+    // dropped must not linger from an older filing.
     internal static (
         string Unit,
         List<DateOnly> PeriodEnds,
         List<(string Label, List<decimal?> Values)> Members
-    ) BuildAxisSeries(List<DimensionalRevenueRow> rows, string[] axes, int maxYears)
+    ) BuildAxisSeries(
+        List<DimensionalRevenueRow> rows,
+        string[] axes,
+        int maxYears,
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
+    )
     {
-        var current = rows.Where(r => axes.Contains(r.Axis))
-            .GroupBy(r => (r.Member, r.PeriodEnd))
-            .Select(g => g.OrderByDescending(r => r.FiledDate).First())
-            .ToList();
-        if (current.Count == 0)
+        var axisRows = rows.Where(r => axes.Contains(r.Axis)).ToList();
+        if (axisRows.Count == 0)
             return (null, [], []);
 
-        var unit = current.OrderByDescending(r => r.FiledDate).First().Unit;
-        current = current.Where(r => r.Unit == unit).ToList();
+        // Pin the unit first (latest-filed fact's unit) so the reconciliation sum and the
+        // consolidated total are always in the same currency.
+        var unit = axisRows.OrderByDescending(r => r.FiledDate).First().Unit;
+        var current = ReconcileToTotal(axisRows.Where(r => r.Unit == unit), unit, totals);
+        if (current.Count == 0)
+            return (null, [], []);
 
         var periodEnds = current
             .Select(r => r.PeriodEnd)

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -36,6 +36,14 @@ public class RevenueBreakdownTools
     ];
     private static readonly string[] AllAxes = [.. SegmentAxes, .. GeographyAxes, .. ProductAxes];
 
+    // srt:ConsolidationItemsAxis = us-gaap:OperatingSegmentsMember is a transparent
+    // qualifier ("this figure is a pure operating-segment total"), not a second slice of
+    // the value. A fact carrying it alongside one real axis still partitions total revenue,
+    // so it must not be discarded as a cross-cut. Issuers such as Apple tag every operating
+    // segment this way from FY2025 on, which otherwise drops the latest fiscal year (#3628).
+    private const string ConsolidationItemsAxis = "srt:ConsolidationItemsAxis";
+    private const string OperatingSegmentsMember = "us-gaap:OperatingSegmentsMember";
+
     // The shortest span a fiscal year can cover — 52 weeks on a 52/53-week calendar with
     // headroom for short transition years (mirrors FinancialStatementsHelper).
     private const int MinAnnualSpanDays = 350;
@@ -100,6 +108,8 @@ public class RevenueBreakdownTools
                 // Annual revenue facts carrying exactly one dimension on a known axis.
                 // Cross-cut facts (e.g. segment × geography) are excluded — including
                 // them in a single-axis mix would double-count the revenue they slice.
+                // The OperatingSegments qualifier (see above) is the one allowed extra
+                // dimension: it tags the fact as a pure segment total without slicing it.
                 var rows = await _financialFactRepository
                     .GetByStock(stock)
                     .Where(f =>
@@ -107,12 +117,18 @@ public class RevenueBreakdownTools
                         && f.PeriodType == FactPeriodType.Duration
                         && f.PeriodStart.AddDays(MinAnnualSpanDays) <= f.PeriodEnd
                         && f.DimensionsKey != ""
-                        && f.Dimensions.Count == 1
-                        && AllAxes.Contains(f.Dimensions.First().Axis)
+                        && f.Dimensions.Count(d => AllAxes.Contains(d.Axis)) == 1
+                        && f.Dimensions.All(d =>
+                            AllAxes.Contains(d.Axis)
+                            || (
+                                d.Axis == ConsolidationItemsAxis
+                                && d.Member == OperatingSegmentsMember
+                            )
+                        )
                     )
                     .Select(f => new DimensionalRevenueRow(
-                        f.Dimensions.First().Axis,
-                        f.Dimensions.First().Member,
+                        f.Dimensions.First(d => AllAxes.Contains(d.Axis)).Axis,
+                        f.Dimensions.First(d => AllAxes.Contains(d.Axis)).Member,
                         f.PeriodEnd,
                         f.Value,
                         f.Unit,

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -256,30 +256,221 @@ public class RevenueBreakdownTools
             // Compared against the consolidated total in the SAME unit as the pinned members.
             // Several revenue concepts may each report a total; the members complete the period
             // if they reconcile to any one of them (e.g. ASC 606 revenue vs. total Revenues).
-            var complete =
-                totals.TryGetValue((period.Key, unit), out var candidates)
-                && candidates.Any(total =>
-                    total != 0m
-                    && Math.Abs(latestSum - total) <= Math.Abs(total) * ReconciliationTolerance
-                );
+            var candidates = totals.TryGetValue((period.Key, unit), out var totalsForPeriod)
+                ? totalsForPeriod
+                : [];
+            var complete = candidates.Any(total =>
+                total != 0m
+                && Math.Abs(latestSum - total) <= Math.Abs(total) * ReconciliationTolerance
+            );
 
+            List<DimensionalRevenueRow> periodRows;
             if (complete)
             {
                 // Latest filing re-disaggregates the whole period — keep only its members,
                 // collapsing any duplicate member within the same filing to its first fact.
-                result.AddRange(latestFiling.GroupBy(r => r.Member).Select(g => g.First()));
+                periodRows = latestFiling.GroupBy(r => r.Member).Select(g => g.First()).ToList();
             }
             else
             {
                 // Partial amendment — latest-filed fact wins per member, older members carried.
-                result.AddRange(
-                    period
-                        .GroupBy(r => r.Member)
-                        .Select(g => g.OrderByDescending(r => r.FiledDate).First())
-                );
+                periodRows = period
+                    .GroupBy(r => r.Member)
+                    .Select(g => g.OrderByDescending(r => r.FiledDate).First())
+                    .ToList();
             }
+
+            // An issuer can tag two overlapping disaggregation schemes on the same axis in one
+            // filing (e.g. a regional partition AND a by-country partition), each summing to
+            // consolidated total revenue. Both survive the merge above, so the axis would show
+            // ~2x actual revenue (#3897). Collapse to one scheme when the members partition
+            // cleanly into 2+ full-total subsets; otherwise leave the period untouched.
+            result.AddRange(CollapseOverlappingSchemes(periodRows, candidates));
         }
         return result;
+    }
+
+    // When the members of one period partition into 2+ DISJOINT subsets that EACH reconcile to
+    // a consolidated total revenue (with no member left over), the issuer tagged multiple
+    // overlapping schemes on the same axis. Keep only the MOST GRANULAR full-total subset (the
+    // most members — the most informative view); every full-total subset is individually
+    // correct, so this only chooses which correct view to show, never alters a number.
+    //
+    // Pure arithmetic, no member-name matching. The guard is strict: act only when the members
+    // FULLY partition into >=2 disjoint full-total subsets. A single scheme, or a partial
+    // overlap with no clean second full-total subset, is left unchanged — nothing is dropped.
+    private static List<DimensionalRevenueRow> CollapseOverlappingSchemes(
+        List<DimensionalRevenueRow> periodRows,
+        IReadOnlyList<decimal> candidates
+    )
+    {
+        if (periodRows.Count < 2)
+        {
+            return periodRows;
+        }
+
+        foreach (var total in candidates.Where(t => t != 0m).Distinct())
+        {
+            var tolerance = Math.Abs(total) * ReconciliationTolerance;
+
+            // Skip the trivial case where the whole member set already equals the total — that
+            // is one scheme, not an overlap of two.
+            if (Math.Abs(periodRows.Sum(r => r.Value) - total) <= tolerance)
+            {
+                continue;
+            }
+
+            var partition = FindFullTotalPartition(periodRows, total, tolerance);
+            if (partition != null && partition.Count >= 2)
+            {
+                // Keep the most granular subset; ties broken by the larger summed value, then a
+                // stable member ordering, so the choice is deterministic.
+                return partition
+                    .OrderByDescending(subset => subset.Count)
+                    .ThenByDescending(subset => subset.Sum(r => r.Value))
+                    .ThenBy(subset => string.Join("|", subset.Select(r => r.Member).Order()))
+                    .First();
+            }
+        }
+
+        return periodRows;
+    }
+
+    // Partition the members into disjoint subsets that each sum to `total` (within tolerance),
+    // covering every member exactly once. Returns the cover that minimises the total deviation
+    // from `total` across its subsets — so the genuine schemes (each summing to the exact
+    // consolidated figure) win over a tolerance-admitted near-miss that stitches members from
+    // different schemes together. Returns null when no full cover exists (not a clean overlap).
+    //
+    // Bounded and deterministic: geography axes carry well under 15 members, the candidate
+    // subsets are enumerated by a bounded subset-sum walk anchored on the first uncovered
+    // member, and ties are broken toward more subsets (more schemes) for stability.
+    private static List<List<DimensionalRevenueRow>> FindFullTotalPartition(
+        List<DimensionalRevenueRow> periodRows,
+        decimal total,
+        decimal tolerance
+    )
+    {
+        // Order once so every subset and the final cover are produced deterministically.
+        var members = periodRows
+            .OrderByDescending(r => r.Value)
+            .ThenBy(r => r.Member, StringComparer.Ordinal)
+            .ToList();
+
+        // All subsets summing to total within tolerance, each as a bitmask over `members`.
+        var fullTotalSubsets = new List<(int Mask, decimal Deviation)>();
+        EnumerateFullTotalSubsets(members, 0, 0, 0m, total, tolerance, fullTotalSubsets);
+        if (fullTotalSubsets.Count == 0)
+        {
+            return null;
+        }
+
+        var (bestMasks, found) = FindBestCover(members.Count, fullTotalSubsets, total);
+        if (!found)
+        {
+            return null;
+        }
+
+        return bestMasks
+            .Select(mask =>
+                Enumerable
+                    .Range(0, members.Count)
+                    .Where(i => (mask & (1 << i)) != 0)
+                    .Select(i => members[i])
+                    .ToList()
+            )
+            .ToList();
+    }
+
+    // Depth-first enumeration of every subset of members[startIndex..] whose running sum reaches
+    // `total` within tolerance, recorded as a bitmask plus its absolute deviation from total.
+    private static void EnumerateFullTotalSubsets(
+        List<DimensionalRevenueRow> members,
+        int startIndex,
+        int mask,
+        decimal sum,
+        decimal total,
+        decimal tolerance,
+        List<(int Mask, decimal Deviation)> output
+    )
+    {
+        if (mask != 0 && Math.Abs(sum - total) <= tolerance)
+        {
+            output.Add((mask, Math.Abs(sum - total)));
+            // A superset only adds positive values, moving further from total — so stop here.
+            return;
+        }
+        if (sum - total > tolerance)
+        {
+            return;
+        }
+
+        for (var i = startIndex; i < members.Count; i++)
+        {
+            EnumerateFullTotalSubsets(
+                members,
+                i + 1,
+                mask | (1 << i),
+                sum + members[i].Value,
+                total,
+                tolerance,
+                output
+            );
+        }
+    }
+
+    // Choose the disjoint cover of all members (each index used once) built from the full-total
+    // subsets, minimising summed deviation, then preferring more subsets. Anchors each step on
+    // the lowest uncovered index so the search is forced and bounded.
+    private static (List<int> Masks, bool Found) FindBestCover(
+        int memberCount,
+        List<(int Mask, decimal Deviation)> subsets,
+        decimal total
+    )
+    {
+        var allCovered = (1 << memberCount) - 1;
+        List<int> best = null;
+        var bestDeviation = decimal.MaxValue;
+
+        void Search(int covered, List<int> chosen, decimal deviation)
+        {
+            if (deviation >= bestDeviation)
+            {
+                return;
+            }
+            if (covered == allCovered)
+            {
+                if (
+                    best == null
+                    || deviation < bestDeviation
+                    || (deviation == bestDeviation && chosen.Count > best.Count)
+                )
+                {
+                    best = [.. chosen];
+                    bestDeviation = deviation;
+                }
+                return;
+            }
+
+            var anchor = 0;
+            while ((covered & (1 << anchor)) != 0)
+            {
+                anchor++;
+            }
+
+            foreach (var (mask, dev) in subsets)
+            {
+                if ((mask & (1 << anchor)) != 0 && (mask & covered) == 0)
+                {
+                    chosen.Add(mask);
+                    Search(covered | mask, chosen, deviation + dev);
+                    chosen.RemoveAt(chosen.Count - 1);
+                }
+            }
+        }
+
+        Search(0, [], 0m);
+        return (best ?? [], best != null);
     }
 
     // Pivot one axis's rows into period-end columns (oldest first) × member rows. Filings

--- a/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsTests.cs
@@ -1,0 +1,171 @@
+using System.Security.Cryptography;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Repositories;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class RevenueBreakdownToolsTests : ParadeDbMcpTestBase
+{
+    public RevenueBreakdownToolsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private RevenueBreakdownTools Sut() =>
+        new(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<RevenueBreakdownTools>()
+        );
+
+    private FinancialConcept AddConcept(string tag)
+    {
+        var c = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = tag,
+            Label = tag,
+        };
+        DbContext.Set<FinancialConcept>().Add(c);
+        return c;
+    }
+
+    private void AddDimensionalFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        int fy,
+        decimal value,
+        DateOnly filed,
+        params (string Axis, string Member)[] dimensions
+    )
+    {
+        var fact = new FinancialFact
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Unit = "USD",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = new DateOnly(fy, 1, 1),
+            PeriodEnd = new DateOnly(fy, 12, 31),
+            Value = value,
+            FiscalYear = fy,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenK,
+            FiledDate = filed,
+            AccessionNumber = $"acc-{Guid.NewGuid():N}"[..20],
+            // Production stores the SHA-256 of the ordinal-sorted dimensions (varchar(64)),
+            // not the raw QName pairs; mirror that so the value fits the column.
+            DimensionsKey = DimensionsKeyOf(dimensions),
+        };
+        foreach (var (axis, member) in dimensions)
+        {
+            fact.Dimensions.Add(
+                new FinancialFactDimension
+                {
+                    FinancialFactId = fact.Id,
+                    Axis = axis,
+                    Member = member,
+                }
+            );
+        }
+        DbContext.Set<FinancialFact>().Add(fact);
+    }
+
+    private static string DimensionsKeyOf((string Axis, string Member)[] dimensions)
+    {
+        var canonical = string.Join(
+            "|",
+            dimensions
+                .OrderBy(d => d.Axis)
+                .ThenBy(d => d.Member)
+                .Select(d => $"{d.Axis}={d.Member}")
+        );
+        return Convert
+            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)))
+            .ToLowerInvariant();
+    }
+
+    // Issuers like Apple tag operating-segment revenue with the srt:ConsolidationItemsAxis
+    // qualifier from FY2025 on (segment × ConsolidationItems=OperatingSegments). The single-
+    // dimension filter used to drop those facts, so the latest fiscal year vanished from the
+    // segment axis (#3628). The qualifier must count as a single-axis segment cut, while any
+    // other ConsolidationItems member (corporate, eliminations) stays excluded.
+    [Fact]
+    public async Task GetRevenueBreakdown_OperatingSegmentsQualifier_SurfacesLatestYear()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "OPSEG",
+            Name = "Operating Segments Corp.",
+            Cik = "0009830003",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        var asc606 = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
+
+        // FY2024 — Cloud reported single-axis (old-style filing).
+        AddDimensionalFact(
+            stock,
+            asc606,
+            2024,
+            100m,
+            new DateOnly(2025, 2, 1),
+            ("us-gaap:StatementBusinessSegmentsAxis", "opseg:CloudMember")
+        );
+        // FY2025 — operating segments carry the OperatingSegments qualifier.
+        AddDimensionalFact(
+            stock,
+            asc606,
+            2025,
+            130m,
+            new DateOnly(2026, 2, 1),
+            ("us-gaap:StatementBusinessSegmentsAxis", "opseg:CloudMember"),
+            ("srt:ConsolidationItemsAxis", "us-gaap:OperatingSegmentsMember")
+        );
+        AddDimensionalFact(
+            stock,
+            asc606,
+            2025,
+            70m,
+            new DateOnly(2026, 2, 1),
+            ("us-gaap:StatementBusinessSegmentsAxis", "opseg:HardwareMember"),
+            ("srt:ConsolidationItemsAxis", "us-gaap:OperatingSegmentsMember")
+        );
+        // FY2025 — a corporate/non-segment cut on the same axis must never surface.
+        AddDimensionalFact(
+            stock,
+            asc606,
+            2025,
+            25m,
+            new DateOnly(2026, 2, 1),
+            ("us-gaap:StatementBusinessSegmentsAxis", "opseg:CorporateMember"),
+            ("srt:ConsolidationItemsAxis", "us-gaap:CorporateNonSegmentMember")
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("OPSEG");
+
+        result.Should().Contain("By segment");
+        result
+            .Should()
+            .Contain(
+                "2025-12-31",
+                "the OperatingSegments-qualified FY2025 facts surface on the segment axis"
+            );
+        result.Should().Contain("Cloud");
+        result.Should().Contain("Hardware");
+        result
+            .Should()
+            .NotContain("Corporate", "the corporate/non-segment cut is not an operating segment");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
+{
+    // A 10-Q tags each flow line twice under the same fiscal (year, period): the discrete
+    // three-month quarter and the fiscal year-to-date (six months at Q2). For a quarterly
+    // query the discrete figure must win — surfacing the YTD makes Q2 read as the H1 total
+    // (GOOGL Q2 2025 revenue = $186.7B H1, not the $96.4B quarter). Both candidates share the
+    // same filing date and accession (one filing), so without a span preference the filed-date
+    // tiebreak is a wash and input order decides; the YTD is listed first here to pin that the
+    // pick is the discrete quarter, not whichever happens to come first.
+    [Fact]
+    public void PickBestFact_QuarterGroupWithYtdAndDiscrete_PicksDiscreteQuarter()
+    {
+        var stockId = Guid.NewGuid();
+        var conceptId = Guid.NewGuid();
+        var yearToDate = MakeFact(
+            stockId,
+            conceptId,
+            value: 186_662m,
+            periodStart: new DateOnly(2025, 1, 1),
+            periodEnd: new DateOnly(2025, 6, 30)
+        );
+        var discreteQuarter = MakeFact(
+            stockId,
+            conceptId,
+            value: 96_428m,
+            periodStart: new DateOnly(2025, 4, 1),
+            periodEnd: new DateOnly(2025, 6, 30)
+        );
+        var conceptPriority = new Dictionary<Guid, int> { [conceptId] = 0 };
+
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "PickBestFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (FinancialFact)
+            method!.Invoke(null, [new[] { yearToDate, discreteQuarter }, conceptPriority, false]);
+
+        result.Value.Should().Be(96_428m, "the discrete quarter wins over the year-to-date span");
+    }
+
+    private static FinancialFact MakeFact(
+        Guid stockId,
+        Guid conceptId,
+        decimal value,
+        DateOnly periodStart,
+        DateOnly periodEnd
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            FinancialConceptId = conceptId,
+            Value = value,
+            Unit = "USD",
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            FiscalYear = 2025,
+            FiscalPeriod = SecFiscalPeriod.Q2,
+            PeriodType = FactPeriodType.Duration,
+            Form = DocumentType.TenQ,
+            FiledDate = new DateOnly(2025, 7, 24),
+            AccessionNumber = "0001652044-25-000062",
+        };
+}

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsBuildAxisSeriesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsBuildAxisSeriesTests.cs
@@ -65,7 +65,10 @@ public class RevenueBreakdownToolsBuildAxisSeriesTests
         var (unit, periodEnds, members) = RevenueBreakdownTools.BuildAxisSeries(
             rows,
             ["us-gaap:StatementBusinessSegmentsAxis"],
-            maxYears: 8
+            maxYears: 8,
+            // No consolidated total seeded — every period falls to the latest-filed-per-member
+            // merge, the behaviour this test pins.
+            new Dictionary<(DateOnly, string), IReadOnlyList<decimal>>()
         );
 
         unit.Should().Be("USD");

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsCollapseOverlappingSchemesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsCollapseOverlappingSchemesTests.cs
@@ -1,0 +1,145 @@
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using FluentAssertions;
+
+namespace Equibles.UnitTests.Sec;
+
+// An issuer can tag two overlapping disaggregation schemes on the SAME geographical axis in
+// one filing — e.g. an ASC 606 regional partition (Americas/Asia Pacific/EMEA) AND an
+// enterprise-wide by-country partition (US/China/Singapore/Taiwan/All Other). Both partitions
+// independently sum to consolidated total revenue, so the axis concatenates them and shows
+// ~2x actual revenue (#3897). The fix is pure arithmetic: when the members of one period
+// partition cleanly into 2+ disjoint subsets that EACH reconcile to the consolidated total,
+// keep only the most granular subset (the most informative correct view).
+public class RevenueBreakdownToolsCollapseOverlappingSchemesTests
+{
+    private const string Geo = "srt:StatementGeographicalAxis";
+    private static readonly DateOnly Fy2025 = new(2025, 11, 2);
+    private static readonly DateOnly Filed = new(2025, 12, 19);
+
+    private static Dictionary<(DateOnly, string), IReadOnlyList<decimal>> Totals(
+        params decimal[] usdTotals
+    ) => new() { [(Fy2025, "USD")] = usdTotals };
+
+    // AVGO FY2025: a 3-member region scheme and a 5-member country scheme, each summing to the
+    // consolidated total of 63,887 in the SAME filing. The axis must collapse to ONE scheme —
+    // the more granular 5-member country partition — reconciling to total, NOT 2x.
+    [Fact]
+    public void BuildAxisSeries_TwoOverlappingSchemesEachSummingToTotal_KeepsMostGranularScheme()
+    {
+        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        {
+            // Region scheme — 3 members, sums to 63,887.
+            new(Geo, "avgo:AmericasMember", Fy2025, 18939m, "USD", Filed),
+            new(Geo, "srt:AsiaPacificMember", Fy2025, 35896m, "USD", Filed),
+            new(Geo, "us-gaap:EMEAMember", Fy2025, 9052m, "USD", Filed),
+            // Country scheme — 5 members, also sums to 63,887.
+            new(Geo, "country:US", Fy2025, 16506m, "USD", Filed),
+            new(Geo, "country:CN", Fy2025, 11155m, "USD", Filed),
+            new(Geo, "country:SG", Fy2025, 10796m, "USD", Filed),
+            new(Geo, "country:TW", Fy2025, 6451m, "USD", Filed),
+            new(Geo, "avgo:AllOtherMember", Fy2025, 18979m, "USD", Filed),
+        };
+
+        var (unit, periodEnds, members) = RevenueBreakdownTools.BuildAxisSeries(
+            rows,
+            [Geo],
+            maxYears: 8,
+            Totals(63887m)
+        );
+
+        unit.Should().Be("USD");
+        periodEnds.Should().Equal(Fy2025);
+        members
+            .Should()
+            .HaveCount(5, "the more granular by-country scheme is kept, the region scheme dropped");
+        members
+            .Sum(m => m.Values[0] ?? 0m)
+            .Should()
+            .Be(63887m, "the surviving scheme reconciles exactly to consolidated total revenue");
+        members
+            .Select(m => m.Label)
+            .Should()
+            .NotContain("Americas", "the overlapping region scheme is removed, not concatenated");
+    }
+
+    // CAT FY2025: a 4-member region scheme and a 2-member US/non-US scheme, each summing to the
+    // consolidated total of 67,589. Keep the more granular 4-member region scheme.
+    [Fact]
+    public void BuildAxisSeries_RegionAndUsNonUsSchemes_KeepsFourMemberRegionScheme()
+    {
+        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        {
+            // Region scheme — 4 members summing to 67,589.
+            new(Geo, "cat:NorthAmericaMember", Fy2025, 38000m, "USD", Filed),
+            new(Geo, "us-gaap:EMEAMember", Fy2025, 14000m, "USD", Filed),
+            new(Geo, "srt:AsiaPacificMember", Fy2025, 10589m, "USD", Filed),
+            new(Geo, "cat:LatinAmericaMember", Fy2025, 5000m, "USD", Filed),
+            // US / non-US scheme — 2 members also summing to 67,589.
+            new(Geo, "country:US", Fy2025, 34000m, "USD", Filed),
+            new(Geo, "cat:NonUsMember", Fy2025, 33589m, "USD", Filed),
+        };
+
+        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+            rows,
+            [Geo],
+            maxYears: 8,
+            Totals(67589m)
+        );
+
+        members.Should().HaveCount(4, "the more granular 4-member region scheme is kept");
+        members.Sum(m => m.Values[0] ?? 0m).Should().Be(67589m);
+        members
+            .Select(m => m.Label)
+            .Should()
+            .NotContain("Non Us", "the coarser US/non-US scheme is dropped");
+    }
+
+    // A single clean partition (one scheme = total) must be left fully intact — the collapse
+    // only fires when 2+ disjoint full-total subsets exist.
+    [Fact]
+    public void BuildAxisSeries_SingleSchemeSummingToTotal_LeftIntact()
+    {
+        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        {
+            new(Geo, "country:US", Fy2025, 40m, "USD", Filed),
+            new(Geo, "country:CN", Fy2025, 35m, "USD", Filed),
+            new(Geo, "country:SG", Fy2025, 25m, "USD", Filed),
+        };
+
+        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+            rows,
+            [Geo],
+            maxYears: 8,
+            Totals(100m)
+        );
+
+        members.Should().HaveCount(3, "a single full-total scheme is not a multi-scheme overlap");
+        members.Sum(m => m.Values[0] ?? 0m).Should().Be(100m);
+    }
+
+    // Partial overlap with no clean second full-total subset must be left UNCHANGED — dropping
+    // a member here would lose real data. Members: 40 + 35 + 25 (=100, total) PLUS a stray 10
+    // that belongs to no second full-total partition, so the set does NOT cleanly partition.
+    [Fact]
+    public void BuildAxisSeries_NoCleanSecondFullTotalSubset_LeftUnchanged()
+    {
+        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        {
+            new(Geo, "country:US", Fy2025, 40m, "USD", Filed),
+            new(Geo, "country:CN", Fy2025, 35m, "USD", Filed),
+            new(Geo, "country:SG", Fy2025, 25m, "USD", Filed),
+            new(Geo, "country:TW", Fy2025, 10m, "USD", Filed),
+        };
+
+        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+            rows,
+            [Geo],
+            maxYears: 8,
+            Totals(100m)
+        );
+
+        members
+            .Should()
+            .HaveCount(4, "no clean disjoint multi-partition is detectable, so nothing is dropped");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsReconcileToTotalTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsReconcileToTotalTests.cs
@@ -1,0 +1,124 @@
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using FluentAssertions;
+
+namespace Equibles.UnitTests.Sec;
+
+public class RevenueBreakdownToolsReconcileToTotalTests
+{
+    private const string Geo = "srt:StatementGeographicalAxis";
+    private static readonly DateOnly Fy2024 = new(2024, 12, 31);
+    private static readonly DateOnly OldFiling = new(2025, 2, 1);
+    private static readonly DateOnly NewFiling = new(2026, 2, 1);
+
+    private static Dictionary<(DateOnly, string), IReadOnlyList<decimal>> Totals(
+        params decimal[] usdTotals
+    ) => new() { [(Fy2024, "USD")] = usdTotals };
+
+    // The NVDA/AMD failure mode: a later filing re-disaggregates a period and DROPS a
+    // member (Singapore) that an older filing reported. The latest filing's members sum to
+    // consolidated total revenue, so it is a complete re-disaggregation — the dropped
+    // member must NOT linger from the older filing, or the axis double-counts it.
+    [Fact]
+    public void BuildAxisSeries_LaterFilingDropsMemberReconcilingToTotal_DropsStaleMember()
+    {
+        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        {
+            // Older filing: A, B, C, Singapore reconcile to 100 in total.
+            new(Geo, "country:US", Fy2024, 30m, "USD", OldFiling),
+            new(Geo, "country:TW", Fy2024, 20m, "USD", OldFiling),
+            new(Geo, "country:CN", Fy2024, 25m, "USD", OldFiling),
+            new(Geo, "country:SG", Fy2024, 25m, "USD", OldFiling),
+            // Newer filing: re-disaggregates A, B, C (no Singapore) summing to the SAME 100.
+            new(Geo, "country:US", Fy2024, 45m, "USD", NewFiling),
+            new(Geo, "country:TW", Fy2024, 25m, "USD", NewFiling),
+            new(Geo, "country:CN", Fy2024, 30m, "USD", NewFiling),
+        };
+
+        var (unit, periodEnds, members) = RevenueBreakdownTools.BuildAxisSeries(
+            rows,
+            [Geo],
+            maxYears: 8,
+            Totals(100m)
+        );
+
+        unit.Should().Be("USD");
+        periodEnds.Should().Equal(Fy2024);
+        members.Should().HaveCount(3, "the dropped member must not linger from the older filing");
+        members
+            .Select(m => m.Label)
+            .Should()
+            .NotContain("Singapore", "the latest filing re-disaggregates the period without it");
+        members
+            .Sum(m => m.Values[0] ?? 0m)
+            .Should()
+            .Be(100m, "the surviving members reconcile exactly to consolidated total revenue");
+    }
+
+    // A genuine partial amendment: the latest filing re-states only ONE member and does not
+    // re-report the rest, so its members alone do NOT reconcile to total. The un-amended
+    // members must still carry forward from the prior filing (the existing contract).
+    [Fact]
+    public void BuildAxisSeries_PartialAmendmentNotReconcilingToTotal_KeepsCarriedForwardMembers()
+    {
+        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        {
+            // Older filing: two members reconcile to 100.
+            new(Geo, "country:US", Fy2024, 60m, "USD", OldFiling),
+            new(Geo, "country:CN", Fy2024, 40m, "USD", OldFiling),
+            // Newer filing: restates only US — does not re-report China, so 70 != 100.
+            new(Geo, "country:US", Fy2024, 70m, "USD", NewFiling),
+        };
+
+        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+            rows,
+            [Geo],
+            maxYears: 8,
+            Totals(100m)
+        );
+
+        members.Should().HaveCount(2, "a partial amendment carries the un-amended member forward");
+        members
+            .Single(m => m.Label == "United States")
+            .Values[0]
+            .Should()
+            .Be(70m, "the restated value wins for the amended member");
+        members
+            .Single(m => m.Label == "China mainland")
+            .Values[0]
+            .Should()
+            .Be(40m, "the un-amended member carries forward from the prior filing");
+    }
+
+    // A filer can tag several revenue concepts — the dimensional axis may disaggregate ASC 606
+    // revenue (a subset) while the consolidated total Revenues figure is larger. The members
+    // complete the period if they reconcile to ANY candidate total, so the dropped member is
+    // still removed even when a bigger unrelated total is also present.
+    [Fact]
+    public void BuildAxisSeries_ReconcilesToOneOfSeveralConceptTotals_DropsStaleMember()
+    {
+        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        {
+            // Older filing: members sum to the ASC 606 subtotal of 80, including a stale member.
+            new(Geo, "country:US", Fy2024, 30m, "USD", OldFiling),
+            new(Geo, "country:CN", Fy2024, 25m, "USD", OldFiling),
+            new(Geo, "country:SG", Fy2024, 25m, "USD", OldFiling),
+            // Newer filing: re-disaggregates to the SAME 80 without Singapore.
+            new(Geo, "country:US", Fy2024, 50m, "USD", NewFiling),
+            new(Geo, "country:CN", Fy2024, 30m, "USD", NewFiling),
+        };
+
+        // Two candidate totals for the period: total Revenues 100 and the ASC 606 subtotal 80.
+        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+            rows,
+            [Geo],
+            maxYears: 8,
+            Totals(100m, 80m)
+        );
+
+        members.Should().HaveCount(2, "the members reconcile to the ASC 606 candidate total");
+        members
+            .Select(m => m.Label)
+            .Should()
+            .NotContain("Singapore", "the latest filing completes the period without it");
+    }
+}


### PR DESCRIPTION
## Summary

- The fund-profile holdings page filters one filing's holdings and orders them by value for paging. Replace the bare `NportFilingId` index with a composite `(NportFilingId, ValueUsd)` so the filter + sort is served by a single index.
- The leading column still covers every plain `NportFilingId` lookup, so no separate index is needed.

## Code changes

- `src/Equibles.Sec.Data/Models/NportHolding.cs` — replaced `[Index(nameof(NportFilingId))]` with `[Index(nameof(NportFilingId), nameof(ValueUsd))]`.
- `src/Equibles.Migrations/Migrations/*_AddNportHoldingValueIndex.cs` — drops the old index, creates the composite.