### PR TITLE
fix(common-stocks): fan Wikidata website out to all stocks sharing a CIK

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/WikidataWebsiteSource.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/WikidataWebsiteSource.cs
@@ -29,18 +29,23 @@ public class WikidataWebsiteSource : IWebsiteSource
         CancellationToken cancellationToken
     )
     {
-        var stocksByCik = stocks
+        var stockGroups = stocks
             .Where(s => !string.IsNullOrWhiteSpace(s.Cik))
             .GroupBy(s => s.Cik)
-            .ToDictionary(g => g.Key, g => g.First());
-        if (stocksByCik.Count == 0)
+            .ToList();
+        if (stockGroups.Count == 0)
             return new Dictionary<Guid, string>();
 
         var websitesByCik = await _wikidataClient.GetOfficialWebsitesByCik(
-            stocksByCik.Keys,
+            stockGroups.Select(g => g.Key).ToList(),
             cancellationToken
         );
 
-        return websitesByCik.ToDictionary(pair => stocksByCik[pair.Key].Id, pair => pair.Value);
+        // One Wikidata website per CIK fans out to every stock sharing that CIK
+        // (dual-class issuers like GOOGL/GOOG), not just the first one seen.
+        return stockGroups
+            .Where(g => websitesByCik.ContainsKey(g.Key))
+            .SelectMany(g => g.Select(s => (s.Id, Website: websitesByCik[g.Key])))
+            .ToDictionary(x => x.Id, x => x.Website);
     }
 }

--- a/tests/Equibles.UnitTests/CommonStocks/WikidataWebsiteSourceTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/WikidataWebsiteSourceTests.cs
@@ -38,9 +38,7 @@ public class WikidataWebsiteSourceTests
             .Be(new KeyValuePair<Guid, string>(withAnswer.Id, "https://apple.com/"));
     }
 
-    [Fact(
-        Skip = "GH-3818 — FindWebsites drops CIK-siblings; only the first stock sharing a CIK gets the website"
-    )]
+    [Fact]
     public async Task TwoStocksSharingACik_BothReceiveTheWebsite()
     {
         // Dual-class issuers (e.g. GOOGL/GOOG) are separate stocks that share one CIK; Wikidata


### PR DESCRIPTION
## Summary

- Fixes #3818. `WikidataWebsiteSource.FindWebsites` deduplicated input stocks by CIK keeping only `g.First()`, then keyed the resolved website to that one stock — so for dual-class issuers sharing a CIK (e.g. GOOGL/GOOG) only one ticker got the website and the sibling was silently dropped.
- The fix keeps one SPARQL query per CIK but fans the resolved website out to every stock in that CIK's group. Un-skips the regression test; full unit suite green (3010 tests).

## Code changes

- `src/Equibles.CommonStocks.HostedService/Services/WikidataWebsiteSource.cs` — group stocks by CIK (keep the full group), query each CIK once, then `SelectMany` the website across every stock sharing the CIK when projecting the result.
- `tests/Equibles.UnitTests/CommonStocks/WikidataWebsiteSourceTests.cs` — removes the `[Skip]` marker from the CIK-sibling regression test.