### PR TITLE
fix(holdings): range-check the HoldingsValueRecalculator share-value casts

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
@@ -170,12 +170,12 @@ public class HoldingsValueRecalculator
 
             foreach (var holding in pendingHoldings)
             {
-                holding.Value = (long)(holding.Shares * closePrice);
+                holding.Value = ToBoundedValue(holding.Shares, closePrice);
                 holding.ValuePending = false;
 
                 foreach (var entry in holding.ManagerEntries)
                 {
-                    entry.Value = (long)(entry.Shares * closePrice);
+                    entry.Value = ToBoundedValue(entry.Shares, closePrice);
                 }
             }
 
@@ -183,5 +183,14 @@ public class HoldingsValueRecalculator
             totalUpdated += pendingHoldings.Count;
         }
         return totalUpdated;
+    }
+
+    // shares comes from filer-controlled SSHPRNAMT; an oversized count makes the decimal
+    // product exceed Int64, so range-check before the cast (mirrors ParseHoldingRow and
+    // Filing13DGXmlParser) instead of throwing OverflowException and aborting the batch.
+    private static long ToBoundedValue(long shares, decimal closePrice)
+    {
+        var product = shares * closePrice;
+        return product >= long.MinValue && product <= long.MaxValue ? (long)product : 0L;
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorOversizedSharesOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorOversizedSharesOverflowTests.cs
@@ -25,7 +25,7 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class HoldingsValueRecalculatorOversizedSharesOverflowTests
 {
-    [Fact(Skip = "GH-3855 — Recalculate throws OverflowException on an oversized pending holding")]
+    [Fact]
     public async Task Recalculate_PendingHoldingSharesTimesPriceExceedsInt64_DoesNotThrowOverflow()
     {
         await using var db = CreateDbContext();


### PR DESCRIPTION
## Summary

- Fixes GH-3855: `HoldingsValueRecalculator.ResolveHoldingsWithNewPrices` recomputed `(long)(Shares * closePrice)` for both the holding and each manager entry with no range-check and no try/catch. A pending holding stored with an oversized `Shares` (filer `SSHPRNAMT`, up to `long.MaxValue`) overflowed `Int64` once a price landed and threw `OverflowException` out of `Recalculate`, aborting the entire nightly batch and leaving every other pending holding unresolved.
- Minimal fix routes both casts through a `ToBoundedValue` helper that range-checks the decimal product before casting (falls back to `0` on overflow) — mirroring `ParseHoldingRow` (#3852) and the sibling `Filing13DGXmlParser`. Non-overflow behavior unchanged.
- Un-skips the regression test merged in #3856.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs` — added `ToBoundedValue(long, decimal)`; `holding.Value` and `entry.Value` now use it instead of the raw `(long)` cast.
- `tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorOversizedSharesOverflowTests.cs` — removed the `[Skip]` (GH-3855); now passes.