### PR TITLE
test(insider-trading): pin IsPlausibleTransactionDate inclusive year floor

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserIsPlausibleTransactionDateYearFloorTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserIsPlausibleTransactionDateYearFloorTests.cs
@@ -1,0 +1,23 @@
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// Pins the inclusive lower bracket of
+/// <see cref="InsiderFilingParser.IsPlausibleTransactionDate"/>: the year floor is
+/// <c>MinPlausibleTransactionYear</c> (1900) and the bound is inclusive, so a
+/// transaction dated exactly on 1900 (and on/before the filing date) is plausible.
+/// Existing tests cover the filing-date upper edge and far-past anchoring (year 0022)
+/// but not the exact floor — the off-by-one spot (<c>&gt;=</c> vs <c>&gt;</c>).
+/// </summary>
+public class InsiderFilingParserIsPlausibleTransactionDateYearFloorTests
+{
+    [Fact]
+    public void IsPlausibleTransactionDate_TransactionInFloorYear_IsPlausible()
+    {
+        var atFloor = new DateOnly(1900, 1, 1);
+        var filingDate = new DateOnly(2025, 1, 13);
+
+        InsiderFilingParser.IsPlausibleTransactionDate(atFloor, filingDate).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the inclusive lower bracket of `InsiderFilingParser.IsPlausibleTransactionDate`: the year floor is `MinPlausibleTransactionYear` (1900) and `>=` makes it inclusive, so a transaction dated exactly in 1900 (and on/before the filing date) is plausible.
- Existing tests cover the filing-date upper edge and far-past anchoring (year 0022) but not the exact floor — the `>=` vs `>` off-by-one spot. Test passes against current code; no production change.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserIsPlausibleTransactionDateYearFloorTests.cs` — new single-fact test asserting `IsPlausibleTransactionDate(1900-01-01, 2025-01-13)` is `true`.