### PR TITLE
fix(yahoo): recompute MarketCapitalization from EDGAR shares × price when Yahoo's own market cap is unusable

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -223,13 +223,26 @@ public class YahooPriceImportService
             changed = true;
         }
         // Reconcile Yahoo's market cap onto the authoritative EDGAR share base so it never
-        // disagrees with SharesOutStanding by the share-count ratio (#3575/#2503).
+        // disagrees with SharesOutStanding by the share-count ratio (#3575/#2503). When Yahoo's own
+        // market cap is unusable, fall back to EDGAR shares × the latest stored close (#5238) —
+        // otherwise a corrected SharesOutStanding never gets a matching MarketCapitalization.
+        decimal? currentPrice = null;
+        if (stats.MarketCapitalization == 0 && edgarShares is > 0)
+        {
+            var priceRepo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+            currentPrice = await priceRepo
+                .GetByStock(stock)
+                .OrderByDescending(p => p.Date)
+                .Select(p => (decimal?)p.Close)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
         var marketCap = ReconcileMarketCap(
             edgarShares,
             stats.SharesOutstanding,
-            stats.MarketCapitalization
+            stats.MarketCapitalization,
+            currentPrice
         );
-        if (stats.MarketCapitalization != 0 && stock.MarketCapitalization != marketCap)
+        if (marketCap != 0 && stock.MarketCapitalization != marketCap)
         {
             stock.MarketCapitalization = marketCap;
             changed = true;
@@ -258,14 +271,24 @@ public class YahooPriceImportService
     // The caller passes edgarShares == null for foreign private issuers (20-F/40-F), whose EDGAR
     // count is in ordinary shares — a different unit from the US-listed ADR — so they keep Yahoo's
     // self-consistent ADR market cap rather than being rescaled onto the ordinary base.
+    //
+    // Yahoo sometimes returns no market cap at all (summaryDetail.marketCap missing — common for
+    // multi-class issuers it hasn't reconciled, #5238): with no Yahoo market cap there is nothing
+    // to rescale, and the figure would otherwise stay stale forever even after EDGAR's share count
+    // is corrected. When a current price is available (the same import cycle's freshly-fetched
+    // close), compute EDGAR shares × price directly instead of leaving the stored value untouched.
     private static double ReconcileMarketCap(
         long? edgarShares,
         long yahooShares,
-        double yahooMarketCap
-    ) =>
-        edgarShares is > 0 && yahooShares > 0 && yahooMarketCap > 0
-            ? yahooMarketCap * ((double)edgarShares.Value / yahooShares)
-            : yahooMarketCap;
+        double yahooMarketCap,
+        decimal? currentPrice = null
+    ) {
+        if (edgarShares is > 0 && yahooShares > 0 && yahooMarketCap > 0)
+            return yahooMarketCap * ((double)edgarShares.Value / yahooShares);
+        if (edgarShares is > 0 && currentPrice is > 0)
+            return (double)edgarShares.Value * (double)currentPrice.Value;
+        return yahooMarketCap;
+    }
 
     private async Task SyncCompanyProfile(
         string ticker,

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -282,7 +282,8 @@ public class YahooPriceImportService
         long yahooShares,
         double yahooMarketCap,
         decimal? currentPrice = null
-    ) {
+    )
+    {
         if (edgarShares is > 0 && yahooShares > 0 && yahooMarketCap > 0)
             return yahooMarketCap * ((double)edgarShares.Value / yahooShares);
         if (edgarShares is > 0 && currentPrice is > 0)

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapMultiClassTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapMultiClassTests.cs
@@ -23,7 +23,7 @@ public class YahooPriceImportServiceReconcileMarketCapMultiClassTests
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
-    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap]);
+    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
 
     [Fact]
     public void ReconcileMarketCap_EdgarSharesExceedYahoo_ScalesMarketCapUpOntoEdgarBase()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapMultiClassTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapMultiClassTests.cs
@@ -23,7 +23,9 @@ public class YahooPriceImportServiceReconcileMarketCapMultiClassTests
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
-    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
+    ) =>
+        (double)
+            ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
 
     [Fact]
     public void ReconcileMarketCap_EdgarSharesExceedYahoo_ScalesMarketCapUpOntoEdgarBase()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapTests.cs
@@ -28,7 +28,7 @@ public class YahooPriceImportServiceReconcileMarketCapTests
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
-    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap]);
+    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
 
     [Fact]
     public void ReconcileMarketCap_EdgarSharesDifferFromYahoo_RescalesOntoEdgarBase()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapTests.cs
@@ -28,7 +28,9 @@ public class YahooPriceImportServiceReconcileMarketCapTests
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
-    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
+    ) =>
+        (double)
+            ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
 
     [Fact]
     public void ReconcileMarketCap_EdgarSharesDifferFromYahoo_RescalesOntoEdgarBase()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests.cs
@@ -24,7 +24,7 @@ public class YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
-    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap]);
+    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
 
     [Fact]
     public void ReconcileMarketCap_EdgarShareCountZero_KeepsYahooMarketCap()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests.cs
@@ -24,7 +24,9 @@ public class YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
-    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
+    ) =>
+        (double)
+            ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
 
     [Fact]
     public void ReconcileMarketCap_EdgarShareCountZero_KeepsYahooMarketCap()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooMarketCapTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooMarketCapTests.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Sibling to <see cref="YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests"/>, pinning the
+/// THIRD unusable-Yahoo-input leg: a zero Yahoo market cap (Yahoo's <c>summaryDetail.marketCap</c> is
+/// missing/unpopulated, common for multi-class issuers — #5238). Without a price fallback, the
+/// reconcile has nothing to rescale (<c>yahooMarketCap == 0</c>) and degrades to 0 forever, even
+/// though EDGAR's authoritative share count is known and a current price exists. The contract: when
+/// EDGAR shares and a current price are both known, compute <c>edgarShares × price</c> directly
+/// rather than leaving the stored market cap stale indefinitely.
+/// </summary>
+public class YahooPriceImportServiceReconcileMarketCapZeroYahooMarketCapTests
+{
+    private static readonly MethodInfo ReconcileMarketCapMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "ReconcileMarketCap",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static double ReconcileMarketCap(
+        long? edgarShares,
+        long yahooShares,
+        double yahooMarketCap,
+        decimal? currentPrice
+    ) =>
+        (double)
+            ReconcileMarketCapMethod.Invoke(
+                null,
+                [edgarShares, yahooShares, yahooMarketCap, currentPrice]
+            );
+
+    [Fact]
+    public void ReconcileMarketCap_YahooMarketCapZeroButPriceKnown_ComputesFromEdgarSharesTimesPrice()
+    {
+        // CHTR-shaped scenario: EDGAR shares are known (122,984,537), Yahoo's own market cap is
+        // unusable (0 — Yahoo hasn't reconciled the multi-class figure), but a current price
+        // ($146.17) is available from the same import cycle. The result must be the EDGAR share
+        // count priced at the current close, not the stale 0.
+        const long edgarShares = 122_984_537L;
+        const decimal currentPrice = 146.17m;
+
+        var reconciled = ReconcileMarketCap(edgarShares, 0L, 0d, currentPrice);
+
+        reconciled.Should().BeApproximately((double)(edgarShares * currentPrice), 1d);
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests.cs
@@ -23,7 +23,9 @@ public class YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
-    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
+    ) =>
+        (double)
+            ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
 
     [Fact]
     public void ReconcileMarketCap_YahooShareCountZero_KeepsYahooMarketCap()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests.cs
@@ -23,7 +23,7 @@ public class YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
-    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap]);
+    ) => (double)ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
 
     [Fact]
     public void ReconcileMarketCap_YahooShareCountZero_KeepsYahooMarketCap()


### PR DESCRIPTION
## Summary

- `ReconcileMarketCap` had no fallback when Yahoo's own `summaryDetail.marketCap` is missing/0 (common for multi-class issuers Yahoo hasn't reconciled) — with nothing to rescale, it returned `yahooMarketCap` (0) unchanged, and the caller's write guard then skipped the update entirely, leaving `CommonStock.MarketCapitalization` frozen even after `SharesOutStanding` was corrected by the EDGAR resync.
- Adds a price fallback: when EDGAR shares are known and a current price is available (the same import cycle's freshly-fetched close), compute `edgarShares × price` directly instead of leaving the stored value stale.
- Root-caused via the commercial repo's `#5238` (confirmed live on prod: CHTR/CMCSA/UAA/V all had their `SharesOutStanding` corrected by #5158/#5169 but `MarketCapitalization` stayed at the pre-correction value).

## Code changes

- `src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — `ReconcileMarketCap` gains an optional `currentPrice` parameter and a price-based fallback branch; `SyncKeyStatistics` fetches the latest stored close (only when Yahoo's own market cap is 0 and EDGAR shares are known) and loosens the write guard from `stats.MarketCapitalization != 0` to `marketCap != 0` so the fallback-derived value can actually be persisted.
- `tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooMarketCapTests.cs` — new test pinning the fallback (CHTR-shaped scenario: edgar shares known, Yahoo market cap 0, price known → `edgarShares × price`).
- `tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCap*Tests.cs` (4 files) — updated the reflection-based invocation to pass the new 4th parameter (`null` — unchanged scenarios, no price involved).