### PR TITLE
docs(guide): add how-to — view financial statements (TOC + page)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -32,6 +32,7 @@ Task-focused recipes for someone who has Equibles running.
 - [View a fund's portfolio holdings (SEC Form N-PORT)](how-to-view-fund-holdings.md)
 - [View a fund's operations (SEC Form N-CEN)](how-to-view-fund-operations.md)
 - [View a company's exempt offerings (SEC Form D)](how-to-view-exempt-offerings.md)
+- [View a company's financial statements (SEC XBRL)](how-to-view-financial-statements.md)
 - [Use the 13F holdings screener](how-to-use-holdings-screener.md)
 - [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)
 - [View the latest 13F filings](how-to-view-latest-13f-filings.md)

--- a/docs/guide/how-to-view-financial-statements.md
+++ b/docs/guide/how-to-view-financial-statements.md
@@ -1,0 +1,40 @@
+# View a company's financial statements
+
+This guide shows you how to read a company's income statement, balance sheet, and cash-flow figures on its stock profile — the numbers Equibles extracts from the company's SEC filings (10-K annual and 10-Q quarterly reports) and standardises so you can compare periods.
+
+These figures come from the structured XBRL data in SEC filings, so the tab fills in only for companies that file 10-K/10-Q reports. Funds and companies with no ingested filings yet show a "No Financial Data" message.
+
+## Open the Financials tab
+
+1. Search for a company by its ticker — for example, `AAPL` — and open its profile page.
+
+2. Click the **Financials** tab (or go to `http://localhost:8080/stocks/{ticker}/financials`).
+
+3. If structured financial facts have been ingested, you see the statement table with two selectors above it. If not, the tab shows a "No Financial Data" message.
+
+## Choose a statement and period
+
+Two dropdowns above the table control what you see:
+
+- **Statement** — switch between **Income Statement**, **Balance Sheet**, and **Cash Flow**. Each shows a curated, ordered set of standard line items for that statement.
+- **Period** — pick the fiscal period, such as a full year or a single quarter. The list shows the periods that have data, newest first.
+
+Changing either dropdown reloads the tab with the new selection.
+
+## Read the table
+
+Each row is one line item from the selected statement. The columns are:
+
+- **Line Item** — the standardised name of the figure (for example, *Revenue*, *Net Income*, *Total Assets*).
+- **Value** — the reported amount. Money figures are shown as whole dollars (for example, `$1,234,567`); per-share figures such as earnings per share are shown to the cent (for example, `$1.23`). A dash (`—`) means the company did not report that line item for the selected period.
+- **Unit** — the unit the figure is reported in, such as `USD` or `USD/shares`.
+- **Period End** — the last day of the period the figure covers.
+- **Form** — the SEC form the figure came from (for example, `10-K` or `10-Q`).
+- **Filed** — when that filing was submitted to the SEC.
+
+The **Unit**, **Period End**, **Form**, and **Filed** columns are hidden on narrow screens; widen the window to see them.
+
+## Related
+
+- To ask your AI assistant for the same figures, connect it and query the financial-statement tools — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- To walk through every tab on a stock profile, see [Explore a company's data on the web portal](tutorial-explore-stock.md).


### PR DESCRIPTION
## Summary

- **Expand lane** — adds the one missing how-to for a stock-profile tab: the **Financials** tab (income statement / balance sheet / cash flow from SEC XBRL) had no guide page, while every other tab does.
- New page covers opening the tab, the Statement/Period selectors, and each table column; one TOC bullet added to the guide index next to the other company SEC-data tabs.

## Code changes

- `docs/guide/how-to-view-financial-statements.md` — new how-to page.
- `docs/guide/README.md` — TOC bullet linking the new page.