### PR TITLE
docs(technical/architecture): complete the outbound HTTP client source list

### DIFF
--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -78,7 +78,7 @@ Data (entities) → Repositories (IQueryable) → Managers (write paths) → Con
 | `EquiblesFinancialDbContext` + module builder | `Equibles.Data` |
 | `BaseRepository<T>` | `Equibles.Data` |
 | Migrations snapshot | `Equibles.Migrations` |
-| Outbound HTTP clients (SEC, FRED, Yahoo, FINRA, CFTC, CBOE) | `Equibles.Integrations.<Source>` |
+| Outbound HTTP clients (SEC, FRED, Yahoo, FINRA, CFTC, CBOE, GovernmentContracts, Wikidata) | `Equibles.Integrations.<Source>` |
 | Smart-enum types, shared utilities | `Equibles.Core` |
 | MCP host wiring (`AddModule`, middleware) | `Equibles.Mcp` |
 | Cross-module search abstractions | `Equibles.Search.Abstractions`, `Equibles.Search` |


### PR DESCRIPTION
## Summary

- The "What lives where" table in `docs/technical/architecture.md` listed only six integration sources (SEC, FRED, Yahoo, FINRA, CFTC, CBOE) for `Equibles.Integrations.<Source>`, but two more clients exist: GovernmentContracts (USAspending) and Wikidata.
- Complete the list so it matches the authoritative table in `scrapers.md` and the actual `src/Equibles.Integrations.*` projects.

## Code changes

- `docs/technical/architecture.md` — add GovernmentContracts and Wikidata to the outbound HTTP client source enumeration.