### PR TITLE
docs(guide): add how-to — portfolio overlap between two funds

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -46,6 +46,7 @@ Task-focused recipes for someone who has Equibles running.
 - [View the Smart Money Index](how-to-view-smart-money-index.md)
 - [Compare institutions with the overlap matrix](how-to-compare-institution-overlap.md)
 - [Compare institutions side by side](how-to-compare-institutions-side-by-side.md)
+- [Ask your AI assistant about portfolio overlap between two funds](how-to-ask-about-fund-overlap.md)
 - [View the combined portfolio of several institutions](how-to-view-combined-institution-portfolio.md)
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)
 - [Search for stocks, filings, institutions, and more](how-to-search.md)

--- a/docs/guide/how-to-ask-about-fund-overlap.md
+++ b/docs/guide/how-to-ask-about-fund-overlap.md
@@ -1,0 +1,24 @@
+# Ask your AI assistant about portfolio overlap between two funds
+
+Equibles can compare any two institutions' reported 13F portfolios and exposes the comparison through the MCP server, so you can ask your AI assistant "do these two funds own the same stocks, and where do they diverge?" The web portal compares institutions too — an [overlap matrix](how-to-compare-institution-overlap.md) across several filers and a [side-by-side view](how-to-compare-institutions-side-by-side.md) — but only the assistant gives a deep pairwise breakdown in one question.
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so both institutions' quarterly 13F holdings have been imported.
+
+## Ask for an overlap
+
+Name two institutions:
+
+- "How much do Berkshire Hathaway and Bridgewater overlap?"
+- "Compare the portfolios of Renaissance Technologies and Two Sigma."
+- "Where do Citadel and Millennium diverge in their holdings?"
+
+The assistant calls the `GetFundOverlap` tool. It picks the two filers' latest common report date by default — pass a date (YYYY-MM-DD) to compare a specific quarter — and returns up to 30 stocks by default (ask for more or fewer).
+
+## What you should see
+
+A reply with two summary measures plus a side-by-side table. The measures are the Jaccard similarity (the share of stocks the two funds hold in common) and a dollar-weighted overlap (how aligned the portfolios are by position size, not just by name count). The table lists each stock with each fund's shares and the position as a percent of that fund's portfolio, so you can see both what they share and where they diverge.
+
+If the reply says it couldn't compare them, the most likely reasons are that one name didn't match a tracked filer (the tool takes the first match on a partial name — try a more specific name) or the two filers have no 13F report for a common quarter yet. Use large, well-known filers such as Berkshire Hathaway to confirm the data is flowing.


### PR DESCRIPTION
## Summary

- Adds a user-guide how-to for the `GetFundOverlap` MCP tool, which compares two institutions' 13F portfolios for their latest common report date — Jaccard similarity, dollar-weighted overlap, and a side-by-side stock table showing what they share and where they diverge.
- Expand lane: the web portal has an overlap matrix and a side-by-side comparison, but no conversational pairwise-overlap page. Follows the existing "ask your AI assistant about X" shape and links the two web comparison how-tos so it complements rather than duplicates them.

## Code changes

- `docs/guide/how-to-ask-about-fund-overlap.md` — new how-to with example prompts, the latest-common-quarter default and date/maxResults parameters, an explanation of the Jaccard and dollar-weighted measures, and guidance on partial-name matching.
- `docs/guide/README.md` — adds the how-to to the guide index, next to the institution comparison pages.