### PR TITLE
fix(congress): drop trades dated after their filing date

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -201,6 +201,22 @@ public class CongressionalTradeSyncService
                 continue;
             }
 
+            // A trade is disclosed after it happens, so the transaction date can never be after
+            // the filing date. A source typo (e.g. a wrong year) that breaks this would otherwise
+            // sort to the top of the member's newest-first trade history.
+            if (tx.TransactionDate > tx.FilingDate)
+            {
+                _logger.LogWarning(
+                    "Skipping congressional trade with transaction date {TransactionDate} after "
+                        + "filing date {FilingDate} for {Member} ({Ticker})",
+                    tx.TransactionDate,
+                    tx.FilingDate,
+                    tx.MemberName,
+                    tx.Ticker
+                );
+                continue;
+            }
+
             var stock = stocks[tx.Ticker];
 
             trades.Add(

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesFutureDateTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesFutureDateTests.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Congress;
+
+public class CongressionalTradeSyncServiceBuildTradesFutureDateTests
+{
+    private static CongressionalTradeSyncService CreateSut() =>
+        new(
+            Substitute.For<IServiceScopeFactory>(),
+            Options.Create(new WorkerOptions()),
+            Substitute.For<ILogger<CongressionalTradeSyncService>>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+    private static List<CongressionalTrade> InvokeBuildTrades(
+        CongressionalTradeSyncService sut,
+        DisclosureTransaction tx,
+        CommonStock stock,
+        CongressMember member
+    )
+    {
+        var method = typeof(CongressionalTradeSyncService).GetMethod(
+            "BuildTrades",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        return (List<CongressionalTrade>)
+            method.Invoke(
+                sut,
+                [
+                    new List<DisclosureTransaction> { tx },
+                    new Dictionary<string, CongressMember> { [member.Name] = member },
+                    new Dictionary<string, CommonStock> { [stock.Ticker] = stock },
+                ]
+            );
+    }
+
+    private static (CommonStock, CongressMember) Fixtures()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "IBM",
+            Name = "International Business Machines",
+            Cik = "0000051143",
+        };
+        var member = new CongressMember { Id = Guid.NewGuid(), Name = "Pete Sessions" };
+        return (stock, member);
+    }
+
+    // A trade is always disclosed after it happens, so the transaction date can never be after
+    // the filing date. A source typo (e.g. year 3031) that violates this must be dropped, not
+    // stored — otherwise it sorts to the top of the member's newest-first trade history.
+    [Fact]
+    public void BuildTrades_TransactionDateAfterFilingDate_SkipsTrade()
+    {
+        var sut = CreateSut();
+        var (stock, member) = Fixtures();
+        var tx = new DisclosureTransaction
+        {
+            MemberName = member.Name,
+            Ticker = stock.Ticker,
+            AssetName = "International Business Machines Corporation (IBM)",
+            TransactionType = CongressTransactionType.Purchase,
+            OwnerType = "SP",
+            TransactionDate = new DateOnly(3031, 4, 30),
+            FilingDate = new DateOnly(2021, 5, 3),
+            AmountFrom = 1001,
+            AmountTo = 15000,
+        };
+
+        var trades = InvokeBuildTrades(sut, tx, stock, member);
+
+        trades.Should().BeEmpty();
+    }
+
+    // A normal trade (disclosed on or after the transaction) is still built.
+    [Fact]
+    public void BuildTrades_TransactionDateOnOrBeforeFilingDate_BuildsTrade()
+    {
+        var sut = CreateSut();
+        var (stock, member) = Fixtures();
+        var tx = new DisclosureTransaction
+        {
+            MemberName = member.Name,
+            Ticker = stock.Ticker,
+            AssetName = "International Business Machines Corporation (IBM)",
+            TransactionType = CongressTransactionType.Purchase,
+            OwnerType = "SP",
+            TransactionDate = new DateOnly(2021, 4, 30),
+            FilingDate = new DateOnly(2021, 5, 3),
+            AmountFrom = 1001,
+            AmountTo = 15000,
+        };
+
+        var trades = InvokeBuildTrades(sut, tx, stock, member);
+
+        trades.Should().HaveCount(1);
+        trades[0].TransactionDate.Should().Be(new DateOnly(2021, 4, 30));
+    }
+}


### PR DESCRIPTION
## Summary

Some congressional trades were stored with a transaction date *after* their filing date, which is impossible — a trade is always disclosed after it occurs. Source typos (e.g. a year keyed as `3031` or `2202`) were parsed verbatim, and because trade lists are ordered newest-first these absurd-dated rows sorted to the very top of a member's trade history.

## Code changes

- **`CongressionalTradeSyncService.BuildTrades`** — skip (and log) any disclosure whose transaction date is after its filing date, instead of building a trade from it. This is the single chokepoint for both the House and Senate sources.
- **Tests** — a transaction dated after its filing date is dropped; a normally-dated one is still built.