### PR TITLE
fix(ir-discovery): prefer IR subdomain and reject press-release pages

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
@@ -13,8 +13,9 @@ public class InvestorRelationsDiscoveryOptions : ScraperOptions
 
     /// <summary>
     /// Relative paths probed against the company website (e.g.
-    /// <c>https://acme.com/investor-relations</c>). Tried in order; the first that
-    /// resolves to a validated IR page wins.
+    /// <c>https://acme.com/investor-relations</c>). Tried in order, but only after
+    /// the subdomain candidates — a generic on-site path is often a redirecting
+    /// marketing stub, so the dedicated IR subdomain is preferred when it exists.
     /// </summary>
     public List<string> CandidatePaths { get; set; } =
     [
@@ -29,7 +30,8 @@ public class InvestorRelationsDiscoveryOptions : ScraperOptions
 
     /// <summary>
     /// Subdomain prefixes probed against the registrable domain (e.g.
-    /// <c>https://ir.acme.com</c>). Tried after the path candidates.
+    /// <c>https://ir.acme.com</c>). Tried before the path candidates: the dedicated
+    /// IR host is the canonical investor portal and the first that validates wins.
     /// </summary>
     public List<string> CandidateSubdomains { get; set; } =
     ["ir", "investors", "investor", "investorrelations"];

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsCandidateBuilder.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsCandidateBuilder.cs
@@ -8,9 +8,14 @@ namespace Equibles.CommonStocks.HostedService.Services;
 public static class InvestorRelationsCandidateBuilder
 {
     /// <summary>
-    /// Produces candidate URLs for <paramref name="website"/>: first the company
-    /// website with each <paramref name="paths"/> segment appended, then each
-    /// <paramref name="subdomains"/> prefix in front of the registrable domain.
+    /// Produces candidate URLs for <paramref name="website"/>: first each
+    /// <paramref name="subdomains"/> prefix in front of the registrable domain
+    /// (ir.acme.com, investors.acme.com), then the company website with each
+    /// <paramref name="paths"/> segment appended. Subdomains lead because the
+    /// dedicated IR host (the Q4 / GCS / Notified portal) is the canonical
+    /// investor site, whereas a generic on-site path like <c>/investor</c> is
+    /// often a marketing stub that client-side redirects to a single press
+    /// release — which then passes a keyword check while exposing no events feed.
     /// Returns an empty list when the website is missing or unparseable. Results
     /// are de-duplicated case-insensitively while preserving order.
     /// </summary>
@@ -45,18 +50,21 @@ public static class InvestorRelationsCandidateBuilder
 
         var candidates = new List<string>();
 
-        foreach (var path in paths)
-        {
-            if (string.IsNullOrWhiteSpace(path))
-                continue;
-            candidates.Add($"{scheme}://{host}/{path.Trim('/')}");
-        }
-
+        // Subdomains first: the dedicated IR host is the canonical investor portal,
+        // so probe it before falling back to guessed on-site paths (which can be
+        // redirecting marketing stubs).
         foreach (var subdomain in subdomains)
         {
             if (string.IsNullOrWhiteSpace(subdomain))
                 continue;
             candidates.Add($"{scheme}://{subdomain.Trim('.')}.{registrableDomain}");
+        }
+
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                continue;
+            candidates.Add($"{scheme}://{host}/{path.Trim('/')}");
         }
 
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsPageValidator.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsPageValidator.cs
@@ -41,7 +41,11 @@ public static class InvestorRelationsPageValidator
     /// <summary>
     /// True when <paramref name="html"/> looks like an investor-relations page:
     /// the page title carries an IR phrase, or the visible text contains at least
-    /// two distinct IR content keywords.
+    /// two distinct IR content keywords. A page that declares itself a single
+    /// news/press article (Open Graph <c>og:type=article</c> or an
+    /// <c>article:published_time</c>/<c>article:modified_time</c> timestamp) is never
+    /// an IR landing page — even when it is stuffed with IR keywords — so it is
+    /// rejected up front.
     /// </summary>
     public static bool IsInvestorRelationsPage(string html)
     {
@@ -50,6 +54,16 @@ public static class InvestorRelationsPageValidator
 
         var document = new HtmlDocument();
         document.LoadHtml(html);
+
+        // A generic on-site path like /investor is often a marketing stub that
+        // client-side redirects to a single press release; that article is full of
+        // IR boilerplate (an "Investor Relations" contact block, "financial
+        // results") and would clear the keyword check below, yet it exposes no
+        // events/webcast feed and is the wrong URL to store. Open Graph article
+        // metadata is the page declaring its own type, so trust it: an IR
+        // landing/events hub is og:type=website, never an article.
+        if (IsNewsArticle(document))
+            return false;
 
         // Drop script/style so their contents don't count as "visible" keywords.
         var noise = document.DocumentNode.SelectNodes("//script|//style");
@@ -67,5 +81,48 @@ public static class InvestorRelationsPageValidator
         var text = HtmlEntity.DeEntitize(document.DocumentNode.InnerText ?? "").ToLowerInvariant();
         var distinctHits = BodyKeywords.Count(text.Contains);
         return distinctHits >= 2;
+    }
+
+    // The article: properties that mark a page as a single dated news item. Deliberately
+    // narrow: article:published_time / article:modified_time are emitted per-article, whereas
+    // article:publisher / article:author are injected site-wide by some CMSs (WordPress/Yoast)
+    // on every page — including og:type=website homepages and IR hubs — so matching those would
+    // wrongly reject genuine IR pages.
+    private static readonly string[] ArticleTimestampProperties =
+    [
+        "article:published_time",
+        "article:modified_time",
+    ];
+
+    // True when the page's own Open Graph metadata declares it a single news article:
+    // og:type=article, or an article publish/modify timestamp. Both property="…" (the spec)
+    // and the name="…" variant some CMSs emit are checked.
+    private static bool IsNewsArticle(HtmlDocument document)
+    {
+        var metas = document.DocumentNode.SelectNodes("//meta");
+        if (metas == null)
+            return false;
+
+        foreach (var meta in metas)
+        {
+            var key = (
+                meta.GetAttributeValue("property", null) ?? meta.GetAttributeValue("name", "")
+            ).Trim().ToLowerInvariant();
+
+            if (ArticleTimestampProperties.Contains(key))
+                return true;
+
+            if (
+                key == "og:type"
+                && string.Equals(
+                    meta.GetAttributeValue("content", "").Trim(),
+                    "article",
+                    StringComparison.OrdinalIgnoreCase
+                )
+            )
+                return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsCandidateBuilderTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsCandidateBuilderTests.cs
@@ -25,11 +25,11 @@ public class InvestorRelationsCandidateBuilderTests
     }
 
     [Fact]
-    public void Build_PathsPrecedeSubdomains_AndUseRegistrableDomainForSubdomains()
+    public void Build_SubdomainsPrecedePaths_AndUseRegistrableDomainForSubdomains()
     {
-        // Contract: probe the company website's own paths first (strongest match
-        // when present), then IR subdomains of the registrable domain. The "www."
-        // is kept for same-origin path probes but stripped for subdomain hosts.
+        // Contract: probe the IR subdomains of the registrable domain first (the
+        // canonical investor portal), then the company website's own paths. The
+        // "www." is stripped for subdomain hosts but kept for same-origin path probes.
         var result = InvestorRelationsCandidateBuilder.Build(
             "https://www.acme.com",
             Paths,
@@ -39,10 +39,10 @@ public class InvestorRelationsCandidateBuilderTests
         result
             .Should()
             .Equal(
-                "https://www.acme.com/investor-relations",
-                "https://www.acme.com/ir",
                 "https://ir.acme.com",
-                "https://investors.acme.com"
+                "https://investors.acme.com",
+                "https://www.acme.com/investor-relations",
+                "https://www.acme.com/ir"
             );
     }
 
@@ -61,7 +61,7 @@ public class InvestorRelationsCandidateBuilderTests
     {
         var result = InvestorRelationsCandidateBuilder.Build("http://acme.com", ["ir"], ["ir"]);
 
-        result.Should().Equal("http://acme.com/ir", "http://ir.acme.com");
+        result.Should().Equal("http://ir.acme.com", "http://acme.com/ir");
     }
 
     [Fact]
@@ -94,6 +94,6 @@ public class InvestorRelationsCandidateBuilderTests
             [".ir."]
         );
 
-        result.Should().Equal("https://acme.com/investors", "https://ir.acme.com");
+        result.Should().Equal("https://ir.acme.com", "https://acme.com/investors");
     }
 }

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsPageValidatorTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsPageValidatorTests.cs
@@ -62,4 +62,79 @@ public class InvestorRelationsPageValidatorTests
 
         InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeFalse();
     }
+
+    [Fact]
+    public void IsInvestorRelationsPage_OgTypeArticle_ReturnsFalse_EvenWithIrTitleAndKeywords()
+    {
+        // The real failure case: /investor client-side redirects to a press release.
+        // That article is full of IR boilerplate (an "Investor Relations" contact
+        // block, "financial results") and even an IR-ish title, so it would clear the
+        // keyword check — but og:type=article means it's a single news item, not the
+        // IR portal, so it must be rejected.
+        const string html =
+            "<html><head><title>Acme to Participate in Investor Conferences</title>"
+            + "<meta property=\"og:type\" content=\"article\" /></head><body>"
+            + "<h1>Acme to Participate in Investor Conferences</h1>"
+            + "<p>Investor Contact: Jane Roe, Vice President, Investor Relations.</p>"
+            + "<p>The webcasts will discuss the most recently reported financial results.</p>"
+            + "</body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInvestorRelationsPage_ArticlePropertyMetadata_ReturnsFalse()
+    {
+        // Even without og:type, an article:* property marks the page as a single
+        // news article rather than an IR landing page.
+        const string html =
+            "<html><head><title>Investor Relations</title>"
+            + "<meta property=\"article:modified_time\" content=\"2019-05-20\" /></head>"
+            + "<body><p>Quarterly results and SEC filings.</p></body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInvestorRelationsPage_OgTypeArticleViaNameAttribute_ReturnsFalse()
+    {
+        // Some CMSs emit name="og:type" instead of the spec's property="og:type";
+        // both forms must be honoured.
+        const string html =
+            "<html><head><title>Investor Relations | Acme</title>"
+            + "<meta name=\"og:type\" content=\"article\" /></head>"
+            + "<body><p>News.</p></body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInvestorRelationsPage_SiteWideArticlePublisherMeta_DoesNotReject()
+    {
+        // article:publisher / article:author are injected site-wide by some CMSs
+        // (WordPress/Yoast) on every page, including og:type=website IR hubs. They
+        // must NOT trigger the article guard — only the per-article timestamps and
+        // og:type=article do — so a genuine IR page carrying them still validates.
+        const string html =
+            "<html><head><title>Investor Relations | Acme</title>"
+            + "<meta property=\"og:type\" content=\"website\" />"
+            + "<meta property=\"article:publisher\" content=\"https://facebook.com/acme\" /></head>"
+            + "<body><h1>Quarterly earnings and SEC filings</h1></body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsInvestorRelationsPage_OgTypeWebsite_WithIrKeywords_ReturnsTrue()
+    {
+        // The real IR portal declares og:type=website (not article) — it must still
+        // pass on its IR content so the article guard doesn't reject genuine pages.
+        const string html =
+            "<html><head><title>Events &amp; Presentations</title>"
+            + "<meta property=\"og:type\" content=\"website\" /></head><body>"
+            + "<h1>Quarterly earnings webcasts and SEC filings</h1>"
+            + "</body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary

Investor-relations URL auto-discovery was storing the wrong page for companies whose on-site `/investor` path is a marketing stub that **client-side redirects** to a single press release. The rendered press release is full of IR boilerplate (an "Investor Relations" contact block, "financial results"), so it cleared the keyword-only validator and got stored as the IR URL — even though it exposes no events/webcast feed. Everything downstream then fails: the IR-events scraper finds "no events listing", and webcast capture has no console to resolve.

Example: `www.emergentbiosolutions.com/investor` JS-redirects to a 2019 press release about the IR contact; the real portal is the separate `investors.emergentbiosolutions.com` Q4 site, whose events page carries "Listen to Webcast" links to media-server (Notified) consoles we can capture.

## Code changes

- **`InvestorRelationsCandidateBuilder`** — emit subdomain candidates (`ir.`/`investors.<domain>`) **before** on-site path candidates. The dedicated IR host is the canonical investor portal; first-validating-candidate-wins now prefers it over a guessed path. Doc comments on `InvestorRelationsDiscoveryOptions` updated to match.
- **`InvestorRelationsPageValidator`** — reject pages whose Open Graph metadata declares them a single news article (`og:type=article`, or an `article:published_time`/`article:modified_time` timestamp) before the keyword check. The match is deliberately narrow: site-wide `article:publisher`/`article:author` tags (injected by WordPress/Yoast on every page) do **not** reject, so genuine IR hubs still validate. Both `property="…"` and the `name="…"` variant are honoured.
- **Tests** — candidate-builder order expectations flipped; validator gains cases for `og:type=article` (rejected even with IR title+keywords), `article:modified_time` (rejected), `name="og:type"` variant (rejected), site-wide `article:publisher` (still accepted), and `og:type=website` with IR keywords (accepted).

All 3166 unit tests pass.