### PR TITLE
docs(guide): add how-to — ask about a member of Congress's net worth

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -47,6 +47,7 @@ Task-focused recipes for someone who has Equibles running.
 - [View an insider's trading profile](how-to-view-insider-profile.md)
 - [View proposed insider sales (SEC Form 144)](how-to-view-proposed-sales.md)
 - [View a member of Congress's trading profile](how-to-view-congress-member-trades.md)
+- [Ask your AI assistant about a member of Congress's net worth](how-to-ask-about-congress-member-net-worth.md)
 - [Browse market-wide short data (most shorted and largest short volume)](how-to-browse-short-data.md)
 - [Browse economic indicators](how-to-browse-economic-data.md)
 - [Browse market indicators (VIX and put/call ratios)](how-to-browse-market-indicators.md)

--- a/docs/guide/how-to-ask-about-congress-member-net-worth.md
+++ b/docs/guide/how-to-ask-about-congress-member-net-worth.md
@@ -1,0 +1,33 @@
+# Ask your AI assistant about a member of Congress's net worth
+
+Equibles reads the annual financial disclosures that members of Congress file and exposes each member's net worth history through the MCP server, so you can ask your AI assistant how a politician's wealth has changed over the years. This data is available to AI assistants only — the web portal shows a member's *trades*, but their net worth is reached through your assistant.
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run for a while after first startup so the congressional scraper has imported annual disclosure reports.
+
+## Ask about a member's net worth
+
+Name the member in your question:
+
+- "What is Nancy Pelosi's net worth history?"
+- "Show me Marsha Blackburn's net worth over the last 10 years."
+- "How has Dan Crenshaw's disclosed net worth changed?"
+
+The assistant calls the `GetMemberNetWorth` tool and replies with one row per filing year, newest first. Each row shows the disclosure year, the date it was filed, the net worth band (minimum and maximum), and how many assets and liabilities the member reported that year.
+
+If the assistant can't match the name, ask it to search first ("find members named Warren") — it uses `SearchCongressMembers` to confirm the exact spelling before looking up the net worth.
+
+## Why every year is a range
+
+Members disclose each asset and liability in a broad dollar band rather than an exact figure, so a year's net worth is also a band: the low end sums the asset minimums and subtracts the liability maximums, and the high end does the reverse. Equibles never invents a single point estimate. A band can be negative when reported liabilities exceed reported assets.
+
+## What you should see
+
+A Markdown table in the assistant's reply, with one row per year. A missing year means the member filed no *electronic* report for it — paper filings are not read — so a gap is not the same as zero net worth. If nothing comes back at all, the scraper may not have imported that member's annual disclosures yet; try a long-serving, well-known member to confirm the data is flowing.
+
+## See also
+
+- [View a member of Congress's trading profile](how-to-view-congress-member-trades.md) — their reported stock trades, on the web portal.
+- [Connect an AI assistant and ask your first question](tutorial-connect-ai-assistant.md)


### PR DESCRIPTION
## Summary

- Add a user-guide how-to for the MCP-only `GetMemberNetWorth` tool: how to ask an AI assistant for a member of Congress's net worth history from their annual financial disclosures.
- Explains why each year is a min–max band (never a point estimate), that bands can be negative, and that a missing year means no electronic filing rather than zero net worth.
- Expand lane — fills a documented-feature gap: the guide covered member *trades* but not net worth.

## Code changes

- `docs/guide/how-to-ask-about-congress-member-net-worth.md` — new how-to page (ask-your-assistant shape, matching the government-contracts / FDA-catalysts pages).
- `docs/guide/README.md` — one TOC bullet under **How-to guides**, after the congress member trades entry.