### PR TITLE
fix(government-contracts): normalize a suffix-only recipient name to null

### DIFF
--- a/src/Equibles.GovernmentContracts.HostedService/Services/RecipientNameNormalizer.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/RecipientNameNormalizer.cs
@@ -58,7 +58,10 @@ public static class RecipientNameNormalizer
         if (tokens.Count > 1 && tokens[0] == "THE")
             tokens.RemoveAt(0);
 
-        while (tokens.Count > 1 && LegalSuffixes.Contains(tokens[^1]))
+        // Strip every trailing legal suffix, including the last remaining token: a name that is
+        // nothing but suffixes ("Corporation", "The Company") must reduce to an empty key so it
+        // falls through to null below, rather than leaking a generic word into exact-match resolution.
+        while (tokens.Count > 0 && LegalSuffixes.Contains(tokens[^1]))
             tokens.RemoveAt(tokens.Count - 1);
 
         var key = string.Join(' ', tokens);

--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerSuffixOnlyTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerSuffixOnlyTests.cs
@@ -13,11 +13,16 @@ namespace Equibles.UnitTests.GovernmentContracts;
 /// </summary>
 public class RecipientNameNormalizerSuffixOnlyTests
 {
-    [Fact(Skip = "GH-3845 — suffix-only name >= min length leaks a generic key instead of null")]
-    public void Normalize_SuffixOnlyNameAtOrAboveMinLength_ReturnsNull()
+    [Theory]
+    [InlineData("Corporation")]
+    [InlineData("Company")]
+    [InlineData("Limited")]
+    [InlineData("Incorporated")]
+    [InlineData("The Company")]
+    public void Normalize_SuffixOnlyNameAtOrAboveMinLength_ReturnsNull(string input)
     {
-        // "Corporation" is a pure legal-entity suffix (no real name token); the contract strips
+        // These collapse to a pure legal-entity suffix with no real name token; the contract strips
         // it and returns null, exactly as "Inc"/"Co" do. Nothing meaningful remains to key on.
-        RecipientNameNormalizer.Normalize("Corporation").Should().BeNull();
+        RecipientNameNormalizer.Normalize(input).Should().BeNull();
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #3845. `RecipientNameNormalizer.Normalize` is documented to strip trailing legal-entity suffixes and return null "when nothing meaningful remains", but a pure legal suffix that is itself ≥ 4 characters (e.g. `Corporation`, `Company`, `Limited`) survived as a generic key.
- Such a key would exact-match any other entity normalizing to the same word, risking a federal contract being attached to the wrong company — the false positive the conservative, never-fuzzy design avoids.

## Code changes

- `src/Equibles.GovernmentContracts.HostedService/Services/RecipientNameNormalizer.cs` — the trailing-suffix loop was guarded by `tokens.Count > 1`, so it never removed the last remaining token. Changed to `tokens.Count > 0` so a name that is nothing but suffixes reduces to an empty key and falls through to null. Multi-word names keep their real tokens (the loop stops at the first non-suffix), so existing behavior is unchanged.
- `tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerSuffixOnlyTests.cs` — un-skipped and broadened the GH-3845 repro into a theory across `Corporation`, `Company`, `Limited`, `Incorporated`, and `The Company`; fails before the fix, passes after. Full module suite (38 tests) green.