### PR TITLE
refactor(web): normalize ticker lookups via TickerNormalizer

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
@@ -40,7 +41,7 @@ public class HoldingsExportController : BaseController
         if (string.IsNullOrWhiteSpace(ticker))
             return NotFound();
 
-        var stock = await _stockRepository.GetByTicker(ticker.ToUpperInvariant());
+        var stock = await _stockRepository.GetByTicker(TickerNormalizer.Normalize(ticker));
         if (stock == null)
             return NotFound();
 

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Repositories;
 using Equibles.Sec.FinancialFacts.Data.Enums;
@@ -267,7 +268,7 @@ public class StocksController : BaseController
 
     private async Task<Equibles.CommonStocks.Data.Models.CommonStock> LoadStock(string ticker)
     {
-        return await _commonStockRepository.GetByTicker(ticker.ToUpperInvariant());
+        return await _commonStockRepository.GetByTicker(TickerNormalizer.Normalize(ticker));
     }
 
     private StockDetailViewModel BuildStockViewModel(
@@ -314,7 +315,7 @@ public class StocksController : BaseController
     [HttpGet("~/stocks/{ticker}/holders/{cik}")]
     public async Task<IActionResult> ShowHolder(string ticker, string cik)
     {
-        var stock = await _commonStockRepository.GetByTicker(ticker.ToUpperInvariant());
+        var stock = await _commonStockRepository.GetByTicker(TickerNormalizer.Normalize(ticker));
         if (stock == null)
             return NotFound();
 


### PR DESCRIPTION
## Summary

- Three Web controller lookup sites hand-rolled `ticker.ToUpperInvariant()` before `GetByTicker`, while `SearchController` and the shared `CommonStockRepositoryExtensions.ResolveByTicker` already use the canonical `TickerNormalizer.Normalize`.
- Route all ticker lookups through the same helper so there is one normalization rule and stray whitespace in the route/query value is trimmed consistently (previously a value like `"AAPL "` would 404 here but resolve elsewhere).

## Code changes

- `src/Equibles.Web/Controllers/StocksController.cs` — `LoadStock` and `ShowHolder` now resolve the stock via `TickerNormalizer.Normalize(ticker)` instead of `ticker.ToUpperInvariant()`; added the `Equibles.CommonStocks.Data.Helpers` using. Display-only uppercasing (page titles / view model) is unchanged.
- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — `Holders` export resolves the stock via `TickerNormalizer.Normalize(ticker)`; added the same using.

No schema, serialized-format, external-contract, or dependency changes. Same routes and same `NotFound` behavior on a miss. Build, the 479 Web unit tests, and csharpier check are green.