### PR TITLE
fix(sec-mcp): clamp maxResults in GetFundsHoldingStock to avoid a negative SQL LIMIT

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -130,7 +130,7 @@ public class NportTools
 
                 var positions = await currentPositions
                     .OrderByDescending(p => p.ValueUsd)
-                    .Take(maxResults)
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
                 var result = MarkdownTable.Start(

--- a/tests/Equibles.IntegrationTests/Mcp/NportToolsGetFundsHoldingStockNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportToolsGetFundsHoldingStockNegativeMaxResultsTests.cs
@@ -24,7 +24,7 @@ public class NportToolsGetFundsHoldingStockNegativeMaxResultsTests : ParadeDbMcp
             NullLogger<NportTools>()
         );
 
-    [Fact(Skip = "GH-3830 — GetFundsHoldingStock surfaces an internal error on a negative maxResults")]
+    [Fact]
     public async Task GetFundsHoldingStock_NegativeMaxResults_DegradesGracefullyWithoutInternalError()
     {
         // Contract: maxResults is documented as "Maximum number of fund positions to return" — a


### PR DESCRIPTION
## Summary

- Fixes GH-3830: `NportTools.GetFundsHoldingStock` passed the client-supplied `maxResults` straight into EF Core's `.Take()`, so a negative value became a negative SQL `LIMIT` that PostgreSQL rejects — the caller saw the generic internal-error sentinel.
- Now routes `maxResults` through `McpLimit.Clamp` (floors at 1, caps at the shared maximum), matching the sibling MCP tools. Un-skips the regression test committed for GH-3830.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/NportTools.cs` — `GetFundsHoldingStock` wraps the `.Take(maxResults)` in `McpLimit.Clamp(maxResults)`.
- `tests/Equibles.IntegrationTests/Mcp/NportToolsGetFundsHoldingStockNegativeMaxResultsTests.cs` — removed the `Skip` so the regression test runs (fails before the fix, passes after).