### PR TITLE
fix(insider-trading): anchor implausible Form 4 transaction dates to the period of report

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -216,6 +216,15 @@ public static class InsiderFilingParser
         if (!TryParseTransactionDate(transactionDateStr, out var transactionDate))
             return null;
 
+        // A Form 4 reports an already-executed trade and must be filed within two business
+        // days of it, so the transaction can never post-date its filing. Filer year typos (a
+        // date keyed 2035 or 0022) otherwise pass through verbatim and sort to the top or
+        // bottom of the insider history. Anchor an implausible date to the filing's period of
+        // report — the date SEC requires to match the transaction, and the same anchor the
+        // holding path already trusts.
+        if (!IsPlausibleTransactionDate(transactionDate, filing.FilingDate))
+            transactionDate = filing.ReportDate;
+
         return new InsiderTransaction
         {
             InsiderOwnerId = owner.Id,
@@ -361,6 +370,17 @@ public static class InsiderFilingParser
         // Fix unescaped ampersands in entity names
         return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
     }
+
+    // SEC's electronic ownership filings describe modern trades; a year before this floor
+    // (the earliest seen in production was 0022) is a keyed-wrong date, not a real trade.
+    // Paired with the "never after the filing date" rule it brackets a plausible transaction
+    // date in both directions.
+    internal const int MinPlausibleTransactionYear = 1900;
+
+    internal static bool IsPlausibleTransactionDate(
+        DateOnly transactionDate,
+        DateOnly filingDate
+    ) => transactionDate.Year >= MinPlausibleTransactionYear && transactionDate <= filingDate;
 
     // Form 4 transactionDate is ISO yyyy-MM-dd (ownership XSD). Parse it
     // culture-independently — under a non-Gregorian host culture (e.g.

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseTransactionImplausibleDateTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseTransactionImplausibleDateTests.cs
@@ -1,0 +1,57 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserParseTransactionImplausibleDateTests
+{
+    [Fact]
+    public void ParseTransactions_TransactionDateAfterFilingDate_AnchorsToPeriodOfReport()
+    {
+        // Contract: a Form 4 reports an already-executed trade and must be filed within two
+        // business days of it, so a transaction can never post-date its filing. A filer year
+        // typo (here 2035-01-10, taken from ELDN accession 0000950170-25-004920 whose
+        // periodOfReport is the correct 2025-01-10) must not be stored verbatim — the parser
+        // anchors it to the filing's period of report rather than letting a year-2035 row sort
+        // to the very top of the insider history.
+        var root = XElement.Parse(
+            """
+            <ownershipDocument>
+              <nonDerivativeTable>
+                <nonDerivativeTransaction>
+                  <securityTitle><value>Common Stock</value></securityTitle>
+                  <transactionDate><value>2035-01-10</value></transactionDate>
+                  <transactionCoding>
+                    <transactionCode>A</transactionCode>
+                  </transactionCoding>
+                  <transactionAmounts>
+                    <transactionShares><value>31000</value></transactionShares>
+                    <transactionPricePerShare><value>0</value></transactionPricePerShare>
+                    <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+                  </transactionAmounts>
+                </nonDerivativeTransaction>
+              </nonDerivativeTable>
+            </ownershipDocument>
+            """
+        );
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000950170-25-004920",
+            FilingDate = new DateOnly(2025, 1, 13),
+            ReportDate = new DateOnly(2025, 1, 10),
+        };
+
+        var result = InsiderFilingParser.ParseTransactions(
+            root,
+            new InsiderOwner { Id = Guid.NewGuid() },
+            Guid.NewGuid(),
+            filing,
+            isAmendment: false
+        );
+
+        var transaction = result.Should().ContainSingle().Subject;
+        transaction.TransactionDate.Should().Be(new DateOnly(2025, 1, 10));
+    }
+}


### PR DESCRIPTION
## Summary

- A Form 4 reports an already-executed trade and must be filed within two business days of it, so a transaction can never post-date its filing. The parser read the per-line `transactionDate` verbatim, so a filer's year typo passed through unvalidated.
- Because the insider-trades tab sorts newest-first, a year-2035 (or year-0022) row sorts to the very top or bottom of a stock's history, ahead of every real trade. In production this affected 218 rows across 135 tickers (max date 2035-01-10), plus 21 impossible-past rows (earliest year 0022).
- Example: ELDN accession `0000950170-25-004920` carries `<transactionDate>2035-01-10</transactionDate>` (a typo) while its `<periodOfReport>` is the correct `2025-01-10`.
- The fix validates the parsed date against the filing date and a sane year floor (1900); when it fails, it anchors the date to the filing's period of report — the reliable date SEC requires to match the transaction, and the same anchor the holding path already trusts.

This is the insider-trading counterpart of the congressional-trade date validation; the insider Form 4 path had no equivalent check.

## Code changes

- `src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs` — add `IsPlausibleTransactionDate` (and a `MinPlausibleTransactionYear` floor); in `ParseTransaction`, fall back to the filing's period of report when the parsed transaction date is implausible.
- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseTransactionImplausibleDateTests.cs` — regression test: a transaction dated after its filing is anchored to the period of report.