### PR TITLE
fix(common-stocks): prefer the shallowest IR path so an IR landing outranks a deep article

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
@@ -76,8 +76,18 @@ public static class InvestorRelationsLinkExtractor
             }
         }
 
-        return primary.Concat(secondary).Take(max).ToList();
+        // Among the primary candidates prefer the shallowest path, so an IR landing / overview page
+        // outranks a deep article / press-release detail page on the same IR host — downstream takes
+        // the first candidate that validates, and a deep "latest news" article validates too
+        // (GH-5018). OrderBy is stable, so equal-depth candidates keep their document order.
+        return primary.OrderBy(PathDepth).Concat(secondary).Take(max).ToList();
     }
+
+    // Number of non-empty path segments, used to rank a shallow IR landing above a deep article.
+    private static int PathDepth(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            ? uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries).Length
+            : int.MaxValue;
 
     // The link's host is an ir. / investor(s). subdomain, or its path carries an "ir" segment
     // (e.g. a locale-prefixed /ja/ir/) — strong IR signals even when the anchor text isn't English.

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorShallowestIrPathTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorShallowestIrPathTests.cs
@@ -1,0 +1,25 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsLinkExtractorShallowestIrPathTests
+{
+    // Contract: among IR candidates on the same ir. host, the shallowest path (the landing /
+    // overview page) must outrank a deep article / press-release detail page — even when the
+    // deep article appears first in the markup. Downstream takes the first candidate that
+    // validates, so a deep "latest news" article that happens to come first must not become the
+    // canonical IR URL (GH-5018).
+    [Fact]
+    public void Extract_DeepArticleBeforeLandingOnSameIrHost_RanksLandingFirst()
+    {
+        const string html =
+            // deep press-release article on the ir. host appears FIRST in the DOM
+            "<a href=\"https://ir.acme.com/news/news-release-details/2026/Acme-Update/default.aspx\">Latest news</a>"
+            // IR landing / overview appears later
+            + "<a href=\"https://ir.acme.com/overview/default.aspx\">Investor Relations</a>";
+
+        var links = InvestorRelationsLinkExtractor.Extract(html, "https://acme.com");
+
+        links.First().Should().Be("https://ir.acme.com/overview/default.aspx");
+    }
+}


### PR DESCRIPTION
## Summary

- `InvestorRelationsLinkExtractor.Extract` returned primary candidates in document order, so a deep press-release / article link on an `ir.` host that appeared earlier in the markup could outrank the IR landing page. Downstream IR discovery takes the first candidate that validates, and a deep article validates too — so a one-off article URL could become a company's canonical IR entry point.
- Now orders primary candidates by path depth (stable `OrderBy`), so the shallowest IR landing/overview page is tried first; equal-depth candidates keep document order.

## Code changes

- `src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs` — order primary candidates by a new `PathDepth` helper before concatenating secondaries.
- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorShallowestIrPathTests.cs` — regression test: a deep article appearing before the landing on the same `ir.` host must rank the landing first. Fails before the fix, passes after; all 11 extractor tests green.

Surfaces equibles-commercial GH-5018.