### PR TITLE
fix(web): render the branded error page for 404 and other status codes

### DIFF
--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -218,6 +218,14 @@ public partial class Program
             app.UseHsts();
         }
 
+        // Re-execute to the branded Error page for status-code responses that
+        // carry no body — most importantly a 404 from an unmatched route, which
+        // otherwise reaches the user as an empty browser error page. Registered in
+        // every environment: UseExceptionHandler above only covers thrown
+        // exceptions, not bare status codes. HomeController.Error reads the {0}
+        // status code from the route and renders the matching message.
+        app.UseStatusCodePagesWithReExecute("/home/error/{0}");
+
         app.UseSecurityHeaders();
         app.UseResponseCompression();
 

--- a/tests/Equibles.IntegrationTests/Web/HomeControllerStatusCodePageTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HomeControllerStatusCodePageTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Contract: a status-code response with no body — most importantly a 404 from
+/// an unmatched route — must re-execute to the branded <c>HomeController.Error</c>
+/// page rather than reach the user as an empty browser error. The global
+/// <c>UseExceptionHandler</c> only covers thrown exceptions, so without
+/// <c>UseStatusCodePagesWithReExecute</c> in the pipeline a bare 404 returns an
+/// empty body. These tests pin that the re-execution is wired and preserves the
+/// original status code.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HomeControllerStatusCodePageTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HomeControllerStatusCodePageTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task UnmatchedRoute_RendersBrandedNotFoundPage_With404Status()
+    {
+        var response = await _fixture.Client.GetAsync("/this-route-does-not-exist");
+
+        response
+            .StatusCode.Should()
+            .Be(
+                HttpStatusCode.NotFound,
+                "the re-executed error page must preserve the original 404 status"
+            );
+
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should()
+            .Contain(
+                "Page Not Found",
+                "a 404 must reach the user as the branded error view, not an empty body"
+            );
+        html.Should()
+            .Contain("Go Home", "the error view offers a recovery link back to the home page");
+    }
+}


### PR DESCRIPTION
## Summary

- A frontend review found that visiting an unmatched route (e.g. an old or mistyped link) returned an **empty browser error page** instead of a friendly one.
- The Web pipeline only wired `UseExceptionHandler`, which handles thrown exceptions but not bare status-code responses, so a 404 with no body never reached the existing `HomeController.Error` view (which already renders a status-aware message and a "Go Home" link).
- Wired `UseStatusCodePagesWithReExecute("/home/error/{0}")` so those responses re-execute to the branded error page while preserving the original status code.

## Code changes

- `src/Equibles.Web/Program.cs` — add `UseStatusCodePagesWithReExecute("/home/error/{0}")` to the pipeline. Placed outside the non-development block because the exception handler is non-development only and status codes need handling in every environment; `HomeController.Error` reads the `{0}` status code from the route and renders the matching message ("Page Not Found" for 404, etc.).
- `tests/Equibles.IntegrationTests/Web/HomeControllerStatusCodePageTests.cs` — new regression test asserting an unmatched route renders the branded 404 page (status preserved, contains "Page Not Found" + "Go Home").

## Verification

- `dotnet build` of the affected projects: succeeded.
- Web integration suite (`Equibles.IntegrationTests.Web`): 379 passed, including the new test.