### PR TITLE
feat(sec): replace a document's content in place, keeping its id

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -8,6 +8,7 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Models;
 using Equibles.Sec.Repositories;
 using MassTransit;
+using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.HostedService.Services;
 
@@ -16,16 +17,19 @@ public class DocumentPersistenceService : IDocumentPersistenceService
     private const int MaxFileNameLength = 256;
 
     private readonly DocumentRepository _documentRepository;
+    private readonly ChunkRepository _chunkRepository;
     private readonly IFileManager _fileManager;
     private readonly IBus _bus;
 
     public DocumentPersistenceService(
         DocumentRepository documentRepository,
+        ChunkRepository chunkRepository,
         IFileManager fileManager,
         IBus bus
     )
     {
         _documentRepository = documentRepository;
+        _chunkRepository = chunkRepository;
         _fileManager = fileManager;
         _bus = bus;
     }
@@ -103,6 +107,36 @@ public class DocumentPersistenceService : IDocumentPersistenceService
     {
         await ApplyXbrlCapture(document, xbrl ?? XbrlCaptureResult.NotChecked);
         await _documentRepository.SaveChanges();
+    }
+
+    public async Task ReplaceContent(
+        Document document,
+        byte[] content,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var transaction = await _documentRepository.CreateTransaction(
+            IsolationLevel.ReadCommitted,
+            cancellationToken
+        );
+
+        // Swap in a new content file and recount lines. The document keeps its id, so every soft
+        // reference to it (e.g. an earnings call's TranscriptDocumentId) stays valid with no re-link.
+        var fileName = document.Content?.NameWithExtension ?? $"{document.Id}.txt";
+        var file = await _fileManager.SaveFile(content, fileName);
+        document.Content = file;
+        document.LineCount = Encoding.UTF8.GetString(content).Split('\n').Length;
+        _documentRepository.Update(document);
+
+        // Drop the stale chunks (their embeddings cascade at the DB level) so the chunking worker,
+        // which polls for documents that have no chunks, re-chunks the new body on its next pass.
+        await _chunkRepository
+            .GetAll()
+            .Where(c => c.DocumentId == document.Id)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        await _documentRepository.SaveChanges();
+        await transaction.CommitAsync(cancellationToken);
     }
 
     // Stores the captured XBRL envelope as a gzip-compressed internal File and records its

--- a/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
@@ -33,4 +33,17 @@ public interface IDocumentPersistenceService
     /// ingested before capture was enabled.
     /// </summary>
     Task UpdateXbrl(Document document, XbrlCaptureResult xbrl);
+
+    /// <summary>
+    /// Replaces the body of an already-persisted <see cref="Document"/> in place, keeping its id —
+    /// so soft references to it (e.g. an earnings call's TranscriptDocumentId) stay valid with no
+    /// re-link — and dropping its stale chunks (their embeddings cascade) so the chunking worker
+    /// re-chunks the new body on its next pass. Used when a document's source data is re-derived,
+    /// e.g. an audio transcript regenerated after its speakers are re-resolved.
+    /// </summary>
+    Task ReplaceContent(
+        Document document,
+        byte[] content,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceSaveTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceSaveTests.cs
@@ -86,6 +86,7 @@ public class DocumentPersistenceServiceSaveTests : ParadeDbMcpTestBase
         var bus = Substitute.For<IBus>();
         var sut = new DocumentPersistenceService(
             new DocumentRepository(DbContext),
+            new ChunkRepository(DbContext),
             fileManager,
             bus
         );

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceTests.cs
@@ -98,7 +98,12 @@ public class DocumentPersistenceServiceTests : IDisposable
             .Returns(savedFile);
 
         var documentRepo = new DocumentRepository(_dbContext);
-        var sut = new DocumentPersistenceService(documentRepo, fileManager, Substitute.For<IBus>());
+        var sut = new DocumentPersistenceService(
+            documentRepo,
+            new ChunkRepository(_dbContext),
+            fileManager,
+            Substitute.For<IBus>()
+        );
 
         var content = Encoding.UTF8.GetBytes("First line\nSecond line\nThird line");
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
@@ -46,6 +46,7 @@ public class DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests : Parade
         await using var ctx = Fixture.CreateDbContext();
         var service = new DocumentPersistenceService(
             new DocumentRepository(ctx),
+            new ChunkRepository(ctx),
             fileManager,
             Substitute.For<IBus>()
         );

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceXbrlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceXbrlTests.cs
@@ -53,6 +53,7 @@ public class DocumentPersistenceServiceXbrlTests : ParadeDbMcpTestBase
     private DocumentPersistenceService BuildSut() =>
         new(
             new DocumentRepository(DbContext),
+            new ChunkRepository(DbContext),
             new FileManager(new FileRepository(DbContext)),
             Substitute.For<IBus>()
         );

--- a/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceSkippedCeilingTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceSkippedCeilingTests.cs
@@ -83,6 +83,7 @@ public class XbrlBackfillServiceSkippedCeilingTests : ParadeDbMcpTestBase
         var repo = new DocumentRepository(DbContext);
         var persistence = new DocumentPersistenceService(
             repo,
+            new ChunkRepository(DbContext),
             new FileManager(new FileRepository(DbContext)),
             Substitute.For<IBus>()
         );

--- a/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
@@ -90,6 +90,7 @@ public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
         var repo = new DocumentRepository(DbContext);
         var persistence = new DocumentPersistenceService(
             repo,
+            new ChunkRepository(DbContext),
             new FileManager(new FileRepository(DbContext)),
             Substitute.For<IBus>()
         );
@@ -205,6 +206,7 @@ public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
         var repo = new DocumentRepository(DbContext);
         var persistence = new DocumentPersistenceService(
             repo,
+            new ChunkRepository(DbContext),
             new FileManager(new FileRepository(DbContext)),
             Substitute.For<IBus>()
         );


### PR DESCRIPTION
## Summary

Adds `DocumentPersistenceService.ReplaceContent(document, content)` — swaps a persisted `Document`'s content file and recomputes its line count, and drops its stale `Chunk` rows (their `Embedding` rows cascade at the DB level) so the polling chunk worker re-chunks the new body on its next pass.

The document keeps its id, so every soft reference to it stays valid with no re-link, and BM25/keyword search reflects the new body once re-chunked. This is the in-place alternative to delete-then-insert (which would change the id and orphan references).

## Code changes

- `IDocumentPersistenceService` / `DocumentPersistenceService` — new `ReplaceContent`; inject `ChunkRepository` to drop stale chunks. Runs in a transaction: new content file → swap `Content` + `LineCount` → `ExecuteDelete` the document's chunks → save.
- Integration tests — updated existing `new DocumentPersistenceService(...)` call sites for the new `ChunkRepository` constructor argument.

## Notes

- Uses `ExecuteDeleteAsync` (relational), exercised by the Testcontainers tier, not InMemory.
- No `DocumentSaved` republish: chunking is poll-based (`DocumentProcessorWorker` over documents with no chunks), so deleting the chunks is enough to trigger a re-chunk.