### PR TITLE
test(government-contracts): add skipped repro for GH-3786 — UsaSpendingAwardMapper surrogate split

### DIFF
--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs
@@ -97,4 +97,20 @@ public class UsaSpendingAwardMapperTests
 
         entity.NaicsCode.Should().Be("541512");
     }
+
+    [Fact(Skip = "GH-3786 — Truncate splits surrogate pairs, leaving an orphaned surrogate")]
+    public void Map_truncating_an_over_long_recipient_name_does_not_split_a_surrogate_pair()
+    {
+        // Contract: truncation must yield a well-formed prefix. Slicing by char index at
+        // the 512 cap can orphan a surrogate pair, producing invalid UTF-16 Postgres rejects.
+        var record = SampleRecord();
+        record.RecipientName = new string('A', 511) + "😀"; // 511 chars + 😀 = 513 > 512
+
+        var entity = UsaSpendingAwardMapper.Map(record, Guid.NewGuid());
+
+        entity.RecipientName.Should().NotBeNull();
+        char.IsHighSurrogate(entity.RecipientName![^1])
+            .Should()
+            .BeFalse("truncating at the 512-char cap must not leave an orphaned high surrogate");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds an adversarial unit test for `UsaSpendingAwardMapper` proving that the `Truncate` char-index slice (`trimmed[..maxLength]`) splits a UTF-16 surrogate pair when the cap falls inside one, leaving an orphaned surrogate in the stored field.
- The test fails on current code, so it is committed skipped — see GH-3786. Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs` — new `[Fact(Skip = "GH-3786 …")]` `Map_truncating_an_over_long_recipient_name_does_not_split_a_surrogate_pair`, mapping a 513-char recipient name (511 chars + an emoji) through the 512 cap and asserting the result does not end with an unpaired high surrogate.