### PR TITLE
fix(fda-catalysts): dedup meeting slug only after a row passes validation

### DIFF
--- a/src/Equibles.FdaCatalysts.BusinessLogic/FdaAdvisoryCommitteeCalendarParser.cs
+++ b/src/Equibles.FdaCatalysts.BusinessLogic/FdaAdvisoryCommitteeCalendarParser.cs
@@ -82,7 +82,7 @@ public static class FdaAdvisoryCommitteeCalendarParser
 
             var href = link.GetAttributeValue("href", string.Empty).Trim();
             var slug = ExtractSlug(href);
-            if (slug.Length == 0 || !seenSlugs.Add(slug))
+            if (slug.Length == 0)
             {
                 continue;
             }
@@ -101,6 +101,14 @@ public static class FdaAdvisoryCommitteeCalendarParser
 
             var center = HtmlEntity.DeEntitize(cells[centerCol].InnerText).Trim();
             if (center.Length == 0)
+            {
+                continue;
+            }
+
+            // Dedup only after the row is known good. Registering the slug earlier let a skipped row
+            // (e.g. one with no parseable Start Date) consume the slug and suppress a later, fully
+            // valid listing of the same meeting — dropping it entirely (#3861).
+            if (!seenSlugs.Add(slug))
             {
                 continue;
             }

--- a/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserSkippedRowSlugTests.cs
+++ b/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserSkippedRowSlugTests.cs
@@ -13,7 +13,7 @@ public class FdaAdvisoryCommitteeCalendarParserSkippedRowSlugTests
     // skipped row must not consume the slug — the later, fully valid row for the same meeting must
     // still be captured. Adversarial: the parser registers the slug as "seen" before validating the
     // Start Date, so a date-less first row suppresses the valid duplicate and the meeting is lost.
-    [Fact(Skip = "GH-3861 — date-less first row consumes the slug, dropping a valid duplicate row")]
+    [Fact]
     public void Parse_FirstRowWithoutStartDateSharesSlug_StillCapturesTheValidRow()
     {
         const string html =


### PR DESCRIPTION
## Summary

- Fixes **#3861**: `FdaAdvisoryCommitteeCalendarParser.Parse` registered a row's meeting slug in its dedup set *before* validating the Start Date, so a skipped (e.g. date-less) row consumed the slug and suppressed a later, fully valid listing of the same meeting — dropping it entirely.
- The slug is now added to `seenSlugs` only once a row has passed every validation (slug present, parseable Start Date, non-empty title and center), so a skipped row truly leaves no trace and a valid duplicate is captured.
- Un-skips the existing repro test (GH-3861), which now passes; the duplicate-slug dedup of two *valid* rows is unchanged (still keeps the first).

## Code changes

- `src/Equibles.FdaCatalysts.BusinessLogic/FdaAdvisoryCommitteeCalendarParser.cs` — split the early `slug.Length == 0 || !seenSlugs.Add(slug)` guard: keep the empty-slug skip up front, but move `seenSlugs.Add(slug)` down to after the date/title/center validation, just before the catalyst is built.
- `tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserSkippedRowSlugTests.cs` — removed the `[Skip]` marker; the regression test now runs green.