### PR TITLE
fix(financial-facts): register SharesOutstandingProvider behind ISharesOutstandingProvider

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
@@ -1,0 +1,30 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic;
+
+/// <summary>
+/// Reads a stock's shares-outstanding figures from the SEC cover-page XBRL facts. Abstracted so
+/// callers in other modules (e.g. the Yahoo price importer) depend on the contract rather than the
+/// concrete provider, which lets module-isolated tests substitute it without pulling in the
+/// FinancialFacts/SEC entity model.
+/// </summary>
+public interface ISharesOutstandingProvider
+{
+    /// <summary>
+    /// The shares on the most-recently-filed consolidated cover-page fact, or null when the issuer
+    /// has none on record (e.g. a multi-class filer that reports the count only per share class).
+    /// </summary>
+    Task<long?> GetReportedSharesOutstanding(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// The entity total summed across a multi-class issuer's per-share-class cover-page facts, or
+    /// null when no per-class facts are on record.
+    /// </summary>
+    Task<long?> GetSummedPerClassSharesOutstanding(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -3,6 +3,7 @@ using Equibles.Core.AutoWiring;
 using Equibles.Sec.FinancialFacts.Data.Statements;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Equibles.Sec.FinancialFacts.BusinessLogic;
 
@@ -14,8 +15,8 @@ namespace Equibles.Sec.FinancialFacts.BusinessLogic;
 // issuer reports the count only per share class (dimensional facts on the class-of-stock axis,
 // no consolidated fact), so GetSummedPerClassSharesOutstanding sums those classes into the entity
 // total (#2503).
-[Service]
-public class SharesOutstandingProvider
+[Service(ServiceLifetime.Scoped, typeof(ISharesOutstandingProvider))]
+public class SharesOutstandingProvider : ISharesOutstandingProvider
 {
     private const string SharesUnit = "shares";
 

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -150,7 +150,7 @@ public class FinancialFactsImportService
     )
     {
         using var scope = _scopeFactory.CreateScope();
-        var sharesProvider = scope.ServiceProvider.GetRequiredService<SharesOutstandingProvider>();
+        var sharesProvider = scope.ServiceProvider.GetRequiredService<ISharesOutstandingProvider>();
         var shares =
             await sharesProvider.GetReportedSharesOutstanding(stock, cancellationToken)
             ?? await sharesProvider.GetSummedPerClassSharesOutstanding(stock, cancellationToken);

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -189,7 +189,7 @@ public class YahooPriceImportService
         // current; Yahoo's figure is per-share-class and lags corporate actions. Defer to EDGAR
         // for the share count when the issuer has a consolidated SEC fact, so Yahoo can't overwrite
         // it with a stale or single-class value (#3575/#2503).
-        var sharesProvider = scope.ServiceProvider.GetRequiredService<SharesOutstandingProvider>();
+        var sharesProvider = scope.ServiceProvider.GetRequiredService<ISharesOutstandingProvider>();
         var edgarShares = await sharesProvider.GetReportedSharesOutstanding(
             stock,
             cancellationToken

--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceIdempotencyTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceIdempotencyTests.cs
@@ -4,6 +4,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models.Responses;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.HostedService.Services;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -67,6 +68,8 @@ public class FinancialFactsImportServiceIdempotencyTests : IAsyncLifetime
                 sp.GetService(typeof(FinancialFactsSyncStatusRepository))
                     .Returns(new FinancialFactsSyncStatusRepository(ctx));
                 sp.GetService(typeof(DocumentRepository)).Returns(new DocumentRepository(ctx));
+                sp.GetService(typeof(ISharesOutstandingProvider))
+                    .Returns(Substitute.For<ISharesOutstandingProvider>());
                 var scope = Substitute.For<IServiceScope>();
                 scope.ServiceProvider.Returns(sp);
                 return scope;

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -8,6 +8,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Yahoo.Contracts;
 using Equibles.Integrations.Yahoo.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Data.Models;
@@ -52,7 +53,8 @@ public class YahooPriceImportServiceTests : IDisposable
         // TickerMapService resolves CommonStockRepository from scoped DI.
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(DailyStockPriceRepository), _priceRepo),
-            (typeof(CommonStockRepository), _stockRepo)
+            (typeof(CommonStockRepository), _stockRepo),
+            (typeof(ISharesOutstandingProvider), Substitute.For<ISharesOutstandingProvider>())
         );
 
         var tickerMapService = new TickerMapService(scopeFactory);


### PR DESCRIPTION
## Summary

- Fixes the red `main` CI: 5 integration tests were failing (4 `YahooPriceImportServiceTests` KeyStatistics + 1 `FinancialFactsImportServiceIdempotencyTests`).
- Root cause: the shares-outstanding work made `YahooPriceImportService` and `FinancialFactsImportService` resolve the concrete `SharesOutstandingProvider` via `GetRequiredService`. Its dependency chain (FinancialFacts module → `AddSec()` → Pgvector `Vector`) can't be hosted by the in-memory EF harness the Yahoo tests use, and the isolated FinancialFacts fixture didn't register it either.
- Extract `ISharesOutstandingProvider` and register the provider behind it (mirrors the existing `IUsaSpendingClient`/`ISecEdgarClient` pattern). Module-isolated test fixtures now substitute the interface. Production keeps the same hard dependency and Scoped lifetime — just on the interface.

## Code changes

- `ISharesOutstandingProvider.cs` (new) — interface with `GetReportedSharesOutstanding` / `GetSummedPerClassSharesOutstanding`.
- `SharesOutstandingProvider` — `[Service(ServiceLifetime.Scoped, typeof(ISharesOutstandingProvider))]`, implements the interface.
- `YahooPriceImportService` + `FinancialFactsImportService` — resolve `ISharesOutstandingProvider`.
- The two failing integration-test fixtures — register `Substitute.For<ISharesOutstandingProvider>()`.

## Verification

- Solution builds clean (Release); CSharpier passes; full unit suite green (3012); the 4 in-memory Yahoo KeyStatistics tests now pass (22/22 in that class). The 1 ParadeDB FinancialFacts test is verified by CI (no local Docker). Reviewed by code-reviewer (approve; behavior-equivalent in production).