### PR TITLE
fix(govcontracts): dispose HttpRequestMessage in UsaSpendingClient.PostQuery

### DIFF
--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -126,12 +126,12 @@ public class UsaSpendingClient : IUsaSpendingClient
     private async Task<UsaSpendingAwardResponse> PostQuery(object body)
     {
         var json = JsonConvert.SerializeObject(body);
-        var content = await SendWithRetry(() =>
+        var content = await SendWithRetry(async () =>
         {
-            var request = new HttpRequestMessage(HttpMethod.Post, SearchUrl);
+            using var request = new HttpRequestMessage(HttpMethod.Post, SearchUrl);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            return _httpClient.SendAsync(request);
+            return await _httpClient.SendAsync(request);
         });
 
         var response =


### PR DESCRIPTION
## Summary

- The per-request `HttpRequestMessage` (and its `StringContent`) created in `PostQuery` was never disposed, leaking the message and its content on every USAspending API call (flagged by CodeQL `cs/local-not-disposed`, alert #596).

## Code changes

- `src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs` — switch the `SendWithRetry` callback to an async lambda with a `using` declaration so the request is disposed once the send completes. Behavior is unchanged; the response is still read and disposed by `SendWithRetry` as before.