### PR TITLE
test(common-stocks): pin IR extractor host-subdomain classification

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorHostSubdomainTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorHostSubdomainTests.cs
@@ -1,0 +1,24 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsLinkExtractorHostSubdomainTests
+{
+    // Contract: an `ir.` / `investor(s).` host subdomain is a strong IR signal on its own —
+    // the link must be classified even when the anchor text carries no English IR keyword
+    // (a regional/localised IR portal). The other tests classify via keyword text; this pins
+    // the host-subdomain leg of HasIrHostOrPath, which exists precisely for non-English anchors.
+    [Fact]
+    public void Extract_AnchorOnIrSubdomainWithNonEnglishText_IsReturnedAsCandidate()
+    {
+        const string html = """
+            <html><body>
+            <a href="https://ir.acme.com/">投資家情報</a>
+            </body></html>
+            """;
+
+        var links = InvestorRelationsLinkExtractor.Extract(html, "https://acme.com");
+
+        links.Should().ContainSingle().Which.Should().Be("https://ir.acme.com/");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the host-subdomain leg of `InvestorRelationsLinkExtractor.HasIrHostOrPath`: an anchor on an `ir.` subdomain must be returned even when its visible text carries no English IR keyword — the localised/non-English IR-portal case the method exists for.
- Existing tests classify via keyword text only; this covers the host-signal branch. Test passes against current code; no production change.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorHostSubdomainTests.cs` — new single-fact test asserting a non-English anchor on `https://ir.acme.com/` is returned as a candidate.