### PR TITLE
refactor(sec): parameterless GetPendingAsFiledHtml + builder version in Data

### DIFF
--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -159,5 +159,13 @@ public class Document
     /// <summary>Retry ceiling for <see cref="AsFiledHtmlAttempts"/>.</summary>
     public const int MaxAsFiledHtmlAttempts = 5;
 
+    /// <summary>
+    /// Current as-filed HTML stitcher version — the single source of truth for "which documents
+    /// still need stitching". Lives here (Data) rather than in the worker so both the backfill
+    /// work-set query and the backoffice "pending" metric can reference it without depending on
+    /// the hosted-service assembly. Bump it after a stitcher change to re-stitch the corpus.
+    /// </summary>
+    public const int AsFiledHtmlBuilderVersion = 1;
+
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Sec.HostedService/Services/AsFiledHtmlBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/AsFiledHtmlBackfillService.cs
@@ -58,10 +58,7 @@ public class AsFiledHtmlBackfillService
             return result;
         }
 
-        var query = _documentRepository.GetPendingAsFiledHtml(
-            AsFiledHtmlCaptureService.CurrentVersion,
-            Document.MaxAsFiledHtmlAttempts
-        );
+        var query = _documentRepository.GetPendingAsFiledHtml();
 
         if (minReportingDate.HasValue)
         {

--- a/src/Equibles.Sec.HostedService/Services/AsFiledHtmlCaptureService.cs
+++ b/src/Equibles.Sec.HostedService/Services/AsFiledHtmlCaptureService.cs
@@ -22,8 +22,10 @@ public class AsFiledHtmlCaptureService
     /// Stitcher version stamped onto a processed document. The backfill re-stitches 8-K
     /// documents whose <c>AsFiledHtmlVersion</c> is below this, so bumping it after a stitcher
     /// change reprocesses the corpus (same version-stamp redrain as the XBRL-facts extractor).
+    /// Forwards to <see cref="Document.AsFiledHtmlBuilderVersion"/> — the single source of truth
+    /// in the Data layer, so the backoffice can read it without depending on this assembly.
     /// </summary>
-    public const int CurrentVersion = 1;
+    public const int CurrentVersion = Document.AsFiledHtmlBuilderVersion;
 
     // Upper bound on the stitched page we'll store, matching the viewer's serve-time cap
     // (DocumentOriginalHtmlProvider.MaxOriginalHtmlBytes). A page bigger than this could never be

--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -75,20 +75,21 @@ public class DocumentRepository : BaseRepository<Document>
 
     /// <summary>
     /// The as-filed HTML backfill work-set: EDGAR-sourced 8-K documents whose stitched as-filed
-    /// HTML is below <paramref name="belowVersion"/> (the builder's current version) and still
-    /// under the retry ceiling. Scoped to 8-Ks because that's where the linked exhibits (the
-    /// Exhibit 99.1 press release) and the broken citations live; widen the type set to extend
+    /// HTML is below the current builder version (<see cref="Document.AsFiledHtmlBuilderVersion"/>)
+    /// and still under the retry ceiling. Scoped to 8-Ks because that's where the linked exhibits
+    /// (the Exhibit 99.1 press release) and the broken citations live; widen the type set to extend
     /// coverage. A document qualifies only when it came from an EDGAR filing (the accession is
     /// stored or recoverable from the submission URL) and its issuer has a CIK, so the backfill
-    /// can re-fetch the submission to stitch.
+    /// can re-fetch the submission to stitch. This is the single definition of "pending as-filed
+    /// HTML" shared by the worker and the backoffice dashboard metric.
     /// </summary>
-    public IQueryable<Document> GetPendingAsFiledHtml(int belowVersion, int maxAttempts)
+    public IQueryable<Document> GetPendingAsFiledHtml()
     {
         return GetAll()
             .Where(d =>
                 (d.DocumentType == DocumentType.EightK || d.DocumentType == DocumentType.EightKa)
-                && d.AsFiledHtmlVersion < belowVersion
-                && d.AsFiledHtmlAttempts < maxAttempts
+                && d.AsFiledHtmlVersion < Document.AsFiledHtmlBuilderVersion
+                && d.AsFiledHtmlAttempts < Document.MaxAsFiledHtmlAttempts
                 && (
                     d.AccessionNumber != null
                     || (d.SourceUrl != null && d.SourceUrl.Contains("/Archives/edgar/data/"))


### PR DESCRIPTION
Lets the backoffice show an as-filed backfill 'pending' count using the same shared work-set predicate the worker uses. Moves the stitcher version to `Document.AsFiledHtmlBuilderVersion` (Data, single source of truth; `AsFiledHtmlCaptureService.CurrentVersion` forwards to it) and makes `DocumentRepository.GetPendingAsFiledHtml()` parameterless, mirroring `GetPendingXbrlBackfill()`. No behavior change.