### PR TITLE
docs(technical/web-portal): refresh vite.config.js entry reference

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -61,7 +61,7 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 ## Frontend build
 
 - [`package.json`](../../src/Equibles.Web/package.json) — Vite 6, Tailwind v4 (`@tailwindcss/postcss`), DaisyUI v5, plus `chart.js`, `aos`, `typed.js`.
-- [`vite.config.js`](../../src/Equibles.Web/vite.config.js) — single entry `src/index.js`, output to `wwwroot/dist/` as `bundle.js` + `main.css`. `emptyOutDir: true` cleans the bundle on each build.
+- [`vite.config.js`](../../src/Equibles.Web/vite.config.js) — two entries (`src/index.js` → `bundle.js`, `src/chart.js` → `chart.js`), output to `wwwroot/dist/` with CSS emitted as `main.css`. `emptyOutDir: true` cleans the output on each build.
 - [`src/css/main.css`](../../src/Equibles.Web/src/css/main.css) — Tailwind v4 CSS-first config.
   - `@import "tailwindcss"`.
   - `@plugin "daisyui"` + `@plugin "@tailwindcss/typography"`.


### PR DESCRIPTION
## Summary

- The frontend build section of the Web portal technical docs described `vite.config.js` as a single entry (`src/index.js`) producing `bundle.js` + `main.css`.
- The Vite config now defines two Rollup entries — `src/index.js` → `bundle.js` and `src/chart.js` → `chart.js` — plus the `main.css` asset. Updated the reference to match.

## Code changes

- `docs/technical/web-portal.md` — corrected the `vite.config.js` bullet to list both entry points and their output bundles.