### PR TITLE
test(sec): pin SecHeadingKeyword.MatchesKeywordIdentifier nbsp separator

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/SecHeadingKeywordMatchesKeywordIdentifierTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/SecHeadingKeywordMatchesKeywordIdentifierTests.cs
@@ -1,0 +1,34 @@
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class SecHeadingKeywordMatchesKeywordIdentifierTests
+{
+    // Contract (from the doc-comment): MatchesKeywordIdentifier tells a real "Part" header
+    // apart from prose that merely starts with the keyword, and EDGAR renders the separator
+    // between keyword and identifier as a non-breaking space (U+00A0) — "any Unicode
+    // whitespace counts". This pins both halves of that discriminator on the shared helper:
+    // the nbsp-separated header is recognised (guards against an ASCII-only `== ' '` check),
+    // while a keyword-prefixed word ("Partnership") has no whitespace boundary and is rejected.
+    [Fact]
+    public void MatchesKeywordIdentifier_NonBreakingSpaceSeparator_RecognisesHeaderNotProse()
+    {
+        var nbspHeader = SecHeadingKeyword.MatchesKeywordIdentifier(
+            "Part IV",
+            "PART",
+            SecHeadingKeyword.IsRomanNumeral
+        );
+        var prefixedProse = SecHeadingKeyword.MatchesKeywordIdentifier(
+            "Partnership",
+            "PART",
+            SecHeadingKeyword.IsRomanNumeral
+        );
+
+        nbspHeader
+            .Should()
+            .BeTrue("EDGAR separates 'Part' from its numeral with a non-breaking space (U+00A0)");
+        prefixedProse
+            .Should()
+            .BeFalse("'Partnership' has no whitespace boundary after 'Part' and is not a header");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the previously-untested shared `SecHeadingKeyword.MatchesKeywordIdentifier` helper, which both `HeadingConversionStep` and `PaginationRemovalStep` rely on to tell a real "Part" section header apart from prose that merely starts with the keyword.
- Locks in the documented EDGAR behavior that the separator between keyword and identifier is a non-breaking space (U+00A0), so the discriminator can't silently regress to an ASCII-only space check.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/SecHeadingKeywordMatchesKeywordIdentifierTests.cs` — adds one unit test asserting that "Part" followed by a U+00A0 + Roman numeral is recognised as a header, while "Partnership" (no whitespace boundary) is rejected.