### PR TITLE
style: format embeddings/search/RAG files with CSharpier

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
+++ b/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
@@ -121,9 +121,17 @@ public class EmbeddingClient : IEmbeddingClient
         {
             var payload = new { model = _config.ModelName, input = batch };
             var json = JsonSerializer.Serialize(payload);
-            using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            using var content = new StringContent(
+                json,
+                System.Text.Encoding.UTF8,
+                "application/json"
+            );
 
-            var response = await _httpClient.PostAsync("/v1/embeddings", content, cancellationToken);
+            var response = await _httpClient.PostAsync(
+                "/v1/embeddings",
+                content,
+                cancellationToken
+            );
             response.EnsureSuccessStatusCode();
 
             var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
@@ -153,7 +161,11 @@ public class EmbeddingClient : IEmbeddingClient
             // Same { model, input } payload either way; only the endpoint and response shape differ.
             var payload = new { model = _config.ModelName, input = text };
             var json = JsonSerializer.Serialize(payload);
-            using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            using var content = new StringContent(
+                json,
+                System.Text.Encoding.UTF8,
+                "application/json"
+            );
 
             return _config.Provider == EmbeddingProvider.OpenAI
                 ? await EmbedViaOpenAi(content, cancellationToken)
@@ -161,7 +173,10 @@ public class EmbeddingClient : IEmbeddingClient
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Skipping a chunk that failed to embed (continuing with the rest)");
+            _logger.LogWarning(
+                ex,
+                "Skipping a chunk that failed to embed (continuing with the rest)"
+            );
             return null;
         }
     }

--- a/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
@@ -181,9 +181,7 @@ public class HybridChunkSearcher
 
         var scored = new List<(Guid Id, double Similarity)>();
         foreach (var stored in storedVectors)
-            scored.Add(
-                (stored.ChunkId, CosineSimilarity(queryVector, stored.Vector.ToArray()))
-            );
+            scored.Add((stored.ChunkId, CosineSimilarity(queryVector, stored.Vector.ToArray())));
 
         return scored
             .OrderByDescending(entry => entry.Similarity)
@@ -241,10 +239,7 @@ public class HybridChunkSearcher
                 byId[chunk.Id] = chunk;
         }
 
-        return orderedIds
-            .Where(id => byId.ContainsKey(id))
-            .Select(id => byId[id])
-            .ToList();
+        return orderedIds.Where(id => byId.ContainsKey(id)).Select(id => byId[id]).ToList();
     }
 
     private static DateTime? ToUtc(DateOnly? date)

--- a/src/Equibles.Sec.Repositories/EmbeddingRepository.cs
+++ b/src/Equibles.Sec.Repositories/EmbeddingRepository.cs
@@ -72,7 +72,9 @@ public class EmbeddingRepository : BaseRepository<Embedding>
         if (ticker != null)
         {
             var loweredTicker = ticker.ToLowerInvariant();
-            query = query.Where(e => e.Chunk.Ticker != null && e.Chunk.Ticker.ToLower() == loweredTicker);
+            query = query.Where(e =>
+                e.Chunk.Ticker != null && e.Chunk.Ticker.ToLower() == loweredTicker
+            );
         }
 
         if (documentId.HasValue)

--- a/tests/Equibles.UnitTests/Sec/RagManagerBuildContextCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagManagerBuildContextCultureInvarianceTests.cs
@@ -59,7 +59,11 @@ public class RagManagerBuildContextCultureInvarianceTests
             },
         };
 
-        var sut = new RagManager(hybridChunkSearcher: null, commonStockRepository: null, logger: null);
+        var sut = new RagManager(
+            hybridChunkSearcher: null,
+            commonStockRepository: null,
+            logger: null
+        );
 
         var original = CultureInfo.CurrentCulture;
         string invariantOutput;

--- a/tests/Equibles.UnitTests/Sec/RagManagerBuildContextStartLineNumberTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagManagerBuildContextStartLineNumberTests.cs
@@ -47,7 +47,11 @@ public class RagManagerBuildContextStartLineNumberTests
             },
         };
 
-        var sut = new RagManager(hybridChunkSearcher: null, commonStockRepository: null, logger: null);
+        var sut = new RagManager(
+            hybridChunkSearcher: null,
+            commonStockRepository: null,
+            logger: null
+        );
 
         var output = await sut.BuildContext(chunks);
 

--- a/tests/Equibles.UnitTests/Sec/RagManagerBuildContextWhitespaceChunkTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagManagerBuildContextWhitespaceChunkTests.cs
@@ -53,7 +53,11 @@ public class RagManagerBuildContextWhitespaceChunkTests
             },
         };
 
-        var sut = new RagManager(hybridChunkSearcher: null, commonStockRepository: null, logger: null);
+        var sut = new RagManager(
+            hybridChunkSearcher: null,
+            commonStockRepository: null,
+            logger: null
+        );
 
         var result = await sut.BuildContext(chunks);
 

--- a/tests/Equibles.UnitTests/Sec/RagManagerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagManagerTests.cs
@@ -63,7 +63,11 @@ public class RagManagerTests
             },
         };
 
-        var sut = new RagManager(hybridChunkSearcher: null, commonStockRepository: null, logger: null);
+        var sut = new RagManager(
+            hybridChunkSearcher: null,
+            commonStockRepository: null,
+            logger: null
+        );
 
         var result = await sut.BuildContext(chunks);
 
@@ -103,7 +107,11 @@ public class RagManagerTests
         // The pair (non-empty → ordered excerpts, empty → friendly empty-message)
         // distinguishes a working guard from BOTH guard-dropped (NRE catchpath)
         // AND guard-inverted (wrong message for non-empty case) regressions.
-        var sut = new RagManager(hybridChunkSearcher: null, commonStockRepository: null, logger: null);
+        var sut = new RagManager(
+            hybridChunkSearcher: null,
+            commonStockRepository: null,
+            logger: null
+        );
 
         var result = await sut.BuildContext(new List<Chunk>());
 

--- a/tests/Equibles.UnitTests/Sec/RrfFusionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RrfFusionTests.cs
@@ -18,7 +18,9 @@ public class RrfFusionTests
         var b = Id(2);
         var c = Id(3);
 
-        var result = RrfFusion.Fuse([[a, b, c]]);
+        var result = RrfFusion.Fuse([
+            [a, b, c],
+        ]);
 
         result.Should().Equal(a, b, c);
     }
@@ -50,7 +52,9 @@ public class RrfFusionTests
         var first = Id(1);
         var second = Id(2);
 
-        var result = RrfFusion.Fuse([[first, second]]);
+        var result = RrfFusion.Fuse([
+            [first, second],
+        ]);
 
         result.Should().Equal(first, second);
     }
@@ -63,8 +67,14 @@ public class RrfFusionTests
         var low = Id(1);
         var high = Id(2);
 
-        var forward = RrfFusion.Fuse([[high], [low]]);
-        var reversed = RrfFusion.Fuse([[low], [high]]);
+        var forward = RrfFusion.Fuse([
+            [high],
+            [low],
+        ]);
+        var reversed = RrfFusion.Fuse([
+            [low],
+            [high],
+        ]);
 
         forward.Should().Equal(low, high);
         reversed.Should().Equal(low, high);


### PR DESCRIPTION
OSS main CI lint has been red since the #4017 squash merge landed several embeddings/search/RAG files unformatted. This runs the pinned CSharpier 1.3.0 over the tree (8 files, formatting only) to green the lint check.