### PR TITLE
docs(guide): add how-to — ask your AI assistant about financial statements

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -35,6 +35,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Ask your AI assistant about funds in the directory](how-to-ask-about-fund-directory.md)
 - [View a company's exempt offerings (SEC Form D)](how-to-view-exempt-offerings.md)
 - [View a company's financial statements (SEC XBRL)](how-to-view-financial-statements.md)
+- [Ask your AI assistant about a company's financial statements](how-to-ask-about-financial-statements.md)
 - [Ask your AI assistant for a company's revenue breakdown](how-to-ask-about-revenue-breakdown.md)
 - [Use the 13F holdings screener](how-to-use-holdings-screener.md)
 - [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)

--- a/docs/guide/how-to-ask-about-financial-statements.md
+++ b/docs/guide/how-to-ask-about-financial-statements.md
@@ -1,0 +1,43 @@
+# Ask your AI assistant about a company's financial statements
+
+Equibles parses the structured XBRL facts in a company's SEC filings and exposes them through the MCP server, so you can ask your AI assistant for a full financial statement, follow a single metric over time, or compare one figure across competitors — all keyed by ticker.
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run for a while after first startup so the financial-statement scraper has imported the XBRL facts. It needs no API key — the data comes from SEC EDGAR.
+
+## Ask for a full statement
+
+Name a company, a statement, and a period:
+
+- "Show me Apple's income statement for fiscal 2024."
+- "What did Microsoft's balance sheet look like last fiscal year?"
+- "Pull NVDA's cash-flow statement for its latest annual period."
+
+The assistant calls the `GetFinancialStatement` tool and replies with the standard line items — revenue, net income, total assets, operating cash flow, and the rest — for the fiscal year and period you asked for, using the latest restated values.
+
+## Follow one metric over time
+
+To track a single concept across periods rather than a whole statement:
+
+- "How has Apple's revenue changed over the last several years?"
+- "Show me Tesla's diluted EPS history."
+
+The assistant uses `GetFinancialFact`, which returns a time series with one row per fiscal period. Common concepts include revenue, net income, diluted EPS, total assets, and operating cash flow.
+
+## Compare companies side by side
+
+To put the same figure next to several peers:
+
+- "Compare net income across AAPL, MSFT, and GOOGL for the latest fiscal year."
+
+The assistant calls `CompareFinancialFact`, returning one row per ticker for the period — any company with no data for that period is listed separately so the comparison stays honest.
+
+## What you should see
+
+A Markdown table (or several) with figures taken directly from the company's XBRL filings, labelled by fiscal year and period. Values are the latest restated numbers unless you ask for them as originally reported.
+
+If a statement or metric is missing, the most likely reasons are that the scraper hasn't imported that company's XBRL facts yet, or the company doesn't tag that concept. For a breakdown of revenue by segment, geography, or product — which lives in dimensional facts rather than the standard statements — see [Ask your AI assistant for a company's revenue breakdown](how-to-ask-about-revenue-breakdown.md).
+
+To read the same statements in the browser, see [View a company's financial statements (SEC XBRL)](how-to-view-financial-statements.md).


### PR DESCRIPTION
## Summary

- Expand lane: adds the MCP counterpart to the web `view-financial-statements` how-to. Existing MCP financial coverage was revenue-breakdown only; the core statement / single-fact / peer-comparison flow had no how-to.
- Documents `GetFinancialStatement` (full income/balance/cash-flow), `GetFinancialFact` (one concept over time), and `CompareFinancialFact` (peer comparison); links to the revenue-breakdown how-to for dimensional facts and the web view.

## Code changes

- `docs/guide/how-to-ask-about-financial-statements.md` — new how-to page.
- `docs/guide/README.md` — one TOC bullet grouped with the financial-statement entries.