### PR TITLE
test(yahoo): pin ReconcileMarketCap zero yahoo-share-base fallback

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Sibling to <see cref="YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests"/>, pinning the
+/// OTHER catastrophic leg of the guard: a zero Yahoo share base. The reconcile divides by
+/// yahooShares, so without the <c>yahooShares &gt; 0</c> guard a 0 base would divide to +Infinity and
+/// store an Infinity market cap. The contract falls back to Yahoo's figure when there is no usable
+/// Yahoo share base to rescale from — so a 0 yahooShares must return Yahoo's market cap unchanged,
+/// never Infinity. No existing test exercises the 0 yahooShares input.
+/// </summary>
+public class YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests
+{
+    private static readonly MethodInfo ReconcileMarketCapMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "ReconcileMarketCap",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static double ReconcileMarketCap(
+        long? edgarShares,
+        long yahooShares,
+        double yahooMarketCap
+    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap]);
+
+    [Fact]
+    public void ReconcileMarketCap_YahooShareCountZero_KeepsYahooMarketCap()
+    {
+        // A zero Yahoo share base is unusable: rescaling would divide by zero and yield +Infinity.
+        // The contract falls back to Yahoo's figure when there is no usable Yahoo share base, so the
+        // result must be Yahoo's market cap unchanged — a finite value, never Infinity.
+        const long edgarShares = 14_061_261L;
+        const double yahooMarketCap = 315_000_000d;
+
+        var reconciled = ReconcileMarketCap(edgarShares, 0L, yahooMarketCap);
+
+        reconciled.Should().Be(yahooMarketCap);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `yahooShares > 0` guard in `YahooPriceImportService.ReconcileMarketCap`: a zero Yahoo share base is unusable, and without the guard the rescale `yahooMarketCap × (edgarShares / yahooShares)` would divide by zero and store an Infinity market cap.
- Sibling to the existing zero-EDGAR-shares test; this pins the other catastrophic leg of the same guard. Contract falls back to Yahoo's figure when there's no usable Yahoo share base. Test passes against current code; no production change.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests.cs` — new single-fact test asserting `ReconcileMarketCap(edgarShares, 0, yahooMarketCap)` returns `yahooMarketCap` (finite, never Infinity).