### PR TITLE
test(government-contracts): add skipped repro for GH-3845 — RecipientNameNormalizer suffix-only name

### DIFF
--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerSuffixOnlyTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerSuffixOnlyTests.cs
@@ -1,0 +1,23 @@
+using Equibles.GovernmentContracts.HostedService.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+/// <summary>
+/// Adversarial cover for <see cref="RecipientNameNormalizer.Normalize"/> on a suffix-only name
+/// at or above the minimum key length. The contract strips trailing legal-entity suffixes and
+/// returns null "when nothing meaningful remains" — the existing suite pins that for the short
+/// suffixes "Inc"/"Co", but those return null on the 4-char length floor, not on suffix stripping.
+/// A pure legal suffix that is itself >= 4 chars exercises the stripping promise directly.
+/// </summary>
+public class RecipientNameNormalizerSuffixOnlyTests
+{
+    [Fact(Skip = "GH-3845 — suffix-only name >= min length leaks a generic key instead of null")]
+    public void Normalize_SuffixOnlyNameAtOrAboveMinLength_ReturnsNull()
+    {
+        // "Corporation" is a pure legal-entity suffix (no real name token); the contract strips
+        // it and returns null, exactly as "Inc"/"Co" do. Nothing meaningful remains to key on.
+        RecipientNameNormalizer.Normalize("Corporation").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `RecipientNameNormalizer.Normalize` covering a suffix-only company name at or above the minimum key length.
- The test fails against current behavior and is committed `[Skip]` — it documents GH-3845 and should be un-skipped as part of that fix.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerSuffixOnlyTests.cs` — asserts `Normalize("Corporation")` returns `null` (a pure legal suffix leaves nothing meaningful). Current behavior returns `"CORPORATION"`, because the trailing-suffix loop is guarded by `tokens.Count > 1` and never strips the last remaining token — so a generic key leaks into exact-match recipient resolution. Skipped — see GH-3845.