### PR TITLE
fix(stealth): render via DOMContentLoaded + bounded CDP connect timeout

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Configuration/StealthFetchOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/StealthFetchOptions.cs
@@ -32,4 +32,12 @@ public class StealthFetchOptions
     /// IR fetch goes through the sidecar.
     /// </summary>
     public int MaxConcurrency { get; set; } = 6;
+
+    /// <summary>
+    /// Timeout (seconds) for the CDP connect to the sidecar. ConnectOverCDPAsync has no built-in
+    /// timeout, so a wedged or over-loaded sidecar can leave a connect hanging forever, holding a
+    /// concurrency slot and — enough of them — stalling the whole discovery sweep. On timeout the
+    /// fetch degrades to a miss and the stock is re-probed later.
+    /// </summary>
+    public int ConnectTimeoutSeconds { get; set; } = 20;
 }

--- a/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
@@ -103,10 +103,14 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
         {
             var playwright = await EnsureDriver(cancellationToken);
 
-            // cloakserve speaks CDP over WebSocket; connect, work, disconnect.
-            await using var browser = await playwright.Chromium.ConnectOverCDPAsync(
-                _options.SidecarUrl
-            );
+            // cloakserve speaks CDP over WebSocket; connect, work, disconnect. The connect is bounded
+            // by a timeout: a wedged/over-loaded sidecar can leave ConnectOverCDPAsync hanging
+            // indefinitely (no built-in timeout), and a single hung connect holds a concurrency slot
+            // forever — enough of them stall the whole discovery sweep. On timeout this degrades to a
+            // miss like any other connect failure, and the caller re-probes the stock later.
+            await using var browser = await playwright
+                .Chromium.ConnectOverCDPAsync(_options.SidecarUrl)
+                .WaitAsync(TimeSpan.FromSeconds(_options.ConnectTimeoutSeconds), cancellationToken);
             var context = await browser.NewContextAsync();
             try
             {
@@ -122,6 +126,13 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
         {
             throw;
         }
+        catch (TimeoutException)
+        {
+            // The CDP connect outran ConnectTimeoutSeconds (wedged/over-loaded sidecar). Degrade to a
+            // miss rather than holding the concurrency slot; the stock is re-probed on a later cycle.
+            _logger.LogWarning("Stealth connect timed out for {Url}", url);
+            return null;
+        }
         catch (PlaywrightException ex)
         {
             // Connection refused, navigation failure, or render timeout. Enabled-but-
@@ -135,19 +146,23 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
     private Task Navigate(IPage page, string url) =>
         NavigateWaitingForNetworkIdle(page, url, _options.RenderTimeoutSeconds * 1000, _logger);
 
+    // Brief settle after DOMContentLoaded to let client-rendered / post-bot-challenge content appear,
+    // capped well below the full render budget. Waiting for full network-idle instead burned the
+    // whole budget (~45s) on every IR/company page, because most stream background telemetry/ads that
+    // never let the network fall idle — which made a full-universe discovery sweep infeasible.
+    private const int SettleTimeoutMilliseconds = 8000;
+
     /// <summary>
-    /// Navigates to <paramref name="url"/> waiting for the network to fall idle, but
-    /// treats an idle-wait timeout as non-fatal. Some hosts (e.g. the FDA advisory-
-    /// committee calendar) stream background telemetry that never lets the network go
-    /// idle, so <see cref="WaitUntilState.NetworkIdle"/> times out even though the
-    /// document has fully rendered within the budget. On that timeout the already-loaded
-    /// DOM is kept rather than discarding an otherwise successful render. A genuine
-    /// navigation failure — refused connection, DNS, protocol error — is a different
-    /// exception that still propagates, so the fetch degrades to a miss as before.
-    /// Playwright .NET surfaces the wait timeout as a <see cref="System.TimeoutException"/>
-    /// (not a <see cref="PlaywrightException"/>), so that is caught directly; the
-    /// message-matched <see cref="PlaywrightException"/> clause is kept as a belt-and-braces
-    /// guard for any path that reports the same timeout as a Playwright error.
+    /// Navigates to <paramref name="url"/> waiting only for <see cref="WaitUntilState.DOMContentLoaded"/>
+    /// — the document, not full network-idle — then gives the page a brief settle window for any
+    /// client-rendered or post-challenge content to appear. Most IR/company pages stream background
+    /// telemetry that never lets the network fall idle, so waiting for idle burned the entire render
+    /// budget on every page; DOMContentLoaded plus a short settle captures the real content in
+    /// seconds instead. A settle-wait timeout is non-fatal — the already-loaded DOM is kept. A genuine
+    /// navigation failure (refused connection, DNS, protocol error) is a different exception that
+    /// still propagates, so the fetch degrades to a miss as before. The settle timeout surfaces as a
+    /// <see cref="System.TimeoutException"/> (or, on some paths, a message-matched
+    /// <see cref="PlaywrightException"/>), both caught here.
     /// </summary>
     internal static async Task NavigateWaitingForNetworkIdle(
         IPage page,
@@ -156,24 +171,29 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
         ILogger logger
     )
     {
+        await page.GotoAsync(
+            url,
+            new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.DOMContentLoaded,
+                Timeout = timeoutMilliseconds,
+            }
+        );
+
         try
         {
-            await page.GotoAsync(
-                url,
-                new PageGotoOptions
-                {
-                    WaitUntil = WaitUntilState.NetworkIdle,
-                    Timeout = timeoutMilliseconds,
-                }
+            await page.WaitForLoadStateAsync(
+                LoadState.NetworkIdle,
+                new PageWaitForLoadStateOptions { Timeout = SettleTimeoutMilliseconds }
             );
         }
         catch (System.TimeoutException)
         {
-            logger.LogDebug("NetworkIdle wait timed out for {Url}; using the loaded DOM.", url);
+            logger.LogDebug("Settle wait timed out for {Url}; using the loaded DOM.", url);
         }
         catch (PlaywrightException ex) when (IsNetworkIdleTimeout(ex))
         {
-            logger.LogDebug("NetworkIdle wait timed out for {Url}; using the loaded DOM.", url);
+            logger.LogDebug("Settle wait timed out for {Url}; using the loaded DOM.", url);
         }
     }
 

--- a/tests/Equibles.UnitTests/CommonStocks/CloakBrowserStealthClientNavigateTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CloakBrowserStealthClientNavigateTests.cs
@@ -10,21 +10,41 @@ using Xunit;
 namespace Equibles.UnitTests.CommonStocks;
 
 /// <summary>
-/// Contract: the stealth navigation waits for the network to fall idle, but a host that
-/// streams background telemetry (e.g. the FDA advisory-committee calendar) never lets the
-/// network go idle, so the idle wait times out even though the document is fully rendered.
-/// That timeout must be non-fatal — the loaded DOM is kept — while a genuine navigation
-/// failure still propagates so the fetch degrades to a miss rather than returning a
-/// half-broken page.
+/// Contract: the stealth navigation waits only for DOMContentLoaded, then a brief settle for any
+/// client-rendered / post-challenge content — not full network-idle, which most IR/company pages
+/// (streaming background telemetry) never reach, burning the whole render budget. A settle-wait
+/// timeout must be non-fatal — the loaded DOM is kept — while a genuine navigation failure on the
+/// initial load still propagates so the fetch degrades to a miss rather than returning a broken page.
 /// </summary>
 public class CloakBrowserStealthClientNavigateTests
 {
     [Fact]
-    public async Task NavigateWaitingForNetworkIdle_SwallowsIdleTimeout_SoTheLoadedDomIsKept()
+    public async Task Navigate_WaitsForDomContentLoaded_NotNetworkIdle()
     {
         var page = Substitute.For<IPage>();
-        page.GotoAsync(Arg.Any<string>(), Arg.Any<PageGotoOptions>())
-            .ThrowsAsync(new PlaywrightException("Timeout 45000ms exceeded."));
+
+        await CloakBrowserStealthClient.NavigateWaitingForNetworkIdle(
+            page,
+            "https://www.example.com",
+            45000,
+            NullLogger.Instance
+        );
+
+        await page.Received()
+            .GotoAsync(
+                "https://www.example.com",
+                Arg.Is<PageGotoOptions>(o => o.WaitUntil == WaitUntilState.DOMContentLoaded)
+            );
+    }
+
+    [Fact]
+    public async Task Navigate_SwallowsSettleTimeout_SoTheLoadedDomIsKept()
+    {
+        // The DOM loads, but the page streams background telemetry so the settle's network-idle wait
+        // times out. That must be non-fatal — the already-loaded DOM is kept.
+        var page = Substitute.For<IPage>();
+        page.WaitForLoadStateAsync(Arg.Any<LoadState>(), Arg.Any<PageWaitForLoadStateOptions>())
+            .ThrowsAsync(new PlaywrightException("Timeout 8000ms exceeded."));
 
         var navigate = async () =>
             await CloakBrowserStealthClient.NavigateWaitingForNetworkIdle(
@@ -38,14 +58,13 @@ public class CloakBrowserStealthClientNavigateTests
     }
 
     [Fact]
-    public async Task NavigateWaitingForNetworkIdle_SwallowsSystemTimeoutException_SoTheLoadedDomIsKept()
+    public async Task Navigate_SwallowsSystemTimeoutExceptionOnSettle_SoTheLoadedDomIsKept()
     {
-        // Playwright .NET surfaces a GotoAsync wait timeout as System.TimeoutException — NOT a
-        // PlaywrightException — which is what the FDA calendar actually throws in production. The
-        // idle-wait timeout must still be non-fatal regardless of the concrete timeout type.
+        // Playwright .NET surfaces a wait timeout as System.TimeoutException — NOT a
+        // PlaywrightException. The settle timeout must be non-fatal regardless of the concrete type.
         var page = Substitute.For<IPage>();
-        page.GotoAsync(Arg.Any<string>(), Arg.Any<PageGotoOptions>())
-            .ThrowsAsync(new System.TimeoutException("Timeout 45000ms exceeded."));
+        page.WaitForLoadStateAsync(Arg.Any<LoadState>(), Arg.Any<PageWaitForLoadStateOptions>())
+            .ThrowsAsync(new System.TimeoutException("Timeout 8000ms exceeded."));
 
         var navigate = async () =>
             await CloakBrowserStealthClient.NavigateWaitingForNetworkIdle(
@@ -59,7 +78,7 @@ public class CloakBrowserStealthClientNavigateTests
     }
 
     [Fact]
-    public async Task NavigateWaitingForNetworkIdle_Rethrows_OnGenuineNavigationFailure()
+    public async Task Navigate_Rethrows_OnGenuineNavigationFailure()
     {
         var page = Substitute.For<IPage>();
         page.GotoAsync(Arg.Any<string>(), Arg.Any<PageGotoOptions>())


### PR DESCRIPTION
## Summary

The discovery stealth renders waited for full **network-idle** (45s budget). Most IR/company pages stream background telemetry that never lets the network fall idle, so **every** page burned the whole budget — a full-universe sweep was infeasible, and raising concurrency just crashed/wedged the single shared Chromium (one Chromium tops out ~12–16 contexts).

Two fixes:
1. **Fast render** — wait for `DOMContentLoaded` then a brief **8s settle** for client-rendered / post-bot-challenge content, instead of full network-idle. Captures the real page in seconds (~5–8s vs 45s).
2. **Bounded CDP connect** — `ConnectOverCDPAsync` has no built-in timeout, so a wedged/over-loaded sidecar left connects hanging forever, holding a concurrency slot and stalling the whole sweep. Bound it with `StealthFetch:ConnectTimeoutSeconds` (default 20); on timeout, degrade to a miss and re-probe later.

Together: discovery drains fast **and** can't hang on a bad sidecar, at modest concurrency.

## Changes
- `CloakBrowserStealthClient` — DOMContentLoaded + settle render; connect wrapped in a timeout.
- `StealthFetchOptions` — `ConnectTimeoutSeconds`.
- Tests updated (settle-timeout non-fatal, DOMContentLoaded asserted, genuine nav failure still propagates).