### PR TITLE
fix(worker): defer Errors-table report until a fault streak is sustained

### DIFF
--- a/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
+++ b/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
@@ -11,6 +11,15 @@ public class DocumentProcessorWorker : BaseScraperWorker
     protected override TimeSpan SleepInterval => TimeSpan.FromSeconds(15);
     protected override ErrorSource ErrorSource => ErrorSource.DocumentProcessor;
 
+    // The embedding sidecar (vLLM) is recycled by autoheal and on every deploy, and then reloads
+    // its model for a minute or two. During that window every embedding cycle faults ("no
+    // embeddings produced — server likely down"). A faulted cycle backs off ~15s (ErrorBackoff is
+    // capped at SleepInterval), so this many consecutive faults is roughly five minutes of solid
+    // outage — comfortably past a normal reload. Below it the faults are transient and stay out of
+    // the Errors page; only a genuinely sustained outage records a single row. Live "is it down"
+    // visibility comes from the System Health probe + activity feed, not these rows.
+    protected override int ErrorReportThreshold => 20;
+
     public DocumentProcessorWorker(
         ILogger<DocumentProcessorWorker> logger,
         IServiceScopeFactory scopeFactory,

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -19,6 +19,7 @@ public abstract class BaseScraperWorker : BackgroundService
     private bool _retrySoonRequested;
     private bool _continuationRequested;
     private int _consecutiveFailures;
+    private bool _errorReportedForStreak;
 
     protected abstract string WorkerName { get; }
     protected abstract TimeSpan SleepInterval { get; }
@@ -122,6 +123,19 @@ public abstract class BaseScraperWorker : BackgroundService
     /// </summary>
     protected virtual TimeSpan MaxErrorBackoffInterval => TimeSpan.FromMinutes(15);
 
+    /// <summary>
+    /// Number of consecutive faulted cycles a streak must reach before it is persisted to the
+    /// Errors table. Default 1 — the first faulted cycle is reported immediately (the long-standing
+    /// behavior). A worker whose dependency restarts routinely — e.g. the embeddings processor,
+    /// whose vLLM sidecar is recycled by autoheal and then reloads its model over a cycle or two —
+    /// raises this so a brief, self-healing blip logs a warning and backs off (still retrying via
+    /// <see cref="ErrorBackoff"/>) WITHOUT flooding the Errors page. Only a streak that reaches the
+    /// threshold records a single Error row for the episode; once recorded the rest of the streak
+    /// stays warnings, and a clean cycle resets the streak. Live liveness is unaffected — the
+    /// "cycle failed" activity row is still published every faulted cycle regardless of this.
+    /// </summary>
+    protected virtual int ErrorReportThreshold => 1;
+
     protected BaseScraperWorker(
         ILogger logger,
         IServiceScopeFactory scopeFactory,
@@ -197,16 +211,36 @@ public abstract class BaseScraperWorker : BackgroundService
                 // never throws, so the backoff path below always runs.
                 faulted = true;
                 _consecutiveFailures++;
-                Logger.LogCritical(ex, "Critical error in {Worker}", WorkerName);
-                // ErrorReporter publishes its own ScraperActivity with the same
-                // source + the error message, so the activity feed gets a row
-                // without double-emitting here.
-                await ErrorReporter.Report(
-                    ErrorSource,
-                    $"{WorkerName}.DoWork",
-                    ex.Message,
-                    ex.StackTrace
-                );
+
+                // A streak only lands in the Errors table once it reaches ErrorReportThreshold
+                // (default 1 → the first fault), and only once per streak. Below the threshold —
+                // a brief, self-healing blip on a worker that opts into a higher threshold — we
+                // log a warning and let the backoff retry, keeping transient restarts out of the
+                // Errors page operators watch for real defects. A clean cycle resets the streak.
+                if (_consecutiveFailures >= ErrorReportThreshold && !_errorReportedForStreak)
+                {
+                    _errorReportedForStreak = true;
+                    Logger.LogCritical(ex, "Critical error in {Worker}", WorkerName);
+                    // ErrorReporter publishes its own ScraperActivity with the same
+                    // source + the error message, so the activity feed gets a row
+                    // without double-emitting here.
+                    await ErrorReporter.Report(
+                        ErrorSource,
+                        $"{WorkerName}.DoWork",
+                        ex.Message,
+                        ex.StackTrace
+                    );
+                }
+                else
+                {
+                    Logger.LogWarning(
+                        ex,
+                        "{Worker} cycle faulted ({Failures} in a row; reports at {Threshold})",
+                        WorkerName,
+                        _consecutiveFailures,
+                        ErrorReportThreshold
+                    );
+                }
             }
 
             TimeSpan interval;
@@ -228,8 +262,9 @@ public abstract class BaseScraperWorker : BackgroundService
             else
             {
                 // A clean cycle clears the failure streak, so the next fault starts
-                // again from the base ErrorBackoffInterval.
+                // again from the base ErrorBackoffInterval and a fresh report streak.
                 _consecutiveFailures = 0;
+                _errorReportedForStreak = false;
                 if (_retrySoonRequested)
                 {
                     interval = NotReadyRetryInterval;

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerErrorReportThresholdTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerErrorReportThresholdTests.cs
@@ -1,0 +1,177 @@
+#nullable enable
+
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Worker;
+
+// A worker whose dependency restarts routinely (the embeddings processor — its vLLM sidecar is
+// recycled by autoheal/deploys and reloads its model for a cycle or two) would otherwise log a
+// hard Error row every faulted cycle, flooding the Errors page with self-healing blips. The
+// ErrorReportThreshold defers the Errors-table report until a fault streak proves sustained, and
+// records only one row per streak. These tests pin that gating via the log levels the loop emits
+// (Critical = reported to the Errors table, Warning = deferred), since ErrorReporter.Report
+// swallows its own failures and can't be observed directly through a bare substitute.
+public class BaseScraperWorkerErrorReportThresholdTests
+{
+    [Fact]
+    public async Task FaultsBelowThreshold_LogWarningAndBackOff_WithoutReportingToErrorsTable()
+    {
+        var logger = Substitute.For<ILogger>();
+        var parked = new TaskCompletionSource();
+        using var worker = new ThresholdTestWorker(
+            logger,
+            errorReportThreshold: 3,
+            doWork: (cycle, stoppingToken) =>
+            {
+                // Two faults, both below the threshold of 3, then park.
+                if (cycle <= 2)
+                    throw new InvalidOperationException($"blip {cycle}");
+                parked.TrySetResult();
+                return Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await parked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        // Sub-threshold faults are warnings, never escalated to the Errors table.
+        logger
+            .DidNotReceive()
+            .Log(
+                LogLevel.Critical,
+                Arg.Any<EventId>(),
+                Arg.Any<object>(),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+        logger
+            .Received()
+            .Log(
+                LogLevel.Warning,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("faulted")),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+    }
+
+    [Fact]
+    public async Task FaultStreakReachesThreshold_ReportsExactlyOncePerStreak()
+    {
+        var logger = Substitute.For<ILogger>();
+        var parked = new TaskCompletionSource();
+        using var worker = new ThresholdTestWorker(
+            logger,
+            errorReportThreshold: 3,
+            doWork: (cycle, stoppingToken) =>
+            {
+                // Five consecutive faults (threshold 3): the streak crosses the threshold once
+                // and the two faults after it must NOT add more rows.
+                if (cycle <= 5)
+                    throw new InvalidOperationException($"down {cycle}");
+                parked.TrySetResult();
+                return Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await parked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        // One outage episode → one Errors-table report, no matter how long it persists.
+        logger
+            .Received(1)
+            .Log(
+                LogLevel.Critical,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("Critical error in")),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+    }
+
+    [Fact]
+    public async Task CleanCycle_ResetsStreak_SoTheNextOutageReportsAgain()
+    {
+        var logger = Substitute.For<ILogger>();
+        var parked = new TaskCompletionSource();
+        using var worker = new ThresholdTestWorker(
+            logger,
+            errorReportThreshold: 3,
+            doWork: (cycle, stoppingToken) =>
+            {
+                // Streak A (cycles 1-3) reaches the threshold and reports once. Cycle 4 succeeds
+                // and resets the streak. Streak B (cycles 5-7) reaches the threshold again.
+                if (cycle is >= 1 and <= 3 or >= 5 and <= 7)
+                    throw new InvalidOperationException($"down {cycle}");
+                if (cycle == 4)
+                    return Task.CompletedTask;
+                parked.TrySetResult();
+                return Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await parked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        // Two distinct outage episodes → two reports; the clean cycle between them resets the streak.
+        logger
+            .Received(2)
+            .Log(
+                LogLevel.Critical,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("Critical error in")),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+    }
+
+    // Drives the loop deterministically: WaitForNextCycle returns immediately (no real waiting),
+    // DoWork runs the supplied delegate per cycle, and the final cycle parks on an infinite delay
+    // until StopAsync cancels it.
+    private sealed class ThresholdTestWorker : BaseScraperWorker
+    {
+        private readonly int _errorReportThreshold;
+        private readonly Func<int, CancellationToken, Task> _doWork;
+        private int _cycle;
+
+        public ThresholdTestWorker(
+            ILogger logger,
+            int errorReportThreshold,
+            Func<int, CancellationToken, Task> doWork
+        )
+            : base(
+                logger,
+                Substitute.For<IServiceScopeFactory>(),
+                new ErrorReporter(
+                    Substitute.For<IServiceScopeFactory>(),
+                    Substitute.For<ILogger<ErrorReporter>>()
+                )
+            )
+        {
+            _errorReportThreshold = errorReportThreshold;
+            _doWork = doWork;
+        }
+
+        protected override string WorkerName => "Threshold test";
+        protected override TimeSpan SleepInterval => TimeSpan.FromMilliseconds(1);
+        protected override TimeSpan ErrorBackoffInterval => TimeSpan.FromMilliseconds(1);
+        protected override int ErrorReportThreshold => _errorReportThreshold;
+        protected override ErrorSource ErrorSource => ErrorSource.Other;
+
+        protected override Task DoWork(CancellationToken stoppingToken) =>
+            _doWork(++_cycle, stoppingToken);
+
+        protected override Task WaitForNextCycle(
+            TimeSpan interval,
+            CancellationToken stoppingToken
+        ) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

A scraper worker (`BaseScraperWorker`) logged a hard Error row to the Errors table on **every** faulted cycle. The embeddings processor's vLLM sidecar is recycled routinely (autoheal, every deploy) and then reloads its model for a minute or two — during that window every embedding cycle faults with "no embeddings produced — server likely down", flooding the Errors page operators watch for real defects. (In one recent ~12h incident this produced 150+ near-identical rows.)

## Code changes

- **`src/Equibles.Worker/BaseScraperWorker.cs`** — new `protected virtual int ErrorReportThreshold => 1`. A fault streak must reach this many consecutive cycles before it's persisted via `ErrorReporter.Report`, and it's recorded **once per streak** (a new `_errorReportedForStreak` flag, reset on any clean cycle alongside the existing `_consecutiveFailures`). Below the threshold the cycle logs a warning and backs off exactly as before. The default of 1 preserves the long-standing "report on the first fault" behavior for every existing worker. Live liveness is unchanged — the "cycle failed" activity row is still published every faulted cycle.
- **`src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs`** — overrides `ErrorReportThreshold => 20` (~5 min, since a faulted cycle backs off ~15s), so a normal embedding-server reload no longer reaches the Errors page; only a genuinely sustained outage records a single row.
- **`tests/Equibles.UnitTests/Worker/BaseScraperWorkerErrorReportThresholdTests.cs`** — sub-threshold faults stay warnings (no report), a streak crossing the threshold reports exactly once, and a clean cycle resets the streak so the next outage reports again.

## Testing

`dotnet vstest Equibles.UnitTests.dll --TestCaseFilter:FullyQualifiedName~BaseScraperWorker` → 34/34 pass (3 new + existing backoff/report suite, no regression).