### PR TITLE
refactor(sec): share the XBRL backfill work-set via DocumentRepository

### DIFF
--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -96,6 +96,14 @@ public class Document
     public int XbrlCaptureAttempts { get; set; }
 
     /// <summary>
+    /// Retry ceiling for <see cref="XbrlCaptureAttempts"/>: once a
+    /// <see cref="XbrlCaptureStatus.NotChecked"/> document has failed to reach a terminal
+    /// capture this many times it leaves the backfill working set, so a permanently
+    /// unfetchable filing can't starve the rest of the queue.
+    /// </summary>
+    public const int MaxXbrlCaptureAttempts = 5;
+
+    /// <summary>
     /// Version of the dimensional-fact extractor that last processed this document's
     /// captured XBRL envelope. 0 = never extracted; the extraction sweep selects
     /// <see cref="XbrlCaptureStatus.Captured"/> documents whose version is below the

--- a/src/Equibles.Sec.HostedService/Services/XbrlBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/XbrlBackfillService.cs
@@ -18,11 +18,6 @@ namespace Equibles.Sec.HostedService.Services;
 /// </summary>
 public class XbrlBackfillService
 {
-    // After this many failed cycles a document is no longer selected, so a permanently
-    // unfetchable filing (deleted/superseded on EDGAR, unparseable) can't sit at the head of
-    // the newest-first queue and starve every older document behind it.
-    private const int MaxAttempts = 5;
-
     // Rows ingested before AccessionNumber existed carry it only inside the stored EDGAR
     // full-submission URL (https://www.sec.gov/Archives/edgar/data/{cik}/{accession}.txt).
     // The accession is the file name; recovering it makes those rows backfillable.
@@ -64,22 +59,10 @@ public class XbrlBackfillService
             return result;
         }
 
-        // Only documents that came from a filing and whose issuer has a CIK qualify: either
-        // they carry the accession directly, or it can be recovered from the stored EDGAR
-        // submission URL (rows ingested before AccessionNumber existed). Non-EDGAR documents
-        // (e.g. earnings-call transcripts) have neither and are never selected. Documents
-        // that have exhausted their retry ceiling are dropped from the working set so they
-        // can't block the queue. Newest first so recent filings fill in soonest.
-        var query = _documentRepository
-            .GetByXbrlStatus(XbrlCaptureStatus.NotChecked)
-            .Where(d =>
-                (
-                    d.AccessionNumber != null
-                    || (d.SourceUrl != null && d.SourceUrl.Contains("/Archives/edgar/data/"))
-                )
-                && d.CommonStock.Cik != null
-                && d.XbrlCaptureAttempts < MaxAttempts
-            );
+        // The repository defines the work-set (EDGAR-sourced, issuer has a CIK, under the
+        // retry ceiling). Apply the optional minimum-reporting-date floor on top, then take the
+        // newest first so recent filings fill in soonest.
+        var query = _documentRepository.GetPendingXbrlBackfill();
 
         if (minReportingDate.HasValue)
         {

--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -50,6 +50,29 @@ public class DocumentRepository : BaseRepository<Document>
         return GetAll().Where(d => d.XbrlStatus == status);
     }
 
+    /// <summary>
+    /// The XBRL backfill work-set: the <see cref="XbrlCaptureStatus.NotChecked"/> documents the
+    /// backfill will actually select. A document qualifies only when it came from an EDGAR filing
+    /// — the accession is stored directly, or recoverable from the stored EDGAR submission URL
+    /// (rows ingested before AccessionNumber existed) — and its issuer has a CIK. Non-EDGAR
+    /// documents (e.g. earnings-call transcripts) are NotChecked but have no filing to re-fetch,
+    /// so they are never selected and must not count as pending work. Documents that have
+    /// exhausted their retry ceiling are excluded too, since they can no longer be reselected.
+    /// This is the single definition of "pending backfill" shared by the worker and the dashboard.
+    /// </summary>
+    public IQueryable<Document> GetPendingXbrlBackfill()
+    {
+        return GetByXbrlStatus(XbrlCaptureStatus.NotChecked)
+            .Where(d =>
+                (
+                    d.AccessionNumber != null
+                    || (d.SourceUrl != null && d.SourceUrl.Contains("/Archives/edgar/data/"))
+                )
+                && d.CommonStock.Cik != null
+                && d.XbrlCaptureAttempts < Document.MaxXbrlCaptureAttempts
+            );
+    }
+
     public async Task<Document> GetWithContent(Guid id)
     {
         // The content bytes ride along eagerly: leaving File.FileContent to a lazy load

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceXbrlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceXbrlTests.cs
@@ -53,6 +53,7 @@ public class DocumentPersistenceServiceXbrlTests : ParadeDbMcpTestBase
     private DocumentPersistenceService BuildSut() =>
         new(
             new DocumentRepository(DbContext),
+            new ChunkRepository(DbContext),
             new FileManager(new FileRepository(DbContext)),
             Substitute.For<IBus>()
         );

--- a/tests/Equibles.IntegrationTests/Sec/DocumentRepositoryGetPendingXbrlBackfillTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentRepositoryGetPendingXbrlBackfillTests.cs
@@ -125,10 +125,7 @@ public class DocumentRepositoryGetPendingXbrlBackfillTests : ParadeDbMcpTestBase
         await using var verify = Fixture.CreateDbContext();
         var sut = new DocumentRepository(verify);
 
-        var pending = await sut.GetPendingXbrlBackfill()
-            .Where(d => d.CommonStock.Cik == "0000320193" || d.CommonStock.Ticker == "NOCIK")
-            .AsNoTracking()
-            .ToListAsync();
+        var pending = await sut.GetPendingXbrlBackfill().AsNoTracking().ToListAsync();
 
         pending
             .Select(d => d.Id)

--- a/tests/Equibles.IntegrationTests/Sec/DocumentRepositoryGetPendingXbrlBackfillTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentRepositoryGetPendingXbrlBackfillTests.cs
@@ -1,0 +1,138 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins <see cref="DocumentRepository.GetPendingXbrlBackfill"/>: the backfill work-set the
+/// worker actually selects and the dashboard "XBRL backfill pending" stat counts. The guard is
+/// that a <see cref="XbrlCaptureStatus.NotChecked"/> document only qualifies when it has a
+/// re-fetchable EDGAR filing (accession, or an EDGAR submission URL) and a CIK, and hasn't
+/// exhausted its retry ceiling. Without this, non-EDGAR documents (e.g. earnings-call
+/// transcripts) — which are NotChecked but have no filing to fetch — inflate the pending count
+/// and make the backfill look permanently stuck.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class DocumentRepositoryGetPendingXbrlBackfillTests : ParadeDbMcpTestBase
+{
+    public DocumentRepositoryGetPendingXbrlBackfillTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static File NewContent()
+    {
+        return new File
+        {
+            Name = "content",
+            Extension = "txt",
+            ContentType = "text/plain",
+            Size = 4,
+            FileContent = new() { Bytes = "body"u8.ToArray() },
+        };
+    }
+
+    [Fact]
+    public async Task GetPendingXbrlBackfill_ReturnsOnlyReFetchableNotCheckedDocuments()
+    {
+        var withCik = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var withoutCik = new CommonStock { Ticker = "NOCIK", Name = "No Cik Inc." };
+
+        // Qualifies: NotChecked, carries an accession, issuer has a CIK, under the ceiling.
+        var eligibleByAccession = new Document
+        {
+            CommonStock = withCik,
+            Content = NewContent(),
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 2, 1),
+            AccessionNumber = "0000320193-24-000001",
+            XbrlStatus = XbrlCaptureStatus.NotChecked,
+        };
+        // Qualifies: accession is null but recoverable from the EDGAR submission URL.
+        var eligibleByEdgarUrl = new Document
+        {
+            CommonStock = withCik,
+            Content = NewContent(),
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 1, 1),
+            SourceUrl = "https://www.sec.gov/Archives/edgar/data/320193/0000320193-24-000002.txt",
+            XbrlStatus = XbrlCaptureStatus.NotChecked,
+        };
+        // Excluded: non-EDGAR document (transcript) — NotChecked but no filing to fetch. This is
+        // the row class that was inflating the dashboard's pending count.
+        var nonEdgar = new Document
+        {
+            CommonStock = withCik,
+            Content = NewContent(),
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 3, 1),
+            SourceUrl = "https://www.alphavantage.co/query?function=EARNINGS_CALL_TRANSCRIPT",
+            XbrlStatus = XbrlCaptureStatus.NotChecked,
+        };
+        // Excluded: issuer has no CIK, so the filing can't be re-fetched.
+        var missingCik = new Document
+        {
+            CommonStock = withoutCik,
+            Content = NewContent(),
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 2, 1),
+            AccessionNumber = "0000000000-24-000003",
+            XbrlStatus = XbrlCaptureStatus.NotChecked,
+        };
+        // Excluded: exhausted its retry ceiling, so it can no longer be reselected.
+        var exhausted = new Document
+        {
+            CommonStock = withCik,
+            Content = NewContent(),
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 2, 1),
+            AccessionNumber = "0000320193-24-000004",
+            XbrlStatus = XbrlCaptureStatus.NotChecked,
+            XbrlCaptureAttempts = Document.MaxXbrlCaptureAttempts,
+        };
+        // Excluded: already terminal (captured), not pending.
+        var captured = new Document
+        {
+            CommonStock = withCik,
+            Content = NewContent(),
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 2, 1),
+            AccessionNumber = "0000320193-24-000005",
+            XbrlStatus = XbrlCaptureStatus.Captured,
+        };
+
+        DbContext.AddRange(
+            withCik,
+            withoutCik,
+            eligibleByAccession,
+            eligibleByEdgarUrl,
+            nonEdgar,
+            missingCik,
+            exhausted,
+            captured
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new DocumentRepository(verify);
+
+        var pending = await sut.GetPendingXbrlBackfill()
+            .Where(d => d.CommonStock.Cik == "0000320193" || d.CommonStock.Ticker == "NOCIK")
+            .AsNoTracking()
+            .ToListAsync();
+
+        pending
+            .Select(d => d.Id)
+            .Should()
+            .BeEquivalentTo([eligibleByAccession.Id, eligibleByEdgarUrl.Id]);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceSkippedCeilingTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceSkippedCeilingTests.cs
@@ -105,7 +105,7 @@ public class XbrlBackfillServiceSkippedCeilingTests : ParadeDbMcpTestBase
     [Fact]
     public async Task Backfill_DocumentStuckOnSkippedPath_StopsBeingSelectedAfterRetryCeiling()
     {
-        const int maxAttempts = 5;
+        const int maxAttempts = Document.MaxXbrlCaptureAttempts;
         var company = await SeedCompany();
         await SeedDocument(company.Id, "STUCK-SKIPPED", new DateOnly(2024, 3, 1));
         DbContext.ChangeTracker.Clear();


### PR DESCRIPTION
## Summary

Centralizes the definition of the XBRL backfill *work-set* — the `NotChecked` documents the backfill can actually process — so the worker and any reporting consumer share one source of truth.

A document qualifies only when it came from an EDGAR filing (accession stored directly, or recoverable from the stored EDGAR submission URL), its issuer has a CIK, and it hasn't exhausted the retry ceiling. Non-EDGAR documents (e.g. earnings-call transcripts) are `NotChecked` but have no filing to re-fetch, so they are never selected — and must not be counted as pending work.

This unblocks a commercial-side fix where the backoffice dashboard's "XBRL backfill pending" stat was counting *all* `NotChecked` rows (~77k, ~99% of them non-EDGAR transcripts that the worker never touches), making the backfill look permanently stuck.

> Stacked on `feat/alvis-error-source` (the commit the commercial submodule currently pins) so the diff is just these two commits; cherry-pick onto `main` when that branch lands.

## Code changes

- **`DocumentRepository.GetPendingXbrlBackfill()`** — new query encoding the work-set predicate (single source of truth).
- **`XbrlBackfillService`** — now consumes `GetPendingXbrlBackfill()` instead of inlining the predicate; no change to what the worker selects.
- **`Document.MaxXbrlCaptureAttempts`** — retry ceiling moved onto the model (was a private const in the service).
- **`DocumentRepositoryGetPendingXbrlBackfillTests`** — pins the work-set, including that non-EDGAR `NotChecked` documents are excluded.
- **`DocumentPersistenceServiceXbrlTests`** — fix a pre-existing compile break (stale three-argument `DocumentPersistenceService` constructor) so the integration project builds.

## Tests

Affected Sec XBRL integration tests pass against real ParadeDB (12 passed / 0 failed); csharpier clean.