### PR TITLE
fix(government-contracts): keep Truncate from splitting surrogate pairs

### DIFF
--- a/src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs
@@ -89,6 +89,14 @@ public static class UsaSpendingAwardMapper
         if (string.IsNullOrWhiteSpace(value))
             return null;
         var trimmed = value.Trim();
-        return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength];
+        if (trimmed.Length <= maxLength)
+            return trimmed;
+        // Don't split a surrogate pair at the cap — back off one unit so the result
+        // stays well-formed UTF-16 (Postgres rejects lone surrogates in text columns).
+        var end =
+            maxLength > 0 && char.IsHighSurrogate(trimmed[maxLength - 1])
+                ? maxLength - 1
+                : maxLength;
+        return trimmed[..end];
     }
 }

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs
@@ -98,7 +98,7 @@ public class UsaSpendingAwardMapperTests
         entity.NaicsCode.Should().Be("541512");
     }
 
-    [Fact(Skip = "GH-3786 — Truncate splits surrogate pairs, leaving an orphaned surrogate")]
+    [Fact]
     public void Map_truncating_an_over_long_recipient_name_does_not_split_a_surrogate_pair()
     {
         // Contract: truncation must yield a well-formed prefix. Slicing by char index at


### PR DESCRIPTION
## Summary

- Fixes #3786. `UsaSpendingAwardMapper.Truncate` capped over-long fields with a raw char-index slice (`trimmed[..maxLength]`), which split a UTF-16 surrogate pair when the cap landed inside one — leaving an orphaned surrogate that is invalid UTF-8 and can fail to persist to a Postgres text column.
- Applies the same surrogate-aware back-off already used by `EdgarXmlSubmissionParser.Truncate`, `DisclosureParsingHelper.Truncate`, and `ErrorManager`: when the boundary char is a high surrogate, drop the whole pair.
- Un-skips the existing regression test, which now passes (full unit suite green: 3002 tests).

## Code changes

- `src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs` — `Truncate` backs off one unit when `char.IsHighSurrogate(trimmed[maxLength - 1])` so the result is always well-formed UTF-16. Affects every truncated field (`AwardUniqueKey`, `AwardId`, `RecipientName`, `RecipientId`, `AwardingAgency`, and NAICS/PSC via `LeadingToken`).
- `tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs` — removes the `[Skip]` marker from the surrogate-split regression test.