### PR TITLE
docs(guide): add how-to — ask your AI assistant about exempt offerings (TOC + page)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -34,6 +34,7 @@ Task-focused recipes for someone who has Equibles running.
 - [View a fund's operations (SEC Form N-CEN)](how-to-view-fund-operations.md)
 - [Ask your AI assistant about funds in the directory](how-to-ask-about-fund-directory.md)
 - [View a company's exempt offerings (SEC Form D)](how-to-view-exempt-offerings.md)
+- [Ask your AI assistant about a company's exempt offerings (Form D)](how-to-ask-about-exempt-offerings.md)
 - [View a company's financial statements (SEC XBRL)](how-to-view-financial-statements.md)
 - [Ask your AI assistant about a company's financial statements](how-to-ask-about-financial-statements.md)
 - [Ask your AI assistant for a company's revenue breakdown](how-to-ask-about-revenue-breakdown.md)

--- a/docs/guide/how-to-ask-about-exempt-offerings.md
+++ b/docs/guide/how-to-ask-about-exempt-offerings.md
@@ -1,0 +1,24 @@
+# Ask your AI assistant about a company's exempt offerings (Form D)
+
+Equibles imports SEC Form D notices — the filings companies submit when they raise private capital through a Regulation D exempt offering — and exposes them through the MCP server, so you can ask your AI assistant how a company is raising money privately, alongside its public filings. To browse the same notices on the web portal, see [View a company's exempt offerings](how-to-view-exempt-offerings.md).
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so Form D notices have been imported from SEC EDGAR.
+
+## Ask about exempt offerings
+
+Name a company and ask about its private fundraising:
+
+- "Has AAPL filed any Form D offerings?"
+- "Show me Stripe's recent private placements."
+- "How much has this company raised privately, and from how many investors?"
+
+The assistant picks the `GetExemptOfferings` tool and returns the company's recent Form D notices.
+
+## What you should see
+
+A table of recent Form D offerings, each showing the issuer, the total offering amount and the amount sold so far (a dollar figure, or "Indefinite" when the issuer doesn't cap it), the minimum investment, the number of investors, the claimed Regulation D exemptions, and whether the notice is an amendment.
+
+If the reply says there are no exempt offerings, the company may simply have no Form D filings — confirm the worker has run, then try a company known to raise private capital.


### PR DESCRIPTION
## Summary

- Expand lane (user guide): adds a how-to for asking an AI assistant about a company's Form D exempt offerings (private placements). Completes the "ask your AI assistant about X" series — `GetExemptOfferings` had only a web browse page.

## Code changes

- `docs/guide/how-to-ask-about-exempt-offerings.md` — new how-to covering `GetExemptOfferings` (Regulation D private placements: offering amount, amount sold, minimum investment, investor count, exemptions), example questions, and expected output. Mirrors the sibling "ask-about" page format.
- `docs/guide/README.md` — one TOC bullet linking the new page, beside the existing exempt-offerings browse entry.