### PR TITLE
docs(technical): refresh module index enumeration with new modules

### DIFF
--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -6,7 +6,7 @@ Reference for developers working inside the Equibles codebase. Pairs with [`../g
 
 - [Architecture](architecture.md) — modular-monolith composition, the shared `EquiblesFinancialDbContext` module system, repo → manager → host data flow.
 - [Hosts](hosts.md) — the three host apps: `Equibles.Web` (MVC portal), `Equibles.Mcp.Server` (MCP transport), `Equibles.Worker.Host` (background scrapers).
-- [Modules](modules.md) — index of the financial-domain modules (SEC, SEC Financial Facts, Holdings, Insider, Congress, FRED, Yahoo, FINRA, CFTC, CBOE) with data source, key entities, and scraper entry point per row.
+- [Modules](modules.md) — index of the financial-domain modules (SEC, SEC Financial Facts, Holdings, Insider, Congress, FRED, Yahoo, FINRA, CFTC, CBOE, Government Contracts, FDA Catalysts) with data source, key entities, and scraper entry point per row.
 - [MCP tools](mcp-tools.md) — catalog of the tools exposed by each module's `*.Mcp` project and the wiring path through `Equibles.Mcp` → `Equibles.Mcp.Server`.
 - [Scrapers and integrations](scrapers.md) — `*.HostedService` worker pattern, `Equibles.Integrations.*` client pattern, rate limiting, retry, `ProcessedDataSet` / `ProcessedFiling` bookkeeping.
 - [Web portal](web-portal.md) — `StocksController` tab pattern, `StockTabService`, DaisyUI v5 + Tailwind v4 + Vite, Razor partial conventions.


### PR DESCRIPTION
## Summary

- Maintain lane (technical): the module index entry in `docs/technical/README.md` enumerated the domains through CBOE, but the modules page itself now lists two more.
- Adds Government Contracts and FDA Catalysts to the enumeration so the index description matches `modules.md`.

## Code changes

- `docs/technical/README.md` — extend the modules-index enumeration with Government Contracts and FDA Catalysts.