### PR TITLE
test(congress): pin HouseAnnualReportClient.ExtractFilerStatus multi-word status

### DIFF
--- a/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientExtractFilerStatusTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientExtractFilerStatusTests.cs
@@ -1,0 +1,31 @@
+using Equibles.Congress.HostedService.Services;
+using static Equibles.Congress.HostedService.Services.HouseAnnualReportClient;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Contract (HouseAnnualReportClient.ExtractFilerStatus): the preamble renders
+/// the filer status as a "Status:" label token followed by its value, before
+/// the first schedule header. The value can be more than one word — the doc
+/// comment names "Status: Congressional Candidate" — so the method must return
+/// the WHOLE value, skipping unrelated preamble lines on the way. A regression
+/// that returned only the first token after the label (e.g. `line[1].Text`)
+/// would drop "Candidate" and surface here.
+/// </summary>
+public class HouseAnnualReportClientExtractFilerStatusTests
+{
+    private static List<ScheduleToken> Tokens(params (string text, double left)[] words) =>
+        words.Select(w => new ScheduleToken(w.text, w.left)).ToList();
+
+    [Fact]
+    public void ExtractFilerStatus_MultiWordStatusBeforeSchedule_ReturnsFullStatus()
+    {
+        var result = HouseAnnualReportClient.ExtractFilerStatus([
+            Tokens(("Name:", 25), ("Jane", 60), ("Doe", 85)),
+            Tokens(("Status:", 25), ("Congressional", 70), ("Candidate", 160)),
+            Tokens(("S", 22), ("A:", 92)),
+        ]);
+
+        result.Should().Be("Congressional Candidate");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first dedicated test for `HouseAnnualReportClient.ExtractFilerStatus`, which had zero coverage.
- Lane A (adversarial) — oracle derived from the contract: the preamble's `Status:` value can be multi-word ("Status: Congressional Candidate"), so the method must return the *whole* value while skipping unrelated preamble lines. Test passes — pins the behavior.
- Guards the `Skip(1)+Join` against a regression to a single-token read (which would drop "Candidate").

## Code changes

- `tests/Equibles.UnitTests/Congress/HouseAnnualReportClientExtractFilerStatusTests.cs` — new unit test asserting a multi-word filer status appearing before the first schedule header is returned in full.