### PR TITLE
docs(guide): add how-to — ask your AI assistant about stock prices (TOC + page)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -69,6 +69,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Ask your AI assistant about the economic release calendar](how-to-ask-about-economic-calendar.md)
 - [Browse market indicators (VIX and put/call ratios)](how-to-browse-market-indicators.md)
 - [Ask your AI assistant about market sentiment (VIX and put/call ratios)](how-to-ask-about-market-sentiment.md)
+- [Ask your AI assistant about a stock's price history](how-to-ask-about-stock-prices.md)
 - [Ask your AI assistant for technical indicators](how-to-ask-about-technical-indicators.md)
 - [Browse futures positioning (CFTC Commitments of Traders)](how-to-browse-futures.md)
 - [Ask your AI assistant about futures positioning (CFTC Commitments of Traders)](how-to-ask-about-futures-positioning.md)

--- a/docs/guide/how-to-ask-about-stock-prices.md
+++ b/docs/guide/how-to-ask-about-stock-prices.md
@@ -1,0 +1,26 @@
+# Ask your AI assistant about a stock's price history
+
+Equibles imports daily OHLCV (Open, High, Low, Close, Volume) price history from Yahoo Finance and exposes it through the MCP server, so you can ask your AI assistant for a stock's recent prices over a window you choose, or the latest close across a whole watchlist at once. The web portal charts the same prices on a stock profile — see [Explore a company's data on the web portal](tutorial-explore-stock.md) — while the assistant returns the values as a table.
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so the stock's daily prices have been imported from Yahoo.
+
+## Ask about prices
+
+Name a stock and the period you want, or list several tickers for a quick check:
+
+- "What's AAPL's price history for the last three months?"
+- "Show me Tesla's daily closes so far this year."
+- "How did NVDA's stock move between 2024-01-01 and 2024-03-31?"
+- "What are the latest prices for AAPL, MSFT, and GOOG?"
+
+For a single stock over a date range the assistant picks `GetStockPrices`; for the most recent close across one or more tickers it picks `GetLatestPrices`. Mention a start and end date or a number of days and the assistant passes them through — otherwise it returns about the last year of daily bars, newest first.
+
+## What you should see
+
+- **`GetStockPrices`** — a table of daily bars with one row per trading day: Date, Open, High, Low, Close, and Volume. Use it for charting, trend questions, or as the basis for the [technical indicators](how-to-ask-about-technical-indicators.md) Equibles computes on top of the same history.
+- **`GetLatestPrices`** — the most recent closing price and volume for each ticker you named, ideal for a one-line portfolio or watchlist check.
+
+If the reply says there's no price data, the stock's prices probably haven't been imported yet — confirm the worker has run, then try a large, liquid ticker such as AAPL.


### PR DESCRIPTION
## Summary

- Expand lane (user guide): adds a how-to for asking an AI assistant about a stock's price history. Fills the one obvious gap in the "ask your AI assistant about X" series — stock prices, the most fundamental data type, had no page despite the `GetStockPrices` and `GetLatestPrices` MCP tools existing.

## Code changes

- `docs/guide/how-to-ask-about-stock-prices.md` — new how-to covering `GetStockPrices` (daily OHLCV history over a date range) and `GetLatestPrices` (latest close across a watchlist), with example questions and expected output. Mirrors the sibling "ask-about" page format.
- `docs/guide/README.md` — one TOC bullet linking the new page, placed in the market/technical group.