### PR TITLE
docs(guide): add how-to — ask for technical indicators

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -61,6 +61,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Browse economic indicators](how-to-browse-economic-data.md)
 - [Ask your AI assistant about the economic release calendar](how-to-ask-about-economic-calendar.md)
 - [Browse market indicators (VIX and put/call ratios)](how-to-browse-market-indicators.md)
+- [Ask your AI assistant for technical indicators](how-to-ask-about-technical-indicators.md)
 - [Browse futures positioning (CFTC Commitments of Traders)](how-to-browse-futures.md)
 - [Ask your AI assistant about federal government contracts](how-to-ask-about-government-contracts.md)
 - [Ask your AI assistant about upcoming FDA catalysts](how-to-ask-about-fda-catalysts.md)

--- a/docs/guide/how-to-ask-about-technical-indicators.md
+++ b/docs/guide/how-to-ask-about-technical-indicators.md
@@ -1,0 +1,30 @@
+# Ask your AI assistant for technical indicators
+
+Equibles computes technical indicators on demand from a stock's daily price history and exposes them through the MCP server, so you can ask your AI assistant for a stock's Bollinger Bands, Stochastic Oscillator, Average True Range, or On-Balance Volume as numbers. The web portal draws these indicators on the stock's price chart — see [Explore a company's data on the web portal](tutorial-explore-stock.md) — while the assistant returns the computed values for a window you choose.
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so the stock's daily prices have been imported from Yahoo — the indicators are computed from that price history.
+
+## Ask for an indicator
+
+Name a stock and the indicator you want:
+
+- "What are AAPL's Bollinger Bands?"
+- "Show me Tesla's Stochastic Oscillator."
+- "What's NVDA's Average True Range over the last 14 days?"
+- "Give me Microsoft's On-Balance Volume."
+
+The assistant picks the matching tool — `GetBollingerBands`, `GetStochasticOscillator`, `GetAverageTrueRange`, or `GetOnBalanceVolume` — and returns the series. Mention the lookback window (for example "14-day") or the number of points you want, and the assistant passes it through.
+
+## What you should see
+
+A table of values over the recent trading days, with the columns specific to each indicator:
+
+- **Bollinger Bands** — a middle band (a simple moving average of the close) with an upper and a lower band set a number of standard deviations above and below it. Wide bands mean high volatility.
+- **Stochastic Oscillator** — %K, which measures the close relative to the high/low range over the lookback window, and %D, its smoothed signal line. Both run 0–100.
+- **Average True Range** — Wilder's volatility measure, the average of each bar's true range (how far price moved, allowing for gaps).
+- **On-Balance Volume** — a running cumulative volume that adds a bar's volume on up-closes and subtracts it on down-closes, tracking buying versus selling pressure.
+
+If the reply says there's no data, the stock's prices probably haven't been imported yet — confirm the worker has run, then try a large, liquid ticker such as AAPL.


### PR DESCRIPTION
## Summary

- Adds a user-guide how-to for the MCP technical-indicator tools (`GetBollingerBands`, `GetStochasticOscillator`, `GetAverageTrueRange`, `GetOnBalanceVolume`), which compute indicators on demand from a stock's daily prices and return the values conversationally.
- Expand lane: the web portal draws these indicators on the stock chart, but the conversational "give me AAPL's Bollinger Bands" capability had no guide page. Follows the existing "ask your AI assistant about X" shape and links the explore-stock tutorial for the web chart path.

## Code changes

- `docs/guide/how-to-ask-about-technical-indicators.md` — new how-to with example prompts per indicator, a plain-language description of each (Bollinger Bands, Stochastic %K/%D, ATR, OBV), and the lookback-window note.
- `docs/guide/README.md` — adds the how-to to the guide index, next to the market-indicators page.