### PR TITLE
feat(ir-discovery): cascade from website, version-gated re-probe, parallel + chained batches

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -62,6 +62,15 @@ public class CommonStock
     public DateTime? InvestorRelationsCheckedAt { get; set; }
 
     /// <summary>
+    /// The IR-discovery code generation under which this stock was last probed (see
+    /// <c>InvestorRelationsDiscoveryVersion</c>). Defaults to 0 so the whole pre-existing corpus
+    /// counts as the oldest generation; when the probe logic improves and the version is bumped, a
+    /// stock stamped with an older version becomes eligible for re-probe immediately, without waiting
+    /// out its cooldown — so an improvement reaches the backlog of misses on deploy, not over 30 days.
+    /// </summary>
+    public int InvestorRelationsDiscoveryVersion { get; set; }
+
+    /// <summary>
     /// When an IR content scraper (news/events) last worked through this stock (UTC),
     /// stamped on every cycle the stock is scraped — whether or not new rows were
     /// found. Null until first scraped. Scrapers order their cohort least-recently

--- a/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
@@ -41,4 +41,12 @@ public class InvestorRelationsDiscoveryOptions : ScraperOptions
     /// next cycle.
     /// </summary>
     public int ProbeCooldownDays { get; set; } = 30;
+
+    /// <summary>
+    /// How many candidate probes to run concurrently within a cycle. Each probe escalates to a
+    /// stealth-browser render for bot-walled hosts, which can take up to the render timeout, so a
+    /// serial loop made a batch with many such hosts take many minutes. Bounded to keep within the
+    /// shared stealth sidecar's own concurrency cap (contended with slide/webcast capture).
+    /// </summary>
+    public int ProbeConcurrency { get; set; } = 6;
 }

--- a/src/Equibles.CommonStocks.HostedService/Consumers/StockWebsiteDiscoveredConsumer.cs
+++ b/src/Equibles.CommonStocks.HostedService/Consumers/StockWebsiteDiscoveredConsumer.cs
@@ -1,0 +1,45 @@
+using Equibles.CommonStocks.HostedService.Services;
+using Equibles.Messaging.Attributes;
+using Equibles.Messaging.Contracts.CommonStocks;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.CommonStocks.HostedService.Consumers;
+
+/// <summary>
+/// When website discovery fills a stock's website, probe that stock for an IR page immediately off
+/// the new website — so a fresh website cascades straight into IR discovery instead of waiting out
+/// that worker's own cooldown (the cascade <see cref="WebsiteDiscoveryService"/> publishes for).
+/// Idempotent: <see cref="InvestorRelationsDiscoveryService.DiscoverForStock"/> no-ops when the stock
+/// has no website or already has an IR page, so a duplicate event is harmless.
+/// </summary>
+[Consumer]
+public class StockWebsiteDiscoveredConsumer : IConsumer<StockWebsiteDiscovered>
+{
+    private readonly InvestorRelationsDiscoveryService _discovery;
+    private readonly ILogger<StockWebsiteDiscoveredConsumer> _logger;
+
+    public StockWebsiteDiscoveredConsumer(
+        InvestorRelationsDiscoveryService discovery,
+        ILogger<StockWebsiteDiscoveredConsumer> logger
+    )
+    {
+        _discovery = discovery;
+        _logger = logger;
+    }
+
+    public async Task Consume(ConsumeContext<StockWebsiteDiscovered> context)
+    {
+        var found = await _discovery.DiscoverForStock(
+            context.Message.CommonStockId,
+            context.CancellationToken
+        );
+
+        _logger.LogInformation(
+            "Website discovered for {Ticker} ({Website}); IR probe {Outcome}",
+            context.Message.Ticker,
+            context.Message.Website,
+            found ? "found an IR page" : "found none (or one already existed)"
+        );
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/InvestorRelationsDiscoveryWorker.cs
+++ b/src/Equibles.CommonStocks.HostedService/InvestorRelationsDiscoveryWorker.cs
@@ -30,6 +30,17 @@ public class InvestorRelationsDiscoveryWorker : BaseScraperWorker
         SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
     }
 
-    protected override Task DoWork(CancellationToken stoppingToken) =>
-        RunImport<InvestorRelationsDiscoveryService>(stoppingToken);
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var service = scope.ServiceProvider.GetRequiredService<InvestorRelationsDiscoveryService>();
+
+        // Drain a large backlog in successive bursts: when a cycle fills a full batch there are
+        // still pending stocks, so chain into the next batch after the short ContinuationInterval
+        // instead of sleeping the full SleepInterval (one batch per cycle).
+        if (await service.DiscoverBatch(stoppingToken))
+        {
+            RequestImmediateContinuation();
+        }
+    }
 }

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
@@ -15,7 +15,9 @@ namespace Equibles.CommonStocks.HostedService.Services;
 
 /// <summary>
 /// Fills in <c>CommonStock.InvestorRelationsUrl</c> for stocks that have a known
-/// website but no discovered IR page yet, one bounded batch per cycle.
+/// website but no discovered IR page yet, one bounded batch per cycle. Probes
+/// candidates concurrently and chains successive full batches so a large backlog
+/// drains in bursts rather than one batch per cycle.
 /// </summary>
 [Service]
 public class InvestorRelationsDiscoveryService : IImporter
@@ -41,7 +43,14 @@ public class InvestorRelationsDiscoveryService : IImporter
         _options = options.Value;
     }
 
-    public async Task Import(CancellationToken cancellationToken)
+    public Task Import(CancellationToken cancellationToken) => DiscoverBatch(cancellationToken);
+
+    /// <summary>
+    /// Runs one discovery batch and returns true when it filled a full batch — i.e. more pending
+    /// stocks remain — so the worker chains into the next batch instead of sleeping the full
+    /// interval, draining a large backlog in successive bursts.
+    /// </summary>
+    public async Task<bool> DiscoverBatch(CancellationToken cancellationToken)
     {
         var batch = await LoadCandidates(cancellationToken);
         if (batch.Count == 0)
@@ -49,69 +58,113 @@ public class InvestorRelationsDiscoveryService : IImporter
             _logger.LogInformation(
                 "Investor relations discovery: no stocks with a website pending discovery"
             );
-            return;
+            return false;
         }
 
         _logger.LogInformation("Investor relations discovery: probing {Count} stocks", batch.Count);
 
+        // Probe candidates concurrently: each probe escalates to a stealth-browser render for
+        // bot-walled hosts, which can take up to the render timeout, so a serial loop made a batch
+        // with many such hosts take many minutes. The stealth client caps actual renders via its own
+        // semaphore and a shared rate limiter, and Persist/MarkChecked each open their own scope, so
+        // this is safe to fan out.
         var discovered = 0;
-        foreach (var candidate in batch)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            try
+        await Parallel.ForEachAsync(
+            batch,
+            new ParallelOptions
             {
-                var result = await _probeClient.Discover(
-                    candidate.Website,
-                    _options.CandidatePaths,
-                    _options.CandidateSubdomains,
-                    cancellationToken
-                );
-                // Definitive miss — every candidate was probed and none validated. Stamp
-                // the attempt so the stock backs off for the cooldown window instead of
-                // re-occupying a batch slot (and starving the rest of the universe) every
-                // cycle. Transient errors below deliberately skip the stamp.
-                if (result == null)
-                {
-                    await MarkChecked(candidate.Id);
-                    continue;
-                }
-
-                if (await Persist(candidate.Id, result))
-                {
-                    discovered++;
-                    _logger.LogDebug(
-                        "Discovered investor relations page for {Ticker}: {Url} ({Platform})",
-                        candidate.Ticker,
-                        result.Url,
-                        result.Platform
-                    );
-                }
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                MaxDegreeOfParallelism = Math.Max(1, _options.ProbeConcurrency),
+                CancellationToken = cancellationToken,
+            },
+            async (candidate, ct) =>
             {
-                throw;
+                if (await ProbeAndPersist(candidate, ct))
+                    Interlocked.Increment(ref discovered);
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(
-                    ex,
-                    "Error discovering investor relations page for {Ticker}",
-                    candidate.Ticker
-                );
-                await _errorReporter.Report(
-                    ErrorSource.InvestorRelationsDiscovery,
-                    $"Discover({candidate.Ticker})",
-                    ex.Message,
-                    ex.StackTrace
-                );
-            }
-        }
+        );
 
         _logger.LogInformation(
             "Investor relations discovery complete. Discovered {Count} new IR pages",
             discovered
         );
+
+        // A full batch means more pending stocks remain (the query was capped by BatchSize), so
+        // signal the worker to chain into the next batch rather than sleeping the full interval.
+        return batch.Count >= _options.BatchSize;
+    }
+
+    /// <summary>
+    /// Probes one stock for an IR page now, off its current website — the immediate path the
+    /// <c>StockWebsiteDiscovered</c> consumer takes when website discovery has just filled a website,
+    /// so a new website cascades straight into an IR probe instead of waiting for the next batch.
+    /// No-op when the stock has no website yet or already has an IR page. Idempotent.
+    /// </summary>
+    public async Task<bool> DiscoverForStock(
+        Guid commonStockId,
+        CancellationToken cancellationToken
+    )
+    {
+        var candidate = await LoadCandidate(commonStockId, cancellationToken);
+        if (candidate == null)
+            return false;
+
+        return await ProbeAndPersist(candidate, cancellationToken);
+    }
+
+    private async Task<bool> ProbeAndPersist(
+        CandidateStock candidate,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            var result = await _probeClient.Discover(
+                candidate.Website,
+                _options.CandidatePaths,
+                _options.CandidateSubdomains,
+                cancellationToken
+            );
+            // Definitive miss — every candidate was probed and none validated. Stamp the attempt so
+            // the stock backs off for the cooldown window instead of re-occupying a batch slot every
+            // cycle. Transient errors below deliberately skip the stamp.
+            if (result == null)
+            {
+                await MarkChecked(candidate.Id);
+                return false;
+            }
+
+            if (await Persist(candidate.Id, result))
+            {
+                _logger.LogDebug(
+                    "Discovered investor relations page for {Ticker}: {Url} ({Platform})",
+                    candidate.Ticker,
+                    result.Url,
+                    result.Platform
+                );
+                return true;
+            }
+
+            return false;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Error discovering investor relations page for {Ticker}",
+                candidate.Ticker
+            );
+            await _errorReporter.Report(
+                ErrorSource.InvestorRelationsDiscovery,
+                $"Discover({candidate.Ticker})",
+                ex.Message,
+                ex.StackTrace
+            );
+            return false;
+        }
     }
 
     private async Task<List<CandidateStock>> LoadCandidates(CancellationToken cancellationToken)
@@ -120,9 +173,13 @@ public class InvestorRelationsDiscoveryService : IImporter
         var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
         var cutoff = DateTime.UtcNow.AddDays(-_options.ProbeCooldownDays);
+        // Largest companies first: high-value names (TSLA, WMT) shouldn't wait behind thousands of
+        // obscure tickers. Market cap is the priority signal; unknown caps (0) drain last,
+        // tie-broken alphabetically for a stable order.
         var rows = await repo.GetAll()
-            .Where(PendingDiscovery(cutoff))
-            .OrderBy(s => s.Ticker)
+            .Where(PendingDiscovery(cutoff, InvestorRelationsDiscoveryVersion.Current))
+            .OrderByDescending(s => s.MarketCapitalization)
+            .ThenBy(s => s.Ticker)
             .Take(_options.BatchSize)
             .Select(s => new
             {
@@ -133,6 +190,28 @@ public class InvestorRelationsDiscoveryService : IImporter
             .ToListAsync(cancellationToken);
 
         return rows.Select(r => new CandidateStock(r.Id, r.Ticker, r.Website)).ToList();
+    }
+
+    private async Task<CandidateStock> LoadCandidate(
+        Guid commonStockId,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var stock = await repo.Get(commonStockId);
+        // Skip when the stock has no website to probe or already has an IR page. A redelivered event
+        // for an already-resolved stock no-ops here; one for a stock still missing an IR page re-runs
+        // the probe (harmless — no duplicate rows, no loop, idempotent DB effect).
+        if (
+            stock == null
+            || string.IsNullOrEmpty(stock.Website)
+            || stock.InvestorRelationsUrl != null
+        )
+            return null;
+
+        return new CandidateStock(stock.Id, stock.Ticker, stock.Website);
     }
 
     private async Task<bool> Persist(Guid commonStockId, IrDiscoveryResult result)
@@ -149,6 +228,7 @@ public class InvestorRelationsDiscoveryService : IImporter
         stock.InvestorRelationsUrl = result.Url;
         stock.IrPlatformType = result.Platform;
         stock.InvestorRelationsCheckedAt = DateTime.UtcNow;
+        stock.InvestorRelationsDiscoveryVersion = InvestorRelationsDiscoveryVersion.Current;
         await repo.SaveChanges();
         return true;
     }
@@ -163,21 +243,33 @@ public class InvestorRelationsDiscoveryService : IImporter
             return;
 
         stock.InvestorRelationsCheckedAt = DateTime.UtcNow;
+        stock.InvestorRelationsDiscoveryVersion = InvestorRelationsDiscoveryVersion.Current;
         await repo.SaveChanges();
     }
 
     /// <summary>
-    /// Stocks eligible for an IR discovery probe: a known website, no discovered IR
-    /// page yet, and no probe since <paramref name="cutoff"/> (never-probed stocks are
-    /// always eligible).
+    /// Stocks eligible for an IR discovery probe: a known website, no discovered IR page yet, and one
+    /// of — never probed; probed before the cooldown (periodic recheck for an externally-added page);
+    /// probed under an older discovery version (<paramref name="currentVersion"/> — our probe improved,
+    /// re-sweep the backlog now); or probed before the website was found
+    /// (<c>InvestorRelationsCheckedAt &lt; WebsiteCheckedAt</c> — the input changed; the reconciliation
+    /// backstop for a website-discovered event lost to a crash).
     /// </summary>
-    public static Expression<Func<CommonStock, bool>> PendingDiscovery(DateTime cutoff)
+    public static Expression<Func<CommonStock, bool>> PendingDiscovery(
+        DateTime cutoff,
+        int currentVersion
+    )
     {
         return s =>
             s.Website != null
             && s.Website != ""
             && s.InvestorRelationsUrl == null
-            && (s.InvestorRelationsCheckedAt == null || s.InvestorRelationsCheckedAt < cutoff);
+            && (
+                s.InvestorRelationsCheckedAt == null
+                || s.InvestorRelationsCheckedAt < cutoff
+                || s.InvestorRelationsDiscoveryVersion < currentVersion
+                || s.InvestorRelationsCheckedAt < s.WebsiteCheckedAt
+            );
     }
 
     private sealed record CandidateStock(Guid Id, string Ticker, string Website);

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryVersion.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryVersion.cs
@@ -1,0 +1,30 @@
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// The current generation of the investor-relations page discovery logic — the candidate paths and
+/// subdomains probed, the homepage crawl, the stealth render, and the page validation, taken
+/// together. Every <see cref="Equibles.CommonStocks.Data.Models.CommonStock"/> records the version
+/// it was last probed under.
+///
+/// A stock that came up a definitive miss backs off for the cooldown so it isn't re-probed every
+/// cycle. But that cooldown also delays the benefit of a probe improvement: a smarter probe can't
+/// re-examine the backlog of misses until each one's cooldown independently expires. Bumping this
+/// constant makes every stock stamped with an older version eligible for re-probe immediately, so an
+/// improvement reaches the whole backlog on deploy rather than over the cooldown window. After the
+/// re-probe the stock is re-stamped to the current version, so it is reconsidered only when the
+/// version advances again.
+///
+/// BUMP THIS by one in the same change that ships a discovery improvement that could newly find an IR
+/// page the prior generation missed (a new candidate path/subdomain, a better crawl, a render fix,
+/// looser validation).
+/// </summary>
+public static class InvestorRelationsDiscoveryVersion
+{
+    /// <summary>
+    /// v1: the discovery logic as it stands today (plain-HTTP-first with stealth fallback, path +
+    /// subdomain guessing, homepage crawl, platform classification). The column defaults the
+    /// pre-existing corpus to 0, so every stock probed before this generation is reconsidered once
+    /// against it.
+    /// </summary>
+    public const int Current = 1;
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/WebsiteDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/WebsiteDiscoveryService.cs
@@ -7,7 +7,9 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.Messaging.Contracts.CommonStocks;
 using Equibles.Worker;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -33,6 +35,7 @@ public class WebsiteDiscoveryService : IImporter
     private readonly ErrorReporter _errorReporter;
     private readonly ILogger<WebsiteDiscoveryService> _logger;
     private readonly WebsiteDiscoveryOptions _options;
+    private readonly IBus _bus;
 
     public WebsiteDiscoveryService(
         IServiceScopeFactory scopeFactory,
@@ -40,7 +43,8 @@ public class WebsiteDiscoveryService : IImporter
         WebsiteProbeClient probeClient,
         ErrorReporter errorReporter,
         ILogger<WebsiteDiscoveryService> logger,
-        IOptions<WebsiteDiscoveryOptions> options
+        IOptions<WebsiteDiscoveryOptions> options,
+        IBus bus
     )
     {
         _scopeFactory = scopeFactory;
@@ -49,6 +53,7 @@ public class WebsiteDiscoveryService : IImporter
         _errorReporter = errorReporter;
         _logger = logger;
         _options = options.Value;
+        _bus = bus;
     }
 
     public Task Import(CancellationToken cancellationToken) => DiscoverBatch(cancellationToken);
@@ -213,6 +218,13 @@ public class WebsiteDiscoveryService : IImporter
         stock.Website = website;
         stock.WebsiteCheckedAt = DateTime.UtcNow;
         await repo.SaveChanges();
+
+        // The website is the input IR discovery needs, so cascade straight into an IR probe instead
+        // of waiting out that worker's own cooldown. Published via the root bus after the write
+        // commits (financial-domain event, bypasses any bus outbox); the consumer is idempotent and
+        // a reconciliation backstop in IR discovery's candidate query catches a publish lost to a
+        // crash, so at-least-once delivery is safe.
+        await _bus.Publish(new StockWebsiteDiscovered(stock.Id, stock.Ticker, website));
         return true;
     }
 

--- a/src/Equibles.Messaging/Contracts/CommonStocks/StockWebsiteDiscovered.cs
+++ b/src/Equibles.Messaging/Contracts/CommonStocks/StockWebsiteDiscovered.cs
@@ -1,0 +1,7 @@
+namespace Equibles.Messaging.Contracts.CommonStocks;
+
+// Raised when website discovery fills a CommonStock's Website (a previously-empty value). Lets IR
+// discovery re-probe the stock immediately for an investor-relations page off the new website,
+// instead of waiting out its own independent cooldown — the website is the input IR discovery needs,
+// so a new website should cascade straight into an IR probe.
+public record StockWebsiteDiscovered(Guid CommonStockId, string Ticker, string Website);

--- a/src/Equibles.Migrations/Migrations/20260628123049_AddInvestorRelationsDiscoveryVersion.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260628123049_AddInvestorRelationsDiscoveryVersion.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260628123049_AddInvestorRelationsDiscoveryVersion")]
+    partial class AddInvestorRelationsDiscoveryVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260628123049_AddInvestorRelationsDiscoveryVersion.cs
+++ b/src/Equibles.Migrations/Migrations/20260628123049_AddInvestorRelationsDiscoveryVersion.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvestorRelationsDiscoveryVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "InvestorRelationsDiscoveryVersion",
+                table: "CommonStock",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InvestorRelationsDiscoveryVersion",
+                table: "CommonStock");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsDiscoveryServicePendingDiscoveryTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsDiscoveryServicePendingDiscoveryTests.cs
@@ -6,6 +6,7 @@ namespace Equibles.UnitTests.CommonStocks;
 public class InvestorRelationsDiscoveryServicePendingDiscoveryTests
 {
     private static readonly DateTime Cutoff = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private const int CurrentVersion = 5;
 
     [Theory]
     [InlineData(null, true)] // never probed → always eligible
@@ -13,17 +14,21 @@ public class InvestorRelationsDiscoveryServicePendingDiscoveryTests
     [InlineData("2026-06-05", false)] // probed within the cooldown → backs off
     public void PendingDiscovery_CheckedAt_GatesOnCooldownCutoff(string checkedAt, bool expected)
     {
-        // Contract: persistent misses back off — a stock probed within the cooldown
-        // window is skipped, while never-probed stocks and stocks whose cooldown has
-        // elapsed are eligible again.
+        // Contract: persistent misses back off — a stock probed within the cooldown window is
+        // skipped, while never-probed stocks and stocks whose cooldown has elapsed are eligible.
+        // Version is current and the website wasn't found after the probe, so the cooldown clause
+        // is isolated.
         var stock = new CommonStock
         {
             Website = "https://acme.com",
             InvestorRelationsCheckedAt =
                 checkedAt == null ? null : DateTime.Parse(checkedAt).ToUniversalTime(),
+            InvestorRelationsDiscoveryVersion = CurrentVersion,
         };
 
-        var eligible = InvestorRelationsDiscoveryService.PendingDiscovery(Cutoff).Compile();
+        var eligible = InvestorRelationsDiscoveryService
+            .PendingDiscovery(Cutoff, CurrentVersion)
+            .Compile();
 
         eligible(stock).Should().Be(expected);
     }
@@ -38,10 +43,61 @@ public class InvestorRelationsDiscoveryServicePendingDiscoveryTests
         bool expected
     )
     {
-        var stock = new CommonStock { Website = website, InvestorRelationsUrl = irUrl };
+        var stock = new CommonStock
+        {
+            Website = website,
+            InvestorRelationsUrl = irUrl,
+            InvestorRelationsDiscoveryVersion = CurrentVersion,
+        };
 
-        var eligible = InvestorRelationsDiscoveryService.PendingDiscovery(Cutoff).Compile();
+        var eligible = InvestorRelationsDiscoveryService
+            .PendingDiscovery(Cutoff, CurrentVersion)
+            .Compile();
 
         eligible(stock).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(CurrentVersion - 1, true)] // probed under an older generation → re-sweep now
+    [InlineData(CurrentVersion, false)] // already at the current generation → wait for the cooldown
+    public void PendingDiscovery_OlderVersion_IsEligibleWithinCooldown(int version, bool expected)
+    {
+        // Contract: a probe-logic improvement (version bump) re-opens the backlog of misses
+        // immediately, bypassing the cooldown — even a stock probed moments ago is reconsidered when
+        // it was probed under an older version.
+        var stock = new CommonStock
+        {
+            Website = "https://acme.com",
+            InvestorRelationsCheckedAt = new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc), // within cooldown
+            WebsiteCheckedAt = new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc),
+            InvestorRelationsDiscoveryVersion = version,
+        };
+
+        var eligible = InvestorRelationsDiscoveryService
+            .PendingDiscovery(Cutoff, CurrentVersion)
+            .Compile();
+
+        eligible(stock).Should().Be(expected);
+    }
+
+    [Fact]
+    public void PendingDiscovery_WebsiteFoundAfterLastProbe_IsEligibleWithinCooldown()
+    {
+        // Contract: the reconciliation backstop for the website-discovered cascade — a stock probed
+        // (and missed) BEFORE its website was found is re-probed even within the cooldown and at the
+        // current version, because the input it needs only arrived afterwards.
+        var stock = new CommonStock
+        {
+            Website = "https://acme.com",
+            InvestorRelationsCheckedAt = new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc),
+            WebsiteCheckedAt = new DateTime(2026, 6, 6, 0, 0, 0, DateTimeKind.Utc), // website found later
+            InvestorRelationsDiscoveryVersion = CurrentVersion,
+        };
+
+        var eligible = InvestorRelationsDiscoveryService
+            .PendingDiscovery(Cutoff, CurrentVersion)
+            .Compile();
+
+        eligible(stock).Should().BeTrue();
     }
 }

--- a/tests/Equibles.UnitTests/CommonStocks/WebsiteDiscoveryServiceTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/WebsiteDiscoveryServiceTests.cs
@@ -80,7 +80,8 @@ public class WebsiteDiscoveryServiceTests
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Substitute.For<ILogger<WebsiteDiscoveryService>>(),
-            Options.Create(discoveryOptions)
+            Options.Create(discoveryOptions),
+            Substitute.For<MassTransit.IBus>()
         );
     }
 


### PR DESCRIPTION
## Summary

IR-URL discovery filled `CommonStock.InvestorRelationsUrl` on its own slow cadence, decoupled from website discovery: a stock probed before its website was found (stamped `InvestorRelationsCheckedAt`) never re-probed once the website arrived, so a newly-discovered website never cascaded into an IR page. Tesla is the canonical case — website found, but `ir.tesla.com` (a probe candidate that loads fine via the stealth renderer) was never probed.

## Changes (all three)

1. **Cascade** — `WebsiteDiscoveryService` publishes `StockWebsiteDiscovered` (root `IBus`, after SaveChanges) when it fills a website; `StockWebsiteDiscoveredConsumer` re-probes that stock's IR immediately. `PendingDiscovery` also re-probes when `InvestorRelationsCheckedAt < WebsiteCheckedAt` — the reconciliation backstop for an event lost to a crash and for stocks already websited before this ships.
2. **Version gate** — stamp `InvestorRelationsDiscoveryVersion` per probe; eligibility re-probes when it trails `Current`, so a probe-logic improvement re-sweeps the backlog of misses on deploy instead of waiting out each 30-day cooldown.
3. **Throughput** — parallel probe (`ProbeConcurrency`), chained full batches (`DiscoverBatch` + `RequestImmediateContinuation`), market-cap ordering.

`DiscoverForStock` is the shared single-stock entry (batch + consumer), idempotent. Adds `CommonStock.InvestorRelationsDiscoveryVersion` (financial migration, default 0).

Reviewed (code-reviewer): no Critical/High/Medium; EF-translatability, event/outbox, parallel safety, and loop-freedom all confirmed.