### PR TITLE
docs(technical/scrapers): add government contracts integration client to the table

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -47,6 +47,7 @@ Each upstream source has its own integration project:
 | `Equibles.Integrations.Finra` | FINRA API |
 | `Equibles.Integrations.Cftc` | CFTC Commitments of Traders |
 | `Equibles.Integrations.Cboe` | CBOE indicators |
+| `Equibles.Integrations.GovernmentContracts` | USAspending.gov federal contract awards |
 | `Equibles.Integrations.Common` | Shared infrastructure — currently `RateLimiter` only |
 
 Every client follows the same shape: one interface + one implementation registered via `[Service(ServiceLifetime.Scoped, typeof(IXxxClient))]` (the AutoWire attribute from `Equibles.Core.AutoWiring`). The interface lives in `Contracts/`, the DTOs in `Models/`, and the wire/transport details in the client class itself.


### PR DESCRIPTION
## Summary

- Maintain lane (technical): the integration-clients table in `docs/technical/scrapers.md` listed every `Equibles.Integrations.*` source but the recently-added USAspending client was missing.
- Adds the `Equibles.Integrations.GovernmentContracts` row so the table matches the integration projects in `src/`.

## Code changes

- `docs/technical/scrapers.md` — add the `Equibles.Integrations.GovernmentContracts` (USAspending.gov) row to the integration-clients table.