### PR TITLE
test(revenue-breakdown): identify country members by derived label, not ICU name

### DIFF
--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsReconcileToTotalTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsReconcileToTotalTests.cs
@@ -77,13 +77,15 @@ public class RevenueBreakdownToolsReconcileToTotalTests
         );
 
         members.Should().HaveCount(2, "a partial amendment carries the un-amended member forward");
+        // Identify members by the same label the code derives, so the assertion does not depend
+        // on the runtime's ICU/CLDR English name for a country (e.g. "China mainland" vs "China").
         members
-            .Single(m => m.Label == "United States")
+            .Single(m => m.Label == RevenueBreakdownTools.Humanize("country:US"))
             .Values[0]
             .Should()
             .Be(70m, "the restated value wins for the amended member");
         members
-            .Single(m => m.Label == "China mainland")
+            .Single(m => m.Label == RevenueBreakdownTools.Humanize("country:CN"))
             .Values[0]
             .Should()
             .Be(40m, "the un-amended member carries forward from the prior filing");


### PR DESCRIPTION
## Summary

CI on `main` has been red since #3782: the unit test `RevenueBreakdownToolsReconcileToTotalTests.BuildAxisSeries_PartialAmendmentNotReconcilingToTotal_KeepsCarriedForwardMembers` fails with `Sequence contains no matching element`.

The test looked up the China member by the literal label `"China mainland"` — the CLDR English name that `RegionInfo("CN").EnglishName` returns on the local ICU. The Linux CI runner ships a different ICU/CLDR version that returns a different spelling for CN, so `.Single(m => m.Label == "China mainland")` matched nothing and threw. The production code was fine; only the test's hard-coded country name was environment-dependent.

## Code changes

- `tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsReconcileToTotalTests.cs` — identify the US and China members by the same `RevenueBreakdownTools.Humanize("country:..")` call the production code uses, so the assertion verifies the carry-forward value regardless of the runtime's country-name spelling.