### PR TITLE
test(sec): pin SecHeadingKeyword.WordCount treats a non-breaking space as a separator

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/SecHeadingKeywordWordCountTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/SecHeadingKeywordWordCountTests.cs
@@ -1,0 +1,19 @@
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class SecHeadingKeywordWordCountTests
+{
+    // Contract (from the doc-comment): WordCount is a whitespace-delimited word count in which
+    // EDGAR's non-breaking space (U+00A0) "counts as a separator like any other Unicode
+    // whitespace". A header whose keyword and identifier are joined only by an nbsp must still
+    // count as two words — pins that the split sees all Unicode whitespace, not just ASCII
+    // spaces, so a refactor to Split(' ') (which would undercount this to one) is caught.
+    [Fact]
+    public void WordCount_NonBreakingSpaceSeparator_CountsTokensOnBothSides()
+    {
+        var count = SecHeadingKeyword.WordCount("Item\u00A01A");
+
+        count.Should().Be(2, "U+00A0 is Unicode whitespace and must separate 'Item' from '1A'");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the documented contract of `SecHeadingKeyword.WordCount` that EDGAR's non-breaking space (U+00A0) counts as a word separator like any other Unicode whitespace.
- `WordCount` had no direct test; this guards against a refactor to an ASCII-only split (e.g. `Split(' ')`) that would silently undercount nbsp-joined "Part"/"Item" headers and break the header-vs-prose discriminator.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/SecHeadingKeywordWordCountTests.cs` — new unit test asserting `WordCount("Item 1A") == 2`, i.e. a non-breaking space separates the keyword from its identifier.