### PR TITLE
fix(shares-outstanding): prefer current per-class total over stale consolidated cover-page fact

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
@@ -29,6 +29,20 @@ public interface ISharesOutstandingProvider
     );
 
     /// <summary>
+    /// The issuer's current entity-wide share count: the more-recently-filed of the latest
+    /// consolidated cover-page fact and the latest per-class sum. A single-class issuer (only a
+    /// consolidated fact) or a multi-class issuer that never reported a consolidated count (only
+    /// per-class facts) returns that one figure. When an issuer reports <em>both</em> — e.g. a
+    /// dual-class filer whose classless cover-page series ended years ago when it switched to
+    /// per-class reporting — the stale consolidated value must not win, so the figure from the
+    /// most recent filing is used. Null when the issuer has neither on record.
+    /// </summary>
+    Task<long?> GetCurrentSharesOutstanding(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// True when the authoritative shares-outstanding fact comes from a foreign-private-issuer
     /// annual form (20-F or 40-F). Such issuers report the cover-page count in <em>ordinary</em>
     /// shares, a different unit from the US-listed ADR a price feed quotes, so the reported count

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -44,29 +44,7 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     public async Task<long?> GetReportedSharesOutstanding(
         CommonStock stock,
         CancellationToken cancellationToken = default
-    )
-    {
-        var conceptIds = await ResolveConceptIds(cancellationToken);
-        if (conceptIds.Count == 0)
-            return null;
-
-        // The latest filing wins (FiledDate), then the most recent as-of date within it; the value
-        // is a whole share count.
-        var value = await _financialFactRepository
-            .GetConsolidatedByStock(stock)
-            .Where(f => conceptIds.Contains(f.FinancialConceptId) && f.Unit == SharesUnit)
-            .OrderByDescending(f => f.FiledDate)
-            .ThenByDescending(f => f.PeriodEnd)
-            .Select(f => (decimal?)f.Value)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        // A corrupt/typo'd cover-page fact can carry a count that parses but exceeds Int64; the
-        // decimal->long cast would throw, crashing the caller. Treat an unrepresentable figure as
-        // none on record (null), matching how every other decimal->long cast here is range-checked.
-        return value.HasValue && value.Value >= long.MinValue && value.Value <= long.MaxValue
-            ? (long)value.Value
-            : (long?)null;
-    }
+    ) => (await GetLatestConsolidated(stock, cancellationToken))?.Shares;
 
     // The entity-wide share count for a multi-class issuer, summed across its share classes from
     // the latest filing's per-class cover-page facts, or null when the issuer reports no per-class
@@ -76,6 +54,70 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     public async Task<long?> GetSummedPerClassSharesOutstanding(
         CommonStock stock,
         CancellationToken cancellationToken = default
+    ) => (await GetLatestPerClass(stock, cancellationToken))?.Shares;
+
+    // The issuer's current entity total: the more-recently-filed of the latest consolidated fact
+    // and the latest per-class sum. Most issuers have only one of the two, in which case that one
+    // is returned. A dual-class filer (e.g. Mastercard, Visa) can have BOTH — its classless
+    // dei:EntityCommonStockSharesOutstanding series ended years ago when it moved to per-class
+    // reporting, leaving a stale consolidated fact alongside current per-class facts — so the
+    // figure from the most recent filing wins; a same-filing tie keeps the consolidated total,
+    // which is the entity figure directly (#5158).
+    public async Task<long?> GetCurrentSharesOutstanding(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var consolidated = await GetLatestConsolidated(stock, cancellationToken);
+        var perClass = await GetLatestPerClass(stock, cancellationToken);
+
+        if (consolidated == null)
+            return perClass?.Shares;
+        if (perClass == null)
+            return consolidated.Value.Shares;
+
+        return perClass.Value.Filed > consolidated.Value.Filed
+            ? perClass.Value.Shares
+            : consolidated.Value.Shares;
+    }
+
+    // The latest-filed consolidated (classless) cover-page count and the date it was filed, or null
+    // when the issuer has no consolidated fact on record or the count is unrepresentable as Int64.
+    private async Task<(long Shares, DateOnly Filed)?> GetLatestConsolidated(
+        CommonStock stock,
+        CancellationToken cancellationToken
+    )
+    {
+        var conceptIds = await ResolveConceptIds(cancellationToken);
+        if (conceptIds.Count == 0)
+            return null;
+
+        // The latest filing wins (FiledDate), then the most recent as-of date within it; the value
+        // is a whole share count.
+        var match = await _financialFactRepository
+            .GetConsolidatedByStock(stock)
+            .Where(f => conceptIds.Contains(f.FinancialConceptId) && f.Unit == SharesUnit)
+            .OrderByDescending(f => f.FiledDate)
+            .ThenByDescending(f => f.PeriodEnd)
+            .Select(f => new { f.Value, f.FiledDate })
+            .FirstOrDefaultAsync(cancellationToken);
+        if (match == null)
+            return null;
+
+        // A corrupt/typo'd cover-page fact can carry a count that parses but exceeds Int64; the
+        // decimal->long cast would throw, crashing the caller. Treat an unrepresentable figure as
+        // none on record (null), matching how every other decimal->long cast here is range-checked.
+        return match.Value >= long.MinValue && match.Value <= long.MaxValue
+            ? ((long)match.Value, match.FiledDate)
+            : ((long, DateOnly)?)null;
+    }
+
+    // The entity total summed across the latest filing's per-class cover-page facts and that
+    // filing's filed date, or null when the issuer reports no per-class count on the class-of-stock
+    // axis or the sum is unrepresentable as Int64.
+    private async Task<(long Shares, DateOnly Filed)?> GetLatestPerClass(
+        CommonStock stock,
+        CancellationToken cancellationToken
     )
     {
         var conceptIds = await ResolveConceptIds(cancellationToken);
@@ -115,7 +157,9 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
 
         // Same range-check: a corrupt per-class count can push the sum past Int64; degrade to null
         // rather than let the decimal->long cast throw.
-        return total > 0 && total <= long.MaxValue ? (long)total : (long?)null;
+        return total > 0 && total <= long.MaxValue
+            ? ((long)total, latest.FiledDate)
+            : ((long, DateOnly)?)null;
     }
 
     // True when the latest-filed consolidated shares fact — the one GetReportedSharesOutstanding

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -140,10 +140,10 @@ public class FinancialFactsImportService
 
     // Sets the stock's share count from the authoritative SEC cover-page fact the import just
     // ingested, so the lagging per-share-class Yahoo figure no longer drives market cap and
-    // ownership percentages (#3575/#2503). Uses the single-class consolidated fact when present
-    // (#3575); for a multi-class issuer, which carries no consolidated fact, falls back to the sum
-    // across its per-class cover-page facts (#2503). No-ops when neither is on record or the value
-    // is unchanged.
+    // ownership percentages (#3575/#2503). Takes the more-recently-filed of the single-class
+    // consolidated fact (#3575) and the summed per-class facts (#2503), so a dual-class issuer
+    // whose classless series ended years ago is not frozen on a stale consolidated value (#5158).
+    // No-ops when neither is on record or the value is unchanged.
     private async Task UpdateSharesOutstanding(
         CommonStock stock,
         CancellationToken cancellationToken
@@ -151,9 +151,7 @@ public class FinancialFactsImportService
     {
         using var scope = _scopeFactory.CreateScope();
         var sharesProvider = scope.ServiceProvider.GetRequiredService<ISharesOutstandingProvider>();
-        var shares =
-            await sharesProvider.GetReportedSharesOutstanding(stock, cancellationToken)
-            ?? await sharesProvider.GetSummedPerClassSharesOutstanding(stock, cancellationToken);
+        var shares = await sharesProvider.GetCurrentSharesOutstanding(stock, cancellationToken);
         if (shares == null)
             return;
 

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -187,10 +187,12 @@ public class YahooPriceImportService
 
         // The SEC cover-page count (dei:EntityCommonStockSharesOutstanding) is authoritative and
         // current; Yahoo's figure is per-share-class and lags corporate actions. Defer to EDGAR
-        // for the share count when the issuer has a consolidated SEC fact, so Yahoo can't overwrite
-        // it with a stale or single-class value (#3575/#2503).
+        // for the share count when the issuer has an SEC fact, so Yahoo can't overwrite it with a
+        // stale or single-class value (#3575/#2503). Uses the more-recently-filed of the
+        // consolidated and per-class facts so a dual-class issuer frozen on a stale consolidated
+        // value falls through to its current per-class total (#5158).
         var sharesProvider = scope.ServiceProvider.GetRequiredService<ISharesOutstandingProvider>();
-        var edgarShares = await sharesProvider.GetReportedSharesOutstanding(
+        var edgarShares = await sharesProvider.GetCurrentSharesOutstanding(
             stock,
             cancellationToken
         );

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
@@ -394,6 +394,72 @@ public class SharesOutstandingProviderTests
         shares.Should().Be(12_116_000_000);
     }
 
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_StaleConsolidatedAndCurrentPerClass_PrefersCurrentPerClassSum()
+    {
+        await using var db = NewDb();
+        // Mastercard: the classless dei:EntityCommonStockSharesOutstanding series stopped in 2010
+        // when it switched to per-class reporting, so the latest CONSOLIDATED fact is the stale
+        // 2010 122,530,193 while the current entity total is the sum of the 2026 per-class facts.
+        // The stale consolidated value must not win (#5158).
+        var stock = new CommonStock
+        {
+            Ticker = "MA",
+            Name = "Mastercard Incorporated",
+            Cik = "0001141391",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, concept);
+        // The stale classless cover-page fact, last reported in the 2010 Q3 10-Q.
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                122_530_193m,
+                new DateOnly(2010, 10, 27),
+                new DateOnly(2010, 9, 30)
+            )
+        );
+        // The current entity total, reported per share class in the latest 2026 filing.
+        const string acc = "0001141391-26-000050";
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                900_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                acc,
+                "us-gaap:CommonClassAMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                8_000_000m,
+                new(2026, 4, 30),
+                new(2026, 4, 23),
+                acc,
+                "ma:ClassBMember"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(908_000_000);
+    }
+
     [Theory]
     [InlineData("TwentyF")]
     [InlineData("FortyF")]


### PR DESCRIPTION
## Summary

For dual-class issuers (Mastercard, Visa, …) the classless `dei:EntityCommonStockSharesOutstanding` cover-page series ends when the issuer switches to per-share-class reporting (around 2010 for MA/V). The share-count resolver chose the latest *consolidated* fact whenever one existed and only fell back to the per-class sum when none did — so these issuers were frozen on a ~16-year-old value (Mastercard's 2010 `122,530,193`). That understates market cap ~7x and inflates everything derived from it: buyback yield, ownership %, and screener size.

## Code changes

- **`SharesOutstandingProvider` / `ISharesOutstandingProvider`** — add `GetCurrentSharesOutstanding`, which returns the more-recently-filed of the latest consolidated fact and the latest per-class sum. The latest-consolidated and latest-per-class queries are extracted into private helpers that also surface the filing date; the two existing public methods now delegate to them (behavior unchanged). A same-filing tie keeps the consolidated total (it is the entity figure directly).
- **`FinancialFactsImportService` / `YahooPriceImportService`** — route the share-count update through `GetCurrentSharesOutstanding` instead of `GetReportedSharesOutstanding() ?? GetSummedPerClassSharesOutstanding()`.
- **Tests** — add a regression test reproducing the Mastercard scenario (stale 2010 consolidated fact + current 2026 per-class facts → expects the summed per-class total, not the stale value). Fails on the old selection (returns `122,530,193`), passes now.

Single-class issuers (consolidated only) and multi-class issuers that never reported a consolidated count (per-class only) are unaffected.