### PR TITLE
fix(government-contracts): parse USAspending NAICS/PSC object fields

### DIFF
--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardRecord.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardRecord.cs
@@ -45,9 +45,11 @@ public class UsaSpendingAwardRecord
     public string LastModifiedDate { get; set; }
 
     [JsonProperty("NAICS")]
+    [JsonConverter(typeof(UsaSpendingCodeConverter))]
     public string Naics { get; set; }
 
     [JsonProperty("PSC")]
+    [JsonConverter(typeof(UsaSpendingCodeConverter))]
     public string Psc { get; set; }
 
     [JsonProperty("Description")]

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingCodeConverter.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingCodeConverter.cs
@@ -1,0 +1,33 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Equibles.Integrations.GovernmentContracts.Models;
+
+/// <summary>
+/// Reads a USAspending classification field (NAICS, PSC) that the API returns either as a
+/// bare string (<c>"561210"</c>) or as an object (<c>{ "code": "561210", "description": "..." }</c>).
+/// Always yields the bare code string (or null), so downstream mapping stays shape-agnostic.
+/// </summary>
+public class UsaSpendingCodeConverter : JsonConverter<string>
+{
+    public override string ReadJson(
+        JsonReader reader,
+        Type objectType,
+        string existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer
+    )
+    {
+        var token = JToken.Load(reader);
+        return token.Type switch
+        {
+            JTokenType.Null => null,
+            JTokenType.Object => (string)token["code"],
+            JTokenType.String => (string)token,
+            _ => token.ToString(),
+        };
+    }
+
+    public override void WriteJson(JsonWriter writer, string value, JsonSerializer serializer) =>
+        writer.WriteValue(value);
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardResponseDeserializationTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardResponseDeserializationTests.cs
@@ -1,0 +1,63 @@
+using Equibles.Integrations.GovernmentContracts.Models;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class UsaSpendingAwardResponseDeserializationTests
+{
+    // USAspending returns NAICS and PSC as objects ({ code, description }), not bare
+    // strings. The response must deserialize and expose the bare code for each.
+    [Fact]
+    public void Deserialize_WhenNaicsAndPscAreObjects_ExposesTheBareCode()
+    {
+        const string json = """
+            {
+              "results": [
+                {
+                  "generated_internal_id": "CONT_AWD_DEAC0494AL85000",
+                  "Award ID": "DEAC0494AL85000",
+                  "Award Amount": 48063763681.32,
+                  "NAICS": { "code": "561210", "description": "FACILITIES SUPPORT SERVICES" },
+                  "PSC": { "code": "M181", "description": "OPER OF GOVT R&D GOCO FACILITIES" },
+                  "Recipient Name": "LOCKHEED MARTIN CORP"
+                }
+              ],
+              "page_metadata": { "page": 1, "hasNext": false }
+            }
+            """;
+
+        var response = JsonConvert.DeserializeObject<UsaSpendingAwardResponse>(json);
+
+        response.Should().NotBeNull();
+        response!.Results.Should().HaveCount(1);
+        var record = response.Results[0];
+        record.Naics.Should().Be("561210");
+        record.Psc.Should().Be("M181");
+    }
+
+    // The bare-string shape must keep working, so the client tolerates either form.
+    [Fact]
+    public void Deserialize_WhenNaicsAndPscAreStrings_KeepsTheValue()
+    {
+        const string json = """
+            {
+              "results": [
+                {
+                  "generated_internal_id": "CONT_AWD_ABC",
+                  "Award ID": "ABC",
+                  "NAICS": "336411",
+                  "PSC": "1510"
+                }
+              ],
+              "page_metadata": { "page": 1, "hasNext": false }
+            }
+            """;
+
+        var response = JsonConvert.DeserializeObject<UsaSpendingAwardResponse>(json);
+
+        response!.Results[0].Naics.Should().Be("336411");
+        response.Results[0].Psc.Should().Be("1510");
+    }
+}


### PR DESCRIPTION
## Summary

The USAspending `spending_by_award` endpoint returns each result's `NAICS` and `PSC` fields as objects (`{ "code": "561210", "description": "..." }`), but the award record modelled both as bare strings. Deserialization threw `JsonReaderException` on every response, so the Government Contracts import window aborted and no contract awards were stored — a continuous failure in production.

## Code changes

- **`UsaSpendingCodeConverter`** (new) — reads a USAspending classification field whether it arrives as the object shape or the legacy bare-string shape, and yields the bare code (or null).
- **`UsaSpendingAwardRecord`** — annotate `Naics` and `Psc` with the converter. The field type stays `string` and the downstream mapper is unchanged.
- **Tests** — new deserialization tests covering both the object shape (regression) and the bare-string shape (backward compatibility).