### PR TITLE
fix(congress): guard missing Type column in Senate liability parsing

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
@@ -342,7 +342,10 @@ public partial class SenateAnnualReportClient
             if (range == null)
                 continue;
 
-            var type = CellText(cells[typeColumn]);
+            // The entry gate only requires "creditor" and "amount"; a table
+            // without a Type column leaves typeColumn at -1 (the bounds check
+            // above already tolerates it), so read it only when present.
+            var type = typeColumn >= 0 ? CellText(cells[typeColumn]) : "";
             var creditor = CellText(cells[creditorColumn]);
             var description = string.IsNullOrEmpty(creditor) ? type : $"{type} ({creditor})";
             if (string.IsNullOrEmpty(description))

--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityMissingTypeColumnTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityMissingTypeColumnTests.cs
@@ -11,7 +11,7 @@ public class SenateAnnualReportClientLiabilityMissingTypeColumnTests
     // liability layout and must degrade gracefully (the electronic-layout
     // design never crashes on header variance), not throw while indexing a
     // missing column.
-    [Fact(Skip = "GH-3938 — ParseLiabilityTable throws (cells[-1]) on a liability table without a Type column")]
+    [Fact]
     public void ParseAnnualReportHtml_LiabilityTableWithoutTypeColumn_DoesNotThrow()
     {
         const string html = """


### PR DESCRIPTION
## Summary

- Fixes #3938: `SenateAnnualReportClient.ParseLiabilityTable` threw `ArgumentOutOfRangeException` on a Part 7 liability table whose header row had `creditor`+`amount` but no `Type` column — `typeColumn` was `-1`, so `cells[-1]` crashed and the whole report was dropped.
- Minimal fix: read the type cell only when `typeColumn >= 0` (the bounds check already tolerated `-1`); `amount`/`creditor` columns are guaranteed by the entry gate. Empty-type rows now surface keyed on creditor + amount, matching the parser's graceful-degradation design.
- Un-skips the regression test added in #3939.

## Code changes

- `src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs` — guard the optional `Type` column before indexing in `ParseLiabilityTable`.
- `tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityMissingTypeColumnTests.cs` — un-skip the GH-3938 repro (now passes; full Congress unit suite green, 223/223).