### PR TITLE
test(financial-facts): pin SharesOutstandingProvider dedups a restated per-class row

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
@@ -319,6 +319,81 @@ public class SharesOutstandingProviderTests
         shares.Should().BeNull();
     }
 
+    [Fact]
+    public async Task GetSummedPerClassSharesOutstanding_DeduplicatesRestatedClassRow_InLatestFiling()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "GOOGL",
+            Name = "Alphabet",
+            Cik = "0001652044",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, concept);
+        // The latest filing carries Class A twice (a restated/duplicate row). The contract pins each
+        // class is counted once, so the entity total must not double-count Class A.
+        const string acc = "0001652044-26-000048";
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                5_824_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                acc,
+                "us-gaap:CommonClassAMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                5_824_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                acc,
+                "us-gaap:CommonClassAMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                5_456_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                acc,
+                "goog:CapitalClassCMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                836_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                acc,
+                "us-gaap:CommonClassBMember"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetSummedPerClassSharesOutstanding(stock);
+
+        shares.Should().Be(12_116_000_000);
+    }
+
     private static FinancialFact ClassFact(
         CommonStock stock,
         FinancialConcept concept,


### PR DESCRIPTION
## Summary

- Adversarial unit test for `SharesOutstandingProvider.GetSummedPerClassSharesOutstanding`, pinning its documented guarantee that a restated/duplicate per-class cover-page row in the latest filing is counted once (grouped by class member), never double-counted into the entity total.
- This contract had no test coverage; the test passes, confirming the behavior.

## Code changes

- `tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs` — new `[Fact]` seeding the latest filing with Class A reported twice plus Class B and Class C, asserting the summed total equals A+B+C once (12,116,000,000), not a double-counted A.