### PR TITLE
docs(technical/operations): add FDA catalyst scraper to per-scraper tuning table

### DIFF
--- a/docs/technical/operations.md
+++ b/docs/technical/operations.md
@@ -58,6 +58,7 @@ Each scraper has its own option section. All scraper option binds live in [`src/
 | `YahooPriceScraper` | Yahoo price worker cadence + per-ticker backoff. |
 | `CftcScraper` | CFTC COT worker cadence + contract subset. |
 | `CboeScraper` | CBOE worker cadence. |
+| `FdaCatalystScraper` | FDA advisory-committee calendar worker cadence + source calendar URL. |
 | `DocumentScraper` | SEC document download cadence + concurrency. |
 | `Worker` | Cross-cutting: `MinSyncDate`, `TickersToSync`. |
 


### PR DESCRIPTION
## Summary

- Maintain lane (technical): the per-scraper tuning table in `docs/technical/operations.md` lists every scraper's option section but was missing the FDA catalysts worker, which binds the `FdaCatalystScraper` config section.
- Adds that row so operators can find its cadence and calendar-URL keys.

## Code changes

- `docs/technical/operations.md` — add the `FdaCatalystScraper` row to the per-scraper tuning table.