### PR TITLE
test(wikidata): pin GetOfficialWebsitesByCik ordinal tie-break

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/WikidataClientTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/WikidataClientTests.cs
@@ -70,6 +70,23 @@ public class WikidataClientTests
     }
 
     [Fact]
+    public async Task EqualLengthWebsites_OrdinallySmallestWins_RegardlessOfBindingOrder()
+    {
+        // Contract: among equal-length candidates the pick is the ordinally-smallest URL,
+        // deterministically — so binding order must not change the result.
+        var (client, _) = BuildSut(
+            SparqlJson(
+                ("0000320193", "https://zzz.example/"),
+                ("0000320193", "https://aaa.example/")
+            )
+        );
+
+        var result = await client.GetOfficialWebsitesByCik(["320193"], CancellationToken.None);
+
+        result["320193"].Should().Be("https://aaa.example/");
+    }
+
+    [Fact]
     public async Task UnknownCiks_AreAbsentFromTheResult()
     {
         var (client, _) = BuildSut(SparqlJson(("0000320193", "https://apple.com/")));


### PR DESCRIPTION
## Summary

- Adversarial unit test pinning `WikidataClient.GetOfficialWebsitesByCik`'s documented determinism guarantee: among equal-length website candidates for one CIK, the ordinally-smallest URL wins regardless of binding order.
- This tie-break branch was previously uncovered (the existing "shortest wins" test only used differing lengths). The test passes, confirming the behavior.

## Code changes

- `tests/Equibles.UnitTests/Integrations/WikidataClientTests.cs` — new `[Fact]` feeding two equal-length URLs (`zzz` before `aaa`) for one CIK and asserting `aaa` is chosen, proving the ordinal tie-break overrides first-seen.