### PR TITLE
test(sec): pin SecInlineCss.ContainsDeclaration detects both EDGAR colon-space forms

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/SecInlineCssContainsDeclarationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/SecInlineCssContainsDeclarationTests.cs
@@ -1,0 +1,30 @@
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class SecInlineCssContainsDeclarationTests
+{
+    // Contract (from the doc-comment): SEC EDGAR emits inline CSS both with and without a
+    // space after the colon ("text-align:center" and "text-align: center"), and
+    // ContainsDeclaration must detect *both* forms. The spaced form is the non-obvious half —
+    // a naive source.Contains("text-align:center") would miss it, silently breaking the
+    // center-alignment / bold / list-wrapper detection that drives heading and list
+    // normalization across every filing that emits the spaced form. This pins that guarantee.
+    [Fact]
+    public void ContainsDeclaration_SpacedAndUnspacedColonForms_BothDetected()
+    {
+        var unspaced = SecInlineCss.ContainsDeclaration(
+            "text-align:center",
+            "text-align",
+            "center"
+        );
+        var spaced = SecInlineCss.ContainsDeclaration("text-align: center", "text-align", "center");
+
+        unspaced.Should().BeTrue("EDGAR emits the unspaced 'property:value' form");
+        spaced
+            .Should()
+            .BeTrue(
+                "EDGAR also emits the spaced 'property: value' form, which a single Contains would miss"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `SecInlineCss.ContainsDeclaration` — the shared inline-CSS matcher used by `HeadingConversionStep` and `ListConversionStep` — to detect *both* colon-space forms SEC EDGAR emits (`property:value` and `property: value`).
- The helper was added recently (last 30 days) with no test. The spaced form is the non-obvious guarantee: a naive single `source.Contains("property:value")` would miss it, silently breaking center-alignment / bold / list-wrapper detection across every filing that emits the spaced form.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/SecInlineCssContainsDeclarationTests.cs` — new unit test asserting both the unspaced and spaced colon forms of `text-align: center` are detected. Lane A (adversarial-derived from the doc-comment contract); passes on current code, guards against a regression that collapses the two-form match back to one.