### PR TITLE
test(finra): pin ShortSqueezeScoreManager.Percentiles tied-maximum case

### DIFF
--- a/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerPercentilesTiedMaximumTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerPercentilesTiedMaximumTests.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using Equibles.Finra.BusinessLogic;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Mirror of the tied-minimum percentile pin, attacking the opposite extreme: a tie
+/// at the MAXIMUM must share the mean of the ranks it spans (not snap to 100), while
+/// the distinct minimum maps to 0. Guards the average-rank loop's handling of a tie
+/// that runs to the end of the ordered set — an off-by-one there would mis-score the
+/// most-shorted names, which sit at the top of the squeeze board.
+/// </summary>
+public class ShortSqueezeScoreManagerPercentilesTiedMaximumTests
+{
+    [Fact]
+    public void Percentiles_TiedMaximumSpanningTwoRanks_SharesMeanRankAndMinMapsTo0()
+    {
+        var min = Guid.NewGuid();
+        var tiedA = Guid.NewGuid();
+        var tiedB = Guid.NewGuid();
+        var values = new List<(Guid Id, decimal Value)> { (tiedA, 20m), (min, 10m), (tiedB, 20m) };
+
+        var result = InvokePercentiles(values);
+
+        // Distinct minimum sits at rank 0 → 0. The two tied maxima share the mean of
+        // 0-based ranks 1..2 = 1.5; 1.5 / (3 - 1) * 100 = 75 — never 100.
+        result[min].Should().Be(0, "the distinct minimum maps to the bottom of the scale");
+        result[tiedA].Should().BeApproximately(75, 1e-9);
+        result[tiedB].Should().BeApproximately(75, 1e-9);
+    }
+
+    private static Dictionary<Guid, double> InvokePercentiles(
+        IEnumerable<(Guid Id, decimal Value)> values
+    )
+    {
+        var method = typeof(ShortSqueezeScoreManager).GetMethod(
+            "Percentiles",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.Should().NotBeNull("the percentile normalization helper should exist");
+        return (Dictionary<Guid, double>)method!.Invoke(null, [values]);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an adversarial unit test mirroring the existing tied-minimum percentile pin against the opposite extreme: in `ShortSqueezeScoreManager.Percentiles`, a tie at the maximum value must share the mean of the ranks it spans (not snap to 100), and the distinct minimum must map to 0.
- Guards the average-rank loop's handling of a tie that runs to the end of the ordered set — an off-by-one there would mis-score the most-shorted names, which sit at the top of the squeeze board. The test passes, confirming the documented contract holds at both extremes.

## Code changes

- `tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerPercentilesTiedMaximumTests.cs` — new test `Percentiles_TiedMaximumSpanningTwoRanks_SharesMeanRankAndMinMapsTo0` (values 10, 20, 20 → 0, 75, 75), reflection-invoking the private helper as the existing percentile test does.