### PR TITLE
test(government-contracts): add skipped repro for GH-3827 — Shorten surrogate split

### DIFF
--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -56,6 +56,7 @@
     <ProjectReference Include="..\..\src\Equibles.Congress.HostedService\Equibles.Congress.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.GovernmentContracts.Data\Equibles.GovernmentContracts.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.GovernmentContracts.HostedService\Equibles.GovernmentContracts.HostedService.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.GovernmentContracts.Mcp\Equibles.GovernmentContracts.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.GovernmentContracts\Equibles.Integrations.GovernmentContracts.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.Repositories\Equibles.InsiderTrading.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.BusinessLogic\Equibles.InsiderTrading.BusinessLogic.csproj" />

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using Equibles.GovernmentContracts.Mcp.Tools;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class GovernmentContractsToolsShortenSurrogateTests
+{
+    // Contract: Shorten caps a display string at maxLength for an MCP markdown
+    // cell (GetGovernmentContracts truncates each contract Description to 80).
+    // Truncation must leave the result well-formed UTF-16 — the sibling
+    // UsaSpendingAwardMapper.Truncate in this same module was fixed for exactly
+    // this (GH-3786): slicing through a surrogate pair orphans a lone surrogate,
+    // which is invalid UTF-16 and corrupts JSON serialization of the tool reply.
+    // Here the cut lands between the two halves of "😀" (U+1F600), so a raw
+    // value[..80] keeps the high half and drops the low half.
+    //
+    // Reflection-invoke since Shorten is private static.
+    [Fact(Skip = "GH-3827 — Shorten orphans a surrogate pair when truncating")]
+    public void Shorten_CutThroughSurrogatePair_DoesNotOrphanSurrogate()
+    {
+        var method = typeof(GovernmentContractsTools).GetMethod(
+            "Shorten",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        // 79 BMP chars place the high surrogate of "😀" at index 79, so a raw
+        // value[..80] retains the high half and orphans it.
+        var input = new string('a', 79) + "😀" + new string('b', 10);
+
+        var result = (string)method!.Invoke(null, [input, 80]);
+
+        HasUnpairedSurrogate(result)
+            .Should()
+            .BeFalse("truncation must not split a surrogate pair into a lone surrogate");
+    }
+
+    private static bool HasUnpairedSurrogate(string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (char.IsHighSurrogate(value[i]))
+            {
+                if (i + 1 >= value.Length || !char.IsLowSurrogate(value[i + 1]))
+                    return true;
+                i++;
+            }
+            else if (char.IsLowSurrogate(value[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped regression test capturing GH-3827: `GovernmentContractsTools.Shorten` orphans a surrogate pair when it truncates a string at a cut index that falls inside a non-BMP character, producing invalid UTF-16 in the MCP tool's JSON reply.
- The sibling `UsaSpendingAwardMapper.Truncate` in the same module was already made surrogate-safe (GH-3786); `Shorten` was not. Test is `[Skip]` pending the fix — un-skip it as part of resolving GH-3827.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs` — new test reflection-invoking the private static `Shorten` with an input whose surrogate pair straddles the 80-char cap; asserts the result contains no unpaired surrogate. Skipped — see GH-3827.
- `tests/Equibles.UnitTests/Equibles.UnitTests.csproj` — add a project reference to `Equibles.GovernmentContracts.Mcp` (matching the existing references to the other modules' `.Mcp` projects) so the tool's helper is reachable.