### PR TITLE
docs(guide): add how-to — ask your AI assistant about a stock's short data (TOC + page)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -63,6 +63,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Ask your AI assistant about congressional stock trades](how-to-ask-about-congressional-trades.md)
 - [Ask your AI assistant about a member of Congress's net worth](how-to-ask-about-congress-member-net-worth.md)
 - [Browse market-wide short data (most shorted and largest short volume)](how-to-browse-short-data.md)
+- [Ask your AI assistant about a stock's short data](how-to-ask-about-short-data.md)
 - [Ask your AI assistant about off-exchange (dark pool) volume](how-to-ask-about-off-exchange-volume.md)
 - [Ask your AI assistant for short-squeeze candidates](how-to-ask-about-short-squeeze-candidates.md)
 - [Browse economic indicators](how-to-browse-economic-data.md)

--- a/docs/guide/how-to-ask-about-short-data.md
+++ b/docs/guide/how-to-ask-about-short-data.md
@@ -1,0 +1,28 @@
+# Ask your AI assistant about a stock's short data
+
+Equibles imports short-selling data — daily short volume from FINRA, bi-monthly short interest (including days to cover) from FINRA, and fails-to-deliver records from the SEC — and exposes it through the MCP server, so you can ask your AI assistant how heavily a specific stock is shorted. To browse market-wide short rankings on the web portal, see [Browse market-wide short data](how-to-browse-short-data.md). For squeeze-specific scoring see [Ask for short-squeeze candidates](how-to-ask-about-short-squeeze-candidates.md); for dark-pool volume see [Ask about off-exchange volume](how-to-ask-about-off-exchange-volume.md).
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Short volume and short interest come from FINRA, which needs a free API key — see [Add a FINRA API key](how-to-set-up-finra-api-key.md). Fails-to-deliver comes from the SEC and needs no key.
+- Let the worker run after startup so the data has been imported.
+
+## Ask about a stock's short data
+
+Name a stock and what you want to know:
+
+- "What's GME's short interest?"
+- "How many days to cover does AMC have?"
+- "Show me Tesla's daily short volume over the last month."
+- "Are there any fails-to-deliver for SPCE?"
+
+The assistant picks the matching tool — `GetShortInterest`, `GetShortVolume`, or `GetFailsToDeliver` — and returns the series for the date range you mention (or its default window).
+
+## What you should see
+
+- **`GetShortInterest`** — the reported short position, its change from the previous period, average daily volume, and days to cover. Published bi-monthly; a high days-to-cover (above ~5) points to a potential squeeze.
+- **`GetShortVolume`** — daily short volume, exempt volume, total volume, and the short-volume percentage. A high percentage (above ~50%) signals heavy intraday short selling.
+- **`GetFailsToDeliver`** — SEC settlement records: each settlement date, the quantity of shares that failed to deliver, and the price at settlement.
+
+If the reply says there's no short volume or short interest, the FINRA key probably isn't set or the worker hasn't run yet. Fails-to-deliver is independent of the FINRA key — if that's also empty, confirm the worker has run and try a heavily-shorted ticker such as GME.


### PR DESCRIPTION
## Summary

- Expand lane (user guide): adds a how-to for asking an AI assistant about a specific stock's short data. The existing short-data pages cover market-wide browsing, squeeze scoring, and off-exchange volume; per-stock short interest / short volume / fails-to-deliver had no ask-about page despite the `GetShortInterest`, `GetShortVolume`, and `GetFailsToDeliver` MCP tools.

## Code changes

- `docs/guide/how-to-ask-about-short-data.md` — new how-to covering the three per-stock short tools (FINRA short interest with days-to-cover, FINRA daily short volume %, SEC fails-to-deliver), the FINRA-key prerequisite (FTD excepted), example questions, and expected output. Mirrors the sibling "ask-about" page format.
- `docs/guide/README.md` — one TOC bullet linking the new page, placed in the short-data cluster.