### PR TITLE
docs(guide): add how-to — ask about a company's revenue breakdown

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -34,6 +34,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Ask your AI assistant about funds in the directory](how-to-ask-about-fund-directory.md)
 - [View a company's exempt offerings (SEC Form D)](how-to-view-exempt-offerings.md)
 - [View a company's financial statements (SEC XBRL)](how-to-view-financial-statements.md)
+- [Ask your AI assistant for a company's revenue breakdown](how-to-ask-about-revenue-breakdown.md)
 - [Use the 13F holdings screener](how-to-use-holdings-screener.md)
 - [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)
 - [View the latest 13F filings](how-to-view-latest-13f-filings.md)

--- a/docs/guide/how-to-ask-about-revenue-breakdown.md
+++ b/docs/guide/how-to-ask-about-revenue-breakdown.md
@@ -1,0 +1,24 @@
+# Ask your AI assistant for a company's revenue breakdown
+
+Equibles reads the dimensional XBRL facts a company tags in its own SEC filings and exposes them through the MCP server, so you can ask your AI assistant how a company's revenue splits by business segment, geography, and product or service. This breakdown is available to AI assistants only; the web portal shows a company's headline financial statements per stock, not the disaggregated revenue tables.
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run for a while after first startup so the financial-statement scraper has imported the company's XBRL facts. It needs no API key — the data comes from SEC EDGAR.
+
+## Ask for a breakdown
+
+Name a company and ask how its revenue splits:
+
+- "Break down Apple's revenue by segment, geography, and product."
+- "How does Microsoft's revenue split across business segments over the last few years?"
+- "Show me NVDA's revenue by product and service."
+
+The assistant calls the `GetRevenueBreakdown` tool and replies with one table per axis the company actually reports — by segment, by geography, and by product and service. Each table lists annual fiscal years across the top and the company's own reported categories down the side, using the latest restated values. By default it covers the last 8 fiscal years; ask for fewer or more (up to 12) if you want a different window.
+
+## What you should see
+
+One or more Markdown tables in the assistant's reply, one per axis the company discloses. The figures are exactly as the company reported them — never estimated or allocated by Equibles — and annual only (quarterly slices are not included).
+
+If a table is missing or the reply says there's no breakdown, the most likely reasons are that the company doesn't disaggregate revenue on that axis in its filings, or the scraper hasn't imported its XBRL facts yet. Companies vary widely in how much they break out: a large, diversified issuer (for example AAPL or MSFT) is the best place to confirm the data is flowing.


### PR DESCRIPTION
## Summary

- Adds a user-guide how-to for the `GetRevenueBreakdown` MCP tool, which disaggregates a company's revenue by business segment, geography, and product/service from the dimensional XBRL facts the issuer tags in its filings.
- Expand lane: the tool ships in the open-source MCP server but had no guide page; it is exposed to AI assistants only (no web view), so the page follows the existing "ask your AI assistant about X" shape and links the connect-an-assistant tutorial.

## Code changes

- `docs/guide/how-to-ask-about-revenue-breakdown.md` — new how-to with example prompts, the annual/as-reported/one-table-per-axis behavior, the default-8/max-12-year window, and guidance on why some companies report no breakdown.
- `docs/guide/README.md` — adds the how-to to the guide index, next to the financial-statements page.