### PR TITLE
test(congress): add skipped repro for GH-3964 — liability description without Type column

### DIFF
--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityDescriptionWithoutTypeTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityDescriptionWithoutTypeTests.cs
@@ -1,0 +1,32 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class SenateAnnualReportClientLiabilityDescriptionWithoutTypeTests
+{
+    // Contract: a liability line's description reads "Type (Creditor)" when both are present
+    // (e.g. "Mortgage (Sample Bank)"). When the Type column is absent there is no type, so the
+    // description must be the creditor alone — not an empty-type wrapper with a leading space.
+    [Fact(
+        Skip = "GH-3964 — missing Type column yields description \" (Creditor)\" instead of the creditor alone"
+    )]
+    public void ParseAnnualReportHtml_LiabilityWithoutTypeColumn_DescriptionIsCreditorAlone()
+    {
+        const string html = """
+            <html><body>
+            <h3>Part 3. Assets</h3>
+            <p>None disclosed.</p>
+            <h3>Part 7. Liabilities</h3>
+            <table>
+              <thead><tr><th>Debtor</th><th>Amount</th><th>Creditor</th></tr></thead>
+              <tbody><tr><td>Self</td><td>$100,001 - $250,000</td><td>Sample Bank</td></tr></tbody>
+            </table>
+            </body></html>
+            """;
+
+        var lines = SenateAnnualReportClient.ParseAnnualReportHtml(html);
+
+        lines.Should().ContainSingle().Which.Description.Should().Be("Sample Bank");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial coverage of `SenateAnnualReportClient.ParseLiabilityTable` for a Part 7 liability table that omits the Type column.
- The test asserts the row's description should be the creditor alone; it currently fails because the description is built as `" (Creditor)"` (leading space + empty-type parens). The existing missing-type test only asserted `.Contain("Sample Bank")`, which hid this.
- Committed **skipped — see GH-3964**; un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityDescriptionWithoutTypeTests.cs` — new `[Fact(Skip = "GH-3964 …")]` repro pinning the expected clean description for a missing-Type-column liability row.