### PR TITLE
fix(government-contracts): retry transient USAspending transport failures and stop flooding the error log

### DIFF
--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -112,6 +112,20 @@ public class GovernmentContractsImportService : IImporter
                     ex.StackTrace,
                     $"window: {windowStart}..{windowEnd}"
                 );
+
+                // A transport-level failure (the API is unreachable, even after the client's retries)
+                // is systemic: every remaining window would fail identically and record its own error,
+                // turning one outage into hundreds of duplicate rows. Stop the cycle after reporting
+                // once; the next run resumes from the same start date once the API is reachable again.
+                // Other (window-specific) failures fall through and the scan continues.
+                if (ex is HttpRequestException)
+                {
+                    _logger.LogWarning(
+                        "Government contracts import: aborting this cycle after a transport failure; "
+                            + "remaining windows will be retried on the next run"
+                    );
+                    break;
+                }
             }
         }
 

--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -149,13 +149,23 @@ public class UsaSpendingClient : IUsaSpendingClient
         {
             await RateLimiter.WaitAsync();
 
-            using var response = await sendRequest();
-
-            if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
+            HttpResponseMessage response;
+            try
             {
+                response = await sendRequest();
+            }
+            catch (Exception ex)
+                when (ex is HttpRequestException or TaskCanceledException && attempt < MaxRetries)
+            {
+                // A transport-level failure — connection reset, DNS blip, TLS error or a request
+                // timeout — throws here and never reaches the status-code checks below. Without this
+                // a momentary network hiccup fails the whole import window (and, repeated across every
+                // window, floods the error log); retry it with the same backoff a 5xx gets.
                 var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
-                    "USAspending rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                    ex,
+                    "USAspending request failed ({Error}), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                    ex.Message,
                     delay.TotalSeconds,
                     attempt + 1,
                     MaxRetries
@@ -164,22 +174,38 @@ public class UsaSpendingClient : IUsaSpendingClient
                 continue;
             }
 
-            if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
+            using (response)
             {
-                var delay = ExponentialBackoff(attempt);
-                _logger.LogWarning(
-                    "USAspending server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
-                    (int)response.StatusCode,
-                    delay.TotalSeconds,
-                    attempt + 1,
-                    MaxRetries
-                );
-                await Task.Delay(delay);
-                continue;
-            }
+                if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
+                {
+                    var delay = ExponentialBackoff(attempt);
+                    _logger.LogWarning(
+                        "USAspending rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                        delay.TotalSeconds,
+                        attempt + 1,
+                        MaxRetries
+                    );
+                    await Task.Delay(delay);
+                    continue;
+                }
 
-            response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStringAsync();
+                if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
+                {
+                    var delay = ExponentialBackoff(attempt);
+                    _logger.LogWarning(
+                        "USAspending server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                        (int)response.StatusCode,
+                        delay.TotalSeconds,
+                        attempt + 1,
+                        MaxRetries
+                    );
+                    await Task.Delay(delay);
+                    continue;
+                }
+
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync();
+            }
         }
 
         throw new HttpRequestException("Max retries exceeded for USAspending API request");

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientSendWithRetryTransientNetworkTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientSendWithRetryTransientNetworkTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Net.Sockets;
+using Equibles.Integrations.GovernmentContracts;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+/// <summary>
+/// Pins the transport-level retry branch of <see cref="UsaSpendingClient"/>'s SendWithRetry. A
+/// DNS/socket/TLS blip or request timeout reaching api.usaspending.gov surfaces as an
+/// <see cref="HttpRequestException"/> that never reaches the status-code checks; before the fix it
+/// bubbled straight to the import, failing the window and — repeated across every window of a backfill
+/// — flooding the dashboard with hundreds of identical "An error occurred while sending the request"
+/// rows. It must now be retried like a 5xx so a momentary hiccup is transparent.
+/// </summary>
+public class UsaSpendingClientSendWithRetryTransientNetworkTests
+{
+    [Fact]
+    public async Task GetContractAwards_FirstCallTransportFailure_RetriesThenSucceeds()
+    {
+        var okBody =
+            "{\"results\":[{\"generated_internal_id\":\"CONT_AWD_1\",\"Award ID\":\"PIID-1\"}],"
+            + "\"page_metadata\":{\"page\":1,\"hasNext\":false}}";
+        var handler = new TransientThenOkHandler(okBody);
+        var sut = new UsaSpendingClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<UsaSpendingClient>>()
+        );
+
+        var awards = await sut.GetContractAwards(
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            minimumAmount: 0m
+        );
+
+        // Two calls + a parsed award prove the transport failure drove a retry that then succeeded —
+        // before the fix the first throw aborted the window with no status-code branch to catch it.
+        handler.CallCount.Should().Be(2);
+        awards.Should().ContainSingle().Which.GeneratedInternalId.Should().Be("CONT_AWD_1");
+    }
+
+    private sealed class TransientThenOkHandler : HttpMessageHandler
+    {
+        private readonly string _successBody;
+        public int CallCount { get; private set; }
+
+        public TransientThenOkHandler(string successBody)
+        {
+            _successBody = successBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            CallCount++;
+            if (CallCount == 1)
+            {
+                throw new HttpRequestException(
+                    "An error occurred while sending the request.",
+                    new SocketException()
+                );
+            }
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_successBody),
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A momentary network failure to `api.usaspending.gov` (DNS/socket/TLS blip or request timeout) throws an `HttpRequestException` from `HttpClient.SendAsync` that never reached the 429/5xx retry branches in `SendWithRetry` — so a brief hiccup failed the whole import window. Because the import catches per window and continues, a backfill spanning hundreds of date-windows turned one short outage into hundreds of identical "An error occurred while sending the request" rows on the errors dashboard.

## Code changes

- `UsaSpendingClient.SendWithRetry` — wrap `sendRequest()` and retry transport-level failures (`HttpRequestException`/`TaskCanceledException`) with the same exponential backoff a 5xx gets; after the retries are exhausted the real exception still propagates.
- `GovernmentContractsImportService.Import` — after reporting a window failure, abort the cycle when the exception is a transport-level `HttpRequestException` (systemic — every remaining window would fail identically), instead of recording one error per window. Window-specific failures still fall through and the scan continues. The next run resumes from the same start date once the API is reachable.
- Test: `UsaSpendingClientSendWithRetryTransientNetworkTests` — first call throws a transport `HttpRequestException`, second returns 200; asserts the client retried and recovered (mirrors the existing SEC transient-network test).

Verified locally: `Equibles.UnitTests` GovernmentContracts suite green (41 tests), csharpier clean.