### PR TITLE
fix(web): register SEC hybrid-search services so the host resolves the search provider

### DIFF
--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -77,6 +77,15 @@ public partial class Program
         // Holdings business-logic services the portal consumes directly (e.g. the smart-money
         // index manager). Repositories these depend on are registered by AddAllRepositories.
         builder.Services.AutoWireServicesFrom<Equibles.Holdings.BusinessLogic.SmartMoneyIndexManager>();
+        // The SEC Filings search provider (discovered by AddEquiblesSearch) depends on the hybrid
+        // BM25 + semantic searcher and the embedding client, both [Service]s in Sec.BusinessLogic.
+        // Register that assembly + bind EmbeddingConfig so the query can embed at request time —
+        // mirrors the MCP host; without it SecDocumentSearchProvider can't resolve HybridChunkSearcher
+        // and service-provider validation fails at startup.
+        builder.Services.AutoWireServicesFrom<Equibles.Sec.BusinessLogic.Search.RagManager>();
+        builder.Services.Configure<Equibles.Sec.BusinessLogic.Embeddings.EmbeddingConfig>(
+            builder.Configuration.GetSection("Embedding")
+        );
 
         var authSettings =
             builder.Configuration.GetSection("Auth").Get<AuthSettings>() ?? new AuthSettings();


### PR DESCRIPTION
## Problem
OSS `main` functional tests have been fully red since #4017 — every test fails at host startup with 'Unable to resolve service for type HybridChunkSearcher while attempting to activate SecDocumentSearchProvider'. #4017 made SecDocumentSearchProvider (auto-discovered by AddEquiblesSearch) depend on HybridChunkSearcher + IEmbeddingClient, both [Service]s in Sec.BusinessLogic, but the web host never auto-wired that assembly, so ValidateOnBuild throws.

## Fix
Auto-wire Sec.BusinessLogic (anchored on RagManager) and bind EmbeddingConfig in Equibles.Web, mirroring the MCP host.

## Verification
The previously-failing functional test passes locally (Postgres via Testcontainers + Playwright).