### PR TITLE
feat(ir-discovery): exponential re-probe backoff instead of a flat 30-day cooldown

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -71,6 +71,16 @@ public class CommonStock
     public int InvestorRelationsDiscoveryVersion { get; set; }
 
     /// <summary>
+    /// Earliest time (UTC) this stock may be re-probed after a definitive miss. Each miss backs off
+    /// exponentially — the wait doubles from the initial backoff up to the configured cap — so a
+    /// transiently-blocked site (a Cloudflare "access denied", a one-off render failure) is retried
+    /// within a day rather than written off for weeks, while a persistently-missing site still settles
+    /// at the cap. Null until the first miss; a row stamped before this field existed (or eligible by
+    /// version / website-changed) is re-probed immediately, then gets its own backoff schedule.
+    /// </summary>
+    public DateTime? InvestorRelationsRetryAfter { get; set; }
+
+    /// <summary>
     /// When an IR content scraper (news/events) last worked through this stock (UTC),
     /// stamped on every cycle the stock is scraped — whether or not new rows were
     /// found. Null until first scraped. Scrapers order their cohort least-recently

--- a/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
@@ -35,12 +35,19 @@ public class InvestorRelationsDiscoveryOptions : ScraperOptions
     ["ir", "investors", "investor", "investorrelations"];
 
     /// <summary>
-    /// Days to wait before re-probing a stock whose last discovery attempt found no
-    /// IR page. Definitive misses are stamped on the stock, so persistent misses back
-    /// off for this window; transient probe errors are not stamped and retry on the
-    /// next cycle.
+    /// Initial backoff (days) before re-probing a stock whose last attempt found no IR page. Each
+    /// subsequent definitive miss doubles the wait, capped at <see cref="RetryMaxBackoffDays"/>, so a
+    /// transiently-blocked site (a Cloudflare "access denied", a one-off render failure) is retried
+    /// within a day instead of written off for weeks, while a persistent miss still backs off to the
+    /// cap. Transient probe errors are not stamped at all and retry on the next cycle.
     /// </summary>
-    public int ProbeCooldownDays { get; set; } = 30;
+    public int RetryInitialBackoffDays { get; set; } = 1;
+
+    /// <summary>
+    /// Cap (days) on the exponential re-probe backoff — a miss never waits longer than this between
+    /// attempts, so even a long-failing site is re-checked at least this often.
+    /// </summary>
+    public int RetryMaxBackoffDays { get; set; } = 15;
 
     /// <summary>
     /// How many candidate probes to run concurrently within a cycle. Each probe escalates to a

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
@@ -172,12 +172,12 @@ public class InvestorRelationsDiscoveryService : IImporter
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
-        var cutoff = DateTime.UtcNow.AddDays(-_options.ProbeCooldownDays);
+        var now = DateTime.UtcNow;
         // Largest companies first: high-value names (TSLA, WMT) shouldn't wait behind thousands of
         // obscure tickers. Market cap is the priority signal; unknown caps (0) drain last,
         // tie-broken alphabetically for a stable order.
         var rows = await repo.GetAll()
-            .Where(PendingDiscovery(cutoff, InvestorRelationsDiscoveryVersion.Current))
+            .Where(PendingDiscovery(now, InvestorRelationsDiscoveryVersion.Current))
             .OrderByDescending(s => s.MarketCapitalization)
             .ThenBy(s => s.Ticker)
             .Take(_options.BatchSize)
@@ -242,21 +242,55 @@ public class InvestorRelationsDiscoveryService : IImporter
         if (stock == null)
             return;
 
-        stock.InvestorRelationsCheckedAt = DateTime.UtcNow;
+        var now = DateTime.UtcNow;
+        // Exponential backoff: double the previous wait each miss, starting at the initial backoff and
+        // capped at the max — so a transiently-blocked site is re-probed within a day while a
+        // persistent miss settles at the cap. Computed from the prior schedule BEFORE the stamps below
+        // overwrite it.
+        stock.InvestorRelationsRetryAfter = now.Add(NextBackoff(stock));
+        stock.InvestorRelationsCheckedAt = now;
         stock.InvestorRelationsDiscoveryVersion = InvestorRelationsDiscoveryVersion.Current;
         await repo.SaveChanges();
     }
 
+    // The wait already served before this miss, recovered from the gap between the last check and its
+    // scheduled retry — so the schedule advances without a separate attempt counter.
+    private TimeSpan NextBackoff(CommonStock stock)
+    {
+        var previous =
+            stock.InvestorRelationsCheckedAt.HasValue && stock.InvestorRelationsRetryAfter.HasValue
+                ? stock.InvestorRelationsRetryAfter.Value - stock.InvestorRelationsCheckedAt.Value
+                : TimeSpan.Zero;
+        return ComputeBackoff(
+            previous,
+            _options.RetryInitialBackoffDays,
+            _options.RetryMaxBackoffDays
+        );
+    }
+
+    /// <summary>
+    /// The next re-probe backoff for a definitive miss: the initial backoff on the first miss (when
+    /// <paramref name="previous"/> is zero), then double the previous wait on each subsequent miss,
+    /// capped at <paramref name="maxDays"/>. E.g. with 1/15 the schedule is 1, 2, 4, 8, 15, 15… days.
+    /// </summary>
+    public static TimeSpan ComputeBackoff(TimeSpan previous, int initialDays, int maxDays)
+    {
+        var initial = TimeSpan.FromDays(Math.Max(1, initialDays));
+        var max = TimeSpan.FromDays(Math.Max(maxDays, Math.Max(1, initialDays)));
+        var next = previous <= TimeSpan.Zero ? initial : TimeSpan.FromTicks(previous.Ticks * 2);
+        return next > max ? max : next;
+    }
+
     /// <summary>
     /// Stocks eligible for an IR discovery probe: a known website, no discovered IR page yet, and one
-    /// of — never probed; probed before the cooldown (periodic recheck for an externally-added page);
-    /// probed under an older discovery version (<paramref name="currentVersion"/> — our probe improved,
-    /// re-sweep the backlog now); or probed before the website was found
-    /// (<c>InvestorRelationsCheckedAt &lt; WebsiteCheckedAt</c> — the input changed; the reconciliation
-    /// backstop for a website-discovered event lost to a crash).
+    /// of — never probed; due for a re-probe (its exponential miss-backoff has elapsed, or it predates
+    /// the backoff field and so re-probes once); probed under an older discovery version
+    /// (<paramref name="currentVersion"/> — our probe improved, re-sweep the backlog now); or probed
+    /// before the website was found (<c>InvestorRelationsCheckedAt &lt; WebsiteCheckedAt</c> — the
+    /// input changed; the reconciliation backstop for a website-discovered event lost to a crash).
     /// </summary>
     public static Expression<Func<CommonStock, bool>> PendingDiscovery(
-        DateTime cutoff,
+        DateTime now,
         int currentVersion
     )
     {
@@ -266,7 +300,8 @@ public class InvestorRelationsDiscoveryService : IImporter
             && s.InvestorRelationsUrl == null
             && (
                 s.InvestorRelationsCheckedAt == null
-                || s.InvestorRelationsCheckedAt < cutoff
+                || s.InvestorRelationsRetryAfter == null
+                || s.InvestorRelationsRetryAfter <= now
                 || s.InvestorRelationsDiscoveryVersion < currentVersion
                 || s.InvestorRelationsCheckedAt < s.WebsiteCheckedAt
             );

--- a/src/Equibles.Migrations/Migrations/20260628230405_AddInvestorRelationsRetryAfter.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260628230405_AddInvestorRelationsRetryAfter.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260628230405_AddInvestorRelationsRetryAfter")]
+    partial class AddInvestorRelationsRetryAfter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260628230405_AddInvestorRelationsRetryAfter.cs
+++ b/src/Equibles.Migrations/Migrations/20260628230405_AddInvestorRelationsRetryAfter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvestorRelationsRetryAfter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "InvestorRelationsRetryAfter",
+                table: "CommonStock",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InvestorRelationsRetryAfter",
+                table: "CommonStock");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsDiscoveryServicePendingDiscoveryTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsDiscoveryServicePendingDiscoveryTests.cs
@@ -5,29 +5,35 @@ namespace Equibles.UnitTests.CommonStocks;
 
 public class InvestorRelationsDiscoveryServicePendingDiscoveryTests
 {
-    private static readonly DateTime Cutoff = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Now = new(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
     private const int CurrentVersion = 5;
 
+    private static DateTime Utc(string value) => DateTime.Parse(value).ToUniversalTime();
+
     [Theory]
-    [InlineData(null, true)] // never probed → always eligible
-    [InlineData("2026-05-15", true)] // probed before the cutoff → cooldown elapsed
-    [InlineData("2026-06-05", false)] // probed within the cooldown → backs off
-    public void PendingDiscovery_CheckedAt_GatesOnCooldownCutoff(string checkedAt, bool expected)
+    [InlineData(null, true)] // probed, but no backoff stamped (legacy row) → re-probe once
+    [InlineData("2026-06-10", true)] // backoff elapsed (RetryAfter in the past) → eligible
+    [InlineData("2026-06-20", false)] // still backing off (RetryAfter in the future) → skipped
+    public void PendingDiscovery_RetryAfter_GatesOnExponentialBackoff(
+        string retryAfter,
+        bool expected
+    )
     {
-        // Contract: persistent misses back off — a stock probed within the cooldown window is
-        // skipped, while never-probed stocks and stocks whose cooldown has elapsed are eligible.
-        // Version is current and the website wasn't found after the probe, so the cooldown clause
-        // is isolated.
+        // Contract: a definitive miss backs off on an exponential schedule — once RetryAfter has
+        // elapsed (or was never stamped) the stock is re-probed; while it's still in the future the
+        // stock is skipped. Version is current and the website wasn't found after the probe, so only
+        // the backoff clause is in play.
         var stock = new CommonStock
         {
             Website = "https://acme.com",
-            InvestorRelationsCheckedAt =
-                checkedAt == null ? null : DateTime.Parse(checkedAt).ToUniversalTime(),
+            InvestorRelationsCheckedAt = Utc("2026-06-09"),
+            InvestorRelationsRetryAfter = retryAfter == null ? null : Utc(retryAfter),
+            WebsiteCheckedAt = Utc("2026-06-09"),
             InvestorRelationsDiscoveryVersion = CurrentVersion,
         };
 
         var eligible = InvestorRelationsDiscoveryService
-            .PendingDiscovery(Cutoff, CurrentVersion)
+            .PendingDiscovery(Now, CurrentVersion)
             .Compile();
 
         eligible(stock).Should().Be(expected);
@@ -51,7 +57,7 @@ public class InvestorRelationsDiscoveryServicePendingDiscoveryTests
         };
 
         var eligible = InvestorRelationsDiscoveryService
-            .PendingDiscovery(Cutoff, CurrentVersion)
+            .PendingDiscovery(Now, CurrentVersion)
             .Compile();
 
         eligible(stock).Should().Be(expected);
@@ -59,45 +65,62 @@ public class InvestorRelationsDiscoveryServicePendingDiscoveryTests
 
     [Theory]
     [InlineData(CurrentVersion - 1, true)] // probed under an older generation → re-sweep now
-    [InlineData(CurrentVersion, false)] // already at the current generation → wait for the cooldown
-    public void PendingDiscovery_OlderVersion_IsEligibleWithinCooldown(int version, bool expected)
+    [InlineData(CurrentVersion, false)] // already at the current generation → wait out the backoff
+    public void PendingDiscovery_OlderVersion_IsEligibleWhileBackingOff(int version, bool expected)
     {
         // Contract: a probe-logic improvement (version bump) re-opens the backlog of misses
-        // immediately, bypassing the cooldown — even a stock probed moments ago is reconsidered when
-        // it was probed under an older version.
+        // immediately, bypassing the backoff — even a stock still mid-backoff is reconsidered when it
+        // was probed under an older version.
         var stock = new CommonStock
         {
             Website = "https://acme.com",
-            InvestorRelationsCheckedAt = new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc), // within cooldown
-            WebsiteCheckedAt = new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc),
+            InvestorRelationsCheckedAt = Utc("2026-06-14"),
+            InvestorRelationsRetryAfter = Utc("2026-06-20"), // still backing off
+            WebsiteCheckedAt = Utc("2026-06-14"),
             InvestorRelationsDiscoveryVersion = version,
         };
 
         var eligible = InvestorRelationsDiscoveryService
-            .PendingDiscovery(Cutoff, CurrentVersion)
+            .PendingDiscovery(Now, CurrentVersion)
             .Compile();
 
         eligible(stock).Should().Be(expected);
     }
 
     [Fact]
-    public void PendingDiscovery_WebsiteFoundAfterLastProbe_IsEligibleWithinCooldown()
+    public void PendingDiscovery_WebsiteFoundAfterLastProbe_IsEligibleWhileBackingOff()
     {
         // Contract: the reconciliation backstop for the website-discovered cascade — a stock probed
-        // (and missed) BEFORE its website was found is re-probed even within the cooldown and at the
-        // current version, because the input it needs only arrived afterwards.
+        // (and missed) BEFORE its website was found is re-probed even mid-backoff and at the current
+        // version, because the input it needs only arrived afterwards.
         var stock = new CommonStock
         {
             Website = "https://acme.com",
-            InvestorRelationsCheckedAt = new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc),
-            WebsiteCheckedAt = new DateTime(2026, 6, 6, 0, 0, 0, DateTimeKind.Utc), // website found later
+            InvestorRelationsCheckedAt = Utc("2026-06-14"),
+            InvestorRelationsRetryAfter = Utc("2026-06-20"), // still backing off
+            WebsiteCheckedAt = Utc("2026-06-16"), // website found later
             InvestorRelationsDiscoveryVersion = CurrentVersion,
         };
 
         var eligible = InvestorRelationsDiscoveryService
-            .PendingDiscovery(Cutoff, CurrentVersion)
+            .PendingDiscovery(Now, CurrentVersion)
             .Compile();
 
         eligible(stock).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0, 1)] // first miss → the initial backoff
+    [InlineData(1, 2)] // then double each subsequent miss…
+    [InlineData(2, 4)]
+    [InlineData(4, 8)]
+    [InlineData(8, 15)] // 16 would exceed the cap → clamped to 15
+    [InlineData(15, 15)] // and stays at the cap thereafter
+    public void ComputeBackoff_DoublesFromInitialUpToCap(double previousDays, double expectedDays)
+    {
+        InvestorRelationsDiscoveryService
+            .ComputeBackoff(TimeSpan.FromDays(previousDays), initialDays: 1, maxDays: 15)
+            .Should()
+            .Be(TimeSpan.FromDays(expectedDays));
     }
 }


### PR DESCRIPTION
## Summary

A definitive IR-discovery miss was stamped and not re-probed for a **flat 30 days**. So a *transiently*-blocked site (a Cloudflare "access denied", a one-off render failure) got written off for a month even though a retry the next day would usually succeed.

This replaces the fixed cooldown with a **per-stock exponential backoff**: the wait starts at `RetryInitialBackoffDays` (1) and **doubles each consecutive miss**, capped at `RetryMaxBackoffDays` (15) → **1, 2, 4, 8, 15, 15… days**.

## Changes

- **CommonStock** — new nullable `InvestorRelationsRetryAfter` (next-eligible time; mirrors `EarningsCallEvent.WebcastResolveAfter`). Migration adds one nullable column.
- **InvestorRelationsDiscoveryService** — `MarkChecked` stamps the doubled backoff; the schedule advances off the gap between the last check and its retry (no attempt counter). `PendingDiscovery` gates on `RetryAfter <= now`; legacy rows (no `RetryAfter`) re-probe once then get their own schedule. Version-bump and website-changed fast-paths unchanged. `ComputeBackoff` extracted as a pure static.
- **InvestorRelationsDiscoveryOptions** — `ProbeCooldownDays` → `RetryInitialBackoffDays` (1) + `RetryMaxBackoffDays` (15).
- **Tests** — `RetryAfter` gating + the 1/2/4/8/15 schedule.