### PR TITLE
fix(yahoo): reconcile market cap onto the authoritative EDGAR share base

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -208,12 +208,16 @@ public class YahooPriceImportService
             stock.SharesOutStanding = stats.SharesOutstanding;
             changed = true;
         }
-        if (
-            stats.MarketCapitalization != 0
-            && stock.MarketCapitalization != stats.MarketCapitalization
-        )
+        // Reconcile Yahoo's market cap onto the authoritative EDGAR share base so it never
+        // disagrees with SharesOutStanding by the share-count ratio (#3575/#2503).
+        var marketCap = ReconcileMarketCap(
+            edgarShares,
+            stats.SharesOutstanding,
+            stats.MarketCapitalization
+        );
+        if (stats.MarketCapitalization != 0 && stock.MarketCapitalization != marketCap)
         {
-            stock.MarketCapitalization = stats.MarketCapitalization;
+            stock.MarketCapitalization = marketCap;
             changed = true;
         }
 
@@ -228,6 +232,23 @@ public class YahooPriceImportService
             stats.MarketCapitalization
         );
     }
+
+    // Yahoo's market cap is its own (per-share-class / stale) share count times price. When EDGAR
+    // is the authoritative share source the importer keeps EDGAR's SharesOutStanding, so storing
+    // Yahoo's market cap verbatim leaves the two figures on different share bases — they disagree
+    // by the share-count ratio (a reverse-split lag inflates market cap ~20x, COPR #3575; a
+    // multi-class issuer understates Yahoo's shares ~2x, #2503). Rescale Yahoo's market cap onto
+    // the EDGAR base (== EDGAR shares × the same implied price) so market cap stays consistent with
+    // SharesOutStanding and the screener's derived price (market cap ÷ shares) holds. Falls back to
+    // Yahoo's figure when there is no EDGAR count or no usable Yahoo share base to rescale from.
+    private static double ReconcileMarketCap(
+        long? edgarShares,
+        long yahooShares,
+        double yahooMarketCap
+    ) =>
+        edgarShares is > 0 && yahooShares > 0 && yahooMarketCap > 0
+            ? yahooMarketCap * ((double)edgarShares.Value / yahooShares)
+            : yahooMarketCap;
 
     private async Task SyncCompanyProfile(
         string ticker,

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapTests.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Pins <c>ReconcileMarketCap</c>, the pure-logic guard the importer uses to keep a stock's stored
+/// market cap consistent with its authoritative share count (#3575/#2503).
+///
+/// Yahoo's market cap is its own (per-share-class / stale) share count times price. When EDGAR is
+/// the authoritative share source, the importer keeps EDGAR's <c>SharesOutStanding</c> but used to
+/// store Yahoo's market cap verbatim, so the two figures came from different share bases and
+/// disagreed by the share-count ratio. For Idaho Copper (COPR, #3575) a reverse-split lag inflated
+/// the Yahoo share count ~20x, so the stored market cap was ~20x too high — and the screener's
+/// derived price (market cap ÷ shares) collapsed to a nonsensical figure that appears nowhere in
+/// the price history. <c>ReconcileMarketCap</c> rescales Yahoo's market cap onto the EDGAR base so
+/// market cap == shares × price again.
+/// </summary>
+public class YahooPriceImportServiceReconcileMarketCapTests
+{
+    private static readonly MethodInfo ReconcileMarketCapMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "ReconcileMarketCap",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static double ReconcileMarketCap(
+        long? edgarShares,
+        long yahooShares,
+        double yahooMarketCap
+    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap]);
+
+    [Fact]
+    public void ReconcileMarketCap_EdgarSharesDifferFromYahoo_RescalesOntoEdgarBase()
+    {
+        // COPR (#3575): Yahoo lags a reverse split. Yahoo reports 276,898,105 shares and a market
+        // cap of $1,744,458,061 (= the stale share count × the $6.30 close). EDGAR's authoritative
+        // post-split count is 14,061,261. The reconciled market cap must equal
+        // 14,061,261 × $6.30 ≈ $88.6M (the EDGAR share base × the same price), NOT the stale
+        // $1.74B. The pre-fix code stored Yahoo's $1.74B verbatim, which this assertion rejects.
+        const long yahooShares = 276_898_105L;
+        const double yahooMarketCap = 1_744_458_061d; // ≈ 276,898,105 × $6.30
+        const long edgarShares = 14_061_261L;
+
+        var reconciled = ReconcileMarketCap(edgarShares, yahooShares, yahooMarketCap);
+
+        // == edgarShares × the implied $6.30 price == yahooMarketCap × (edgarShares / yahooShares).
+        var expected = yahooMarketCap * ((double)edgarShares / yahooShares);
+        reconciled.Should().BeApproximately(expected, 1d);
+        // Sanity: the corrected figure is ~$88.6M, an order of magnitude below the stale $1.74B.
+        reconciled.Should().BeLessThan(100_000_000d);
+    }
+
+    [Fact]
+    public void ReconcileMarketCap_NoEdgarShareCount_KeepsYahooMarketCap()
+    {
+        // No EDGAR cover-page count on record (edgarShares == null): Yahoo's market cap and share
+        // count are mutually consistent, so the stored value is left exactly as Yahoo reported it.
+        const long yahooShares = 50_000_000L;
+        const double yahooMarketCap = 315_000_000d;
+
+        var reconciled = ReconcileMarketCap(null, yahooShares, yahooMarketCap);
+
+        reconciled.Should().Be(yahooMarketCap);
+    }
+
+    [Fact]
+    public void ReconcileMarketCap_YahooShareBaseUnknown_KeepsYahooMarketCap()
+    {
+        // EDGAR shares are known but Yahoo returned no share count (0 = "unknown" elsewhere in the
+        // importer): there is no Yahoo base to rescale from, so degrade to Yahoo's market cap
+        // rather than divide by zero / fabricate a figure.
+        const double yahooMarketCap = 420_000_000d;
+
+        var reconciled = ReconcileMarketCap(7_500_000L, 0L, yahooMarketCap);
+
+        reconciled.Should().Be(yahooMarketCap);
+    }
+}


### PR DESCRIPTION
## Summary

- When EDGAR supplies the authoritative share count, the Yahoo importer keeps EDGAR's `SharesOutStanding` but stored Yahoo's market cap **verbatim** — so the two figures sat on different share bases and disagreed by the share-count ratio.
- A reverse-split lag (Idaho Copper, COPR) inflated the stored market cap ~20x; the screener's derived price (`market cap / shares`) then collapsed to a value that appears nowhere in the price history (COPR showed $1.74B market cap and a phantom $124.06 against a real $6.30 close). Mirrors EquiblesCommercial #3575 (reopened).
- Multi-class issuers hit the same class of inconsistency in the other direction (~2x understatement, #2503).

## Code changes

- `src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — new pure-static `ReconcileMarketCap(edgarShares, yahooShares, yahooMarketCap)` guard: when EDGAR has an authoritative share count, rescale Yahoo's market cap onto the EDGAR base (`= EDGAR shares × the same implied price`) so it stays consistent with `SharesOutStanding`; fall back to Yahoo's figure when there is no EDGAR count or no usable Yahoo share base. Wired into `SyncKeyStatistics` at the single market-cap write site. No schema/API change.
- `tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapTests.cs` — regression tests: the COPR rescale case (fails on pre-fix code, passes after) plus the two fall-back cases (no EDGAR count; unknown Yahoo share base).