### PR TITLE
fix(financial-facts): range-check the decimal->long share-count casts

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -59,7 +59,12 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
             .Select(f => (decimal?)f.Value)
             .FirstOrDefaultAsync(cancellationToken);
 
-        return value.HasValue ? (long)value.Value : (long?)null;
+        // A corrupt/typo'd cover-page fact can carry a count that parses but exceeds Int64; the
+        // decimal->long cast would throw, crashing the caller. Treat an unrepresentable figure as
+        // none on record (null), matching how every other decimal->long cast here is range-checked.
+        return value.HasValue && value.Value >= long.MinValue && value.Value <= long.MaxValue
+            ? (long)value.Value
+            : (long?)null;
     }
 
     // The entity-wide share count for a multi-class issuer, summed across its share classes from
@@ -107,7 +112,9 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
             .GroupBy(f => f.Dimensions[0].Member)
             .Sum(g => g.First().Value);
 
-        return total > 0 ? (long)total : (long?)null;
+        // Same range-check: a corrupt per-class count can push the sum past Int64; degrade to null
+        // rather than let the decimal->long cast throw.
+        return total > 0 && total <= long.MaxValue ? (long)total : (long?)null;
     }
 
     // The financial-concept ids the "shares-outstanding" alias resolves to, or an empty list when

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderReportedSharesOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderReportedSharesOverflowTests.cs
@@ -41,9 +41,7 @@ public class SharesOutstandingProviderReportedSharesOverflowTests
         return ctx;
     }
 
-    [Fact(
-        Skip = "GH-3836 — GetReportedSharesOutstanding throws OverflowException on an out-of-range fact value"
-    )]
+    [Fact]
     public async Task GetReportedSharesOutstanding_FactValueExceedsInt64_DegradesToNullInsteadOfThrowing()
     {
         await using var db = NewDb();
@@ -81,6 +79,78 @@ public class SharesOutstandingProviderReportedSharesOverflowTests
         var shares = await provider.GetReportedSharesOutstanding(stock);
 
         shares.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSummedPerClassSharesOutstanding_SumExceedsInt64_DegradesToNullInsteadOfThrowing()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "BIGCO",
+            Name = "Overflow Industries",
+            Cik = "0009999999",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, concept);
+        // A single corrupt per-class count of 1e20 makes the summed total exceed long.MaxValue;
+        // the same unguarded (long)total cast must degrade to null, not throw.
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                100_000_000_000_000_000_000m,
+                new DateOnly(2026, 4, 30),
+                new DateOnly(2026, 4, 23),
+                "0009999999-26-000001",
+                "us-gaap:CommonClassAMember"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetSummedPerClassSharesOutstanding(stock);
+
+        shares.Should().BeNull();
+    }
+
+    private static FinancialFact ClassFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        decimal value,
+        DateOnly filed,
+        DateOnly asOf,
+        string accession,
+        string member,
+        string axis = "us-gaap:StatementClassOfStockAxis"
+    )
+    {
+        var fact = new FinancialFact
+        {
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Unit = "shares",
+            PeriodType = FactPeriodType.Instant,
+            PeriodStart = asOf,
+            PeriodEnd = asOf,
+            Value = value,
+            FiscalYear = asOf.Year,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenQ,
+            FiledDate = filed,
+            AccessionNumber = accession,
+            DimensionsKey = $"{axis}={member}",
+        };
+        fact.Dimensions.Add(new FinancialFactDimension { Axis = axis, Member = member });
+        return fact;
     }
 
     private static FinancialFact Fact(


### PR DESCRIPTION
## Summary

- `SharesOutstandingProvider` converted the selected cover-page share count from `decimal` to `long` with two unguarded casts. Because `FinancialFact.Value` is a `numeric` column (not `bigint`), a corrupt/typo'd filing value larger than `Int64.MaxValue` made the cast throw `System.OverflowException`, crashing the caller instead of degrading gracefully.
- Range-check both casts so an unrepresentable figure is treated as "none on record" (`null`), matching the existing precedent (`Filing13DGXmlParser.ParseShares`, `ParsePercent`). Closes #3836.

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs` — guard the `(long)value.Value` cast in `GetReportedSharesOutstanding` and the `(long)total` cast in `GetSummedPerClassSharesOutstanding` with a `long` range check; out-of-range → `null`.
- `tests/Equibles.UnitTests/Sec/SharesOutstandingProviderReportedSharesOverflowTests.cs` — un-skip the reported-shares overflow repro and add a sibling test for the summed-per-class path; both fail before the fix (OverflowException) and pass after.