### PR TITLE
test(finra): pin ShortSqueezeScoreManager.ApplyPercentiles null-metric handling

### DIFF
--- a/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerApplyPercentilesNullMetricsTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerApplyPercentilesNullMetricsTests.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.BusinessLogic.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Contract (ShortSqueezeScoreManager.ApplyPercentiles): days-to-cover and
+/// short-volume trend are optional metrics. A score missing one is excluded
+/// from that metric's peer-relative percentile set (its percentile stays
+/// null) and contributes one fewer factor to the composite Score — so a score
+/// with BOTH optionals null must score on short-interest alone and must not
+/// throw. Pins the `.Where(x != null).Select(x.Value)` null-guard against a
+/// regression that drops the filter (the case CodeQL flags as a null deref).
+/// </summary>
+public class ShortSqueezeScoreManagerApplyPercentilesNullMetricsTests
+{
+    [Fact]
+    public void ApplyPercentiles_ScoreMissingBothOptionalMetrics_ScoresOnShortInterestAloneWithoutThrowing()
+    {
+        // s1 has the distinct-max short interest and no optional metrics; s2/s3
+        // carry days-to-cover so the optional percentile set is non-empty.
+        var s1 = new ShortSqueezeScore
+        {
+            CommonStockId = Guid.NewGuid(),
+            ShortInterestPercentOfShares = 30m,
+            DaysToCover = null,
+            ShortVolumeShareTrend = null,
+        };
+        var s2 = new ShortSqueezeScore
+        {
+            CommonStockId = Guid.NewGuid(),
+            ShortInterestPercentOfShares = 10m,
+            DaysToCover = 5m,
+            ShortVolumeShareTrend = null,
+        };
+        var s3 = new ShortSqueezeScore
+        {
+            CommonStockId = Guid.NewGuid(),
+            ShortInterestPercentOfShares = 20m,
+            DaysToCover = 15m,
+            ShortVolumeShareTrend = 0.5m,
+        };
+        var scores = new List<ShortSqueezeScore> { s1, s2, s3 };
+
+        var method = typeof(ShortSqueezeScoreManager).GetMethod(
+            "ApplyPercentiles",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.Should().NotBeNull();
+
+        method!.Invoke(null, [scores]);
+
+        // s1's null optionals are excluded, not defaulted to a percentile.
+        s1.DaysToCoverPercentile.Should().BeNull();
+        s1.ShortVolumeTrendPercentile.Should().BeNull();
+        // With both optionals absent the composite is short-interest alone.
+        s1.Score.Should().Be(s1.ShortInterestPercentile);
+        // A present optional is still ranked: s3 is the distinct max of {5,15}.
+        s3.DaysToCoverPercentile.Should().Be(100);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first unit test for `ShortSqueezeScoreManager.ApplyPercentiles`. The existing Finra unit test covers only the lower-level `Percentiles` helper.
- Lane A (adversarial) — oracle from the contract: a score missing an optional metric (days-to-cover, short-volume trend) is excluded from that metric's percentile set, scores on short interest alone, and must not throw. Test passes — pins the behavior.
- Guards the `.Where(x != null).Select(x.Value)` null-filter (the line CodeQL flags as a possible null deref, alerts 570/571) against a regression that drops the filter.

## Code changes

- `tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerApplyPercentilesNullMetricsTests.cs` — new unit test asserting a score with both optional metrics null gets null optional percentiles, a composite Score equal to its short-interest percentile, and that a present optional is still ranked.