### PR TITLE
test(holdings): pin HoldingsFilingTypeExtensions.ToHoldingsFilingType maps a /A amendment to its base form type

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsFilingTypeExtensionsAmendmentMapsToBaseFormTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsFilingTypeExtensionsAmendmentMapsToBaseFormTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Extensions;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsFilingTypeExtensionsAmendmentMapsToBaseFormTests
+{
+    [Fact]
+    public void ToHoldingsFilingType_AmendmentFormType_MapsToSameTypeAsBaseForm()
+    {
+        // Contract (doc): the "/A" amendment marker is ignored — an amendment maps to
+        // the same FilingType as its base form, so "13F-HR/A" must resolve to Form13F
+        // exactly as the base "13F-HR" form does.
+        var result = "13F-HR/A".ToHoldingsFilingType();
+
+        result
+            .Should()
+            .Be(
+                FilingType.Form13F,
+                "the documented contract ignores the /A amendment marker, so an amended "
+                    + "13F-HR resolves to the same type as the base 13F-HR form"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `HoldingsFilingTypeExtensions` had zero test coverage. Its documented contract states the `/A` amendment marker is ignored — an amendment maps to the same `FilingType` as its base form.
- This pins that contract with an adversarial test derived from the doc (not the implementation), exercising the `/A`-strip branch.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsFilingTypeExtensionsAmendmentMapsToBaseFormTests.cs` — new unit test asserting `"13F-HR/A".ToHoldingsFilingType()` resolves to `FilingType.Form13F`, exactly as the base `13F-HR` form does. Passes — confirms behavior, guards against regression.