### PR TITLE
fix(financial-facts): select the currently-reported instant in the statement tool

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -3,7 +3,6 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
-using Equibles.Data.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -122,11 +121,18 @@ public class FinancialStatementTools
                     )
                     .ToListAsync();
 
-                // Restatements re-emit the same concept; the latest-filed value
-                // is the currently-reported one.
+                // A 10-Q tags each line under one fiscal (year, period) for both the
+                // discrete quarter and the fiscal year-to-date span, and re-reports prior
+                // comparative instants (the prior fiscal-year-end balance) under that same
+                // identity. Picking by filed date alone surfaces the year-to-date as the
+                // quarter and mixes the comparative balance-sheet columns, so the statement
+                // stops balancing (#1546). Prefer the span matching the period's granularity,
+                // then the instant ending latest, then the latest restatement — the same
+                // selection the web surfaces apply in
+                // FinancialStatementsHelper.PickCurrentlyReportedFact.
                 var latestByConcept = facts
-                    .LatestPerGroup(f => f.FinancialConceptId, f => f.FiledDate)
-                    .ToDictionary(f => f.FinancialConceptId);
+                    .GroupBy(f => f.FinancialConceptId)
+                    .ToDictionary(g => g.Key, g => PickCurrentlyReportedFact(g, selectedPeriod));
 
                 return RenderStatementTable(
                     stock,
@@ -268,6 +274,48 @@ public class FinancialStatementTools
                 type = default;
                 return false;
         }
+    }
+
+    // The longest span a discrete fiscal quarter can cover — 13 weeks on a 4-4-5
+    // calendar plus the occasional 14-week quarter, with headroom.
+    private const int MaxDiscreteQuarterDays = 100;
+
+    // The shortest span a fiscal year can cover — 52 weeks on a 52/53-week
+    // calendar, with headroom for short transition years.
+    private const int MinAnnualSpanDays = 350;
+
+    // The currently-reported fact for one concept within a single fiscal (year, period).
+    // A 10-Q reports each flow line twice under that identity — the discrete quarter and
+    // the fiscal year-to-date — and a balance-sheet line carries the period-end instant
+    // alongside re-stated comparative instants from prior filings. Prefer the span that
+    // matches the period's granularity (instants span zero days and always qualify), then
+    // the instant ending latest so a comparative column never stands in for the current
+    // one, then the latest restatement among same-ending candidates (#1546). Mirrors
+    // FinancialStatementsHelper.PickCurrentlyReportedFact on the web surfaces; facts are
+    // already consolidated-only here via GetConsolidatedByStock.
+    internal static FinancialFact PickCurrentlyReportedFact(
+        IEnumerable<FinancialFact> facts,
+        SecFiscalPeriod fiscalPeriod
+    )
+    {
+        var candidates = facts.ToList();
+
+        var preferred = candidates
+            .Where(f =>
+            {
+                var spanDays = f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber;
+                return fiscalPeriod == SecFiscalPeriod.FullYear
+                    ? spanDays == 0 || spanDays >= MinAnnualSpanDays
+                    : spanDays <= MaxDiscreteQuarterDays;
+            })
+            .ToList();
+        if (preferred.Count > 0)
+            candidates = preferred;
+
+        return candidates
+            .OrderByDescending(f => f.PeriodEnd)
+            .ThenByDescending(f => f.FiledDate)
+            .First();
     }
 
     // Chronological order within a fiscal year: Q1 < Q2 < Q3 < Q4 < FullYear.

--- a/tests/Equibles.UnitTests/Sec/FinancialStatementToolsPickCurrentlyReportedFactInstantTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialStatementToolsPickCurrentlyReportedFactInstantTests.cs
@@ -1,0 +1,56 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialStatementToolsPickCurrentlyReportedFactInstantTests
+{
+    // A 10-Q balance sheet carries the current period-end instant alongside a prior
+    // comparative instant (the prior fiscal-year-end), both re-tagged under the same
+    // fiscal (year, period) and filed on the same day. The currently-reported figure is
+    // the instant ending latest; selecting by filed date alone is a wash on the shared
+    // date, so a comparative column could stand in for the current one — which is exactly
+    // why the balance sheet stopped balancing (#1546: AAPL FY2025 Q2 equity showed the
+    // $74.1B 2023-12-30 comparative instead of the real $66.8B at 2025-03-29). The
+    // comparative is listed first to pin that the pick is the latest period-end, not
+    // input order.
+    [Fact]
+    public void PickCurrentlyReportedFact_BalanceSheetWithComparativeInstant_PicksLatestPeriodEnd()
+    {
+        var conceptId = Guid.NewGuid();
+        var comparative = MakeInstant(
+            conceptId,
+            value: 74_100m,
+            periodEnd: new DateOnly(2023, 12, 30)
+        );
+        var current = MakeInstant(conceptId, value: 66_796m, periodEnd: new DateOnly(2025, 3, 29));
+
+        var result = FinancialStatementTools.PickCurrentlyReportedFact(
+            [comparative, current],
+            SecFiscalPeriod.Q2
+        );
+
+        result
+            .Value.Should()
+            .Be(66_796m, "the current period-end instant outranks the comparative column");
+    }
+
+    private static FinancialFact MakeInstant(Guid conceptId, decimal value, DateOnly periodEnd) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            FinancialConceptId = conceptId,
+            Value = value,
+            Unit = "USD",
+            PeriodStart = periodEnd,
+            PeriodEnd = periodEnd,
+            FiscalYear = 2025,
+            FiscalPeriod = SecFiscalPeriod.Q2,
+            PeriodType = FactPeriodType.Instant,
+            Form = DocumentType.TenQ,
+            FiledDate = new DateOnly(2025, 5, 2),
+            AccessionNumber = "0000320193-25-000057",
+        };
+}


### PR DESCRIPTION
## Summary

- `FinancialStatementTools.GetFinancialStatement` selected one fact per concept by latest filed date alone, so a balance sheet could return a prior comparative instant (AAPL FY2025 Q2 equity = the $74.1B 2023-12-30 column, not the real $66.8B at 2025-03-29) and an income statement the year-to-date span instead of the discrete quarter — the standardized statement stopped balancing.
- Now selects per concept the way the web surfaces do: prefer the span matching the period's granularity, then the instant ending latest, then the latest restatement (mirrors `FinancialStatementsHelper.PickCurrentlyReportedFact`).

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs` — replace `LatestPerGroup(…, FiledDate)` with a `PickCurrentlyReportedFact` per-concept selector; drop the now-unused `Equibles.Data.Extensions` using.
- `tests/Equibles.UnitTests/Sec/FinancialStatementToolsPickCurrentlyReportedFactInstantTests.cs` — regression test: a comparative balance-sheet instant must not outrank the current period-end instant.

(The commercial repo pins the equivalent commit `19580f5d` on the anchor branch `fix/1546-mcp-statement-period-instant`; this brings the fix to `main`.)