### PR TITLE
fix(economic-data): stop projecting daily target-range carry-forward as an FOMC release event

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/FredReleaseCalendarImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredReleaseCalendarImportService.cs
@@ -177,6 +177,44 @@ public class FredReleaseCalendarImportService : IImporter
             return;
         }
 
+        // Drop releases whose value is merely carried forward every calendar day
+        // rather than published on scheduled announcement dates. With
+        // include_release_dates_with_no_data=true, FRED fills a "release date" for
+        // EVERY day — including weekends — for releases backed by a continuously
+        // carried-forward daily rate level (e.g. the FOMC Press Release driven by
+        // the DFEDTARL/DFEDTARU target range). The daily level update is not an
+        // announcement event, so projecting it onto the calendar produced a phantom
+        // "FOMC Press Release" entry on every single day (the only row on weekends).
+        //
+        // The defensible, data-only discriminator: no genuine statistical release
+        // (CPI, Employment Situation, GDP) — and no genuine business-day daily print
+        // (EFFR, SOFR, VIXCLS) — is ever published on a Saturday or Sunday. A release
+        // that FRED reports on any weekend day is therefore a 7-day carry-forward, not
+        // an announcement. We never model the 8 real FOMC meeting dates from this feed,
+        // so suppressing such a release entirely is the conservative correct outcome.
+        var carriedForwardReleases = parsed
+            .Where(p => p.Date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+            .Select(p => p.ReleaseId)
+            .ToHashSet();
+
+        if (carriedForwardReleases.Count > 0)
+        {
+            var dropped = parsed.RemoveAll(p => carriedForwardReleases.Contains(p.ReleaseId));
+            _logger.LogDebug(
+                "Skipped {Count} carry-forward release dates across {Releases} continuously-updated releases",
+                dropped,
+                carriedForwardReleases.Count
+            );
+
+            if (parsed.Count == 0)
+            {
+                _logger.LogDebug(
+                    "No scheduled FRED release dates after dropping carry-forward fills"
+                );
+                return;
+            }
+        }
+
         var minDate = parsed.Min(p => p.Date);
         var maxDate = parsed.Max(p => p.Date);
 

--- a/tests/Equibles.IntegrationTests/Fred/FredReleaseCalendarImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredReleaseCalendarImportServiceTests.cs
@@ -128,6 +128,74 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Import_ContinuousCarryForwardRelease_DropsItButKeepsGenuinePeriodicRelease()
+    {
+        // The FOMC Press Release is driven by the DFEDTARL/DFEDTARU target range,
+        // a daily 7-day rate level whose value is carried forward every calendar
+        // day. With include_release_dates_with_no_data=true, FRED fills a release
+        // date for EVERY day — including weekends — producing a phantom daily
+        // "FOMC Press Release". A genuine periodic release (CPI) prints on real
+        // distinct scheduled dates and never on a weekend.
+        _seriesRepo.Add(new FredSeries { SeriesId = "DFEDTARU", Title = "Fed Funds Upper" });
+        _seriesRepo.Add(new FredSeries { SeriesId = "CPIAUCSL", Title = "CPI All Items" });
+        await _seriesRepo.SaveChanges();
+
+        var fomcRelease = new FredReleaseRecord
+        {
+            Id = 101,
+            Name = "FOMC Press Release",
+            PressRelease = true,
+        };
+        var cpiRelease = new FredReleaseRecord
+        {
+            Id = 10,
+            Name = "Consumer Price Index",
+            PressRelease = true,
+        };
+        _fredClient.GetSeriesRelease("DFEDTARU").Returns(Task.FromResult(fomcRelease));
+        _fredClient.GetSeriesRelease("CPIAUCSL").Returns(Task.FromResult(cpiRelease));
+        _fredClient
+            .GetReleaseDates(Arg.Any<DateOnly?>())
+            .Returns(
+                Task.FromResult(
+                    new List<FredReleaseDateRecord>
+                    {
+                        // FOMC carried forward every day, incl. a Sat (20th) and Sun (21st).
+                        new() { ReleaseId = 101, Date = "2026-06-19" }, // Fri
+                        new() { ReleaseId = 101, Date = "2026-06-20" }, // Sat
+                        new() { ReleaseId = 101, Date = "2026-06-21" }, // Sun
+                        new() { ReleaseId = 101, Date = "2026-06-22" }, // Mon
+                        // Genuine CPI print on one real weekday date.
+                        new() { ReleaseId = 10, Date = "2026-06-11" },
+                    }
+                )
+            );
+
+        await _sut.Import(CancellationToken.None);
+
+        var fomc = _releaseRepo.GetAll().Single(r => r.ReleaseId == 101);
+        var cpi = _releaseRepo.GetAll().Single(r => r.ReleaseId == 10);
+
+        var dates = _dateRepo.GetAll().ToList();
+        dates
+            .Should()
+            .OnlyContain(
+                d => d.FredReleaseId == cpi.Id,
+                "the carried-forward FOMC press release must not appear on the calendar at all"
+            );
+        dates
+            .Select(d => d.Date)
+            .Should()
+            .BeEquivalentTo(
+                [new DateOnly(2026, 6, 11)],
+                "only the genuine periodic CPI date survives"
+            );
+        dates
+            .Should()
+            .NotContain(d => d.FredReleaseId == fomc.Id, "no FOMC phantom on weekdays either");
+    }
+
+    [Fact]
     public async Task Import_DateAlreadyStored_InsertsOnlyTheNewDate()
     {
         var release = new FredRelease { ReleaseId = 10, Name = "Consumer Price Index" };


### PR DESCRIPTION
## Summary
The economic release calendar listed an "FOMC Press Release" on every single day (including weekends, where it was the only row) because FRED's `/releases/dates` with `include_release_dates_with_no_data=true` fills a release date for every calendar day for releases backed by a continuously carried-forward daily rate level (the FOMC Press Release driven by the `DFEDTARL`/`DFEDTARU` target range). The daily level carry-forward is not an announcement event.

## Code changes
- `FredReleaseCalendarImportService`: drop every date for any release that FRED reports on a weekend (Sat/Sun). No genuine statistical release or business-day daily print is ever published on a weekend, so a weekend date is a 7-day carry-forward, not an announcement. The genuine 8-per-year FOMC meeting dates are not modeled from this feed, so suppressing the carried-forward release entirely is the conservative correct outcome — removes the phantom without dropping real periodic prints (CPI, Employment Situation, GDP).
- Integration test covering the carry-forward suppression and that a genuine periodic release survives.

Addresses the upstream of the commercial economic-calendar FOMC-daily bug.