### PR TITLE
docs(readme): add Government Contracts row to data table

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See [`docs/`](docs/README.md) for the user guide and technical documentation.
 | **Stock Prices** | Yahoo Finance | Daily OHLCV prices with technical indicators (SMA, RSI, MACD) |
 | **Futures Positioning** | CFTC | Commitments of Traders (COT) data for 30+ futures contracts |
 | **Market Indicators** | CBOE | VIX volatility index (1990+) and put/call ratios by category |
+| **Government Contracts** | USAspending.gov | Federal contract awards to public companies — amounts, awarding agencies, dates, and NAICS/PSC codes |
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Maintain lane (README drift): the front-door "What's Included" table omitted the Government Contracts module, which shipped recently and is already documented in `docs/technical/modules.md`.

## Code changes

- `README.md` — add a Government Contracts row (USAspending.gov; federal contract awards to public companies — amounts, awarding agencies, dates, NAICS/PSC codes) to the data-source table.