### PR TITLE
style: apply csharpier formatting to shares-outstanding files

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -1,7 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
-using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Data;
 using Equibles.Data.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -9,6 +8,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models.Responses;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -142,7 +142,10 @@ public class FinancialFactsImportService
     // ingested, so the lagging per-share-class Yahoo figure no longer drives market cap and
     // ownership percentages (#3575/#2503). No-ops when the issuer has no consolidated fact
     // (multi-class filers — summed across classes elsewhere) or the value is unchanged.
-    private async Task UpdateSharesOutstanding(CommonStock stock, CancellationToken cancellationToken)
+    private async Task UpdateSharesOutstanding(
+        CommonStock stock,
+        CancellationToken cancellationToken
+    )
     {
         using var scope = _scopeFactory.CreateScope();
         var sharesProvider = scope.ServiceProvider.GetRequiredService<SharesOutstandingProvider>();

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -190,7 +190,10 @@ public class YahooPriceImportService
         // for the share count when the issuer has a consolidated SEC fact, so Yahoo can't overwrite
         // it with a stale or single-class value (#3575/#2503).
         var sharesProvider = scope.ServiceProvider.GetRequiredService<SharesOutstandingProvider>();
-        var edgarShares = await sharesProvider.GetReportedSharesOutstanding(stock, cancellationToken);
+        var edgarShares = await sharesProvider.GetReportedSharesOutstanding(
+            stock,
+            cancellationToken
+        );
 
         // Per-field conservative writes: only update on actual change, and never
         // overwrite a known value with 0 (treated as Yahoo "unknown" by the rest of

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
@@ -54,12 +54,30 @@ public class SharesOutstandingProviderTests
         };
         db.AddRange(stock, concept);
         // Older filing — the stale pre-split figure Yahoo also carries.
-        db.Add(Fact(stock, concept, 276_898_105m, new DateOnly(2025, 11, 25), new DateOnly(2025, 11, 25)));
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                276_898_105m,
+                new DateOnly(2025, 11, 25),
+                new DateOnly(2025, 11, 25)
+            )
+        );
         // Latest filing — the current post-reverse-split entity total.
-        db.Add(Fact(stock, concept, 14_061_261m, new DateOnly(2026, 6, 1), new DateOnly(2026, 5, 29)));
+        db.Add(
+            Fact(stock, concept, 14_061_261m, new DateOnly(2026, 6, 1), new DateOnly(2026, 5, 29))
+        );
         // A per-class dimensional fact in the same latest filing must never be chosen.
-        db.Add(Fact(stock, concept, 99_999m, new DateOnly(2026, 6, 1), new DateOnly(2026, 5, 29),
-            dimensionsKey: "dei:SecurityClassAxis=copr:ClassAMember"));
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                99_999m,
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 5, 29),
+                dimensionsKey: "dei:SecurityClassAxis=copr:ClassAMember"
+            )
+        );
         await db.SaveChangesAsync();
 
         var provider = new SharesOutstandingProvider(
@@ -91,10 +109,26 @@ public class SharesOutstandingProviderTests
         // Multi-class issuer: the cover-page count is reported only per share class (dimensional),
         // so there is no consolidated fact for the entity total — that is summed across classes
         // separately, not sourced here.
-        db.Add(Fact(stock, concept, 5_800_000_000m, new DateOnly(2026, 4, 24), new DateOnly(2026, 4, 17),
-            dimensionsKey: "dei:SecurityClassAxis=goog:ClassAMember"));
-        db.Add(Fact(stock, concept, 6_400_000_000m, new DateOnly(2026, 4, 24), new DateOnly(2026, 4, 17),
-            dimensionsKey: "dei:SecurityClassAxis=goog:ClassCMember"));
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                5_800_000_000m,
+                new DateOnly(2026, 4, 24),
+                new DateOnly(2026, 4, 17),
+                dimensionsKey: "dei:SecurityClassAxis=goog:ClassAMember"
+            )
+        );
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                6_400_000_000m,
+                new DateOnly(2026, 4, 24),
+                new DateOnly(2026, 4, 17),
+                dimensionsKey: "dei:SecurityClassAxis=goog:ClassCMember"
+            )
+        );
         await db.SaveChangesAsync();
 
         var provider = new SharesOutstandingProvider(


### PR DESCRIPTION
## Summary

- The CSharpier format check on `main` was failing: three files merged in the shares-outstanding work were committed un-formatted, which blocks the lint gate on every PR.
- Ran the repo-pinned CSharpier to bring them into canonical formatting. No behavior change — import ordering and line wrapping only.

## Code changes

- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs` — reorder a using directive and wrap the `UpdateSharesOutstanding` signature.
- `src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — wrap the `GetReportedSharesOutstanding` call arguments.
- `tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs` — wrap the multi-argument `Fact(...)` builder calls.