### PR TITLE
test(insider-trading): pin IsPlausibleTransactionDate same-day filing boundary

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserIsPlausibleTransactionDateOnFilingDateTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserIsPlausibleTransactionDateOnFilingDateTests.cs
@@ -1,0 +1,17 @@
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserIsPlausibleTransactionDateOnFilingDateTests
+{
+    [Fact]
+    public void IsPlausibleTransactionDate_TransactionOnFilingDate_IsPlausible()
+    {
+        // Contract: a Form 4 may be filed the same day as the trade, so a transaction dated
+        // exactly on the filing date does not post-date it and stays plausible (inclusive upper
+        // bound). Guards <= against regressing to <, which would wrongly anchor same-day trades.
+        var sameDay = new DateOnly(2025, 1, 13);
+
+        InsiderFilingParser.IsPlausibleTransactionDate(sameDay, sameDay).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- `InsiderFilingParser.IsPlausibleTransactionDate` had no direct test; existing coverage only exercises the implausible cases (year before 1900, date after the filing). The inclusive upper bound — a transaction dated exactly on the filing date — was unguarded.
- Adds one adversarial boundary test asserting a same-day trade is plausible, so a Form 4 filed the same day it was executed is kept verbatim rather than anchored to the period of report.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserIsPlausibleTransactionDateOnFilingDateTests.cs` — new fact pinning `IsPlausibleTransactionDate(d, d) == true`, guarding the `<=` upper bound against regressing to `<`.