### PR TITLE
docs(guide): add how-to — ask your AI assistant about an institution's portfolio (TOC + page)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -41,6 +41,7 @@ Task-focused recipes for someone who has Equibles running.
 - [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)
 - [Ask your AI assistant which stocks institutions hold most](how-to-ask-about-most-held-stocks.md)
 - [Ask your AI assistant who owns a stock (institutional holders)](how-to-ask-about-institutional-ownership.md)
+- [Ask your AI assistant about an institution's portfolio](how-to-ask-about-institution-portfolio.md)
 - [View the latest 13F filings](how-to-view-latest-13f-filings.md)
 - [View 13F statistics](how-to-view-13f-statistics.md)
 - [View 13F trend charts](how-to-view-13f-trends.md)

--- a/docs/guide/how-to-ask-about-institution-portfolio.md
+++ b/docs/guide/how-to-ask-about-institution-portfolio.md
@@ -1,0 +1,28 @@
+# Ask your AI assistant about an institution's portfolio
+
+Equibles tracks the quarterly 13F-HR filings of institutional investors (fund managers) and exposes them through the MCP server, so you can ask your AI assistant what a specific fund holds, how large and concentrated it is, how it splits across sectors, and what it bought or sold last quarter. To browse the same data on the web portal instead, see [Browse institutional portfolios and run a backtest](how-to-browse-institutions.md). To ask which institutions own a particular stock, see [Ask your AI assistant who owns a stock](how-to-ask-about-institutional-ownership.md).
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so 13F-HR filings have been imported from SEC EDGAR.
+
+## Ask about a fund
+
+Name the fund and what you want to know:
+
+- "What does Berkshire Hathaway hold?"
+- "How big and concentrated is Bridgewater's portfolio?"
+- "What's Renaissance Technologies' sector allocation?"
+- "What did Citadel buy and sell last quarter?"
+
+If the name is ambiguous, the assistant first resolves it with `SearchInstitutions` (which returns matching funds with their SEC CIK number and location), then picks the matching tool. Institution lookups match on a partial name — the closest match wins — and default to the fund's latest report unless you name a quarter.
+
+## What you should see
+
+- **`GetInstitutionPortfolio`** — the fund's holdings: each tracked stock with share count and market value.
+- **`GetInstitutionSummary`** — a header with reported AUM, position count, top-10 / top-25 concentration, quarter-over-quarter turnover, and the latest and prior report dates. Good for "how big and how concentrated is this fund?"
+- **`GetInstitutionSectorAllocation`** — holdings grouped by industry/sector and sorted by percentage of the portfolio. Good for "is this fund a tech specialist or a generalist?"
+- **`GetInstitutionQuarterlyActivity`** — the stocks the fund initiated, increased, reduced, or exited versus the prior quarter, sorted by the size of the change.
+
+If the reply says the institution wasn't found, try a fuller or more distinctive part of its name, or run `SearchInstitutions` first to confirm how it's listed.


### PR DESCRIPTION
## Summary

- Expand lane (user guide): adds a how-to for asking an AI assistant about a specific institution's 13F portfolio. The existing institutional how-to covers "who owns a stock"; this covers the inverse — what a given fund holds — which had no page despite the `SearchInstitutions`, `GetInstitutionPortfolio`, `GetInstitutionSummary`, `GetInstitutionSectorAllocation`, and `GetInstitutionQuarterlyActivity` MCP tools.

## Code changes

- `docs/guide/how-to-ask-about-institution-portfolio.md` — new how-to covering fund-name resolution and the four portfolio tools (holdings, summary/concentration, sector allocation, quarterly activity), with example questions and expected output. Mirrors the sibling "ask-about" page format.
- `docs/guide/README.md` — one TOC bullet linking the new page, placed in the institutional cluster after the "who owns a stock" entry.