### PR TITLE
test(financial-facts): pin PickCurrentlyReportedFact selects the discrete quarter over the YTD span

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialStatementToolsPickCurrentlyReportedFactQuarterSpanTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialStatementToolsPickCurrentlyReportedFactQuarterSpanTests.cs
@@ -1,0 +1,70 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialStatementToolsPickCurrentlyReportedFactQuarterSpanTests
+{
+    // The income-statement half of #1546/#3835: a 10-Q tags each flow line twice under the same
+    // fiscal (year, period) — the discrete quarter AND the fiscal year-to-date span — and both
+    // end on the same period-end date, so the PeriodEnd/FiledDate tiebreaks can't separate them.
+    // The contract resolves this by the span filter: prefer the span matching the period's
+    // granularity, so a quarter request must return the discrete-quarter figure, never the larger
+    // YTD cumulative. The YTD is listed first with the same filed date to pin that the span filter
+    // (not input order or filed date) does the selection. The instant-only sibling test never
+    // exercises this duration branch.
+    [Fact]
+    public void PickCurrentlyReportedFact_QuarterWithYearToDateSpanSamePeriodEnd_PicksDiscreteQuarter()
+    {
+        var conceptId = Guid.NewGuid();
+        var periodEnd = new DateOnly(2025, 3, 29);
+
+        // ~26-week cumulative span ending on the same date — must be rejected for a quarter request.
+        var yearToDate = MakeDuration(
+            conceptId,
+            value: 210_000m,
+            periodStart: new DateOnly(2024, 9, 29),
+            periodEnd: periodEnd
+        );
+        // ~13-week discrete quarter ending on the same date — the currently-reported quarter figure.
+        var discreteQuarter = MakeDuration(
+            conceptId,
+            value: 95_000m,
+            periodStart: new DateOnly(2025, 1, 1),
+            periodEnd: periodEnd
+        );
+
+        var result = FinancialStatementTools.PickCurrentlyReportedFact(
+            [yearToDate, discreteQuarter],
+            SecFiscalPeriod.Q2
+        );
+
+        result
+            .Value.Should()
+            .Be(95_000m, "a quarter request resolves to the discrete-quarter span, not the YTD");
+    }
+
+    private static FinancialFact MakeDuration(
+        Guid conceptId,
+        decimal value,
+        DateOnly periodStart,
+        DateOnly periodEnd
+    ) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            FinancialConceptId = conceptId,
+            Value = value,
+            Unit = "USD",
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            FiscalYear = 2025,
+            FiscalPeriod = SecFiscalPeriod.Q2,
+            PeriodType = FactPeriodType.Duration,
+            Form = DocumentType.TenQ,
+            FiledDate = new DateOnly(2025, 5, 2),
+            AccessionNumber = "0000320193-25-000057",
+        };
+}


### PR DESCRIPTION
## Summary

- Adds the income-statement half of the `PickCurrentlyReportedFact` contract introduced in #3835. The shipped test covered only the balance-sheet instant case; the discrete-quarter-vs-year-to-date span selection — the exact scenario that made standardized income statements stop balancing — had no unit coverage.
- The test passes against current code, pinning the span filter against regression.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialStatementToolsPickCurrentlyReportedFactQuarterSpanTests.cs` — given two flow facts that share a period-end (a ~13-week discrete quarter and a ~26-week YTD cumulative), a quarter request must resolve to the discrete-quarter figure. The YTD is listed first with an identical filed date so the assertion pins that the span filter, not input order or filed date, drives the pick.