### PR TITLE
test(common-stocks): add skipped repro for GH-3818 — WikidataWebsiteSource drops CIK-siblings

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/WikidataWebsiteSourceTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/WikidataWebsiteSourceTests.cs
@@ -38,6 +38,31 @@ public class WikidataWebsiteSourceTests
             .Be(new KeyValuePair<Guid, string>(withAnswer.Id, "https://apple.com/"));
     }
 
+    [Fact(
+        Skip = "GH-3818 — FindWebsites drops CIK-siblings; only the first stock sharing a CIK gets the website"
+    )]
+    public async Task TwoStocksSharingACik_BothReceiveTheWebsite()
+    {
+        // Dual-class issuers (e.g. GOOGL/GOOG) are separate stocks that share one CIK; Wikidata
+        // keys websites by CIK, so both tickers should receive the resolved website — not just one.
+        var classA = new WebsiteSourceStock(Guid.NewGuid(), "GOOGL", "1652044");
+        var classC = new WebsiteSourceStock(Guid.NewGuid(), "GOOG", "1652044");
+        var client = Substitute.For<IWikidataClient>();
+        client
+            .GetOfficialWebsitesByCik(
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(new Dictionary<string, string> { ["1652044"] = "https://abc.xyz/" });
+
+        var result = await new WikidataWebsiteSource(client).FindWebsites(
+            [classA, classC],
+            CancellationToken.None
+        );
+
+        result.Should().ContainKeys(classA.Id, classC.Id);
+    }
+
     [Fact]
     public async Task StocksWithoutCik_AreNotQueried()
     {


### PR DESCRIPTION
## Summary

- Adversarial unit test for `WikidataWebsiteSource.FindWebsites`: two stocks sharing one CIK (dual-class issuers like GOOGL/GOOG) should both receive the Wikidata website, but only the first is returned — the CIK dedup keeps `g.First()` and never fans the result back out to the siblings.
- The test fails on current code, so it is committed skipped — see GH-3818. Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/WikidataWebsiteSourceTests.cs` — new `[Fact(Skip = "GH-3818 …")]` asserting both same-CIK stock Ids appear in the result (skipped — see GH-3818).