### PR TITLE
fix(worker): register the government contracts scraper in the worker host

### DIFF
--- a/src/Equibles.Worker.Host/Equibles.Worker.Host.csproj
+++ b/src/Equibles.Worker.Host/Equibles.Worker.Host.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\Equibles.Finra.HostedService\Equibles.Finra.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Fred.HostedService\Equibles.Fred.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.FdaCatalysts.HostedService\Equibles.FdaCatalysts.HostedService.csproj" />
+    <ProjectReference Include="..\Equibles.GovernmentContracts.HostedService\Equibles.GovernmentContracts.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Yahoo\Equibles.Integrations.Yahoo.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.HostedService\Equibles.Yahoo.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Cftc.HostedService\Equibles.Cftc.HostedService.csproj" />

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -17,6 +17,8 @@ using Equibles.Finra.Data.Extensions;
 using Equibles.Finra.HostedService.Extensions;
 using Equibles.Fred.Data.Extensions;
 using Equibles.Fred.HostedService.Extensions;
+using Equibles.GovernmentContracts.HostedService.Configuration;
+using Equibles.GovernmentContracts.HostedService.Extensions;
 using Equibles.Holdings.Data.Extensions;
 using Equibles.Holdings.HostedService.Extensions;
 using Equibles.InsiderTrading.Data.Extensions;
@@ -117,6 +119,9 @@ builder.Services.Configure<Equibles.CommonStocks.HostedService.Configuration.Ste
 builder.Services.Configure<FdaCatalystScraperOptions>(
     builder.Configuration.GetSection("FdaCatalystScraper")
 );
+builder.Services.Configure<GovernmentContractsScraperOptions>(
+    builder.Configuration.GetSection("GovernmentContractsScraper")
+);
 
 // Without this bind, IOptions<EmbeddingConfig> is always default (Enabled=false),
 // so GenerateEmbeddingBatch short-circuits and no embeddings are ever produced —
@@ -150,6 +155,7 @@ builder.Services.AddCommonStocksWorker();
 // Reads the stealth browser registered by AddCommonStocksWorker above to render the
 // client-side FDA.gov advisory-committee calendar.
 builder.Services.AddFdaCatalystWorker();
+builder.Services.AddGovernmentContractsWorker();
 
 var host = builder.Build();
 host.Run();


### PR DESCRIPTION
## Summary

- The GovernmentContracts module shipped without being wired into the Worker Host: `Equibles.Worker.Host` never referenced `Equibles.GovernmentContracts.HostedService` and never called `AddGovernmentContractsWorker()`.
- As a result the USAspending federal-contracts scraper never ran — the `government_contracts` table and the `GetGovernmentContracts` / `GetTopGovernmentContractors` MCP tools existed but nothing populated the data.
- Wires the module in, mirroring the FDA catalysts module: adds the project reference, binds `GovernmentContractsScraperOptions` to the `GovernmentContractsScraper` config section, and registers the worker.

## Code changes

- `src/Equibles.Worker.Host/Equibles.Worker.Host.csproj` — add a project reference to `Equibles.GovernmentContracts.HostedService`.
- `src/Equibles.Worker.Host/Program.cs` — import the module's Configuration/Extensions namespaces, bind `GovernmentContractsScraperOptions`, and call `AddGovernmentContractsWorker()`.

## Verification

- Solution builds clean in Release; CSharpier passes; the GovernmentContracts unit suite (30 tests) is green.