### PR TITLE
test(common-stocks): pin CandidateBuilder dedups path segments case-insensitively

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsCandidateBuilderCaseInsensitiveDedupTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsCandidateBuilderCaseInsensitiveDedupTests.cs
@@ -1,0 +1,17 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsCandidateBuilderCaseInsensitiveDedupTests
+{
+    // Contract: results are de-duplicated CASE-INSENSITIVELY while preserving order. Two path
+    // segments differing only in case ("IR" then "ir") describe the same probe target, so only
+    // the first survives — order-preserving dedup keeps the earlier candidate with its casing.
+    [Fact]
+    public void Build_PathSegmentsDifferingOnlyByCase_DedupesKeepingTheFirst()
+    {
+        var result = InvestorRelationsCandidateBuilder.Build("https://acme.com", ["IR", "ir"], []);
+
+        result.Should().Equal("https://acme.com/IR");
+    }
+}


### PR DESCRIPTION
## Summary

- `InvestorRelationsCandidateBuilder.Build` documents that results are de-duplicated *case-insensitively* while preserving order, but the existing dedup test only exercised same-case duplicates (`["ir","ir"]`).
- This pins the case-insensitive facet: two path segments differing only in case (`"IR"` then `"ir"`) collapse to a single candidate, keeping the first occurrence with its original casing.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsCandidateBuilderCaseInsensitiveDedupTests.cs` — new single-fact test asserting case-only-differing path segments dedupe to the first.