### PR TITLE
chore(sec): run as-filed HTML backfill by default (drop BackfillEnabled flag)

### DIFF
--- a/src/Equibles.Sec.HostedService/AsFiledHtmlBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/AsFiledHtmlBackfillWorker.cs
@@ -13,9 +13,11 @@ namespace Equibles.Sec.HostedService;
 
 /// <summary>
 /// Builds the stitched as-filed HTML for 8-K documents ingested before the as-filed view
-/// existed (or stitched by an older builder version). Runs alongside the live scraper (sharing
-/// the EDGAR request budget) and is gated on both the master capture switch and the dedicated
-/// backfill switch, so the historical sweep only runs when an operator opts in.
+/// existed (or stitched by an older builder version). Runs by default and self-drains: each
+/// cycle stitches a batch of pending 8-Ks (newest first), and once every 8-K is at the current
+/// builder version the work-set is empty and the cycle idles on the cheap selecting query — no
+/// operator opt-in needed. Bumping <see cref="AsFiledHtmlCaptureService.CurrentVersion"/>
+/// re-fills the work-set. Runs alongside the live scraper, sharing the EDGAR request budget.
 /// </summary>
 public class AsFiledHtmlBackfillWorker : BaseScraperWorker
 {
@@ -63,9 +65,9 @@ public class AsFiledHtmlBackfillWorker : BaseScraperWorker
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
-        if (!_captureOptions.Enabled || !_captureOptions.BackfillEnabled)
+        if (!_captureOptions.Enabled)
         {
-            Logger.LogDebug("As-filed HTML backfill disabled; skipping cycle.");
+            Logger.LogDebug("As-filed HTML capture disabled; skipping backfill cycle.");
             return;
         }
 

--- a/src/Equibles.Sec.HostedService/Configuration/AsFiledHtmlCaptureOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/AsFiledHtmlCaptureOptions.cs
@@ -3,21 +3,15 @@ namespace Equibles.Sec.HostedService.Configuration;
 /// <summary>
 /// Controls building the stitched "as-filed" HTML (the primary document + its displayable
 /// exhibits) onto each <c>Document</c>. Forward capture at ingest reads the submission already
-/// fetched for the filing, so it adds no extra EDGAR round-trip; the historical backfill
-/// re-fetches each pending filing and so spends the shared EDGAR budget — off by default.
+/// fetched for the filing, so it adds no extra EDGAR round-trip; the backfill of older 8-Ks runs
+/// by default and self-drains (each is stamped to the current builder version once stitched, so
+/// the work-set empties and the worker idles). <see cref="Enabled"/> is the only on/off switch
+/// and defaults on — it works out of the box with no configuration.
 /// </summary>
 public class AsFiledHtmlCaptureOptions
 {
     /// <summary>Master switch — no as-filed HTML is built (forward or backfill) unless this is true.</summary>
     public bool Enabled { get; set; } = true;
-
-    /// <summary>
-    /// When true (and <see cref="Enabled"/> is true), a background worker walks 8-K documents
-    /// whose stitched HTML is missing or stale (below the builder version) and builds it. Off by
-    /// default — the historical sweep re-fetches each pending filing's submission, so opt in for a
-    /// deliberate re-sweep via <c>AsFiledHtml__BackfillEnabled=true</c>.
-    /// </summary>
-    public bool BackfillEnabled { get; set; } = false;
 
     /// <summary>How many pending documents the backfill processes per cycle.</summary>
     public int BackfillBatchSize { get; set; } = 128;


### PR DESCRIPTION
Follow-up to #3976/#3977. The as-filed HTML backfill is version-stamped and self-draining, so it doesn't need an opt-in: drop `AsFiledHtmlCaptureOptions.BackfillEnabled`, gate the worker only on the master `Enabled` switch (default on). Works out of the box and idles once every 8-K is at the current builder version; a version bump re-fills the work-set.