### PR TITLE
docs(guide): add how-to — view an insider's trading profile

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -44,6 +44,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)
 - [Search for stocks, filings, institutions, and more](how-to-search.md)
 - [View market-wide insider trading activity](how-to-view-insider-activity.md)
+- [View an insider's trading profile](how-to-view-insider-profile.md)
 - [View proposed insider sales (SEC Form 144)](how-to-view-proposed-sales.md)
 - [View a member of Congress's trading profile](how-to-view-congress-member-trades.md)
 - [Browse market-wide short data (most shorted and largest short volume)](how-to-browse-short-data.md)

--- a/docs/guide/how-to-view-insider-profile.md
+++ b/docs/guide/how-to-view-insider-profile.md
@@ -1,0 +1,32 @@
+# View an insider's trading profile
+
+This guide shows you how to open a corporate insider's profile and read their most recent reported transactions.
+
+## Find an insider
+
+1. Go to `http://localhost:8080` and click the search box in the top navigation (or go directly to `http://localhost:8080/search`).
+
+2. Type the person's name and submit. Matching people appear under the **Insiders** category in the results.
+
+3. Click the insider's name to open their profile.
+
+There is no separate Insiders page in the menu — search is how you reach an individual insider's profile. For the whole market's insider buying and selling instead, see [View market-wide insider trading activity](how-to-view-insider-activity.md).
+
+## Read the profile
+
+The profile header shows the insider's name followed by a summary line: their role (an officer title, board director, or 10% owner), their location, and the SEC CIK number that identifies them. Below it, a **Recent transactions** table lists up to their 25 most recent reported trades (holdings-only reports are left out):
+
+| Column | What it shows |
+|--------|---------------|
+| **Ticker** | The company the trade is in. Click it to open the company page. |
+| **Date** | The transaction date the insider reported. |
+| **Security** | The type of security traded, such as common stock or stock options. |
+| **Shares** | The number of shares in the transaction. |
+| **Price** | The price per share, in US dollars. |
+
+If the insider has no reported transactions on file, the page shows "No reported transactions" instead of the table.
+
+## See also
+
+- [View market-wide insider trading activity](how-to-view-insider-activity.md)
+- [Search for stocks, filings, institutions, and more](how-to-search.md)


### PR DESCRIPTION
## Summary

- Add a user-guide how-to for the individual insider profile page (`/insiders/{ownerCik}`), reachable through global search but previously undocumented (the existing insider page covers market-wide activity, not a single person's profile).
- Explains finding an insider via search and reading the header (role, location, CIK) and recent-transactions table.

## Code changes

- `docs/guide/how-to-view-insider-profile.md` — new how-to: finding an insider through search and reading the profile's transaction table.
- `docs/guide/README.md` — add the new how-to to the guide table of contents beside the other insider entries.