### PR TITLE
docs(guide): add how-to — view a member of Congress's trading profile

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -45,6 +45,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Search for stocks, filings, institutions, and more](how-to-search.md)
 - [View market-wide insider trading activity](how-to-view-insider-activity.md)
 - [View proposed insider sales (SEC Form 144)](how-to-view-proposed-sales.md)
+- [View a member of Congress's trading profile](how-to-view-congress-member-trades.md)
 - [Browse market-wide short data (most shorted and largest short volume)](how-to-browse-short-data.md)
 - [Browse economic indicators](how-to-browse-economic-data.md)
 - [Browse market indicators (VIX and put/call ratios)](how-to-browse-market-indicators.md)

--- a/docs/guide/how-to-view-congress-member-trades.md
+++ b/docs/guide/how-to-view-congress-member-trades.md
@@ -1,0 +1,36 @@
+# View a member of Congress's trading profile
+
+This guide shows you how to open a member of Congress's profile and read their most recent reported stock trades.
+
+## Find a member of Congress
+
+1. Go to `http://localhost:8080` and click the search box in the top navigation (or go directly to `http://localhost:8080/search`).
+
+2. Type the member's name and submit. Matching people appear under the **Congress** category in the results.
+
+3. Click the member's name to open their profile.
+
+There is no separate Congress page in the menu — search is how you reach a member's profile. If no member matches, the worker has not finished importing congressional trade data yet; check back after the initial sync.
+
+## Read the profile
+
+The profile header shows the member's name with a **Member of Congress** label, followed by a **Recent trades** table of up to their 25 most recent reported transactions:
+
+| Column | What it shows |
+|--------|---------------|
+| **Ticker** | The traded company's ticker. Click it to open the company page. |
+| **Date** | The transaction date the member reported. |
+| **Asset** | The name of the traded asset, as filed. |
+| **Owner** | Who in the household made the trade — the member, a spouse, or a dependent — as disclosed. |
+| **Amount (USD)** | The disclosed dollar range of the trade (for example, `1,001 – 15,000`). |
+
+If the member has no reported trades on file, the page shows "No reported trades" instead of the table.
+
+## Why amounts are shown as a range
+
+Under the STOCK Act, members of Congress disclose each transaction in a broad dollar band rather than an exact figure, so Equibles shows the lower and upper bound of the reported band instead of a single number.
+
+## See also
+
+- Looking for the trades on a specific company instead? Open that company's page and check its congressional-trades tab — see [Explore a company's data on the web portal](tutorial-explore-stock.md).
+- [Search for stocks, filings, institutions, and more](how-to-search.md)


### PR DESCRIPTION
## Summary

- Add a user-guide how-to for the congressional member profile page (`/congress/{id}`), which is reachable through global search but had no documentation.
- Explains how to find a member via search, read the recent-trades table, and why amounts are shown as dollar ranges (STOCK Act bands).

## Code changes

- `docs/guide/how-to-view-congress-member-trades.md` — new how-to page: finding a member through search, the recent-trades table columns, and a note on disclosed amount ranges.
- `docs/guide/README.md` — add the new how-to to the guide table of contents next to the insider-trading entries.