### PR TITLE
fix(search): show a company's most recent filings when the query is a ticker

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/SecDocumentSearchProvider.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/SecDocumentSearchProvider.cs
@@ -1,10 +1,15 @@
 using Equibles.Search.Abstractions;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.BusinessLogic.Search;
 
 /// <summary>
-/// SEC filings group. Reuses the production BM25 + semantic hybrid search and collapses chunk hits
-/// to one entry per document, preserving relevance order.
+/// SEC filings group. When the query is an exact ticker it lists that company's most recent
+/// filings (newest first); otherwise it reuses the production BM25 + semantic hybrid search and
+/// collapses chunk hits to one entry per document, preserving relevance order.
 /// </summary>
 public class SecDocumentSearchProvider : ISearchProvider
 {
@@ -13,10 +18,15 @@ public class SecDocumentSearchProvider : ISearchProvider
     private const int ChunkOverFetchFactor = 4;
 
     private readonly HybridChunkSearcher _chunkSearcher;
+    private readonly DocumentRepository _documentRepository;
 
-    public SecDocumentSearchProvider(HybridChunkSearcher chunkSearcher)
+    public SecDocumentSearchProvider(
+        HybridChunkSearcher chunkSearcher,
+        DocumentRepository documentRepository
+    )
     {
         _chunkSearcher = chunkSearcher;
+        _documentRepository = documentRepository;
     }
 
     public string Category => "SEC Filings";
@@ -24,6 +34,61 @@ public class SecDocumentSearchProvider : ISearchProvider
     public int Order => 10;
 
     public async Task<SearchResultGroup> Search(
+        SearchRequest request,
+        CancellationToken cancellationToken
+    )
+    {
+        // A typed ticker ("ARE") means "this company's filings" — surface its most RECENT ones, not
+        // chunks that merely contain the token. A content search for a short, common ticker word
+        // ("are") otherwise ranks old filings heavy on that word and buries this year's filings.
+        var hits = await SearchRecentFilingsByTicker(request, cancellationToken);
+        if (hits.Count == 0)
+        {
+            hits = await SearchByContent(request, cancellationToken);
+        }
+
+        return new SearchResultGroup
+        {
+            Category = Category,
+            Order = Order,
+            Hits = hits,
+        };
+    }
+
+    // The exact-ticker path: the company's newest filings first, within any requested date window.
+    // Returns an empty list when the query isn't a ticker, so the caller falls back to content search.
+    private async Task<List<SearchHit>> SearchRecentFilingsByTicker(
+        SearchRequest request,
+        CancellationToken cancellationToken
+    )
+    {
+        var ticker = request.Query.Trim();
+        if (string.IsNullOrEmpty(ticker))
+        {
+            return [];
+        }
+
+        var query = _documentRepository.GetByTicker(ticker);
+        if (request.DateFrom.HasValue)
+        {
+            query = query.Where(document => document.ReportingDate >= request.DateFrom.Value);
+        }
+        if (request.DateTo.HasValue)
+        {
+            query = query.Where(document => document.ReportingDate <= request.DateTo.Value);
+        }
+
+        var documents = await query
+            .OrderByDescending(document => document.ReportingDate)
+            .Take(request.MaxPerProvider)
+            .ToListAsync(cancellationToken);
+
+        return documents.Select(ProjectDocument).ToList();
+    }
+
+    // The free-text path: hybrid BM25 + semantic over chunk content, collapsed to one entry per
+    // document in relevance order.
+    private async Task<List<SearchHit>> SearchByContent(
         SearchRequest request,
         CancellationToken cancellationToken
     )
@@ -36,30 +101,35 @@ public class SecDocumentSearchProvider : ISearchProvider
             cancellationToken: cancellationToken
         );
 
-        var documents = chunks
+        return chunks
             .GroupBy(chunk => chunk.DocumentId)
             .Select(group => group.First())
             .Take(request.MaxPerProvider)
+            .Select(ProjectChunk)
             .ToList();
-
-        return new SearchResultGroup
-        {
-            Category = Category,
-            Order = Order,
-            Hits = documents
-                .Select(chunk => new SearchHit
-                {
-                    Title = $"{chunk.DocumentType.DisplayName} · {chunk.Ticker}",
-                    Subtitle = chunk.ReportingDate.ToString("yyyy-MM-dd"),
-                    Kind = "Filing",
-                    Date = DateOnly.FromDateTime(chunk.ReportingDate),
-                    RouteValues =
-                    {
-                        ["ticker"] = chunk.Ticker,
-                        ["id"] = chunk.DocumentId.ToString(),
-                    },
-                })
-                .ToList(),
-        };
     }
+
+    private static SearchHit ProjectDocument(Document document) =>
+        new()
+        {
+            Title = $"{document.DocumentType.DisplayName} · {document.CommonStock.Ticker}",
+            Subtitle = document.ReportingDate.ToString("yyyy-MM-dd"),
+            Kind = "Filing",
+            Date = document.ReportingDate,
+            RouteValues =
+            {
+                ["ticker"] = document.CommonStock.Ticker,
+                ["id"] = document.Id.ToString(),
+            },
+        };
+
+    private static SearchHit ProjectChunk(Chunk chunk) =>
+        new()
+        {
+            Title = $"{chunk.DocumentType.DisplayName} · {chunk.Ticker}",
+            Subtitle = chunk.ReportingDate.ToString("yyyy-MM-dd"),
+            Kind = "Filing",
+            Date = DateOnly.FromDateTime(chunk.ReportingDate),
+            RouteValues = { ["ticker"] = chunk.Ticker, ["id"] = chunk.DocumentId.ToString() },
+        };
 }

--- a/tests/Equibles.IntegrationTests/Sec/SecDocumentSearchProviderDedupTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecDocumentSearchProviderDedupTests.cs
@@ -47,8 +47,13 @@ public class SecDocumentSearchProviderDedupTests : ParadeDbMcpTestBase
 
         await DbContext.SaveChangesAsync();
 
-        var sut = new SecDocumentSearchProvider(HybridChunkSearcherFactory.Bm25Only(DbContext));
+        var sut = new SecDocumentSearchProvider(
+            HybridChunkSearcherFactory.Bm25Only(DbContext),
+            new DocumentRepository(DbContext)
+        );
 
+        // "zzqxquantum" is no company's ticker, so the exact-ticker path finds nothing and the
+        // provider falls back to the content search this test is pinning.
         var group = await sut.Search(
             new SearchRequest { Query = "zzqxquantum", MaxPerProvider = 5 },
             CancellationToken.None

--- a/tests/Equibles.IntegrationTests/Sec/SecDocumentSearchProviderTickerRecencyTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecDocumentSearchProviderTickerRecencyTests.cs
@@ -1,0 +1,135 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Search.Abstractions;
+using Equibles.Sec.BusinessLogic.Search;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins <see cref="SecDocumentSearchProvider.Search"/>'s exact-ticker behaviour: typing a ticker
+/// ("ARE") must surface that company's MOST RECENT filings, not chunks that merely contain the
+/// token. Before this, a content search for a short common ticker word ranked old filings heavy on
+/// the word (e.g. ARE's 2002–2012 10-Ks) and the per-group cap dropped this year's filings entirely.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class SecDocumentSearchProviderTickerRecencyTests : ParadeDbMcpTestBase
+{
+    public SecDocumentSearchProviderTickerRecencyTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Search_ExactTicker_ReturnsCompanysMostRecentFilingsNewestFirst()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "ARE",
+            Name = "Alexandria Real Estate",
+            Cik = "ARE",
+        };
+        DbContext.Add(stock);
+
+        // Span old → new; only the 5 newest should come back, newest first — even though the older
+        // ones outnumber the cap.
+        var dates = new[]
+        {
+            new DateOnly(2002, 3, 29),
+            new DateOnly(2011, 3, 1),
+            new DateOnly(2012, 2, 21),
+            new DateOnly(2025, 7, 21),
+            new DateOnly(2025, 12, 8),
+            new DateOnly(2026, 1, 12),
+            new DateOnly(2026, 1, 26),
+        };
+        foreach (var date in dates)
+        {
+            SeedDocument(stock, date);
+        }
+        await DbContext.SaveChangesAsync();
+
+        var sut = new SecDocumentSearchProvider(
+            HybridChunkSearcherFactory.Bm25Only(DbContext),
+            new DocumentRepository(DbContext)
+        );
+
+        var group = await sut.Search(
+            new SearchRequest { Query = "ARE", MaxPerProvider = 5 },
+            CancellationToken.None
+        );
+
+        group
+            .Hits.Select(hit => hit.Date)
+            .Should()
+            .ContainInOrder(
+                new DateOnly(2026, 1, 26),
+                new DateOnly(2026, 1, 12),
+                new DateOnly(2025, 12, 8),
+                new DateOnly(2025, 7, 21),
+                new DateOnly(2012, 2, 21)
+            );
+        group.Hits.Should().HaveCount(5);
+        group.Hits.Should().AllSatisfy(hit => hit.Kind.Should().Be("Filing"));
+    }
+
+    [Fact]
+    public async Task Search_ExactTicker_IsCaseInsensitive()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "ARE",
+            Name = "Alexandria Real Estate",
+            Cik = "ARE",
+        };
+        DbContext.Add(stock);
+        SeedDocument(stock, new DateOnly(2026, 1, 26));
+        await DbContext.SaveChangesAsync();
+
+        var sut = new SecDocumentSearchProvider(
+            HybridChunkSearcherFactory.Bm25Only(DbContext),
+            new DocumentRepository(DbContext)
+        );
+
+        var group = await sut.Search(
+            new SearchRequest { Query = "are", MaxPerProvider = 5 },
+            CancellationToken.None
+        );
+
+        group.Hits.Should().ContainSingle();
+        group.Hits[0].RouteValues["ticker"].Should().Be("ARE");
+    }
+
+    private void SeedDocument(CommonStock stock, DateOnly reportingDate)
+    {
+        var fileContent = new Equibles.Media.Data.Models.FileContent
+        {
+            Bytes = "placeholder"u8.ToArray(),
+        };
+        var file = new File
+        {
+            Name = "filing",
+            Extension = "txt",
+            ContentType = "text/plain",
+            Size = fileContent.Bytes.Length,
+            FileContent = fileContent,
+        };
+        fileContent.FileId = file.Id;
+        DbContext.Add(file);
+
+        DbContext.Add(
+            new Document
+            {
+                CommonStock = stock,
+                CommonStockId = stock.Id,
+                Content = file,
+                ContentId = file.Id,
+                DocumentType = DocumentType.TenK,
+                ReportingDate = reportingDate,
+                ReportingForDate = reportingDate.AddDays(-30),
+                LineCount = 1,
+            }
+        );
+    }
+}

--- a/tests/Equibles.UnitTests/Search/SecDocumentSearchProviderIdentityTests.cs
+++ b/tests/Equibles.UnitTests/Search/SecDocumentSearchProviderIdentityTests.cs
@@ -45,7 +45,7 @@ public class SecDocumentSearchProviderIdentityTests
     [Fact]
     public void Category_AndOrder_ArePinnedConstants()
     {
-        var sut = new SecDocumentSearchProvider(null);
+        var sut = new SecDocumentSearchProvider(null, null);
 
         sut.Category.Should().Be("SEC Filings");
         sut.Order.Should().Be(10);


### PR DESCRIPTION
## Summary

In the ⌘K command palette, the **SEC Filings** group showed old filings for a ticker query. Searching **"ARE"** surfaced 2002–2012 10-Ks even though Alexandria Real Estate has filings from 2026/2025.

Root cause: the group ran a BM25 + semantic **content** search for the raw query string. For a ticker that's also a common word ("are"), the top content matches are old filings heavy on that word; the per-group cap (the palette shows ~5) is applied to those, so recent filings never enter the candidate set — and the aggregator's date sort only reorders the already-stale top-5.

## Change

- **`SecDocumentSearchProvider`** — when the query exactly matches a ticker (`DocumentRepository.GetByTicker`, case-insensitive, primary or secondary), return that company's **most recent filings, newest first**, within any requested date window. Free-text queries that match no ticker fall back to the existing hybrid content search. Injects `DocumentRepository`; splits the projection per source (Document vs Chunk).
- **Tests** — new `SecDocumentSearchProviderTickerRecencyTests` (ParadeDB): newest-first within the cap, case-insensitive. `SecDocumentSearchProviderDedupTests` updated for the new constructor; its "zzqxquantum" query still exercises the content fallback (no such ticker).

Tests: 3 SEC-provider integration tests + the identity unit test pass.