### PR TITLE
fix(government-contracts): keep Shorten from splitting surrogate pairs

### DIFF
--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -168,7 +168,15 @@ public class GovernmentContractsTools
         if (string.IsNullOrWhiteSpace(value))
             return null;
         var trimmed = value.Trim();
-        return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength] + "…";
+        if (trimmed.Length <= maxLength)
+            return trimmed;
+        // Don't split a surrogate pair at the cap — back off one unit so the result stays
+        // well-formed UTF-16 (a lone surrogate corrupts the tool's JSON reply).
+        var end =
+            maxLength > 0 && char.IsHighSurrogate(trimmed[maxLength - 1])
+                ? maxLength - 1
+                : maxLength;
+        return trimmed[..end] + "…";
     }
 
     // Markdown cells can't contain a raw pipe or newline without breaking the table.

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs
@@ -15,7 +15,7 @@ public class GovernmentContractsToolsShortenSurrogateTests
     // value[..80] keeps the high half and drops the low half.
     //
     // Reflection-invoke since Shorten is private static.
-    [Fact(Skip = "GH-3827 — Shorten orphans a surrogate pair when truncating")]
+    [Fact]
     public void Shorten_CutThroughSurrogatePair_DoesNotOrphanSurrogate()
     {
         var method = typeof(GovernmentContractsTools).GetMethod(


### PR DESCRIPTION
## Summary

- Fixes GH-3827: `GovernmentContractsTools.Shorten` truncated with a raw `value[..maxLength]` slice, so a cut landing inside a surrogate pair (any non-BMP character) orphaned a lone surrogate — invalid UTF-16 that corrupts the `GetGovernmentContracts` MCP tool's JSON reply.
- Now backs off one unit when the cap lands on a high surrogate, matching the sibling `UsaSpendingAwardMapper.Truncate` (GH-3786). Un-skips the regression test committed for GH-3827.

## Code changes

- `src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs` — `Shorten` checks `char.IsHighSurrogate(value[maxLength - 1])` and trims one unit shorter so the result stays well-formed UTF-16.
- `tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs` — removed the `Skip` so the regression test runs (fails before the fix, passes after).