### PR TITLE
test(funds): pin BuildSlug caps slug when discriminator exceeds the limit

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceBuildSlugDiscriminatorOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceBuildSlugDiscriminatorOverflowTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FundSeriesRefreshServiceBuildSlugDiscriminatorOverflowTests
+{
+    // Mirror of the long-name cap pin, attacking the opposite overflow: when the discriminator
+    // ALONE exceeds the 200-char slug cap there is no room for the name, so BuildSlug must still
+    // return a slug within the cap (it backs the unique Slug column) by truncating the
+    // discriminator itself and dropping the name — never emit an over-cap slug that the column
+    // rejects. A naive build that always appended "{name}-{discriminator}" would overflow here.
+    [Fact]
+    public void BuildSlug_DiscriminatorLongerThanCap_TruncatesToCapAndDropsName()
+    {
+        const string name = "iShares Test Fund";
+        var discriminator = new string('b', 250);
+
+        var method = typeof(FundSeriesRefreshService).GetMethod(
+            "BuildSlug",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var slug = (string)method!.Invoke(null, [name, discriminator]);
+
+        slug.Length.Should()
+            .BeLessThanOrEqualTo(
+                200,
+                "the slug must fit the cap even when the discriminator alone exceeds it"
+            );
+        slug.Should()
+            .Be(
+                new string('b', 200),
+                "the over-cap discriminator is truncated and the name dropped for want of room"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an adversarial unit test mirroring the existing long-name slug cap against the opposite overflow: when the discriminator alone exceeds the 200-char slug cap in `FundSeriesRefreshService.BuildSlug`, there is no room for the name, so the slug must still fit the cap by truncating the discriminator and dropping the name.
- The slug backs the unique `FundSeries.Slug` column; a build that always appended `{name}-{discriminator}` would emit an over-cap slug. The test passes, confirming the overflow branch caps the result and drops the name.

## Code changes

- `tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceBuildSlugDiscriminatorOverflowTests.cs` — new test `BuildSlug_DiscriminatorLongerThanCap_TruncatesToCapAndDropsName` (250-char discriminator → 200-char slug, name dropped), reflection-invoking the private helper as the existing slug test does.