### PR TITLE
test(financial-facts): pin FiscalPeriodResolver early-January FYE nine-month YTD

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverEarlyJanuaryNineMonthTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverEarlyJanuaryNineMonthTests.cs
@@ -1,0 +1,32 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FiscalPeriodResolverEarlyJanuaryNineMonthTests
+{
+    // Adversarial combination pin. The early-January-FYE normalisation (#3888 /
+    // #4423) was proven only on the quarter and annual shapes; this guards the
+    // combination it left untested — an early-January filer's nine-month YTD,
+    // which travels the quarterly-resolution path (the monthsElapsed <= 10 arm).
+    // Johnson & Johnson reports SEC fiscalYearEnd "0103" yet is December-anchored
+    // (FY2025 ended 2025-12-28, so FY2026 opens 2025-12-29). Its nine-month YTD
+    // ending 2026-09-27 (272 days, the nine-month band) must resolve to FY2026 Q3.
+    // Without the normalisation the only FYE on-or-after periodEnd is 2027-01-03,
+    // so the period would be labelled FY2027 Q3 — one fiscal year too high, the
+    // exact off-by-one #3888 fixed for the quarter shape. A normalisation applied
+    // only in the annual/quarter branch (not at the top of Resolve) would regress
+    // this case while leaving the existing pins green.
+    [Fact]
+    public void Resolve_EarlyJanuaryFye_NineMonthYtd_IsDecemberAnchoredQ3()
+    {
+        var result = FiscalPeriodResolver.Resolve(
+            periodStart: new DateOnly(2025, 12, 29),
+            periodEnd: new DateOnly(2026, 9, 27),
+            fyeMonth: 1,
+            fyeDay: 3
+        );
+
+        result.Should().Be((2026, SecFiscalPeriod.Q3));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an adversarial unit test for `FiscalPeriodResolver.Resolve` covering the early-January fiscal-year-end normalization (#3888) combined with a nine-month YTD period — a shape the original fix was only proven against for the quarter and annual cases.
- A December-anchored 52/53-week filer (Johnson & Johnson, SEC `fiscalYearEnd` "0103") reporting a nine-month YTD ending 2026-09-27 must resolve to FY2026 Q3. Without the year-turn normalization the only fiscal-year-end on or after the period end is 2027-01-03, so the period would be labeled FY2027 Q3 — one fiscal year too high. The test passes, confirming the normalization composes correctly across all recognized period shapes.

## Code changes

- `tests/Equibles.UnitTests/Sec/FiscalPeriodResolverEarlyJanuaryNineMonthTests.cs` — new test `Resolve_EarlyJanuaryFye_NineMonthYtd_IsDecemberAnchoredQ3`; guards against a future change that narrows the normalization to only the annual/quarter branch.