### PR TITLE
docs(guide): add how-to — ask your AI assistant about top 13F buyers and sellers (TOC + page)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -43,6 +43,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Ask your AI assistant which stocks institutions hold most](how-to-ask-about-most-held-stocks.md)
 - [Ask your AI assistant what institutions are buying and selling (13F leaderboards)](how-to-ask-about-market-wide-13f-activity.md)
 - [Ask your AI assistant who owns a stock (institutional holders)](how-to-ask-about-institutional-ownership.md)
+- [Ask your AI assistant who's buying or selling a stock (top 13F buyers and sellers)](how-to-ask-about-top-buyers-sellers.md)
 - [Ask your AI assistant about an institution's portfolio](how-to-ask-about-institution-portfolio.md)
 - [View the latest 13F filings](how-to-view-latest-13f-filings.md)
 - [View 13F statistics](how-to-view-13f-statistics.md)

--- a/docs/guide/how-to-ask-about-top-buyers-sellers.md
+++ b/docs/guide/how-to-ask-about-top-buyers-sellers.md
@@ -1,0 +1,27 @@
+# Ask your AI assistant who's buying or selling a stock (top 13F buyers and sellers)
+
+Equibles compares each stock's institutional holdings against the previous quarter's 13F-HR filings and exposes the result through the MCP server, so you can ask your AI assistant which funds moved the needle most on a single stock last quarter. This is the per-stock flow view — for the consensus move across all stocks see [Ask what institutions are buying and selling](how-to-ask-about-market-wide-13f-activity.md), and for the current holder snapshot see [Ask who owns a stock](how-to-ask-about-institutional-ownership.md).
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so 13F-HR filings for at least two consecutive quarters have been imported (the comparison needs a prior quarter).
+
+## Ask who's buying or selling
+
+Name a stock and ask about the quarter's institutional flow:
+
+- "Who's been buying NVDA?"
+- "Which funds added the most Tesla last quarter?"
+- "Did any institutions sell out of AAPL?"
+
+The assistant picks the `GetTopBuyersSellers` tool and returns the result for the stock.
+
+## What you should see
+
+A table with two sections for the quarter:
+
+- **Top buyers** — the institutions with the biggest absolute increase in shares held versus the prior 13F report, including funds that opened a brand-new position.
+- **Top sellers** — the institutions with the biggest absolute reduction, including funds that exited the position entirely.
+
+If the reply is empty, only one quarter of 13F data has likely been imported, so there's no prior quarter to compare against — let the worker keep running and try again once a second quarter has loaded.


### PR DESCRIPTION
## Summary

- Expand lane (user guide): adds a how-to for asking an AI assistant who moved the needle most on a specific stock last quarter (top 13F buyers and sellers). The `GetTopBuyersSellers` MCP tool had no ask-about page; it's the per-stock flow view, distinct from the holder snapshot and the market-wide leaderboards.

## Code changes

- `docs/guide/how-to-ask-about-top-buyers-sellers.md` — new how-to covering `GetTopBuyersSellers` (biggest quarterly share additions/reductions per stock, incl. new and sold-out positions), example questions, expected two-section output, and the two-quarter prerequisite. Mirrors the sibling "ask-about" page format.
- `docs/guide/README.md` — one TOC bullet linking the new page, in the institutional cluster.