### PR TITLE
fix(common-stocks): dedup IR links among candidates, not across every anchor

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
@@ -57,16 +57,23 @@ public static class InvestorRelationsLinkExtractor
         {
             if (!TryResolveHref(baseUri, anchor.GetAttributeValue("href", ""), out var absolute))
                 continue;
-            if (!seen.Add(absolute))
-                continue;
 
             var text = HtmlEntity.DeEntitize(anchor.InnerText ?? "").Trim().ToLowerInvariant();
             var haystack = text + " " + absolute.ToLowerInvariant();
 
+            // De-duplicate among the candidates only — recording the dedup key here, after
+            // classification, means a non-IR anchor to a URL can't consume the slot and suppress
+            // a later IR anchor to that same URL (GH-3957).
             if (PrimaryKeywords.Any(haystack.Contains) || HasIrHostOrPath(absolute))
-                primary.Add(absolute);
+            {
+                if (seen.Add(absolute))
+                    primary.Add(absolute);
+            }
             else if (SecondaryKeywords.Any(haystack.Contains))
-                secondary.Add(absolute);
+            {
+                if (seen.Add(absolute))
+                    secondary.Add(absolute);
+            }
         }
 
         return primary.Concat(secondary).Take(max).ToList();

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests.cs
@@ -10,9 +10,7 @@ public class InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests
     // slot and silently suppress a later IR anchor to that URL. Here a generic "Company
     // Overview" link and an "Investor Relations" link share /overview; the page clearly has an
     // IR link, so /overview must be returned.
-    [Fact(
-        Skip = "GH-3957 — dedup key recorded before IR classification drops a valid later IR link"
-    )]
+    [Fact]
     public void Extract_NonIrAnchorPrecedesIrAnchorToSameUrl_StillReturnsTheIrCandidate()
     {
         const string html =


### PR DESCRIPTION
## Summary

- `InvestorRelationsLinkExtractor.Extract` recorded the de-dup key for every resolved anchor *before* classifying it as an IR candidate. A non-IR anchor pointing at a URL earlier in the document consumed the dedup slot, so a later anchor whose text clearly was about investor relations and pointed at the same URL was silently dropped — `Extract` returned nothing for a page that plainly had an IR link.
- The fix records the dedup key only when an anchor is actually added to a candidate list, so de-duplication applies among the candidates rather than across every anchor. Same defect class as the dedup-key-before-validation fix in `FdaCalendarParser` (GH-3861).
- Un-skips the regression test added in #3958; it failed on the old code (empty result) and now passes.

## Code changes

- `src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs` — removed the premature `seen.Add(...)` dedup before classification; each candidate now records its dedup key inside the primary/secondary branch, gating the add on first-seen.
- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDedupSuppressesLaterIrAnchorTests.cs` — removed `[Fact(Skip=...)]` so the GH-3957 regression test runs.

closes #3957