### PR TITLE
feat(investor-relations): optional second-pass IR page confirmer extension point

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/IInvestorRelationsPageConfirmer.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IInvestorRelationsPageConfirmer.cs
@@ -1,0 +1,33 @@
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Optional second-pass confirmation for a candidate page that has already cleared the cheap
+/// keyword prefilter (<see cref="InvestorRelationsPageValidator"/>). The keyword check only asks
+/// "does this look IR-ish?" — it counts keyword presence, so a link-dense page (a sitemap, an A–Z
+/// index, a mega-menu homepage) or a single press release stuffed with IR boilerplate passes it
+/// while not actually being the company's IR landing/events hub. A confirmer is the place to apply
+/// a stronger, possibly expensive check (e.g. an LLM classification) that the OSS core deliberately
+/// does not depend on.
+///
+/// OSS ships NO implementation, so a standalone build resolves an empty set and discovery stays
+/// keyword-only — exactly as before. A downstream build (the commercial product) registers an
+/// implementation, and the probe persists a discovered URL only when every registered confirmer
+/// agrees the page is a real IR page. This mirrors how <see cref="IStealthBrowserClient"/> keeps the
+/// third-party render engine out of the OSS core: the extension point lives in OSS, the heavy
+/// dependency lives downstream.
+/// </summary>
+public interface IInvestorRelationsPageConfirmer
+{
+    /// <summary>
+    /// True when <paramref name="html"/> (rendered from <paramref name="url"/>) is genuinely an
+    /// investor-relations landing/events page, false when it is something the keyword prefilter
+    /// can't tell apart (a sitemap, a press release, a generic homepage, a soft-404).
+    ///
+    /// A rejection is treated as a CONCLUSIVE assessment of that candidate (assessed, not an IR
+    /// page) — the probe moves on to the next candidate. So an implementation that cannot reach a
+    /// verdict (its backing engine timed out or errored) MUST return true ("fail open"): a confirmer
+    /// outage then degrades discovery to keyword-only behavior rather than wrongly writing a real IR
+    /// page off as absent and exiling the stock on the miss back-off.
+    /// </summary>
+    Task<bool> IsInvestorRelationsPage(string url, string html, CancellationToken cancellationToken);
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -17,16 +17,22 @@ public class InvestorRelationsProbeClient
 
     private readonly IStealthBrowserClient _stealthClient;
     private readonly OutboundHostGate _hostGate;
+    private readonly IReadOnlyList<IInvestorRelationsPageConfirmer> _confirmers;
     private readonly ILogger<InvestorRelationsProbeClient> _logger;
 
     public InvestorRelationsProbeClient(
         IStealthBrowserClient stealthClient,
         OutboundHostGate hostGate,
-        ILogger<InvestorRelationsProbeClient> logger
+        ILogger<InvestorRelationsProbeClient> logger,
+        IEnumerable<IInvestorRelationsPageConfirmer> confirmers = null
     )
     {
         _stealthClient = stealthClient;
         _hostGate = hostGate;
+        // Optional second-pass confirmers. None in a standalone OSS build (the prefilter is the only
+        // gate); the commercial build registers one. A null is the no-confirmer case for the tests
+        // that construct the client directly.
+        _confirmers = confirmers?.ToList() ?? [];
         _logger = logger;
     }
 
@@ -85,12 +91,44 @@ public class InvestorRelationsProbeClient
     )
     {
         var fetch = await FetchRendered(url, cancellationToken);
-        return fetch.Status switch
+        if (fetch.Status == StealthFetchStatus.Rendered)
         {
-            StealthFetchStatus.Rendered => (BuildResult(fetch.Html, url, fallbackUrl), false),
-            StealthFetchStatus.PageUnavailable => (null, false),
-            _ => (null, true),
-        };
+            var page = BuildResult(fetch.Html, url, fallbackUrl);
+            // A keyword-validated page must also clear the optional second-pass confirmers before it
+            // counts as found. A confirmer rejection is a conclusive assessment of THIS candidate
+            // (assessed, not an IR page), so the probe keeps looking rather than retrying.
+            if (page == null || !await IsConfirmedIrPage(page.Url, fetch.Html, cancellationToken))
+                return (null, false);
+            return (page, false);
+        }
+
+        // PageUnavailable is conclusive (definitively absent); anything else is a transient engine miss.
+        return (null, fetch.Status != StealthFetchStatus.PageUnavailable);
+    }
+
+    // Runs the optional second-pass confirmers on a candidate that already passed the keyword
+    // prefilter. With no confirmer registered (the OSS default) every page is accepted, so behavior
+    // is keyword-only. The commercial build registers a confirmer that rejects the link-dense pages
+    // (sitemaps, indexes) and press releases the keyword check can't distinguish from a real IR hub.
+    private async Task<bool> IsConfirmedIrPage(
+        string url,
+        string html,
+        CancellationToken cancellationToken
+    )
+    {
+        foreach (var confirmer in _confirmers)
+        {
+            if (!await confirmer.IsInvestorRelationsPage(url, html, cancellationToken))
+            {
+                _logger.LogDebug(
+                    "Investor relations candidate rejected by page confirmer: {Url}",
+                    url
+                );
+                return false;
+            }
+        }
+
+        return true;
     }
 
     // Renders the page through the stealth sidecar (most IR hosts are bot-protected), returning its
@@ -166,9 +204,10 @@ public class InvestorRelationsProbeClient
 
         var html = fetch.Html;
 
-        // The website itself might BE the IR site (e.g. investor.acme.com).
+        // The website itself might BE the IR site (e.g. investor.acme.com). It must clear the
+        // confirmers too; if it doesn't, fall through to following the homepage's IR links.
         var self = BuildResult(html, homepage, website);
-        if (self != null)
+        if (self != null && await IsConfirmedIrPage(self.Url, html, cancellationToken))
             return (self, false);
 
         var anyTransient = false;

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -233,8 +233,89 @@ public class InvestorRelationsProbeClientTests
         await stealth.DidNotReceive().TryFetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
-    private static InvestorRelationsProbeClient NewClient(IStealthBrowserClient stealth) =>
-        new(stealth, NewGate(), NullLogger<InvestorRelationsProbeClient>.Instance);
+    [Fact]
+    public async Task Discover_KeywordValidButConfirmerRejects_IsConclusiveMiss()
+    {
+        // The page clears the keyword prefilter but the second-pass confirmer rejects it (e.g. it is a
+        // sitemap that merely links to IR sections, or a single press release stuffed with IR
+        // boilerplate). The candidate is assessed and is not a real IR page, so the probe reports a
+        // conclusive miss instead of persisting the wrong URL.
+        var stealth = EnabledStealth(_ => IrPage);
+        var confirmer = RejectingConfirmer();
+
+        var client = NewClient(stealth, confirmer);
+
+        var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
+
+        result.Outcome.Should().Be(IrProbeOutcome.NoIrPageFound);
+        result.Page.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Discover_KeywordValidAndConfirmerApproves_ReturnsFound()
+    {
+        // Keyword prefilter passes and the confirmer agrees it is a real IR page — it is persisted.
+        var stealth = EnabledStealth(_ => IrPage);
+        var confirmer = ApprovingConfirmer();
+
+        var client = NewClient(stealth, confirmer);
+
+        var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
+
+        result.Outcome.Should().Be(IrProbeOutcome.Found);
+        result.Page!.Url.Should().Be("https://acme.com/investors");
+    }
+
+    [Fact]
+    public async Task Discover_KeywordRejects_ConfirmerNotConsulted()
+    {
+        // The confirmer is the expensive second pass; it must run ONLY on pages that already cleared
+        // the cheap keyword prefilter — never on every render — so cost stays bounded to plausible
+        // candidates.
+        var stealth = EnabledStealth(_ => NotIr);
+        var confirmer = ApprovingConfirmer();
+
+        var client = NewClient(stealth, confirmer);
+
+        var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
+
+        result.Outcome.Should().Be(IrProbeOutcome.NoIrPageFound);
+        await confirmer
+            .DidNotReceive()
+            .IsInvestorRelationsPage(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    private static IInvestorRelationsPageConfirmer ApprovingConfirmer() => Confirmer(true);
+
+    private static IInvestorRelationsPageConfirmer RejectingConfirmer() => Confirmer(false);
+
+    private static IInvestorRelationsPageConfirmer Confirmer(bool verdict)
+    {
+        var confirmer = Substitute.For<IInvestorRelationsPageConfirmer>();
+        confirmer
+            .IsInvestorRelationsPage(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(verdict);
+        return confirmer;
+    }
+
+    private static InvestorRelationsProbeClient NewClient(
+        IStealthBrowserClient stealth,
+        params IInvestorRelationsPageConfirmer[] confirmers
+    ) =>
+        new(
+            stealth,
+            NewGate(),
+            NullLogger<InvestorRelationsProbeClient>.Instance,
+            confirmers.Length == 0 ? null : confirmers
+        );
 
     // A gate with no inter-request delay so tests don't pay the throttle wait.
     private static OutboundHostGate NewGate() =>


### PR DESCRIPTION
## Summary

IR-URL discovery decides whether a candidate page is a real investor-relations page using `InvestorRelationsPageValidator` — a keyword heuristic. It counts keyword *presence*, so a link-dense page (a sitemap, an A–Z index, a mega-menu homepage) or a single press release stuffed with IR boilerplate clears it while not being the company's IR landing/events hub. The keyword check answers "looks IR-ish?", never "is this the IR hub?".

This adds an **optional second-pass extension point** so a downstream build can apply a stronger check (e.g. an LLM classification) **without bringing that dependency into the OSS core** — the same way `IStealthBrowserClient` keeps the third-party render engine out of OSS.

## Code changes

- **`IInvestorRelationsPageConfirmer`** (new) — `Task<bool> IsInvestorRelationsPage(url, html, ct)`. OSS ships no implementation. Contract documents fail-open (return true when a verdict can't be reached) so a confirmer outage degrades to keyword-only rather than wrongly exiling a real IR page.
- **`InvestorRelationsProbeClient`** — injects `IEnumerable<IInvestorRelationsPageConfirmer>` (empty in a standalone build → keyword-only, unchanged behavior). After a candidate clears the keyword prefilter, every registered confirmer must also agree before it's accepted; a rejection is a conclusive assessment of that candidate (the probe moves on). The confirmer runs **only** on pages that already passed the cheap prefilter, so cost stays bounded. Same gate applied to the homepage self-match.
- Tests: confirmer-rejects → conclusive miss; confirmer-approves → found; keyword-rejects → confirmer never consulted. Existing probe behavior unchanged when no confirmer is registered.

No new dependencies; no behavior change for a build that registers no confirmer.