### PR TITLE
refactor(core): extract surrogate-safe TruncateToFit into a shared string helper

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.HostedService.Models;
+using Equibles.Core.Extensions;
 using HtmlAgilityPack;
 
 namespace Equibles.Congress.HostedService.Services;
@@ -209,12 +210,7 @@ public static partial class DisclosureParsingHelper
     {
         if (maxLength <= 0)
             return value == null ? value : string.Empty;
-        if (value == null || value.Length <= maxLength)
-            return value;
-
-        var end =
-            maxLength > 0 && char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
-        return value[..end];
+        return value.TruncateToFit(maxLength);
     }
 
     public static DateOnly? ParseDate(string text)

--- a/src/Equibles.Core/Extensions/StringExtensions.cs
+++ b/src/Equibles.Core/Extensions/StringExtensions.cs
@@ -1,0 +1,23 @@
+namespace Equibles.Core.Extensions;
+
+public static class StringExtensions
+{
+    /// <summary>
+    /// Caps <paramref name="value"/> at <paramref name="maxLength"/> UTF-16 units without splitting
+    /// a surrogate pair. External free text (filings, exception messages, award descriptions, file
+    /// names) can contain non-BMP characters; a raw <c>[..maxLength]</c> slice can leave an orphan
+    /// high surrogate that corrupts the PostgreSQL UTF-8 round-trip (error 22001) and any JSON
+    /// serialization. <c>null</c> and values already within the bound pass through unchanged.
+    /// </summary>
+    public static string TruncateToFit(this string value, int maxLength)
+    {
+        if (value == null || value.Length <= maxLength)
+            return value;
+
+        // Back off one unit when the cap lands on the high half of a surrogate pair so the kept
+        // prefix never ends in a lone surrogate.
+        var end =
+            maxLength > 0 && char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
+        return value[..end];
+    }
+}

--- a/src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Equibles.Core.Extensions;
 using Equibles.GovernmentContracts.Data.Models;
 using Equibles.Integrations.GovernmentContracts.Models;
 
@@ -88,15 +89,6 @@ public static class UsaSpendingAwardMapper
     {
         if (string.IsNullOrWhiteSpace(value))
             return null;
-        var trimmed = value.Trim();
-        if (trimmed.Length <= maxLength)
-            return trimmed;
-        // Don't split a surrogate pair at the cap — back off one unit so the result
-        // stays well-formed UTF-16 (Postgres rejects lone surrogates in text columns).
-        var end =
-            maxLength > 0 && char.IsHighSurrogate(trimmed[maxLength - 1])
-                ? maxLength - 1
-                : maxLength;
-        return trimmed[..end];
+        return value.Trim().TruncateToFit(maxLength);
     }
 }

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.GovernmentContracts.Data.Models;
@@ -170,13 +171,7 @@ public class GovernmentContractsTools
         var trimmed = value.Trim();
         if (trimmed.Length <= maxLength)
             return trimmed;
-        // Don't split a surrogate pair at the cap — back off one unit so the result stays
-        // well-formed UTF-16 (a lone surrogate corrupts the tool's JSON reply).
-        var end =
-            maxLength > 0 && char.IsHighSurrogate(trimmed[maxLength - 1])
-                ? maxLength - 1
-                : maxLength;
-        return trimmed[..end] + "…";
+        return trimmed.TruncateToFit(maxLength) + "…";
     }
 
     // Markdown cells can't contain a raw pipe or newline without breaking the table.

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Core.Contracts;
+using Equibles.Core.Extensions;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
@@ -492,16 +493,8 @@ public class HoldingsImportService
     // Truncates a parsed string to its destination column bound. The cover page is
     // free text; a value past the bound is malformed, and storing the prefix beats
     // losing the filer's whole batch to a 22001 abort.
-    internal static string ClampLength(string value, int maxLength)
-    {
-        if (value == null || value.Length <= maxLength)
-            return value;
-        // Back off one unit if the cap lands on a high surrogate, so the kept prefix never
-        // ends in an orphan surrogate that corrupts the PostgreSQL UTF-8 round-trip (22001).
-        var end =
-            maxLength > 0 && char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
-        return value[..end];
-    }
+    internal static string ClampLength(string value, int maxLength) =>
+        value.TruncateToFit(maxLength);
 
     private async Task ParseOtherManagers(
         ImportContext context,

--- a/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Sec.Models;
@@ -135,14 +136,7 @@ internal static class EdgarXmlSubmissionParser
     /// INSERT with a length-overflow. Pass the column's <c>[MaxLength]</c> as
     /// <paramref name="maxLength"/>; <c>null</c> and shorter values pass through unchanged.
     /// </summary>
-    internal static string Truncate(string value, int maxLength)
-    {
-        if (value == null || value.Length <= maxLength)
-            return value;
-        var end =
-            maxLength > 0 && char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
-        return value[..end];
-    }
+    internal static string Truncate(string value, int maxLength) => value.TruncateToFit(maxLength);
 
     /// <summary>
     /// Trimmed text with the "N/A" placeholder and blanks normalized to <c>null</c>.

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.Extensions;
 using Equibles.Media.BusinessLogic;
 using Equibles.Messaging.Contracts.Sec;
 using Equibles.Sec.Data.Models;
@@ -117,18 +118,8 @@ public class DocumentPersistenceService : IDocumentPersistenceService
 
         var compressed = GzipCompressor.Compress(xbrl.RawBytes);
         // File.Name is capped at 256 chars; EDGAR document names are bare short tokens, but
-        // guard against a pathological envelope value so the insert can never overflow. A raw
-        // slice can split a surrogate pair, leaving an orphan high surrogate that corrupts the
-        // UTF-8 round-trip on insert — back off one unit when the cut lands mid-pair (mirrors
-        // EdgarXmlSubmissionParser.Truncate).
-        var name = xbrl.SourceFileName;
-        if (name?.Length > MaxFileNameLength)
-        {
-            var end = char.IsHighSurrogate(name[MaxFileNameLength - 1])
-                ? MaxFileNameLength - 1
-                : MaxFileNameLength;
-            name = name[..end];
-        }
+        // guard against a pathological envelope value so the insert can never overflow.
+        var name = xbrl.SourceFileName.TruncateToFit(MaxFileNameLength);
         var xbrlFile = await _fileManager.SaveInternalFile(
             compressed,
             name,


### PR DESCRIPTION
## Summary

- The UTF-16-surrogate-safe length-cap slice (`var end = maxLength > 0 && char.IsHighSurrogate(value[maxLength-1]) ? maxLength-1 : maxLength; return value[..end];`) was duplicated across **6 sites in 5 modules** — a recurring bug class (GH-3408, GH-3518, GH-3786, GH-3827, GH-3849 each fixed the same slice independently in a different file).
- Extracted into one shared `Equibles.Core.Extensions.StringExtensions.TruncateToFit(this string value, int maxLength)`; every site now delegates, keeping its own preamble. A single source of truth for the surrogate-safe boundary so the bug can't recur per-site.
- Behavior-preserving: `TruncateToFit` is character-identical to the guarded slice all 6 sites already used; each site retains its unique pre/post logic (whitespace→null, `Trim`, ellipsis `…`, `maxLength<=0` short-circuit, file-name constant). `ErrorManager.Truncate` is **deliberately left untouched** — it is unguarded and differs at `maxLength==0`.

## Code changes

- `src/Equibles.Core/Extensions/StringExtensions.cs` — **new** shared `TruncateToFit` extension (matches the existing `EnumExtensions`/`QueryableLatestExtensions` convention).
- `src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs` — `Truncate` delegates.
- `src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs` — inline XBRL file-name cap delegates.
- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — `ClampLength` delegates.
- `src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs` — `Shorten` delegates (keeps the `…` append on genuine truncation).
- `src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs` — `Truncate` delegates (keeps whitespace→null + `Trim`).
- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — `Truncate` delegates (keeps `maxLength<=0` short-circuit).

Proof: Release build 0 errors; full `Equibles.UnitTests` suite (3041) green incl. every truncation/surrogate pin; csharpier check clean; independent code review found no behavior change at any site.