### PR TITLE
fix(congress): use creditor alone when a liability row has no Type

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
@@ -347,7 +347,13 @@ public partial class SenateAnnualReportClient
             // above already tolerates it), so read it only when present.
             var type = typeColumn >= 0 ? CellText(cells[typeColumn]) : "";
             var creditor = CellText(cells[creditorColumn]);
-            var description = string.IsNullOrEmpty(creditor) ? type : $"{type} ({creditor})";
+            // Combine into "Type (Creditor)" only when both are present; with one missing
+            // (e.g. a table that omits the Type column) use the other alone, so the
+            // description never carries an empty-type wrapper like " (Creditor)".
+            var description =
+                string.IsNullOrEmpty(type) ? creditor
+                : string.IsNullOrEmpty(creditor) ? type
+                : $"{type} ({creditor})";
             if (string.IsNullOrEmpty(description))
                 continue;
 

--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityDescriptionWithoutTypeTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityDescriptionWithoutTypeTests.cs
@@ -8,9 +8,7 @@ public class SenateAnnualReportClientLiabilityDescriptionWithoutTypeTests
     // Contract: a liability line's description reads "Type (Creditor)" when both are present
     // (e.g. "Mortgage (Sample Bank)"). When the Type column is absent there is no type, so the
     // description must be the creditor alone — not an empty-type wrapper with a leading space.
-    [Fact(
-        Skip = "GH-3964 — missing Type column yields description \" (Creditor)\" instead of the creditor alone"
-    )]
+    [Fact]
     public void ParseAnnualReportHtml_LiabilityWithoutTypeColumn_DescriptionIsCreditorAlone()
     {
         const string html = """


### PR DESCRIPTION
## Summary

- `SenateAnnualReportClient.ParseLiabilityTable` built each liability description as `"{type} ({creditor})"` whenever a creditor was present. A Part 7 liability table that omits the Type column leaves `type` empty, so the stored description became `" (Creditor)"` — a leading space plus an empty-type parens wrapper.
- The fix combines into `"Type (Creditor)"` only when both parts are present; with either missing, it uses the other alone. Both-empty rows are still skipped exactly as before.
- Un-skips the GH-3964 regression test added in #3965 (failed on the old code, passes now).

## Code changes

- `src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs` — replace the two-way description ternary with a three-way one handling the empty-type and empty-creditor cases.
- `tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityDescriptionWithoutTypeTests.cs` — removed the `[Skip]` so the regression test runs.

closes #3964