### PR TITLE
feat(errors): add WebRequest error source

### DIFF
--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -34,6 +34,7 @@ public sealed class ErrorSource
     public static readonly ErrorSource FdaCatalystScraper = new("FdaCatalystScraper");
     public static readonly ErrorSource Authentication = new("Authentication");
     public static readonly ErrorSource Alvis = new("Alvis");
+    public static readonly ErrorSource WebRequest = new("WebRequest");
     public static readonly ErrorSource Other = new("Other");
 
     public static IEnumerable<ErrorSource> GetAll() =>
@@ -62,6 +63,7 @@ public sealed class ErrorSource
             FdaCatalystScraper,
             Authentication,
             Alvis,
+            WebRequest,
             Other,
         ];
 


### PR DESCRIPTION
## Summary

Adds a `WebRequest` value to the `ErrorSource` smart enum so the web hosts can record unhandled HTTP request exceptions to the `Errors` table under a dedicated source, distinct from the scraper sources and `Authentication`.

## Code changes

- `src/Equibles.Errors.Data/Models/ErrorSource.cs` — new `WebRequest` static value, added to `GetAll()` (used by the dashboard filter). Persisted as a string through the existing value converter, so no migration is required.