### PR TITLE
fix(ir-discovery): retry transient sidecar render failures instead of exiling on the conclusive-miss backoff

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
@@ -35,19 +35,29 @@ public class InvestorRelationsDiscoveryOptions : ScraperOptions
     ["ir", "investors", "investor", "investorrelations"];
 
     /// <summary>
-    /// Initial backoff (days) before re-probing a stock whose last attempt found no IR page. Each
-    /// subsequent definitive miss doubles the wait, capped at <see cref="RetryMaxBackoffDays"/>, so a
-    /// transiently-blocked site (a Cloudflare "access denied", a one-off render failure) is retried
-    /// within a day instead of written off for weeks, while a persistent miss still backs off to the
-    /// cap. Transient probe errors are not stamped at all and retry on the next cycle.
+    /// Initial backoff (days) before re-probing a stock whose last attempt <em>conclusively</em> found
+    /// no IR page (every candidate was assessed and none validated). Each subsequent conclusive miss
+    /// doubles the wait, capped at <see cref="RetryMaxBackoffDays"/>, so a persistent miss settles at
+    /// the cap. An <em>inconclusive</em> attempt — the stealth engine was unavailable for a candidate —
+    /// uses the shorter <see cref="RetryTransientBackoffHours"/> instead, so a stock with a reachable IR
+    /// page isn't exiled for weeks over one bad sidecar moment.
     /// </summary>
     public int RetryInitialBackoffDays { get; set; } = 1;
 
     /// <summary>
-    /// Cap (days) on the exponential re-probe backoff — a miss never waits longer than this between
-    /// attempts, so even a long-failing site is re-checked at least this often.
+    /// Cap (days) on the exponential re-probe backoff — a conclusive miss never waits longer than this
+    /// between attempts, so even a long-failing site is re-checked at least this often.
     /// </summary>
     public int RetryMaxBackoffDays { get; set; } = 15;
+
+    /// <summary>
+    /// Backoff (hours) before re-probing a stock whose last attempt was <em>inconclusive</em> — the
+    /// stealth engine was unavailable for a candidate, so a real IR page may have been missed. Short and
+    /// fixed (it does not escalate): long enough not to re-occupy a batch slot every cycle, short enough
+    /// that a transiently-unreachable IR page is recovered within the day rather than after the
+    /// multi-day conclusive-miss schedule.
+    /// </summary>
+    public int RetryTransientBackoffHours { get; set; } = 6;
 
     /// <summary>
     /// How many candidate probes to run concurrently within a cycle. Each probe escalates to a

--- a/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
@@ -54,7 +54,10 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
 
     public bool IsEnabled => !string.IsNullOrWhiteSpace(_options.SidecarUrl);
 
-    public Task<string> FetchHtml(string url, CancellationToken cancellationToken) =>
+    public async Task<string> FetchHtml(string url, CancellationToken cancellationToken) =>
+        (await TryFetchHtml(url, cancellationToken)).Html;
+
+    public Task<StealthFetchResult> TryFetchHtml(string url, CancellationToken cancellationToken) =>
         RunInStealthPage(
             url,
             async page =>
@@ -65,12 +68,12 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
             cancellationToken
         );
 
-    public Task<string> FetchRaw(string url, CancellationToken cancellationToken)
+    public async Task<string> FetchRaw(string url, CancellationToken cancellationToken)
     {
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
-            return Task.FromResult<string>(null);
+            return null;
 
-        return RunInStealthPage(
+        var result = await RunInStealthPage(
             url,
             async page =>
             {
@@ -82,21 +85,24 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
             },
             cancellationToken
         );
+        return result.Html;
     }
 
     /// <summary>
     /// Connects to the sidecar, runs <paramref name="action"/> against a fresh page
-    /// in an isolated context, and disconnects. Returns null (degrading to a miss)
-    /// when the engine is disabled or the connection/navigation/render fails.
+    /// in an isolated context, and disconnects. Returns a classified
+    /// <see cref="StealthFetchResult"/> — rendered HTML on success, or a page-/sidecar-unavailable
+    /// status when the connection/navigation/render fails — so the caller can tell a conclusive miss
+    /// from a transient infrastructure failure. Never throws except on caller cancellation.
     /// </summary>
-    private async Task<string> RunInStealthPage(
+    private async Task<StealthFetchResult> RunInStealthPage(
         string url,
         Func<IPage, Task<string>> action,
         CancellationToken cancellationToken
     )
     {
         if (!IsEnabled)
-            return null;
+            return StealthFetchResult.Disabled;
 
         await _concurrencyLimiter.WaitAsync(cancellationToken);
         try
@@ -122,7 +128,8 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
                     .WaitAsync(TimeSpan.FromSeconds(_options.ConnectTimeoutSeconds), opToken);
                 context = await browser.NewContextAsync().WaitAsync(opToken);
                 var page = await context.NewPageAsync().WaitAsync(opToken);
-                return await action(page).WaitAsync(opToken);
+                var html = await action(page).WaitAsync(opToken);
+                return StealthFetchResult.Rendered(html);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -131,22 +138,22 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
             catch (OperationCanceledException)
             {
                 // Outran OperationTimeoutSeconds (a wedged sidecar hung connect, context, page, or
-                // render). Degrade to a miss rather than holding the slot.
+                // render). Transient — degrade to a sidecar-unavailable miss rather than holding the slot.
                 _logger.LogWarning("Stealth operation timed out for {Url}", url);
-                return null;
+                return StealthFetchResult.SidecarUnavailable;
             }
             catch (TimeoutException)
             {
-                // The CDP connect outran ConnectTimeoutSeconds (wedged/over-loaded sidecar).
+                // The CDP connect outran ConnectTimeoutSeconds (wedged/over-loaded sidecar). Transient.
                 _logger.LogWarning("Stealth connect timed out for {Url}", url);
-                return null;
+                return StealthFetchResult.SidecarUnavailable;
             }
             catch (PlaywrightException ex)
             {
-                // Connection refused, navigation failure, or render timeout. The caller degrades to a
-                // miss rather than failing the batch.
+                // A navigation/render/connection failure. Classify it: a host that does not exist is a
+                // conclusive miss for this URL, everything else is a transient sidecar-side failure.
                 _logger.LogWarning(ex, "Stealth fetch failed for {Url}", url);
-                return null;
+                return ClassifyPlaywrightFailure(ex);
             }
             finally
             {
@@ -189,6 +196,25 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
         {
             _logger.LogDebug(ex, "Stealth browser disconnect failed (sidecar likely wedged)");
         }
+    }
+
+    // A navigation that fails because the host does not exist (DNS) or is unreachable is a CONCLUSIVE
+    // miss for that URL — re-probing won't change it. Anything else (connection refused/closed, a render
+    // timeout, or a reaped/wedged sidecar surfacing as "Target/Browser/Page closed" or "Process exited")
+    // is treated as a TRANSIENT sidecar-side failure, so the caller retries rather than writing the page
+    // off. Erring toward transient is deliberate: a wrongly-transient verdict costs a re-probe, a
+    // wrongly-conclusive one exiles a live page for the full backoff.
+    private static StealthFetchResult ClassifyPlaywrightFailure(PlaywrightException ex)
+    {
+        var message = ex.Message ?? "";
+        var hostDefinitivelyAbsent =
+            message.Contains("ERR_NAME_NOT_RESOLVED", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("ERR_ADDRESS_UNREACHABLE", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("ERR_ADDRESS_INVALID", StringComparison.OrdinalIgnoreCase);
+
+        return hostDefinitivelyAbsent
+            ? StealthFetchResult.PageUnavailable
+            : StealthFetchResult.SidecarUnavailable;
     }
 
     private Task Navigate(IPage page, string url) =>

--- a/src/Equibles.CommonStocks.HostedService/Services/IStealthBrowserClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IStealthBrowserClient.cs
@@ -26,6 +26,15 @@ public interface IStealthBrowserClient
     Task<string> FetchHtml(string url, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Like <see cref="FetchHtml"/>, but returns a <see cref="StealthFetchResult"/> that classifies the
+    /// outcome — rendered, page-unavailable (conclusive), or sidecar-unavailable (transient). Callers
+    /// that must distinguish "the page genuinely isn't there" from "the engine couldn't reach it this
+    /// time" use this; everyone else can keep using <see cref="FetchHtml"/>. Degrades rather than
+    /// throwing, on the same contract as <see cref="FetchHtml"/>.
+    /// </summary>
+    Task<StealthFetchResult> TryFetchHtml(string url, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Clears the host's bot challenge in the stealth browser, then fetches
     /// <paramref name="url"/> from within that cleared page context and returns the
     /// raw response body. Unlike <see cref="FetchHtml"/> this returns the bytes the

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
@@ -124,27 +124,35 @@ public class InvestorRelationsDiscoveryService : IImporter
                 _options.CandidateSubdomains,
                 cancellationToken
             );
-            // Definitive miss — every candidate was probed and none validated. Stamp the attempt so
-            // the stock backs off for the cooldown window instead of re-occupying a batch slot every
-            // cycle. Transient errors below deliberately skip the stamp.
-            if (result == null)
-            {
-                await MarkChecked(candidate.Id);
-                return false;
-            }
 
-            if (await Persist(candidate.Id, result))
+            switch (result.Outcome)
             {
-                _logger.LogDebug(
-                    "Discovered investor relations page for {Ticker}: {Url} ({Platform})",
-                    candidate.Ticker,
-                    result.Url,
-                    result.Platform
-                );
-                return true;
-            }
+                case IrProbeOutcome.Found:
+                    if (await Persist(candidate.Id, result.Page))
+                    {
+                        _logger.LogDebug(
+                            "Discovered investor relations page for {Ticker}: {Url} ({Platform})",
+                            candidate.Ticker,
+                            result.Page.Url,
+                            result.Page.Platform
+                        );
+                        return true;
+                    }
+                    return false;
 
-            return false;
+                case IrProbeOutcome.Inconclusive:
+                    // The stealth engine was unavailable for a candidate, so a real IR page may have
+                    // been missed. Back off briefly and retry rather than exiling the stock on the
+                    // escalating conclusive-miss schedule.
+                    await MarkTransientMiss(candidate.Id);
+                    return false;
+
+                default:
+                    // Conclusive miss — every candidate was assessed and none validated. Stamp the
+                    // exponential backoff so the stock isn't re-occupying a batch slot every cycle.
+                    await MarkConclusiveMiss(candidate.Id);
+                    return false;
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -233,7 +241,9 @@ public class InvestorRelationsDiscoveryService : IImporter
         return true;
     }
 
-    private async Task MarkChecked(Guid commonStockId)
+    // A conclusive miss: every candidate was assessed and none was an IR page. Stamp the escalating
+    // backoff so a persistent miss settles at the cap instead of re-occupying a batch slot every cycle.
+    private async Task MarkConclusiveMiss(Guid commonStockId)
     {
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
@@ -248,6 +258,29 @@ public class InvestorRelationsDiscoveryService : IImporter
         // persistent miss settles at the cap. Computed from the prior schedule BEFORE the stamps below
         // overwrite it.
         stock.InvestorRelationsRetryAfter = now.Add(NextBackoff(stock));
+        stock.InvestorRelationsCheckedAt = now;
+        stock.InvestorRelationsDiscoveryVersion = InvestorRelationsDiscoveryVersion.Current;
+        await repo.SaveChanges();
+    }
+
+    // An inconclusive attempt: the stealth engine was unavailable for a candidate this cycle, so a real
+    // IR page may have been missed. Stamp a short, fixed cooldown — long enough not to re-occupy a batch
+    // slot every cycle, short enough that a stock with a reachable IR page isn't exiled on the escalating
+    // conclusive-miss schedule over one bad sidecar moment. Deliberately does NOT advance the exponential
+    // schedule.
+    private async Task MarkTransientMiss(Guid commonStockId)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var stock = await repo.Get(commonStockId);
+        if (stock == null)
+            return;
+
+        var now = DateTime.UtcNow;
+        stock.InvestorRelationsRetryAfter = now.AddHours(
+            Math.Max(1, _options.RetryTransientBackoffHours)
+        );
         stock.InvestorRelationsCheckedAt = now;
         stock.InvestorRelationsDiscoveryVersion = InvestorRelationsDiscoveryVersion.Current;
         await repo.SaveChanges();

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -26,11 +26,14 @@ public class InvestorRelationsProbeClient
     }
 
     /// <summary>
-    /// Returns the validated investor-relations URL for <paramref name="website"/> together with the
-    /// platform classified from its page, or null when no candidate resolves to a recognisable IR
-    /// page (or no sidecar is configured).
+    /// Probes <paramref name="website"/> for an investor-relations page and returns a classified
+    /// <see cref="IrProbeResult"/>: <c>Found</c> with the validated URL + platform; <c>NoIrPageFound</c>
+    /// when every candidate was assessed and none was an IR page; or <c>Inconclusive</c> when the
+    /// stealth engine was unavailable for one or more candidates, so a real IR page may have been
+    /// missed. With no sidecar configured the probe reports <c>NoIrPageFound</c> (it can't get past bot
+    /// walls anyway, and re-probing won't help).
     /// </summary>
-    public async Task<IrDiscoveryResult> Discover(
+    public async Task<IrProbeResult> Discover(
         string website,
         IEnumerable<string> paths,
         IEnumerable<string> subdomains,
@@ -38,42 +41,64 @@ public class InvestorRelationsProbeClient
     )
     {
         if (!_stealthClient.IsEnabled)
-            return null;
+            return IrProbeResult.NoIrPage;
 
         var candidates = InvestorRelationsCandidateBuilder.Build(website, paths, subdomains);
 
-        // Render each guessed path/subdomain through the sidecar; the first that validates wins.
+        // Render each guessed path/subdomain through the sidecar; the first that validates wins. Track
+        // whether any candidate couldn't be assessed (engine unavailable) so a transient failure isn't
+        // reported as a conclusive "no IR page".
+        var anyTransient = false;
         foreach (var candidate in candidates)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var resolved = await TryResolve(candidate, cancellationToken);
-            if (resolved != null)
-                return resolved;
+            var (page, transient) = await ProbeCandidate(candidate, candidate, cancellationToken);
+            if (page != null)
+                return IrProbeResult.Found(page);
+            anyTransient |= transient;
         }
 
         // None of the guesses validated. Crawl the homepage and follow the investor-relations link it
         // exposes — the IR page is often at a location guessing can't reach (a Q4 / GCS host, a
         // regional or locale path, a deeper path), and the homepage URL itself is sometimes the IR site.
-        return await CrawlHomepage(website, cancellationToken);
+        var (homepageResult, homepageTransient) = await CrawlHomepage(website, cancellationToken);
+        if (homepageResult != null)
+            return IrProbeResult.Found(homepageResult);
+        anyTransient |= homepageTransient;
+
+        return anyTransient ? IrProbeResult.Inconclusive : IrProbeResult.NoIrPage;
     }
 
-    private async Task<IrDiscoveryResult> TryResolve(
+    // Renders one candidate and classifies it: a validated page; a non-validating render or a
+    // definitively-absent host (both conclusive — assessed, not an IR page here); or a transient engine
+    // failure that left the candidate unassessed.
+    private async Task<(IrDiscoveryResult Page, bool Transient)> ProbeCandidate(
+        string url,
+        string fallbackUrl,
+        CancellationToken cancellationToken
+    )
+    {
+        var fetch = await FetchRendered(url, cancellationToken);
+        return fetch.Status switch
+        {
+            StealthFetchStatus.Rendered => (BuildResult(fetch.Html, url, fallbackUrl), false),
+            StealthFetchStatus.PageUnavailable => (null, false),
+            _ => (null, true),
+        };
+    }
+
+    // Renders the page through the stealth sidecar (most IR hosts are bot-protected), returning its
+    // classified outcome. Degrades an unexpected throw to a transient sidecar-unavailable result so a
+    // single host never fails the discovery batch nor is wrongly written off as having no IR page.
+    private async Task<StealthFetchResult> FetchRendered(
         string url,
         CancellationToken cancellationToken
     )
     {
-        var html = await FetchRendered(url, cancellationToken);
-        return html == null ? null : BuildResult(html, url, url);
-    }
-
-    // Renders the page through the stealth sidecar (most IR hosts are bot-protected). Degrades to
-    // null on any error so a single host never fails the discovery batch.
-    private async Task<string> FetchRendered(string url, CancellationToken cancellationToken)
-    {
         try
         {
-            return await _stealthClient.FetchHtml(url, cancellationToken);
+            return await _stealthClient.TryFetchHtml(url, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -81,21 +106,18 @@ public class InvestorRelationsProbeClient
         }
         catch (Exception ex)
         {
-            // FetchHtml is contracted to degrade to null, but a sidecar navigation timeout/error can
-            // still surface as an exception. Swallow it: a single host that throws must not bubble out
-            // of the probe, or the caller skips the definitive-miss back-off and the stock re-occupies
-            // every batch, starving the rest of the universe.
             _logger.LogDebug(ex, "Investor relations stealth probe failed for {Url}", url);
-            return null;
+            return StealthFetchResult.SidecarUnavailable;
         }
     }
 
     /// <summary>
     /// Fetches the company homepage and either validates it directly as the IR site (when the website
     /// itself is an investor.* host) or follows the investor-relations link(s) it exposes — catching
-    /// IR pages at locations path/subdomain guessing can't reach.
+    /// IR pages at locations path/subdomain guessing can't reach. Returns the validated page (or null)
+    /// and whether any fetch was transiently unassessable.
     /// </summary>
-    private async Task<IrDiscoveryResult> CrawlHomepage(
+    private async Task<(IrDiscoveryResult Result, bool Transient)> CrawlHomepage(
         string website,
         CancellationToken cancellationToken
     )
@@ -105,34 +127,39 @@ public class InvestorRelationsProbeClient
         // normalize it here too.
         var homepage = NormalizeWebsite(website);
         if (homepage == null)
-            return null;
+            return (null, false);
 
-        var html = await FetchRendered(homepage, cancellationToken);
-        if (html == null)
-            return null;
+        var fetch = await FetchRendered(homepage, cancellationToken);
+        if (fetch.Status != StealthFetchStatus.Rendered)
+            // Couldn't load the homepage — transient unless the host is definitively absent.
+            return (null, fetch.Status != StealthFetchStatus.PageUnavailable);
+
+        var html = fetch.Html;
 
         // The website itself might BE the IR site (e.g. investor.acme.com).
         var self = BuildResult(html, homepage, website);
         if (self != null)
-            return self;
+            return (self, false);
 
+        var anyTransient = false;
         foreach (var link in InvestorRelationsLinkExtractor.Extract(html, homepage))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var resolved = await TryResolve(link, cancellationToken);
-            if (resolved != null)
+            var (page, transient) = await ProbeCandidate(link, link, cancellationToken);
+            if (page != null)
             {
                 _logger.LogInformation(
                     "Investor relations page resolved via homepage link {Link} for {Website}",
                     link,
                     website
                 );
-                return resolved;
+                return (page, false);
             }
+            anyTransient |= transient;
         }
 
-        return null;
+        return (null, anyTransient);
     }
 
     // Turns a possibly-scheme-less website into an absolute http(s) URL, or null when it can't be

--- a/src/Equibles.CommonStocks.HostedService/Services/IrProbeOutcome.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IrProbeOutcome.cs
@@ -1,0 +1,24 @@
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// The result of probing a company for an investor-relations page, distinguishing a conclusive answer
+/// from one the probe could not establish this cycle.
+/// </summary>
+public enum IrProbeOutcome
+{
+    /// <summary>A candidate validated as an IR page; see the accompanying result.</summary>
+    Found,
+
+    /// <summary>
+    /// Every candidate was assessed — rendered real content that didn't validate, or was definitively
+    /// absent — and none was an IR page. Conclusive: the stock can back off on the miss schedule.
+    /// </summary>
+    NoIrPageFound,
+
+    /// <summary>
+    /// At least one candidate couldn't be assessed because the stealth engine was unavailable (timeout,
+    /// reaped/wedged sidecar), so a real IR page may have been missed. Transient: retry soon rather than
+    /// writing the stock off for the full backoff.
+    /// </summary>
+    Inconclusive,
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/IrProbeResult.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IrProbeResult.cs
@@ -1,0 +1,14 @@
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Outcome of an IR-page probe: the <see cref="Outcome"/> and, when an IR page was found, the
+/// validated <see cref="Page"/> (null otherwise).
+/// </summary>
+public sealed record IrProbeResult(IrProbeOutcome Outcome, IrDiscoveryResult Page)
+{
+    public static IrProbeResult Found(IrDiscoveryResult page) => new(IrProbeOutcome.Found, page);
+
+    public static readonly IrProbeResult NoIrPage = new(IrProbeOutcome.NoIrPageFound, null);
+
+    public static readonly IrProbeResult Inconclusive = new(IrProbeOutcome.Inconclusive, null);
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/StealthFetchResult.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/StealthFetchResult.cs
@@ -1,0 +1,23 @@
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Outcome of a stealth fetch: the <see cref="Status"/> classifying what happened and, when the page
+/// rendered, its <see cref="Html"/> (null otherwise).
+/// </summary>
+public sealed record StealthFetchResult(StealthFetchStatus Status, string Html)
+{
+    public static StealthFetchResult Rendered(string html) =>
+        new(StealthFetchStatus.Rendered, html);
+
+    public static readonly StealthFetchResult PageUnavailable = new(
+        StealthFetchStatus.PageUnavailable,
+        null
+    );
+
+    public static readonly StealthFetchResult SidecarUnavailable = new(
+        StealthFetchStatus.SidecarUnavailable,
+        null
+    );
+
+    public static readonly StealthFetchResult Disabled = new(StealthFetchStatus.Disabled, null);
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/StealthFetchStatus.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/StealthFetchStatus.cs
@@ -1,0 +1,27 @@
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Why a stealth fetch produced (or failed to produce) HTML. Lets a caller tell a
+/// <em>conclusive</em> answer about the page apart from a <em>transient</em> infrastructure
+/// failure, so a momentarily-unavailable sidecar is not mistaken for "the page isn't there".
+/// </summary>
+public enum StealthFetchStatus
+{
+    /// <summary>The page navigated and returned HTML — the caller inspects the content to decide.</summary>
+    Rendered,
+
+    /// <summary>
+    /// The page is definitively not there: DNS did not resolve, or the address was unreachable/invalid.
+    /// Conclusive — re-probing won't change the answer.
+    /// </summary>
+    PageUnavailable,
+
+    /// <summary>
+    /// The stealth engine could not complete the render: connect/operation timeout, render timeout, or a
+    /// reaped/wedged sidecar. Transient — the page may well render on a later attempt.
+    /// </summary>
+    SidecarUnavailable,
+
+    /// <summary>No stealth engine is configured, so nothing was fetched.</summary>
+    Disabled,
+}

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -6,8 +6,11 @@ namespace Equibles.UnitTests.CommonStocks;
 
 /// <summary>
 /// Contract: the IR probe resolves entirely through the stealth sidecar — every candidate (and the
-/// homepage crawl) is rendered, the first that validates as an IR page wins, a render failure is a
-/// miss, and with no sidecar configured the probe is a no-op. There is no plain-HTTP path.
+/// homepage crawl) is rendered, the first that validates as an IR page wins, and the probe reports a
+/// classified outcome: <c>Found</c>, <c>NoIrPageFound</c> (every candidate was assessed and none was an
+/// IR page), or <c>Inconclusive</c> (the engine was unavailable for a candidate, so a real IR page may
+/// have been missed). With no sidecar configured it reports <c>NoIrPageFound</c>. There is no
+/// plain-HTTP path.
 /// </summary>
 public class InvestorRelationsProbeClientTests
 {
@@ -19,7 +22,7 @@ public class InvestorRelationsProbeClientTests
         "<html><head><title>Page not found</title></head><body>404</body></html>";
 
     [Fact]
-    public async Task Discover_SidecarRendersValidIrPage_ReturnsCandidateUrl()
+    public async Task Discover_SidecarRendersValidIrPage_ReturnsFoundWithCandidateUrl()
     {
         var stealth = EnabledStealth(_ => IrPage);
 
@@ -30,15 +33,111 @@ public class InvestorRelationsProbeClientTests
 
         var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
 
-        result.Should().NotBeNull();
-        result!.Url.Should().Be("https://acme.com/investors");
+        result.Outcome.Should().Be(IrProbeOutcome.Found);
+        result.Page!.Url.Should().Be("https://acme.com/investors");
     }
 
     [Fact]
-    public async Task Discover_NoSidecar_IsNoOp()
+    public async Task Discover_AllCandidatesRenderNonIrContent_IsConclusiveMiss()
     {
-        // No stealth browser configured: the probe can't get past bot walls, so it finds nothing
-        // (there is no plain-HTTP fallback).
+        // Every candidate (and the homepage) renders real content that doesn't validate — the site was
+        // fully assessed and has no IR page. This is the only case that earns the escalating backoff.
+        var stealth = EnabledStealth(_ => NotIr);
+
+        var client = new InvestorRelationsProbeClient(
+            stealth,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover(
+            "acme.com",
+            ["investors", "ir"],
+            ["ir"],
+            CancellationToken.None
+        );
+
+        result.Outcome.Should().Be(IrProbeOutcome.NoIrPageFound);
+        result.Page.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Discover_HostDefinitivelyAbsentForAll_IsConclusiveMiss()
+    {
+        // DNS doesn't resolve / host unreachable for every candidate: assessed and definitively absent,
+        // so re-probing won't help — a conclusive miss, not a transient one.
+        var stealth = EnabledStealthResults(_ => StealthFetchResult.PageUnavailable);
+
+        var client = new InvestorRelationsProbeClient(
+            stealth,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover(
+            "acme.com",
+            ["investors"],
+            ["ir"],
+            CancellationToken.None
+        );
+
+        result.Outcome.Should().Be(IrProbeOutcome.NoIrPageFound);
+    }
+
+    [Fact]
+    public async Task Discover_EngineUnavailableForACandidate_IsInconclusive()
+    {
+        // The sidecar couldn't render a candidate (timeout / reaped sidecar). Nothing validated, but the
+        // site wasn't fully assessed, so the answer is inconclusive — the caller must retry soon rather
+        // than exile the stock on the multi-day miss schedule. This is the EBS regression: a reachable
+        // IR page was missed only because the engine was momentarily unavailable.
+        var stealth = EnabledStealthResults(url =>
+            url == "https://acme.com/investors"
+                ? StealthFetchResult.SidecarUnavailable
+                : StealthFetchResult.Rendered(NotIr)
+        );
+
+        var client = new InvestorRelationsProbeClient(
+            stealth,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
+
+        result.Outcome.Should().Be(IrProbeOutcome.Inconclusive);
+        result.Page.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Discover_ValidPageWinsEvenWhenAnotherCandidateWasTransient()
+    {
+        // A transient failure on one candidate must not prevent a later candidate from validating — a
+        // found page always wins over an inconclusive signal.
+        var stealth = EnabledStealthResults(url =>
+            url == "https://acme.com/ir" ? StealthFetchResult.SidecarUnavailable
+            : url == "https://acme.com/investors" ? StealthFetchResult.Rendered(IrPage)
+            : StealthFetchResult.Rendered(NotIr)
+        );
+
+        var client = new InvestorRelationsProbeClient(
+            stealth,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover(
+            "acme.com",
+            ["ir", "investors"],
+            [],
+            CancellationToken.None
+        );
+
+        result.Outcome.Should().Be(IrProbeOutcome.Found);
+        result.Page!.Url.Should().Be("https://acme.com/investors");
+    }
+
+    [Fact]
+    public async Task Discover_NoSidecar_IsNoOpConclusiveMiss()
+    {
+        // No stealth browser configured: the probe can't get past bot walls, so it finds nothing (there
+        // is no plain-HTTP fallback) and re-probing won't help — report a conclusive miss.
         var stealth = Substitute.For<IStealthBrowserClient>();
         stealth.IsEnabled.Returns(false);
 
@@ -49,33 +148,35 @@ public class InvestorRelationsProbeClientTests
 
         var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
 
-        result.Should().BeNull();
-        await stealth.DidNotReceive().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        result.Outcome.Should().Be(IrProbeOutcome.NoIrPageFound);
+        await stealth.DidNotReceive().TryFetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Discover_SidecarThrows_DegradesToMiss()
+    public async Task Discover_SidecarThrows_DegradesToInconclusive()
     {
-        // The sidecar render throws (e.g. a navigation timeout) instead of the contractual null. The
-        // probe must degrade that to a miss — if it bubbles out, the caller skips the definitive-miss
-        // back-off, the stock is never stamped, re-occupies every batch, and starves the universe.
+        // The sidecar render throws (e.g. a navigation timeout) instead of the contractual classified
+        // result. The probe must degrade that to a transient inconclusive outcome — not a conclusive
+        // miss — so the stock retries soon instead of being written off as having no IR page.
         var stealth = Substitute.For<IStealthBrowserClient>();
         stealth.IsEnabled.Returns(true);
         stealth
-            .FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<string>(new TimeoutException("navigation timeout")));
+            .TryFetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromException<StealthFetchResult>(new TimeoutException("navigation timeout"))
+            );
 
         var client = new InvestorRelationsProbeClient(
             stealth,
             NullLogger<InvestorRelationsProbeClient>.Instance
         );
 
-        IrDiscoveryResult result = null;
+        IrProbeResult result = null;
         var act = async () =>
             result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
 
         await act.Should().NotThrowAsync();
-        result.Should().BeNull();
+        result!.Outcome.Should().Be(IrProbeOutcome.Inconclusive);
     }
 
     [Fact]
@@ -105,17 +206,22 @@ public class InvestorRelationsProbeClientTests
             CancellationToken.None
         );
 
-        result.Should().NotBeNull();
-        result!.Url.Should().Be("https://acme.com/en-us/investors");
+        result.Outcome.Should().Be(IrProbeOutcome.Found);
+        result.Page!.Url.Should().Be("https://acme.com/en-us/investors");
     }
 
-    private static IStealthBrowserClient EnabledStealth(Func<string, string> bodyForUrl)
+    private static IStealthBrowserClient EnabledStealth(Func<string, string> bodyForUrl) =>
+        EnabledStealthResults(url => StealthFetchResult.Rendered(bodyForUrl(url)));
+
+    private static IStealthBrowserClient EnabledStealthResults(
+        Func<string, StealthFetchResult> resultForUrl
+    )
     {
         var stealth = Substitute.For<IStealthBrowserClient>();
         stealth.IsEnabled.Returns(true);
         stealth
-            .FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(ci => Task.FromResult(bodyForUrl(ci.ArgAt<string>(0))));
+            .TryFetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(resultForUrl(ci.ArgAt<string>(0))));
         return stealth;
     }
 }


### PR DESCRIPTION
## Summary

A stock with a perfectly reachable investor-relations page could be left with no `InvestorRelationsUrl` — so the portal summary hides the IR link — for up to 15 days, because the discovery probe couldn't tell a **transient render failure** from a **genuine "no IR page"**.

`InvestorRelationsProbeClient` renders every candidate through the stealth sidecar and collapsed any failure to `null`. A candidate that rendered real content and failed validation (a genuine miss) and one that couldn't be rendered at all (a render timeout, or a reaped/contended sidecar) both became `null`. `InvestorRelationsDiscoveryService` treated every `null` as a definitive miss and stamped the escalating backoff (1 → 2 → 4 → 8 → cap 15 days). One bad sidecar moment exiled a live IR page for days.

Verified by driving the exact pinned sidecar image (`cloakhq/cloakbrowser:0.4.4`) over CDP with the same client path: it resolves the affected stock's IR page reliably (6/6 runs) — the pipeline is capable; the miss was transient and misclassified.

## Code changes

- **`StealthFetchStatus` / `StealthFetchResult`** (new) — classify a stealth fetch as `Rendered`, `PageUnavailable` (DNS/unreachable — conclusive), `SidecarUnavailable` (timeout / wedged sidecar — transient), or `Disabled`.
- **`IStealthBrowserClient.TryFetchHtml`** (new) — returns the classified result. `FetchHtml`/`FetchRaw` keep their existing null-on-failure contract (FDA + website probes are unchanged); only the IR probe uses the new path.
- **`CloakBrowserStealthClient`** — `RunInStealthPage` returns the classified result; navigation failures are classified (only `ERR_NAME_NOT_RESOLVED` / `ERR_ADDRESS_UNREACHABLE` / `ERR_ADDRESS_INVALID` are conclusive page-absent, everything else is treated as transient — erring toward retry).
- **`IrProbeOutcome` / `IrProbeResult`** (new) — the probe now reports `Found` / `NoIrPageFound` / `Inconclusive`, propagating a transient signal across all candidates and the homepage crawl.
- **`InvestorRelationsDiscoveryService`** — applies the escalating backoff only on a conclusive miss; an inconclusive probe gets a short fixed cooldown and retries soon. (`MarkChecked` → `MarkConclusiveMiss`, plus `MarkTransientMiss`.)
- **`InvestorRelationsDiscoveryOptions.RetryTransientBackoffHours`** (new, default 6) — the fixed, non-escalating transient cooldown.
- **Tests** — `InvestorRelationsProbeClientTests` updated for the classified outcome and extended: conclusive miss (non-IR content / host absent), inconclusive (engine unavailable), a found page winning over a transient sibling, and a thrown sidecar error degrading to inconclusive.

Refines the exponential-backoff behaviour from #4024.
