### PR TITLE
test(insider-trading): pin IsPlausibleTransactionDate anchors a pre-1900 transaction date to the period of report

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseTransactionPrehistoricDateTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseTransactionPrehistoricDateTests.cs
@@ -1,0 +1,65 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// Sibling to <see cref="InsiderFilingParserParseTransactionImplausibleDateTests"/>, which pins the
+/// upper bracket of the plausibility window (a date AFTER the filing date is anchored to the period
+/// of report). This pins the opposite, equally-promised lower bracket: <c>IsPlausibleTransactionDate</c>
+/// also floors the year at <c>MinPlausibleTransactionYear</c> (1900) so a keyed-wrong far-past year
+/// — the earliest seen in production was <c>0022</c> — is treated as implausible and anchored to the
+/// period of report rather than stored verbatim and sorted to the very bottom of the insider history.
+/// </summary>
+public class InsiderFilingParserParseTransactionPrehistoricDateTests
+{
+    [Fact]
+    public void ParseTransactions_TransactionDateYearBeforeFloor_AnchorsToPeriodOfReport()
+    {
+        // Contract: the plausibility window brackets the transaction date in BOTH directions. A year
+        // below the 1900 floor (here 0022-01-10, the keyed-wrong far-past style the doc cites as the
+        // earliest seen in production) is a filer typo, not a real trade, so the parser must anchor it
+        // to the filing's period of report — NOT store the year-0022 date, which would sort to the
+        // very bottom of the insider history. A regression that floored only the upper bound (date
+        // after filing) would leave the 0022 date verbatim and fail here.
+        var root = XElement.Parse(
+            """
+            <ownershipDocument>
+              <nonDerivativeTable>
+                <nonDerivativeTransaction>
+                  <securityTitle><value>Common Stock</value></securityTitle>
+                  <transactionDate><value>0022-01-10</value></transactionDate>
+                  <transactionCoding>
+                    <transactionCode>A</transactionCode>
+                  </transactionCoding>
+                  <transactionAmounts>
+                    <transactionShares><value>31000</value></transactionShares>
+                    <transactionPricePerShare><value>0</value></transactionPricePerShare>
+                    <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+                  </transactionAmounts>
+                </nonDerivativeTransaction>
+              </nonDerivativeTable>
+            </ownershipDocument>
+            """
+        );
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000950170-25-004920",
+            FilingDate = new DateOnly(2025, 1, 13),
+            ReportDate = new DateOnly(2025, 1, 10),
+        };
+
+        var result = InsiderFilingParser.ParseTransactions(
+            root,
+            new InsiderOwner { Id = Guid.NewGuid() },
+            Guid.NewGuid(),
+            filing,
+            isAmendment: false
+        );
+
+        var transaction = result.Should().ContainSingle().Subject;
+        transaction.TransactionDate.Should().Be(new DateOnly(2025, 1, 10));
+    }
+}


### PR DESCRIPTION
## Summary

- `InsiderFilingParser.IsPlausibleTransactionDate` brackets a Form 4 transaction date in both directions — a year floor of 1900 and a "never after the filing date" ceiling. The existing tests pinned only the ceiling (a date after the filing is anchored to the period of report). This adds the missing lower bracket: a far-past keyed-wrong year (the doc cites `0022` as the earliest seen in production) must also be treated as implausible and anchored to the period of report, not stored verbatim and sorted to the bottom of the insider history.
- Behavior-pinning test only — no production changes. Test passes against current behavior.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseTransactionPrehistoricDateTests.cs` — new test driving `ParseTransactions` with a `0022-01-10` transaction date and asserting the stored date is anchored to the filing's period of report (2025-01-10).