### PR TITLE
feat(errors): add Authentication error source

### DIFF
--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -32,6 +32,7 @@ public sealed class ErrorSource
     );
     public static readonly ErrorSource InvestorRelationsScraper = new("InvestorRelationsScraper");
     public static readonly ErrorSource FdaCatalystScraper = new("FdaCatalystScraper");
+    public static readonly ErrorSource Authentication = new("Authentication");
     public static readonly ErrorSource Other = new("Other");
 
     public static IEnumerable<ErrorSource> GetAll() =>
@@ -58,6 +59,7 @@ public sealed class ErrorSource
             InvestorRelationsDiscovery,
             InvestorRelationsScraper,
             FdaCatalystScraper,
+            Authentication,
             Other,
         ];
 


### PR DESCRIPTION
## Summary

- Adds an `Authentication` value to the `ErrorSource` smart enum so web hosts can record login / register / OAuth failures into the Errors table.
- These then surface on the backoffice Errors page, filterable by source — giving visibility into auth failures that were previously silent.

## Code changes

- `src/Equibles.Errors.Data/Models/ErrorSource.cs` — new `ErrorSource.Authentication` static field, added to `GetAll()` (so it appears in the backoffice source filter). Stored as the string `"Authentication"`; no schema change.