### PR TITLE
feat(corporate-actions): add StockSplit entity and split-adjustment factor helper

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
@@ -184,6 +184,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.GovernmentContracts.HostedService", "src\Equibles.GovernmentContracts.HostedService\Equibles.GovernmentContracts.HostedService.csproj", "{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.GovernmentContracts.Mcp", "src\Equibles.GovernmentContracts.Mcp\Equibles.GovernmentContracts.Mcp.csproj", "{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.CorporateActions.Data", "src\Equibles.CorporateActions.Data\Equibles.CorporateActions.Data.csproj", "{F3A92105-ABAC-473D-9FD0-5B52F470CA19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.CorporateActions.Repositories", "src\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj", "{EAB7368B-C8E8-4E56-A07C-85909EC937FB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1263,6 +1267,30 @@ Global
 		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Release|x64.Build.0 = Release|Any CPU
 		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Release|x86.ActiveCfg = Release|Any CPU
 		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Release|x86.Build.0 = Release|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Debug|x64.Build.0 = Debug|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Debug|x86.Build.0 = Debug|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Release|x64.ActiveCfg = Release|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Release|x64.Build.0 = Release|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Release|x86.ActiveCfg = Release|Any CPU
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19}.Release|x86.Build.0 = Release|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Debug|x64.Build.0 = Debug|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Debug|x86.Build.0 = Debug|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Release|x64.ActiveCfg = Release|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Release|x64.Build.0 = Release|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Release|x86.ActiveCfg = Release|Any CPU
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1357,6 +1385,8 @@ Global
 		{5376726C-12F9-4B30-A930-FA1548017724} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{F3A92105-ABAC-473D-9FD0-5B52F470CA19} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{EAB7368B-C8E8-4E56-A07C-85909EC937FB} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.CorporateActions.Data/CorporateActionsModuleConfiguration.cs
+++ b/src/Equibles.CorporateActions.Data/CorporateActionsModuleConfiguration.cs
@@ -1,0 +1,12 @@
+using Equibles.CorporateActions.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CorporateActions.Data;
+
+public class CorporateActionsModuleConfiguration : Equibles.Data.IFinancialModule
+{
+    public void ConfigureEntities(ModelBuilder builder)
+    {
+        builder.Entity<StockSplit>().Property(s => s.Source).HasConversion<string>();
+    }
+}

--- a/src/Equibles.CorporateActions.Data/Equibles.CorporateActions.Data.csproj
+++ b/src/Equibles.CorporateActions.Data/Equibles.CorporateActions.Data.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Data\Equibles.Data.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.CorporateActions.Data/Extensions/ModuleBuilderExtensions.cs
+++ b/src/Equibles.CorporateActions.Data/Extensions/ModuleBuilderExtensions.cs
@@ -1,0 +1,11 @@
+using Equibles.Data;
+
+namespace Equibles.CorporateActions.Data.Extensions;
+
+public static class ModuleBuilderExtensions
+{
+    public static EquiblesModuleBuilder AddCorporateActions(this EquiblesModuleBuilder builder)
+    {
+        return builder.AddModule<CorporateActionsModuleConfiguration>();
+    }
+}

--- a/src/Equibles.CorporateActions.Data/Models/StockSplit.cs
+++ b/src/Equibles.CorporateActions.Data/Models/StockSplit.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CorporateActions.Data.Models;
+
+/// <summary>
+/// An as-reported corporate-action stock split for a <see cref="CommonStock"/>.
+/// The ratio is expressed as <see cref="Numerator"/>:<see cref="Denominator"/>
+/// (e.g. 10:1 is a forward split, 1:12 is a reverse split).
+/// <see cref="PriceAdjustmentAppliedTime"/> is the idempotency marker for the
+/// price back-adjustment pass — a null value means historical prices have not
+/// yet been reconciled for this split.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(EffectiveDate), IsUnique = true)]
+[Index(nameof(PriceAdjustmentAppliedTime))]
+public class StockSplit
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    public DateOnly EffectiveDate { get; set; }
+
+    public decimal Numerator { get; set; }
+
+    public decimal Denominator { get; set; }
+
+    public StockSplitSource Source { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+
+    public DateTime? PriceAdjustmentAppliedTime { get; set; }
+}

--- a/src/Equibles.CorporateActions.Data/Models/StockSplitSource.cs
+++ b/src/Equibles.CorporateActions.Data/Models/StockSplitSource.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.CorporateActions.Data.Models;
+
+public enum StockSplitSource
+{
+    [Display(Name = "Yahoo")]
+    Yahoo,
+
+    [Display(Name = "Massive")]
+    Massive,
+
+    [Display(Name = "SEC Filing")]
+    SecFiling,
+
+    [Display(Name = "Manual")]
+    Manual,
+}

--- a/src/Equibles.CorporateActions.Data/SplitAdjustment.cs
+++ b/src/Equibles.CorporateActions.Data/SplitAdjustment.cs
@@ -1,0 +1,44 @@
+using Equibles.CorporateActions.Data.Models;
+
+namespace Equibles.CorporateActions.Data;
+
+/// <summary>
+/// Helpers that convert a value observed as-of a past date onto today's
+/// post-split basis, using the set of splits that have occurred since.
+/// </summary>
+public static class SplitAdjustment
+{
+    /// <summary>
+    /// Factor that converts a share COUNT observed as-of <paramref name="asOf"/>
+    /// onto today's basis. Each split with an <see cref="StockSplit.EffectiveDate"/>
+    /// strictly after <paramref name="asOf"/> multiplies the count by its
+    /// <see cref="StockSplit.Numerator"/>/<see cref="StockSplit.Denominator"/>
+    /// ratio. The comparison is strict (<c>&gt;</c>) because a report dated on the
+    /// effective date already reflects the post-split count. Splits with a
+    /// non-positive denominator are skipped to guard against divide-by-zero.
+    /// </summary>
+    public static decimal ShareCountFactor(DateOnly asOf, IEnumerable<StockSplit> splits)
+    {
+        var factor = 1m;
+        foreach (var split in splits)
+        {
+            if (split.EffectiveDate > asOf && split.Denominator > 0)
+            {
+                factor *= split.Numerator / split.Denominator;
+            }
+        }
+        return factor;
+    }
+
+    /// <summary>
+    /// Factor that converts a PRICE observed as-of <paramref name="asOf"/> onto
+    /// today's basis — the inverse of <see cref="ShareCountFactor"/>, since a
+    /// split moves price opposite to share count. Returns 1 when the share-count
+    /// factor is zero to avoid a divide-by-zero.
+    /// </summary>
+    public static decimal PriceFactor(DateOnly asOf, IEnumerable<StockSplit> splits)
+    {
+        var f = ShareCountFactor(asOf, splits);
+        return f == 0m ? 1m : 1m / f;
+    }
+}

--- a/src/Equibles.CorporateActions.Repositories/Equibles.CorporateActions.Repositories.csproj
+++ b/src/Equibles.CorporateActions.Repositories/Equibles.CorporateActions.Repositories.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.CorporateActions.Data\Equibles.CorporateActions.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.CorporateActions.Repositories/StockSplitRepository.cs
+++ b/src/Equibles.CorporateActions.Repositories/StockSplitRepository.cs
@@ -1,0 +1,21 @@
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Data;
+using Equibles.Data.Extensions;
+
+namespace Equibles.CorporateActions.Repositories;
+
+public class StockSplitRepository : BaseRepository<StockSplit>
+{
+    public StockSplitRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<StockSplit> GetByStock(Guid commonStockId)
+    {
+        return GetAll().Where(s => s.CommonStockId == commonStockId);
+    }
+
+    public IQueryable<StockSplit> GetPendingPriceAdjustment()
+    {
+        return GetAll().Where(s => s.PriceAdjustmentAppliedTime == null);
+    }
+}

--- a/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
+++ b/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
@@ -2,6 +2,7 @@ using Equibles.Cboe.Data;
 using Equibles.Cftc.Data;
 using Equibles.CommonStocks.Data;
 using Equibles.Congress.Data;
+using Equibles.CorporateActions.Data;
 using Equibles.Data;
 using Equibles.Errors.Data;
 using Equibles.FdaCatalysts.Data;
@@ -59,6 +60,7 @@ public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<EquiblesFi
             new YahooModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration(),
+            new CorporateActionsModuleConfiguration(),
             new FdaCatalystsModuleConfiguration(),
             new GovernmentContractsModuleConfiguration(),
             new SecModuleConfiguration(),

--- a/src/Equibles.Migrations/Equibles.Migrations.csproj
+++ b/src/Equibles.Migrations/Equibles.Migrations.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Equibles.Yahoo.Data\Equibles.Yahoo.Data.csproj" />
     <ProjectReference Include="..\Equibles.Cftc.Data\Equibles.Cftc.Data.csproj" />
     <ProjectReference Include="..\Equibles.Cboe.Data\Equibles.Cboe.Data.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Data\Equibles.CorporateActions.Data.csproj" />
     <ProjectReference Include="..\Equibles.FdaCatalysts.Data\Equibles.FdaCatalysts.Data.csproj" />
     <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Data\Equibles.Sec.FinancialFacts.Data.csproj" />

--- a/src/Equibles.Migrations/Migrations/20260701003809_AddStockSplit.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260701003809_AddStockSplit.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701003809_AddStockSplit")]
+    partial class AddStockSplit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260701003809_AddStockSplit.cs
+++ b/src/Equibles.Migrations/Migrations/20260701003809_AddStockSplit.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStockSplit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StockSplit",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EffectiveDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    Numerator = table.Column<decimal>(type: "numeric", nullable: false),
+                    Denominator = table.Column<decimal>(type: "numeric", nullable: false),
+                    Source = table.Column<string>(type: "text", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    PriceAdjustmentAppliedTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StockSplit", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_StockSplit_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockSplit_CommonStockId_EffectiveDate",
+                table: "StockSplit",
+                columns: new[] { "CommonStockId", "EffectiveDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockSplit_PriceAdjustmentAppliedTime",
+                table: "StockSplit",
+                column: "PriceAdjustmentAppliedTime");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StockSplit");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/CorporateActions/SplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/SplitAdjustmentTests.cs
@@ -1,0 +1,97 @@
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+
+namespace Equibles.UnitTests.CorporateActions;
+
+/// <summary>
+/// <see cref="SplitAdjustment"/> converts a value observed as-of a past date
+/// onto today's post-split basis. The canonical case is NVDA: a 4:1 split on
+/// 2021-07-20 and a 10:1 split on 2024-06-10, so a share count reported before
+/// both must be multiplied by 40 to reach today's basis, and price by 1/40.
+/// </summary>
+public class SplitAdjustmentTests
+{
+    private static readonly StockSplit Nvda4For1 = new()
+    {
+        EffectiveDate = new DateOnly(2021, 7, 20),
+        Numerator = 4m,
+        Denominator = 1m,
+    };
+
+    private static readonly StockSplit Nvda10For1 = new()
+    {
+        EffectiveDate = new DateOnly(2024, 6, 10),
+        Numerator = 10m,
+        Denominator = 1m,
+    };
+
+    private static StockSplit[] NvdaSplits => [Nvda4For1, Nvda10For1];
+
+    [Fact]
+    public void ShareCountFactor_NoSplits_IsOne()
+    {
+        SplitAdjustment.ShareCountFactor(new DateOnly(2020, 1, 1), []).Should().Be(1m);
+    }
+
+    [Fact]
+    public void ShareCountFactor_BeforeBothSplits_CompoundsToForty()
+    {
+        SplitAdjustment.ShareCountFactor(new DateOnly(2021, 1, 1), NvdaSplits).Should().Be(40m);
+    }
+
+    [Fact]
+    public void ShareCountFactor_BetweenSplits_OnlyLaterSplitApplies()
+    {
+        SplitAdjustment.ShareCountFactor(new DateOnly(2022, 1, 1), NvdaSplits).Should().Be(10m);
+    }
+
+    [Fact]
+    public void ShareCountFactor_OnEffectiveDate_TreatsReportAsPostSplit()
+    {
+        SplitAdjustment.ShareCountFactor(new DateOnly(2024, 6, 10), NvdaSplits).Should().Be(1m);
+    }
+
+    [Fact]
+    public void ShareCountFactor_AfterAllSplits_IsOne()
+    {
+        SplitAdjustment.ShareCountFactor(new DateOnly(2025, 1, 1), NvdaSplits).Should().Be(1m);
+    }
+
+    [Fact]
+    public void PriceFactor_IsInverseOfShareCountFactor()
+    {
+        SplitAdjustment.PriceFactor(new DateOnly(2021, 1, 1), NvdaSplits).Should().Be(1m / 40m);
+    }
+
+    [Fact]
+    public void ShareCountFactor_ReverseSplit_ShrinksPreSplitCount()
+    {
+        StockSplit[] splits =
+        [
+            new()
+            {
+                EffectiveDate = new DateOnly(2024, 1, 1),
+                Numerator = 1m,
+                Denominator = 12m,
+            },
+        ];
+
+        SplitAdjustment.ShareCountFactor(new DateOnly(2023, 1, 1), splits).Should().Be(1m / 12m);
+    }
+
+    [Fact]
+    public void ShareCountFactor_ZeroDenominator_IsSkippedNoDivideByZero()
+    {
+        StockSplit[] splits =
+        [
+            new()
+            {
+                EffectiveDate = new DateOnly(2024, 1, 1),
+                Numerator = 5m,
+                Denominator = 0m,
+            },
+        ];
+
+        SplitAdjustment.ShareCountFactor(new DateOnly(2023, 1, 1), splits).Should().Be(1m);
+    }
+}

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -91,6 +91,7 @@
     <ProjectReference Include="..\..\src\Equibles.Cftc.Data\Equibles.Cftc.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cftc.Repositories\Equibles.Cftc.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Data\Equibles.Cboe.Data.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.CorporateActions.Data\Equibles.CorporateActions.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Repositories\Equibles.Cboe.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cboe\Equibles.Integrations.Cboe.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cftc\Equibles.Integrations.Cftc.csproj" />


### PR DESCRIPTION
## Summary

Foundational PR introducing a new `Equibles.CorporateActions` module. This lands the data model and the shared math for split adjustment only — capture/scraping comes in a later PR.

- New `StockSplit` entity (financial DB): as-reported corporate-action split for a `CommonStock`, ratio expressed as `Numerator:Denominator` (e.g. 10:1 forward, 1:12 reverse). `PriceAdjustmentAppliedTime` is the idempotency marker for the later price back-adjustment pass (null = prices not yet reconciled).
- `StockSplitSource` enum (`Yahoo`, `Massive`, `SecFiling`, `Manual`), stored as string via a Fluent `HasConversion<string>()`.
- `SplitAdjustment` helper: `ShareCountFactor` compounds every split effective strictly after the as-of date onto today's basis (guards non-positive denominators); `PriceFactor` is its inverse.
- `StockSplitRepository` with `GetByStock` and `GetPendingPriceAdjustment`.
- `AddCorporateActions` module-builder extension.

## Code changes

- `src/Equibles.CorporateActions.Data` — new project: `StockSplit`, `StockSplitSource`, `CorporateActionsModuleConfiguration` (`IFinancialModule`), `SplitAdjustment`, `Extensions/ModuleBuilderExtensions`.
- `src/Equibles.CorporateActions.Repositories` — new project: `StockSplitRepository`.
- `src/Equibles.Migrations` — register the module in the design-time factory + `AddStockSplit` migration (creates the `StockSplit` table with the unique `(CommonStockId, EffectiveDate)` index).
- `tests/Equibles.UnitTests/CorporateActions/SplitAdjustmentTests.cs` — 8 tests (NVDA 4:1 + 10:1 compounding, on-effective-date boundary, price inversion, reverse split, zero-denominator guard).
- Both new projects added to `Equibles.sln`.

Build green (Release), new tests pass (8/8).

refs #2879