### PR TITLE
test(government-contracts): pin RecipientNameNormalizer 4-char minimum-key boundary

### DIFF
--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerMinimumKeyLengthBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerMinimumKeyLengthBoundaryTests.cs
@@ -1,0 +1,16 @@
+using Equibles.GovernmentContracts.HostedService.Services;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class RecipientNameNormalizerMinimumKeyLengthBoundaryTests
+{
+    [Fact]
+    public void Normalize_KeyExactlyAtMinimumLength_IsReturned()
+    {
+        // Contract: a key shorter than the 4-char minimum is dropped to null, so a key of
+        // EXACTLY 4 chars is the inclusive lower edge and must be kept. "Ford Inc" strips the
+        // INC suffix to "FORD" (4 chars). Guards >= against regressing to >, which would drop
+        // legitimate four-letter recipient names from exact-match resolution.
+        RecipientNameNormalizer.Normalize("Ford Inc").Should().Be("FORD");
+    }
+}


### PR DESCRIPTION
## Summary

- `RecipientNameNormalizer.Normalize` drops any normalized key shorter than the 4-char minimum to null, but the existing tests only assert longer results (shortest is "BOEING", 6 chars) — the inclusive lower edge was unguarded.
- Adds one boundary test asserting a key of exactly 4 chars survives ("Ford Inc" → "FORD"), guarding the `>=` against regressing to `>`, which would silently drop legitimate four-letter recipient names from exact-match resolution.

## Code changes

- `tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerMinimumKeyLengthBoundaryTests.cs` — new fact pinning `Normalize("Ford Inc") == "FORD"`.