### PR TITLE
docs(technical/mcp-tools): sync catalog with new FRED, holdings, and congress tools

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -33,6 +33,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetFundOverlap` — 13F portfolio overlap between two filers at their latest common `ReportDate`: Jaccard similarity, dollar-weighted overlap, and a side-by-side stock table with per-fund shares + percent of portfolio.
 - `GetConsensusHoldings` — combined portfolio of 2-25 filers at their latest common `ReportDate`; stocks ranked by holder count then combined value, with optional `minFunds` floor.
 - `GetMostHeldStocks` — cross-sectional ranking of stocks by institutional 13F breadth for a quarter, ordered by filer count (default), quarter-over-quarter change in filer count (warming / cooling), or total reported value; includes Δ filers, total value, Δ value, and the stock's share of the 13F universe.
+- `GetFundCloneBacktest` — backtest cloning a filer's reported 13F portfolio against a benchmark over a trailing window, rebalancing on the SEC filing lag; returns total return, CAGR, and max drawdown for both the clone and the benchmark plus the alpha between them.
 
 ### `mcp.AddInsiderTrading()` — Form 3 / 4
 
@@ -106,6 +107,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetCongressionalTrades` — trades for a ticker across all members.
 - `GetMemberTrades` — trades by one member of Congress.
 - `SearchCongressMembers` — search members by name / chamber / position.
+- `GetMemberNetWorth` — a member's net-worth history from annual financial disclosures, reported as yearly min–max bands (electronic filings only).
 
 ### `mcp.AddFred()` — FRED economic indicators
 
@@ -114,6 +116,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetEconomicIndicator` — observations for a FRED series (e.g. `DGS10`, `UNRATE`).
 - `GetLatestEconomicData` — latest snapshot across the curated macro indicators.
 - `SearchEconomicIndicators` — keyword search across series titles / categories.
+- `GetEconomicCalendar` — scheduled and recent US macro release dates (CPI, Employment Situation, GDP, …) and the FRED series each updates; defaults to the next 30 days.
 
 ### `mcp.AddStockPrices()` — Yahoo OHLCV + technical indicators
 


### PR DESCRIPTION
## Summary

- Maintain lane (technical): the MCP tool catalog had fallen behind the code by three exposed tools.
- Adds `GetFundCloneBacktest` (Holdings), `GetMemberNetWorth` (Congress), and `GetEconomicCalendar` (FRED) so the catalog matches the tools in `src/`.

## Code changes

- `docs/technical/mcp-tools.md` — one bullet added to each of the Holdings, Congress, and FRED tool groups.