### PR TITLE
test(fred): pin importer drops every weekend-flagged release without throwing on empty

### DIFF
--- a/tests/Equibles.IntegrationTests/Fred/FredReleaseCalendarImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredReleaseCalendarImportServiceTests.cs
@@ -247,4 +247,44 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
             .Should()
             .BeEquivalentTo([new DateOnly(2026, 6, 11), new DateOnly(2026, 7, 14)]);
     }
+
+    [Fact]
+    public async Task Import_EveryTrackedReleaseCarriedForward_PersistsNoDatesAndDoesNotThrow()
+    {
+        // When every tracked release is a weekend-flagged carry-forward, the drop
+        // empties the parsed list. The importer must return cleanly with no calendar
+        // rows — and crucially without throwing: the date-range computation right
+        // after the drop calls Min/Max, which throw on an empty sequence.
+        _seriesRepo.Add(new FredSeries { SeriesId = "DFEDTARU", Title = "Fed Funds Upper" });
+        await _seriesRepo.SaveChanges();
+
+        var fomcRelease = new FredReleaseRecord
+        {
+            Id = 101,
+            Name = "FOMC Press Release",
+            PressRelease = true,
+        };
+        _fredClient.GetSeriesRelease("DFEDTARU").Returns(Task.FromResult(fomcRelease));
+        _fredClient
+            .GetReleaseDates(Arg.Any<DateOnly?>())
+            .Returns(
+                Task.FromResult(
+                    new List<FredReleaseDateRecord>
+                    {
+                        new() { ReleaseId = 101, Date = "2026-06-19" }, // Fri
+                        new() { ReleaseId = 101, Date = "2026-06-20" }, // Sat
+                        new() { ReleaseId = 101, Date = "2026-06-22" }, // Mon
+                    }
+                )
+            );
+
+        var import = async () => await _sut.Import(CancellationToken.None);
+
+        await import.Should().NotThrowAsync();
+        _dateRepo
+            .GetAll()
+            .ToList()
+            .Should()
+            .BeEmpty("a release seen on any weekend is a carry-forward and contributes no dates");
+    }
 }


### PR DESCRIPTION
## Summary

- The release-calendar importer drops any release FRED reports on a weekend, treating it as a continuously carried-forward daily level rather than a scheduled announcement.
- When *every* tracked release is such a carry-forward, the post-drop list is empty — and the date-range step right after calls `Min`/`Max`, which throw on an empty sequence. An early-return guard handles this; this test pins that branch.

## Code changes

- `tests/Equibles.IntegrationTests/Fred/FredReleaseCalendarImportServiceTests.cs` — add a case where the only tracked release is weekend-flagged: asserts the import completes without throwing and persists no calendar dates.