### PR TITLE
refactor(web): extract shared PagedBrowserViewModel base for browser list viewmodels

### DIFF
--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
@@ -1,9 +1,9 @@
 using Equibles.Holdings.Data.Models;
-using Equibles.Web.Extensions;
+using Equibles.Web.ViewModels.Shared;
 
 namespace Equibles.Web.ViewModels.Institutions;
 
-public class InstitutionBrowserViewModel
+public class InstitutionBrowserViewModel : PagedBrowserViewModel
 {
     public List<InstitutionListItemViewModel> Institutions { get; set; } = [];
     public string Search { get; set; }
@@ -33,9 +33,4 @@ public class InstitutionBrowserViewModel
     // Latest universe-wide 13F report date — drives the per-filer aggregates
     // and the page subtitle. Null when no holdings have been ingested yet.
     public DateOnly? LatestReportDate { get; set; }
-
-    public int Page { get; set; } = 1;
-    public int PageSize { get; set; } = 50;
-    public int TotalCount { get; set; }
-    public int TotalPages => Pagination.PageCount(TotalCount, PageSize);
 }

--- a/src/Equibles.Web/ViewModels/Shared/PagedBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Shared/PagedBrowserViewModel.cs
@@ -1,0 +1,13 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.Web.ViewModels.Shared;
+
+// Shared paging state for the search/browse list pages. TotalPages floors at 1 via
+// Pagination.PageCount so an empty result set still renders a single (empty) page.
+public abstract class PagedBrowserViewModel
+{
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 50;
+    public int TotalCount { get; set; }
+    public int TotalPages => Pagination.PageCount(TotalCount, PageSize);
+}

--- a/src/Equibles.Web/ViewModels/ShortActivity/MostShortedBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/ShortActivity/MostShortedBrowserViewModel.cs
@@ -1,8 +1,8 @@
-using Equibles.Web.Extensions;
+using Equibles.Web.ViewModels.Shared;
 
 namespace Equibles.Web.ViewModels.ShortActivity;
 
-public class MostShortedBrowserViewModel
+public class MostShortedBrowserViewModel : PagedBrowserViewModel
 {
     public List<MostShortedListItemViewModel> Records { get; set; } = [];
 
@@ -16,8 +16,4 @@ public class MostShortedBrowserViewModel
     public List<DateOnly> AvailableDates { get; set; } = [];
 
     public MostShortedSort Sort { get; set; }
-    public int Page { get; set; } = 1;
-    public int PageSize { get; set; } = 50;
-    public int TotalCount { get; set; }
-    public int TotalPages => Pagination.PageCount(TotalCount, PageSize);
 }

--- a/src/Equibles.Web/ViewModels/ShortVolume/ShortVolumeBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/ShortVolume/ShortVolumeBrowserViewModel.cs
@@ -1,8 +1,8 @@
-using Equibles.Web.Extensions;
+using Equibles.Web.ViewModels.Shared;
 
 namespace Equibles.Web.ViewModels.ShortVolume;
 
-public class ShortVolumeBrowserViewModel
+public class ShortVolumeBrowserViewModel : PagedBrowserViewModel
 {
     public List<ShortVolumeListItemViewModel> Records { get; set; } = [];
 
@@ -16,8 +16,4 @@ public class ShortVolumeBrowserViewModel
     public List<DateOnly> AvailableDates { get; set; } = [];
 
     public ShortVolumeSort Sort { get; set; }
-    public int Page { get; set; } = 1;
-    public int PageSize { get; set; } = 50;
-    public int TotalCount { get; set; }
-    public int TotalPages => Pagination.PageCount(TotalCount, PageSize);
 }


### PR DESCRIPTION
## Summary

- Three browser list view models — `InstitutionBrowserViewModel`, `ShortVolumeBrowserViewModel`, and `MostShortedBrowserViewModel` — each independently declared the same four paging members (`Page`, `PageSize`, `TotalCount`, and a computed `TotalPages => Pagination.PageCount(TotalCount, PageSize)`).
- Pulled that duplicated block into a new abstract `PagedBrowserViewModel` base the three now inherit, removing the repetition. The computation is unchanged, so the rendered pages behave identically.

## Code changes

- `src/Equibles.Web/ViewModels/Shared/PagedBrowserViewModel.cs` — new abstract base holding the shared `Page`/`PageSize`/`TotalCount`/`TotalPages` paging members (mirrors the existing `Shared/StatsViewModel` base).
- `src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs` — inherits the base; drops the four duplicated members.
- `src/Equibles.Web/ViewModels/ShortVolume/ShortVolumeBrowserViewModel.cs` — same.
- `src/Equibles.Web/ViewModels/ShortActivity/MostShortedBrowserViewModel.cs` — same.