### PR TITLE
docs(guide): add how-to — ask about a fund's operations (N-CEN)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -33,6 +33,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Ask your AI assistant about investment advisers (SEC Form ADV)](how-to-ask-about-investment-advisers.md)
 - [View a fund's portfolio holdings (SEC Form N-PORT)](how-to-view-fund-holdings.md)
 - [View a fund's operations (SEC Form N-CEN)](how-to-view-fund-operations.md)
+- [Ask your AI assistant about a fund's operations (SEC Form N-CEN)](how-to-ask-about-fund-operations.md)
 - [Ask your AI assistant about funds in the directory](how-to-ask-about-fund-directory.md)
 - [Ask your AI assistant which funds and ETFs hold a stock](how-to-ask-about-funds-holding-a-stock.md)
 - [View a company's exempt offerings (SEC Form D)](how-to-view-exempt-offerings.md)

--- a/docs/guide/how-to-ask-about-fund-operations.md
+++ b/docs/guide/how-to-ask-about-fund-operations.md
@@ -1,0 +1,24 @@
+# Ask your AI assistant about a fund's operations (SEC Form N-CEN)
+
+Equibles ingests the SEC Form N-CEN annual reports that registered funds file and exposes them through the MCP server, so you can ask your AI assistant who runs and services a mutual fund, ETF, or closed-end fund — its investment advisers, custodians, transfer agents, auditors, and more. This is the operational side of a fund; to ask what a fund *owns* instead, see [ask about funds in the directory](how-to-ask-about-fund-directory.md). To browse the same data on the web portal, see [view a fund's operations](how-to-view-fund-operations.md).
+
+## Before you start
+
+- Connect an AI assistant to the MCP server first — see [Connect an AI assistant](tutorial-connect-ai-assistant.md).
+- Let the worker run after startup so fund N-CEN reports have been imported.
+
+## Ask about a fund's operations
+
+Name a fund by its ticker:
+
+- "Who is the custodian and auditor for SPY?"
+- "What service providers does VOO use?"
+- "Show me the operational filings for the Mexico Fund (MXF)."
+
+The assistant calls the `GetFundOperations` tool with the fund's ticker and returns up to 10 annual reports by default (ask for more or fewer), newest first.
+
+## What you should see
+
+For each N-CEN report, a summary of the fund's classification (for example N-1A open-end or N-2 closed-end), its Investment Company Act file number, the reporting period, and whether it was the fund's first or last filing — followed by the fund's named service providers: investment advisers and sub-advisers, custodians, transfer agents, administrators, auditors, and underwriters.
+
+If the reply comes back empty, the ticker may not belong to a registered fund — only mutual funds, ETFs, and closed-end funds file N-CEN, so an operating company returns no data — or its N-CEN may not have been imported yet. Try a large, well-known fund such as SPY to confirm the data is flowing.


### PR DESCRIPTION
## Summary

- Add a user-guide how-to for the `GetFundOperations` MCP tool (SEC Form N-CEN) — a fund's service providers (advisers, custodians, transfer agents, auditors), which had no "ask your AI assistant" guide page.
- Distinct from the fund-holdings/profile tools (which cover what a fund owns); the MCP counterpart to the existing web "view a fund's operations" page.

## Code changes

- `docs/guide/how-to-ask-about-fund-operations.md` — new how-to: ask who runs and services a fund, what each N-CEN reply shows, and how to troubleshoot an empty result.
- `docs/guide/README.md` — add the TOC bullet under How-to guides, paired right after the web "View a fund's operations" entry.