### PR TITLE
fix(sec): clamp Form D investor count before narrowing to int

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
@@ -106,9 +106,15 @@ public class FormDFilingProcessor : IssuerFeedFilingProcessor<FormDFiling, FormD
             IsRemainingIndefinite = remainingIndefinite,
             MinimumInvestmentAccepted = ParseLong(Val(offeringData, "minimumInvestmentAccepted")),
             HasNonAccreditedInvestors = ParseBool(Val(investors, "hasNonAccreditedInvestors")),
-            TotalNumberAlreadyInvested = (int)ParseLong(
-                Val(investors, "totalNumberAlreadyInvested")
-            ),
+            // The XML is filer-entered, so an out-of-range count (a typo, or a figure pasted
+            // into the wrong field) must not wrap negative when narrowed to the int column.
+            // Clamp to a non-negative, representable value before casting.
+            TotalNumberAlreadyInvested = (int)
+                Math.Clamp(
+                    ParseLong(Val(investors, "totalNumberAlreadyInvested")),
+                    0,
+                    int.MaxValue
+                ),
         };
 
         foreach (var personElement in Els(El(root, "relatedPersonsList"), "relatedPersonInfo"))

--- a/tests/Equibles.IntegrationTests/Sec/FormDFilingProcessorParseFilingOutOfRangeInvestorCountTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FormDFilingProcessorParseFilingOutOfRangeInvestorCountTests.cs
@@ -21,9 +21,7 @@ public class FormDFilingProcessorParseFilingOutOfRangeInvestorCountTests
     // count, or a figure pasted into the wrong field) must not silently corrupt the stored
     // row. ParseLong reads the long correctly (3,000,000,000 < Int64.Max); the bug is the
     // unchecked (int) narrowing at the call site, which wraps it to a negative count.
-    [Fact(
-        Skip = "GH-3839 — (int) narrowing wraps an out-of-range Form D investor count to a negative value"
-    )]
+    [Fact]
     public async Task Process_InvestorCountAboveInt32Max_DoesNotStoreNegativeCount()
     {
         var (processor, repo, secClient) = CreateProcessorWithDeps();


### PR DESCRIPTION
## Summary

- Fixes #3839: `FormDFilingProcessor.ParseFiling` narrowed the filer-entered `totalNumberAlreadyInvested` to its `int` column with an unchecked `(int)` cast, silently wrapping any value above `Int32.MaxValue` to a **negative** stored count (`3000000000` → `-1294967296`).
- Clamps the parsed value to `[0, int.MaxValue]` before narrowing, so an out-of-range or typo'd figure saturates instead of corrupting the row. Mirrors the range-checking the sibling casts already do.
- Un-skips the GH-3839 regression test.

## Code changes

- `src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs` — wrap the `totalNumberAlreadyInvested` parse in `Math.Clamp(…, 0, int.MaxValue)` before the `(int)` cast.
- `tests/Equibles.IntegrationTests/Sec/FormDFilingProcessorParseFilingOutOfRangeInvestorCountTests.cs` — removed the `[Skip]` marker; the test now passes (asserts the stored count is never negative).

Local: Form D processor suite (24) green; Sec unit suite (1033) green.