### PR TITLE
feat(errors): add Alvis error source for agent run failures

### DIFF
--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -33,6 +33,7 @@ public sealed class ErrorSource
     public static readonly ErrorSource InvestorRelationsScraper = new("InvestorRelationsScraper");
     public static readonly ErrorSource FdaCatalystScraper = new("FdaCatalystScraper");
     public static readonly ErrorSource Authentication = new("Authentication");
+    public static readonly ErrorSource Alvis = new("Alvis");
     public static readonly ErrorSource Other = new("Other");
 
     public static IEnumerable<ErrorSource> GetAll() =>
@@ -60,6 +61,7 @@ public sealed class ErrorSource
             InvestorRelationsScraper,
             FdaCatalystScraper,
             Authentication,
+            Alvis,
             Other,
         ];
 


### PR DESCRIPTION
## Summary

Adds an `Alvis` value to the `ErrorSource` smart enum so failures from the ALVIS agent runtime can be recorded and triaged distinctly from scraper/auth errors. Including it in `GetAll()` makes it appear in the backoffice Errors source filter and dashboard counts.

## Code changes

- `src/Equibles.Errors.Data/Models/ErrorSource.cs` — new `Alvis` static source, added to `GetAll()`.