### PR TITLE
docs(guide): add how-to — ask your AI assistant about economic indicators

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -65,6 +65,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Ask your AI assistant about off-exchange (dark pool) volume](how-to-ask-about-off-exchange-volume.md)
 - [Ask your AI assistant for short-squeeze candidates](how-to-ask-about-short-squeeze-candidates.md)
 - [Browse economic indicators](how-to-browse-economic-data.md)
+- [Ask your AI assistant about economic indicators (FRED data)](how-to-ask-about-economic-indicators.md)
 - [Ask your AI assistant about the economic release calendar](how-to-ask-about-economic-calendar.md)
 - [Browse market indicators (VIX and put/call ratios)](how-to-browse-market-indicators.md)
 - [Ask your AI assistant for technical indicators](how-to-ask-about-technical-indicators.md)

--- a/docs/guide/how-to-ask-about-economic-indicators.md
+++ b/docs/guide/how-to-ask-about-economic-indicators.md
@@ -1,0 +1,35 @@
+# Ask your AI assistant about economic indicators (FRED data)
+
+Equibles pulls macroeconomic series from the Federal Reserve's FRED database — interest rates, inflation, employment, GDP, yield spreads, and more — and exposes them through the MCP server, so you can ask your AI assistant for the value or trend of any tracked indicator.
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- FRED data needs a free API key — see [Add a FRED API key](how-to-set-up-fred-api-key.md). Once it is set, let the worker run for a while so the economic scraper imports the series.
+
+## Ask for one indicator over time
+
+Name an indicator and ask for its history:
+
+- "What has the unemployment rate done over the past year?"
+- "Show me CPI inflation since 2020."
+- "How has the 10-year/2-year yield spread moved recently?"
+
+The assistant calls the `GetEconomicIndicator` tool and replies with the time series of observations. Common series include the fed funds rate, CPI, unemployment, GDP, the 10Y/2Y yield spread, and the 30-year mortgage rate. If it is unsure of the exact series, it uses `SearchEconomicIndicators` to look it up by name.
+
+## Ask for a macro snapshot
+
+To see where the economy stands across the board:
+
+- "Give me a snapshot of current macro conditions."
+- "What are the latest readings on rates, inflation, and employment?"
+
+The assistant uses `GetLatestEconomicData`, which returns the most recent value for key indicators grouped by category — interest rates, yield spreads, inflation, employment, GDP, money supply, sentiment, housing, exchange rates, and market indicators.
+
+## What you should see
+
+A table of dated observations for each series, taken straight from FRED. Economic data is revised, so the latest value for a series may change as the source publishes revisions.
+
+If the reply says there's no data, the most likely reason is that the FRED API key is not set yet — see the link above — or the scraper has not imported that series.
+
+To see when the next releases are scheduled, see [Ask your AI assistant about the economic release calendar](how-to-ask-about-economic-calendar.md). To browse the same indicators in the browser, see [Browse economic indicators](how-to-browse-economic-data.md).


### PR DESCRIPTION
## Summary

- Expand lane: adds the MCP how-to for FRED indicator data (values/trends). The existing economic MCP how-to covers only the release calendar; the actual series lookup had none.
- Documents `GetEconomicIndicator` (one series over time), `GetLatestEconomicData` (macro snapshot), and `SearchEconomicIndicators`; links to the FRED API-key, calendar, and web-browse how-tos.

## Code changes

- `docs/guide/how-to-ask-about-economic-indicators.md` — new how-to page.
- `docs/guide/README.md` — one TOC bullet grouped with the economic entries.