### PR TITLE
feat(financial-facts): show financial-sector top lines on the income statement

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialStatementConcepts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialStatementConcepts.cs
@@ -25,6 +25,19 @@ public static class FinancialStatementConcepts
             "RevenueFromContractWithCustomerExcludingAssessedTax",
             "Revenue (ASC 606)"
         ),
+        // Financial-sector top lines. Banks, broker-dealers and insurers never file the
+        // operating-company revenue tags above, so without these their income statement
+        // shows no top line at all. Ordered as a financial income statement reads; a given
+        // filer reports only the subset that fits it, and unreported lines simply don't render.
+        new(
+            FactTaxonomy.UsGaap,
+            "InterestAndDividendIncomeOperating",
+            "Interest & Dividend Income"
+        ),
+        new(FactTaxonomy.UsGaap, "InterestIncomeExpenseNet", "Net Interest Income"),
+        new(FactTaxonomy.UsGaap, "NoninterestIncome", "Noninterest Income"),
+        new(FactTaxonomy.UsGaap, "RevenuesNetOfInterestExpense", "Total Net Revenue"),
+        new(FactTaxonomy.UsGaap, "PremiumsEarnedNet", "Premiums Earned (Net)"),
         new(FactTaxonomy.UsGaap, "CostOfRevenue", "Cost of Revenue"),
         new(FactTaxonomy.UsGaap, "GrossProfit", "Gross Profit"),
         new(FactTaxonomy.UsGaap, "OperatingExpenses", "Operating Expenses"),

--- a/tests/Equibles.UnitTests/Sec/FinancialStatementConceptsIncomeFinancialSectorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialStatementConceptsIncomeFinancialSectorTests.cs
@@ -1,0 +1,26 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialStatementConceptsIncomeFinancialSectorTests
+{
+    // Banks, broker-dealers and insurers never file the operating-company revenue tags
+    // (Revenues / RevenueFromContractWithCustomerExcludingAssessedTax), so without their
+    // sector top-line concepts the income statement renders no top line at all — the
+    // original defect, where a bank's card collapsed to Operating Income + Net Income + EPS.
+    // Pin that the shared catalog carries the financial-sector top lines so a future trim
+    // can't silently re-break every financial company on all four surfaces that share it.
+    [Theory]
+    [InlineData("RevenuesNetOfInterestExpense")]
+    [InlineData("InterestIncomeExpenseNet")]
+    [InlineData("InterestAndDividendIncomeOperating")]
+    [InlineData("NoninterestIncome")]
+    [InlineData("PremiumsEarnedNet")]
+    public void IncomeStatement_IncludesFinancialSectorTopLine(string tag)
+    {
+        var income = FinancialStatementConcepts.For(FinancialStatementType.IncomeStatement);
+
+        income.Should().Contain(line => line.Tag == tag && line.Taxonomy == FactTaxonomy.UsGaap);
+    }
+}


### PR DESCRIPTION
## Summary

Banks, broker-dealers and insurers never file the operating-company revenue tags (`Revenues` / `RevenueFromContractWithCustomerExcludingAssessedTax`). The shared statement catalog only listed those two, so a financial company's income statement rendered no top line at all — collapsing to Operating Income, Net Income and EPS.

This adds the financial-sector top-line concepts to the income-statement catalog so every filer shows its real top line. A given company reports only the subset that fits it; unreported lines still don't render, so non-financial companies are unchanged.

Verified against production: JPM, Goldman Sachs, Morgan Stanley and Fannie Mae all file `RevenuesNetOfInterestExpense` with no `Revenues` fact; 964 companies file `InterestIncomeExpenseNet`, 444 `InterestAndDividendIncomeOperating`, 388 `NoninterestIncome`, 130 `PremiumsEarnedNet`.

## Code changes

- `FinancialStatementConcepts.cs` — add five financial-sector top-line us-gaap concepts (interest & dividend income, net interest income, noninterest income, total net revenue, premiums earned) to the income-statement catalog, ordered as a financial income statement reads, above Cost of Revenue.
- `FinancialStatementConceptsIncomeFinancialSectorTests.cs` — new test pinning that the catalog carries each financial-sector top line, so a future trim can't silently re-break financials on the four surfaces that share the catalog.

The catalog is shared by the Web Financials tab, the MCP `GetFinancialStatement` tool and the agent card, so all surfaces pick this up.