### PR TITLE
fix(sec): cap stitched as-filed HTML at serve size, harden attribute escaping

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
@@ -316,6 +316,9 @@ public static class SecDocumentEnvelopeParser
 
             // Most SEC formatting is inline style attributes (kept on the elements when we take
             // the body inner HTML); hoist any explicit <head><style> blocks so they survive too.
+            // The stitched documents share one cascade, so an exhibit's styles can in principle
+            // restyle the cover-page section — acceptable inside the script-free sandboxed frame
+            // this is served into (display only; no script/network via the page's CSP).
             if (parsed.Head != null)
             {
                 foreach (var style in parsed.Head.QuerySelectorAll("style"))
@@ -404,11 +407,17 @@ public static class SecDocumentEnvelopeParser
             || filename.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
         );
 
-    // Minimal escaping for a value placed inside a double-quoted HTML attribute.
+    // Escaping for a value (an untrusted SGML FILENAME/TYPE) placed inside a double-quoted HTML
+    // attribute. Escaping the quote is what prevents attribute breakout; & < > are escaped too so
+    // the value can't start a tag or entity.
     private static string Escape(string value) =>
         string.IsNullOrEmpty(value)
             ? string.Empty
-            : value.Replace("&", "&amp;").Replace("\"", "&quot;").Replace("<", "&lt;");
+            : value
+                .Replace("&", "&amp;")
+                .Replace("\"", "&quot;")
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;");
 
     // One displayable document inside a filing while it's being stitched.
     private sealed class AsFiledBlock(

--- a/src/Equibles.Sec.HostedService/Services/AsFiledHtmlCaptureService.cs
+++ b/src/Equibles.Sec.HostedService/Services/AsFiledHtmlCaptureService.cs
@@ -25,6 +25,12 @@ public class AsFiledHtmlCaptureService
     /// </summary>
     public const int CurrentVersion = 1;
 
+    // Upper bound on the stitched page we'll store, matching the viewer's serve-time cap
+    // (DocumentOriginalHtmlProvider.MaxOriginalHtmlBytes). A page bigger than this could never be
+    // served, so we drop it at capture rather than persist an un-servable blob — the viewer then
+    // degrades to the primary-only inline-iXBRL page. Keep the two caps in sync.
+    private const long MaxHtmlBytes = 30L * 1024 * 1024;
+
     private readonly AsFiledHtmlCaptureOptions _options;
 
     public AsFiledHtmlCaptureService(IOptions<AsFiledHtmlCaptureOptions> options)
@@ -47,12 +53,21 @@ public class AsFiledHtmlCaptureService
         if (!_options.Enabled)
             return AsFiledHtmlCaptureResult.None;
 
-        return SecDocumentEnvelopeParser.TryBuildAsFiledHtml(
-            submissionContent,
-            filing.PrimaryDocument,
-            out var html
+        if (
+            !SecDocumentEnvelopeParser.TryBuildAsFiledHtml(
+                submissionContent,
+                filing.PrimaryDocument,
+                out var html
+            )
         )
-            ? AsFiledHtmlCaptureResult.Built(Encoding.UTF8.GetBytes(html))
-            : AsFiledHtmlCaptureResult.None;
+        {
+            return AsFiledHtmlCaptureResult.None;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(html);
+        // Too big to ever serve — treat as nothing to stitch so we don't store a dead blob.
+        return bytes.Length > MaxHtmlBytes
+            ? AsFiledHtmlCaptureResult.None
+            : AsFiledHtmlCaptureResult.Built(bytes);
     }
 }


### PR DESCRIPTION
Follow-up to #3976 (code-review items). Drops a stitched as-filed page larger than the viewer's 30 MB serve cap at capture time (returns None → viewer degrades to the primary-only page) so the backfill never stores an un-servable blob; escapes `>` in the section data-attributes as defense-in-depth on untrusted SGML FILENAME/TYPE values; documents the intentional shared CSS cascade. Stitcher unit tests green.