### PR TITLE
feat(financial-facts): source shares outstanding from the SEC cover-page tag

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Equibles.Sec.FinancialFacts.BusinessLogic.csproj
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Equibles.Sec.FinancialFacts.BusinessLogic.csproj
@@ -11,5 +11,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Data\Equibles.Sec.FinancialFacts.Data.csproj" />
+    <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Repositories\Equibles.Sec.FinancialFacts.Repositories.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -1,0 +1,64 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic;
+
+// Resolves a stock's common shares outstanding from the authoritative SEC cover-page tag
+// (dei:EntityCommonStockSharesOutstanding) the financial-facts importer already ingests, rather
+// than the per-share-class figure Yahoo returns (which understates multi-class issuers ~2x and
+// lags corporate actions like reverse splits). Consolidated facts only: a multi-class issuer
+// reports the count only per share class, so it has no consolidated fact and yields null here —
+// the entity total is summed across classes separately (#2503). A single-class issuer's latest
+// filing gives the current entity total (#3575).
+[Service]
+public class SharesOutstandingProvider
+{
+    private const string SharesUnit = "shares";
+
+    private readonly FinancialFactRepository _financialFactRepository;
+    private readonly FinancialConceptRepository _financialConceptRepository;
+
+    public SharesOutstandingProvider(
+        FinancialFactRepository financialFactRepository,
+        FinancialConceptRepository financialConceptRepository
+    )
+    {
+        _financialFactRepository = financialFactRepository;
+        _financialConceptRepository = financialConceptRepository;
+    }
+
+    // The shares on the most-recently-filed consolidated cover-page fact, or null when the issuer
+    // has none on record (e.g. a multi-class filer that reports the count only per share class).
+    public async Task<long?> GetReportedSharesOutstanding(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (!FinancialConceptAliases.TryResolve("shares-outstanding", out var refs))
+            return null;
+
+        var taxonomies = refs.Select(r => r.Taxonomy).Distinct().ToList();
+        var tags = refs.Select(r => r.Tag).ToList();
+        var conceptIds = await _financialConceptRepository
+            .GetMatching(taxonomies, tags)
+            .Select(c => c.Id)
+            .ToListAsync(cancellationToken);
+        if (conceptIds.Count == 0)
+            return null;
+
+        // The latest filing wins (FiledDate), then the most recent as-of date within it; the value
+        // is a whole share count.
+        var value = await _financialFactRepository
+            .GetConsolidatedByStock(stock)
+            .Where(f => conceptIds.Contains(f.FinancialConceptId) && f.Unit == SharesUnit)
+            .OrderByDescending(f => f.FiledDate)
+            .ThenByDescending(f => f.PeriodEnd)
+            .Select(f => (decimal?)f.Value)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return value.HasValue ? (long)value.Value : (long?)null;
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -47,6 +47,10 @@ public static class FinancialConceptAliases
         ["stockholders-equity"] = [new(FactTaxonomy.UsGaap, "StockholdersEquity")],
         ["retained-earnings"] = [new(FactTaxonomy.UsGaap, "RetainedEarningsAccumulatedDeficit")],
         ["cash"] = [new(FactTaxonomy.UsGaap, "CashAndCashEquivalentsAtCarryingValue")],
+        // The issuer's cover-page common shares outstanding. Single-class filers report it
+        // consolidated (no dimension); multi-class filers report it only per share class, so a
+        // consolidated fact is absent and the entity total is the sum across classes.
+        ["shares-outstanding"] = [new(FactTaxonomy.Dei, "EntityCommonStockSharesOutstanding")],
         ["operating-cash-flow"] =
         [
             new(FactTaxonomy.UsGaap, "NetCashProvidedByUsedInOperatingActivities"),

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Data;
 using Equibles.Data.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -102,14 +104,18 @@ public class FinancialFactsImportService
         if (lastSeen.HasValue && lastSeen.Value >= maxFiled)
         {
             // Nothing filed since the last successful sync — record the check
-            // and skip the (expensive) re-upsert of the full history.
+            // and skip the (expensive) re-upsert of the full history. Still re-source the share
+            // count: an already-ingested cover-page fact may post-date the stale Yahoo figure
+            // (and this corrects existing rows the first cycle after the change ships).
             await UpsertSyncStatus(stock, lastSeen, cancellationToken);
+            await UpdateSharesOutstanding(stock, cancellationToken);
             return;
         }
 
         try
         {
             await PersistFacts(stock, parsed, maxFiled, cancellationToken);
+            await UpdateSharesOutstanding(stock, cancellationToken);
         }
         // Per-company fault isolation (mirrors FtdImportService): one company's
         // failure is reported and skipped so the worker cycle continues for the
@@ -130,6 +136,29 @@ public class FinancialFactsImportService
                 $"ticker: {stock.Ticker}, cik: {stock.Cik}"
             );
         }
+    }
+
+    // Sets the stock's share count from the authoritative SEC cover-page fact the import just
+    // ingested, so the lagging per-share-class Yahoo figure no longer drives market cap and
+    // ownership percentages (#3575/#2503). No-ops when the issuer has no consolidated fact
+    // (multi-class filers — summed across classes elsewhere) or the value is unchanged.
+    private async Task UpdateSharesOutstanding(CommonStock stock, CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var sharesProvider = scope.ServiceProvider.GetRequiredService<SharesOutstandingProvider>();
+        var shares = await sharesProvider.GetReportedSharesOutstanding(stock, cancellationToken);
+        if (shares == null)
+            return;
+
+        var stockRepository = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var tracked = await stockRepository
+            .GetByIds([stock.Id])
+            .FirstOrDefaultAsync(cancellationToken);
+        if (tracked == null || tracked.SharesOutStanding == shares.Value)
+            return;
+
+        tracked.SharesOutStanding = shares.Value;
+        await stockRepository.SaveChanges();
     }
 
     private async Task PersistFacts(

--- a/src/Equibles.Yahoo.HostedService/Equibles.Yahoo.HostedService.csproj
+++ b/src/Equibles.Yahoo.HostedService/Equibles.Yahoo.HostedService.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Yahoo\Equibles.Integrations.Yahoo.csproj" />
+    <ProjectReference Include="..\Equibles.Sec.FinancialFacts.BusinessLogic\Equibles.Sec.FinancialFacts.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Worker\Equibles.Worker.csproj" />
   </ItemGroup>

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -5,6 +5,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Yahoo.Contracts;
 using Equibles.Integrations.Yahoo.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Worker;
 using Equibles.Yahoo.Data.Models;
 using Equibles.Yahoo.Repositories;
@@ -184,11 +185,22 @@ public class YahooPriceImportService
 
         var stock = await stockRepo.Get(commonStockId);
 
+        // The SEC cover-page count (dei:EntityCommonStockSharesOutstanding) is authoritative and
+        // current; Yahoo's figure is per-share-class and lags corporate actions. Defer to EDGAR
+        // for the share count when the issuer has a consolidated SEC fact, so Yahoo can't overwrite
+        // it with a stale or single-class value (#3575/#2503).
+        var sharesProvider = scope.ServiceProvider.GetRequiredService<SharesOutstandingProvider>();
+        var edgarShares = await sharesProvider.GetReportedSharesOutstanding(stock, cancellationToken);
+
         // Per-field conservative writes: only update on actual change, and never
         // overwrite a known value with 0 (treated as Yahoo "unknown" by the rest of
         // the codebase).
         var changed = false;
-        if (stats.SharesOutstanding != 0 && stock.SharesOutStanding != stats.SharesOutstanding)
+        if (
+            edgarShares == null
+            && stats.SharesOutstanding != 0
+            && stock.SharesOutStanding != stats.SharesOutstanding
+        )
         {
             stock.SharesOutStanding = stats.SharesOutstanding;
             changed = true;

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsTestModuleConfiguration.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsTestModuleConfiguration.cs
@@ -1,0 +1,32 @@
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Registers the financial-fact entities for in-memory tests, ignoring the
+/// <see cref="FinancialFact.Document"/> navigation — it pulls in <c>Chunk</c> whose
+/// <c>Pgvector.Vector</c> property the in-memory EF Core provider can't bind (mirrors
+/// <see cref="DocumentOnlyModuleConfiguration"/>).
+/// </summary>
+internal sealed class FinancialFactsTestModuleConfiguration : IModuleConfiguration
+{
+    public void ConfigureEntities(ModelBuilder builder)
+    {
+        var conv = new ValueConverter<DocumentType, string>(
+            v => v.Value,
+            v => DocumentType.FromValue(v) ?? new DocumentType(v)
+        );
+
+        builder.Entity<FinancialConcept>();
+        builder.Entity<FinancialFact>(b =>
+        {
+            b.Property(e => e.Form).HasConversion(conv);
+            b.Ignore(e => e.Document);
+        });
+        builder.Entity<FinancialFactDimension>();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
@@ -1,0 +1,134 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.Data;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+// Pins SharesOutstandingProvider: the entity share count comes from the latest-filed CONSOLIDATED
+// dei:EntityCommonStockSharesOutstanding cover-page fact (so a reverse split is reflected at once,
+// #3575), and a multi-class issuer — which reports the count only per share class (dimensional
+// facts) — yields null so a single class is never mistaken for the entity total (#2503).
+public class SharesOutstandingProviderTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new FinancialFactsTestModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    [Fact]
+    public async Task GetReportedSharesOutstanding_PicksLatestFiledConsolidatedFact_IgnoringDimensional()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "COPR",
+            Name = "Idaho Copper",
+            Cik = "0001263364",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, concept);
+        // Older filing — the stale pre-split figure Yahoo also carries.
+        db.Add(Fact(stock, concept, 276_898_105m, new DateOnly(2025, 11, 25), new DateOnly(2025, 11, 25)));
+        // Latest filing — the current post-reverse-split entity total.
+        db.Add(Fact(stock, concept, 14_061_261m, new DateOnly(2026, 6, 1), new DateOnly(2026, 5, 29)));
+        // A per-class dimensional fact in the same latest filing must never be chosen.
+        db.Add(Fact(stock, concept, 99_999m, new DateOnly(2026, 6, 1), new DateOnly(2026, 5, 29),
+            dimensionsKey: "dei:SecurityClassAxis=copr:ClassAMember"));
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetReportedSharesOutstanding(stock);
+
+        shares.Should().Be(14_061_261);
+    }
+
+    [Fact]
+    public async Task GetReportedSharesOutstanding_OnlyDimensionalPerClassFacts_ReturnsNull()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "GOOGL",
+            Name = "Alphabet",
+            Cik = "0001652044",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, concept);
+        // Multi-class issuer: the cover-page count is reported only per share class (dimensional),
+        // so there is no consolidated fact for the entity total — that is summed across classes
+        // separately, not sourced here.
+        db.Add(Fact(stock, concept, 5_800_000_000m, new DateOnly(2026, 4, 24), new DateOnly(2026, 4, 17),
+            dimensionsKey: "dei:SecurityClassAxis=goog:ClassAMember"));
+        db.Add(Fact(stock, concept, 6_400_000_000m, new DateOnly(2026, 4, 24), new DateOnly(2026, 4, 17),
+            dimensionsKey: "dei:SecurityClassAxis=goog:ClassCMember"));
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetReportedSharesOutstanding(stock);
+
+        shares.Should().BeNull();
+    }
+
+    private static FinancialFact Fact(
+        CommonStock stock,
+        FinancialConcept concept,
+        decimal value,
+        DateOnly filed,
+        DateOnly asOf,
+        string dimensionsKey = ""
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Unit = "shares",
+            PeriodType = FactPeriodType.Instant,
+            PeriodStart = asOf,
+            PeriodEnd = asOf,
+            Value = value,
+            FiscalYear = asOf.Year,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenQ,
+            FiledDate = filed,
+            AccessionNumber = $"ACC-{Guid.NewGuid():N}"[..20],
+            DimensionsKey = dimensionsKey,
+        };
+}


### PR DESCRIPTION
## Summary

- Shares outstanding was written only from Yahoo, which returns a single share class's count and lags corporate actions — multi-class issuers were understated ~2x and reverse-split names kept a stale count that inflated market cap.
- Source it from the authoritative `dei:EntityCommonStockSharesOutstanding` cover-page fact the financial-facts importer already ingests: after an import, the latest-filed **consolidated** value sets `CommonStock.SharesOutStanding`, and the Yahoo importer defers to it when present.
- Consolidated facts only (`GetConsolidatedByStock`), so a multi-class issuer — which reports the count only per share class — yields null and keeps its existing value; summing per-class facts is a follow-up.

## Changes

- `FinancialConceptAliases` — add a `shares-outstanding` alias (`dei:EntityCommonStockSharesOutstanding`).
- `SharesOutstandingProvider` (new, FinancialFacts.BusinessLogic) — latest-filed consolidated share count for a stock.
- `FinancialFactsImportService` — set `SharesOutStanding` from the provider after import (and on the no-new-filing path, to correct existing rows).
- `YahooPriceImportService` — skip the shares write when an EDGAR fact exists.
- Unit tests: latest-filed consolidated wins / dimensional ignored / multi-class → null.

Refs daniel3303/EquiblesCommercial#3575, daniel3303/EquiblesCommercial#2503 (cross-repo; consumed via a submodule pin bump there).