### PR TITLE
docs(readme): fix stale worker scraper list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This starts:
 | **db** | 5432 | ParadeDB (PostgreSQL + pgvector + pg_search) |
 | **web** | 8080 | Web portal for browsing data |
 | **mcp** | 8081 | MCP server for AI assistants |
-| **worker** | — | Scrapers (SEC, FINRA, Congress, FRED, Yahoo) |
+| **worker** | — | Scrapers (SEC, FINRA, Congress, FRED, Yahoo, CFTC, CBOE, USAspending, FDA) |
 
 Data scraping starts automatically. SEC filings, holdings, insider trades, and congressional trades will begin populating within minutes.
 


### PR DESCRIPTION
## Summary

- The Docker Compose service table in the README listed the worker as running only the SEC, FINRA, Congress, FRED, and Yahoo scrapers.
- The worker also registers the CFTC, CBOE, USAspending (government contracts), and FDA scrapers, so the list was out of date.

## Code changes

- `README.md` — extend the worker row's scraper list to include CFTC, CBOE, USAspending, and FDA, matching the workers registered in `Equibles.Worker.Host/Program.cs`.