### PR TITLE
test(common-stocks): pin PageValidator requires distinct keywords, not a repeated one

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsPageValidatorDistinctKeywordTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsPageValidatorDistinctKeywordTests.cs
@@ -1,0 +1,19 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsPageValidatorDistinctKeywordTests
+{
+    // Contract: a page with no IR title phrase qualifies only on at least two DISTINCT content
+    // keywords. A single keyword repeated many times is still one distinct hit, so it must NOT
+    // qualify — repetition cannot stand in for breadth of IR signal.
+    [Fact]
+    public void IsInvestorRelationsPage_SingleKeywordRepeatedManyTimes_ReturnsFalse()
+    {
+        const string html =
+            "<html><head><title>Acme Corporation</title></head>"
+            + "<body><p>annual report</p><p>annual report</p><p>annual report</p></body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- `InvestorRelationsPageValidator.IsInvestorRelationsPage` qualifies a page with no IR title phrase only on at least two *distinct* body keywords. Existing tests cover 2-distinct→true and a single mention→false, but none verify that one keyword repeated many times still counts as a single distinct hit.
- This pins that boundary: a page whose body repeats "annual report" three times (and has no IR title phrase) is not classified as an IR page. Guards against a future occurrence-counting reimplementation passing on repetition alone.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsPageValidatorDistinctKeywordTests.cs` — new single-fact test asserting a repeated single keyword does not satisfy the two-distinct-keyword threshold.