### PR TITLE
chore(embedding): default to qwen3-embedding:0.6b instead of bge-m3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,5 +42,5 @@ MINIMUM_LOG_LEVEL=Warning
 # Use "docker compose --profile embedding up" to start the bundled Ollama server.
 # Embedding__Enabled=true
 # Embedding__BaseUrl=http://localhost:11434
-# Embedding__ModelName=bge-m3
+# Embedding__ModelName=qwen3-embedding:0.6b
 # Embedding__BatchSize=10

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Worker__MinSyncDate=2024-01-01
 |---------|---------|-------------|
 | `Embedding__Enabled` | `false` | Set to `true` to enable vector embedding generation |
 | `Embedding__BaseUrl` | — | Ollama or OpenAI-compatible endpoint (e.g., `http://localhost:11434`) |
-| `Embedding__ModelName` | — | Model name (e.g., `bge-m3`) |
+| `Embedding__ModelName` | — | Model name (e.g., `qwen3-embedding:0.6b`) |
 | `Embedding__BatchSize` | `10` | Texts per embedding batch |
 
 **Update notifications (optional):**
@@ -242,7 +242,7 @@ Any MCP-compatible client can connect to `http://localhost:8081/mcp` (HTTP trans
 
 ## Vector Embeddings (advanced, opt-in)
 
-Vector embeddings enable semantic search over SEC filings (e.g., "find revenue growth discussion in Apple's 10-K"). This requires downloading the Ollama runtime (~2GB) and the BGE-M3 model (~1.2GB).
+Vector embeddings enable semantic search over SEC filings (e.g., "find revenue growth discussion in Apple's 10-K"). This requires downloading the Ollama runtime (~2GB) and the Qwen3-Embedding-0.6B model (~640MB).
 
 ```bash
 docker compose --profile embedding up
@@ -252,7 +252,7 @@ This adds:
 
 | Service | Port | Description |
 |---------|------|-------------|
-| **embedding** | 11434 | Ollama server with BGE-M3 model |
+| **embedding** | 11434 | Ollama server with Qwen3-Embedding-0.6B model |
 | **worker-embedding** | — | Worker with embedding generation enabled |
 
 Without the embedding profile, BM25 full-text search via ParadeDB still works out of the box — vector search is purely additive.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       embedding:
         condition: service_healthy
     restart: "no"
-    entrypoint: ["ollama", "pull", "bge-m3"]
+    entrypoint: ["ollama", "pull", "qwen3-embedding:0.6b"]
     environment:
       OLLAMA_HOST: http://embedding:11434
 
@@ -121,7 +121,7 @@ services:
       Sec__ContactEmail: ${SEC_CONTACT_EMAIL}
       Embedding__Enabled: "true"
       Embedding__BaseUrl: "http://embedding:11434"
-      Embedding__ModelName: "bge-m3"
+      Embedding__ModelName: "qwen3-embedding:0.6b"
       Embedding__BatchSize: "10"
       MinimumLogLevel: ${MINIMUM_LOG_LEVEL:-Warning}
     depends_on:

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -8,7 +8,7 @@ The web portal checks GitHub Releases on a schedule and shows a banner when a ne
 
 ## How much disk space does Equibles need?
 
-Plan for about 5 GB to start, growing over time as scrapers backfill more history. The database (held in the `db-data` Docker volume) is by far the largest consumer; the cached SEC filings are smaller. Pulling the full default range (2020 onwards) for every U.S. ticker is the baseline — restricting to a [chosen list of tickers](how-to-restrict-ticker-sync.md) or [a later sync start date](how-to-change-sync-start-date.md) keeps it much smaller, while extending back to 2000 makes it substantially larger. Enabling the [embedding profile](how-to-enable-embedding-search.md) adds roughly 3 GB more (~2 GB Ollama image, ~1.2 GB BGE-M3 model, plus per-chunk vectors).
+Plan for about 5 GB to start, growing over time as scrapers backfill more history. The database (held in the `db-data` Docker volume) is by far the largest consumer; the cached SEC filings are smaller. Pulling the full default range (2020 onwards) for every U.S. ticker is the baseline — restricting to a [chosen list of tickers](how-to-restrict-ticker-sync.md) or [a later sync start date](how-to-change-sync-start-date.md) keeps it much smaller, while extending back to 2000 makes it substantially larger. Enabling the [embedding profile](how-to-enable-embedding-search.md) adds roughly 2.6 GB more (~2 GB Ollama image, ~640 MB Qwen3-Embedding-0.6B model, plus per-chunk vectors).
 
 ## How do I wipe the database and start over?
 

--- a/docs/guide/how-to-enable-embedding-search.md
+++ b/docs/guide/how-to-enable-embedding-search.md
@@ -2,7 +2,7 @@
 
 Turn on the embedding profile so the MCP `SearchDocuments` / `SearchCompanyDocuments` tools can do meaning-based ("semantic") search across SEC filings — e.g. find every passage about supply-chain risk in Apple's 10-K, even when the words don't match. Without this, only exact-keyword search works.
 
-The profile adds a local Ollama runtime and the BGE-M3 embedding model. Expect a one-time ~3.2 GB download (~2 GB Ollama image + ~1.2 GB model) and around 4 GB of additional RAM use while running.
+The profile adds a local Ollama runtime and the Qwen3-Embedding-0.6B embedding model. Expect a one-time ~2.6 GB download (~2 GB Ollama image + ~640 MB model) and around 3 GB of additional RAM use while running.
 
 1. If the stack is currently running, stop it first so Docker Compose can apply the new profile cleanly:
 
@@ -18,7 +18,7 @@ The profile adds a local Ollama runtime and the BGE-M3 embedding model. Expect a
    docker compose --profile embedding up -d
    ```
 
-   The first run pulls the Ollama image, starts an `embedding-pull` init container that downloads BGE-M3 (~1.2 GB), then starts a `worker-embedding` service in place of the default `worker`. Watch progress with `docker compose --profile embedding logs -f embedding embedding-pull`.
+   The first run pulls the Ollama image, starts an `embedding-pull` init container that downloads Qwen3-Embedding-0.6B (~640 MB), then starts a `worker-embedding` service in place of the default `worker`. Watch progress with `docker compose --profile embedding logs -f embedding embedding-pull`.
 
 3. Wait for `embedding-pull` to exit successfully — its log ends with something like `success`. After that the `embedding` container's healthcheck flips to healthy and `worker-embedding` starts generating embeddings for every SEC document chunk in the database. The first backfill can take an hour or more, depending on how many filings you've ingested.
 
@@ -28,7 +28,7 @@ The profile adds a local Ollama runtime and the BGE-M3 embedding model. Expect a
 
    *"Use the Equibles SearchDocuments tool to find passages in Apple's most recent 10-K about supply-chain risk. Summarise the top three matches."*
 
-   If `SearchDocuments` returns empty results even though the worker is running, the embedding endpoint isn't configured for the MCP server. Confirm `Embedding__BaseUrl=http://embedding:11434` and `Embedding__ModelName=bge-m3` are set in the `mcp` container's environment — `docker compose --profile embedding config mcp` should show them.
+   If `SearchDocuments` returns empty results even though the worker is running, the embedding endpoint isn't configured for the MCP server. Confirm `Embedding__BaseUrl=http://embedding:11434` and `Embedding__ModelName=qwen3-embedding:0.6b` are set in the `mcp` container's environment — `docker compose --profile embedding config mcp` should show them.
 
 To turn embeddings back off, run `docker compose --profile embedding down` followed by `docker compose up -d` (no profile flag). The embeddings already in the database stay searchable; only new chunks stop getting embedded.
 

--- a/docs/guide/how-to-use-external-embedding-endpoint.md
+++ b/docs/guide/how-to-use-external-embedding-endpoint.md
@@ -15,10 +15,10 @@ Use this when you want to avoid the extra ~3 GB Docker download, share a GPU acr
     curl http://ollama.local:11434/api/tags
     ```
 
-    The response should list a model. BGE-M3 is the default Equibles expects:
+    The response should list a model. Qwen3-Embedding-0.6B is the default Equibles expects:
 
     ```bash
-    ollama pull bge-m3
+    ollama pull qwen3-embedding:0.6b
     ```
 
     For an OpenAI-compatible endpoint, confirm with the provider which embedding model name to use (e.g., `text-embedding-3-small`).
@@ -28,7 +28,7 @@ Use this when you want to avoid the extra ~3 GB Docker download, share a GPU acr
     ```env
     Embedding__Enabled=true
     Embedding__BaseUrl=http://ollama.local:11434
-    Embedding__ModelName=bge-m3
+    Embedding__ModelName=qwen3-embedding:0.6b
     # Optional — defaults to 10
     # Embedding__BatchSize=20
     ```

--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -50,7 +50,7 @@ The background-scraper host. Plain `Host.CreateApplicationBuilder` (not `WebAppl
 
 ## Embedding profile
 
-`docker-compose.yml` defines `worker-embedding` under the `embedding` profile alongside an `embedding` Ollama service. Activate with `docker compose --profile embedding up`. The profile substitutes the default `worker` with `worker-embedding`, which sets `Embedding__Enabled=true`, `Embedding__BaseUrl=http://embedding:11434`, `Embedding__ModelName=bge-m3`. The same `EmbeddingConfig` binding the MCP server reads is what enables SEC chunk embedding generation on this worker.
+`docker-compose.yml` defines `worker-embedding` under the `embedding` profile alongside an `embedding` Ollama service. Activate with `docker compose --profile embedding up`. The profile substitutes the default `worker` with `worker-embedding`, which sets `Embedding__Enabled=true`, `Embedding__BaseUrl=http://embedding:11434`, `Embedding__ModelName=qwen3-embedding:0.6b`. The same `EmbeddingConfig` binding the MCP server reads is what enables SEC chunk embedding generation on this worker.
 
 ## Shared startup sequence
 

--- a/docs/technical/operations.md
+++ b/docs/technical/operations.md
@@ -77,8 +77,8 @@ Activating the profile adds two services and swaps the default worker:
 | Service | Image | Role |
 |---|---|---|
 | `embedding` | `ollama/ollama` | Ollama runtime on port `11434`. |
-| `embedding-pull` | `ollama/ollama` | One-shot init container that runs `ollama pull bge-m3` after `embedding` becomes healthy. |
-| `worker-embedding` | Equibles worker image | Replaces the default `worker` with `Embedding__Enabled=true` + the BGE-M3 endpoint. |
+| `embedding-pull` | `ollama/ollama` | One-shot init container that runs `ollama pull qwen3-embedding:0.6b` after `embedding` becomes healthy. |
+| `worker-embedding` | Equibles worker image | Replaces the default `worker` with `Embedding__Enabled=true` + the Qwen3-Embedding-0.6B endpoint. |
 
 Embedding-related variables (override only if running Ollama elsewhere):
 
@@ -86,7 +86,7 @@ Embedding-related variables (override only if running Ollama elsewhere):
 |---|---|
 | `Embedding__Enabled` | `false` (or `true` under the embedding profile's worker) |
 | `Embedding__BaseUrl` | `http://embedding:11434` (the in-network DNS name) |
-| `Embedding__ModelName` | `bge-m3` |
+| `Embedding__ModelName` | `qwen3-embedding:0.6b` |
 | `Embedding__BatchSize` | `10` |
 
 The MCP server's `RagManager` reads the same `EmbeddingConfig` binding for query-time embedding; the worker reads it for chunk-time embedding. Without both bound to a working endpoint, `RagSearchTools` returns empty results.
@@ -114,7 +114,7 @@ Bumping to `Information` is useful for diagnosing slow scraper cycles; `Debug` i
 | `mcp` | built from `src/Equibles.Mcp.Server/Dockerfile` | `8081:8080` | MCP transport at `/mcp`. Depends on `web` being healthy. |
 | `worker` | built from `src/Equibles.Worker.Host/Dockerfile` | — | Background scrapers. Depends on `web` being healthy. |
 | `embedding` (profile `embedding`) | `ollama/ollama:latest` | `11434:11434` | Ollama for embeddings. |
-| `embedding-pull` (profile `embedding`) | `ollama/ollama:latest` | — | Pulls the BGE-M3 model once and exits. |
+| `embedding-pull` (profile `embedding`) | `ollama/ollama:latest` | — | Pulls the Qwen3-Embedding-0.6B model once and exits. |
 | `worker-embedding` (profile `embedding`) | built from `src/Equibles.Worker.Host/Dockerfile` | — | Worker with `Embedding__Enabled=true`. Replaces the default `worker`. |
 
 ## Upgrading
@@ -137,7 +137,7 @@ Two named volumes survive container rebuilds:
 |---|---|---|
 | `db-data` | `/var/lib/postgresql` on `db` | Everything — your data. |
 | `web-keys` | `/app/keys` on `web` | Data-protection keys for auth cookies + anti-forgery. |
-| `ollama-data` (profile `embedding`) | `/root/.ollama` on `embedding` | The downloaded BGE-M3 model (~1.2 GB). |
+| `ollama-data` (profile `embedding`) | `/root/.ollama` on `embedding` | The downloaded Qwen3-Embedding-0.6B model (~640 MB). |
 
 A `docker compose down` keeps these volumes. `docker compose down -v` deletes them — only use when you want to wipe the database.
 
@@ -160,7 +160,7 @@ A `docker compose down` keeps these volumes. `docker compose down -v` deletes th
 ## Air-gapped deploys
 
 - Set `CHECK_FOR_UPDATES=false` to stop the GitHub Releases poll.
-- Do not activate the `embedding` profile unless your network can reach the upstream Ollama image and the BGE-M3 model. Pre-pulling and saving via `docker image save` works.
+- Do not activate the `embedding` profile unless your network can reach the upstream Ollama image and the Qwen3-Embedding-0.6B model. Pre-pulling and saving via `docker image save` works.
 - Most scrapers will simply error if their upstream is unreachable — those errors land on the Status dashboard, not the container's stderr alone.
 
 ## Common operational issues

--- a/src/Equibles.Worker.Host/appsettings.json
+++ b/src/Equibles.Worker.Host/appsettings.json
@@ -9,7 +9,7 @@
   "Embedding": {
     "Enabled": false,
     "BaseUrl": "http://localhost:11434",
-    "ModelName": "bge-m3",
+    "ModelName": "qwen3-embedding:0.6b",
     "BatchSize": 10
   },
   "Serilog": {


### PR DESCRIPTION
## Summary

Switches the default embedding model from `bge-m3` to `qwen3-embedding:0.6b` across the worker config, the embedding Docker profile, and the docs.

Reasons:
- Retrieves better on SEC / financial filings in local benchmarking (hybrid BM25 + vector recall@k and MRR were higher than bge-m3 on a financial chunk corpus).
- Smaller download (~640 MB vs ~1.2 GB) and Apache-2.0 licensed.
- Aligns the open-source default with what the production deployment already overrides to, removing a confusing mismatch.

Embeddings remain opt-in and disabled by default (`Embedding__Enabled=false`), so existing setups are unaffected unless they enable the `embedding` profile.

## Code changes
- `src/Equibles.Worker.Host/appsettings.json` — default `Embedding:ModelName`.
- `docker-compose.yml` — `embedding-pull` model + `worker-embedding` `Embedding__ModelName`.
- `.env.example` — sample model name.
- Docs (`README.md`, `docs/guide/*`, `docs/technical/*`) — model name and download/RAM sizes.