### PR TITLE
fix(ir-discovery): release the stealth permit, probe via sidecar only, bound the op

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Configuration/StealthFetchOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/StealthFetchOptions.cs
@@ -40,4 +40,13 @@ public class StealthFetchOptions
     /// fetch degrades to a miss and the stock is re-probed later.
     /// </summary>
     public int ConnectTimeoutSeconds { get; set; } = 20;
+
+    /// <summary>
+    /// Hard ceiling (seconds) on the whole stealth operation — connect, context, page, and render
+    /// combined. None of the underlying Playwright calls has a built-in timeout, so a wedged sidecar
+    /// could hang any of them forever; this bounds the entire operation so it always releases its
+    /// concurrency slot and degrades to a miss. Set above ConnectTimeoutSeconds + RenderTimeoutSeconds
+    /// so it only fires on a genuine hang, not a legitimately slow render.
+    /// </summary>
+    public int OperationTimeoutSeconds { get; set; } = 90;
 }

--- a/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -34,15 +34,9 @@ public static class ServiceCollectionExtensions
 
         // Typed client: short timeout and a contact User-Agent, following many
         // redirects to land on the real IR page. Response size is capped so a
-        // misbehaving host can't stream an unbounded body into memory.
-        services.AddHttpClient<InvestorRelationsProbeClient>(client =>
-        {
-            client.Timeout = TimeSpan.FromSeconds(10);
-            client.DefaultRequestHeaders.UserAgent.ParseAdd(
-                "EquiblesBot/1.0 (+https://equibles.com)"
-            );
-            client.MaxResponseContentBufferSize = 2 * 1024 * 1024;
-        });
+        // IR-page discovery probes through the stealth sidecar only (no plain-HTTP client): IR hosts
+        // are bot-protected, so plain HTTP only ever returned challenge pages that failed validation.
+        services.AddScoped<InvestorRelationsProbeClient>();
 
         services.AddHostedService<InvestorRelationsDiscoveryWorker>();
 

--- a/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
@@ -101,45 +101,93 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
         await _concurrencyLimiter.WaitAsync(cancellationToken);
         try
         {
-            var playwright = await EnsureDriver(cancellationToken);
+            // Hard ceiling on the WHOLE operation (connect + context + page + render). None of the
+            // Playwright calls below has a built-in timeout, so a wedged/over-loaded sidecar could
+            // leave any of them hanging indefinitely. Every await is observed against this linked
+            // token, so a hang at any stage degrades to a miss and the caller re-probes later.
+            using var opCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            opCts.CancelAfter(TimeSpan.FromSeconds(_options.OperationTimeoutSeconds));
+            var opToken = opCts.Token;
 
-            // cloakserve speaks CDP over WebSocket; connect, work, disconnect. The connect is bounded
-            // by a timeout: a wedged/over-loaded sidecar can leave ConnectOverCDPAsync hanging
-            // indefinitely (no built-in timeout), and a single hung connect holds a concurrency slot
-            // forever — enough of them stall the whole discovery sweep. On timeout this degrades to a
-            // miss like any other connect failure, and the caller re-probes the stock later.
-            await using var browser = await playwright
-                .Chromium.ConnectOverCDPAsync(_options.SidecarUrl)
-                .WaitAsync(TimeSpan.FromSeconds(_options.ConnectTimeoutSeconds), cancellationToken);
-            var context = await browser.NewContextAsync();
+            IBrowser browser = null;
+            IBrowserContext context = null;
             try
             {
-                var page = await context.NewPageAsync();
-                return await action(page);
+                var playwright = await EnsureDriver(opToken);
+
+                // cloakserve speaks CDP over WebSocket; connect, work, disconnect. A tighter connect
+                // timeout fails a dead sidecar faster than the overall ceiling.
+                browser = await playwright
+                    .Chromium.ConnectOverCDPAsync(_options.SidecarUrl)
+                    .WaitAsync(TimeSpan.FromSeconds(_options.ConnectTimeoutSeconds), opToken);
+                context = await browser.NewContextAsync().WaitAsync(opToken);
+                var page = await context.NewPageAsync().WaitAsync(opToken);
+                return await action(page).WaitAsync(opToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                // Outran OperationTimeoutSeconds (a wedged sidecar hung connect, context, page, or
+                // render). Degrade to a miss rather than holding the slot.
+                _logger.LogWarning("Stealth operation timed out for {Url}", url);
+                return null;
+            }
+            catch (TimeoutException)
+            {
+                // The CDP connect outran ConnectTimeoutSeconds (wedged/over-loaded sidecar).
+                _logger.LogWarning("Stealth connect timed out for {Url}", url);
+                return null;
+            }
+            catch (PlaywrightException ex)
+            {
+                // Connection refused, navigation failure, or render timeout. The caller degrades to a
+                // miss rather than failing the batch.
+                _logger.LogWarning(ex, "Stealth fetch failed for {Url}", url);
+                return null;
             }
             finally
             {
-                await context.CloseAsync();
+                // Best-effort, bounded teardown: on a wedged sidecar CloseAsync / CDP-disconnect can
+                // itself hang, which would hold the concurrency slot past the ceiling. Cap each and
+                // swallow — a leaked context/connection on the dying sidecar is the lesser evil.
+                await CloseQuietly(context, browser);
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        finally
         {
-            throw;
+            // Always release the permit — the missing release here previously leaked one slot per
+            // call, so after MaxConcurrency calls every stealth render blocked forever (the sweep
+            // froze: "running but never completing").
+            _concurrencyLimiter.Release();
         }
-        catch (TimeoutException)
+    }
+
+    // Tears down the page context and CDP connection best-effort, each bounded by a short budget: on
+    // a wedged sidecar the close/disconnect can itself hang, which would hold the concurrency slot
+    // past the operation ceiling. A leaked context on the dying sidecar is the lesser evil.
+    private async Task CloseQuietly(IBrowserContext context, IBrowser browser)
+    {
+        try
         {
-            // The CDP connect outran ConnectTimeoutSeconds (wedged/over-loaded sidecar). Degrade to a
-            // miss rather than holding the concurrency slot; the stock is re-probed on a later cycle.
-            _logger.LogWarning("Stealth connect timed out for {Url}", url);
-            return null;
+            if (context != null)
+                await context.CloseAsync().WaitAsync(TimeSpan.FromSeconds(5));
         }
-        catch (PlaywrightException ex)
+        catch (Exception ex)
         {
-            // Connection refused, navigation failure, or render timeout. Enabled-but-
-            // broken is a misconfiguration worth surfacing, but the caller still
-            // degrades to a miss rather than failing the batch.
-            _logger.LogWarning(ex, "Stealth fetch failed for {Url}", url);
-            return null;
+            _logger.LogDebug(ex, "Stealth context close failed (sidecar likely wedged)");
+        }
+
+        try
+        {
+            if (browser != null)
+                await browser.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Stealth browser disconnect failed (sidecar likely wedged)");
         }
     }
 

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
@@ -116,14 +116,6 @@ public class InvestorRelationsDiscoveryService : IImporter
         CancellationToken cancellationToken
     )
     {
-        // TEMP DEBUG INSTRUMENTATION (#ir-probe-timing): a "start" with no matching "end" marks a
-        // hung stock (and names the host to test directly). Remove once the stall is fixed.
-        _logger.LogInformation(
-            "IR-PROBE-TIMING start {Ticker} {Website}",
-            candidate.Ticker,
-            candidate.Website
-        );
-        var stockSw = System.Diagnostics.Stopwatch.StartNew();
         try
         {
             var result = await _probeClient.Discover(
@@ -131,12 +123,6 @@ public class InvestorRelationsDiscoveryService : IImporter
                 _options.CandidatePaths,
                 _options.CandidateSubdomains,
                 cancellationToken
-            );
-            _logger.LogInformation(
-                "IR-PROBE-TIMING end {Ticker}: {Result} in {Ms}ms",
-                candidate.Ticker,
-                result != null ? "HIT" : "miss",
-                stockSw.ElapsedMilliseconds
             );
             // Definitive miss — every candidate was probed and none validated. Stamp the attempt so
             // the stock backs off for the cooldown window instead of re-occupying a batch slot every

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -1,49 +1,34 @@
-using Equibles.Integrations.Common.RateLimiter;
-using Microsoft.Extensions.Logging;
-
 namespace Equibles.CommonStocks.HostedService.Services;
 
 /// <summary>
-/// Probes a company's candidate investor-relations URLs and returns the first one
-/// that resolves to a validated IR page. Tries plain HTTP first (the typed
-/// <see cref="HttpClient"/> from <c>AddCommonStocksWorker</c>): it is cheap and never touches the
-/// shared stealth sidecar, which is contended with the slide/webcast capture. Only when the
-/// plain-HTTP pass finds nothing AND a sidecar is configured does it run a second pass that renders
-/// every candidate through <see cref="IStealthBrowserClient"/> — catching the bot-protected hosts
-/// (where plain HTTP gets a challenge page that fails validation) and the JS-rendered homepages
-/// whose IR nav links aren't in the static HTML. Escalating only on a plain-HTTP miss keeps sidecar
-/// load proportional to the hard cases instead of every stock.
+/// Probes a company's candidate investor-relations URLs and returns the first one that resolves to a
+/// validated IR page. All fetches go through the stealth sidecar (<see cref="IStealthBrowserClient"/>):
+/// virtually every IR host is bot-protected, so a plain-HTTP pass only ever returned a challenge page
+/// that failed validation — it found nothing while adding ~100s of dead-host timeouts per stock before
+/// the stealth pass even started. With no sidecar configured the client is a no-op (a build without a
+/// stealth browser can't get past the bot walls anyway), so discovery simply finds nothing.
 /// </summary>
 public class InvestorRelationsProbeClient
 {
     // Column ceiling for CommonStock.InvestorRelationsUrl.
     private const int MaxUrlLength = 256;
 
-    // Polite shared throttle so a discovery cycle doesn't hammer many sites at once.
-    private static readonly IRateLimiter RateLimiter = new RateLimiter(
-        maxRequests: 5,
-        timeWindow: TimeSpan.FromSeconds(1)
-    );
-
-    private readonly HttpClient _httpClient;
     private readonly IStealthBrowserClient _stealthClient;
     private readonly ILogger<InvestorRelationsProbeClient> _logger;
 
     public InvestorRelationsProbeClient(
-        HttpClient httpClient,
         IStealthBrowserClient stealthClient,
         ILogger<InvestorRelationsProbeClient> logger
     )
     {
-        _httpClient = httpClient;
         _stealthClient = stealthClient;
         _logger = logger;
     }
 
     /// <summary>
-    /// Returns the validated investor-relations URL for <paramref name="website"/>
-    /// together with the platform classified from its page, or null when no
-    /// candidate resolves to a recognisable IR page.
+    /// Returns the validated investor-relations URL for <paramref name="website"/> together with the
+    /// platform classified from its page, or null when no candidate resolves to a recognisable IR
+    /// page (or no sidecar is configured).
     /// </summary>
     public async Task<IrDiscoveryResult> Discover(
         string website,
@@ -52,107 +37,43 @@ public class InvestorRelationsProbeClient
         CancellationToken cancellationToken
     )
     {
+        if (!_stealthClient.IsEnabled)
+            return null;
+
         var candidates = InvestorRelationsCandidateBuilder.Build(website, paths, subdomains);
 
-        // TEMP DEBUG INSTRUMENTATION (#ir-probe-timing): per-pass timing to locate the discovery
-        // sweep stall. Remove once the bottleneck is fixed.
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-
-        // Pass 1 — plain HTTP. Cheap, polite, and never touches the shared stealth sidecar; most
-        // IR pages that aren't bot-walled resolve here.
-        var direct = await Probe(candidates, website, useSidecar: false, cancellationToken);
-        _logger.LogInformation(
-            "IR-PROBE-TIMING pass1(plain) {Website}: {Result} in {Ms}ms ({Candidates} candidates)",
-            website,
-            direct != null ? "HIT" : "miss",
-            sw.ElapsedMilliseconds,
-            candidates.Count
-        );
-        if (direct != null)
-            return direct;
-
-        // Pass 2 — stealth render, only when a sidecar is configured and only after plain HTTP came
-        // up empty. Catches the bot-protected hosts (plain HTTP saw a challenge page that failed
-        // validation) and the JS-rendered homepages whose IR nav links aren't in the static HTML.
-        if (_stealthClient.IsEnabled)
-        {
-            sw.Restart();
-            var rendered = await Probe(candidates, website, useSidecar: true, cancellationToken);
-            _logger.LogInformation(
-                "IR-PROBE-TIMING pass2(stealth) {Website}: {Result} in {Ms}ms",
-                website,
-                rendered != null ? "HIT" : "miss",
-                sw.ElapsedMilliseconds
-            );
-            return rendered;
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Runs one discovery pass over the guessed candidates and then the homepage crawl, all over
-    /// the requested transport (plain HTTP or the stealth sidecar). Returns the first validated IR
-    /// page, or null when nothing resolves in this pass.
-    /// </summary>
-    private async Task<IrDiscoveryResult> Probe(
-        IReadOnlyList<string> candidates,
-        string website,
-        bool useSidecar,
-        CancellationToken cancellationToken
-    )
-    {
+        // Render each guessed path/subdomain through the sidecar; the first that validates wins.
         foreach (var candidate in candidates)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var resolved = await TryResolve(candidate, useSidecar, cancellationToken);
+            var resolved = await TryResolve(candidate, cancellationToken);
             if (resolved != null)
                 return resolved;
         }
 
-        // None of the guessed paths/subdomains validated. Crawl the homepage and follow the
-        // investor-relations link it exposes — the IR page is often at a location guessing can't
-        // reach (a Q4 / GCS host, a regional or locale path, a deeper path), and the homepage URL
-        // itself is sometimes the IR site.
-        return await CrawlHomepage(website, useSidecar, cancellationToken);
+        // None of the guesses validated. Crawl the homepage and follow the investor-relations link it
+        // exposes — the IR page is often at a location guessing can't reach (a Q4 / GCS host, a
+        // regional or locale path, a deeper path), and the homepage URL itself is sometimes the IR site.
+        return await CrawlHomepage(website, cancellationToken);
     }
 
     private async Task<IrDiscoveryResult> TryResolve(
         string url,
-        bool useSidecar,
         CancellationToken cancellationToken
     )
     {
-        var (html, finalUrl) = await Fetch(url, useSidecar, cancellationToken);
-        if (html == null)
-            return null;
-
-        return BuildResult(html, finalUrl, url);
+        var html = await FetchRendered(url, cancellationToken);
+        return html == null ? null : BuildResult(html, url, url);
     }
 
-    /// <summary>
-    /// Fetches the page's HTML and the URL it actually landed on, over the requested transport: the
-    /// stealth sidecar when <paramref name="useSidecar"/> is set, otherwise plain HTTP. Returns
-    /// <c>(null, url)</c> on any miss; a single host never fails the discovery batch.
-    /// </summary>
-    private Task<(string Html, string FinalUrl)> Fetch(
-        string url,
-        bool useSidecar,
-        CancellationToken cancellationToken
-    ) => useSidecar ? FetchRendered(url, cancellationToken) : FetchPlain(url, cancellationToken);
-
-    // Renders the page through the stealth sidecar (most IR hosts are bot-protected). The stealth
-    // fetch follows redirects internally, so the requested URL is the best one we have.
-    private async Task<(string Html, string FinalUrl)> FetchRendered(
-        string url,
-        CancellationToken cancellationToken
-    )
+    // Renders the page through the stealth sidecar (most IR hosts are bot-protected). Degrades to
+    // null on any error so a single host never fails the discovery batch.
+    private async Task<string> FetchRendered(string url, CancellationToken cancellationToken)
     {
         try
         {
-            var rendered = await _stealthClient.FetchHtml(url, cancellationToken);
-            return (rendered, url);
+            return await _stealthClient.FetchHtml(url, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -160,90 +81,46 @@ public class InvestorRelationsProbeClient
         }
         catch (Exception ex)
         {
-            // FetchHtml is contracted to degrade to null, but a sidecar navigation timeout/error
-            // can still surface as an exception. Swallow it the same way the plain-HTTP path does:
-            // a single host that throws must not bubble out of the probe, or the caller skips the
-            // definitive-miss back-off and the stock re-occupies every batch, starving the rest of
-            // the universe.
+            // FetchHtml is contracted to degrade to null, but a sidecar navigation timeout/error can
+            // still surface as an exception. Swallow it: a single host that throws must not bubble out
+            // of the probe, or the caller skips the definitive-miss back-off and the stock re-occupies
+            // every batch, starving the rest of the universe.
             _logger.LogDebug(ex, "Investor relations stealth probe failed for {Url}", url);
-            return (null, url);
-        }
-    }
-
-    // Fetches the page over plain HTTP, politely rate-limited. Only HTML is read (it can be
-    // keyword-validated); a non-HTML body, an error status, or a dead host is a miss.
-    private async Task<(string Html, string FinalUrl)> FetchPlain(
-        string url,
-        CancellationToken cancellationToken
-    )
-    {
-        try
-        {
-            await RateLimiter.WaitAsync();
-
-            using var response = await _httpClient.GetAsync(url, cancellationToken);
-
-            // Only HTML is worth reading: it can be keyword-validated. PDFs, JSON login
-            // walls, etc. carry nothing useful — skip the body entirely.
-            var mediaType = response.Content.Headers.ContentType?.MediaType;
-            var isHtml = string.Equals(mediaType, "text/html", StringComparison.OrdinalIgnoreCase);
-            var body = isHtml ? await response.Content.ReadAsStringAsync(cancellationToken) : null;
-
-            if (response.IsSuccessStatusCode && body != null)
-            {
-                // Where the request actually landed after redirects.
-                var finalUrl = response.RequestMessage?.RequestUri?.ToString() ?? url;
-                return (body, finalUrl);
-            }
-
-            return (null, url);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            // A dead host, TLS error, or timeout on a guessed URL is expected and
-            // not worth reporting — most candidates won't exist.
-            _logger.LogDebug(ex, "Investor relations probe failed for {Url}", url);
-            return (null, url);
+            return null;
         }
     }
 
     /// <summary>
-    /// Fetches the company homepage and either validates it directly as the IR site (when the
-    /// website itself is an investor.* host) or follows the investor-relations link(s) it
-    /// exposes — catching IR pages at locations path/subdomain guessing can't reach. Uses the same
-    /// transport (<paramref name="useSidecar"/>) as the pass it runs in.
+    /// Fetches the company homepage and either validates it directly as the IR site (when the website
+    /// itself is an investor.* host) or follows the investor-relations link(s) it exposes — catching
+    /// IR pages at locations path/subdomain guessing can't reach.
     /// </summary>
     private async Task<IrDiscoveryResult> CrawlHomepage(
         string website,
-        bool useSidecar,
         CancellationToken cancellationToken
     )
     {
         // EDGAR-sourced websites occasionally omit the scheme ("acme.com"); the candidate builder
         // normalizes for the guessed probes, but the homepage fetch consumes the raw value, so
-        // normalize it here too or HttpClient would reject the non-absolute URL.
+        // normalize it here too.
         var homepage = NormalizeWebsite(website);
         if (homepage == null)
             return null;
 
-        var (html, finalUrl) = await Fetch(homepage, useSidecar, cancellationToken);
+        var html = await FetchRendered(homepage, cancellationToken);
         if (html == null)
             return null;
 
         // The website itself might BE the IR site (e.g. investor.acme.com).
-        var self = BuildResult(html, finalUrl, website);
+        var self = BuildResult(html, homepage, website);
         if (self != null)
             return self;
 
-        foreach (var link in InvestorRelationsLinkExtractor.Extract(html, finalUrl))
+        foreach (var link in InvestorRelationsLinkExtractor.Extract(html, homepage))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var resolved = await TryResolve(link, useSidecar, cancellationToken);
+            var resolved = await TryResolve(link, cancellationToken);
             if (resolved != null)
             {
                 _logger.LogInformation(
@@ -277,10 +154,9 @@ public class InvestorRelationsProbeClient
     }
 
     /// <summary>
-    /// Validates rendered HTML and, when it is an IR page, builds the result with the
-    /// classified platform. Uses <paramref name="preferredUrl"/>, falling back to
-    /// <paramref name="fallbackUrl"/> when it overruns the column ceiling; returns
-    /// null when neither fits or the page does not validate.
+    /// Validates rendered HTML and, when it is an IR page, builds the result with the classified
+    /// platform. Uses <paramref name="preferredUrl"/>, falling back to <paramref name="fallbackUrl"/>
+    /// when it overruns the column ceiling; returns null when neither fits or the page does not validate.
     /// </summary>
     private static IrDiscoveryResult BuildResult(
         string html,

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -1,39 +1,29 @@
-using System.Net;
-using System.Text;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.HostedService.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
 namespace Equibles.UnitTests.CommonStocks;
 
+/// <summary>
+/// Contract: the IR probe resolves entirely through the stealth sidecar — every candidate (and the
+/// homepage crawl) is rendered, the first that validates as an IR page wins, a render failure is a
+/// miss, and with no sidecar configured the probe is a no-op. There is no plain-HTTP path.
+/// </summary>
 public class InvestorRelationsProbeClientTests
 {
-    private const string RenderedIrPage =
-        "<html><head><title>Investor Relations - Emergent</title></head>"
+    private const string IrPage =
+        "<html><head><title>Investor Relations - Acme</title></head>"
         + "<body><h1>Quarterly results</h1></body></html>";
 
-    private const string IncapsulaStub =
-        "<html><head><script src=\"/_Incapsula_Resource?SWJIYLWA=719d\"></script>"
-        + "</head><body>Request unsuccessful.</body></html>";
+    private const string NotIr =
+        "<html><head><title>Page not found</title></head><body>404</body></html>";
 
     [Fact]
-    public async Task Discover_Sidecar_PlainHttpResolves_SidecarNotTouched()
+    public async Task Discover_SidecarRendersValidIrPage_ReturnsCandidateUrl()
     {
-        // Plain HTTP is tried first even when a sidecar is configured: a reachable IR page resolves
-        // over plain HTTP and the contended stealth sidecar is never touched.
-        var stealth = Substitute.For<IStealthBrowserClient>();
-        stealth.IsEnabled.Returns(true);
-        stealth.FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(RenderedIrPage);
+        var stealth = EnabledStealth(_ => IrPage);
 
         var client = new InvestorRelationsProbeClient(
-            new HttpClient(
-                new ConstantHandler(
-                    HttpStatusCode.OK,
-                    "text/html",
-                    "<html><head><title>Investor Relations - Acme</title></head><body></body></html>"
-                )
-            ),
             stealth,
             NullLogger<InvestorRelationsProbeClient>.Instance
         );
@@ -42,45 +32,33 @@ public class InvestorRelationsProbeClientTests
 
         result.Should().NotBeNull();
         result!.Url.Should().Be("https://acme.com/investors");
-        await stealth.DidNotReceive().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Discover_Sidecar_PlainHttpBotWalled_FallsBackToSidecarRender()
+    public async Task Discover_NoSidecar_IsNoOp()
     {
-        // When plain HTTP only gets a bot-wall challenge (which fails validation), discovery
-        // escalates to the stealth render — and only then — which resolves the real IR page.
+        // No stealth browser configured: the probe can't get past bot walls, so it finds nothing
+        // (there is no plain-HTTP fallback).
         var stealth = Substitute.For<IStealthBrowserClient>();
-        stealth.IsEnabled.Returns(true);
-        stealth.FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(RenderedIrPage);
+        stealth.IsEnabled.Returns(false);
 
-        var plain = new ConstantHandler(HttpStatusCode.OK, "text/html", IncapsulaStub);
         var client = new InvestorRelationsProbeClient(
-            new HttpClient(plain),
             stealth,
             NullLogger<InvestorRelationsProbeClient>.Instance
         );
 
-        var result = await client.Discover(
-            "emergentbiosolutions.com",
-            ["investors"],
-            [],
-            CancellationToken.None
-        );
+        var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
 
-        result.Should().NotBeNull();
-        result!.Url.Should().Be("https://emergentbiosolutions.com/investors");
-        plain.Calls.Should().BeGreaterThan(0); // plain HTTP was tried before the sidecar
-        await stealth.Received().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        result.Should().BeNull();
+        await stealth.DidNotReceive().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Discover_Sidecar_PlainHttpMissesAndSidecarThrows_DegradesToMiss()
+    public async Task Discover_SidecarThrows_DegradesToMiss()
     {
-        // Plain HTTP misses (bot wall), then the sidecar render fails with an exception (e.g. a
-        // navigation timeout) instead of the contractual null. The probe must degrade that to a
-        // miss — if it bubbles out of Discover, the caller skips the definitive-miss back-off, so
-        // the stock is never stamped, re-occupies every batch, and starves the rest of the universe.
+        // The sidecar render throws (e.g. a navigation timeout) instead of the contractual null. The
+        // probe must degrade that to a miss — if it bubbles out, the caller skips the definitive-miss
+        // back-off, the stock is never stamped, re-occupies every batch, and starves the universe.
         var stealth = Substitute.For<IStealthBrowserClient>();
         stealth.IsEnabled.Returns(true);
         stealth
@@ -88,7 +66,6 @@ public class InvestorRelationsProbeClientTests
             .Returns(Task.FromException<string>(new TimeoutException("navigation timeout")));
 
         var client = new InvestorRelationsProbeClient(
-            new HttpClient(new ConstantHandler(HttpStatusCode.OK, "text/html", IncapsulaStub)),
             stealth,
             NullLogger<InvestorRelationsProbeClient>.Instance
         );
@@ -99,109 +76,30 @@ public class InvestorRelationsProbeClientTests
 
         await act.Should().NotThrowAsync();
         result.Should().BeNull();
-        await stealth.Received().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Discover_NoSidecar_DirectIrPage_ResolvesViaPlainHttp()
+    public async Task Discover_GuessedPathsMiss_FollowsHomepageIrLink()
     {
-        // Standalone build with no sidecar: a reachable IR page resolves over plain HTTP
-        // and the stealth path is never touched.
-        var stealth = DisabledStealth();
-
-        var client = new InvestorRelationsProbeClient(
-            new HttpClient(
-                new ConstantHandler(
-                    HttpStatusCode.OK,
-                    "text/html",
-                    "<html><head><title>Investor Relations - Acme</title></head><body></body></html>"
-                )
-            ),
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
-
-        var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
-
-        result.Should().NotBeNull();
-        result!.Url.Should().Be("https://acme.com/investors");
-        await stealth.DidNotReceive().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task Discover_NoSidecar_BotWall_IsMiss()
-    {
-        // No sidecar: a bot-wall challenge stub is not a valid IR page, so it is a miss
-        // and the stealth path is never touched.
-        var stealth = DisabledStealth();
-
-        var client = new InvestorRelationsProbeClient(
-            new HttpClient(new ConstantHandler(HttpStatusCode.OK, "text/html", IncapsulaStub)),
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
-
-        var result = await client.Discover(
-            "emergentbiosolutions.com",
-            ["investors"],
-            [],
-            CancellationToken.None
-        );
-
-        result.Should().BeNull();
-        await stealth.DidNotReceive().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task Discover_NoSidecar_RedirectAboveColumnCeiling_FallsBackToProbedCandidate()
-    {
-        // Plain path (no sidecar): the returned URL must stay within
-        // CommonStock.InvestorRelationsUrl's 256-char ceiling. When a probe lands (after
-        // redirects) on a longer URL, the short probed candidate is returned instead.
-        var overLongFinalUrl = "https://acme.com/" + new string('a', 300);
-        var client = new InvestorRelationsProbeClient(
-            new HttpClient(new LongFinalUrlHandler(overLongFinalUrl)),
-            DisabledStealth(),
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
-
-        var result = await client.Discover("https://acme.com", ["ir"], [], CancellationToken.None);
-
-        result!.Url.Should().Be("https://acme.com/ir");
-        result.Url.Length.Should().BeLessThanOrEqualTo(256);
-    }
-
-    [Theory]
-    [InlineData("https://acme.com")]
-    [InlineData("acme.com")] // EDGAR data often omits the scheme; the crawl must still run.
-    public async Task Discover_NoSidecar_GuessedPathsMiss_FollowsHomepageIrLink(string website)
-    {
-        // The guessed paths/subdomains don't validate, but the homepage links to the real IR
-        // page at a non-guessed location (/en-us/investors) — the homepage crawl follows it.
+        // The guessed paths/subdomains don't validate, but the homepage links to the real IR page at
+        // a non-guessed location (/en-us/investors) — the homepage crawl follows it.
         const string homepage =
             "<html><head><title>Acme Corp</title></head><body>"
             + "<a href=\"/en-us/investors\">Investors</a></body></html>";
-        const string irPage =
-            "<html><head><title>Investor Relations - Acme</title></head>"
-            + "<body><h1>Quarterly results</h1></body></html>";
-        const string notIr =
-            "<html><head><title>Page not found</title></head><body>404</body></html>";
 
-        var handler = new RoutingHandler(uri =>
-        {
-            var key = uri.Host + uri.AbsolutePath;
-            return key == "acme.com/" ? homepage
-                : key == "acme.com/en-us/investors" ? irPage
-                : notIr;
-        });
+        var stealth = EnabledStealth(url =>
+            url == "https://acme.com" ? homepage
+            : url == "https://acme.com/en-us/investors" ? IrPage
+            : NotIr
+        );
+
         var client = new InvestorRelationsProbeClient(
-            new HttpClient(handler),
-            DisabledStealth(),
+            stealth,
             NullLogger<InvestorRelationsProbeClient>.Instance
         );
 
         var result = await client.Discover(
-            website,
+            "acme.com",
             ["investors", "ir"],
             ["ir"],
             CancellationToken.None
@@ -211,95 +109,13 @@ public class InvestorRelationsProbeClientTests
         result!.Url.Should().Be("https://acme.com/en-us/investors");
     }
 
-    private static IStealthBrowserClient DisabledStealth()
+    private static IStealthBrowserClient EnabledStealth(Func<string, string> bodyForUrl)
     {
         var stealth = Substitute.For<IStealthBrowserClient>();
-        stealth.IsEnabled.Returns(false);
+        stealth.IsEnabled.Returns(true);
+        stealth
+            .FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(bodyForUrl(ci.ArgAt<string>(0))));
         return stealth;
-    }
-
-    // Serves a body chosen per request URL, echoing the request as the final URL.
-    private sealed class RoutingHandler : HttpMessageHandler
-    {
-        private readonly Func<Uri, string> _bodyFor;
-
-        public RoutingHandler(Func<Uri, string> bodyFor) => _bodyFor = bodyFor;
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken
-        ) =>
-            Task.FromResult(
-                new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(
-                        _bodyFor(request.RequestUri!),
-                        Encoding.UTF8,
-                        "text/html"
-                    ),
-                    RequestMessage = request,
-                }
-            );
-    }
-
-    // Returns a valid IR page (title alone satisfies the validator) but reports a
-    // post-redirect RequestUri far longer than the 256-char column ceiling.
-    private sealed class LongFinalUrlHandler : HttpMessageHandler
-    {
-        private readonly string _finalUrl;
-
-        public LongFinalUrlHandler(string finalUrl) => _finalUrl = finalUrl;
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken
-        )
-        {
-            var response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(
-                    "<html><head><title>Investor Relations</title></head><body>Welcome</body></html>",
-                    Encoding.UTF8,
-                    "text/html"
-                ),
-                // Explicitly set so HttpClient doesn't overwrite it: simulates the
-                // request having landed on an over-long URL after redirects.
-                RequestMessage = new HttpRequestMessage(HttpMethod.Get, _finalUrl),
-            };
-            return Task.FromResult(response);
-        }
-    }
-
-    // Returns a fixed status, content-type, and body for every request, counting how many
-    // requests it served (so a test can prove the plain-HTTP path was exercised).
-    private sealed class ConstantHandler : HttpMessageHandler
-    {
-        private readonly HttpStatusCode _status;
-        private readonly string _mediaType;
-        private readonly string _body;
-        private int _calls;
-
-        public ConstantHandler(HttpStatusCode status, string mediaType, string body)
-        {
-            _status = status;
-            _mediaType = mediaType;
-            _body = body;
-        }
-
-        public int Calls => _calls;
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken
-        )
-        {
-            Interlocked.Increment(ref _calls);
-            return Task.FromResult(
-                new HttpResponseMessage(_status)
-                {
-                    Content = new StringContent(_body, Encoding.UTF8, _mediaType),
-                }
-            );
-        }
     }
 }


### PR DESCRIPTION
## Root cause (the freeze)
`CloakBrowserStealthClient` acquired the `_concurrencyLimiter` semaphore on every render but **never released it** (pre-existing). After `MaxConcurrency` renders the permit pool was exhausted forever, so every subsequent stealth render — IR discovery, website discovery, FDA — blocked permanently. That is why the sweep logged 'running' but never 'completed', with 0 renders after the first burst. Fixed with an outer `finally` that always releases.

## Also
- **Remove the plain-HTTP probe pass** from the IR probe — IR hosts are bot-protected, so plain HTTP only ever returned challenge pages that failed validation, while burning ~100s of dead-host timeouts per stock (11 candidates x 10s) before stealth even started. Sidecar-only now; no sidecar => no-op.
- **Bound the whole stealth operation** (connect + context + page + render) with a linked-token `OperationTimeoutSeconds` ceiling, plus best-effort bounded teardown, so a wedged sidecar degrades to a miss instead of hanging.
- Remove the temporary timing instrumentation + plain-HTTP HttpClient registration.

Reviewed (code-reviewer): the HIGH finding (missing semaphore release) is fixed here; MEDIUM (unbounded teardown) addressed via CloseQuietly.