### PR TITLE
fix(government-contracts): treat a null results page as empty in GetContractAwards

### DIFF
--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -134,8 +134,13 @@ public class UsaSpendingClient : IUsaSpendingClient
             return _httpClient.SendAsync(request);
         });
 
-        return JsonConvert.DeserializeObject<UsaSpendingAwardResponse>(content)
+        var response =
+            JsonConvert.DeserializeObject<UsaSpendingAwardResponse>(content)
             ?? new UsaSpendingAwardResponse();
+        // A page with "results": null overwrites the model's default empty list with null;
+        // restore the non-null invariant so callers can read Results without a guard.
+        response.Results ??= [];
+        return response;
     }
 
     private async Task<string> SendWithRetry(Func<Task<HttpResponseMessage>> sendRequest)

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientGetContractAwardsNullResultsTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientGetContractAwardsNullResultsTests.cs
@@ -14,7 +14,7 @@ namespace Equibles.UnitTests.GovernmentContracts;
 /// </summary>
 public class UsaSpendingClientGetContractAwardsNullResultsTests
 {
-    [Fact(Skip = "GH-3802 — GetContractAwards NREs when a page's results field is JSON null")]
+    [Fact]
     public async Task GetContractAwards_ResultsFieldIsNull_ReturnsEmptyWithoutThrowing()
     {
         const string body = "{\"results\":null,\"page_metadata\":{\"page\":1,\"hasNext\":false}}";


### PR DESCRIPTION
## Summary

- Fixes #3802. `GetContractAwards` threw a `NullReferenceException` when a USAspending page returned `"results": null` — Newtonsoft overwrites the model's default empty list with null, and `response.Results.Count` then NREs.
- `PostQuery` now restores the non-null `Results` invariant after deserialization, so a null results page is treated as empty and the import continues.
- Un-skips the existing regression test; full unit suite green (3007 tests).

## Code changes

- `src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs` — `PostQuery` coalesces `response.Results ??= []` after deserialization, restoring the invariant for every caller.
- `tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientGetContractAwardsNullResultsTests.cs` — removes the `[Skip]` marker from the regression test.