### PR TITLE
docs(guide): add how-to — ask about short-squeeze candidates

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -55,6 +55,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Ask your AI assistant about a member of Congress's net worth](how-to-ask-about-congress-member-net-worth.md)
 - [Browse market-wide short data (most shorted and largest short volume)](how-to-browse-short-data.md)
 - [Ask your AI assistant about off-exchange (dark pool) volume](how-to-ask-about-off-exchange-volume.md)
+- [Ask your AI assistant for short-squeeze candidates](how-to-ask-about-short-squeeze-candidates.md)
 - [Browse economic indicators](how-to-browse-economic-data.md)
 - [Ask your AI assistant about the economic release calendar](how-to-ask-about-economic-calendar.md)
 - [Browse market indicators (VIX and put/call ratios)](how-to-browse-market-indicators.md)

--- a/docs/guide/how-to-ask-about-short-squeeze-candidates.md
+++ b/docs/guide/how-to-ask-about-short-squeeze-candidates.md
@@ -1,0 +1,27 @@
+# Ask your AI assistant for short-squeeze candidates
+
+Equibles ranks every stock that reports short interest into a composite short-squeeze score and exposes the leaderboard through the MCP server, so you can ask your AI assistant which stocks look most squeeze-prone right now. This ranking is available to AI assistants only; the web portal shows short interest per stock, not a squeeze leaderboard.
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- The score is built from FINRA short-interest data, which needs a free FINRA API key — see [Add a FINRA API key](how-to-set-up-finra-api-key.md). Without it there is no short-interest data and no squeeze scores.
+- Let the worker run after startup so short interest has been imported for the latest settlement date.
+
+## Ask for the leaderboard
+
+Ask your assistant for the top squeeze candidates:
+
+- "Which stocks have the highest short-squeeze scores right now?"
+- "Show me the top 10 short-squeeze candidates."
+- "List the most squeeze-prone stocks by score."
+
+The assistant calls the `GetShortSqueezeScores` tool and replies with a ranked table, highest score first. It returns 25 stocks by default; ask for fewer or more (up to 200).
+
+## What you should see
+
+A Markdown table headed by the FINRA settlement date the scores are based on. Each row shows the rank, ticker, composite score, short interest as a percent of shares outstanding, days to cover, and the recent short-volume trend.
+
+The score is a peer-relative 0-100 rank: it averages where each stock falls, as a percentile across every stock reporting short interest, on short percent of shares, days to cover, and the change in short share of total volume. A high score means a stock screens high on those factors relative to its peers — a starting point for research, not a prediction. To dig into one stock's underlying short-interest series, ask about that ticker's short interest instead.
+
+If the reply says no scores are available, the most likely reason is that no short-interest data is on file yet — confirm the FINRA API key is set and the worker has run.


### PR DESCRIPTION
## Summary

- Adds a user-guide how-to for the `GetShortSqueezeScores` MCP tool, which ranks stocks by a composite short-squeeze score (peer-relative percentiles of short interest as a percent of shares, days to cover, and the recent short-volume trend) at the latest FINRA settlement date.
- Expand lane: the squeeze leaderboard ships in the open-source MCP server but had no guide page; it is exposed to AI assistants only (the web portal shows short interest per stock, not a ranking), so the page follows the existing "ask your AI assistant about X" shape, links the connect-an-assistant tutorial, and flags the FINRA API-key dependency.

## Code changes

- `docs/guide/how-to-ask-about-short-squeeze-candidates.md` — new how-to with example prompts, the default-25/max-200 result window, the score's factor makeup, and guidance when no scores are available.
- `docs/guide/README.md` — adds the how-to to the guide index, next to the short-data page.