### PR TITLE
fix(holdings): back off ClampLength from a surrogate-pair boundary

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -494,7 +494,13 @@ public class HoldingsImportService
     // losing the filer's whole batch to a 22001 abort.
     internal static string ClampLength(string value, int maxLength)
     {
-        return value != null && value.Length > maxLength ? value[..maxLength] : value;
+        if (value == null || value.Length <= maxLength)
+            return value;
+        // Back off one unit if the cap lands on a high surrogate, so the kept prefix never
+        // ends in an orphan surrogate that corrupts the PostgreSQL UTF-8 round-trip (22001).
+        var end =
+            maxLength > 0 && char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
+        return value[..end];
     }
 
     private async Task ParseOtherManagers(

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceClampLengthSurrogateTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceClampLengthSurrogateTests.cs
@@ -16,7 +16,7 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class HoldingsImportServiceClampLengthSurrogateTests
 {
-    [Fact(Skip = "GH-3849 — ClampLength orphans a surrogate pair at the column-width cap")]
+    [Fact]
     public void ClampLength_MaxLengthSplitsSurrogatePair_ResultContainsNoOrphanSurrogate()
     {
         // "🏛" (U+1F3DB) is a surrogate pair; placed so maxLength=10 falls between the


### PR DESCRIPTION
## Summary

- Fixes GH-3849: `HoldingsImportService.ClampLength` capped a 13F cover-page free-text field with a raw `value[..maxLength]` slice, orphaning a high surrogate when the cap landed inside a supplementary-plane character — corrupting the PostgreSQL UTF-8 round-trip (the `22001` abort the cap exists to prevent).
- Minimal fix mirrors the precedent `EdgarXmlSubmissionParser.Truncate` (#3408) back-off: when the cut would split a surrogate pair, drop the trailing high surrogate.
- Un-skips the regression test merged in #3850.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — `ClampLength` backs off one unit when `maxLength` lands on a high surrogate, so the kept prefix is always well-formed UTF-16.
- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceClampLengthSurrogateTests.cs` — removed the `[Skip]` (GH-3849); now passes against the fix.