### PR TITLE
fix(congress): keep a genuine repeated initial in NormalizeMemberName

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -57,8 +57,13 @@ public static partial class DisclosureParsingHelper
         {
             if (HonorificTokens.Contains(token.TrimEnd('.')))
                 continue;
+            // Collapse an immediately repeated token (the parser's doubled first
+            // name, "Scott Scott"), but never a repeated single-letter initial:
+            // "C. C. Franklin" is a genuine two-initial name and folding it would
+            // merge a distinct identity (GH-3989).
             if (
                 result.Count > 0
+                && !IsInitialToken(token)
                 && string.Equals(result[^1], token, StringComparison.OrdinalIgnoreCase)
             )
                 continue;
@@ -66,6 +71,13 @@ public static partial class DisclosureParsingHelper
         }
 
         return string.Join(' ', result);
+    }
+
+    // An initial is a single letter, optionally followed by a period ("C" or "C.").
+    private static bool IsInitialToken(string token)
+    {
+        var bare = token.TrimEnd('.');
+        return bare.Length == 1 && char.IsLetter(bare[0]);
     }
 
     public static List<DisclosureTransaction> ParseTransactionsFromHtml(

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameRepeatedInitialTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameRepeatedInitialTests.cs
@@ -14,9 +14,7 @@ namespace Equibles.UnitTests.Congress;
 /// </summary>
 public class DisclosureParsingHelperNormalizeMemberNameRepeatedInitialTests
 {
-    [Fact(
-        Skip = "GH-3989 — doubled-token collapse folds a genuine repeated initial: \"C. C. Franklin\" → \"C. Franklin\""
-    )]
+    [Fact]
     public void NormalizeMemberName_RepeatedGenuineInitial_LeavesBothInitialsIntact()
     {
         DisclosureParsingHelper.NormalizeMemberName("C. C. Franklin").Should().Be("C. C. Franklin");


### PR DESCRIPTION
## Summary

- `NormalizeMemberName` (added in #3979) documents that it keeps genuine initials untouched and avoids over-merging distinct people, but its doubled-token collapse — meant for the parser's doubled *first name* (`Scott Scott` → `Scott`) — also folded a repeated single-letter initial, so `C. C. Franklin` became `C. Franklin`, merging a distinct identity on the upsert key.
- Guard the collapse so it never drops a single-letter initial (`C`/`C.`). Closes #3989.
- Un-skips the regression test shipped in #3990.

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — add `IsInitialToken` guard to the doubled-token collapse so a repeated initial is preserved; full collapse behavior for doubled full names is unchanged.
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameRepeatedInitialTests.cs` — un-skip the `C. C. Franklin` regression test.