### PR TITLE
docs(technical/hosts): refresh Worker Host registration set with common-stocks and FDA workers

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -44,7 +44,7 @@ The background-scraper host. Plain `Host.CreateApplicationBuilder` (not `WebAppl
 - Current binds: `WorkerOptions`, `DocumentScraperOptions`, `FinraOptions` + `FinraScraperOptions`, `FredOptions` + `FredScraperOptions`, `FtdScraperOptions`, `FinancialFactsScraperOptions`, `YahooPriceScraperOptions`, `CftcScraperOptions`, `CboeScraperOptions`.
 - Each scraper reads its own section so per-source tuning never leaks across modules.
 - Per-module `Add*Worker()` extensions register the `BackgroundService` workers from each `.HostedService` project.
-- Current set: `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()`.
+- Current set: `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()`, `AddCommonStocksWorker()`, `AddFdaCatalystWorker()`.
 - `AddWorkerServices()` wires the cross-cutting worker plumbing (`SyncDateResolver`, etc.).
 - Per `Directory.Build.props`, every `.HostedService` project shares the global usings `Microsoft.Extensions.{DependencyInjection,Hosting,Logging,Options}` + `Equibles.Data` + `Equibles.Core`.
 


### PR DESCRIPTION
## Summary

- Maintain lane (technical): the Worker Host "current set" of `Add*Worker()` registrations in `hosts.md` had fallen behind `Program.cs`.
- Adds `AddCommonStocksWorker()` and `AddFdaCatalystWorker()` so the list matches the workers the host actually registers.

## Code changes

- `docs/technical/hosts.md` — extend the Worker Host registration set with the two missing `Add*Worker()` calls.