### PR TITLE
feat(sec): build as-filed HTML with exhibits for 8-K filings

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260622135642_AddAsFiledHtmlArtifact.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260622135642_AddAsFiledHtmlArtifact.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260622135642_AddAsFiledHtmlArtifact")]
+    partial class AddAsFiledHtmlArtifact
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260622135642_AddAsFiledHtmlArtifact.cs
+++ b/src/Equibles.Migrations/Migrations/20260622135642_AddAsFiledHtmlArtifact.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAsFiledHtmlArtifact : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AsFiledHtmlAttempts",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "AsFiledHtmlContentId",
+                table: "Document",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "AsFiledHtmlUncompressedSize",
+                table: "Document",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AsFiledHtmlVersion",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Document_AsFiledHtmlContentId",
+                table: "Document",
+                column: "AsFiledHtmlContentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Document_DocumentType_AsFiledHtmlVersion",
+                table: "Document",
+                columns: new[] { "DocumentType", "AsFiledHtmlVersion" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Document_File_AsFiledHtmlContentId",
+                table: "Document",
+                column: "AsFiledHtmlContentId",
+                principalTable: "File",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Document_File_AsFiledHtmlContentId",
+                table: "Document");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Document_AsFiledHtmlContentId",
+                table: "Document");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Document_DocumentType_AsFiledHtmlVersion",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "AsFiledHtmlAttempts",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "AsFiledHtmlContentId",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "AsFiledHtmlUncompressedSize",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "AsFiledHtmlVersion",
+                table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
@@ -1,3 +1,6 @@
+using System.Text;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
 using Equibles.Sec.Data.Models;
 
 namespace Equibles.Sec.BusinessLogic;
@@ -229,4 +232,198 @@ public static class SecDocumentEnvelopeParser
 
     private static bool TryExtractSgmlTagValue(string block, string tagName, out string value) =>
         SecSgmlEnvelope.TryGetTagValue(block, tagName, out value);
+
+    /// <summary>
+    /// Builds a single "as-filed" HTML page from a full SEC submission envelope: the primary
+    /// document followed by each displayable exhibit (a registered form or <c>EX-* &lt; 100</c>),
+    /// each wrapped in an anchored <c>&lt;section&gt;</c>, with intra-filing links to those
+    /// exhibits rewritten to in-page anchors. This lets the document viewer show the WHOLE
+    /// filing — e.g. an 8-K cover page PLUS its Exhibit 99.1 press release — so a citation
+    /// grounded in an exhibit resolves on the page and the cover page's exhibit links scroll
+    /// in-page instead of dead-ending on a file we don't host. Reads only the in-hand submission,
+    /// so it costs no extra EDGAR round-trip.
+    /// </summary>
+    /// <returns>
+    /// True and the stitched HTML when the filing carries at least one displayable exhibit;
+    /// false when there's nothing to stitch (single document, or no displayable exhibit).
+    /// </returns>
+    public static bool TryBuildAsFiledHtml(
+        string envelope,
+        string primaryDocumentFileName,
+        out string content
+    )
+    {
+        content = string.Empty;
+        if (string.IsNullOrEmpty(envelope))
+            return false;
+
+        var docs = new List<AsFiledBlock>();
+        foreach (var block in EnumerateDocumentBlocks(envelope))
+        {
+            if (
+                !TryExtractSgmlTagValue(block, "TYPE", out var blockType)
+                || string.IsNullOrEmpty(blockType)
+                || !IsDisplayableDocumentType(blockType)
+            )
+                continue;
+
+            TryExtractSgmlTagValue(block, "FILENAME", out var blockFileName);
+            if (!IsHtmlFilename(blockFileName))
+                continue;
+            if (!TryExtractTextBody(block, out var body))
+                continue;
+
+            var isPrimary =
+                !string.IsNullOrEmpty(primaryDocumentFileName)
+                && string.Equals(
+                    blockFileName,
+                    primaryDocumentFileName,
+                    StringComparison.OrdinalIgnoreCase
+                );
+            var isExhibit = blockType.StartsWith("EX-", StringComparison.OrdinalIgnoreCase);
+            docs.Add(new AsFiledBlock(blockFileName, blockType, body, isPrimary, isExhibit));
+        }
+
+        // Nothing to stitch unless there's a primary AND at least one exhibit to fold in.
+        if (docs.Count < 2 || !docs.Exists(d => d.IsExhibit))
+            return false;
+
+        // EDGAR lists the primary document first; if none was flagged (e.g. a backfill that
+        // doesn't know the primary's filename), treat the first displayable block as primary.
+        if (!docs.Exists(d => d.IsPrimary))
+            docs[0].IsPrimary = true;
+
+        // Primary leads, exhibits follow in envelope order. Assign stable section ids and map
+        // each filename to its section so links into the filing can target it.
+        docs = docs.OrderByDescending(d => d.IsPrimary).ToList();
+        var sectionByFile = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < docs.Count; i++)
+        {
+            docs[i].SectionId = $"asfiled-{i}";
+            if (!string.IsNullOrEmpty(docs[i].FileName))
+                sectionByFile[docs[i].FileName] = docs[i].SectionId;
+        }
+
+        var parser = new HtmlParser(
+            new HtmlParserOptions { IsAcceptingCustomElementsEverywhere = true }
+        );
+        var head = new StringBuilder();
+        var sections = new StringBuilder();
+
+        foreach (var doc in docs)
+        {
+            var parsed = parser.ParseDocument(doc.Body);
+
+            // Most SEC formatting is inline style attributes (kept on the elements when we take
+            // the body inner HTML); hoist any explicit <head><style> blocks so they survive too.
+            if (parsed.Head != null)
+            {
+                foreach (var style in parsed.Head.QuerySelectorAll("style"))
+                    head.Append(style.OuterHtml);
+            }
+
+            RewriteIntraFilingLinks(parsed, sectionByFile);
+
+            sections.Append("<section id=\"").Append(doc.SectionId).Append('"');
+            sections.Append(" data-asfiled-type=\"").Append(Escape(doc.Type)).Append('"');
+            sections.Append(" data-asfiled-file=\"").Append(Escape(doc.FileName)).Append("\">");
+            sections.Append(parsed.Body?.InnerHtml ?? string.Empty);
+            sections.Append("</section>");
+        }
+
+        content =
+            "<!DOCTYPE html><html><head><meta charset=\"utf-8\">"
+            + head
+            + "</head><body>"
+            + sections
+            + "</body></html>";
+        return true;
+    }
+
+    // Rewrites every intra-filing anchor — one whose href resolves to a filename we kept as a
+    // section — to the in-page fragment for that section, so the cover page's "Exhibit 99.1"
+    // link scrolls to the stitched exhibit instead of pointing at a file we don't host.
+    private static void RewriteIntraFilingLinks(
+        IDocument document,
+        IReadOnlyDictionary<string, string> sectionByFile
+    )
+    {
+        foreach (var anchor in document.QuerySelectorAll("a[href]"))
+        {
+            var href = anchor.GetAttribute("href");
+            if (string.IsNullOrEmpty(href) || href.StartsWith('#'))
+                continue;
+
+            var fileName = HrefFileName(href);
+            if (fileName != null && sectionByFile.TryGetValue(fileName, out var section))
+                anchor.SetAttribute("href", "#" + section);
+        }
+    }
+
+    // The bare filename an href points at: drop any query/fragment, take the last path segment.
+    // Handles a bare relative name ("ex99-1.htm"), a relative path ("./ex99-1.htm") and an
+    // absolute EDGAR URL that self-references the same filing.
+    private static string HrefFileName(string href)
+    {
+        var cut = href.IndexOfAny(['?', '#']);
+        if (cut >= 0)
+            href = href.Substring(0, cut);
+
+        var slash = href.LastIndexOf('/');
+        var name = slash >= 0 ? href.Substring(slash + 1) : href;
+        return string.IsNullOrEmpty(name) ? null : name;
+    }
+
+    // Whether an SGML <TYPE> line names a document we render in the as-filed view: a registered
+    // form (the primary) or a numbered exhibit below 100 (EX-99.1 etc.). Mirrors the allow rule
+    // the markdown normalizer uses so the two representations cover the same documents.
+    private static bool IsDisplayableDocumentType(string documentTypeLine)
+    {
+        var tokens = documentTypeLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        for (var take = tokens.Length; take >= 1; take--)
+        {
+            if (DocumentType.FromDisplayName(string.Join(' ', tokens[..take])) != null)
+                return true;
+        }
+
+        var documentType = tokens.Length > 0 ? tokens[0] : documentTypeLine;
+        if (documentType.StartsWith("EX-", StringComparison.OrdinalIgnoreCase))
+        {
+            var exNumber = documentType.Substring(3).Split('.')[0];
+            if (int.TryParse(exNumber, out var number) && number < 100)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsHtmlFilename(string filename) =>
+        !string.IsNullOrEmpty(filename)
+        && (
+            filename.EndsWith(".htm", StringComparison.OrdinalIgnoreCase)
+            || filename.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
+        );
+
+    // Minimal escaping for a value placed inside a double-quoted HTML attribute.
+    private static string Escape(string value) =>
+        string.IsNullOrEmpty(value)
+            ? string.Empty
+            : value.Replace("&", "&amp;").Replace("\"", "&quot;").Replace("<", "&lt;");
+
+    // One displayable document inside a filing while it's being stitched.
+    private sealed class AsFiledBlock(
+        string fileName,
+        string type,
+        string body,
+        bool isPrimary,
+        bool isExhibit
+    )
+    {
+        public string FileName { get; } = fileName;
+        public string Type { get; } = type;
+        public string Body { get; } = body;
+        public bool IsPrimary { get; set; } = isPrimary;
+        public bool IsExhibit { get; } = isExhibit;
+        public string SectionId { get; set; }
+    }
 }

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -13,6 +13,7 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(AccessionNumber), IsUnique = false)]
 [Index(nameof(XbrlStatus), IsUnique = false)]
 [Index(nameof(XbrlStatus), nameof(XbrlFactsVersion))]
+[Index(nameof(DocumentType), nameof(AsFiledHtmlVersion))]
 [Index(nameof(CreationTime), IsUnique = false)]
 public class Document
 {
@@ -119,6 +120,44 @@ public class Document
     /// below the extractor's current version.
     /// </summary>
     public int XbrlFactsAttempts { get; set; }
+
+    // --- As-filed display HTML (the primary document + its displayable exhibits, stitched) ---
+    // Kept SEPARATE from XbrlContent (which the dimensional-fact extractor parses): the as-filed
+    // viewer needs the WHOLE filing — an 8-K's cover page PLUS its linked exhibits, e.g. the
+    // Exhibit 99.1 press release — so a citation grounded in an exhibit can be pinpointed and the
+    // cover page's exhibit links resolve in-page. Building it as its own artifact keeps display
+    // enrichment from ever perturbing fact extraction. Only populated for filings that carry a
+    // displayable exhibit (currently 8-Ks); null otherwise.
+
+    /// <summary>
+    /// The file holding the gzip-compressed stitched as-filed HTML, or null when none was built
+    /// (no displayable exhibit, or not yet processed). The pre-compression size is
+    /// <see cref="AsFiledHtmlUncompressedSize"/>.
+    /// </summary>
+    public Guid? AsFiledHtmlContentId { get; set; }
+    public virtual File AsFiledHtmlContent { get; set; }
+
+    /// <summary>Size in bytes of the stitched as-filed HTML before gzip compression. Null when none built.</summary>
+    public long? AsFiledHtmlUncompressedSize { get; set; }
+
+    /// <summary>
+    /// Version of the as-filed HTML stitcher that last processed this document. 0 = never built.
+    /// The backfill selects 8-K documents whose version is below the builder's current one, so
+    /// bumping the builder version re-stitches the corpus (same version-stamp redrain as the
+    /// XBRL-facts extractor). A filing examined and found to carry no displayable exhibit is
+    /// stamped current with a null <see cref="AsFiledHtmlContentId"/> so it isn't re-fetched.
+    /// </summary>
+    public int AsFiledHtmlVersion { get; set; }
+
+    /// <summary>
+    /// How many times building the as-filed HTML (fetch/stitch) has failed for this document.
+    /// The backfill stops selecting it at the ceiling so one unbuildable filing can't starve
+    /// the queue.
+    /// </summary>
+    public int AsFiledHtmlAttempts { get; set; }
+
+    /// <summary>Retry ceiling for <see cref="AsFiledHtmlAttempts"/>.</summary>
+    public const int MaxAsFiledHtmlAttempts = 5;
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Sec.HostedService/AsFiledHtmlBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/AsFiledHtmlBackfillWorker.cs
@@ -1,0 +1,99 @@
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Worker;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Sec.HostedService;
+
+/// <summary>
+/// Builds the stitched as-filed HTML for 8-K documents ingested before the as-filed view
+/// existed (or stitched by an older builder version). Runs alongside the live scraper (sharing
+/// the EDGAR request budget) and is gated on both the master capture switch and the dedicated
+/// backfill switch, so the historical sweep only runs when an operator opts in.
+/// </summary>
+public class AsFiledHtmlBackfillWorker : BaseScraperWorker
+{
+    private readonly IConfiguration _configuration;
+    private readonly AsFiledHtmlCaptureOptions _captureOptions;
+    private readonly WorkerOptions _workerOptions;
+
+    protected override string WorkerName => "As-filed HTML backfill";
+
+    // A historical sweep, not latency-sensitive: a longer idle keeps it from re-spending the
+    // shared EDGAR budget when the queue is drained or stuck on exhausted documents.
+    protected override TimeSpan SleepInterval => TimeSpan.FromMinutes(5);
+
+    // While a backlog is still draining (a cycle that filled its batch) the loop uses this
+    // shorter interval so a large sweep clears in days rather than weeks.
+    protected override TimeSpan ContinuationInterval =>
+        TimeSpan.FromSeconds(_captureOptions.BackfillDrainIntervalSeconds);
+
+    protected override ErrorSource ErrorSource => ErrorSource.DocumentScraper;
+
+    // Yield to the live SEC scrapers at deploy time before spending the shared EDGAR budget.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(10);
+
+    public AsFiledHtmlBackfillWorker(
+        ILogger<AsFiledHtmlBackfillWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<AsFiledHtmlCaptureOptions> captureOptions,
+        IOptions<WorkerOptions> workerOptions,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        _captureOptions = captureOptions.Value;
+        _workerOptions = workerOptions.Value;
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(
+            _configuration,
+            "As-filed HTML backfill",
+            treatWhitespaceAsAbsent: true
+        );
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        if (!_captureOptions.Enabled || !_captureOptions.BackfillEnabled)
+        {
+            Logger.LogDebug("As-filed HTML backfill disabled; skipping cycle.");
+            return;
+        }
+
+        var minReportingDate = _workerOptions.MinSyncDate.HasValue
+            ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
+            : (DateOnly?)null;
+
+        var batchSize = _captureOptions.BackfillBatchSize;
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var backfillService =
+            scope.ServiceProvider.GetRequiredService<AsFiledHtmlBackfillService>();
+        var result = await backfillService.Backfill(batchSize, minReportingDate, stoppingToken);
+
+        // A full batch that made forward progress means the newest-first queue still has
+        // selectable documents, so drain the next batch after the short ContinuationInterval.
+        var madeProgress = result.Failed < result.Processed;
+        if (batchSize > 0 && result.Processed >= batchSize && madeProgress)
+        {
+            RequestImmediateContinuation();
+        }
+
+        Logger.LogInformation(
+            "As-filed HTML backfill cycle complete. Processed: {Processed}, Built: {Built}, "
+                + "NoExhibit: {NoExhibit}, Failed: {Failed}",
+            result.Processed,
+            result.Built,
+            result.NoExhibit,
+            result.Failed
+        );
+    }
+}

--- a/src/Equibles.Sec.HostedService/Configuration/AsFiledHtmlCaptureOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/AsFiledHtmlCaptureOptions.cs
@@ -1,0 +1,31 @@
+namespace Equibles.Sec.HostedService.Configuration;
+
+/// <summary>
+/// Controls building the stitched "as-filed" HTML (the primary document + its displayable
+/// exhibits) onto each <c>Document</c>. Forward capture at ingest reads the submission already
+/// fetched for the filing, so it adds no extra EDGAR round-trip; the historical backfill
+/// re-fetches each pending filing and so spends the shared EDGAR budget — off by default.
+/// </summary>
+public class AsFiledHtmlCaptureOptions
+{
+    /// <summary>Master switch — no as-filed HTML is built (forward or backfill) unless this is true.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// When true (and <see cref="Enabled"/> is true), a background worker walks 8-K documents
+    /// whose stitched HTML is missing or stale (below the builder version) and builds it. Off by
+    /// default — the historical sweep re-fetches each pending filing's submission, so opt in for a
+    /// deliberate re-sweep via <c>AsFiledHtml__BackfillEnabled=true</c>.
+    /// </summary>
+    public bool BackfillEnabled { get; set; } = false;
+
+    /// <summary>How many pending documents the backfill processes per cycle.</summary>
+    public int BackfillBatchSize { get; set; } = 128;
+
+    /// <summary>
+    /// Seconds to wait between back-to-back cycles while a backlog is still draining (a cycle
+    /// that filled its batch). Short so a large sweep clears in days; the gap still yields the
+    /// shared EDGAR budget to the live scrapers between bursts.
+    /// </summary>
+    public int BackfillDrainIntervalSeconds { get; set; } = 30;
+}

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -601,6 +601,31 @@ public class DocumentScraper : IDocumentScraper
                     scope.ServiceProvider.GetRequiredService<XbrlEnvelopeCaptureService>();
                 var xbrl = xbrlCapture.Capture(content, filing);
 
+                // Stitch the as-filed HTML (cover page + exhibits) for the forms that carry
+                // linked exhibits — built from the same submission, so no extra EDGAR fetch.
+                // Best-effort: a malformed envelope must not break ingest, so a failure leaves
+                // AsFiledHtmlVersion at 0 for the backfill to retry.
+                AsFiledHtmlCaptureResult asFiledHtml = null;
+                if (AsFiledHtmlCaptureService.AppliesTo(documentType))
+                {
+                    var asFiledCapture =
+                        scope.ServiceProvider.GetRequiredService<AsFiledHtmlCaptureService>();
+                    try
+                    {
+                        asFiledHtml = asFiledCapture.Capture(content, filing);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "As-filed HTML build failed for {Ticker} - {DocumentType} - {FilingDate}; backfill will retry.",
+                            companyOutContext.Ticker,
+                            documentType,
+                            filing.FilingDate
+                        );
+                    }
+                }
+
                 var normalizedHtml = normalizer.Normalize(content);
                 var markdownDocument = converter.Convert(normalizedHtml);
 
@@ -630,6 +655,7 @@ public class DocumentScraper : IDocumentScraper
                     filing.AccessionNumber,
                     filing.Items,
                     xbrl,
+                    asFiledHtml,
                     cancellationToken
                 );
 

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICompanySyncService, CompanySyncService>();
         services.AddScoped<XbrlEnvelopeCaptureService>();
         services.AddScoped<XbrlBackfillService>();
+        services.AddScoped<AsFiledHtmlCaptureService>();
+        services.AddScoped<AsFiledHtmlBackfillService>();
         services.AddScoped<FilingItemsBackfillService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();
         // Primary IWebsiteSource (consumed by the CommonStocks website discovery
@@ -33,6 +35,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<FtdScraperWorker>();
         services.AddHostedService<FormAdvScraperWorker>();
         services.AddHostedService<XbrlBackfillWorker>();
+        services.AddHostedService<AsFiledHtmlBackfillWorker>();
         services.AddHostedService<FilingItemsBackfillWorker>();
         services.AddHostedService<InsiderFilingReprocessWorker>();
         services.AddHostedService<NportFilingReprocessWorker>();

--- a/src/Equibles.Sec.HostedService/Models/AsFiledHtmlBackfillResult.cs
+++ b/src/Equibles.Sec.HostedService/Models/AsFiledHtmlBackfillResult.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Sec.HostedService.Models;
+
+/// <summary>Per-cycle tally of what the as-filed HTML backfill did, for logging.</summary>
+public class AsFiledHtmlBackfillResult
+{
+    public int Processed { get; set; }
+    public int Built { get; set; }
+    public int NoExhibit { get; set; }
+    public int Failed { get; set; }
+}

--- a/src/Equibles.Sec.HostedService/Models/AsFiledHtmlCaptureResult.cs
+++ b/src/Equibles.Sec.HostedService/Models/AsFiledHtmlCaptureResult.cs
@@ -1,0 +1,17 @@
+namespace Equibles.Sec.HostedService.Models;
+
+/// <summary>
+/// Outcome of building a filing's stitched as-filed HTML (the primary document + its
+/// displayable exhibits), handed to the persistence layer. <see cref="Html"/> is the
+/// uncompressed page (the persistence layer gzips it); null means the filing was examined but
+/// carries no displayable exhibit — there is nothing to stitch, recorded terminally by the
+/// version stamp so the backfill won't re-fetch it.
+/// </summary>
+public record AsFiledHtmlCaptureResult(byte[] Html)
+{
+    /// <summary>The filing carries no displayable exhibit (or capture is disabled) — nothing to stitch.</summary>
+    public static readonly AsFiledHtmlCaptureResult None = new((byte[])null);
+
+    /// <summary>A stitched as-filed page was built and should be stored.</summary>
+    public static AsFiledHtmlCaptureResult Built(byte[] html) => new(html);
+}

--- a/src/Equibles.Sec.HostedService/Services/AsFiledHtmlBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/AsFiledHtmlBackfillService.cs
@@ -1,0 +1,167 @@
+using System.Text.RegularExpressions;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Builds the stitched as-filed HTML for 8-K documents ingested before the as-filed view
+/// existed (or stitched by an older builder version). Each cycle takes a batch of pending 8-Ks
+/// (newest first), re-fetches the filing submission, runs the same stitch as the live ingest
+/// path, and stamps the builder version. Per-document failures are swallowed (the attempt count
+/// advances) so one unbuildable filing can't starve the queue.
+/// </summary>
+public class AsFiledHtmlBackfillService
+{
+    // Rows ingested before AccessionNumber existed carry it only inside the stored EDGAR
+    // full-submission URL; recovering it makes those rows backfillable (same as XBRL backfill).
+    private static readonly Regex EdgarSourceUrlAccession = new(
+        @"/Archives/edgar/data/\d+/(\d{10}-\d{2}-\d{6})\.txt$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
+
+    private readonly DocumentRepository _documentRepository;
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly AsFiledHtmlCaptureService _captureService;
+    private readonly IDocumentPersistenceService _persistenceService;
+    private readonly ILogger<AsFiledHtmlBackfillService> _logger;
+
+    public AsFiledHtmlBackfillService(
+        DocumentRepository documentRepository,
+        ISecEdgarClient secEdgarClient,
+        AsFiledHtmlCaptureService captureService,
+        IDocumentPersistenceService persistenceService,
+        ILogger<AsFiledHtmlBackfillService> logger
+    )
+    {
+        _documentRepository = documentRepository;
+        _secEdgarClient = secEdgarClient;
+        _captureService = captureService;
+        _persistenceService = persistenceService;
+        _logger = logger;
+    }
+
+    public async Task<AsFiledHtmlBackfillResult> Backfill(
+        int batchSize,
+        DateOnly? minReportingDate,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = new AsFiledHtmlBackfillResult();
+        if (batchSize <= 0)
+        {
+            return result;
+        }
+
+        var query = _documentRepository.GetPendingAsFiledHtml(
+            AsFiledHtmlCaptureService.CurrentVersion,
+            Document.MaxAsFiledHtmlAttempts
+        );
+
+        if (minReportingDate.HasValue)
+        {
+            query = query.Where(d => d.ReportingDate >= minReportingDate.Value);
+        }
+
+        var batch = await query
+            .Include(d => d.CommonStock)
+            .OrderByDescending(d => d.ReportingDate)
+            .Take(batchSize)
+            .ToListAsync(cancellationToken);
+
+        foreach (var document in batch)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            result.Processed++;
+            // Count the attempt up front so a fetch/stitch failure still advances the retry
+            // ceiling and the document eventually drops out of the working set.
+            document.AsFiledHtmlAttempts++;
+
+            document.AccessionNumber ??= DeriveAccessionNumber(document.SourceUrl);
+            if (document.AccessionNumber == null)
+            {
+                result.Failed++;
+                _logger.LogWarning(
+                    "As-filed HTML backfill cannot derive an accession number from SourceUrl {SourceUrl} for document {DocumentId}.",
+                    document.SourceUrl,
+                    document.Id
+                );
+                await PersistAttempt();
+                continue;
+            }
+
+            try
+            {
+                var content = await _secEdgarClient.GetDocumentContent(
+                    document.AccessionNumber,
+                    document.CommonStock.Cik
+                );
+                // The submission doesn't name its primary document; TryBuildAsFiledHtml falls
+                // back to the first displayable block (the primary by EDGAR convention).
+                var capture = _captureService.Capture(
+                    content,
+                    new FilingData
+                    {
+                        Cik = document.CommonStock.Cik,
+                        AccessionNumber = document.AccessionNumber,
+                    }
+                );
+                await _persistenceService.UpdateAsFiledHtml(document, capture);
+
+                if (capture.Html != null)
+                {
+                    result.Built++;
+                }
+                else
+                {
+                    result.NoExhibit++;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Best-effort: leave the document below the builder version so a later cycle
+                // retries it, but persist the bumped attempt count so it can't be retried forever.
+                result.Failed++;
+                _logger.LogWarning(
+                    ex,
+                    "As-filed HTML backfill failed for document {DocumentId} ({Accession}); will retry.",
+                    document.Id,
+                    document.AccessionNumber
+                );
+                await PersistAttempt();
+            }
+        }
+
+        return result;
+    }
+
+    private static string DeriveAccessionNumber(string sourceUrl)
+    {
+        if (string.IsNullOrEmpty(sourceUrl))
+        {
+            return null;
+        }
+
+        var match = EdgarSourceUrlAccession.Match(sourceUrl);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    // Saves the bumped attempt count after a failure. Best-effort: a save failure here must not
+    // abort the rest of the batch.
+    private async Task PersistAttempt()
+    {
+        try
+        {
+            await _documentRepository.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to persist as-filed HTML backfill attempt count.");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/AsFiledHtmlCaptureService.cs
+++ b/src/Equibles.Sec.HostedService/Services/AsFiledHtmlCaptureService.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Models;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Builds the stitched "as-filed" HTML (the primary document followed by its displayable
+/// exhibits, intra-filing links rewritten to in-page anchors) for a filing from its
+/// already-fetched submission envelope — see <see cref="SecDocumentEnvelopeParser.TryBuildAsFiledHtml"/>.
+/// Only the forms that carry the linked exhibits citations break on are stitched today (8-Ks,
+/// where the Exhibit 99.1 press release lives); other forms are skipped (<see cref="AppliesTo"/>).
+/// Costs no extra EDGAR round-trip on the live ingest path.
+/// </summary>
+public class AsFiledHtmlCaptureService
+{
+    /// <summary>
+    /// Stitcher version stamped onto a processed document. The backfill re-stitches 8-K
+    /// documents whose <c>AsFiledHtmlVersion</c> is below this, so bumping it after a stitcher
+    /// change reprocesses the corpus (same version-stamp redrain as the XBRL-facts extractor).
+    /// </summary>
+    public const int CurrentVersion = 1;
+
+    private readonly AsFiledHtmlCaptureOptions _options;
+
+    public AsFiledHtmlCaptureService(IOptions<AsFiledHtmlCaptureOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    /// <summary>The document types we stitch exhibits for. Widen this to extend coverage.</summary>
+    public static bool AppliesTo(DocumentType documentType) =>
+        documentType == DocumentType.EightK || documentType == DocumentType.EightKa;
+
+    /// <summary>
+    /// Builds the as-filed HTML from a full submission envelope. Returns
+    /// <see cref="AsFiledHtmlCaptureResult.None"/> when capture is disabled or the filing carries
+    /// no displayable exhibit. Throws on a malformed envelope — the caller decides whether that's
+    /// a swallowed best-effort miss (live ingest) or a counted retry (backfill).
+    /// </summary>
+    public AsFiledHtmlCaptureResult Capture(string submissionContent, FilingData filing)
+    {
+        if (!_options.Enabled)
+            return AsFiledHtmlCaptureResult.None;
+
+        return SecDocumentEnvelopeParser.TryBuildAsFiledHtml(
+            submissionContent,
+            filing.PrimaryDocument,
+            out var html
+        )
+            ? AsFiledHtmlCaptureResult.Built(Encoding.UTF8.GetBytes(html))
+            : AsFiledHtmlCaptureResult.None;
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -55,6 +55,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         string accessionNumber = null,
         string items = null,
         XbrlCaptureResult xbrl = null,
+        AsFiledHtmlCaptureResult asFiledHtml = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -80,6 +81,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         };
 
         await ApplyXbrlCapture(document, xbrl ?? XbrlCaptureResult.NotChecked);
+        await ApplyAsFiledHtmlCapture(document, asFiledHtml);
 
         _documentRepository.Add(document);
         await _documentRepository.SaveChanges();
@@ -106,6 +108,12 @@ public class DocumentPersistenceService : IDocumentPersistenceService
     public async Task UpdateXbrl(Document document, XbrlCaptureResult xbrl)
     {
         await ApplyXbrlCapture(document, xbrl ?? XbrlCaptureResult.NotChecked);
+        await _documentRepository.SaveChanges();
+    }
+
+    public async Task UpdateAsFiledHtml(Document document, AsFiledHtmlCaptureResult asFiledHtml)
+    {
+        await ApplyAsFiledHtmlCapture(document, asFiledHtml);
         await _documentRepository.SaveChanges();
     }
 
@@ -165,5 +173,38 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         document.XbrlType = xbrl.Type;
         document.XbrlUncompressedSize = xbrl.RawBytes.Length;
         document.XbrlStatus = XbrlCaptureStatus.Captured;
+    }
+
+    // Stores the stitched as-filed HTML as a gzip-compressed internal File and stamps the
+    // builder version so the backfill won't re-process it. A null result means "not built this
+    // pass" (left at version 0 for the backfill); an examined-but-no-exhibit result (Html null)
+    // is stamped current with no File so it isn't re-fetched.
+    private async Task ApplyAsFiledHtmlCapture(Document document, AsFiledHtmlCaptureResult result)
+    {
+        if (result == null)
+        {
+            return;
+        }
+
+        if (result.Html == null)
+        {
+            document.AsFiledHtmlVersion = AsFiledHtmlCaptureService.CurrentVersion;
+            return;
+        }
+
+        var compressed = GzipCompressor.Compress(result.Html);
+        var name = $"asfiled-{document.AccessionNumber ?? document.Id.ToString()}".TruncateToFit(
+            MaxFileNameLength
+        );
+        var htmlFile = await _fileManager.SaveInternalFile(
+            compressed,
+            name,
+            "gz",
+            "application/gzip"
+        );
+
+        document.AsFiledHtmlContent = htmlFile;
+        document.AsFiledHtmlUncompressedSize = result.Html.Length;
+        document.AsFiledHtmlVersion = AsFiledHtmlCaptureService.CurrentVersion;
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
@@ -24,6 +24,7 @@ public interface IDocumentPersistenceService
         string accessionNumber = null,
         string items = null,
         XbrlCaptureResult xbrl = null,
+        AsFiledHtmlCaptureResult asFiledHtml = null,
         CancellationToken cancellationToken = default
     );
 
@@ -33,6 +34,13 @@ public interface IDocumentPersistenceService
     /// ingested before capture was enabled.
     /// </summary>
     Task UpdateXbrl(Document document, XbrlCaptureResult xbrl);
+
+    /// <summary>
+    /// Applies a resolved as-filed HTML build onto an already-persisted, tracked
+    /// <see cref="Document"/> and saves — used by the backfill to stitch documents ingested
+    /// before the as-filed view was built (or to re-stitch after a builder-version bump).
+    /// </summary>
+    Task UpdateAsFiledHtml(Document document, AsFiledHtmlCaptureResult asFiledHtml);
 
     /// <summary>
     /// Replaces the body of an already-persisted <see cref="Document"/> in place, keeping its id —

--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -73,6 +73,30 @@ public class DocumentRepository : BaseRepository<Document>
             );
     }
 
+    /// <summary>
+    /// The as-filed HTML backfill work-set: EDGAR-sourced 8-K documents whose stitched as-filed
+    /// HTML is below <paramref name="belowVersion"/> (the builder's current version) and still
+    /// under the retry ceiling. Scoped to 8-Ks because that's where the linked exhibits (the
+    /// Exhibit 99.1 press release) and the broken citations live; widen the type set to extend
+    /// coverage. A document qualifies only when it came from an EDGAR filing (the accession is
+    /// stored or recoverable from the submission URL) and its issuer has a CIK, so the backfill
+    /// can re-fetch the submission to stitch.
+    /// </summary>
+    public IQueryable<Document> GetPendingAsFiledHtml(int belowVersion, int maxAttempts)
+    {
+        return GetAll()
+            .Where(d =>
+                (d.DocumentType == DocumentType.EightK || d.DocumentType == DocumentType.EightKa)
+                && d.AsFiledHtmlVersion < belowVersion
+                && d.AsFiledHtmlAttempts < maxAttempts
+                && (
+                    d.AccessionNumber != null
+                    || (d.SourceUrl != null && d.SourceUrl.Contains("/Archives/edgar/data/"))
+                )
+                && d.CommonStock.Cik != null
+            );
+    }
+
     public async Task<Document> GetWithContent(Guid id)
     {
         // The content bytes ride along eagerly: leaving File.FileContent to a lazy load

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -83,6 +83,9 @@ builder.Services.Configure<Equibles.Sec.HostedService.Configuration.FormAdvScrap
 builder.Services.Configure<Equibles.Sec.HostedService.Configuration.XbrlCaptureOptions>(
     builder.Configuration.GetSection("XbrlCapture")
 );
+builder.Services.Configure<Equibles.Sec.HostedService.Configuration.AsFiledHtmlCaptureOptions>(
+    builder.Configuration.GetSection("AsFiledHtml")
+);
 builder.Services.Configure<Equibles.Sec.HostedService.Configuration.FilingItemsBackfillOptions>(
     builder.Configuration.GetSection("FilingItemsBackfill")
 );

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -154,6 +154,7 @@ public class DocumentScraperTests
                 "0000123456-25-000001",
                 Arg.Any<string>(),
                 Arg.Any<XbrlCaptureResult>(),
+                Arg.Any<AsFiledHtmlCaptureResult>(),
                 Arg.Any<CancellationToken>()
             );
         harness.PdfTextExtractor.DidNotReceiveWithAnyArgs().Extract(default);
@@ -285,6 +286,7 @@ public class DocumentScraperTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<XbrlCaptureResult>(),
+                Arg.Any<AsFiledHtmlCaptureResult>(),
                 Arg.Any<CancellationToken>()
             );
         await harness
@@ -300,6 +302,7 @@ public class DocumentScraperTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<XbrlCaptureResult>(),
+                Arg.Any<AsFiledHtmlCaptureResult>(),
                 Arg.Any<CancellationToken>()
             );
         await harness
@@ -315,6 +318,7 @@ public class DocumentScraperTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<XbrlCaptureResult>(),
+                Arg.Any<AsFiledHtmlCaptureResult>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -676,6 +680,13 @@ public class DocumentScraperTests
                 Options.Create(new XbrlCaptureOptions())
             );
             services.AddScoped<XbrlEnvelopeCaptureService>();
+            // The as-filed HTML stitcher is resolved per scope only for 8-K filings; these tests
+            // exercise non-8-K forms, but register it (with default options) so an 8-K test added
+            // later resolves it instead of throwing.
+            services.AddSingleton<IOptions<AsFiledHtmlCaptureOptions>>(
+                Options.Create(new AsFiledHtmlCaptureOptions())
+            );
+            services.AddScoped<AsFiledHtmlCaptureService>();
 
             var provider = services.BuildServiceProvider();
             ScopeFactory = provider.GetRequiredService<IServiceScopeFactory>();

--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserAsFiledHtmlTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserAsFiledHtmlTests.cs
@@ -1,0 +1,117 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+// TryBuildAsFiledHtml stitches a filing's primary document together with its displayable
+// exhibits so the as-filed viewer can show the WHOLE 8-K — cover page PLUS the Exhibit 99.1
+// press release — and rewrites the cover page's intra-filing exhibit links to in-page anchors.
+public class SecDocumentEnvelopeParserAsFiledHtmlTests
+{
+    private const string PrimaryBody =
+        "<html><body><p>Item 9.01 Financial Statements and Exhibits</p>"
+        + "<a href=\"acme_ex99-1.htm\">Press release issued by Acme, Inc.</a></body></html>";
+
+    private const string ExhibitBody =
+        "<html><body><p>Acme reported revenue of $300M for the quarter.</p></body></html>";
+
+    private static string Submission(string primaryFileName, bool withExhibit)
+    {
+        var exhibitBlock = withExhibit
+            ? $"""
+                <DOCUMENT>
+                <TYPE>EX-99.1
+                <SEQUENCE>2
+                <FILENAME>acme_ex99-1.htm
+                <TEXT>
+                {ExhibitBody}
+                </TEXT>
+                </DOCUMENT>
+                """
+            : string.Empty;
+
+        return $"""
+            <SEC-DOCUMENT>
+            <DOCUMENT>
+            <TYPE>8-K
+            <SEQUENCE>1
+            <FILENAME>{primaryFileName}
+            <TEXT>
+            {PrimaryBody}
+            </TEXT>
+            </DOCUMENT>
+            {exhibitBlock}
+            </SEC-DOCUMENT>
+            """;
+    }
+
+    [Fact]
+    public void TryBuildAsFiledHtml_PrimaryWithExhibit_StitchesBothInAnchoredSections()
+    {
+        var envelope = Submission("acme_8k.htm", withExhibit: true);
+
+        var built = SecDocumentEnvelopeParser.TryBuildAsFiledHtml(
+            envelope,
+            "acme_8k.htm",
+            out var content
+        );
+
+        built.Should().BeTrue();
+        // Both documents are present, each in its own anchored section.
+        content.Should().Contain("Item 9.01 Financial Statements and Exhibits");
+        content.Should().Contain("Acme reported revenue of $300M for the quarter.");
+        content.Should().Contain("id=\"asfiled-0\"");
+        content.Should().Contain("id=\"asfiled-1\"");
+    }
+
+    [Fact]
+    public void TryBuildAsFiledHtml_RewritesIntraFilingExhibitLinkToInPageAnchor()
+    {
+        var envelope = Submission("acme_8k.htm", withExhibit: true);
+
+        SecDocumentEnvelopeParser.TryBuildAsFiledHtml(envelope, "acme_8k.htm", out var content);
+
+        // The cover page's link to the exhibit file becomes a fragment to the exhibit's section,
+        // so it scrolls in-page instead of pointing at a file we don't host.
+        content.Should().Contain("href=\"#asfiled-1\"");
+        content.Should().NotContain("href=\"acme_ex99-1.htm\"");
+    }
+
+    [Fact]
+    public void TryBuildAsFiledHtml_PrimaryNameBlank_TreatsFirstBlockAsPrimary()
+    {
+        // The backfill re-fetches by accession and doesn't know the primary's filename; the
+        // first displayable block (the primary by EDGAR convention) must still lead and the
+        // exhibit link still resolve.
+        var envelope = Submission("acme_8k.htm", withExhibit: true);
+
+        var built = SecDocumentEnvelopeParser.TryBuildAsFiledHtml(
+            envelope,
+            primaryDocumentFileName: "",
+            out var content
+        );
+
+        built.Should().BeTrue();
+        content.Should().Contain("href=\"#asfiled-1\"");
+        content.Should().Contain("Acme reported revenue of $300M for the quarter.");
+    }
+
+    [Fact]
+    public void TryBuildAsFiledHtml_NoExhibit_ReturnsFalse()
+    {
+        var envelope = Submission("acme_8k.htm", withExhibit: false);
+
+        SecDocumentEnvelopeParser
+            .TryBuildAsFiledHtml(envelope, "acme_8k.htm", out _)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void TryBuildAsFiledHtml_EmptyEnvelope_ReturnsFalse()
+    {
+        SecDocumentEnvelopeParser
+            .TryBuildAsFiledHtml(string.Empty, "acme_8k.htm", out _)
+            .Should()
+            .BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

The document viewer serves `Document.XbrlContent` — the primary inline-iXBRL document only — as the as-filed page, so an 8-K renders just its cover page. The substance (the Exhibit 99.1 press release) is a separate document in the same filing, linked only from the cover page, so a citation grounded in the exhibit can't be pinpointed on the page and the cover-page exhibit link points at a file we don't host.

This captures a new, **separate** "as-filed HTML" artifact on `Document`: the primary document followed by each displayable `EX-*` (< 100) exhibit, each wrapped in an anchored `<section>`, with the cover page's intra-filing exhibit links rewritten to in-page anchors. It is stored apart from `XbrlContent` so it never perturbs the dimensional-fact extractor that parses `XbrlContent`.

Scoped to **8-Ks** for now — that's where the linked exhibits and the broken citations are; widen the type set to extend coverage.

## Code changes

- `SecDocumentEnvelopeParser.TryBuildAsFiledHtml` — stitches the page from the already-fetched submission (no extra EDGAR round-trip); AngleSharp rewrites the intra-filing links.
- `AsFiledHtmlCaptureService` + `DocumentScraper` — forward capture builds it for 8-Ks at ingest.
- `AsFiledHtmlBackfillService` / `AsFiledHtmlBackfillWorker` — re-fetch + stitch existing 8-Ks, version-stamped (`AsFiledHtmlVersion`) so bumping the builder version re-stitches the corpus; gated by `AsFiledHtml__BackfillEnabled`.
- `Document` columns: `AsFiledHtmlContent(Id)`, `AsFiledHtmlUncompressedSize`, `AsFiledHtmlVersion`, `AsFiledHtmlAttempts` (+ migration `AddAsFiledHtmlArtifact`).
- Tests: `SecDocumentEnvelopeParserAsFiledHtmlTests` (stitch + link-rewrite + no-exhibit + blank-primary fallback).

## Testing

`Equibles.UnitTests` Sec suite green (stitcher + scraper). Builds clean in Release.