### PR TITLE
test(government-contracts): pin RecipientResolver.BuildLookup drops ambiguous shared-key stocks

### DIFF
--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientResolverTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientResolverTests.cs
@@ -1,5 +1,12 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
 using Equibles.GovernmentContracts.HostedService.Services;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Equibles.UnitTests.GovernmentContracts;
@@ -19,5 +26,74 @@ public class RecipientResolverTests
         // Contract: resolution is an exact match on the NORMALIZED key, so a differently
         // suffixed/punctuated recipient name still resolves — raw string equality would not.
         RecipientResolver.Resolve("LOCKHEED MARTIN CORP.", lookup).Should().Be(stockId);
+    }
+
+    [Fact]
+    public async Task BuildLookup_DropsKeySharedByMoreThanOneDistinctStock()
+    {
+        var options = NewDbOptions();
+        using (var seed = NewContext(options))
+        {
+            // "Acme Corporation" and "Acme Corp" both normalize to "ACME" but are distinct stocks —
+            // ambiguous. "Zenith Industries" is unique.
+            seed.AddRange(
+                new CommonStock
+                {
+                    Ticker = "ACMEA",
+                    Name = "Acme Corporation",
+                    Cik = "1",
+                },
+                new CommonStock
+                {
+                    Ticker = "ACMEB",
+                    Name = "Acme Corp",
+                    Cik = "2",
+                },
+                new CommonStock
+                {
+                    Ticker = "ZNTH",
+                    Name = "Zenith Industries",
+                    Cik = "3",
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var lookup = await new RecipientResolver(ScopeFactory(options)).BuildLookup(
+            CancellationToken.None
+        );
+
+        // Contract: a key shared by more than one distinct stock is dropped so a wrong link is
+        // never asserted, while an unambiguous name still resolves.
+        RecipientResolver.Resolve("Acme Corp", lookup).Should().BeNull();
+        RecipientResolver.Resolve("Zenith Industries", lookup).Should().NotBeNull();
+    }
+
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[] { new CommonStocksModuleConfiguration() }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static IServiceScopeFactory ScopeFactory(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => NewContext(options));
+        services.AddScoped<CommonStockRepository>();
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
 }


### PR DESCRIPTION
## Summary

- Adversarial unit test for `RecipientResolver.BuildLookup`, pinning its safety guarantee: when two distinct stocks normalize to the same name key (e.g. "Acme Corporation" and "Acme Corp" → "ACME"), that key is dropped so a government contract is never linked to the wrong company; unambiguous names still resolve.
- Exercises the real scope-factory + in-memory `CommonStockRepository` path. The test passes, confirming the behavior.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/RecipientResolverTests.cs` — add `BuildLookup_DropsKeySharedByMoreThanOneDistinctStock` plus the in-memory DbContext / scope-factory harness it needs (mirrors the existing CommonStocks unit-test pattern).