### PR TITLE
test(congress): pin NormalizeMemberName keeps both initials when an honorific sits between them

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameHonorificBetweenRepeatedInitialsTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameHonorificBetweenRepeatedInitialsTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Adversarial seam between two documented guarantees of
+/// <see cref="DisclosureParsingHelper.NormalizeMemberName"/>: it drops honorific
+/// tokens in any position (GH-3374) yet must keep a genuine repeated initial
+/// intact to avoid merging distinct people (GH-3989). Dropping an honorific that
+/// sits BETWEEN two same-letter initials ("C. Mr C. Franklin") makes the two
+/// "C." tokens adjacent in the running result — the exact shape the doubled-token
+/// collapse targets — so the initial exemption must still win and preserve both.
+/// </summary>
+public class DisclosureParsingHelperNormalizeMemberNameHonorificBetweenRepeatedInitialsTests
+{
+    [Fact]
+    public void NormalizeMemberName_HonorificBetweenRepeatedInitials_KeepsBothInitials()
+    {
+        DisclosureParsingHelper
+            .NormalizeMemberName("C. Mr C. Franklin")
+            .Should()
+            .Be("C. C. Franklin");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial (Lane A) test pinning the seam between two recent `NormalizeMemberName` fixes: honorific-token dropping (GH-3374) and genuine-repeated-initial preservation (GH-3989).
- Input `"C. Mr C. Franklin"`: dropping the `Mr` honorific makes the two `C.` initials adjacent in the running result — the exact shape the doubled-token collapse targets — so the initial exemption must still win and keep both. Expected `"C. C. Franklin"`. Test passes, confirming no over-merge of a distinct identity.
- No prior test covers this intersection (existing cases pin honorific-between-doubled *first name* and repeated initials *without* an intervening honorific separately).

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameHonorificBetweenRepeatedInitialsTests.cs` — new single-`[Fact]` test asserting `NormalizeMemberName("C. Mr C. Franklin") == "C. C. Franklin"`.