### PR TITLE
perf(as-reported): parallelize R-file capture and raise SEC rate to 5/s

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -19,9 +19,11 @@ namespace Equibles.Integrations.Sec;
 [Service(ServiceLifetime.Scoped, typeof(ISecEdgarClient))]
 public class SecEdgarClient : ISecEdgarClient
 {
-    // SEC has undocumented rolling-window rate limits beyond the 10 req/s rule; use 4 req/s for sustained scraping
+    // SEC has undocumented rolling-window rate limits beyond the 10 req/s rule; 5 req/s stays
+    // comfortably under the documented ceiling while still leaving headroom before the 403
+    // "Request Rate Threshold Exceeded" page (handled below via the penalty pause).
     private static readonly IRateLimiter RateLimiter = new RateLimiter(
-        maxRequests: 4,
+        maxRequests: 5,
         timeWindow: TimeSpan.FromSeconds(1)
     );
     private const int MaxRetries = 10;

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Configuration/ReportedStatementsCaptureOptions.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Configuration/ReportedStatementsCaptureOptions.cs
@@ -4,11 +4,18 @@ namespace Equibles.Sec.FinancialFacts.HostedService.Configuration;
 
 /// <summary>
 /// Options for the as-reported statement capture sweep. Each document costs one EDGAR request
-/// for FilingSummary.xml plus one per statement table, so the batch size is a per-cycle request
-/// budget against the shared SEC rate limit — modest by default.
+/// for FilingSummary.xml plus one per statement table, all funnelled through the shared SEC rate
+/// limiter.
 /// </summary>
 public class ReportedStatementsCaptureOptions : ScraperOptions
 {
     /// <summary>Documents captured per drain iteration.</summary>
-    public int BatchSize { get; set; } = 25;
+    public int BatchSize { get; set; } = 50;
+
+    /// <summary>
+    /// How many statement R-files to fetch concurrently per document. Bounded by the shared SEC
+    /// rate limiter regardless, so this only governs how large a share of that budget the backfill
+    /// claims — higher drains faster but leaves less headroom for the time-sensitive SEC sweeps.
+    /// </summary>
+    public int MaxParallelFetches { get; set; } = 5;
 }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsCaptureWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsCaptureWorker.cs
@@ -27,9 +27,9 @@ public class ReportedStatementsCaptureWorker : BaseScraperWorker
     protected override TimeSpan SleepInterval { get; }
     protected override ErrorSource ErrorSource => ErrorSource.FinancialFactsScraper;
 
-    // Start after the lighter, time-sensitive SEC sweeps so this bulk capture doesn't drain the
-    // shared EDGAR request budget ahead of them after a deploy.
-    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(10);
+    // Start shortly after the other SEC sweeps have booted so they claim their initial watermark,
+    // then this bulk capture drains aggressively alongside them.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(1);
 
     public ReportedStatementsCaptureWorker(
         ILogger<ReportedStatementsCaptureWorker> logger,
@@ -87,6 +87,7 @@ public class ReportedStatementsCaptureWorker : BaseScraperWorker
             {
                 document.ReportedStatementsStatus = await captureService.Capture(
                     document,
+                    _options.MaxParallelFetches,
                     stoppingToken
                 );
                 if (document.ReportedStatementsStatus == XbrlCaptureStatus.Captured)

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsCaptureService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsCaptureService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Sec.Contracts;
@@ -41,8 +42,15 @@ public class ReportedStatementsCaptureService
     /// when at least one statement table was stored, otherwise
     /// <see cref="XbrlCaptureStatus.NotPresent"/> (terminal — nothing to reconstruct).
     /// </summary>
+    /// <param name="maxParallelFetches">
+    /// How many statement R-files to fetch concurrently. Each fetch still funnels through the shared
+    /// SEC rate limiter, so this never exceeds the global req/s ceiling — it just keeps the limiter
+    /// saturated so this bulk backfill claims a larger share of the budget instead of idling between
+    /// serial round-trips. Clamped to at least 1.
+    /// </param>
     public async Task<XbrlCaptureStatus> Capture(
         Document document,
+        int maxParallelFetches,
         CancellationToken cancellationToken
     )
     {
@@ -72,40 +80,54 @@ public class ReportedStatementsCaptureService
             return XbrlCaptureStatus.NotPresent;
         }
 
-        var files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            [FilingSummaryFileName] = summaryXml,
-        };
+        var files = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        files[FilingSummaryFileName] = summaryXml;
 
-        foreach (var report in reports)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            // A role can be listed twice (primary + parenthetical share an R-file occasionally);
-            // fetch each table once.
-            if (files.ContainsKey(report.HtmlFileName))
-            {
-                continue;
-            }
+        // A role can be listed twice (primary + parenthetical share an R-file occasionally);
+        // fetch each table once. Dedup up front so concurrent fetches don't race on the same file.
+        var distinctReports = reports
+            .Where(r =>
+                !string.Equals(
+                    r.HtmlFileName,
+                    FilingSummaryFileName,
+                    StringComparison.OrdinalIgnoreCase
+                )
+            )
+            .DistinctBy(r => r.HtmlFileName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
-            var bytes = await _secEdgarClient.GetDocumentFileBytes(
-                cik,
-                accession,
-                report.HtmlFileName,
-                cancellationToken
-            );
-            if (bytes is { Length: > 0 })
+        // Fetch the statement R-files concurrently. The shared SEC rate limiter still caps total
+        // throughput, so parallelism only keeps the limiter busy (a larger share of the budget)
+        // rather than issuing one serial request at a time.
+        await Parallel.ForEachAsync(
+            distinctReports,
+            new ParallelOptions
             {
-                files[report.HtmlFileName] = Encoding.UTF8.GetString(bytes);
-            }
-            else
+                MaxDegreeOfParallelism = Math.Max(1, maxParallelFetches),
+                CancellationToken = cancellationToken,
+            },
+            async (report, ct) =>
             {
-                _logger.LogWarning(
-                    "As-reported statement table {File} missing for {Accession}; skipping it.",
+                var bytes = await _secEdgarClient.GetDocumentFileBytes(
+                    cik,
+                    accession,
                     report.HtmlFileName,
-                    accession
+                    ct
                 );
+                if (bytes is { Length: > 0 })
+                {
+                    files[report.HtmlFileName] = Encoding.UTF8.GetString(bytes);
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "As-reported statement table {File} missing for {Accession}; skipping it.",
+                        report.HtmlFileName,
+                        accession
+                    );
+                }
             }
-        }
+        );
 
         // Only FilingSummary survived (every R-file 404'd) — nothing usable to parse.
         if (files.Count <= 1)


### PR DESCRIPTION
## Summary

The as-reported financial-statements backfill (R-file capture from EDGAR) was draining far too slowly — on production it was claiming only ~7% of the shared SEC request budget (~1,026 req/hr) while sitting at 22% complete, which projected to ~2 weeks to finish.

Root cause: the capture worker is single-threaded and each document is fetched with fully serial round-trips (FilingSummary.xml + one request per statement table). Because it only ever has one SEC request in flight, it idles between round-trips and the other SEC sweeps (document scraping, company-facts, daily-index) grab the freed rate-limiter tokens. All SEC consumers share one process-wide rate gate with no priority.

This gives the backfill a much larger share of the budget and lifts the shared ceiling slightly.

## Code changes

- **`Equibles.Integrations.Sec/SecEdgarClient.cs`** — raise the shared static EDGAR rate limiter from `4` to `5` req/s (still comfortably under SEC's documented 10/s ceiling; the 403 "Request Rate Threshold Exceeded" penalty pause still guards the upper bound).
- **`Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsCaptureService.cs`** — fetch a filing's statement R-files concurrently via `Parallel.ForEachAsync`, bounded by a new `maxParallelFetches` parameter, collecting into a `ConcurrentDictionary`. R-files are de-duplicated by filename up front so concurrent fetches don't race. Every fetch still funnels through the shared rate limiter, so total throughput never exceeds the SEC ceiling — parallelism only keeps the limiter saturated so the backfill claims a larger share instead of idling.
- **`Equibles.Sec.FinancialFacts.HostedService/Configuration/ReportedStatementsCaptureOptions.cs`** — add `MaxParallelFetches` (default 5) and raise `BatchSize` default `25 → 50` to reduce 30s continuation gaps during a drain.
- **`Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsCaptureWorker.cs`** — cut the deliberate 10-minute startup deferral to 1 minute and pass `MaxParallelFetches` through to the capture service.

## Notes

- No behavior change for the local parse sweep — the stored bundle format is unchanged (JSON map of filename → text).
- `MaxParallelFetches` and `BatchSize` are config-tunable (`ReportedStatementsCapture:*`) so throughput can be dialed back in production if the time-sensitive SEC sweeps need more headroom.