### PR TITLE
docs(guide): add how-to — ask your AI assistant about proposed insider sales (TOC + page)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -59,6 +59,7 @@ Task-focused recipes for someone who has Equibles running.
 - [View an insider's trading profile](how-to-view-insider-profile.md)
 - [View proposed insider sales (SEC Form 144)](how-to-view-proposed-sales.md)
 - [Ask your AI assistant about a company's insider trading](how-to-ask-about-insider-trading.md)
+- [Ask your AI assistant about proposed insider sales (Form 144)](how-to-ask-about-proposed-sales.md)
 - [View a member of Congress's trading profile](how-to-view-congress-member-trades.md)
 - [Ask your AI assistant about congressional stock trades](how-to-ask-about-congressional-trades.md)
 - [Ask your AI assistant about a member of Congress's net worth](how-to-ask-about-congress-member-net-worth.md)

--- a/docs/guide/how-to-ask-about-proposed-sales.md
+++ b/docs/guide/how-to-ask-about-proposed-sales.md
@@ -1,0 +1,26 @@
+# Ask your AI assistant about proposed insider sales (Form 144)
+
+Equibles imports SEC Form 144 notices — an affiliate's declaration of intent to sell restricted or control shares — and exposes them through the MCP server, so you can ask your AI assistant about a company's upcoming insider selling before it executes. Form 144 is the forward-looking complement to executed Form 4 trades — to ask about those, see [Ask about a company's insider trading](how-to-ask-about-insider-trading.md). To browse the same notices on the web portal, see [View proposed insider sales](how-to-view-proposed-sales.md).
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so Form 144 notices have been imported from SEC EDGAR.
+
+## Ask about proposed sales
+
+Name a stock and ask about intended insider selling:
+
+- "What proposed insider sales are there for AAPL?"
+- "Has anyone at Tesla filed to sell shares recently?"
+- "Show me NVDA's Form 144 filings."
+
+The assistant picks the `GetProposedSales` tool and returns the company's recent Form 144 notices.
+
+## What you should see
+
+A table of recent Form 144 notices, each showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the approximate sale date, and the broker.
+
+Remember that a Form 144 is a *declaration of intent*, not a completed trade — the actual sale, if it happens, later appears as an executed [Form 4 insider transaction](how-to-ask-about-insider-trading.md).
+
+If the reply says there are no proposed sales, the company may simply have no recent Form 144 filings — confirm the worker has run, then try a large, actively-traded ticker such as AAPL.


### PR DESCRIPTION
## Summary

- Expand lane (user guide): adds a how-to for asking an AI assistant about a company's proposed insider sales (SEC Form 144). It's the forward-looking complement to the existing "ask about insider trading" (executed Form 4) page, and the `GetProposedSales` MCP tool had no ask-about page (only a web browse page).

## Code changes

- `docs/guide/how-to-ask-about-proposed-sales.md` — new how-to covering `GetProposedSales` (Form 144 intent-to-sell notices), example questions, expected output (seller, relationship, shares/value, sale date, broker), and the Form 144-vs-Form 4 distinction. Mirrors the sibling "ask-about" page format.
- `docs/guide/README.md` — one TOC bullet linking the new page, placed in the insider cluster after the executed-trades entry.