### PR TITLE
fix(search): rank an exact ticker match first in stock search

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -11,25 +11,37 @@ public class CommonStockRepository : BaseRepository<CommonStock>
 
     public IQueryable<CommonStock> Search(string search)
     {
-        var query = GetAll().OrderBy(c => c.Ticker).AsQueryable();
+        var query = GetAll();
 
-        if (!string.IsNullOrEmpty(search))
+        if (string.IsNullOrEmpty(search))
         {
-            foreach (var word in search.Split(" "))
-            {
-                // Escape LIKE metacharacters so a typed '_' or '%' matches literally
-                // rather than behaving as a wildcard.
-                var pattern = LikePattern.Contains(word);
-                query = query.Where(c =>
-                    EF.Functions.ILike(c.Ticker, pattern, LikePattern.EscapeChar)
-                    || EF.Functions.ILike(c.Name, pattern, LikePattern.EscapeChar)
-                    || EF.Functions.ILike(c.Description, pattern, LikePattern.EscapeChar)
-                    || EF.Functions.ILike(c.Industry.Name, pattern, LikePattern.EscapeChar)
-                );
-            }
+            return query.OrderBy(c => c.Ticker);
         }
 
-        return query;
+        foreach (var word in search.Split(" "))
+        {
+            // Escape LIKE metacharacters so a typed '_' or '%' matches literally
+            // rather than behaving as a wildcard.
+            var pattern = LikePattern.Contains(word);
+            query = query.Where(c =>
+                EF.Functions.ILike(c.Ticker, pattern, LikePattern.EscapeChar)
+                || EF.Functions.ILike(c.Name, pattern, LikePattern.EscapeChar)
+                || EF.Functions.ILike(c.Description, pattern, LikePattern.EscapeChar)
+                || EF.Functions.ILike(c.Industry.Name, pattern, LikePattern.EscapeChar)
+            );
+        }
+
+        // Rank an exact ticker hit to the very top, then ticker prefix hits, ahead of the
+        // alphabetical fallback — so a typed symbol (e.g. "ARE") leads its group instead of
+        // sorting past a per-group result cap alphabetically (ARE would otherwise fall behind
+        // ABXXF/ACHC/…). Both comparisons run through ILike so they stay case-insensitive and
+        // metacharacter-safe like the filter above; ordering by the boolean puts matches first.
+        var exact = LikePattern.Escape(search.Trim());
+        var prefix = LikePattern.StartsWith(search.Trim());
+        return query
+            .OrderByDescending(c => EF.Functions.ILike(c.Ticker, exact, LikePattern.EscapeChar))
+            .ThenByDescending(c => EF.Functions.ILike(c.Ticker, prefix, LikePattern.EscapeChar))
+            .ThenBy(c => c.Ticker);
     }
 
     public async Task<CommonStock> GetByCik(string cik)

--- a/src/Equibles.Data/LikePattern.cs
+++ b/src/Equibles.Data/LikePattern.cs
@@ -19,4 +19,11 @@ public static class LikePattern
     {
         return $"%{Escape(text)}%";
     }
+
+    // Escapes LIKE metacharacters and appends % for a prefix (starts-with) match.
+    // Use with EF.Functions.ILike(column, pattern, LikePattern.EscapeChar).
+    public static string StartsWith(string text)
+    {
+        return $"{Escape(text)}%";
+    }
 }

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositorySearchRankingTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositorySearchRankingTests.cs
@@ -1,0 +1,90 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.CommonStocks;
+
+/// <summary>
+/// Pins <see cref="CommonStockRepository.Search"/>'s ranking against real ParadeDB ILike: an exact
+/// ticker hit must lead the results, then ticker prefix hits, then the alphabetical fallback.
+/// Without it a typed symbol sorts purely alphabetically and falls behind earlier tickers that only
+/// match the term in their name/description — so a per-group result cap (the ⌘K palette caps each
+/// group) drops the exact match entirely (e.g. "ARE" buried behind ABXXF/ACHC/ACIW/…). Search uses
+/// EF.Functions.ILike, which the in-memory provider can't translate, so this needs a real database.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class CommonStockRepositorySearchRankingTests : ParadeDbMcpTestBase
+{
+    public CommonStockRepositorySearchRankingTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static CommonStock Stock(string ticker, string name) =>
+        new()
+        {
+            Ticker = ticker,
+            Name = name,
+            Cik = ticker,
+        };
+
+    [Fact]
+    public async Task Search_ExactTickerMatch_RanksFirstEvenWhenAlphabeticallyLast()
+    {
+        // All four match the term "are" (ARE by exact ticker; the rest only in their name), and ARE
+        // sorts alphabetically last — so a naive alphabetical order would bury it.
+        DbContext.AddRange(
+            Stock("ABXXF", "Abaxx Technologies Inc."),
+            Stock("ACHC", "Acadia Healthcare Company, Inc."),
+            Stock("ACRE", "Ares Commercial Real Estate Corp"),
+            Stock("ARE", "Alexandria Real Estate Equities, Inc.")
+        );
+        await DbContext.SaveChangesAsync();
+
+        var results = new CommonStockRepository(DbContext).Search("ARE").ToList();
+
+        Assert.Equal("ARE", results[0].Ticker);
+    }
+
+    [Fact]
+    public async Task Search_IsCaseInsensitive_ForTheExactTickerRanking()
+    {
+        DbContext.AddRange(
+            Stock("ABXXF", "Abaxx Technologies Inc."),
+            Stock("ARE", "Alexandria Real Estate Equities, Inc.")
+        );
+        await DbContext.SaveChangesAsync();
+
+        var results = new CommonStockRepository(DbContext).Search("are").ToList();
+
+        Assert.Equal("ARE", results[0].Ticker);
+    }
+
+    [Fact]
+    public async Task Search_TickerPrefixMatches_RankAheadOfNameOnlyMatches()
+    {
+        // No exact ticker hit: "AR" should still surface the ticker that STARTS with it ahead of one
+        // that only matches the term in its name.
+        DbContext.AddRange(
+            Stock("ABXXF", "Argent Holdings"), // name contains "ar", ticker does not start with it
+            Stock("ARLP", "Alliance Resource Partners") // ticker starts with "AR"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var results = new CommonStockRepository(DbContext).Search("AR").ToList();
+
+        Assert.Equal("ARLP", results[0].Ticker);
+    }
+
+    [Fact]
+    public async Task Search_NoExactOrPrefixHit_FallsBackToAlphabeticalTickerOrder()
+    {
+        DbContext.AddRange(Stock("ZETA", "Zeta Group Holdings"), Stock("BETA", "Beta Group Inc."));
+        await DbContext.SaveChangesAsync();
+
+        // Both match only via their name token ("Group"); with no ticker exact/prefix hit they fall
+        // back to alphabetical ticker order.
+        var results = new CommonStockRepository(DbContext).Search("Group").ToList();
+
+        Assert.Equal(new[] { "BETA", "ZETA" }, results.Select(s => s.Ticker).ToArray());
+    }
+}


### PR DESCRIPTION
## Summary

Stock search (`CommonStockRepository.Search`) ordered results purely alphabetically by ticker, so a typed symbol that also appears in other companies' names sorted by its letters rather than by relevance. With a per-group result cap (the ⌘K command palette shows the top few per category) the exact match could fall off the list entirely — e.g. searching **"ARE"** surfaced ABXXF / ACHC / ACIW / ACRE / ADBE and hid Alexandria Real Estate (ARE) itself.

## Changes

- **`CommonStockRepository.Search`** — after filtering, rank an **exact ticker** hit first, then **ticker-prefix** hits, before the alphabetical fallback. Both comparisons go through `EF.Functions.ILike` so they stay case-insensitive and metacharacter-safe like the existing filter, and translate to `ORDER BY (Ticker ILIKE …) DESC`. The empty/null query keeps its plain alphabetical order.
- **`LikePattern.StartsWith`** — new helper mirroring `Contains`, for the prefix pattern.
- **`CommonStockRepositorySearchRankingTests`** — ParadeDB-backed tests: exact match ranks first even when alphabetically last, case-insensitive, prefix beats name-only matches, and the alphabetical fallback when neither hits.

Tests: the 4 new ranking tests pass against real ParadeDB; 72 related Search tests still green.