### PR TITLE
docs(technical/mcp-tools): add government contracts and FDA catalysts tool sections

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -150,6 +150,19 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetPutCallRatios` — put/call ratios by category (equity, index, total, VIX, ETP).
 - `GetVixHistory` — daily VIX OHLC history (1990-present once backfilled).
 
+### `mcp.AddGovernmentContracts()` — federal contract awards
+
+`GovernmentContractsTools`:
+
+- `GetGovernmentContracts` — federal contract awards (USAspending.gov) won by one public company, with awarding agency, award amount, period dates, and description.
+- `GetTopGovernmentContractors` — rank public companies by total federal contract dollars awarded over a date range.
+
+### `mcp.AddFdaCatalysts()` — FDA advisory-committee meetings
+
+`FdaCatalystTools`:
+
+- `GetFdaCatalysts` — scheduled FDA advisory-committee (AdComm) meetings from the FDA.gov calendar — the regulatory catalyst dates that move biotech and pharma stocks.
+
 ## Tool implementation conventions
 
 - Every tool method runs through [`McpToolExecutor.Execute`](../../src/Equibles.Mcp/McpToolExecutor.cs), which wraps the body in a try/catch and logs failures.


### PR DESCRIPTION
## Summary

- Maintain lane (technical): the MCP tool catalog lists a section per MCP module but was missing the two newest ones, leaving it inconsistent with the module index.
- Adds the `mcp.AddGovernmentContracts()` and `mcp.AddFdaCatalysts()` sections so the catalog covers every MCP-enabled module.

## Code changes

- `docs/technical/mcp-tools.md` — two new tool-catalog sections: Government Contracts (`GetGovernmentContracts`, `GetTopGovernmentContractors`) and FDA Catalysts (`GetFdaCatalysts`).