### PR TITLE
test(sec): add skipped repro for GH-3866 — em-dash Part heading

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartHeadingEmDashNoSpaceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartHeadingEmDashNoSpaceTests.cs
@@ -1,0 +1,33 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepPartHeadingEmDashNoSpaceTests
+{
+    private readonly HeadingConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract: a real SEC "Part" heading is promoted even when its standardized title is
+    // glued to the Roman numeral by an em-dash with no surrounding spaces — the canonical
+    // SEC 10-Q form "PART II—OTHER INFORMATION". The sibling-test pins the spaced variant
+    // ("Part II — Other Information"); SEC EDGAR emits both, and the keyword tokenizer already
+    // splits on the ASCII hyphen ("Part II-Other"), so the em-dash (U+2014) it actually emits
+    // must tokenize the same way. A missed split leaves the header an un-promoted span,
+    // breaking table-of-contents/chunk extraction for that part.
+    [Fact(
+        Skip = "GH-3866 — em-dash-glued Part heading title not tokenized, header left un-promoted"
+    )]
+    public void Execute_PartHeadingEmDashNoSpaceTitle_PromotesItToHeading()
+    {
+        var doc = _parser.ParseDocument(
+            "<html><body><div><span>Part II—Other Information</span></div></body></html>"
+        );
+
+        _step.Execute(doc);
+
+        var body = doc.Body!.InnerHtml;
+        body.Should().Contain("<h1>");
+        body.Should().NotContain("<span");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped regression test capturing GH-3866: a SEC "Part" header whose standardized title is glued to the Roman numeral by a no-space em-dash (`PART II—OTHER INFORMATION`, the canonical EDGAR form) is not promoted to a heading.
- The keyword tokenizer splits on the ASCII hyphen but not the Unicode em/en-dash EDGAR actually emits, so `IsRomanNumeral` sees `II—OTHER` and detection fails. Test is `[Skip]` pending the fix — un-skip it as part of resolving GH-3866.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartHeadingEmDashNoSpaceTests.cs` — new skipped test driving `HeadingConversionStep.Execute` over `Part II—Other Information` and asserting heading promotion (mirrors the passing spaced-form sibling test). Skipped — see GH-3866.