### PR TITLE
test(government-contracts): pin RecipientNameNormalizer parenthesis drop branch

### DIFF
--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerParenthesesTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerParenthesesTests.cs
@@ -1,0 +1,22 @@
+using Equibles.GovernmentContracts.HostedService.Services;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+/// <summary>
+/// Pins <see cref="RecipientNameNormalizer.Normalize"/>'s handling of drop-class punctuation
+/// (parentheses) — a branch the existing suite never exercises, yet real USAspending recipient
+/// names carry parenthetical DBA/division decorations. The contract strips punctuation and the
+/// trailing legal suffix, keeping the inner word, so the normalized key stays comparable.
+/// </summary>
+public class RecipientNameNormalizerParenthesesTests
+{
+    [Fact]
+    public void Normalize_DropsParentheses_KeepsInnerWord_AndStripsTrailingSuffix()
+    {
+        var key = RecipientNameNormalizer.Normalize("Booz Allen Hamilton (Holding) Corporation");
+
+        // Parentheses removed as punctuation, "HOLDING" kept as a real token, "CORPORATION"
+        // stripped as a trailing legal suffix.
+        key.Should().Be("BOOZ ALLEN HAMILTON HOLDING");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one unit test pinning `RecipientNameNormalizer.Normalize` for drop-class punctuation (parentheses) — a code branch the existing suite never exercised, despite real USAspending recipient names carrying parenthetical DBA/division decorations.
- Lane A (adversarial) — oracle derived from the contract (strip punctuation + trailing legal suffix, keep inner words). Behavior confirmed; the key stays comparable.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerParenthesesTests.cs` — asserts `"Booz Allen Hamilton (Holding) Corporation"` normalizes to `"BOOZ ALLEN HAMILTON HOLDING"` (parentheses dropped, inner word kept, `Corporation` stripped).