### PR TITLE
fix(sec): tokenize Part/Item headings on em/en-dash separators

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/SecHeadingKeyword.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/SecHeadingKeyword.cs
@@ -29,7 +29,14 @@ internal static class SecHeadingKeyword
             return false;
 
         var after = upperText.Substring(keyword.Length + 1).Trim();
-        var tokens = after.Split([' ', '.', '-', ':'], StringSplitOptions.RemoveEmptyEntries);
+        // SEC EDGAR separates the identifier from a glued title with an em-dash (U+2014)
+        // or en-dash (U+2013), not the ASCII hyphen — "PART II—OTHER INFORMATION". Treat
+        // all three as token separators so a no-space dash doesn't fuse the numeral to the
+        // next word and defeat the identifier check.
+        var tokens = after.Split(
+            [' ', '.', '-', ':', '—', '–'],
+            StringSplitOptions.RemoveEmptyEntries
+        );
         if (tokens.Length == 0)
             return false;
 

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartHeadingEmDashNoSpaceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartHeadingEmDashNoSpaceTests.cs
@@ -15,9 +15,7 @@ public class HeadingConversionStepPartHeadingEmDashNoSpaceTests
     // splits on the ASCII hyphen ("Part II-Other"), so the em-dash (U+2014) it actually emits
     // must tokenize the same way. A missed split leaves the header an un-promoted span,
     // breaking table-of-contents/chunk extraction for that part.
-    [Fact(
-        Skip = "GH-3866 — em-dash-glued Part heading title not tokenized, header left un-promoted"
-    )]
+    [Fact]
     public void Execute_PartHeadingEmDashNoSpaceTitle_PromotesItToHeading()
     {
         var doc = _parser.ParseDocument(


### PR DESCRIPTION
## Summary

- Fixes GH-3866: SEC "Part"/"Item" headers whose standardized title is glued to the identifier by a no-space em-dash (`PART II—OTHER INFORMATION`, the canonical EDGAR form) were left as un-promoted spans, so table-of-contents/chunk extraction missed those sections.
- Root cause: the keyword tokenizer split on the ASCII hyphen but not the em-dash (U+2014) / en-dash (U+2013) EDGAR actually emits, so the first token became `II—OTHER` and the identifier check failed.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/SecHeadingKeyword.cs` — add `—` (U+2014) and `–` (U+2013) to the post-keyword token-separator set in `MatchesKeywordIdentifier`, so a no-space Unicode dash separates the identifier from the title like the ASCII hyphen already does.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartHeadingEmDashNoSpaceTests.cs` — un-skip the GH-3866 regression test (fails before, passes after).