### PR TITLE
docs(technical/hosts): add the government contracts worker to the registration set

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -44,7 +44,7 @@ The background-scraper host. Plain `Host.CreateApplicationBuilder` (not `WebAppl
 - Current binds: `WorkerOptions`, `DocumentScraperOptions`, `FinraOptions` + `FinraScraperOptions`, `FredOptions` + `FredScraperOptions`, `FtdScraperOptions`, `FinancialFactsScraperOptions`, `YahooPriceScraperOptions`, `CftcScraperOptions`, `CboeScraperOptions`.
 - Each scraper reads its own section so per-source tuning never leaks across modules.
 - Per-module `Add*Worker()` extensions register the `BackgroundService` workers from each `.HostedService` project.
-- Current set: `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()`, `AddCommonStocksWorker()`, `AddFdaCatalystWorker()`.
+- Current set: `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()`, `AddCommonStocksWorker()`, `AddFdaCatalystWorker()`, `AddGovernmentContractsWorker()`.
 - `AddWorkerServices()` wires the cross-cutting worker plumbing (`SyncDateResolver`, etc.).
 - Per `Directory.Build.props`, every `.HostedService` project shares the global usings `Microsoft.Extensions.{DependencyInjection,Hosting,Logging,Options}` + `Equibles.Data` + `Equibles.Core`.
 


### PR DESCRIPTION
## Summary

- Maintain lane (stale reference): the Worker Host "Current set" in `hosts.md` listed every `Add*Worker()` call except `AddGovernmentContractsWorker()`, which is registered at `Program.cs:158`.

## Code changes

- `docs/technical/hosts.md` — append `AddGovernmentContractsWorker()` to the registration set so the doc matches `Equibles.Worker.Host/Program.cs`.