### PR TITLE
test(government-contracts): add skipped repro for GH-3802 — null results NRE

### DIFF
--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientGetContractAwardsNullResultsTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientGetContractAwardsNullResultsTests.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using Equibles.Integrations.GovernmentContracts;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+/// <summary>
+/// Pins <see cref="UsaSpendingClient.GetContractAwards"/> against a well-formed response whose
+/// <c>results</c> field is JSON null. The contract is to return the awards in the window — a page
+/// that carries no results array contributes nothing, so the call must yield an empty list, not
+/// throw. The model defaults Results to an empty list, but a deserialized explicit null overwrites
+/// that default, so reading Results.Count without a guard would NRE.
+/// </summary>
+public class UsaSpendingClientGetContractAwardsNullResultsTests
+{
+    [Fact(Skip = "GH-3802 — GetContractAwards NREs when a page's results field is JSON null")]
+    public async Task GetContractAwards_ResultsFieldIsNull_ReturnsEmptyWithoutThrowing()
+    {
+        const string body = "{\"results\":null,\"page_metadata\":{\"page\":1,\"hasNext\":false}}";
+        var sut = new UsaSpendingClient(
+            new HttpClient(new SingleResponseHandler(body)),
+            Substitute.For<ILogger<UsaSpendingClient>>()
+        );
+
+        var awards = await sut.GetContractAwards(
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            minimumAmount: 0m
+        );
+
+        awards.Should().BeEmpty();
+    }
+
+    private sealed class SingleResponseHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+
+        public SingleResponseHandler(string body) => _body = body;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_body) }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `UsaSpendingClient.GetContractAwards`: a well-formed page whose `results` field is JSON `null` makes `response.Results.Count` throw a `NullReferenceException` (the model's `[]` default is overwritten by Newtonsoft on an explicit null).
- The test fails on current code, so it is committed skipped — see GH-3802. Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientGetContractAwardsNullResultsTests.cs` — new `[Fact(Skip = "GH-3802 …")]` stubbing a `{"results":null,...}` page and asserting `GetContractAwards` returns an empty list instead of throwing (skipped — see GH-3802).