### PR TITLE
feat(financial-facts): sum per-class shares outstanding for multi-class issuers

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -9,14 +9,21 @@ namespace Equibles.Sec.FinancialFacts.BusinessLogic;
 // Resolves a stock's common shares outstanding from the authoritative SEC cover-page tag
 // (dei:EntityCommonStockSharesOutstanding) the financial-facts importer already ingests, rather
 // than the per-share-class figure Yahoo returns (which understates multi-class issuers ~2x and
-// lags corporate actions like reverse splits). Consolidated facts only: a multi-class issuer
-// reports the count only per share class, so it has no consolidated fact and yields null here —
-// the entity total is summed across classes separately (#2503). A single-class issuer's latest
-// filing gives the current entity total (#3575).
+// lags corporate actions like reverse splits). A single-class issuer reports a consolidated fact,
+// read by GetReportedSharesOutstanding, giving the current entity total (#3575). A multi-class
+// issuer reports the count only per share class (dimensional facts on the class-of-stock axis,
+// no consolidated fact), so GetSummedPerClassSharesOutstanding sums those classes into the entity
+// total (#2503).
 [Service]
 public class SharesOutstandingProvider
 {
     private const string SharesUnit = "shares";
+
+    // XBRL axis that distinguishes a per-share-class cover-page count (e.g. Class A vs Class C)
+    // from the consolidated total. Multi-class issuers report
+    // dei:EntityCommonStockSharesOutstanding dimensioned on this axis and carry no consolidated
+    // fact, so the entity total is the sum across its members.
+    private const string ClassOfStockAxis = "us-gaap:StatementClassOfStockAxis";
 
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
@@ -37,15 +44,7 @@ public class SharesOutstandingProvider
         CancellationToken cancellationToken = default
     )
     {
-        if (!FinancialConceptAliases.TryResolve("shares-outstanding", out var refs))
-            return null;
-
-        var taxonomies = refs.Select(r => r.Taxonomy).Distinct().ToList();
-        var tags = refs.Select(r => r.Tag).ToList();
-        var conceptIds = await _financialConceptRepository
-            .GetMatching(taxonomies, tags)
-            .Select(c => c.Id)
-            .ToListAsync(cancellationToken);
+        var conceptIds = await ResolveConceptIds(cancellationToken);
         if (conceptIds.Count == 0)
             return null;
 
@@ -60,5 +59,68 @@ public class SharesOutstandingProvider
             .FirstOrDefaultAsync(cancellationToken);
 
         return value.HasValue ? (long)value.Value : (long?)null;
+    }
+
+    // The entity-wide share count for a multi-class issuer, summed across its share classes from
+    // the latest filing's per-class cover-page facts, or null when the issuer reports no per-class
+    // count on the class-of-stock axis (a single-class filer's consolidated fact is read by
+    // GetReportedSharesOutstanding instead). Sourced straight from the issuer's per-class cover-page
+    // tags — no heuristic, no MarketCap / Price shortcut.
+    public async Task<long?> GetSummedPerClassSharesOutstanding(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var conceptIds = await ResolveConceptIds(cancellationToken);
+        if (conceptIds.Count == 0)
+            return null;
+
+        // Per-share-class cover-page facts only: a single explicit dimension, on the class-of-stock
+        // axis. A fact dimensioned otherwise (segment/geography), on several axes, or with none is
+        // excluded so only genuine per-class counts are summed.
+        var perClassFacts = await _financialFactRepository
+            .GetByStock(stock)
+            .Where(f =>
+                conceptIds.Contains(f.FinancialConceptId)
+                && f.Unit == SharesUnit
+                && f.Dimensions.Count == 1
+                && f.Dimensions.Any(d => d.Axis == ClassOfStockAxis)
+            )
+            .Include(f => f.Dimensions)
+            .ToListAsync(cancellationToken);
+        if (perClassFacts.Count == 0)
+            return null;
+
+        // Sum across share classes from the latest filing only — pinned to that one accession and
+        // as-of date so classes are never mixed across filings, and grouped by class member so a
+        // restated row never double-counts a class.
+        var latest = perClassFacts
+            .OrderByDescending(f => f.FiledDate)
+            .ThenByDescending(f => f.PeriodEnd)
+            .First();
+
+        var total = perClassFacts
+            .Where(f =>
+                f.AccessionNumber == latest.AccessionNumber && f.PeriodEnd == latest.PeriodEnd
+            )
+            .GroupBy(f => f.Dimensions[0].Member)
+            .Sum(g => g.First().Value);
+
+        return total > 0 ? (long)total : (long?)null;
+    }
+
+    // The financial-concept ids the "shares-outstanding" alias resolves to, or an empty list when
+    // the alias is unmapped or no matching concept has been ingested yet.
+    private async Task<List<Guid>> ResolveConceptIds(CancellationToken cancellationToken)
+    {
+        if (!FinancialConceptAliases.TryResolve("shares-outstanding", out var refs))
+            return [];
+
+        var taxonomies = refs.Select(r => r.Taxonomy).Distinct().ToList();
+        var tags = refs.Select(r => r.Tag).ToList();
+        return await _financialConceptRepository
+            .GetMatching(taxonomies, tags)
+            .Select(c => c.Id)
+            .ToListAsync(cancellationToken);
     }
 }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -1,7 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
-using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Data;
 using Equibles.Data.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -9,6 +8,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models.Responses;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -140,13 +140,20 @@ public class FinancialFactsImportService
 
     // Sets the stock's share count from the authoritative SEC cover-page fact the import just
     // ingested, so the lagging per-share-class Yahoo figure no longer drives market cap and
-    // ownership percentages (#3575/#2503). No-ops when the issuer has no consolidated fact
-    // (multi-class filers — summed across classes elsewhere) or the value is unchanged.
-    private async Task UpdateSharesOutstanding(CommonStock stock, CancellationToken cancellationToken)
+    // ownership percentages (#3575/#2503). Uses the single-class consolidated fact when present
+    // (#3575); for a multi-class issuer, which carries no consolidated fact, falls back to the sum
+    // across its per-class cover-page facts (#2503). No-ops when neither is on record or the value
+    // is unchanged.
+    private async Task UpdateSharesOutstanding(
+        CommonStock stock,
+        CancellationToken cancellationToken
+    )
     {
         using var scope = _scopeFactory.CreateScope();
         var sharesProvider = scope.ServiceProvider.GetRequiredService<SharesOutstandingProvider>();
-        var shares = await sharesProvider.GetReportedSharesOutstanding(stock, cancellationToken);
+        var shares =
+            await sharesProvider.GetReportedSharesOutstanding(stock, cancellationToken)
+            ?? await sharesProvider.GetSummedPerClassSharesOutstanding(stock, cancellationToken);
         if (shares == null)
             return;
 

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
@@ -16,7 +16,8 @@ namespace Equibles.UnitTests.Sec;
 // Pins SharesOutstandingProvider: the entity share count comes from the latest-filed CONSOLIDATED
 // dei:EntityCommonStockSharesOutstanding cover-page fact (so a reverse split is reflected at once,
 // #3575), and a multi-class issuer — which reports the count only per share class (dimensional
-// facts) — yields null so a single class is never mistaken for the entity total (#2503).
+// facts on the class-of-stock axis, no consolidated fact) — has its classes summed into the
+// entity total instead of a single class being mistaken for it (#2503).
 public class SharesOutstandingProviderTests
 {
     private static EquiblesFinancialDbContext NewDb()
@@ -54,12 +55,30 @@ public class SharesOutstandingProviderTests
         };
         db.AddRange(stock, concept);
         // Older filing — the stale pre-split figure Yahoo also carries.
-        db.Add(Fact(stock, concept, 276_898_105m, new DateOnly(2025, 11, 25), new DateOnly(2025, 11, 25)));
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                276_898_105m,
+                new DateOnly(2025, 11, 25),
+                new DateOnly(2025, 11, 25)
+            )
+        );
         // Latest filing — the current post-reverse-split entity total.
-        db.Add(Fact(stock, concept, 14_061_261m, new DateOnly(2026, 6, 1), new DateOnly(2026, 5, 29)));
+        db.Add(
+            Fact(stock, concept, 14_061_261m, new DateOnly(2026, 6, 1), new DateOnly(2026, 5, 29))
+        );
         // A per-class dimensional fact in the same latest filing must never be chosen.
-        db.Add(Fact(stock, concept, 99_999m, new DateOnly(2026, 6, 1), new DateOnly(2026, 5, 29),
-            dimensionsKey: "dei:SecurityClassAxis=copr:ClassAMember"));
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                99_999m,
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 5, 29),
+                dimensionsKey: "dei:SecurityClassAxis=copr:ClassAMember"
+            )
+        );
         await db.SaveChangesAsync();
 
         var provider = new SharesOutstandingProvider(
@@ -91,10 +110,26 @@ public class SharesOutstandingProviderTests
         // Multi-class issuer: the cover-page count is reported only per share class (dimensional),
         // so there is no consolidated fact for the entity total — that is summed across classes
         // separately, not sourced here.
-        db.Add(Fact(stock, concept, 5_800_000_000m, new DateOnly(2026, 4, 24), new DateOnly(2026, 4, 17),
-            dimensionsKey: "dei:SecurityClassAxis=goog:ClassAMember"));
-        db.Add(Fact(stock, concept, 6_400_000_000m, new DateOnly(2026, 4, 24), new DateOnly(2026, 4, 17),
-            dimensionsKey: "dei:SecurityClassAxis=goog:ClassCMember"));
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                5_800_000_000m,
+                new DateOnly(2026, 4, 24),
+                new DateOnly(2026, 4, 17),
+                dimensionsKey: "dei:SecurityClassAxis=goog:ClassAMember"
+            )
+        );
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                6_400_000_000m,
+                new DateOnly(2026, 4, 24),
+                new DateOnly(2026, 4, 17),
+                dimensionsKey: "dei:SecurityClassAxis=goog:ClassCMember"
+            )
+        );
         await db.SaveChangesAsync();
 
         var provider = new SharesOutstandingProvider(
@@ -105,6 +140,214 @@ public class SharesOutstandingProviderTests
         var shares = await provider.GetReportedSharesOutstanding(stock);
 
         shares.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSummedPerClassSharesOutstanding_SumsLatestFilingAcrossShareClasses()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "GOOGL",
+            Name = "Alphabet",
+            Cik = "0001652044",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, concept);
+        // An older filing whose per-class counts must be ignored entirely.
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                5_671_000_000m,
+                new(2026, 1, 31),
+                new(2026, 1, 24),
+                "0001652044-26-000018",
+                "us-gaap:CommonClassAMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                5_438_000_000m,
+                new(2026, 1, 31),
+                new(2026, 1, 24),
+                "0001652044-26-000018",
+                "goog:CapitalClassCMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                837_000_000m,
+                new(2026, 1, 31),
+                new(2026, 1, 24),
+                "0001652044-26-000018",
+                "us-gaap:CommonClassBMember"
+            )
+        );
+        // The latest filing: Class A + Class C + Class B = 12,116,000,000 (the entity total).
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                5_824_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                "0001652044-26-000048",
+                "us-gaap:CommonClassAMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                5_456_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                "0001652044-26-000048",
+                "goog:CapitalClassCMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                836_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                "0001652044-26-000048",
+                "us-gaap:CommonClassBMember"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetSummedPerClassSharesOutstanding(stock);
+
+        shares.Should().Be(12_116_000_000);
+    }
+
+    [Fact]
+    public async Task GetSummedPerClassSharesOutstanding_OnlyConsolidatedFact_ReturnsNull()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, concept);
+        // Single-class issuer: only a consolidated fact, no per-class dimensional facts — summing
+        // has nothing to sum, so the consolidated path (GetReportedSharesOutstanding) is used.
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                14_687_356_000m,
+                new DateOnly(2026, 5, 1),
+                new DateOnly(2026, 4, 26)
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetSummedPerClassSharesOutstanding(stock);
+
+        shares.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSummedPerClassSharesOutstanding_IgnoresNonClassAxisDimensionalFacts()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "GOOGL",
+            Name = "Alphabet",
+            Cik = "0001652044",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, concept);
+        // A dimensional fact on a non-class axis must never be summed as a share class — only
+        // genuine per-class counts on the class-of-stock axis count toward the entity total.
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                5_824_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                "0001652044-26-000048",
+                "aapl:IPhoneMember",
+                axis: "srt:ProductOrServiceAxis"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetSummedPerClassSharesOutstanding(stock);
+
+        shares.Should().BeNull();
+    }
+
+    private static FinancialFact ClassFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        decimal value,
+        DateOnly filed,
+        DateOnly asOf,
+        string accession,
+        string member,
+        string axis = "us-gaap:StatementClassOfStockAxis"
+    )
+    {
+        var fact = new FinancialFact
+        {
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Unit = "shares",
+            PeriodType = FactPeriodType.Instant,
+            PeriodStart = asOf,
+            PeriodEnd = asOf,
+            Value = value,
+            FiscalYear = asOf.Year,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenQ,
+            FiledDate = filed,
+            AccessionNumber = accession,
+            DimensionsKey = $"{axis}={member}",
+        };
+        fact.Dimensions.Add(new FinancialFactDimension { Axis = axis, Member = member });
+        return fact;
     }
 
     private static FinancialFact Fact(


### PR DESCRIPTION
## Summary

Multi-class issuers (Alphabet and similar) report `dei:EntityCommonStockSharesOutstanding` only per share class — dimensioned on `us-gaap:StatementClassOfStockAxis` — and carry no consolidated cover-page fact. `SharesOutstandingProvider` only read the consolidated fact, so these issuers kept the lagging single-class Yahoo figure as their share count, which understates the entity total roughly 2x and inflates every ownership percentage that divides by it.

Verified against production data: Alphabet's latest filing carries Class A 5,824,000,000 + Class C 5,456,000,000 + Class B 836,000,000 = 12,116,000,000, while the stored count was a single class's ~5.87B.

## Code changes

- `SharesOutstandingProvider` — add `GetSummedPerClassSharesOutstanding`, which sums the per-class cover-page facts from the issuer's latest filing. It keeps only facts with a single dimension on the class-of-stock axis, pins the sum to one accession and as-of date so classes are never mixed across filings, and groups by class member so a restated row never double-counts a class. The shared concept-id resolution is factored into a private helper used by both read paths. No heuristic, no MarketCap/Price shortcut — the count comes straight from the issuer's per-class SEC cover-page tags.
- `FinancialFactsImportService.UpdateSharesOutstanding` — fall back to the per-class sum when no consolidated fact exists, so multi-class issuers get the correct entity total.
- `SharesOutstandingProviderTests` — three tests: sums the latest filing across share classes (ignoring an older filing), returns null for a single-class consolidated-only issuer, and ignores dimensional facts on a non-class axis.

Consumed on the commercial side via a submodule pin bump, which closes daniel3303/EquiblesCommercial#2503 (part of daniel3303/EquiblesCommercial#4160).