### PR TITLE
chore(ir-discovery): temporary probe timing logs to locate the sweep stall

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
@@ -116,6 +116,14 @@ public class InvestorRelationsDiscoveryService : IImporter
         CancellationToken cancellationToken
     )
     {
+        // TEMP DEBUG INSTRUMENTATION (#ir-probe-timing): a "start" with no matching "end" marks a
+        // hung stock (and names the host to test directly). Remove once the stall is fixed.
+        _logger.LogInformation(
+            "IR-PROBE-TIMING start {Ticker} {Website}",
+            candidate.Ticker,
+            candidate.Website
+        );
+        var stockSw = System.Diagnostics.Stopwatch.StartNew();
         try
         {
             var result = await _probeClient.Discover(
@@ -123,6 +131,12 @@ public class InvestorRelationsDiscoveryService : IImporter
                 _options.CandidatePaths,
                 _options.CandidateSubdomains,
                 cancellationToken
+            );
+            _logger.LogInformation(
+                "IR-PROBE-TIMING end {Ticker}: {Result} in {Ms}ms",
+                candidate.Ticker,
+                result != null ? "HIT" : "miss",
+                stockSw.ElapsedMilliseconds
             );
             // Definitive miss — every candidate was probed and none validated. Stamp the attempt so
             // the stock backs off for the cooldown window instead of re-occupying a batch slot every

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -54,9 +54,20 @@ public class InvestorRelationsProbeClient
     {
         var candidates = InvestorRelationsCandidateBuilder.Build(website, paths, subdomains);
 
+        // TEMP DEBUG INSTRUMENTATION (#ir-probe-timing): per-pass timing to locate the discovery
+        // sweep stall. Remove once the bottleneck is fixed.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
         // Pass 1 — plain HTTP. Cheap, polite, and never touches the shared stealth sidecar; most
         // IR pages that aren't bot-walled resolve here.
         var direct = await Probe(candidates, website, useSidecar: false, cancellationToken);
+        _logger.LogInformation(
+            "IR-PROBE-TIMING pass1(plain) {Website}: {Result} in {Ms}ms ({Candidates} candidates)",
+            website,
+            direct != null ? "HIT" : "miss",
+            sw.ElapsedMilliseconds,
+            candidates.Count
+        );
         if (direct != null)
             return direct;
 
@@ -64,7 +75,17 @@ public class InvestorRelationsProbeClient
         // up empty. Catches the bot-protected hosts (plain HTTP saw a challenge page that failed
         // validation) and the JS-rendered homepages whose IR nav links aren't in the static HTML.
         if (_stealthClient.IsEnabled)
-            return await Probe(candidates, website, useSidecar: true, cancellationToken);
+        {
+            sw.Restart();
+            var rendered = await Probe(candidates, website, useSidecar: true, cancellationToken);
+            _logger.LogInformation(
+                "IR-PROBE-TIMING pass2(stealth) {Website}: {Result} in {Ms}ms",
+                website,
+                rendered != null ? "HIT" : "miss",
+                sw.ElapsedMilliseconds
+            );
+            return rendered;
+        }
 
         return null;
     }


### PR DESCRIPTION
Temporary Info-level instrumentation (`IR-PROBE-TIMING …`) on the IR-discovery probe path — per-stock start/end + per-pass (plain/stealth) timing — to pinpoint where the production sweep stalls (running but never completing). To be reverted once the bottleneck is found and fixed.