### PR TITLE
test(congress): add skipped repro for GH-3938 — Senate liability table without Type column

### DIFF
--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityMissingTypeColumnTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityMissingTypeColumnTests.cs
@@ -1,0 +1,43 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class SenateAnnualReportClientLiabilityMissingTypeColumnTests
+{
+    // Contract: ParseLiabilityTable is entered whenever the header row carries
+    // both "creditor" and "amount" — "type" is NOT part of that gate. A Part 7
+    // table that omits the Type column is therefore still a recognized
+    // liability layout and must degrade gracefully (the electronic-layout
+    // design never crashes on header variance), not throw while indexing a
+    // missing column.
+    [Fact(Skip = "GH-3938 — ParseLiabilityTable throws (cells[-1]) on a liability table without a Type column")]
+    public void ParseAnnualReportHtml_LiabilityTableWithoutTypeColumn_DoesNotThrow()
+    {
+        const string html = """
+            <html><body>
+            <h3>Part 3. Assets</h3>
+            <p>None disclosed.</p>
+            <h3>Part 7. Liabilities</h3>
+            <table>
+              <thead><tr><th>Debtor</th><th>Amount</th><th>Creditor</th></tr></thead>
+              <tbody><tr><td>Self</td><td>$100,001 - $250,000</td><td>Sample Bank</td></tr></tbody>
+            </table>
+            </body></html>
+            """;
+
+        var act = () => SenateAnnualReportClient.ParseAnnualReportHtml(html);
+
+        var lines = act.Should()
+            .NotThrow(
+                "a creditor+amount table without a Type column is a recognized liability layout"
+            )
+            .Subject;
+        lines.Should().NotBeNull("the Part 3 heading marks an electronic layout");
+        var liability = lines.Should().ContainSingle().Subject;
+        liability.Kind.Should().Be(CongressionalDisclosureLineKind.Liability);
+        liability.RangeMinimum.Should().Be(100_001);
+        liability.RangeMaximum.Should().Be(250_000);
+        liability.Description.Should().Contain("Sample Bank");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial `/add-test` found a latent defect: `SenateAnnualReportClient.ParseLiabilityTable` throws `ArgumentOutOfRangeException` when a Part 7 liability table omits the `Type` column.
- The entry gate only requires `creditor`+`amount` headers, but the method then indexes `cells[typeColumn]` where `typeColumn = headers.IndexOf("type")` is `-1`, so `cells[-1]` throws and the whole report is dropped.
- Regression test committed `[Skip]` — see GH-3938. Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityMissingTypeColumnTests.cs` — new skipped repro asserting `ParseAnnualReportHtml` does not throw on a creditor+amount liability table without a `Type` column (skipped — see GH-3938).