### PR TITLE
test(core): pin StringExtensions.TruncateToFit backs off when the cap lands on a surrogate pair

### DIFF
--- a/tests/Equibles.UnitTests/Core/StringExtensionsTruncateToFitSurrogatePairTests.cs
+++ b/tests/Equibles.UnitTests/Core/StringExtensionsTruncateToFitSurrogatePairTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Core.Extensions;
+
+namespace Equibles.UnitTests.Core;
+
+public class StringExtensionsTruncateToFitSurrogatePairTests
+{
+    [Fact]
+    public void TruncateToFit_CapLandsOnHighSurrogate_BacksOffToAvoidSplittingThePair()
+    {
+        // Contract: caps at maxLength UTF-16 units WITHOUT splitting a surrogate pair —
+        // when the cap lands on the high half, it backs off one unit so the kept prefix
+        // never ends in a lone surrogate. "😀" is the pair 😀 at indices 1-2.
+        var result = "a😀b".TruncateToFit(2);
+
+        result
+            .Should()
+            .Be(
+                "a",
+                "maxLength 2 lands on the emoji's high surrogate (index 1), so TruncateToFit "
+                    + "must back off to length 1 rather than return an orphaned high surrogate"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `StringExtensions.TruncateToFit` is the shared surrogate-safe truncation helper that 6 call sites delegate to (extracted in #3886), but it had no direct unit test — only transitive coverage through those sites.
- Adds an adversarial test derived from the doc contract, pinning the core invariant directly on the helper.

## Code changes

- `tests/Equibles.UnitTests/Core/StringExtensionsTruncateToFitSurrogatePairTests.cs` — new unit test asserting `"a😀b".TruncateToFit(2)` returns `"a"` (backs off one unit when the cap lands on the high half of a surrogate pair, rather than returning an orphaned high surrogate). Passes — confirms the surrogate-safe contract, guards against regression.