### PR TITLE
docs(technical/scrapers): refresh Integrations.Common contents

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -49,7 +49,7 @@ Each upstream source has its own integration project:
 | `Equibles.Integrations.Cboe` | CBOE indicators |
 | `Equibles.Integrations.GovernmentContracts` | USAspending.gov federal contract awards |
 | `Equibles.Integrations.Wikidata` | Wikidata SPARQL endpoint (company metadata discovery) |
-| `Equibles.Integrations.Common` | Shared infrastructure — currently `RateLimiter` only |
+| `Equibles.Integrations.Common` | Shared infrastructure — `RateLimiter` plus the `RetryBackoff` exponential-backoff formula and the `HttpRetry.Send` 429/5xx retry helper |
 
 Every client follows the same shape: one interface + one implementation registered via `[Service(ServiceLifetime.Scoped, typeof(IXxxClient))]` (the AutoWire attribute from `Equibles.Core.AutoWiring`). The interface lives in `Contracts/`, the DTOs in `Models/`, and the wire/transport details in the client class itself.
 


### PR DESCRIPTION
## Summary

- The Integration clients table in `scrapers.md` described `Equibles.Integrations.Common` as "currently `RateLimiter` only" — stale since the retry refactors landed.
- That project also ships the shared retry helpers `RetryBackoff` (exponential-backoff formula, #3242) and `HttpRetry.Send` (429/5xx retry loop, #3253). Table now lists both so it matches the project on disk.

## Code changes

- `docs/technical/scrapers.md` — update the `Equibles.Integrations.Common` row to list the `RateLimiter` plus the `RetryBackoff` / `HttpRetry.Send` retry helpers.