### PR TITLE
test(common-stocks): pin Extract keeps primary candidate over earlier secondary under a tight cap

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorPrimaryFirstUnderCapTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorPrimaryFirstUnderCapTests.cs
@@ -1,0 +1,21 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsLinkExtractorPrimaryFirstUnderCapTests
+{
+    // Contract: Extract returns candidates "primary signals first ... capped at max", regardless
+    // of document order. A weaker secondary signal (a SEC-filings link) appears BEFORE a strong
+    // primary signal (an "Investors" link); with max:1 the cap must keep the primary candidate,
+    // not the secondary one that happened to come first in the markup.
+    [Fact]
+    public void Extract_SecondaryAnchorPrecedesPrimaryUnderCap_KeepsThePrimary()
+    {
+        const string html =
+            "<a href=\"/sec-filings\">SEC Filings</a>" + "<a href=\"/investors\">Investors</a>";
+
+        var links = InvestorRelationsLinkExtractor.Extract(html, "https://acme.com", max: 1);
+
+        links.Should().ContainSingle().Which.Should().Be("https://acme.com/investors");
+    }
+}


### PR DESCRIPTION
## Summary

- The existing cap test (`Extract_DedupesAndCaps`) only exercises all-primary candidates, so nothing verified the contract's "primary signals first ... capped at max" ordering when a weaker secondary signal precedes a primary one in the markup.
- This pins that behavior: with `max:1` and a SEC-filings (secondary) anchor before an "Investors" (primary) anchor, the cap keeps the primary candidate.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorPrimaryFirstUnderCapTests.cs` — new single-fact test asserting primary-first ordering survives a tight `max` cap regardless of document order.