### PR TITLE
docs(technical/modules): add government contracts and FDA catalysts modules

### DIFF
--- a/docs/technical/modules.md
+++ b/docs/technical/modules.md
@@ -16,6 +16,8 @@ Index of the financial-domain modules in `src/`. Each row is one logical domain;
 | **FINRA Short Data** ([`Equibles.Finra.*`](../../src/Equibles.Finra.Data)) | FINRA API | `DailyShortVolume`, `ShortInterest` | `FinraScraperWorker` | `Equibles.Finra.Mcp` |
 | **CFTC** ([`Equibles.Cftc.*`](../../src/Equibles.Cftc.Data)) | CFTC Commitments of Traders | `CftcContract`, `CftcContractCategory`, `CftcPositionReport` | `CftcScraperWorker` | `Equibles.Cftc.Mcp` |
 | **CBOE** ([`Equibles.Cboe.*`](../../src/Equibles.Cboe.Data)) | CBOE | `CboeVixDaily`, `CboePutCallRatio` (with `CboePutCallRatioType` enum) | `CboeScraperWorker` | `Equibles.Cboe.Mcp` |
+| **Government Contracts** ([`Equibles.GovernmentContracts.*`](../../src/Equibles.GovernmentContracts.Data)) | USAspending.gov | `GovernmentContract` (with `GovernmentContractAwardType` enum) | `GovernmentContractsScraperWorker` | `Equibles.GovernmentContracts.Mcp` |
+| **FDA Catalysts** ([`Equibles.FdaCatalysts.*`](../../src/Equibles.FdaCatalysts.Data)) | FDA.gov advisory-committee calendar | `FdaCatalyst` (with `FdaCatalystType` enum) | `FdaCatalystScraperWorker` | `Equibles.FdaCatalysts.Mcp` |
 
 ## Cross-cutting modules
 


### PR DESCRIPTION
## Summary

- The module index in `docs/technical/modules.md` listed domains only through CBOE; two newer modules were missing.
- Adds index rows for the Government Contracts (USAspending.gov) and FDA Catalysts (FDA.gov advisory-committee calendar) modules so the index matches the modules now in `src/`.

## Code changes

- `docs/technical/modules.md` — two new index rows: **Government Contracts** (`Equibles.GovernmentContracts.*`, entity `GovernmentContract`, `GovernmentContractsScraperWorker`, `Equibles.GovernmentContracts.Mcp`) and **FDA Catalysts** (`Equibles.FdaCatalysts.*`, entity `FdaCatalyst`, `FdaCatalystScraperWorker`, `Equibles.FdaCatalysts.Mcp`).