### PR TITLE
fix(financial-facts): treat early-January fiscal-year-end as December-anchored

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
@@ -17,6 +17,14 @@ internal static class FiscalPeriodResolver
     // any real-world drift while still rejecting unrelated dates.
     private const int FyeMatchWindowDays = 14;
 
+    // A fiscal-year end in the first days of January marks a 52/53-week filer
+    // whose year-end oscillates around Dec 31 and occasionally lands just into
+    // the new year (e.g. Johnson & Johnson: SEC's submissions fiscalYearEnd is
+    // "0103", yet every recent fiscal year is December-anchored — FY2025 ended
+    // 2025-12-28). It is *not* a genuine late-January retail year-end (Walmart,
+    // Target: day ~31). The day cutoff separates the two.
+    private const int EarlyJanuaryFiscalYearEndDay = 7;
+
     private const int AnnualMinDays = 350;
     private const int AnnualMaxDays = 380;
     private const int QuarterMinDays = 80;
@@ -44,6 +52,17 @@ internal static class FiscalPeriodResolver
             return null;
         if (fyeMonth < 1 || fyeMonth > 12 || fyeDay < 1 || fyeDay > 31)
             return null;
+
+        // Treat an early-January (year-turn) fiscal-year end as December-anchored
+        // so the period lands in the year the company actually reports. Without
+        // this, every period for such a filer is labelled one fiscal year too
+        // high (e.g. J&J's quarter ending 2026-03-29 would resolve to FY2027
+        // instead of FY2026). Issue #4423.
+        if (fyeMonth == 1 && fyeDay <= EarlyJanuaryFiscalYearEndDay)
+        {
+            fyeMonth = 12;
+            fyeDay = 31;
+        }
 
         var candidates = new[]
         {

--- a/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverEarlyJanuaryFiscalYearEndTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverEarlyJanuaryFiscalYearEndTests.cs
@@ -1,0 +1,67 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Adversarial sibling to <see cref="FiscalPeriodResolverTests"/>. SEC's
+/// submissions <c>fiscalYearEnd</c> field reports a single sticky "MMDD" for a
+/// 52/53-week filer whose year-end oscillates around Dec 31 and occasionally
+/// lands just into the new year. Johnson &amp; Johnson reports "0103" (Jan 3)
+/// even though every recent fiscal year is December-anchored (FY2025 ended
+/// 2025-12-28). Treating that as a genuine January year-end labels every period
+/// one fiscal year too high — the quarter ending 2026-03-29 resolves to FY2027
+/// Q1, and the year ending 2025-12-28 to FY2026 (issue #4423). The resolver
+/// must normalise an early-January (year-turn) fiscal-year-end to Dec 31, while
+/// leaving a genuine late-January retail filer (Walmart/Target, day ~31)
+/// untouched.
+/// </summary>
+public class FiscalPeriodResolverEarlyJanuaryFiscalYearEndTests
+{
+    [Fact]
+    public void Resolve_EarlyJanuaryFye_Quarter_IsDecemberAnchoredYear()
+    {
+        // J&J Q1: periodEnd 2026-03-29, SEC fiscalYearEnd "0103". Belongs to
+        // the December-anchored fiscal year 2026 (DocumentFiscalYearFocus=2026),
+        // not 2027.
+        var result = FiscalPeriodResolver.Resolve(
+            periodStart: new DateOnly(2025, 12, 29),
+            periodEnd: new DateOnly(2026, 3, 29),
+            fyeMonth: 1,
+            fyeDay: 3
+        );
+
+        result.Should().Be((2026, SecFiscalPeriod.Q1));
+    }
+
+    [Fact]
+    public void Resolve_EarlyJanuaryFye_Annual_IsDecemberAnchoredYear()
+    {
+        // J&J FY: periodEnd 2025-12-28, SEC fiscalYearEnd "0103". This is
+        // fiscal year 2025 (SEC fy=2025), not 2026.
+        var result = FiscalPeriodResolver.Resolve(
+            periodStart: new DateOnly(2024, 12, 30),
+            periodEnd: new DateOnly(2025, 12, 28),
+            fyeMonth: 1,
+            fyeDay: 3
+        );
+
+        result.Should().Be((2025, SecFiscalPeriod.FullYear));
+    }
+
+    [Fact]
+    public void Resolve_GenuineLateJanuaryFye_Quarter_IsUnaffected()
+    {
+        // Walmart-style retail filer ending Jan 31 is a real January fiscal year
+        // labelled by the ending-January calendar year. Its Q1 (Feb–Apr 2024)
+        // belongs to FY2025; it must NOT be normalised to December.
+        var result = FiscalPeriodResolver.Resolve(
+            periodStart: new DateOnly(2024, 2, 1),
+            periodEnd: new DateOnly(2024, 4, 30),
+            fyeMonth: 1,
+            fyeDay: 31
+        );
+
+        result.Should().Be((2025, SecFiscalPeriod.Q1));
+    }
+}


### PR DESCRIPTION
## Problem

SEC's submissions `fiscalYearEnd` field reports a single sticky `MMDD` for a 52/53-week filer whose year-end oscillates around Dec 31 and occasionally lands just into the new year. **Johnson & Johnson** reports `"0103"` (Jan 3) even though every recent fiscal year is December-anchored (FY2025 ended 2025-12-28).

`FiscalPeriodResolver.Resolve` treated that as a genuine January year-end and labelled **every** J&J period one fiscal year too high:

| Period end | SEC-declared FY | Resolved (before) |
|---|---|---|
| 2026-03-29 (Q1) | 2026 | **FY2027 Q1** |
| 2025-12-28 (FY) | 2025 | **FY2026 FY** |

The per-stock Financials tab then defaulted to a non-existent **FY2027 Q1** and showed every J&J period mislabelled by a year. (Same fiscal-derivation family as the closed NVDA #3401 / calendar-FY #3900, but a distinct symptom for early-January year-turn filers.)

## Fix

Normalise an early-January (`day <= 7`) fiscal-year end to **Dec 31** before period matching — these are December-anchored 52/53-week filers, not genuine late-January retail filers. Genuine late-January filers (Walmart/Target, day ~31) and December filers (KO `"1231"`) are unchanged.

Both ingestion paths (`FinancialFactsImportService` Company-Facts and `XbrlFactExtractionService` raw-XBRL) route through `FiscalPeriodResolver`, so this corrects newly-ingested facts on both; existing stored facts self-heal on re-ingestion.

## Tests

`FiscalPeriodResolverEarlyJanuaryFiscalYearEndTests` — J&J Q1 → FY2026 Q1, J&J FY → FY2025, and a Walmart-style late-January guard that must stay unaffected. Failed before, pass after; the full 135-test fiscal/resolver/import/detection suite stays green.

Fixes the production defect tracked in daniel3303/EquiblesCommercial#4423 (the commercial gitlink bump closes that issue).