### PR TITLE
test(congress): pin NormalizeMemberName honorific between doubled first name

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameHonorificBetweenDoubledTokensTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameHonorificBetweenDoubledTokensTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Pins the single-pass composition of <see cref="DisclosureParsingHelper.NormalizeMemberName"/>'s
+/// two transforms. When a filing injects an honorific BETWEEN a doubled first name
+/// ("Scott Mr Scott Franklin"), dropping the honorific must leave the two "Scott"
+/// tokens adjacent so the repeated-token collapse still fires in the same pass —
+/// yielding the canonical "Scott Franklin", not "Scott Scott Franklin". The existing
+/// theory covers each transform alone but not their interaction (#3374).
+/// </summary>
+public class DisclosureParsingHelperNormalizeMemberNameHonorificBetweenDoubledTokensTests
+{
+    [Fact]
+    public void NormalizeMemberName_HonorificBetweenDoubledFirstName_CollapsesToCanonical()
+    {
+        DisclosureParsingHelper
+            .NormalizeMemberName("Scott Mr Scott Franklin")
+            .Should()
+            .Be("Scott Franklin");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the single-pass composition of `DisclosureParsingHelper.NormalizeMemberName`'s two transforms: when a filing injects an honorific *between* a doubled first name (`"Scott Mr Scott Franklin"`), dropping the honorific leaves the two `Scott` tokens adjacent so the repeated-token collapse still fires in the same pass, yielding the canonical `"Scott Franklin"`.
- The existing theory (#3374) covers each transform alone but not their interaction; this closes that gap. Test passes against current code — no production change.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameHonorificBetweenDoubledTokensTests.cs` — new single-fact regression test asserting the honorific-between-doubled-token case normalizes to `"Scott Franklin"`.