### PR TITLE
test(holdings): add skipped repro for GH-3852 — ParseHoldingRow share-value Int64 overflow

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValueOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValueOverflowTests.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// ParseHoldingRow derives a holding's stored value as (long)(shares × closePrice).
+/// SSHPRNAMT is filer-controlled free text; ParseLong accepts any value up to
+/// long.MaxValue, and a corrupt/fat-fingered share count is exactly why
+/// Corrupt13FShareCountRepairer exists. Every other field parser in this class
+/// degrades malformed input gracefully (ParseLong → 0, ClampLength clamps,
+/// Filing13DGXmlParser range-checks the same decimal→long cast). So one oversized
+/// row must not crash the whole filing's import: casting a decimal product that
+/// exceeds long.MaxValue throws OverflowException. Oracle derived from the
+/// contract (graceful per-field degradation), not the body.
+/// </summary>
+public class HoldingsImportServiceParseHoldingRowValueOverflowTests
+{
+    [Fact(Skip = "GH-3852 — ParseHoldingRow throws OverflowException on an oversized share count")]
+    public void ParseHoldingRow_SharesTimesPriceExceedsInt64_DoesNotThrowOverflow()
+    {
+        var method = typeof(HoldingsImportService).GetMethod(
+            "ParseHoldingRow",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var stockId = Guid.NewGuid();
+        var reportDate = new DateOnly(2025, 3, 31);
+        // long.MaxValue shares × a $2 close overflows Int64 (≈1.84e19 > 9.22e18).
+        var row = new Dictionary<string, string>
+        {
+            ["SSHPRNAMT"] = long.MaxValue.ToString(),
+            ["SSHPRNAMTTYPE"] = "SH",
+        };
+        var context = new ImportContext
+        {
+            CoverPages = new Dictionary<string, CoverPageRow>(),
+            StockPrices = new Dictionary<(Guid, DateOnly), decimal>
+            {
+                [(stockId, reportDate)] = 2m,
+            },
+        };
+        var args = new object[]
+        {
+            row,
+            "0001234567-25-000001",
+            "037833100",
+            stockId,
+            Guid.NewGuid(),
+            new DateOnly(2025, 4, 15),
+            reportDate,
+            context,
+        };
+
+        var ex = Record.Exception(() => method!.Invoke(null, args));
+        var threwOverflow = (ex as TargetInvocationException)?.InnerException is OverflowException;
+
+        threwOverflow
+            .Should()
+            .BeFalse(
+                "a parseable-but-oversized share count must degrade gracefully like every other field parser, not crash the filing import with an OverflowException"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `HoldingsImportService.ParseHoldingRow` revealed a real bug (GH-3852): `(long)(shares * closePrice)` is an unguarded decimal→long cast where `shares` comes from filer-controlled `SSHPRNAMT`. A corrupt/oversized share count (the scenario `Corrupt13FShareCountRepairer` exists for) times a known close price overflows `Int64` and throws `OverflowException`, crashing the filing import before the repairer can run.
- Same decimal→long overflow bug class already fixed in `Filing13DGXmlParser.ParseShares` (#3578), `SharesOutstandingProvider` (#3836), `FormDFilingProcessor` (#3839) — all of which range-check the cast; this site does not.
- Test ships `[Skip]` — un-skip it as part of the GH-3852 fix.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValueOverflowTests.cs` — new unit test (reflection-invokes the private `ParseHoldingRow`) asserting an oversized share count degrades gracefully rather than throwing `OverflowException`. Skipped pending the fix — see GH-3852.