### PR TITLE
refactor(government-contracts): drop redundant DateOnly? cast in DetermineStartDate

### DIFF
--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -197,7 +197,7 @@ public class GovernmentContractsImportService : IImporter
         var latest = await repository
             .GetAll()
             .Where(c => c.ActionDate != null)
-            .MaxAsync(c => (DateOnly?)c.ActionDate, cancellationToken);
+            .MaxAsync(c => c.ActionDate, cancellationToken);
 
         return SyncDateResolver.Resolve(latest ?? default, _workerOptions);
     }


### PR DESCRIPTION
## Summary

- Resolves CodeQL alert #595 (`cs/useless-cast-to-self`): the `(DateOnly?)` cast in `GovernmentContractsImportService.DetermineStartDate` was redundant because `GovernmentContract.ActionDate` is already `DateOnly?`.
- Removing the cast preserves behavior — `MaxAsync` still returns a nullable and yields `null` on an empty sequence via the property's own nullability.

## Code changes

- `src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs` — drop the redundant `(DateOnly?)` cast in the `MaxAsync` selector.