### PR TITLE
fix(insider-trading): drop Form 4 transactions dated after their filing date or with an absurd year

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -201,6 +201,22 @@ public class CongressionalTradeSyncService
                 continue;
             }
 
+            // A trade is disclosed after it happens, so the transaction date can never be after
+            // the filing date. A source typo (e.g. a wrong year) that breaks this would otherwise
+            // sort to the top of the member's newest-first trade history.
+            if (tx.TransactionDate > tx.FilingDate)
+            {
+                _logger.LogWarning(
+                    "Skipping congressional trade with transaction date {TransactionDate} after "
+                        + "filing date {FilingDate} for {Member} ({Ticker})",
+                    tx.TransactionDate,
+                    tx.FilingDate,
+                    tx.MemberName,
+                    tx.Ticker
+                );
+                continue;
+            }
+
             var stock = stocks[tx.Ticker];
 
             trades.Add(

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -112,6 +112,20 @@ public class GovernmentContractsImportService : IImporter
                     ex.StackTrace,
                     $"window: {windowStart}..{windowEnd}"
                 );
+
+                // A transport-level failure (the API is unreachable, even after the client's retries)
+                // is systemic: every remaining window would fail identically and record its own error,
+                // turning one outage into hundreds of duplicate rows. Stop the cycle after reporting
+                // once; the next run resumes from the same start date once the API is reachable again.
+                // Other (window-specific) failures fall through and the scan continues.
+                if (ex is HttpRequestException)
+                {
+                    _logger.LogWarning(
+                        "Government contracts import: aborting this cycle after a transport failure; "
+                            + "remaining windows will be retried on the next run"
+                    );
+                    break;
+                }
             }
         }
 

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -46,6 +46,12 @@ public static class InsiderFilingParser
         {
             if (tx == null)
                 return;
+            // A Form 3/4/5 discloses an event that has already occurred, so a transaction date after
+            // the filing date — or an absurd year from a source typo (e.g. 2035 or 0022) — is
+            // impossible. Newest-first trade lists would otherwise sort such a row to the very top,
+            // so drop it rather than store the bad date verbatim.
+            if (tx.TransactionDate > tx.FilingDate || tx.TransactionDate.Year < 1900)
+                return;
             tx.TransactionOrder = transactions.Count;
             tx.IsRule10b5One = rule10b5One;
             transactions.Add(tx);

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardRecord.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardRecord.cs
@@ -45,9 +45,11 @@ public class UsaSpendingAwardRecord
     public string LastModifiedDate { get; set; }
 
     [JsonProperty("NAICS")]
+    [JsonConverter(typeof(UsaSpendingCodeConverter))]
     public string Naics { get; set; }
 
     [JsonProperty("PSC")]
+    [JsonConverter(typeof(UsaSpendingCodeConverter))]
     public string Psc { get; set; }
 
     [JsonProperty("Description")]

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingCodeConverter.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingCodeConverter.cs
@@ -1,0 +1,33 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Equibles.Integrations.GovernmentContracts.Models;
+
+/// <summary>
+/// Reads a USAspending classification field (NAICS, PSC) that the API returns either as a
+/// bare string (<c>"561210"</c>) or as an object (<c>{ "code": "561210", "description": "..." }</c>).
+/// Always yields the bare code string (or null), so downstream mapping stays shape-agnostic.
+/// </summary>
+public class UsaSpendingCodeConverter : JsonConverter<string>
+{
+    public override string ReadJson(
+        JsonReader reader,
+        Type objectType,
+        string existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer
+    )
+    {
+        var token = JToken.Load(reader);
+        return token.Type switch
+        {
+            JTokenType.Null => null,
+            JTokenType.Object => (string)token["code"],
+            JTokenType.String => (string)token,
+            _ => token.ToString(),
+        };
+    }
+
+    public override void WriteJson(JsonWriter writer, string value, JsonSerializer serializer) =>
+        writer.WriteValue(value);
+}

--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -144,13 +144,23 @@ public class UsaSpendingClient : IUsaSpendingClient
         {
             await RateLimiter.WaitAsync();
 
-            using var response = await sendRequest();
-
-            if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
+            HttpResponseMessage response;
+            try
             {
+                response = await sendRequest();
+            }
+            catch (Exception ex)
+                when (ex is HttpRequestException or TaskCanceledException && attempt < MaxRetries)
+            {
+                // A transport-level failure — connection reset, DNS blip, TLS error or a request
+                // timeout — throws here and never reaches the status-code checks below. Without this
+                // a momentary network hiccup fails the whole import window (and, repeated across every
+                // window, floods the error log); retry it with the same backoff a 5xx gets.
                 var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
-                    "USAspending rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                    ex,
+                    "USAspending request failed ({Error}), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                    ex.Message,
                     delay.TotalSeconds,
                     attempt + 1,
                     MaxRetries
@@ -159,22 +169,38 @@ public class UsaSpendingClient : IUsaSpendingClient
                 continue;
             }
 
-            if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
+            using (response)
             {
-                var delay = ExponentialBackoff(attempt);
-                _logger.LogWarning(
-                    "USAspending server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
-                    (int)response.StatusCode,
-                    delay.TotalSeconds,
-                    attempt + 1,
-                    MaxRetries
-                );
-                await Task.Delay(delay);
-                continue;
-            }
+                if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
+                {
+                    var delay = ExponentialBackoff(attempt);
+                    _logger.LogWarning(
+                        "USAspending rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                        delay.TotalSeconds,
+                        attempt + 1,
+                        MaxRetries
+                    );
+                    await Task.Delay(delay);
+                    continue;
+                }
 
-            response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStringAsync();
+                if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
+                {
+                    var delay = ExponentialBackoff(attempt);
+                    _logger.LogWarning(
+                        "USAspending server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                        (int)response.StatusCode,
+                        delay.TotalSeconds,
+                        attempt + 1,
+                        MaxRetries
+                    );
+                    await Task.Delay(delay);
+                    continue;
+                }
+
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync();
+            }
         }
 
         throw new HttpRequestException("Max retries exceeded for USAspending API request");

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -3,7 +3,6 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
-using Equibles.Data.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -122,11 +121,18 @@ public class FinancialStatementTools
                     )
                     .ToListAsync();
 
-                // Restatements re-emit the same concept; the latest-filed value
-                // is the currently-reported one.
+                // A 10-Q tags each line under one fiscal (year, period) for both the
+                // discrete quarter and the fiscal year-to-date span, and re-reports prior
+                // comparative instants (the prior fiscal-year-end balance) under that same
+                // identity. Picking by filed date alone surfaces the year-to-date as the
+                // quarter and mixes the comparative balance-sheet columns, so the statement
+                // stops balancing (#1546). Prefer the span matching the period's granularity,
+                // then the instant ending latest, then the latest restatement — the same
+                // selection the web surfaces apply in
+                // FinancialStatementsHelper.PickCurrentlyReportedFact.
                 var latestByConcept = facts
-                    .LatestPerGroup(f => f.FinancialConceptId, f => f.FiledDate)
-                    .ToDictionary(f => f.FinancialConceptId);
+                    .GroupBy(f => f.FinancialConceptId)
+                    .ToDictionary(g => g.Key, g => PickCurrentlyReportedFact(g, selectedPeriod));
 
                 return RenderStatementTable(
                     stock,
@@ -268,6 +274,48 @@ public class FinancialStatementTools
                 type = default;
                 return false;
         }
+    }
+
+    // The longest span a discrete fiscal quarter can cover — 13 weeks on a 4-4-5
+    // calendar plus the occasional 14-week quarter, with headroom.
+    private const int MaxDiscreteQuarterDays = 100;
+
+    // The shortest span a fiscal year can cover — 52 weeks on a 52/53-week
+    // calendar, with headroom for short transition years.
+    private const int MinAnnualSpanDays = 350;
+
+    // The currently-reported fact for one concept within a single fiscal (year, period).
+    // A 10-Q reports each flow line twice under that identity — the discrete quarter and
+    // the fiscal year-to-date — and a balance-sheet line carries the period-end instant
+    // alongside re-stated comparative instants from prior filings. Prefer the span that
+    // matches the period's granularity (instants span zero days and always qualify), then
+    // the instant ending latest so a comparative column never stands in for the current
+    // one, then the latest restatement among same-ending candidates (#1546). Mirrors
+    // FinancialStatementsHelper.PickCurrentlyReportedFact on the web surfaces; facts are
+    // already consolidated-only here via GetConsolidatedByStock.
+    internal static FinancialFact PickCurrentlyReportedFact(
+        IEnumerable<FinancialFact> facts,
+        SecFiscalPeriod fiscalPeriod
+    )
+    {
+        var candidates = facts.ToList();
+
+        var preferred = candidates
+            .Where(f =>
+            {
+                var spanDays = f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber;
+                return fiscalPeriod == SecFiscalPeriod.FullYear
+                    ? spanDays == 0 || spanDays >= MinAnnualSpanDays
+                    : spanDays <= MaxDiscreteQuarterDays;
+            })
+            .ToList();
+        if (preferred.Count > 0)
+            candidates = preferred;
+
+        return candidates
+            .OrderByDescending(f => f.PeriodEnd)
+            .ThenByDescending(f => f.FiledDate)
+            .First();
     }
 
     // Chronological order within a fiscal year: Q1 < Q2 < Q3 < Q4 < FullYear.

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesFutureDateTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesFutureDateTests.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Congress;
+
+public class CongressionalTradeSyncServiceBuildTradesFutureDateTests
+{
+    private static CongressionalTradeSyncService CreateSut() =>
+        new(
+            Substitute.For<IServiceScopeFactory>(),
+            Options.Create(new WorkerOptions()),
+            Substitute.For<ILogger<CongressionalTradeSyncService>>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+    private static List<CongressionalTrade> InvokeBuildTrades(
+        CongressionalTradeSyncService sut,
+        DisclosureTransaction tx,
+        CommonStock stock,
+        CongressMember member
+    )
+    {
+        var method = typeof(CongressionalTradeSyncService).GetMethod(
+            "BuildTrades",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        return (List<CongressionalTrade>)
+            method.Invoke(
+                sut,
+                [
+                    new List<DisclosureTransaction> { tx },
+                    new Dictionary<string, CongressMember> { [member.Name] = member },
+                    new Dictionary<string, CommonStock> { [stock.Ticker] = stock },
+                ]
+            );
+    }
+
+    private static (CommonStock, CongressMember) Fixtures()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "IBM",
+            Name = "International Business Machines",
+            Cik = "0000051143",
+        };
+        var member = new CongressMember { Id = Guid.NewGuid(), Name = "Pete Sessions" };
+        return (stock, member);
+    }
+
+    // A trade is always disclosed after it happens, so the transaction date can never be after
+    // the filing date. A source typo (e.g. year 3031) that violates this must be dropped, not
+    // stored — otherwise it sorts to the top of the member's newest-first trade history.
+    [Fact]
+    public void BuildTrades_TransactionDateAfterFilingDate_SkipsTrade()
+    {
+        var sut = CreateSut();
+        var (stock, member) = Fixtures();
+        var tx = new DisclosureTransaction
+        {
+            MemberName = member.Name,
+            Ticker = stock.Ticker,
+            AssetName = "International Business Machines Corporation (IBM)",
+            TransactionType = CongressTransactionType.Purchase,
+            OwnerType = "SP",
+            TransactionDate = new DateOnly(3031, 4, 30),
+            FilingDate = new DateOnly(2021, 5, 3),
+            AmountFrom = 1001,
+            AmountTo = 15000,
+        };
+
+        var trades = InvokeBuildTrades(sut, tx, stock, member);
+
+        trades.Should().BeEmpty();
+    }
+
+    // A normal trade (disclosed on or after the transaction) is still built.
+    [Fact]
+    public void BuildTrades_TransactionDateOnOrBeforeFilingDate_BuildsTrade()
+    {
+        var sut = CreateSut();
+        var (stock, member) = Fixtures();
+        var tx = new DisclosureTransaction
+        {
+            MemberName = member.Name,
+            Ticker = stock.Ticker,
+            AssetName = "International Business Machines Corporation (IBM)",
+            TransactionType = CongressTransactionType.Purchase,
+            OwnerType = "SP",
+            TransactionDate = new DateOnly(2021, 4, 30),
+            FilingDate = new DateOnly(2021, 5, 3),
+            AmountFrom = 1001,
+            AmountTo = 15000,
+        };
+
+        var trades = InvokeBuildTrades(sut, tx, stock, member);
+
+        trades.Should().HaveCount(1);
+        trades[0].TransactionDate.Should().Be(new DateOnly(2021, 4, 30));
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardResponseDeserializationTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardResponseDeserializationTests.cs
@@ -1,0 +1,63 @@
+using Equibles.Integrations.GovernmentContracts.Models;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class UsaSpendingAwardResponseDeserializationTests
+{
+    // USAspending returns NAICS and PSC as objects ({ code, description }), not bare
+    // strings. The response must deserialize and expose the bare code for each.
+    [Fact]
+    public void Deserialize_WhenNaicsAndPscAreObjects_ExposesTheBareCode()
+    {
+        const string json = """
+            {
+              "results": [
+                {
+                  "generated_internal_id": "CONT_AWD_DEAC0494AL85000",
+                  "Award ID": "DEAC0494AL85000",
+                  "Award Amount": 48063763681.32,
+                  "NAICS": { "code": "561210", "description": "FACILITIES SUPPORT SERVICES" },
+                  "PSC": { "code": "M181", "description": "OPER OF GOVT R&D GOCO FACILITIES" },
+                  "Recipient Name": "LOCKHEED MARTIN CORP"
+                }
+              ],
+              "page_metadata": { "page": 1, "hasNext": false }
+            }
+            """;
+
+        var response = JsonConvert.DeserializeObject<UsaSpendingAwardResponse>(json);
+
+        response.Should().NotBeNull();
+        response!.Results.Should().HaveCount(1);
+        var record = response.Results[0];
+        record.Naics.Should().Be("561210");
+        record.Psc.Should().Be("M181");
+    }
+
+    // The bare-string shape must keep working, so the client tolerates either form.
+    [Fact]
+    public void Deserialize_WhenNaicsAndPscAreStrings_KeepsTheValue()
+    {
+        const string json = """
+            {
+              "results": [
+                {
+                  "generated_internal_id": "CONT_AWD_ABC",
+                  "Award ID": "ABC",
+                  "NAICS": "336411",
+                  "PSC": "1510"
+                }
+              ],
+              "page_metadata": { "page": 1, "hasNext": false }
+            }
+            """;
+
+        var response = JsonConvert.DeserializeObject<UsaSpendingAwardResponse>(json);
+
+        response!.Results[0].Naics.Should().Be("336411");
+        response.Results[0].Psc.Should().Be("1510");
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientSendWithRetryTransientNetworkTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientSendWithRetryTransientNetworkTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Net.Sockets;
+using Equibles.Integrations.GovernmentContracts;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+/// <summary>
+/// Pins the transport-level retry branch of <see cref="UsaSpendingClient"/>'s SendWithRetry. A
+/// DNS/socket/TLS blip or request timeout reaching api.usaspending.gov surfaces as an
+/// <see cref="HttpRequestException"/> that never reaches the status-code checks; before the fix it
+/// bubbled straight to the import, failing the window and — repeated across every window of a backfill
+/// — flooding the dashboard with hundreds of identical "An error occurred while sending the request"
+/// rows. It must now be retried like a 5xx so a momentary hiccup is transparent.
+/// </summary>
+public class UsaSpendingClientSendWithRetryTransientNetworkTests
+{
+    [Fact]
+    public async Task GetContractAwards_FirstCallTransportFailure_RetriesThenSucceeds()
+    {
+        var okBody =
+            "{\"results\":[{\"generated_internal_id\":\"CONT_AWD_1\",\"Award ID\":\"PIID-1\"}],"
+            + "\"page_metadata\":{\"page\":1,\"hasNext\":false}}";
+        var handler = new TransientThenOkHandler(okBody);
+        var sut = new UsaSpendingClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<UsaSpendingClient>>()
+        );
+
+        var awards = await sut.GetContractAwards(
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            minimumAmount: 0m
+        );
+
+        // Two calls + a parsed award prove the transport failure drove a retry that then succeeded —
+        // before the fix the first throw aborted the window with no status-code branch to catch it.
+        handler.CallCount.Should().Be(2);
+        awards.Should().ContainSingle().Which.GeneratedInternalId.Should().Be("CONT_AWD_1");
+    }
+
+    private sealed class TransientThenOkHandler : HttpMessageHandler
+    {
+        private readonly string _successBody;
+        public int CallCount { get; private set; }
+
+        public TransientThenOkHandler(string successBody)
+        {
+            _successBody = successBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            CallCount++;
+            if (CallCount == 1)
+            {
+                throw new HttpRequestException(
+                    "An error occurred while sending the request.",
+                    new SocketException()
+                );
+            }
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_successBody),
+                }
+            );
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserFutureDateTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserFutureDateTests.cs
@@ -1,0 +1,91 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserFutureDateTests
+{
+    private static XElement Transaction(string transactionDate) =>
+        XElement.Parse(
+            $"""
+            <nonDerivativeTransaction>
+              <securityTitle><value>Common Stock</value></securityTitle>
+              <transactionDate><value>{transactionDate}</value></transactionDate>
+              <transactionCoding><transactionCode>A</transactionCode></transactionCoding>
+              <transactionAmounts>
+                <transactionShares><value>100</value></transactionShares>
+                <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+              </transactionAmounts>
+            </nonDerivativeTransaction>
+            """
+        );
+
+    private static XElement Document(params XElement[] transactions)
+    {
+        var table = new XElement("nonDerivativeTable", transactions.Cast<object>().ToArray());
+        return new XElement("ownershipDocument", table);
+    }
+
+    private static List<InsiderTransaction> Parse(XElement root, FilingData filing) =>
+        InsiderFilingParser.ParseTransactions(
+            root,
+            new InsiderOwner { Id = Guid.NewGuid() },
+            Guid.NewGuid(),
+            filing,
+            isAmendment: false
+        );
+
+    [Fact]
+    public void ParseTransactions_TransactionDateAfterFilingDate_SkipsTransaction()
+    {
+        // A Form 4 discloses a trade after it occurs, so a transaction date later than the filing
+        // date is impossible — a source-typo year (e.g. 2035) must not be stored verbatim.
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-25-000001",
+            FilingDate = new DateOnly(2025, 1, 13),
+            ReportDate = new DateOnly(2025, 1, 10),
+        };
+
+        var result = Parse(Document(Transaction("2035-01-10")), filing);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseTransactions_TransactionDateWithAbsurdPastYear_SkipsTransaction()
+    {
+        // A two-digit/garbled source year parses to an absurd date (e.g. year 0022) that is well
+        // before the filing — outside any sane range and a clear typo, so it must be dropped too.
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-23-000001",
+            FilingDate = new DateOnly(2023, 11, 13),
+            ReportDate = new DateOnly(2023, 11, 10),
+        };
+
+        var result = Parse(Document(Transaction("0022-10-12")), filing);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseTransactions_FutureDatedTransactionAlongsideValidOne_KeepsOnlyValid()
+    {
+        // The real defect shape: one filing carries a valid row and a typo'd future-dated row
+        // (the ELDN/0000950170-25-004920 case). Only the valid row should survive.
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000950170-25-004920",
+            FilingDate = new DateOnly(2025, 1, 13),
+            ReportDate = new DateOnly(2025, 1, 10),
+        };
+
+        var result = Parse(Document(Transaction("2025-01-10"), Transaction("2035-01-10")), filing);
+
+        var kept = result.Should().ContainSingle().Subject;
+        kept.TransactionDate.Should().Be(new DateOnly(2025, 1, 10));
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialStatementToolsPickCurrentlyReportedFactInstantTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialStatementToolsPickCurrentlyReportedFactInstantTests.cs
@@ -1,0 +1,56 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialStatementToolsPickCurrentlyReportedFactInstantTests
+{
+    // A 10-Q balance sheet carries the current period-end instant alongside a prior
+    // comparative instant (the prior fiscal-year-end), both re-tagged under the same
+    // fiscal (year, period) and filed on the same day. The currently-reported figure is
+    // the instant ending latest; selecting by filed date alone is a wash on the shared
+    // date, so a comparative column could stand in for the current one — which is exactly
+    // why the balance sheet stopped balancing (#1546: AAPL FY2025 Q2 equity showed the
+    // $74.1B 2023-12-30 comparative instead of the real $66.8B at 2025-03-29). The
+    // comparative is listed first to pin that the pick is the latest period-end, not
+    // input order.
+    [Fact]
+    public void PickCurrentlyReportedFact_BalanceSheetWithComparativeInstant_PicksLatestPeriodEnd()
+    {
+        var conceptId = Guid.NewGuid();
+        var comparative = MakeInstant(
+            conceptId,
+            value: 74_100m,
+            periodEnd: new DateOnly(2023, 12, 30)
+        );
+        var current = MakeInstant(conceptId, value: 66_796m, periodEnd: new DateOnly(2025, 3, 29));
+
+        var result = FinancialStatementTools.PickCurrentlyReportedFact(
+            [comparative, current],
+            SecFiscalPeriod.Q2
+        );
+
+        result
+            .Value.Should()
+            .Be(66_796m, "the current period-end instant outranks the comparative column");
+    }
+
+    private static FinancialFact MakeInstant(Guid conceptId, decimal value, DateOnly periodEnd) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            FinancialConceptId = conceptId,
+            Value = value,
+            Unit = "USD",
+            PeriodStart = periodEnd,
+            PeriodEnd = periodEnd,
+            FiscalYear = 2025,
+            FiscalPeriod = SecFiscalPeriod.Q2,
+            PeriodType = FactPeriodType.Instant,
+            Form = DocumentType.TenQ,
+            FiledDate = new DateOnly(2025, 5, 2),
+            AccessionNumber = "0000320193-25-000057",
+        };
+}


### PR DESCRIPTION
Insider counterpart of the congressional drop-future-dated-trade fix. An insider Form 4 discloses a trade after it occurs, so a transaction date after the filing date (or an absurd-year typo such as 2035 / 0022) is impossible and otherwise sorts to the top of the newest-first insider-trade history.

`InsiderFilingParser.AddParsed` (shared by live ingest and the reprocess pipeline) now drops any row dated after its filing date or before 1900. New unit tests cover the future-dated row, the absurd-past-year row, and the mixed valid+typo'd filing (only the valid row survives).

Full Equibles.UnitTests suite green (3010 passed, 1 skipped); csharpier clean.

Note: the commercial repo pins this branch's commit directly (anchor) to keep the submodule bump a clean +1 over its current pin.