### PR TITLE
test(common-stocks): add skipped repro for GH-3957 — InvestorRelationsLinkExtractor

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests.cs
@@ -1,0 +1,24 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests
+{
+    // Contract: Extract returns the URL of any anchor whose visible text or href is about
+    // investor relations. De-duplication must apply among the CANDIDATES, not across every
+    // resolved anchor — a non-IR anchor pointing at the same URL must not consume the dedup
+    // slot and silently suppress a later IR anchor to that URL. Here a generic "Company
+    // Overview" link and an "Investor Relations" link share /overview; the page clearly has an
+    // IR link, so /overview must be returned.
+    [Fact(Skip = "GH-3957 — dedup key recorded before IR classification drops a valid later IR link")]
+    public void Extract_NonIrAnchorPrecedesIrAnchorToSameUrl_StillReturnsTheIrCandidate()
+    {
+        const string html =
+            "<a href=\"/overview\">Company Overview</a>"
+            + "<a href=\"/overview\">Investor Relations</a>";
+
+        var links = InvestorRelationsLinkExtractor.Extract(html, "https://acme.com");
+
+        links.Should().ContainSingle().Which.Should().Be("https://acme.com/overview");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `InvestorRelationsLinkExtractor.Extract` discovered a real defect: a non-IR anchor pointing at a URL consumes the de-dup slot before classification, so a later anchor whose text is about investor relations and points at the same URL is silently dropped — the page's IR link is lost.
- Test is committed skipped — see GH-3957. Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests.cs` — new `[Fact(Skip = "GH-3957 …")]` pinning the expected behavior: a "Company Overview" link and an "Investor Relations" link share `/overview`, and `Extract` must still return `https://acme.com/overview` rather than an empty list.