### PR TITLE
fix(holdings): exclude Schedule 13D/G rows from per-stock institutional-holder surfaces

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -80,12 +80,12 @@ public class InstitutionalHoldingsTools
 
                 var (targetDate, found) = await TryResolveLatestReportDate(
                     reportDate,
-                    _holdingRepository.GetReportDatesByStock(stock)
+                    _holdingRepository.Get13FReportDatesByStock(stock)
                 );
                 if (!found)
                     return $"No institutional holdings data available for {ticker}.";
 
-                var allHoldings = _holdingRepository.GetByStock(stock, targetDate);
+                var allHoldings = _holdingRepository.Get13FByStock(stock, targetDate);
                 var totalInstitutions = await allHoldings
                     .Select(h => h.InstitutionalHolderId)
                     .Distinct()
@@ -170,7 +170,7 @@ public class InstitutionalHoldingsTools
                     return stockError;
 
                 var reportDates = await _holdingRepository
-                    .GetReportDatesByStock(stock)
+                    .Get13FReportDatesByStock(stock)
                     .Take(McpLimit.Clamp(maxPeriods))
                     .ToListAsync();
 
@@ -199,7 +199,7 @@ public class InstitutionalHoldingsTools
         long previousShares = 0;
         foreach (var date in reportDates.OrderBy(d => d))
         {
-            var holdings = await _holdingRepository.GetByStock(stock, date).ToListAsync();
+            var holdings = await _holdingRepository.Get13FByStock(stock, date).ToListAsync();
             var totalShares = holdings.Sum(h => h.Shares);
             var totalValue = holdings.Sum(h => h.Value);
             var institutionCount = holdings.Select(h => h.InstitutionalHolderId).Distinct().Count();
@@ -342,7 +342,7 @@ public class InstitutionalHoldingsTools
                     return stockError;
 
                 var reportDates = await _holdingRepository
-                    .GetReportDatesByStock(stock)
+                    .Get13FReportDatesByStock(stock)
                     .ToListAsync();
 
                 var targetDate = TryParseReportDate(reportDate, out var parsed)
@@ -354,11 +354,11 @@ public class InstitutionalHoldingsTools
                 var previousDate = GetPriorReportDate(reportDates, targetDate);
 
                 var currentHoldings = await _holdingRepository
-                    .GetByStockWithHolder(stock, targetDate)
+                    .Get13FByStockWithHolder(stock, targetDate)
                     .ToListAsync();
                 var previousHoldings = previousDate.HasValue
                     ? await _holdingRepository
-                        .GetByStockWithHolder(stock, previousDate.Value)
+                        .Get13FByStockWithHolder(stock, previousDate.Value)
                         .ToListAsync()
                     : [];
 

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -29,6 +29,26 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return GetByStock(stock, reportDate).Include(h => h.InstitutionalHolder);
     }
 
+    // 13F-only holdings of one stock at a quarter end. Mirrors Get13FByHolder: a holder can
+    // file a Schedule 13D/G whose daily event ReportDate coincides with a 13F quarter end and
+    // shares this table, so a per-stock institutional-holders list must exclude it or the
+    // filer's 13F holding and its 13D/G stake both render as separate rows, double-counting
+    // the filer's ownership (GH-4449).
+    public IQueryable<InstitutionalHolding> Get13FByStock(CommonStock stock, DateOnly reportDate)
+    {
+        return GetByStock(stock, reportDate).Where(h => h.FilingType == FilingType.Form13F);
+    }
+
+    // Same stock/date 13F-only filter as Get13FByStock, with the InstitutionalHolder navigation
+    // eagerly loaded for callers that render holder fields while aggregating rows.
+    public IQueryable<InstitutionalHolding> Get13FByStockWithHolder(
+        CommonStock stock,
+        DateOnly reportDate
+    )
+    {
+        return Get13FByStock(stock, reportDate).Include(h => h.InstitutionalHolder);
+    }
+
     public IQueryable<InstitutionalHolding> GetByHolder(
         InstitutionalHolder holder,
         DateOnly reportDate
@@ -83,6 +103,15 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return GetAll().Where(h => h.CommonStockId == stock.Id);
     }
 
+    // 13F-only history of one stock's institutional holders. Schedule 13D/G rows carry a daily
+    // event date, not a quarter end, and describe a single disclosed stake; an ownership-trend
+    // or report-date series for the stock must exclude them or a 13D/G event date pollutes the
+    // quarter axis and its share count inflates the per-quarter total (GH-4449).
+    public IQueryable<InstitutionalHolding> Get13FHistoryByStock(CommonStock stock)
+    {
+        return GetHistoryByStock(stock).Where(h => h.FilingType == FilingType.Form13F);
+    }
+
     public IQueryable<InstitutionalHolding> GetHistoryByHolder(InstitutionalHolder holder)
     {
         return GetAll().Where(h => h.InstitutionalHolderId == holder.Id);
@@ -112,6 +141,12 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     // Latest dates first — see GetAvailableReportDates for the ordering contract.
     public IQueryable<DateOnly> GetReportDatesByStock(CommonStock stock) =>
         GetHistoryByStock(stock).DistinctReportDatesDescending();
+
+    // Latest 13F quarter-end dates first for one stock — see Get13FHistoryByStock for why
+    // 13D/G event dates are excluded. The per-stock holders surfaces resolve their target and
+    // comparison quarters off this list, so it must stay 13F-only (GH-4449).
+    public IQueryable<DateOnly> Get13FReportDatesByStock(CommonStock stock) =>
+        Get13FHistoryByStock(stock).DistinctReportDatesDescending();
 
     // Latest dates first — see GetAvailableReportDates for the ordering contract.
     public IQueryable<DateOnly> GetReportDatesByHolder(InstitutionalHolder holder) =>
@@ -498,8 +533,15 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     )
     {
         var ids = holderIds.ToList();
+        // 13F-only: "first owned quarter" is the earliest 13F quarter a holder reported the
+        // stock. A Schedule 13D/G stake carries a daily event date that would otherwise win
+        // the Min and mislabel the first-owned quarter (GH-4449).
         return GetAll()
-            .Where(h => h.CommonStockId == stock.Id && ids.Contains(h.InstitutionalHolderId))
+            .Where(h =>
+                h.CommonStockId == stock.Id
+                && ids.Contains(h.InstitutionalHolderId)
+                && h.FilingType == FilingType.Form13F
+            )
             .GroupBy(h => h.InstitutionalHolderId)
             .Select(g => new KeyValuePair<Guid, DateOnly>(g.Key, g.Min(h => h.ReportDate)));
     }

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -712,14 +712,14 @@ public class StockTabService
     private Task<List<InstitutionalHolding>> LoadHoldingsByStockWithHolder(
         CommonStock stock,
         DateOnly reportDate
-    ) => _institutionalHoldingRepository.GetByStockWithHolder(stock, reportDate).ToListAsync();
+    ) => _institutionalHoldingRepository.Get13FByStockWithHolder(stock, reportDate).ToListAsync();
 
     // Report dates for the holdings tab, newest first, clamped to the sync
     // floor: quarters before it hold partial filings, so their dates must not
     // appear in the selector, the stats, or the combined view's quarter pair.
     private Task<List<DateOnly>> LoadClampedReportDates(CommonStock stock)
     {
-        var datesQuery = _institutionalHoldingRepository.GetReportDatesByStock(stock);
+        var datesQuery = _institutionalHoldingRepository.Get13FReportDatesByStock(stock);
         if (_minSyncDate is { } minDate)
         {
             datesQuery = datesQuery.Where(d => d >= minDate);
@@ -732,7 +732,7 @@ public class StockTabService
     // latest point matches the stats shown for the latest quarter.
     private async Task<List<OwnershipTrendPoint>> LoadOwnershipTrend(CommonStock stock)
     {
-        var holdingsQuery = _institutionalHoldingRepository.GetHistoryByStock(stock);
+        var holdingsQuery = _institutionalHoldingRepository.Get13FHistoryByStock(stock);
         if (_minSyncDate is { } trendFloor)
         {
             holdingsQuery = holdingsQuery.Where(h => h.ReportDate >= trendFloor);

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
@@ -1,0 +1,155 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins that <c>GetTopHolders</c> serves only 13F holdings. A filer can also have a
+/// Schedule 13D/G row in the same table (beneficial-ownership disclosure) whose event
+/// ReportDate coincides with the 13F quarter end — Vanguard Capital Management LLC files
+/// both, so its real 13F-HR Apple holding (953,847,648, DFND) and its Schedule 13G
+/// sole-dispositive-power figure (1,099,168,953) sat in the table at 2026-03-31. The
+/// per-stock top-holders query did not filter by filing type, so the same filer rendered
+/// twice and its institutional ownership double-counted (GH-4449). The holder-portfolio and
+/// market-wide surfaces were already made 13F-only (GH-3690); this pins the remaining
+/// per-stock holder surface.
+/// </summary>
+public class InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new HoldingsModuleConfiguration(),
+                new ErrorsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    [Fact]
+    public async Task GetTopHolders_FilerHasBoth13FAnd13GAtSameDate_ExcludesThe13GRow()
+    {
+        await using var db = NewDb();
+
+        var apple = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var vanguardCapital = new InstitutionalHolder
+        {
+            Cik = "0002100119",
+            Name = "VANGUARD CAPITAL MANAGEMENT LLC",
+        };
+        db.AddRange(apple, vanguardCapital);
+
+        var quarterEnd = new DateOnly(2026, 3, 31);
+
+        // The real 13F-HR holding — investment discretion DFND ("Defined").
+        db.Add(
+            MakeHolding(
+                vanguardCapital,
+                apple,
+                quarterEnd,
+                FilingType.Form13F,
+                InvestmentDiscretion.Defined,
+                shares: 953_847_648,
+                value: 242_077_000_000,
+                accession: "13f-hr"
+            )
+        );
+        // The Schedule 13G beneficial-ownership row — sole dispositive power, larger than the
+        // 13F holding. Its ReportDate lands on the same 2026-03-31 quarter end, so an
+        // unfiltered per-stock query returns it alongside the 13F holding.
+        db.Add(
+            MakeHolding(
+                vanguardCapital,
+                apple,
+                quarterEnd,
+                FilingType.Schedule13G,
+                InvestmentDiscretion.Sole,
+                shares: 1_099_168_953,
+                value: 278_958_100_000,
+                accession: "sc-13g"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(db),
+            new InstitutionalHolderRepository(db),
+            new CommonStockRepository(db),
+            new ErrorManager(new ErrorRepository(db)),
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopHolders("AAPL");
+
+        // The real 13F holding is served (guards against a false pass on an error string).
+        output.Should().Contain("953,847,648");
+        // The Schedule 13G sole-dispositive-power figure must never render as a holding row.
+        output.Should().NotContain("1,099,168,953");
+        // The filer appears exactly once, not twice.
+        CountOccurrences(output, "VANGUARD CAPITAL MANAGEMENT LLC").Should().Be(1);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        InstitutionalHolder holder,
+        CommonStock stock,
+        DateOnly reportDate,
+        FilingType filingType,
+        InvestmentDiscretion discretion,
+        long shares,
+        long value,
+        string accession
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            FilingType = filingType,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = discretion,
+            AccessionNumber = accession,
+        };
+}


### PR DESCRIPTION
## Summary

- The `InstitutionalHolding` table stores both 13F-HR holdings and Schedule 13D/G beneficial-ownership disclosures, distinguished by `FilingType`. The holder-portfolio and market-wide surfaces already query 13F-only (`Get13FByHolder` / `Get13FHistoryByHolder` / `Get13FAvailableReportDates`), but the **per-stock** surfaces did not — they returned every filing type.
- When a filer reports both a 13F holding and a Schedule 13D/G stake for the same stock at a quarter-end `ReportDate`, the per-stock top-holders list rendered the filer **twice** and double-counted its institutional ownership. Example: Vanguard Capital Management LLC's Apple position is 953,847,648 shares on its 13F-HR (discretion DFND) plus 1,099,168,953 sole-dispositive-power shares on its Schedule 13G; both rows land on 2026-03-31 and both rendered, inflating Apple's institutional ownership (~63% → ~71%). The same root cause inflated the ownership-history, ownership-trend and buyers/sellers surfaces.
- Fix: add 13F-only per-stock query variants mirroring the existing holder-side pattern, filter `GetFirstOwnedQuarters` to 13F, and route every per-stock institutional-holder read through them. Pinned by a new regression test (fails before, passes after).

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — add `Get13FByStock`, `Get13FByStockWithHolder`, `Get13FHistoryByStock`, `Get13FReportDatesByStock` (each filters `FilingType == Form13F`); filter `GetFirstOwnedQuarters` to 13F so a 13D/G event date can't win the first-owned-quarter `Min`.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — route `GetTopHolders`, `GetOwnershipHistory` and `GetTopBuyersSellers` through the 13F-only variants.
- `src/Equibles.Web/Services/StockTabService.cs` — route the holdings-tab list, report-date selector and ownership trend through the 13F-only variants.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs` — regression test: a filer with both a 13F holding and a same-date Schedule 13G renders once, and the 13G sole-dispositive-power figure never appears as a holding row.