### PR TITLE
fix(common-stocks): prefer shallow IR landing over deep article in link extraction

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 
 namespace Equibles.CommonStocks.HostedService.Services;
@@ -76,7 +77,28 @@ public static class InvestorRelationsLinkExtractor
             }
         }
 
-        return primary.Concat(secondary).Take(max).ToList();
+        // Keep deep press-release / news-article detail pages last among the primaries so a shallower
+        // IR landing/section page wins downstream ("first that validates"). An article is only a
+        // fallback — still returned, so a stock whose sole IR link is an article is unaffected (GH-5018).
+        var landingPrimary = primary.Where(url => !IsDeepArticle(url));
+        var articlePrimary = primary.Where(IsDeepArticle);
+        return landingPrimary.Concat(articlePrimary).Concat(secondary).Take(max).ToList();
+    }
+
+    // A deep press-release / news-article detail page (e.g. ir.host/news-release-details/2026/...)
+    // carries the same IR nav/footer as the landing page, so it validates as an IR page — but it is a
+    // single, often-dated article and a poor canonical IR entry point. Matches the path shape the
+    // GH-5018 audit used: a news/press segment followed by a detail/release/update/video marker or a
+    // dated /20YY/ segment.
+    private static readonly Regex DeepArticlePath = new(
+        @"(news|press)[-/].*(detail|release|update|video|/20\d\d/)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled
+    );
+
+    private static bool IsDeepArticle(string url)
+    {
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            && DeepArticlePath.IsMatch(uri.AbsolutePath);
     }
 
     // The link's host is an ir. / investor(s). subdomain, or its path carries an "ir" segment

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDeepArticleDemotedTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDeepArticleDemotedTests.cs
@@ -1,0 +1,34 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsLinkExtractorDeepArticleDemotedTests
+{
+    // Contract (GH-5018): on an `ir.` host both a deep press-release/news article detail page and
+    // the IR landing/overview page validate as IR pages, so "first that validates wins" downstream
+    // would store whichever the homepage links first — often a one-off dated article. Extract must
+    // rank the shallow IR landing ahead of the deep article so the landing becomes the canonical
+    // IR URL; the article stays as a fallback (still returned, just last), so a stock whose only
+    // IR link is an article is unaffected.
+    [Fact]
+    public void Extract_DeepArticleBeforeLandingOnIrHost_RanksLandingFirst()
+    {
+        // The article anchor appears BEFORE the landing anchor in the document — under the old
+        // document-order behavior the article would win.
+        const string html = """
+            <html><body>
+            <a href="https://ir.acme.com/news/news-release-details/2026/Acme-Reports-Q1/default.aspx">Latest news</a>
+            <a href="https://ir.acme.com/overview/default.aspx">Investor overview</a>
+            </body></html>
+            """;
+
+        var links = InvestorRelationsLinkExtractor.Extract(html, "https://acme.com");
+
+        links[0].Should().Be("https://ir.acme.com/overview/default.aspx");
+        links
+            .Should()
+            .Contain(
+                "https://ir.acme.com/news/news-release-details/2026/Acme-Reports-Q1/default.aspx"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `InvestorRelationsLinkExtractor.Extract` returned candidates in document order. A homepage "latest news" link pointing at a deep press-release detail page on an `ir.` host carries the IR nav/footer, so it validates as an IR page, and "first that validates wins" downstream could store that one-off article as a company's canonical `InvestorRelationsUrl` ahead of the IR landing/overview.
- Demote deep press-release / news-article detail pages to the end of the primary tier so a shallower IR landing wins. An article is still returned as a fallback, so a stock whose only IR link is an article is unaffected.
- Fixes daniel3303/EquiblesCommercial#5018 (consumed there via the submodule pin bump).

## Code changes

- `src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs` — partition the primary candidates into non-article and deep-article, emitting deep-article URLs last; add a `DeepArticlePath` regex + `IsDeepArticle` helper.
- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorDeepArticleDemotedTests.cs` — regression test: a deep article appearing before the landing on an `ir.` host still ranks the landing first.

Verified: all 172 CommonStocks unit tests pass; csharpier check clean.