### PR TITLE
test(government-contracts): pin RecipientResolver.Resolve matches by normalized name

### DIFF
--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientResolverTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientResolverTests.cs
@@ -1,0 +1,23 @@
+using Equibles.GovernmentContracts.HostedService.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class RecipientResolverTests
+{
+    [Fact]
+    public void Resolve_MatchesByNormalizedName_NotRawString()
+    {
+        var stockId = Guid.NewGuid();
+        // The lookup is keyed by the normalized company name, exactly as BuildLookup produces it.
+        var lookup = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            [RecipientNameNormalizer.Normalize("Lockheed Martin Corporation")] = stockId,
+        };
+
+        // Contract: resolution is an exact match on the NORMALIZED key, so a differently
+        // suffixed/punctuated recipient name still resolves — raw string equality would not.
+        RecipientResolver.Resolve("LOCKHEED MARTIN CORP.", lookup).Should().Be(stockId);
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `RecipientResolver.Resolve`, pinning that resolution is an exact match on the *normalized* company-name key (not raw string equality) — so a differently-suffixed/punctuated USAspending recipient name still resolves to the right stock.
- `RecipientResolver` had no test; the static `Resolve` is pure and directly testable. The test passes, confirming the behavior.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/RecipientResolverTests.cs` — new test: a lookup keyed by `Normalize("Lockheed Martin Corporation")` resolves the recipient name `"LOCKHEED MARTIN CORP."` to the same stock id.