### PR TITLE
docs(guide): add how-to — ask your AI assistant about market-wide 13F activity (TOC + page)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -41,6 +41,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Use the 13F holdings screener](how-to-use-holdings-screener.md)
 - [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)
 - [Ask your AI assistant which stocks institutions hold most](how-to-ask-about-most-held-stocks.md)
+- [Ask your AI assistant what institutions are buying and selling (13F leaderboards)](how-to-ask-about-market-wide-13f-activity.md)
 - [Ask your AI assistant who owns a stock (institutional holders)](how-to-ask-about-institutional-ownership.md)
 - [Ask your AI assistant about an institution's portfolio](how-to-ask-about-institution-portfolio.md)
 - [View the latest 13F filings](how-to-view-latest-13f-filings.md)

--- a/docs/guide/how-to-ask-about-market-wide-13f-activity.md
+++ b/docs/guide/how-to-ask-about-market-wide-13f-activity.md
@@ -1,0 +1,30 @@
+# Ask your AI assistant what institutions are buying and selling (13F leaderboards)
+
+Equibles aggregates every SEC 13F-HR filing each quarter into market-wide leaderboards — the stocks most bought, most sold, most newly initiated, and most exited across all institutional filers versus the prior quarter — and exposes them through the MCP server, so you can ask your AI assistant for the consensus institutional move. For a single fund's holdings see [Ask about an institution's portfolio](how-to-ask-about-institution-portfolio.md); for the current most-held snapshot see [Ask which stocks institutions hold most](how-to-ask-about-most-held-stocks.md); to browse this data on the web portal see [View quarterly holdings activity](how-to-view-holdings-activity.md).
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so 13F-HR filings for at least two consecutive quarters have been imported (the leaderboards compare a quarter against the prior one).
+
+## Ask about the consensus move
+
+Ask what institutions did as a group last quarter:
+
+- "What did institutions buy most last quarter?"
+- "Which stocks did funds sell off the most?"
+- "What new positions are institutions initiating?"
+- "Which stocks did the most funds exit?"
+
+The assistant picks the `GetMarketWide13FActivity` tool and selects the matching leaderboard — top buys, top sells, new positions, or sold-out positions.
+
+## What you should see
+
+A ranked table for the leaderboard you asked about:
+
+- **Top buys** — stocks with the largest increase in institutional holdings, ranked by change in market value.
+- **Top sells** — stocks with the largest decrease, ranked by the size of the sell-down.
+- **New positions** — stocks ranked by how many filers initiated a position this quarter.
+- **Sold-out positions** — stocks ranked by how many filers exited entirely.
+
+If the reply is empty, only one quarter of 13F data has likely been imported so far — there's nothing to compare against yet. Let the worker keep running and try again once a second quarter has loaded.


### PR DESCRIPTION
## Summary

- Expand lane (user guide): adds a how-to for asking an AI assistant about market-wide 13F leaderboards (consensus institutional buys/sells/new/exited positions vs the prior quarter). The `GetMarketWide13FActivity` MCP tool had no ask-about page; it's distinct from the most-held snapshot and the single-fund portfolio pages.

## Code changes

- `docs/guide/how-to-ask-about-market-wide-13f-activity.md` — new how-to covering `GetMarketWide13FActivity`'s four leaderboards (top buys, top sells, new positions, sold-out positions), example questions, expected output, and the two-quarter prerequisite. Mirrors the sibling "ask-about" page format.
- `docs/guide/README.md` — one TOC bullet linking the new page, in the institutional cluster beside the most-held entry.