### PR TITLE
fix(holdings): range-check the ParseHoldingRow share-value cast

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -903,7 +903,12 @@ public class HoldingsImportService
             (commonStockId, reportDate),
             out var closePrice
         );
-        var value = hasPrice ? (long)(shares * closePrice) : 0L;
+        // shares comes from filer-controlled SSHPRNAMT; an oversized count makes the decimal
+        // product exceed Int64, so range-check before the cast (mirrors Filing13DGXmlParser)
+        // instead of throwing OverflowException and aborting the whole filing's import.
+        var product = shares * closePrice;
+        var value =
+            hasPrice && product >= long.MinValue && product <= long.MaxValue ? (long)product : 0L;
         var valuePending = !hasPrice;
 
         var otherManagerNumber = ParseNullableInt(GetValue(row, "OTHERMANAGER"));

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValueOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValueOverflowTests.cs
@@ -17,7 +17,7 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class HoldingsImportServiceParseHoldingRowValueOverflowTests
 {
-    [Fact(Skip = "GH-3852 — ParseHoldingRow throws OverflowException on an oversized share count")]
+    [Fact]
     public void ParseHoldingRow_SharesTimesPriceExceedsInt64_DoesNotThrowOverflow()
     {
         var method = typeof(HoldingsImportService).GetMethod(


### PR DESCRIPTION
## Summary

- Fixes GH-3852: `HoldingsImportService.ParseHoldingRow` derived a holding's value via `(long)(shares * closePrice)` where `shares` comes from filer-controlled `SSHPRNAMT` (any value up to `long.MaxValue`). An oversized share count × a known close price overflows `Int64` and threw `OverflowException`, aborting the filing import before `Corrupt13FShareCountRepairer` could run.
- Minimal fix range-checks the decimal product before the cast and falls back to `0` on overflow — mirroring the sibling `Filing13DGXmlParser` (#3578), `SharesOutstandingProvider` (#3836), `FormDFilingProcessor` (#3839). Non-overflow behavior is unchanged.
- Un-skips the regression test merged in #3853.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — `ParseHoldingRow` range-checks `shares * closePrice` against `Int64` bounds before casting; out-of-range degrades to `0` instead of throwing.
- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValueOverflowTests.cs` — removed the `[Skip]` (GH-3852); now passes.