### PR TITLE
fix(worker): back off briefly on a faulted cycle instead of sleeping the full interval

### DIFF
--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -18,6 +18,7 @@ public abstract class BaseScraperWorker : BackgroundService
 
     private bool _retrySoonRequested;
     private bool _continuationRequested;
+    private int _consecutiveFailures;
 
     protected abstract string WorkerName { get; }
     protected abstract TimeSpan SleepInterval { get; }
@@ -104,6 +105,23 @@ public abstract class BaseScraperWorker : BackgroundService
     /// </summary>
     protected void RequestImmediateContinuation() => _continuationRequested = true;
 
+    /// <summary>
+    /// Base wait after a cycle that FAULTED (DoWork threw). Short by design so a transient
+    /// dependency outage — e.g. the database bouncing during a deploy — costs minutes, not
+    /// the full <see cref="SleepInterval"/>. The wait grows exponentially per consecutive
+    /// failure (see <see cref="ErrorBackoff"/>), capped by <see cref="MaxErrorBackoffInterval"/>,
+    /// and a clean cycle resets the streak. Without this a single throw parked the worker for
+    /// a whole <see cref="SleepInterval"/> (up to hours), abandoning any backlog it was draining.
+    /// </summary>
+    protected virtual TimeSpan ErrorBackoffInterval => TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Upper bound for the exponential <see cref="ErrorBackoffInterval"/> growth. A faulted cycle
+    /// never waits longer than this — nor longer than <see cref="SleepInterval"/>, whichever is
+    /// smaller — so a prolonged outage backs off in bounded steps instead of hammering.
+    /// </summary>
+    protected virtual TimeSpan MaxErrorBackoffInterval => TimeSpan.FromMinutes(15);
+
     protected BaseScraperWorker(
         ILogger logger,
         IServiceScopeFactory scopeFactory,
@@ -153,6 +171,7 @@ public abstract class BaseScraperWorker : BackgroundService
             Logger.LogInformation("{Worker} running at: {Time}", WorkerName, DateTimeOffset.Now);
             _retrySoonRequested = false;
             _continuationRequested = false;
+            var faulted = false;
 
             await PublishActivity(ScraperActivitySeverity.Info, "cycle started", stoppingToken);
 
@@ -172,6 +191,12 @@ public abstract class BaseScraperWorker : BackgroundService
             }
             catch (Exception ex)
             {
+                // A faulted cycle backs off briefly and retries instead of sleeping the full
+                // SleepInterval — a transient outage (e.g. the DB bouncing during a deploy)
+                // must not park the worker for hours. ErrorReporter.Report is best-effort and
+                // never throws, so the backoff path below always runs.
+                faulted = true;
+                _consecutiveFailures++;
                 Logger.LogCritical(ex, "Critical error in {Worker}", WorkerName);
                 // ErrorReporter publishes its own ScraperActivity with the same
                 // source + the error message, so the activity feed gets a row
@@ -185,47 +210,68 @@ public abstract class BaseScraperWorker : BackgroundService
             }
 
             TimeSpan interval;
-            if (_retrySoonRequested)
+            if (faulted)
             {
-                interval = NotReadyRetryInterval;
-                Logger.LogInformation(
-                    "{Worker} not ready (dependency pending); retrying in {Interval}",
+                interval = ErrorBackoff();
+                Logger.LogWarning(
+                    "{Worker} cycle failed ({Failures} in a row); backing off {Interval} before retry",
                     WorkerName,
-                    interval
+                    _consecutiveFailures,
+                    FormatInterval(interval)
                 );
                 await PublishActivity(
                     ScraperActivitySeverity.Warn,
-                    $"not ready, retrying in {FormatInterval(interval)}",
-                    stoppingToken
-                );
-            }
-            else if (_continuationRequested)
-            {
-                interval = ContinuationInterval;
-                Logger.LogInformation(
-                    "{Worker} has more work queued; continuing in {Interval}",
-                    WorkerName,
-                    interval
-                );
-                await PublishActivity(
-                    ScraperActivitySeverity.Info,
-                    $"more work queued, continuing in {FormatInterval(interval)}",
+                    $"cycle failed, retrying in {FormatInterval(interval)}",
                     stoppingToken
                 );
             }
             else
             {
-                interval = SleepInterval;
-                Logger.LogInformation(
-                    "{Worker} cycle complete. Sleeping for {Interval}",
-                    WorkerName,
-                    interval
-                );
-                await PublishActivity(
-                    ScraperActivitySeverity.Info,
-                    $"cycle complete, sleeping {FormatInterval(interval)}",
-                    stoppingToken
-                );
+                // A clean cycle clears the failure streak, so the next fault starts
+                // again from the base ErrorBackoffInterval.
+                _consecutiveFailures = 0;
+                if (_retrySoonRequested)
+                {
+                    interval = NotReadyRetryInterval;
+                    Logger.LogInformation(
+                        "{Worker} not ready (dependency pending); retrying in {Interval}",
+                        WorkerName,
+                        interval
+                    );
+                    await PublishActivity(
+                        ScraperActivitySeverity.Warn,
+                        $"not ready, retrying in {FormatInterval(interval)}",
+                        stoppingToken
+                    );
+                }
+                else if (_continuationRequested)
+                {
+                    interval = ContinuationInterval;
+                    Logger.LogInformation(
+                        "{Worker} has more work queued; continuing in {Interval}",
+                        WorkerName,
+                        interval
+                    );
+                    await PublishActivity(
+                        ScraperActivitySeverity.Info,
+                        $"more work queued, continuing in {FormatInterval(interval)}",
+                        stoppingToken
+                    );
+                }
+                else
+                {
+                    interval = SleepInterval;
+                    Logger.LogInformation(
+                        "{Worker} cycle complete. Sleeping for {Interval}",
+                        WorkerName,
+                        interval
+                    );
+                    await PublishActivity(
+                        ScraperActivitySeverity.Info,
+                        $"cycle complete, sleeping {FormatInterval(interval)}",
+                        stoppingToken
+                    );
+                }
             }
             await WaitForNextCycle(interval, stoppingToken);
         }
@@ -238,6 +284,21 @@ public abstract class BaseScraperWorker : BackgroundService
         if (interval.TotalMinutes >= 1)
             return $"{interval.TotalMinutes.ToString("0.#", CultureInfo.InvariantCulture)}m";
         return $"{interval.TotalSeconds.ToString("0", CultureInfo.InvariantCulture)}s";
+    }
+
+    /// <summary>
+    /// Exponential backoff for consecutive faulted cycles: <see cref="ErrorBackoffInterval"/>
+    /// doubled once per consecutive failure, capped at the smaller of <see cref="SleepInterval"/>
+    /// and <see cref="MaxErrorBackoffInterval"/>. Called with <see cref="_consecutiveFailures"/>
+    /// already incremented, so the first failure waits exactly one base interval.
+    /// </summary>
+    private TimeSpan ErrorBackoff()
+    {
+        var cap = SleepInterval < MaxErrorBackoffInterval ? SleepInterval : MaxErrorBackoffInterval;
+        // Cap the doublings so the shift can't overflow a long; this is far past the cap anyway.
+        var doublings = Math.Min(_consecutiveFailures - 1, 16);
+        var scaledTicks = ErrorBackoffInterval.Ticks * (1L << doublings);
+        return TimeSpan.FromTicks(Math.Min(scaledTicks, cap.Ticks));
     }
 
     /// <summary>

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerErrorBackoffActivityTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerErrorBackoffActivityTests.cs
@@ -1,0 +1,105 @@
+#nullable enable
+
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Messaging.Contracts.Activity;
+using Equibles.Worker;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.Core;
+
+namespace Equibles.UnitTests.Worker;
+
+public class BaseScraperWorkerErrorBackoffActivityTests
+{
+    // A faulted cycle must publish a **Warn**-severity ScraperActivity whose message starts
+    // with "cycle failed, retrying in ...", so the live activity feed shows the worker hit a
+    // transient error and is backing off (not the default Info "cycle complete, sleeping ...").
+    // A refactor that hardcoded Info here would silently hide repeated failures on the feed.
+    [Fact]
+    public async Task ExecuteAsync_FaultedCycle_PublishesWarnActivityWithCycleFailedMessage()
+    {
+        var bus = Substitute.For<IBus>();
+        var scope = Substitute.For<IServiceScope>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBus)).Returns(bus);
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+        var errorReporter = new ErrorReporter(
+            scopeFactory,
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+
+        using var worker = new FaultingTestWorker(
+            Substitute.For<ILogger>(),
+            scopeFactory,
+            errorReporter,
+            // Long intervals: we detect the publish then stop, so the worker is parked in
+            // the backoff wait — no real waiting is observed.
+            sleepInterval: TimeSpan.FromHours(1),
+            errorBackoffInterval: TimeSpan.FromHours(1)
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitUntil(() =>
+            bus.ReceivedCalls()
+                .Any(c =>
+                    c.GetMethodInfo().Name == nameof(IBus.Publish)
+                    && Captured(c).Message.StartsWith("cycle failed", StringComparison.Ordinal)
+                )
+        );
+        await worker.StopAsync(CancellationToken.None);
+
+        var cycleFailed = bus.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IBus.Publish))
+            .Select(Captured)
+            .Where(a => a.Message.StartsWith("cycle failed", StringComparison.Ordinal))
+            .ToList();
+
+        cycleFailed
+            .Should()
+            .Contain(a =>
+                a.Source == "FaultingTestWorker" && a.Severity == ScraperActivitySeverity.Warn
+            );
+    }
+
+    private static ScraperActivity Captured(ICall call) => (ScraperActivity)call.GetArguments()[0]!;
+
+    private static async Task WaitUntil(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+                return;
+            await Task.Delay(10);
+        }
+    }
+
+    private sealed class FaultingTestWorker : BaseScraperWorker
+    {
+        protected override string WorkerName => "FaultingTestWorker";
+        protected override TimeSpan SleepInterval { get; }
+        protected override TimeSpan ErrorBackoffInterval { get; }
+        protected override ErrorSource ErrorSource => ErrorSource.Other;
+
+        public FaultingTestWorker(
+            ILogger logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            TimeSpan sleepInterval,
+            TimeSpan errorBackoffInterval
+        )
+            : base(logger, scopeFactory, errorReporter)
+        {
+            SleepInterval = sleepInterval;
+            ErrorBackoffInterval = errorBackoffInterval;
+        }
+
+        protected override Task DoWork(CancellationToken stoppingToken) =>
+            throw new InvalidOperationException("boom");
+    }
+}

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerErrorBackoffTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerErrorBackoffTests.cs
@@ -1,0 +1,237 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Worker;
+
+// A cycle whose DoWork throws (e.g. a transient DB outage while a deploy bounces the
+// database) must back off briefly and retry, NOT sleep the full SleepInterval. Before
+// this, a single throw parked the worker for a whole SleepInterval (6h for the IR-flow
+// and webcast workers), abandoning any backlog it was draining — the worker stayed "up"
+// but did no work for hours. These tests pin the backoff value, its exponential growth,
+// the cap, and the reset-on-success, by capturing the interval the loop chose rather than
+// racing a real clock.
+public class BaseScraperWorkerErrorBackoffTests
+{
+    [Fact]
+    public async Task FaultedCycle_WaitsErrorBackoff_NotFullSleepInterval()
+    {
+        var backoff = TimeSpan.FromMilliseconds(5);
+        var parked = new TaskCompletionSource();
+        using var worker = new TestWorker(
+            sleepInterval: TimeSpan.FromHours(1),
+            errorBackoffInterval: backoff,
+            doWork: (cycle, _, stoppingToken) =>
+            {
+                if (cycle == 1)
+                    throw new InvalidOperationException("boom");
+                parked.TrySetResult();
+                return Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await parked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        worker
+            .Waits.Should()
+            .ContainSingle("the faulted cycle chooses exactly one wait before retrying")
+            .Which.Should()
+            .Be(backoff, "a faulted cycle backs off briefly, not for the full SleepInterval");
+    }
+
+    [Fact]
+    public async Task FaultedCycle_UsesErrorBackoff_EvenWhenContinuationRequested()
+    {
+        var backoff = TimeSpan.FromMilliseconds(5);
+        var parked = new TaskCompletionSource();
+        using var worker = new TestWorker(
+            sleepInterval: TimeSpan.FromHours(1),
+            errorBackoffInterval: backoff,
+            continuationInterval: TimeSpan.FromHours(2),
+            doWork: (cycle, worker, stoppingToken) =>
+            {
+                if (cycle == 1)
+                {
+                    // Request a fast continuation, then fault after it: the fault must win.
+                    worker.CallRequestImmediateContinuation();
+                    throw new InvalidOperationException("boom after requesting continuation");
+                }
+                parked.TrySetResult();
+                return Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await parked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        worker
+            .Waits.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(
+                backoff,
+                "a faulted cycle backs off even if it had requested an immediate continuation"
+            );
+    }
+
+    [Fact]
+    public async Task ConsecutiveFaults_BackOffExponentially_CappedAtMax()
+    {
+        var parked = new TaskCompletionSource();
+        using var worker = new TestWorker(
+            sleepInterval: TimeSpan.FromHours(6),
+            errorBackoffInterval: TimeSpan.FromMinutes(1),
+            maxErrorBackoffInterval: TimeSpan.FromMinutes(4),
+            doWork: (cycle, _, stoppingToken) =>
+            {
+                if (cycle <= 5)
+                    throw new InvalidOperationException($"boom {cycle}");
+                parked.TrySetResult();
+                return Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await parked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        // 1 * 2^0, 2^1, 2^2, then capped at 4m (8m, 16m clamped down).
+        worker
+            .Waits.Should()
+            .Equal(
+                TimeSpan.FromMinutes(1),
+                TimeSpan.FromMinutes(2),
+                TimeSpan.FromMinutes(4),
+                TimeSpan.FromMinutes(4),
+                TimeSpan.FromMinutes(4)
+            );
+    }
+
+    [Fact]
+    public async Task SuccessfulCycle_ResetsBackoff_SoNextFaultStartsFromBase()
+    {
+        var sleep = TimeSpan.FromHours(6);
+        var parked = new TaskCompletionSource();
+        using var worker = new TestWorker(
+            sleepInterval: sleep,
+            errorBackoffInterval: TimeSpan.FromMinutes(1),
+            maxErrorBackoffInterval: TimeSpan.FromHours(1),
+            doWork: (cycle, _, stoppingToken) =>
+            {
+                // fault, fault, succeed, fault, then park.
+                if (cycle is 1 or 2 or 4)
+                    throw new InvalidOperationException($"boom {cycle}");
+                if (cycle == 3)
+                    return Task.CompletedTask;
+                parked.TrySetResult();
+                return Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await parked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        // Fault 1m, fault 2m, success sleeps the full interval and clears the streak,
+        // so the next fault starts again from the 1m base (not 4m).
+        worker
+            .Waits.Should()
+            .Equal(
+                TimeSpan.FromMinutes(1),
+                TimeSpan.FromMinutes(2),
+                sleep,
+                TimeSpan.FromMinutes(1)
+            );
+    }
+
+    [Fact]
+    public async Task ManyConsecutiveFaults_StayPinnedAtCap_AndNeverOverflow()
+    {
+        var cap = TimeSpan.FromMilliseconds(100);
+        var parked = new TaskCompletionSource();
+        using var worker = new TestWorker(
+            sleepInterval: TimeSpan.FromHours(1),
+            errorBackoffInterval: TimeSpan.FromMilliseconds(1),
+            maxErrorBackoffInterval: cap,
+            doWork: (cycle, _, stoppingToken) =>
+            {
+                if (cycle <= 20)
+                    throw new InvalidOperationException($"boom {cycle}");
+                parked.TrySetResult();
+                return Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await parked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        // The doublings clamp keeps the shift from overflowing across a long fault streak:
+        // every wait stays a positive value within the cap, and the tail pins at the cap.
+        worker.Waits.Should().HaveCount(20);
+        worker.Waits.Should().OnlyContain(wait => wait > TimeSpan.Zero && wait <= cap);
+        worker.Waits[^1].Should().Be(cap);
+    }
+
+    // Records the interval the loop chose each cycle (via the WaitForNextCycle override) and
+    // returns immediately, so the loop advances deterministically with no real waiting. The
+    // final cycle parks on an infinite delay until StopAsync cancels it.
+    private sealed class TestWorker : BaseScraperWorker
+    {
+        private readonly TimeSpan _sleep;
+        private readonly TimeSpan _errorBackoff;
+        private readonly TimeSpan _maxErrorBackoff;
+        private readonly TimeSpan _continuation;
+        private readonly Func<int, TestWorker, CancellationToken, Task> _doWork;
+        private int _cycle;
+
+        public List<TimeSpan> Waits { get; } = [];
+
+        public TestWorker(
+            TimeSpan sleepInterval,
+            Func<int, TestWorker, CancellationToken, Task> doWork,
+            TimeSpan? errorBackoffInterval = null,
+            TimeSpan? maxErrorBackoffInterval = null,
+            TimeSpan? continuationInterval = null
+        )
+            : base(
+                NullLogger.Instance,
+                Substitute.For<IServiceScopeFactory>(),
+                new ErrorReporter(
+                    Substitute.For<IServiceScopeFactory>(),
+                    NullLogger<ErrorReporter>.Instance
+                )
+            )
+        {
+            _sleep = sleepInterval;
+            _doWork = doWork;
+            _errorBackoff = errorBackoffInterval ?? TimeSpan.FromMinutes(1);
+            _maxErrorBackoff = maxErrorBackoffInterval ?? TimeSpan.FromMinutes(15);
+            _continuation = continuationInterval ?? TimeSpan.FromSeconds(30);
+        }
+
+        protected override string WorkerName => "Test";
+        protected override TimeSpan SleepInterval => _sleep;
+        protected override TimeSpan ErrorBackoffInterval => _errorBackoff;
+        protected override TimeSpan MaxErrorBackoffInterval => _maxErrorBackoff;
+        protected override TimeSpan ContinuationInterval => _continuation;
+        protected override ErrorSource ErrorSource => ErrorSource.Other;
+
+        public void CallRequestImmediateContinuation() => RequestImmediateContinuation();
+
+        protected override Task DoWork(CancellationToken stoppingToken) =>
+            _doWork(++_cycle, this, stoppingToken);
+
+        protected override Task WaitForNextCycle(TimeSpan interval, CancellationToken stoppingToken)
+        {
+            Waits.Add(interval);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`BaseScraperWorker.ExecuteAsync` — the loop shared by every background scraper — caught an exception from `DoWork`, logged it, then slept the **full `SleepInterval`** before retrying. For the IR-flow and webcast workers that interval is 6h, so a single transient failure (e.g. the database briefly unavailable while a deploy recreates the `db` container) parked the worker for hours. The process stayed *up* (the loop never rethrows), so nothing restarted it — it just did no work until the next scheduled cycle.

This adds a short, bounded **error backoff** so a transient outage costs minutes, not hours.

## Code changes

- `src/Equibles.Worker/BaseScraperWorker.cs`
  - New `ErrorBackoffInterval` (default 1 min) and `MaxErrorBackoffInterval` (default 15 min) `protected virtual` properties, alongside the existing `NotReadyRetryInterval` / `ContinuationInterval`.
  - A faulted cycle now waits `ErrorBackoff()` — the base interval doubled per consecutive failure, capped at `min(SleepInterval, MaxErrorBackoffInterval)` — instead of the full `SleepInterval`. The `faulted` branch outranks retry-soon/continuation; a clean cycle resets the `_consecutiveFailures` streak. It logs a warning and publishes a `Warn` `ScraperActivity` ("cycle failed, retrying in …").
  - Cancellation, retry-soon, continuation and normal-sleep behaviour are unchanged (the existing branches are relocated verbatim under the clean-cycle `else`).
- `tests/Equibles.UnitTests/Worker/BaseScraperWorkerErrorBackoffTests.cs` (new) — backoff value, exponential growth + cap, reset-on-success, fault-beats-continuation, and the overflow-clamp guard. Deterministic: captures the chosen interval via a `WaitForNextCycle` override (no real waiting / clock races).
- `tests/Equibles.UnitTests/Worker/BaseScraperWorkerErrorBackoffActivityTests.cs` (new) — a faulted cycle publishes a `Warn` activity.

## Verification

`dotnet build -c Release` clean; full `Equibles.UnitTests` suite green (3085 passed), including the 6 new tests.