### PR TITLE
fix(sec): drain all pending XBRL backfill, ignore live-scraper sync floor

### DIFF
--- a/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
@@ -1,4 +1,3 @@
-using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Sec.HostedService.Configuration;
@@ -21,7 +20,6 @@ public class XbrlBackfillWorker : BaseScraperWorker
 {
     private readonly IConfiguration _configuration;
     private readonly XbrlCaptureOptions _captureOptions;
-    private readonly WorkerOptions _workerOptions;
 
     protected override string WorkerName => "XBRL backfill";
 
@@ -47,13 +45,11 @@ public class XbrlBackfillWorker : BaseScraperWorker
         IServiceScopeFactory scopeFactory,
         ErrorReporter errorReporter,
         IOptions<XbrlCaptureOptions> captureOptions,
-        IOptions<WorkerOptions> workerOptions,
         IConfiguration configuration
     )
         : base(logger, scopeFactory, errorReporter)
     {
         _captureOptions = captureOptions.Value;
-        _workerOptions = workerOptions.Value;
         _configuration = configuration;
     }
 
@@ -68,14 +64,15 @@ public class XbrlBackfillWorker : BaseScraperWorker
             return;
         }
 
-        var minReportingDate = _workerOptions.MinSyncDate.HasValue
-            ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
-            : (DateOnly?)null;
-
+        // No reporting-date floor: this is a one-time historical sweep that must drain every
+        // remaining NotChecked filing. The live-scraper MinSyncDate floor (shared with the
+        // SEC/Holdings/Congress scrapers and the public-site history clamp) is deliberately not
+        // applied here — bounding the backfill by it permanently stranded the pre-floor backlog as
+        // pending-but-never-selected. Backfill enablement is already an explicit operator opt-in.
         var batchSize = _captureOptions.BackfillBatchSize;
         await using var scope = ScopeFactory.CreateAsyncScope();
         var backfillService = scope.ServiceProvider.GetRequiredService<XbrlBackfillService>();
-        var result = await backfillService.Backfill(batchSize, minReportingDate, stoppingToken);
+        var result = await backfillService.Backfill(batchSize, minReportingDate: null, stoppingToken);
 
         // A full batch that made forward progress means the newest-first queue still has
         // selectable documents, so drain the next batch after the short ContinuationInterval

--- a/tests/Equibles.UnitTests/Sec/XbrlBackfillWorkerWhitespaceEmailTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlBackfillWorkerWhitespaceEmailTests.cs
@@ -1,4 +1,3 @@
-using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Sec.HostedService;
 using Equibles.Sec.HostedService.Configuration;
@@ -49,7 +48,6 @@ public class XbrlBackfillWorkerWhitespaceEmailTests
                 scopeFactory,
                 errorReporter,
                 captureOptions,
-                Options.Create(new WorkerOptions()),
                 configuration
             ) { }
 


### PR DESCRIPTION
## Summary

The historical XBRL backfill bounded its work-set by `Worker.MinSyncDate` — the global sync floor shared with the live SEC/Holdings/Congress scrapers and the public-site history clamp (currently 2020-01-01 in production). Filings older than that floor were counted as pending on the backoffice dashboard but never selected by the worker, so the remaining backlog (554 pre-2020 filings) could never drain — they sat at zero capture attempts indefinitely.

This is a one-time historical sweep, so it should drain every remaining `NotChecked` filing regardless of the live-scraper floor. Backfill enablement is already an explicit operator opt-in, and the per-document retry ceiling (`MaxXbrlCaptureAttempts = 5`) still bounds rows that can't be fetched.

## Code changes

- `XbrlBackfillWorker` now calls `Backfill(batchSize, minReportingDate: null, ...)` — no reporting-date floor. Removed the now-unused `WorkerOptions` dependency (field + constructor parameter + import).
- Updated `XbrlBackfillWorkerWhitespaceEmailTests` to match the trimmed base constructor.