### PR TITLE
test(government-contracts): pin UsaSpendingCodeConverter object-without-code yields null

### DIFF
--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingCodeConverterTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingCodeConverterTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Integrations.GovernmentContracts.Models;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class UsaSpendingCodeConverterTests
+{
+    // Contract (from the converter's doc): a NAICS/PSC field always yields the bare code
+    // string "(or null)". An object that carries a description but no "code" key has no
+    // bare code, so it must deserialize to null — not the description, not the raw object.
+    [Fact]
+    public void ReadJson_WhenObjectHasNoCodeKey_YieldsNull()
+    {
+        const string json = """
+            { "NAICS": { "description": "FACILITIES SUPPORT SERVICES" } }
+            """;
+
+        var record = JsonConvert.DeserializeObject<UsaSpendingAwardRecord>(json);
+
+        record!.Naics.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `UsaSpendingCodeConverter` contract clause "always yields the bare code string **(or null)**" for the previously-untested case of a USAspending NAICS/PSC field returned as an object that has a `description` but **no `code` key**.
- Both happy-path shapes (object-with-code, bare-string) were already covered; this closes the code-less-object edge so a future change to the `JTokenType.Object` branch (e.g. leaking the raw object or NRE-ing on a missing key) is caught.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingCodeConverterTests.cs` — new unit test: deserializing `{ "NAICS": { "description": "..." } }` into `UsaSpendingAwardRecord` yields `Naics == null`. Lane A adversarial test derived from the converter's doc-comment; passes (behavior confirmed, kept as a regression guard).