### PR TITLE
docs(guide): add how-to — ask about investment advisers

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -30,6 +30,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Browse institutional portfolios and run a backtest](how-to-browse-institutions.md)
 - [Ask your AI assistant to backtest cloning a fund's portfolio](how-to-ask-about-fund-clone-backtest.md)
 - [Browse investment advisers (SEC Form ADV)](how-to-browse-investment-advisers.md)
+- [Ask your AI assistant about investment advisers (SEC Form ADV)](how-to-ask-about-investment-advisers.md)
 - [View a fund's portfolio holdings (SEC Form N-PORT)](how-to-view-fund-holdings.md)
 - [View a fund's operations (SEC Form N-CEN)](how-to-view-fund-operations.md)
 - [Ask your AI assistant about funds in the directory](how-to-ask-about-fund-directory.md)

--- a/docs/guide/how-to-ask-about-investment-advisers.md
+++ b/docs/guide/how-to-ask-about-investment-advisers.md
@@ -1,0 +1,31 @@
+# Ask your AI assistant about investment advisers (SEC Form ADV)
+
+Equibles builds a directory of SEC-registered investment advisers from the Form ADV filings it ingests, and exposes it through the MCP server, so you can ask your AI assistant to find an advisory firm by name and then pull its full regulatory profile. To browse the same data on the web portal instead, see [browse investment advisers](how-to-browse-investment-advisers.md).
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so the Form ADV adviser data has been imported.
+
+## Find an adviser by name
+
+Name a firm:
+
+- "Find the investment adviser Renaissance Technologies."
+- "Look up Vanguard's advisory firm."
+- "Which advisers match 'Bridgewater'?"
+
+The assistant calls the `SearchInvestmentAdvisers` tool and replies with a table of matching firms, largest by regulatory assets under management first. Each row shows the firm name, its **CRD number** (the SEC's unique adviser id), main office location, regulatory assets under management, and employee count.
+
+## Get an adviser's full profile
+
+Once you have a firm's CRD number, ask for its profile:
+
+- "Show me the full Form ADV profile for CRD 231."
+- "What are the assets under management and fee structure for that adviser?"
+
+The assistant calls the `GetInvestmentAdviser` tool with the CRD number and replies with the firm's legal and business names, SEC file number, main office and website, regulatory assets under management broken into discretionary, non-discretionary, and total, employee count, and how the firm is compensated (its fee structure).
+
+## What you should see
+
+For a search, a ranked table of advisory firms with their CRD numbers. For a profile, a single firm's complete Form ADV detail. If a search returns nothing, the firm may not be SEC-registered (state advisers and exempt reporting advisers are not in the federal Form ADV set), or its filing may not have been imported yet — try a large, well-known firm such as Vanguard to confirm the data is flowing.


### PR DESCRIPTION
## Summary

- Add a user-guide how-to for the `SearchInvestmentAdvisers` and `GetInvestmentAdviser` MCP tools (SEC Form ADV) — the assistant-driven counterpart to the existing web browse page, which had no "ask your AI assistant" how-to.
- Two-step flow: find an adviser by name, then pull its full Form ADV profile by CRD number.

## Code changes

- `docs/guide/how-to-ask-about-investment-advisers.md` — new how-to: search advisers by name, get a firm's full profile by CRD, what each reply shows, and how to troubleshoot an empty search.
- `docs/guide/README.md` — add the TOC bullet under How-to guides, paired right after the web "Browse investment advisers" entry.