### PR TITLE
fix(holdings): drop a corrupt 13F row whose recovered value exceeds Int64

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/Corrupt13FShareCountRepairer.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Corrupt13FShareCountRepairer.cs
@@ -90,11 +90,28 @@ internal static class Corrupt13FShareCountRepairer
                 && closePrice > 0
             )
             {
-                var shares = (long)Math.Round(reportedDollars / closePrice);
+                var recoveredShares = Math.Round(reportedDollars / closePrice);
+                var recoveredValue = recoveredShares * closePrice;
+                // An oversized corrupt row can push value ÷ price (and the value it
+                // implies) past Int64; it is too large to represent, so drop it like the
+                // neither-anchor case below instead of letting the (long) casts throw
+                // OverflowException and abort the whole import batch.
+                if (
+                    recoveredShares < long.MinValue
+                    || recoveredShares > long.MaxValue
+                    || recoveredValue < long.MinValue
+                    || recoveredValue > long.MaxValue
+                )
+                {
+                    dropped++;
+                    continue;
+                }
+
+                var shares = (long)recoveredShares;
                 // The truncating cast deliberately mirrors ParseHoldingRow's
                 // `(long)(shares * closePrice)` so a repaired row is identical
                 // to what the same filing would have produced if filed correctly.
-                ApplyRepair(row, shares, (long)(shares * closePrice), valuePending: false);
+                ApplyRepair(row, shares, (long)recoveredValue, valuePending: false);
                 repaired++;
                 kept.Add(row);
                 continue;

--- a/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerRepairValueOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerRepairValueOverflowTests.cs
@@ -17,7 +17,7 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class Corrupt13FShareCountRepairerRepairValueOverflowTests
 {
-    [Fact(Skip = "GH-3858 — Repair throws OverflowException on an oversized duplicated row")]
+    [Fact]
     public void Repair_DuplicatedRowValueOverPriceExceedsInt64_DoesNotThrowOverflow()
     {
         // Duplicated row (Shares == ReportedValue) with an oversized value and a $0.50


### PR DESCRIPTION
## Summary

- Fixes GH-3858: `Corrupt13FShareCountRepairer.Repair` recovered a duplicated row's share count via `(long)Math.Round(reportedDollars / closePrice)` (and recomputed value via `(long)(shares * closePrice)`) with no range-check. An oversized corrupt row — exactly the input the repairer exists to handle — over a sub-dollar close overflowed `Int64` and threw `OverflowException`, aborting the import batch.
- Minimal fix range-checks both the recovered share count and the implied value before casting; an un-representable row is dropped like the existing neither-anchor case (`dropped++`). Non-overflow repairs are unchanged.
- Completes the decimal→long overflow vein across the Holdings value pipeline: `ParseHoldingRow` (#3852), `HoldingsValueRecalculator` (#3855), and now `Corrupt13FShareCountRepairer`.
- Un-skips the regression test merged in #3859.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/Corrupt13FShareCountRepairer.cs` — `Repair` range-checks the recovered shares and value; out-of-range rows are dropped instead of throwing.
- `tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerRepairValueOverflowTests.cs` — removed the `[Skip]` (GH-3858); now passes.