### PR TITLE
feat(financial-facts): model for as-reported financial statements

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260625224115_AddReportedFinancialStatements.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260625224115_AddReportedFinancialStatements.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260625224115_AddReportedFinancialStatements")]
+    partial class AddReportedFinancialStatements
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260625224115_AddReportedFinancialStatements.cs
+++ b/src/Equibles.Migrations/Migrations/20260625224115_AddReportedFinancialStatements.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReportedFinancialStatements : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ReportedStatementsCaptureAttempts",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ReportedStatementsContentId",
+                table: "Document",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReportedStatementsParseAttempts",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReportedStatementsParseVersion",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReportedStatementsStatus",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<long>(
+                name: "ReportedStatementsUncompressedSize",
+                table: "Document",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ReportedFinancialStatement",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DocumentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Kind = table.Column<int>(type: "integer", nullable: false),
+                    RoleUri = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    RoleShortName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    ReportFileName = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    IsParenthetical = table.Column<bool>(type: "boolean", nullable: false),
+                    FiscalYear = table.Column<int>(type: "integer", nullable: false),
+                    FiscalPeriod = table.Column<int>(type: "integer", nullable: false),
+                    PrimaryPeriodEnd = table.Column<DateOnly>(type: "date", nullable: false),
+                    Form = table.Column<string>(type: "text", nullable: false),
+                    FiledDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    Position = table.Column<int>(type: "integer", nullable: false),
+                    Currency = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: true),
+                    Scale = table.Column<long>(type: "bigint", nullable: false),
+                    Payload = table.Column<string>(type: "jsonb", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReportedFinancialStatement", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ReportedFinancialStatement_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ReportedFinancialStatement_Document_DocumentId",
+                        column: x => x.DocumentId,
+                        principalTable: "Document",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Document_ReportedStatementsContentId",
+                table: "Document",
+                column: "ReportedStatementsContentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Document_ReportedStatementsStatus",
+                table: "Document",
+                column: "ReportedStatementsStatus");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Document_ReportedStatementsStatus_ReportedStatementsParseVe~",
+                table: "Document",
+                columns: new[] { "ReportedStatementsStatus", "ReportedStatementsParseVersion" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReportedFinancialStatement_CommonStockId_Kind_FiscalYear_Fi~",
+                table: "ReportedFinancialStatement",
+                columns: new[] { "CommonStockId", "Kind", "FiscalYear", "FiscalPeriod" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReportedFinancialStatement_DocumentId",
+                table: "ReportedFinancialStatement",
+                column: "DocumentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReportedFinancialStatement_DocumentId_RoleUri",
+                table: "ReportedFinancialStatement",
+                columns: new[] { "DocumentId", "RoleUri" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Document_File_ReportedStatementsContentId",
+                table: "Document",
+                column: "ReportedStatementsContentId",
+                principalTable: "File",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Document_File_ReportedStatementsContentId",
+                table: "Document");
+
+            migrationBuilder.DropTable(
+                name: "ReportedFinancialStatement");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Document_ReportedStatementsContentId",
+                table: "Document");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Document_ReportedStatementsStatus",
+                table: "Document");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Document_ReportedStatementsStatus_ReportedStatementsParseVe~",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "ReportedStatementsCaptureAttempts",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "ReportedStatementsContentId",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "ReportedStatementsParseAttempts",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "ReportedStatementsParseVersion",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "ReportedStatementsStatus",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "ReportedStatementsUncompressedSize",
+                table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -14,6 +14,8 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(XbrlStatus), IsUnique = false)]
 [Index(nameof(XbrlStatus), nameof(XbrlFactsVersion))]
 [Index(nameof(DocumentType), nameof(AsFiledHtmlVersion))]
+[Index(nameof(ReportedStatementsStatus), IsUnique = false)]
+[Index(nameof(ReportedStatementsStatus), nameof(ReportedStatementsParseVersion))]
 [Index(nameof(CreationTime), IsUnique = false)]
 public class Document
 {
@@ -178,6 +180,71 @@ public class Document
     /// images for filings stitched by the image-less v1 builder.
     /// </remarks>
     public const int AsFiledHtmlBuilderVersion = 2;
+
+    // --- As-reported statement capture (SEC's pre-rendered R-files) ---
+    // SEC renders each financial statement of an XBRL filing into an HTML table (R2.htm,
+    // R3.htm…) from the filing's own presentation/calculation/label linkbases, and indexes
+    // them in FilingSummary.xml. We capture FilingSummary + the "Statements" R-files here as
+    // one gzip bundle (the network step), then a separate local parse step turns them into
+    // ReportedFinancialStatement rows. Kept apart from XbrlContent (fact extraction) and
+    // AsFiledHtmlContent (the human viewer) so presentation capture perturbs neither.
+
+    /// <summary>
+    /// Whether the filing's as-reported statement bundle has been captured. Default
+    /// <see cref="XbrlCaptureStatus.NotChecked"/> is the backfill target;
+    /// <see cref="XbrlCaptureStatus.Captured"/> and <see cref="XbrlCaptureStatus.NotPresent"/>
+    /// (no FilingSummary / no XBRL) are terminal.
+    /// </summary>
+    public XbrlCaptureStatus ReportedStatementsStatus { get; set; } = XbrlCaptureStatus.NotChecked;
+
+    /// <summary>
+    /// The file holding the gzip bundle of FilingSummary.xml plus the "Statements" R-files,
+    /// or null when none was captured. The pre-compression size is
+    /// <see cref="ReportedStatementsUncompressedSize"/>.
+    /// </summary>
+    public Guid? ReportedStatementsContentId { get; set; }
+    public virtual File ReportedStatementsContent { get; set; }
+
+    /// <summary>Size in bytes of the R-file bundle before gzip compression. Null when none captured.</summary>
+    public long? ReportedStatementsUncompressedSize { get; set; }
+
+    /// <summary>
+    /// How many times capturing the R-file bundle has failed for this document. The backfill
+    /// stops selecting it at <see cref="MaxReportedStatementsCaptureAttempts"/> so a
+    /// permanently-unfetchable filing can't starve the queue. Only meaningful while
+    /// <see cref="ReportedStatementsStatus"/> is <see cref="XbrlCaptureStatus.NotChecked"/>.
+    /// </summary>
+    public int ReportedStatementsCaptureAttempts { get; set; }
+
+    /// <summary>Retry ceiling for <see cref="ReportedStatementsCaptureAttempts"/>.</summary>
+    public const int MaxReportedStatementsCaptureAttempts = 5;
+
+    /// <summary>
+    /// Version of the R-file parser that last reconstructed this document's statements from the
+    /// captured bundle. 0 = never parsed; the parse sweep selects
+    /// <see cref="XbrlCaptureStatus.Captured"/> documents whose version is below
+    /// <see cref="ReportedStatementsParserVersion"/>, so bumping the parser re-derives the
+    /// corpus offline without re-fetching EDGAR (same redrain as the XBRL-facts extractor).
+    /// </summary>
+    public int ReportedStatementsParseVersion { get; set; }
+
+    /// <summary>
+    /// How many times parsing the captured R-file bundle has failed for this document. The
+    /// parse sweep stops selecting it at <see cref="MaxReportedStatementsParseAttempts"/> so
+    /// one unparseable bundle can't starve the queue.
+    /// </summary>
+    public int ReportedStatementsParseAttempts { get; set; }
+
+    /// <summary>Retry ceiling for <see cref="ReportedStatementsParseAttempts"/>.</summary>
+    public const int MaxReportedStatementsParseAttempts = 5;
+
+    /// <summary>
+    /// Current R-file parser version — the single source of truth for "which captured filings
+    /// still need (re)parsing". Lives here (Data) so both the parse work-set query and the
+    /// backoffice "pending" metric can reference it without depending on the hosted-service
+    /// assembly. Bump after a parser change to re-derive the corpus.
+    /// </summary>
+    public const int ReportedStatementsParserVersion = 1;
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/Enums/ReportedStatementKind.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Enums/ReportedStatementKind.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Sec.FinancialFacts.Data.Enums;
+
+/// <summary>
+/// Which financial statement an as-reported <see cref="Models.ReportedFinancialStatement"/>
+/// represents, classified from the statement's role name in the filing's FilingSummary.xml
+/// (SEC's own role titles). Drives the statement-type tabs on the Financials surfaces.
+/// <see cref="Other"/> covers a "Statements"-category report that matches none of the named
+/// kinds (rare — e.g. a regulatory capital schedule) so nothing is silently dropped.
+/// </summary>
+public enum ReportedStatementKind
+{
+    [Display(Name = "Income Statement")]
+    Income = 0,
+
+    [Display(Name = "Balance Sheet")]
+    BalanceSheet = 1,
+
+    [Display(Name = "Cash Flow")]
+    CashFlow = 2,
+
+    [Display(Name = "Stockholders' Equity")]
+    Equity = 3,
+
+    [Display(Name = "Comprehensive Income")]
+    ComprehensiveIncome = 4,
+
+    [Display(Name = "Other")]
+    Other = 5,
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/FinancialFactsModuleConfiguration.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/FinancialFactsModuleConfiguration.cs
@@ -25,6 +25,11 @@ public class FinancialFactsModuleConfiguration : Equibles.Data.IFinancialModule
 
         builder.Entity<FinancialFactDimension>();
 
+        builder.Entity<ReportedFinancialStatement>(b =>
+        {
+            b.Property(e => e.Form).HasConversion(docTypeConversion);
+        });
+
         builder.Entity<FinancialFactsSyncStatus>();
     }
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/ReportedFinancialStatement.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/ReportedFinancialStatement.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.FinancialFacts.Data.Models;
+
+/// <summary>
+/// One financial statement reconstructed as-reported from a filing — the issuer's own line
+/// items, labels, indentation, subtotals and comparative period columns. Built by parsing
+/// SEC's pre-rendered R-files (the FilingSummary.xml report index + the per-statement
+/// <c>R#.htm</c> tables it lists), which SEC renders from the filing's own
+/// presentation/calculation/label linkbases. Distinct from <see cref="FinancialFact"/>: a
+/// <see cref="FinancialFact"/> is one normalized concept value for cross-company screening,
+/// whereas this is a whole statement laid out exactly as the company filed it.
+///
+/// <para>
+/// The line-item tree and its period columns live in <see cref="Payload"/> (JSON) rather than
+/// as relational rows: a statement is always read whole, the shape is presentation-oriented
+/// (depth, totals, per-column values), and a column-per-row model would explode into millions
+/// of tiny rows for no query benefit. Restatements are retained as separate rows discriminated
+/// by their source <see cref="Document"/>; the currently-reported statement for a period is the
+/// one from the latest-filed document.
+/// </para>
+/// </summary>
+[Index(nameof(CommonStockId), nameof(Kind), nameof(FiscalYear), nameof(FiscalPeriod))]
+[Index(nameof(DocumentId))]
+[Index(nameof(DocumentId), nameof(RoleUri), IsUnique = true)]
+public class ReportedFinancialStatement
+{
+    // Client-generated Guid key, matching FinancialFact: without
+    // DatabaseGeneratedOption.None EF marks it store-generated and the upsert
+    // omits it from the INSERT, which Postgres (no column default) rejects.
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    /// <summary>The filing this statement was reconstructed from.</summary>
+    public Guid DocumentId { get; set; }
+    public virtual Document Document { get; set; }
+
+    /// <summary>Accession number of the source filing, denormalized for filtering.</summary>
+    [Required]
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    /// <summary>Which statement this is, classified from the role title (drives the type tabs).</summary>
+    public ReportedStatementKind Kind { get; set; }
+
+    /// <summary>
+    /// The issuer's role URI for the statement (FilingSummary <c>Role</c>), e.g.
+    /// <c>http://www.acme.com/role/ConsolidatedStatementsOfOperations</c>. Stable within a
+    /// filing, so it forms the upsert natural key together with <see cref="DocumentId"/>.
+    /// </summary>
+    [Required]
+    [MaxLength(512)]
+    public string RoleUri { get; set; }
+
+    /// <summary>The human title SEC renders for the statement (FilingSummary <c>ShortName</c>).</summary>
+    [MaxLength(512)]
+    public string RoleShortName { get; set; }
+
+    /// <summary>The R-file the statement was parsed from, e.g. <c>R2.htm</c> (traceability / re-parse).</summary>
+    [MaxLength(64)]
+    public string ReportFileName { get; set; }
+
+    /// <summary>
+    /// A parenthetical companion statement (e.g. "Balance Sheet (Parenthetical)" carrying
+    /// per-share and shares-authorized detail) rather than the primary statement.
+    /// </summary>
+    public bool IsParenthetical { get; set; }
+
+    public int FiscalYear { get; set; }
+
+    public SecFiscalPeriod FiscalPeriod { get; set; }
+
+    /// <summary>Period end of the statement's primary (newest) column — the period it represents.</summary>
+    public DateOnly PrimaryPeriodEnd { get; set; }
+
+    /// <summary>Source form (10-K, 10-Q, 20-F, …). Reuses the SEC module's DocumentType.</summary>
+    [Required]
+    public DocumentType Form { get; set; }
+
+    public DateOnly FiledDate { get; set; }
+
+    /// <summary>The report's position within the filing (FilingSummary order), preserved for display ordering.</summary>
+    public int Position { get; set; }
+
+    /// <summary>Reporting currency of the statement, e.g. <c>USD</c>; null when not stated.</summary>
+    [MaxLength(16)]
+    public string Currency { get; set; }
+
+    /// <summary>
+    /// The "$ in Thousands/Millions" multiplier SEC noted on the statement (1, 1000, 1000000).
+    /// The values in <see cref="Payload"/> are already de-scaled to whole units; this is kept
+    /// for reference and to round-trip the issuer's stated presentation scale.
+    /// </summary>
+    public long Scale { get; set; } = 1;
+
+    /// <summary>
+    /// The reconstructed statement as JSON: <c>{ columns: [...], rows: [...] }</c>, where each
+    /// row carries the issuer label, indent depth, abstract/total flags and a per-column value
+    /// list aligned to <c>columns</c>. Stored as <c>jsonb</c> — read whole by the render
+    /// surfaces, queryable if needed. Empty string until the parse step fills it.
+    /// </summary>
+    [Required(AllowEmptyStrings = true)]
+    [Column(TypeName = "jsonb")]
+    public string Payload { get; set; } = string.Empty;
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}


### PR DESCRIPTION
## Summary

First slice of full as-reported financial statements (reconstructed from SEC's pre-rendered R-files). This adds only the storage foundation — no behavior yet.

SEC renders each financial statement of an XBRL filing into an HTML table (`R2.htm`, `R3.htm`…) from the filing's own presentation/calculation/label linkbases, and indexes them in `FilingSummary.xml`. Later slices capture those R-files and parse them into structured statements; this slice is where they will be stored.

## Code changes

- `Document` — new `ReportedStatements*` artifact fields (status, gzip bundle content + size, capture attempts, parser version + attempts) mirroring the existing XBRL-envelope and as-filed-HTML capture pattern: a version-stamped, attempt-capped split between the network capture and the local, re-runnable parse. Reuses `XbrlCaptureStatus`. Adds two work-set indexes.
- `ReportedFinancialStatement` — one statement as filed (issuer labels, indentation, subtotals, comparative period columns) stored as a `jsonb` `{columns, rows}` payload, classified into a `ReportedStatementKind` tab. Restatements are separate rows keyed by source `Document`; upsert natural key `(DocumentId, RoleUri)`. Distinct from `FinancialFact` (the normalized per-concept value used for screening).
- `ReportedStatementKind` enum; registered in `FinancialFactsModuleConfiguration` (financial DbContext) with the shared `DocumentType` string conversion.
- Migration `AddReportedFinancialStatements`.