### PR TITLE
test(government-contracts): pin UsaSpendingClient exponential backoff schedule

### DIFF
--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientExponentialBackoffTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientExponentialBackoffTests.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using Equibles.Integrations.GovernmentContracts;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class UsaSpendingClientExponentialBackoffTests
+{
+    // Contract (method name + shared RetryBackoff): exponential backoff between
+    // USAspending retries, f(n) = 2^(n+1) seconds — f(0)=2s, f(1)=4s, f(2)=8s.
+    // This forwarder is private static and otherwise untested.
+    //
+    // The risk this pin uniquely catches: a "simplification" that stops delegating
+    // to RetryBackoff.Exponential and inlines a drifted formula. Dropping the `+1`
+    // (`Math.Pow(2, attempt)`) compiles and still grows exponentially but HALVES
+    // every interval; USAspending answers an over-eager client with HTTP 429, so a
+    // halved gap turns a transient throttle into a hard ban that silently starves
+    // the federal-contracts ingest. Asserting exactly 8s at attempt=2 distinguishes
+    // the correct 2^(attempt+1) from the halving (4s), index-swap (4s), and
+    // doubled-shift (16s) regressions.
+    //
+    // Reflection-invoke since the method is private static.
+    [Fact]
+    public void ExponentialBackoff_AttemptTwo_Returns8Seconds()
+    {
+        var method = typeof(UsaSpendingClient).GetMethod(
+            "ExponentialBackoff",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (TimeSpan)method!.Invoke(null, [2]);
+
+        result.Should().Be(TimeSpan.FromSeconds(8));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one unit test pinning `UsaSpendingClient.ExponentialBackoff` (private static forwarder, previously untested) to the shared `2^(attempt+1)`-second schedule — mirroring the existing per-client backoff pins (Cftc, Cboe, Fred, Finra, Yahoo, SEC, House, Senate).
- Lane A (adversarial) — oracle from the documented backoff contract. Asserting 8s at attempt=2 catches the halving, index-swap, and doubled-shift regressions that would otherwise compile silently and turn a USAspending 429 throttle into a hard ban.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientExponentialBackoffTests.cs` — reflection-invokes the private static `ExponentialBackoff(2)` and asserts it returns 8 seconds.