### PR TITLE
test(congress): pin SenateAnnualReportClient rejects a lone liability amount

### DIFF
--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLoneAmountLiabilityTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLoneAmountLiabilityTests.cs
@@ -1,0 +1,30 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class SenateAnnualReportClientLoneAmountLiabilityTests
+{
+    // Contract: a liability line carries only the form's own brackets — "$X - $Y" or the
+    // open-top "Over $X". A bare single amount with no range and no "Over" is "any other cell
+    // content" and must yield no liability line.
+    [Fact]
+    public void ParseAnnualReportHtml_LiabilityAmountIsLoneValueWithoutRange_YieldsNoLiability()
+    {
+        const string html = """
+            <html><body>
+            <h3>Part 3. Assets</h3>
+            <p>None disclosed.</p>
+            <h3>Part 7. Liabilities</h3>
+            <table>
+              <thead><tr><th>Type</th><th>Amount</th><th>Creditor</th></tr></thead>
+              <tbody><tr><td>Loan</td><td>$15,000</td><td>Sample Bank</td></tr></tbody>
+            </table>
+            </body></html>
+            """;
+
+        var lines = SenateAnnualReportClient.ParseAnnualReportHtml(html);
+
+        lines.Should().NotContain(l => l.Kind == CongressionalDisclosureLineKind.Liability);
+    }
+}


### PR DESCRIPTION
## Summary

- `SenateAnnualReportClient.ParseLiabilityTable` only emits a liability line when the amount cell carries the form's brackets — a range `$X - $Y` or the open-top `Over $X`. A bare single amount with no range and no "Over" is "any other cell content" and must produce no line.
- Existing tests covered ranges and the open-top bracket but not lone-amount rejection. This pins it: a liability row with amount `$15,000` yields no liability line.

## Code changes

- `tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLoneAmountLiabilityTests.cs` — new single-fact test asserting a lone, non-range amount produces no liability line.