### PR TITLE
docs(technical/hosts): refresh AddEquiblesFinancialDbContext reference

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -57,7 +57,7 @@ The background-scraper host. Plain `Host.CreateApplicationBuilder` (not `WebAppl
 Every host runs the same five steps described in [Architecture → Host composition](architecture.md#host-composition):
 
 1. `PluginLoader.LoadAll()`
-2. `AddEquiblesDbContext(... modules.AddAllModules().AddMessaging() ...)` (Worker calls `AddMessaging` separately as a service registration, not as a module — the module registration still happens via `AddAllModules()`)
+2. `AddEquiblesFinancialDbContext(... modules.AddAllModules().AddMessaging() ...)` (Worker calls `AddMessaging` separately as a service registration, not as a module — the module registration still happens via `AddAllModules()`)
 3. `AddAllRepositories()`
 4. `AutoWireServicesFrom<T>()` (once per assembly to wire)
 5. Host-specific registrations


### PR DESCRIPTION
## Summary

- Maintain lane (stale code reference): the shared-startup sequence in the hosts page still named `AddEquiblesDbContext`, the old registration method. The actual extension all three hosts call is `AddEquiblesFinancialDbContext` (`src/Equibles.Data/Extensions/ServiceCollectionExtensions.cs`). This completes the rename started in the architecture page.

## Code changes

- `docs/technical/hosts.md` — `AddEquiblesDbContext(...)` → `AddEquiblesFinancialDbContext(...)` in startup step 2.