### PR TITLE
style(common-stocks): apply CSharpier formatting to GH-3957 skip repro test

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests.cs
@@ -10,7 +10,9 @@ public class InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests
     // slot and silently suppress a later IR anchor to that URL. Here a generic "Company
     // Overview" link and an "Investor Relations" link share /overview; the page clearly has an
     // IR link, so /overview must be returned.
-    [Fact(Skip = "GH-3957 — dedup key recorded before IR classification drops a valid later IR link")]
+    [Fact(
+        Skip = "GH-3957 — dedup key recorded before IR classification drops a valid later IR link"
+    )]
     public void Extract_NonIrAnchorPrecedesIrAnchorToSameUrl_StillReturnsTheIrCandidate()
     {
         const string html =


### PR DESCRIPTION
## Summary

- The GH-3957 repro test merged in #3958 left a long `[Fact(Skip = "...")]` attribute on a single line, which CSharpier rejects.
- This broke the format-check step of the default-branch CI lint job, leaving `main` red.
- Reflowing the attribute restores a clean `dotnet csharpier check .` across all 2866 files.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests.cs` — split the long `[Fact(Skip = ...)]` attribute across multiple lines per CSharpier. Formatting only; the test stays skipped and its behavior is unchanged.