### PR TITLE
feat(corporate-actions): capture Yahoo stock-split events into StockSplit

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -189,6 +189,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.CorporateActions.D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.CorporateActions.Repositories", "src\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj", "{EAB7368B-C8E8-4E56-A07C-85909EC937FB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.CorporateActions.BusinessLogic", "src\Equibles.CorporateActions.BusinessLogic\Equibles.CorporateActions.BusinessLogic.csproj", "{369C38BD-6BCB-4A85-8648-6603AA96AEB0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1291,6 +1293,18 @@ Global
 		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Release|x64.Build.0 = Release|Any CPU
 		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Release|x86.ActiveCfg = Release|Any CPU
 		{EAB7368B-C8E8-4E56-A07C-85909EC937FB}.Release|x86.Build.0 = Release|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Debug|x64.Build.0 = Debug|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Debug|x86.Build.0 = Debug|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Release|x64.ActiveCfg = Release|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Release|x64.Build.0 = Release|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Release|x86.ActiveCfg = Release|Any CPU
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1387,6 +1401,7 @@ Global
 		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{F3A92105-ABAC-473D-9FD0-5B52F470CA19} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{EAB7368B-C8E8-4E56-A07C-85909EC937FB} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{369C38BD-6BCB-4A85-8648-6603AA96AEB0} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.CorporateActions.BusinessLogic/Equibles.CorporateActions.BusinessLogic.csproj
+++ b/src/Equibles.CorporateActions.BusinessLogic/Equibles.CorporateActions.BusinessLogic.csproj
@@ -7,6 +7,5 @@
     <ProjectReference Include="..\Equibles.CorporateActions.Data\Equibles.CorporateActions.Data.csproj" />
     <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
-    <ProjectReference Include="..\Equibles.Integrations.Yahoo\Equibles.Integrations.Yahoo.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.CorporateActions.BusinessLogic/Equibles.CorporateActions.BusinessLogic.csproj
+++ b/src/Equibles.CorporateActions.BusinessLogic/Equibles.CorporateActions.BusinessLogic.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.CorporateActions.Data\Equibles.CorporateActions.Data.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
+    <ProjectReference Include="..\Equibles.Integrations.Yahoo\Equibles.Integrations.Yahoo.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
@@ -1,0 +1,70 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Integrations.Yahoo.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CorporateActions.BusinessLogic;
+
+// Upserts captured split events into StockSplit. Idempotent by (stock,
+// EffectiveDate): a re-run with the same events writes nothing. A changed ratio
+// for an existing date is updated and its PriceAdjustmentAppliedTime cleared, so
+// the back-adjustment pass re-reconciles historical prices for the new ratio.
+[Service]
+public class StockSplitCaptureManager
+{
+    private readonly StockSplitRepository _splitRepository;
+
+    public StockSplitCaptureManager(StockSplitRepository splitRepository)
+    {
+        _splitRepository = splitRepository;
+    }
+
+    public async Task<int> Capture(CommonStock stock, IReadOnlyCollection<StockSplitEvent> events)
+    {
+        if (events == null || events.Count == 0)
+            return 0;
+
+        var existing = await _splitRepository.GetByStock(stock.Id).ToListAsync();
+        var changes = 0;
+
+        foreach (var splitEvent in events)
+        {
+            if (splitEvent.Denominator <= 0)
+                continue;
+
+            var match = existing.FirstOrDefault(s => s.EffectiveDate == splitEvent.Date);
+            if (match == null)
+            {
+                _splitRepository.Add(
+                    new StockSplit
+                    {
+                        CommonStockId = stock.Id,
+                        EffectiveDate = splitEvent.Date,
+                        Numerator = splitEvent.Numerator,
+                        Denominator = splitEvent.Denominator,
+                        Source = StockSplitSource.Yahoo,
+                    }
+                );
+                changes++;
+            }
+            else if (
+                match.Numerator != splitEvent.Numerator
+                || match.Denominator != splitEvent.Denominator
+            )
+            {
+                match.Numerator = splitEvent.Numerator;
+                match.Denominator = splitEvent.Denominator;
+                // Prices were adjusted for the old ratio — force a re-reconcile.
+                match.PriceAdjustmentAppliedTime = null;
+                changes++;
+            }
+        }
+
+        if (changes > 0)
+            await _splitRepository.SaveChanges();
+
+        return changes;
+    }
+}

--- a/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
@@ -2,7 +2,6 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
 using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
-using Equibles.Integrations.Yahoo.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.CorporateActions.BusinessLogic;
@@ -21,41 +20,40 @@ public class StockSplitCaptureManager
         _splitRepository = splitRepository;
     }
 
-    public async Task<int> Capture(CommonStock stock, IReadOnlyCollection<StockSplitEvent> events)
+    public async Task<int> Capture(CommonStock stock, IReadOnlyCollection<CapturedSplit> splits)
     {
-        if (events == null || events.Count == 0)
+        if (splits == null || splits.Count == 0)
             return 0;
 
         var existing = await _splitRepository.GetByStock(stock.Id).ToListAsync();
         var changes = 0;
 
-        foreach (var splitEvent in events)
+        foreach (var split in splits)
         {
-            if (splitEvent.Denominator <= 0)
+            if (split.Denominator <= 0)
                 continue;
 
-            var match = existing.FirstOrDefault(s => s.EffectiveDate == splitEvent.Date);
+            var match = existing.FirstOrDefault(s => s.EffectiveDate == split.EffectiveDate);
             if (match == null)
             {
                 _splitRepository.Add(
                     new StockSplit
                     {
                         CommonStockId = stock.Id,
-                        EffectiveDate = splitEvent.Date,
-                        Numerator = splitEvent.Numerator,
-                        Denominator = splitEvent.Denominator,
-                        Source = StockSplitSource.Yahoo,
+                        EffectiveDate = split.EffectiveDate,
+                        Numerator = split.Numerator,
+                        Denominator = split.Denominator,
+                        Source = split.Source,
                     }
                 );
                 changes++;
             }
             else if (
-                match.Numerator != splitEvent.Numerator
-                || match.Denominator != splitEvent.Denominator
+                match.Numerator != split.Numerator || match.Denominator != split.Denominator
             )
             {
-                match.Numerator = splitEvent.Numerator;
-                match.Denominator = splitEvent.Denominator;
+                match.Numerator = split.Numerator;
+                match.Denominator = split.Denominator;
                 // Prices were adjusted for the old ratio — force a re-reconcile.
                 match.PriceAdjustmentAppliedTime = null;
                 changes++;

--- a/src/Equibles.CorporateActions.Data/Models/CapturedSplit.cs
+++ b/src/Equibles.CorporateActions.Data/Models/CapturedSplit.cs
@@ -1,0 +1,13 @@
+namespace Equibles.CorporateActions.Data.Models;
+
+// A source-neutral split observation handed to StockSplitCaptureManager for
+// upsert. Each capturing source (Yahoo, massive.com, SEC filings) maps its own
+// payload to this DTO at its worker boundary, so the manager stays decoupled
+// from any one integration. The ratio is Numerator:Denominator.
+public class CapturedSplit
+{
+    public DateOnly EffectiveDate { get; set; }
+    public decimal Numerator { get; set; }
+    public decimal Denominator { get; set; }
+    public StockSplitSource Source { get; set; }
+}

--- a/src/Equibles.Integrations.Yahoo/Contracts/IYahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/Contracts/IYahooFinanceClient.cs
@@ -9,6 +9,7 @@ public interface IYahooFinanceClient
         DateOnly startDate,
         DateOnly endDate
     );
+    Task<YahooChartData> GetChart(string ticker, DateOnly startDate, DateOnly endDate);
     Task<List<RecommendationTrend>> GetRecommendationTrends(string ticker);
     Task<KeyStatistics> GetKeyStatistics(string ticker);
     Task<CompanyProfile> GetCompanyProfile(string ticker);

--- a/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
@@ -28,6 +28,31 @@ public class ChartResult
 
     [JsonProperty("indicators")]
     public ChartIndicators Indicators { get; set; }
+
+    [JsonProperty("events")]
+    public ChartEvents Events { get; set; }
+}
+
+public class ChartEvents
+{
+    // Keyed by the split's epoch-second string (e.g. "1718022600").
+    [JsonProperty("splits")]
+    public Dictionary<string, ChartSplit> Splits { get; set; } = [];
+}
+
+public class ChartSplit
+{
+    [JsonProperty("date")]
+    public long Date { get; set; }
+
+    [JsonProperty("numerator")]
+    public decimal Numerator { get; set; }
+
+    [JsonProperty("denominator")]
+    public decimal Denominator { get; set; }
+
+    [JsonProperty("splitRatio")]
+    public string SplitRatio { get; set; }
 }
 
 public class ChartMeta

--- a/src/Equibles.Integrations.Yahoo/Models/StockSplitEvent.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/StockSplitEvent.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Integrations.Yahoo.Models;
+
+// A stock-split corporate action parsed from the chart endpoint's events node.
+// The ratio is Numerator:Denominator (e.g. 10:1 forward, 1:12 reverse).
+public class StockSplitEvent
+{
+    public DateOnly Date { get; set; }
+    public decimal Numerator { get; set; }
+    public decimal Denominator { get; set; }
+}

--- a/src/Equibles.Integrations.Yahoo/Models/YahooChartData.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/YahooChartData.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Integrations.Yahoo.Models;
+
+// The full payload of a single chart fetch: the daily price bars plus any
+// split events the same request returned (events=split), so callers get both
+// without a second HTTP round-trip.
+public class YahooChartData
+{
+    public List<HistoricalPrice> Prices { get; set; } = [];
+    public List<StockSplitEvent> Splits { get; set; } = [];
+}

--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -54,6 +54,16 @@ public class YahooFinanceClient : IYahooFinanceClient
         string ticker,
         DateOnly startDate,
         DateOnly endDate
+    ) => (await GetChart(ticker, startDate, endDate)).Prices;
+
+    // Single chart fetch that parses BOTH the daily price bars and any split
+    // events Yahoo returns for the window (events=split). Callers that need
+    // only prices go through GetHistoricalPrices; the split capture piggybacks
+    // on this same request so it costs no extra HTTP round-trip.
+    public async Task<YahooChartData> GetChart(
+        string ticker,
+        DateOnly startDate,
+        DateOnly endDate
     )
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ticker);
@@ -68,13 +78,36 @@ public class YahooFinanceClient : IYahooFinanceClient
 
         var url =
             $"{ChartBaseUrl}/{Uri.EscapeDataString(ticker)}"
-            + $"?period1={period1}&period2={period2}&interval=1d";
+            + $"?period1={period1}&period2={period2}&interval=1d&events=split";
 
         var content = await SendWithRetry(url);
         var response = JsonConvert.DeserializeObject<YahooChartResponse>(content);
 
         var result = response?.Chart?.Result?.FirstOrDefault();
-        if (result?.Timestamp == null || result.Timestamp.Count == 0)
+        if (result == null)
+            return new YahooChartData();
+
+        // Exchange-local offset (seconds). Adding it to a UTC epoch shifts the
+        // instant into exchange-local time, so the existing UTC-based
+        // FromUnixTimestamp then yields the correct trading-day calendar date.
+        var offsetSeconds = result.Meta?.GmtOffset ?? 0;
+
+        return new YahooChartData
+        {
+            Prices = BuildPrices(result, ticker, offsetSeconds, startDate, endDate),
+            Splits = BuildSplits(result.Events?.Splits, offsetSeconds, startDate, endDate),
+        };
+    }
+
+    private List<HistoricalPrice> BuildPrices(
+        ChartResult result,
+        string ticker,
+        long offsetSeconds,
+        DateOnly startDate,
+        DateOnly endDate
+    )
+    {
+        if (result.Timestamp == null || result.Timestamp.Count == 0)
             return [];
 
         var quote = result.Indicators?.Quote?.FirstOrDefault();
@@ -82,10 +115,6 @@ public class YahooFinanceClient : IYahooFinanceClient
             return [];
 
         var adjCloseList = result.Indicators?.AdjClose?.FirstOrDefault()?.AdjustedClose;
-        // Exchange-local offset (seconds). Adding it to a UTC epoch shifts the
-        // instant into exchange-local time, so the existing UTC-based
-        // FromUnixTimestamp then yields the correct trading-day calendar date.
-        var offsetSeconds = result.Meta?.GmtOffset ?? 0;
         var prices = new List<HistoricalPrice>();
         var skipped = 0;
         var outsideWindow = 0;
@@ -120,6 +149,43 @@ public class YahooFinanceClient : IYahooFinanceClient
             outsideWindow
         );
         return prices;
+    }
+
+    // Parse the split events into the requested window. Split timestamps are
+    // dated on the same exchange-local calendar as the price bars (offset added
+    // to the UTC epoch), trimmed to [startDate, endDate], and a split with a
+    // non-positive denominator is dropped as unusable (it can't form a ratio).
+    private static List<StockSplitEvent> BuildSplits(
+        Dictionary<string, ChartSplit> splits,
+        long offsetSeconds,
+        DateOnly startDate,
+        DateOnly endDate
+    )
+    {
+        var events = new List<StockSplitEvent>();
+        if (splits == null)
+            return events;
+
+        foreach (var split in splits.Values)
+        {
+            if (split.Denominator <= 0)
+                continue;
+
+            var date = FromUnixTimestamp(split.Date + offsetSeconds);
+            if (date < startDate || date > endDate)
+                continue;
+
+            events.Add(
+                new StockSplitEvent
+                {
+                    Date = date,
+                    Numerator = split.Numerator,
+                    Denominator = split.Denominator,
+                }
+            );
+        }
+
+        return events;
     }
 
     // Build one HistoricalPrice from row i of the chart columns, or null when the row is

--- a/src/Equibles.Yahoo.HostedService/Equibles.Yahoo.HostedService.csproj
+++ b/src/Equibles.Yahoo.HostedService/Equibles.Yahoo.HostedService.csproj
@@ -9,6 +9,8 @@
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.BusinessLogic\Equibles.CorporateActions.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Yahoo\Equibles.Integrations.Yahoo.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.BusinessLogic\Equibles.Sec.FinancialFacts.BusinessLogic.csproj" />

--- a/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.BusinessLogic.Websites;
+using Equibles.CorporateActions.BusinessLogic;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Contracts;
 using Equibles.Yahoo.HostedService.Services;
@@ -12,6 +13,12 @@ public static class ServiceCollectionExtensions
     {
         services.AutoWireServicesFrom<YahooPriceImportService>();
         services.AutoWireServicesFrom<Equibles.Integrations.Yahoo.YahooFinanceClient>();
+
+        // The price import piggybacks split capture on its chart fetch; register
+        // the capture manager so it resolves in the import scope. Its
+        // StockSplitRepository is picked up by AddAllRepositories (PluginLoader
+        // loads Equibles.CorporateActions.Repositories.dll from the output dir).
+        services.AutoWireServicesFrom<StockSplitCaptureManager>();
 
         // Yahoo is the OSS source of stock prices for Holdings valuation.
         services.AddScoped<IStockPriceProvider, YahooStockPriceProvider>();

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -2,6 +2,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.CorporateActions.BusinessLogic;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Yahoo.Contracts;
@@ -176,6 +177,19 @@ public class YahooPriceImportService
         if (splits.Count == 0)
             return;
 
+        // Map Yahoo's split shape onto the source-neutral capture DTO at the
+        // worker boundary, stamping Yahoo as the source, so the domain manager
+        // stays decoupled from this integration.
+        var captured = splits
+            .Select(s => new CapturedSplit
+            {
+                EffectiveDate = s.Date,
+                Numerator = s.Numerator,
+                Denominator = s.Denominator,
+                Source = StockSplitSource.Yahoo,
+            })
+            .ToList();
+
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var stock = await stockRepo.Get(commonStockId);
@@ -184,7 +198,7 @@ public class YahooPriceImportService
 
         var captureManager =
             scope.ServiceProvider.GetRequiredService<StockSplitCaptureManager>();
-        var count = await captureManager.Capture(stock, splits);
+        var count = await captureManager.Capture(stock, captured);
         if (count > 0)
             _logger.LogInformation(
                 "Captured {Count} stock split(s) for {StockId}",

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
+using Equibles.CorporateActions.BusinessLogic;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Yahoo.Contracts;
@@ -101,7 +102,29 @@ public class YahooPriceImportService
         if (startDate >= today)
             return 0;
 
-        var prices = await _yahooClient.GetHistoricalPrices(ticker, startDate, today);
+        // One chart fetch yields both the price bars and any split events for the
+        // window — capture the splits off the same response, no extra HTTP.
+        var chartData = await _yahooClient.GetChart(ticker, startDate, today);
+
+        var inserted = await PersistPrices(
+            ticker,
+            commonStockId,
+            chartData.Prices,
+            cancellationToken
+        );
+
+        await CaptureSplits(commonStockId, chartData.Splits);
+
+        return inserted;
+    }
+
+    private async Task<int> PersistPrices(
+        string ticker,
+        Guid commonStockId,
+        List<HistoricalPrice> prices,
+        CancellationToken cancellationToken
+    )
+    {
         if (prices.Count == 0)
             return 0;
 
@@ -139,6 +162,35 @@ public class YahooPriceImportService
 
         _logger.LogDebug("Inserted {Count} prices for {Ticker}", inserted, ticker);
         return inserted;
+    }
+
+    // Upserts the split events Yahoo returned for this ticker into StockSplit via
+    // the CorporateActions capture manager. Resolved in its own scope (mirrors
+    // the other per-write scopes); skipped when there are no splits so the common
+    // no-split path costs nothing.
+    private async Task CaptureSplits(
+        Guid commonStockId,
+        IReadOnlyCollection<StockSplitEvent> splits
+    )
+    {
+        if (splits.Count == 0)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var stock = await stockRepo.Get(commonStockId);
+        if (stock == null)
+            return;
+
+        var captureManager =
+            scope.ServiceProvider.GetRequiredService<StockSplitCaptureManager>();
+        var count = await captureManager.Capture(stock, splits);
+        if (count > 0)
+            _logger.LogInformation(
+                "Captured {Count} stock split(s) for {StockId}",
+                count,
+                commonStockId
+            );
     }
 
     private async Task FlushPriceBatch(List<DailyStockPrice> batch)

--- a/tests/Equibles.UnitTests/Yahoo/YahooSplitParsingTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooSplitParsingTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using Equibles.Integrations.Yahoo;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Yahoo;
+
+// Contract: the chart endpoint fetched with events=split carries a
+// chart.result[0].events.splits object keyed by epoch-string. GetChart must
+// parse every in-window split — dated on the exchange-local calendar, ratio
+// Numerator:Denominator — alongside the price bars, while GetHistoricalPrices
+// keeps returning only the prices. Fixture mirrors real NVDA data: 4:1 on
+// 2021-07-20 and 10:1 on 2024-06-10 (gmtoffset 0 so each pre-market epoch maps
+// to its own UTC calendar date), plus two price bars.
+public class YahooSplitParsingTests
+{
+    private const string NvdaSplitCassette = """
+        {
+          "chart": {
+            "result": [
+              {
+                "meta": { "gmtoffset": 0, "exchangeTimezoneName": "UTC" },
+                "timestamp": [1719532800, 1719792000],
+                "events": {
+                  "splits": {
+                    "1626787800": { "date": 1626787800, "numerator": 4.0, "denominator": 1.0, "splitRatio": "4:1" },
+                    "1718022600": { "date": 1718022600, "numerator": 10.0, "denominator": 1.0, "splitRatio": "10:1" }
+                  }
+                },
+                "indicators": {
+                  "quote": [
+                    {
+                      "open": [120.0, 122.0],
+                      "high": [121.0, 123.0],
+                      "low": [119.0, 121.0],
+                      "close": [120.5, 122.5],
+                      "volume": [1000, 2000]
+                    }
+                  ]
+                }
+              }
+            ],
+            "error": null
+          }
+        }
+        """;
+
+    private static readonly DateOnly WindowStart = new(2021, 7, 1);
+    private static readonly DateOnly WindowEnd = new(2024, 7, 1);
+
+    [Fact]
+    public async Task GetChart_SplitEventsInWindow_ParsesBothWithCorrectDatesAndRatios()
+    {
+        var client = new SessionStubbedYahooClient(
+            new HttpClient(new CassetteHandler(NvdaSplitCassette))
+        );
+
+        var chart = await client.GetChart("NVDA", WindowStart, WindowEnd);
+
+        chart.Splits.Should().HaveCount(2);
+
+        var forward = chart.Splits.Single(s => s.Date == new DateOnly(2021, 7, 20));
+        forward.Numerator.Should().Be(4m);
+        forward.Denominator.Should().Be(1m);
+
+        var tenForOne = chart.Splits.Single(s => s.Date == new DateOnly(2024, 6, 10));
+        tenForOne.Numerator.Should().Be(10m);
+        tenForOne.Denominator.Should().Be(1m);
+    }
+
+    [Fact]
+    public async Task GetChart_SameResponse_StillReturnsPriceBars()
+    {
+        var client = new SessionStubbedYahooClient(
+            new HttpClient(new CassetteHandler(NvdaSplitCassette))
+        );
+
+        var chart = await client.GetChart("NVDA", WindowStart, WindowEnd);
+
+        chart.Prices.Should().HaveCount(2);
+        chart.Prices.Should().Contain(p => p.Date == new DateOnly(2024, 6, 28) && p.Close == 120.5m);
+        chart.Prices.Should().Contain(p => p.Date == new DateOnly(2024, 7, 1) && p.Close == 122.5m);
+    }
+
+    [Fact]
+    public async Task GetHistoricalPrices_SplitCassette_StillReturnsOnlyPrices()
+    {
+        var client = new SessionStubbedYahooClient(
+            new HttpClient(new CassetteHandler(NvdaSplitCassette))
+        );
+
+        var prices = await client.GetHistoricalPrices("NVDA", WindowStart, WindowEnd);
+
+        prices.Should().HaveCount(2);
+        prices.Select(p => p.Date)
+            .Should()
+            .BeEquivalentTo([new DateOnly(2024, 6, 28), new DateOnly(2024, 7, 1)]);
+    }
+
+    // Overrides the documented protected-virtual session seam so the data fetch
+    // skips the live cookie/crumb bootstrap and runs entirely against the stub.
+    private sealed class SessionStubbedYahooClient(HttpClient httpClient)
+        : YahooFinanceClient(httpClient, NullLogger<YahooFinanceClient>.Instance)
+    {
+        protected override Task<(string Crumb, string CookieHeader)> EnsureSession() =>
+            Task.FromResult<(string Crumb, string CookieHeader)>(("test-crumb", "A=1"));
+    }
+
+    private sealed class CassetteHandler(string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

Capture stock-split corporate actions from Yahoo and upsert them into `StockSplit`, with **zero extra HTTP** — the splits piggyback on the price import's existing chart call (fetched with `&events=split`).

## Code changes

**`Equibles.Integrations.Yahoo`**
- `Models/StockSplitEvent.cs` — `{ DateOnly Date; decimal Numerator; decimal Denominator; }`.
- `Models/YahooChartData.cs` — `{ List<HistoricalPrice> Prices; List<StockSplitEvent> Splits; }`.
- `Models/Responses/YahooChartResponse.cs` — added `ChartResult.Events` + `ChartEvents` / `ChartSplit` DTOs for `chart.result[0].events.splits`.
- `YahooFinanceClient` — new `GetChart(ticker, start, end)` does a single fetch and parses **both** prices and splits; `&events=split` appended to the URL; split dates use the same `meta.gmtoffset` exchange-local offset and window trim as the price bars, and a split with a non-positive denominator is dropped. `GetHistoricalPrices` now delegates to `GetChart(...).Prices` so existing callers/tests are unaffected. `GetChart` added to `IYahooFinanceClient`.

**`Equibles.CorporateActions.BusinessLogic`** (new project, added to the solution)
- `StockSplitCaptureManager` (`[Service]`, depends on `StockSplitRepository`) — `Capture(CommonStock, IReadOnlyCollection<StockSplitEvent>)` loads the stock's splits once, adds a new `StockSplit` (Source = Yahoo) for each unseen `EffectiveDate`, updates the ratio and clears `PriceAdjustmentAppliedTime` when it changed, saves once, returns the count. Idempotent.

**`Equibles.Yahoo.HostedService`**
- `YahooPriceImportService` — per-ticker fetch switched to `GetChart`; price persist extracted to a helper; after the price upsert, `CaptureSplits` resolves `StockSplitCaptureManager` in a fresh scope and calls `Capture(stock, chartData.Splits)` (skipped when there are no splits).
- `ServiceCollectionExtensions.AddYahooWorker` — `AutoWireServicesFrom<StockSplitCaptureManager>()`.
- csproj — ProjectReferences to `Equibles.CorporateActions.BusinessLogic` + `.Repositories`.

**Worker host registration** — `StockSplitRepository` and the `CorporateActions` module register automatically: `PluginLoader.LoadAll()` (Program.cs) loads every `Equibles.*.dll` from the output dir before `AddAllModules`/`AddAllRepositories` scan, and the new ProjectReferences pull those DLLs into the Worker.Host output. No explicit registration needed.

## Tests

`tests/Equibles.UnitTests/Yahoo/YahooSplitParsingTests.cs` — feeds an NVDA `events=split` cassette (4:1 @ 2021-07-20, 10:1 @ 2024-06-10 + two price bars) through the existing session-stub / HTTP-mock seam and asserts `GetChart` returns both splits (correct `EffectiveDate` + ratio) and the price bars, and that `GetHistoricalPrices` still returns only the prices.

- `dotnet build Equibles.sln -c Release` — green.
- All 73 Yahoo unit tests pass (3 new).

refs #2879