### PR TITLE
feat(scraping): per-host outbound rate limiting + Cloudflare 1015 cooldown

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,8 @@
 using Equibles.CommonStocks.BusinessLogic.Websites;
 using Equibles.CommonStocks.HostedService.Services;
 using Equibles.Core.AutoWiring;
-using Microsoft.Extensions.DependencyInjection;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Equibles.CommonStocks.HostedService.Extensions;
 
@@ -11,6 +12,13 @@ public static class ServiceCollectionExtensions
     {
         services.AutoWireServicesFrom<InvestorRelationsDiscoveryService>();
         services.AutoWireServicesFrom<Equibles.Integrations.Wikidata.WikidataClient>();
+
+        // Shared, process-wide politeness gate for outbound scraping (per-host throttle + rate-limit
+        // cooldown). A singleton so every scraper lane (IR discovery here, webcast/slides capture,
+        // IR-flow) shares one view of each host — the rate-limit ban is IP-wide. TryAdd so a host that
+        // also registers it (the commercial worker wires its capture path to the same instance) doesn't
+        // create a second.
+        services.TryAddSingleton<OutboundHostGate>();
 
         // Secondary IWebsiteSource: Wikidata's official-website fact joined on the
         // SEC CIK (the filings source registered by the Sec module is the primary).

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -1,3 +1,5 @@
+using Equibles.Worker;
+
 namespace Equibles.CommonStocks.HostedService.Services;
 
 /// <summary>
@@ -14,14 +16,17 @@ public class InvestorRelationsProbeClient
     private const int MaxUrlLength = 256;
 
     private readonly IStealthBrowserClient _stealthClient;
+    private readonly OutboundHostGate _hostGate;
     private readonly ILogger<InvestorRelationsProbeClient> _logger;
 
     public InvestorRelationsProbeClient(
         IStealthBrowserClient stealthClient,
+        OutboundHostGate hostGate,
         ILogger<InvestorRelationsProbeClient> logger
     )
     {
         _stealthClient = stealthClient;
+        _hostGate = hostGate;
         _logger = logger;
     }
 
@@ -96,9 +101,34 @@ public class InvestorRelationsProbeClient
         CancellationToken cancellationToken
     )
     {
+        // Politeness gate: skip a host parked in a rate-limit cooldown, and otherwise pace requests so
+        // the candidate burst doesn't trip the host's limiter. A skipped/paced host is transient — the
+        // stock retries after the cooldown rather than being recorded as having no IR page.
+        if (_hostGate.IsCoolingDown(url))
+            return StealthFetchResult.SidecarUnavailable;
         try
         {
-            return await _stealthClient.TryFetchHtml(url, cancellationToken);
+            await _hostGate.WaitForTurn(url, cancellationToken);
+        }
+        catch (HostCoolingDownException)
+        {
+            return StealthFetchResult.SidecarUnavailable;
+        }
+
+        try
+        {
+            var result = await _stealthClient.TryFetchHtml(url, cancellationToken);
+            // The render landed on a rate-limit interstitial (Cloudflare 1015): cool the host down so
+            // every lane stops hitting it, and treat this candidate as a transient miss.
+            if (
+                result.Status == StealthFetchStatus.Rendered
+                && RateLimitDetector.IsRateLimited(null, result.Html)
+            )
+            {
+                _hostGate.RecordRateLimited(url);
+                return StealthFetchResult.SidecarUnavailable;
+            }
+            return result;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Equibles.Worker/HostCoolingDownException.cs
+++ b/src/Equibles.Worker/HostCoolingDownException.cs
@@ -1,0 +1,19 @@
+namespace Equibles.Worker;
+
+/// <summary>
+/// Thrown by <see cref="OutboundHostGate.WaitForTurn"/> when the target host is parked in a
+/// rate-limit cooldown. Callers treat it as a transient skip — not a definitive failure — so the
+/// work item is retried after the cooldown rather than written off.
+/// </summary>
+public sealed class HostCoolingDownException : Exception
+{
+    public HostCoolingDownException(string host, DateTimeOffset until)
+        : base($"Host '{host}' is in a rate-limit cooldown until {until:u}.")
+    {
+        Host = host;
+        Until = until;
+    }
+
+    public string Host { get; }
+    public DateTimeOffset Until { get; }
+}

--- a/src/Equibles.Worker/OutboundHostGate.cs
+++ b/src/Equibles.Worker/OutboundHostGate.cs
@@ -1,0 +1,126 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Worker;
+
+/// <summary>
+/// Process-wide politeness gate for outbound scraping. Two jobs, both keyed by registrable domain:
+/// <list type="bullet">
+/// <item>throttle — space requests to a host by <see cref="OutboundHostGateOptions.MinIntervalMilliseconds"/>
+/// so a burst from our single egress IP (e.g. the IR probe's 11 path/subdomain candidates) doesn't trip
+/// the host's rate limiter;</item>
+/// <item>cooldown — when a host DID rate-limit us (Cloudflare 1015 / HTTP 429), park it for
+/// <see cref="OutboundHostGateOptions.CooldownMinutes"/> so every lane stops hitting it.</item>
+/// </list>
+/// Registered as a singleton and shared across all scraper lanes (IR discovery, webcast/slides capture,
+/// IR-flow) because the ban is IP-wide. In-memory: a cooldown does not survive a worker restart, which
+/// is acceptable — the throttle prevents re-tripping it quickly anyway.
+/// </summary>
+public sealed class OutboundHostGate
+{
+    private readonly OutboundHostGateOptions _options;
+    private readonly ILogger<OutboundHostGate> _logger;
+    private readonly ConcurrentDictionary<string, HostState> _hosts = new();
+
+    public OutboundHostGate(
+        IOptions<OutboundHostGateOptions> options,
+        ILogger<OutboundHostGate> logger
+    )
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Waits until a request to <paramref name="url"/>'s host is allowed (at least the min interval
+    /// since the last one), or throws <see cref="HostCoolingDownException"/> when the host is parked in
+    /// a rate-limit cooldown. Call immediately before each outbound request.
+    /// </summary>
+    public async Task WaitForTurn(string url, CancellationToken cancellationToken)
+    {
+        var key = HostKey(url);
+        if (key == null)
+            return;
+
+        var state = _hosts.GetOrAdd(key, _ => new HostState());
+
+        ThrowIfCoolingDown(key, state);
+
+        await state.Gate.WaitAsync(cancellationToken);
+        try
+        {
+            // Re-check under the lock: another caller may have recorded a cooldown while we queued.
+            ThrowIfCoolingDown(key, state);
+
+            var minInterval = TimeSpan.FromMilliseconds(
+                Math.Max(0, _options.MinIntervalMilliseconds)
+            );
+            var elapsed = DateTimeOffset.UtcNow - state.LastRequest;
+            if (elapsed < minInterval)
+                await Task.Delay(minInterval - elapsed, cancellationToken);
+
+            state.LastRequest = DateTimeOffset.UtcNow;
+        }
+        finally
+        {
+            state.Gate.Release();
+        }
+    }
+
+    /// <summary>Parks <paramref name="url"/>'s host for the cooldown window after it rate-limited us.</summary>
+    public void RecordRateLimited(string url)
+    {
+        var key = HostKey(url);
+        if (key == null)
+            return;
+
+        var state = _hosts.GetOrAdd(key, _ => new HostState());
+        var until = DateTimeOffset.UtcNow.AddMinutes(Math.Max(1, _options.CooldownMinutes));
+        state.CooldownUntil = until;
+        _logger.LogWarning(
+            "Outbound host {Host} rate-limited us; cooling down until {Until:u}",
+            key,
+            until
+        );
+    }
+
+    /// <summary>True when the host is currently parked in a rate-limit cooldown.</summary>
+    public bool IsCoolingDown(string url)
+    {
+        var key = HostKey(url);
+        return key != null
+            && _hosts.TryGetValue(key, out var state)
+            && state.CooldownUntil is { } until
+            && DateTimeOffset.UtcNow < until;
+    }
+
+    private static void ThrowIfCoolingDown(string key, HostState state)
+    {
+        if (state.CooldownUntil is { } until && DateTimeOffset.UtcNow < until)
+            throw new HostCoolingDownException(key, until);
+    }
+
+    /// <summary>
+    /// Registrable-domain key: a rate-limit ban is per Cloudflare zone (apex), so investors.bjs.com and
+    /// bjs.com share one cooldown. Approximated as the last two labels — correct for the .com/.net hosts
+    /// that dominate IR; an over-broad key on a multi-part public suffix only throttles slightly more,
+    /// never less, so it never lets a burst through.
+    /// </summary>
+    internal static string HostKey(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.Host))
+            return null;
+
+        var host = uri.Host.ToLowerInvariant();
+        var labels = host.Split('.');
+        return labels.Length <= 2 ? host : $"{labels[^2]}.{labels[^1]}";
+    }
+
+    private sealed class HostState
+    {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+        public DateTimeOffset LastRequest { get; set; } = DateTimeOffset.MinValue;
+        public DateTimeOffset? CooldownUntil { get; set; }
+    }
+}

--- a/src/Equibles.Worker/OutboundHostGateOptions.cs
+++ b/src/Equibles.Worker/OutboundHostGateOptions.cs
@@ -1,0 +1,19 @@
+namespace Equibles.Worker;
+
+/// <summary>
+/// Tuning for <see cref="OutboundHostGate"/> — the shared politeness gate for outbound scraping.
+/// </summary>
+public class OutboundHostGateOptions
+{
+    /// <summary>
+    /// Minimum spacing between requests to the same registrable domain. Smooths a burst (e.g. the IR
+    /// probe's path/subdomain candidates) into paced requests so a host's rate limiter isn't tripped.
+    /// </summary>
+    public int MinIntervalMilliseconds { get; set; } = 1500;
+
+    /// <summary>
+    /// How long to park a host after it rate-limited us (Cloudflare 1015 / HTTP 429) — every lane skips
+    /// the host for this window so we stop hammering an IP-banned host. A few hours by default.
+    /// </summary>
+    public int CooldownMinutes { get; set; } = 180;
+}

--- a/src/Equibles.Worker/RateLimitDetector.cs
+++ b/src/Equibles.Worker/RateLimitDetector.cs
@@ -1,0 +1,23 @@
+namespace Equibles.Worker;
+
+/// <summary>
+/// Recognises a rate-limit response from a host, whether seen as an HTTP status (plain-HTTP probes) or
+/// as the rendered interstitial a stealth browser lands on (browser renders never surface a status).
+/// Deliberately narrow — only the unambiguous Cloudflare 1015 / HTTP 429 signatures — so a page that
+/// merely mentions rate limiting in its copy isn't mistaken for a block.
+/// </summary>
+public static class RateLimitDetector
+{
+    public static bool IsRateLimited(int? statusCode, string html)
+    {
+        if (statusCode == 429)
+            return true;
+
+        if (string.IsNullOrEmpty(html))
+            return false;
+
+        // Cloudflare's 1015 interstitial. Both phrases appear on that page and nowhere benign.
+        return html.Contains("Error 1015", StringComparison.OrdinalIgnoreCase)
+            || html.Contains("You are being rate limited", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.HostedService.Services;
+using Equibles.Worker;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 
 namespace Equibles.UnitTests.CommonStocks;
@@ -26,10 +28,7 @@ public class InvestorRelationsProbeClientTests
     {
         var stealth = EnabledStealth(_ => IrPage);
 
-        var client = new InvestorRelationsProbeClient(
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
+        var client = NewClient(stealth);
 
         var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
 
@@ -44,10 +43,7 @@ public class InvestorRelationsProbeClientTests
         // fully assessed and has no IR page. This is the only case that earns the escalating backoff.
         var stealth = EnabledStealth(_ => NotIr);
 
-        var client = new InvestorRelationsProbeClient(
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
+        var client = NewClient(stealth);
 
         var result = await client.Discover(
             "acme.com",
@@ -67,10 +63,7 @@ public class InvestorRelationsProbeClientTests
         // so re-probing won't help — a conclusive miss, not a transient one.
         var stealth = EnabledStealthResults(_ => StealthFetchResult.PageUnavailable);
 
-        var client = new InvestorRelationsProbeClient(
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
+        var client = NewClient(stealth);
 
         var result = await client.Discover(
             "acme.com",
@@ -95,10 +88,7 @@ public class InvestorRelationsProbeClientTests
                 : StealthFetchResult.Rendered(NotIr)
         );
 
-        var client = new InvestorRelationsProbeClient(
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
+        var client = NewClient(stealth);
 
         var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
 
@@ -117,10 +107,7 @@ public class InvestorRelationsProbeClientTests
             : StealthFetchResult.Rendered(NotIr)
         );
 
-        var client = new InvestorRelationsProbeClient(
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
+        var client = NewClient(stealth);
 
         var result = await client.Discover(
             "acme.com",
@@ -141,10 +128,7 @@ public class InvestorRelationsProbeClientTests
         var stealth = Substitute.For<IStealthBrowserClient>();
         stealth.IsEnabled.Returns(false);
 
-        var client = new InvestorRelationsProbeClient(
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
+        var client = NewClient(stealth);
 
         var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
 
@@ -166,10 +150,7 @@ public class InvestorRelationsProbeClientTests
                 Task.FromException<StealthFetchResult>(new TimeoutException("navigation timeout"))
             );
 
-        var client = new InvestorRelationsProbeClient(
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
+        var client = NewClient(stealth);
 
         IrProbeResult result = null;
         var act = async () =>
@@ -194,10 +175,7 @@ public class InvestorRelationsProbeClientTests
             : NotIr
         );
 
-        var client = new InvestorRelationsProbeClient(
-            stealth,
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
+        var client = NewClient(stealth);
 
         var result = await client.Discover(
             "acme.com",
@@ -209,6 +187,61 @@ public class InvestorRelationsProbeClientTests
         result.Outcome.Should().Be(IrProbeOutcome.Found);
         result.Page!.Url.Should().Be("https://acme.com/en-us/investors");
     }
+
+    [Fact]
+    public async Task Discover_RenderHitsRateLimitInterstitial_IsInconclusiveAndCoolsHostDown()
+    {
+        // The render landed on a Cloudflare 1015 page. The probe must NOT treat that as a validated
+        // page or a conclusive miss — it cools the host down and reports the attempt inconclusive so
+        // the stock retries after the cooldown.
+        const string rateLimited =
+            "<html><head><title>Error 1015</title></head>"
+            + "<body>You are being rate limited</body></html>";
+        var stealth = EnabledStealth(_ => rateLimited);
+        var gate = NewGate();
+
+        var client = new InvestorRelationsProbeClient(
+            stealth,
+            gate,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
+
+        result.Outcome.Should().Be(IrProbeOutcome.Inconclusive);
+        gate.IsCoolingDown("https://acme.com/investors").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Discover_HostAlreadyCoolingDown_SkipsTheRenderEntirely()
+    {
+        // A host parked in cooldown is skipped without a render — no sidecar call — and reported
+        // inconclusive so the stock waits out the cooldown rather than being written off.
+        var stealth = EnabledStealth(_ => IrPage);
+        var gate = NewGate();
+        gate.RecordRateLimited("https://acme.com/investors");
+
+        var client = new InvestorRelationsProbeClient(
+            stealth,
+            gate,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
+
+        result.Outcome.Should().Be(IrProbeOutcome.Inconclusive);
+        await stealth.DidNotReceive().TryFetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private static InvestorRelationsProbeClient NewClient(IStealthBrowserClient stealth) =>
+        new(stealth, NewGate(), NullLogger<InvestorRelationsProbeClient>.Instance);
+
+    // A gate with no inter-request delay so tests don't pay the throttle wait.
+    private static OutboundHostGate NewGate() =>
+        new(
+            Options.Create(new OutboundHostGateOptions { MinIntervalMilliseconds = 0 }),
+            NullLogger<OutboundHostGate>.Instance
+        );
 
     private static IStealthBrowserClient EnabledStealth(Func<string, string> bodyForUrl) =>
         EnabledStealthResults(url => StealthFetchResult.Rendered(bodyForUrl(url)));

--- a/tests/Equibles.UnitTests/Worker/OutboundHostGateTests.cs
+++ b/tests/Equibles.UnitTests/Worker/OutboundHostGateTests.cs
@@ -1,0 +1,62 @@
+using Equibles.Worker;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.UnitTests.Worker;
+
+public class OutboundHostGateTests
+{
+    private static OutboundHostGate Gate(int minIntervalMs = 0, int cooldownMinutes = 180) =>
+        new(
+            Options.Create(
+                new OutboundHostGateOptions
+                {
+                    MinIntervalMilliseconds = minIntervalMs,
+                    CooldownMinutes = cooldownMinutes,
+                }
+            ),
+            NullLogger<OutboundHostGate>.Instance
+        );
+
+    [Fact]
+    public async Task NoCooldown_WaitForTurn_Completes()
+    {
+        var gate = Gate();
+
+        gate.IsCoolingDown("https://acme.com/investors").Should().BeFalse();
+        await gate.WaitForTurn("https://acme.com/investors", CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task AfterRateLimited_WaitForTurn_ThrowsCoolingDown()
+    {
+        var gate = Gate();
+        gate.RecordRateLimited("https://acme.com/investors");
+
+        var act = () => gate.WaitForTurn("https://acme.com/ir", CancellationToken.None);
+
+        await act.Should().ThrowAsync<HostCoolingDownException>();
+    }
+
+    [Fact]
+    public void Cooldown_IsKeyedByRegistrableDomain_SoSubdomainsShareIt()
+    {
+        // A 1015 ban is per Cloudflare zone (apex), so cooling down a subdomain must cool down the
+        // apex and its other subdomains too.
+        var gate = Gate();
+        gate.RecordRateLimited("https://investors.bjs.com/events");
+
+        gate.IsCoolingDown("https://bjs.com/anything").Should().BeTrue();
+        gate.IsCoolingDown("https://ir.bjs.com/x").Should().BeTrue();
+        gate.IsCoolingDown("https://other.com/x").Should().BeFalse();
+    }
+
+    [Fact]
+    public void RecordRateLimited_ZeroOrUnparseableUrl_DoesNotThrow()
+    {
+        var gate = Gate();
+
+        gate.RecordRateLimited("not a url");
+        gate.IsCoolingDown("not a url").Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Worker/RateLimitDetectorTests.cs
+++ b/tests/Equibles.UnitTests/Worker/RateLimitDetectorTests.cs
@@ -1,0 +1,30 @@
+using Equibles.Worker;
+
+namespace Equibles.UnitTests.Worker;
+
+public class RateLimitDetectorTests
+{
+    [Fact]
+    public void IsRateLimited_429Status_True()
+    {
+        RateLimitDetector.IsRateLimited(429, null).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("<html><title>Error 1015</title></html>")]
+    [InlineData("<body>You are being rate limited</body>")]
+    [InlineData("...YOU ARE BEING RATE LIMITED...")] // case-insensitive
+    public void IsRateLimited_CloudflareInterstitial_True(string html)
+    {
+        RateLimitDetector.IsRateLimited(null, html).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(200, "<html><body>Investor relations</body></html>")]
+    [InlineData(null, "")]
+    [InlineData(404, "<html>Page not found</html>")]
+    public void IsRateLimited_BenignResponse_False(int? status, string html)
+    {
+        RateLimitDetector.IsRateLimited(status, html).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
Our scrapers hit each IR host in bursts from one egress IP with no politeness, tripping Cloudflare **Error 1015 / HTTP 429** (seen on `investors.bjs.com`). The IR-discovery probe alone fires up to 11 path/subdomain candidates at one host; once banned, every request to that host fails for the window and shows up as 'could not load' / 'no manifest' / discovery misses — and it's invisible (browser renders bypass `HttpRequestLog`).

## Code changes
- **`OutboundHostGate`** (Equibles.Worker, singleton shared across all scraper lanes — the ban is IP-wide): throttles requests to each registrable domain by `MinIntervalMilliseconds` (default 1500), and parks a host that rate-limited us for `CooldownMinutes` (default 180) so every lane skips it. Keyed by apex (`investors.bjs.com` and `bjs.com` share one cooldown).
- **`RateLimitDetector`** — recognises HTTP 429 and the Cloudflare 1015 interstitial in rendered HTML.
- **IR-discovery probe** consults the gate before each render; a cooled-down or freshly rate-limited host is a **transient (inconclusive)** miss (#4033 semantics), not a conclusive one, so the stock retries after the cooldown instead of being written off.
- Commercial webcast/slides capture wire to the same gate in a follow-up (pin bump).
- Tests: gate (throttle/cooldown/apex-keying), detector, and probe (rate-limit → inconclusive + host cooled; already-cooling host skips the render).

Refs #5031.