### PR TITLE
test(congress): pin Senate liability description type-alone leg

### DIFF
--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityDescriptionEmptyCreditorTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityDescriptionEmptyCreditorTests.cs
@@ -1,0 +1,30 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class SenateAnnualReportClientLiabilityDescriptionEmptyCreditorTests
+{
+    // Contract: a liability description reads "Type (Creditor)" only when both are present;
+    // with one missing it uses the other alone. The sibling tests pin the creditor-alone leg
+    // (Type column absent); this pins the symmetric type-alone leg — a present Type with a
+    // blank Creditor cell must yield the type alone, never a "Type ()" trailing-parens wrapper.
+    [Fact]
+    public void ParseAnnualReportHtml_LiabilityWithEmptyCreditor_DescriptionIsTypeAlone()
+    {
+        const string html = """
+            <html><body>
+            <h3>Part 3. Assets</h3>
+            <p>None disclosed.</p>
+            <h3>Part 7. Liabilities</h3>
+            <table>
+              <thead><tr><th>Type</th><th>Amount</th><th>Creditor</th></tr></thead>
+              <tbody><tr><td>Mortgage</td><td>$100,001 - $250,000</td><td></td></tr></tbody>
+            </table>
+            </body></html>
+            """;
+
+        var lines = SenateAnnualReportClient.ParseAnnualReportHtml(html);
+
+        lines.Should().ContainSingle().Which.Description.Should().Be("Mortgage");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the symmetric type-alone leg of `SenateAnnualReportClient.ParseLiabilityTable`'s description builder: with a present Type but a blank Creditor cell, the description must be the type alone — never a `Type ()` trailing-parens wrapper.
- Sibling tests already pin the creditor-alone leg (Type column absent); this covers the missing counterpart. Test passes against current code; no production change.

## Code changes

- `tests/Equibles.UnitTests/Congress/SenateAnnualReportClientLiabilityDescriptionEmptyCreditorTests.cs` — new single-fact test asserting a liability row with `Type=Mortgage` and an empty Creditor yields description `"Mortgage"`.