### PR TITLE
fix(common-stocks): prefer shallowest IR path over a deep article in IR link extraction

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
@@ -76,8 +76,25 @@ public static class InvestorRelationsLinkExtractor
             }
         }
 
-        return primary.Concat(secondary).Take(max).ToList();
+        // Among primary candidates prefer the shallowest path so an IR landing/section root
+        // outranks a deep article/detail page on the same IR host (e.g. a homepage "latest news"
+        // link to ir.host/.../press-release-details/<year>/<slug> — a one-off article that would
+        // otherwise become the canonical IR URL, #5018). OrderBy is stable, so equal-depth
+        // candidates keep document order; a deep article still wins as a fallback when it is the
+        // only primary that validates downstream.
+        return primary
+            .OrderBy(PathDepth)
+            .Concat(secondary)
+            .Take(max)
+            .ToList();
     }
+
+    // Number of non-empty path segments, used to rank shallower IR pages above deeper ones.
+    // An unparseable URL sorts last so it never displaces a real landing page.
+    private static int PathDepth(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            ? uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries).Length
+            : int.MaxValue;
 
     // The link's host is an ir. / investor(s). subdomain, or its path carries an "ir" segment
     // (e.g. a locale-prefixed /ja/ir/) — strong IR signals even when the anchor text isn't English.

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorShallowestIrPathTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorShallowestIrPathTests.cs
@@ -1,0 +1,28 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsLinkExtractorShallowestIrPathTests
+{
+    // Contract (#5018): among primary candidates the shallowest IR path wins, so an IR
+    // landing/section root outranks a deep article/detail page on the same IR host. Here a
+    // homepage "latest news" link to a deep press-release-details article appears BEFORE the IR
+    // overview landing; without shallowest-first ordering the deep article (first in document
+    // order) would be probed first and stored as the canonical IR URL.
+    [Fact]
+    public void Extract_DeepArticleBeforeLandingOnIrHost_RanksLandingFirst()
+    {
+        const string html =
+            "<a href=\"https://ir.acme.com/news/press-release-details/2026/Acme-Reports-Q4/default.aspx\">Latest news</a>"
+            + "<a href=\"https://ir.acme.com/overview/default.aspx\">Investor Relations</a>";
+
+        var links = InvestorRelationsLinkExtractor.Extract(html, "https://www.acme.com");
+
+        links
+            .Should()
+            .ContainInOrder(
+                "https://ir.acme.com/overview/default.aspx",
+                "https://ir.acme.com/news/press-release-details/2026/Acme-Reports-Q4/default.aspx"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `InvestorRelationsLinkExtractor.Extract` returned primary candidates in document order, so a homepage "latest news" link pointing at a deep `ir.host/.../press-release-details/<year>/<slug>` article could be probed (and stored) as a company's canonical investor-relations URL ahead of the IR landing/overview page.
- That one-off article then seeds the IR-flow scraper and the portal IR link, starving downstream IR event/news discovery for the affected stock (commercial issue #5018; ~0.16% of stocks observed).
- Fix: stable-sort the primary candidates by path depth so the shallowest IR landing/section root wins. A deep article still applies as a fallback when it is the only primary that validates downstream.

## Code changes

- `src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs` — order `primary` by a new `PathDepth` (non-empty path-segment count) before concatenating secondary candidates; `OrderBy` is stable so equal-depth candidates keep document order.
- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorShallowestIrPathTests.cs` — a deep press-release-details article that precedes the IR overview landing on the same `ir.` host must rank the landing first. Fails before the change, passes after.