### PR TITLE
fix(yahoo): re-sync full price history and shares outstanding when a split is detected

### DIFF
--- a/src/Equibles.Core/Configuration/WorkerOptions.cs
+++ b/src/Equibles.Core/Configuration/WorkerOptions.cs
@@ -4,4 +4,12 @@ public class WorkerOptions
 {
     public DateTime? MinSyncDate { get; set; }
     public List<string> TickersToSync { get; set; } = [];
+
+    /// <summary>
+    /// Caps how many stocks the split-price back-adjustment pass re-syncs per cycle, so the
+    /// one-time universe backfill throttles against Yahoo's shared request limiter instead of
+    /// re-pulling every stock's full history at once. Stocks beyond the cap stay pending and are
+    /// picked up on later cycles.
+    /// </summary>
+    public int MaxSplitPriceReconciliationsPerCycle { get; set; } = 50;
 }

--- a/src/Equibles.CorporateActions.BusinessLogic/PendingSplitSelection.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/PendingSplitSelection.cs
@@ -1,0 +1,13 @@
+namespace Equibles.CorporateActions.BusinessLogic;
+
+/// <summary>
+/// The set of stocks the split-price back-adjustment pass will re-sync this cycle.
+/// <see cref="StockIds"/> is the capped, distinct selection; <see cref="TotalPending"/>
+/// is how many distinct stocks had unreconciled splits before the cap, and
+/// <see cref="Skipped"/> is the remainder deferred to a later cycle.
+/// </summary>
+public record PendingSplitSelection(
+    IReadOnlyList<Guid> StockIds,
+    int TotalPending,
+    int Skipped
+);

--- a/src/Equibles.CorporateActions.BusinessLogic/SplitPriceReconciliationManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/SplitPriceReconciliationManager.cs
@@ -1,0 +1,69 @@
+using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CorporateActions.BusinessLogic;
+
+// Split-side coordinator for the price back-adjustment pass. Owns the two data
+// operations the worker drives around its Yahoo fetch: selecting which stocks
+// still have unreconciled splits (capped per cycle) and stamping a stock's
+// pending splits once its prices have been re-synced. Kept off the worker so it
+// is unit-testable without a live scraper, and off the repository so the repo
+// stays pure data-access.
+[Service]
+public class SplitPriceReconciliationManager
+{
+    private readonly StockSplitRepository _splitRepository;
+
+    public SplitPriceReconciliationManager(StockSplitRepository splitRepository)
+    {
+        _splitRepository = splitRepository;
+    }
+
+    /// <summary>
+    /// Returns the distinct stocks with at least one unreconciled split, capped at
+    /// <paramref name="maxPerCycle"/> so the universe backfill throttles against Yahoo's shared
+    /// limiter. The remainder is reported (<see cref="PendingSplitSelection.Skipped"/>) rather than
+    /// silently dropped — it is picked up on a later cycle. A non-positive cap selects all.
+    /// </summary>
+    public async Task<PendingSplitSelection> SelectPendingStocks(int maxPerCycle)
+    {
+        var pendingStockIds = await _splitRepository
+            .GetPendingPriceAdjustment()
+            .Select(s => s.CommonStockId)
+            .Distinct()
+            .OrderBy(id => id)
+            .ToListAsync();
+
+        var selected =
+            maxPerCycle > 0 ? pendingStockIds.Take(maxPerCycle).ToList() : pendingStockIds;
+
+        return new PendingSplitSelection(
+            selected,
+            pendingStockIds.Count,
+            pendingStockIds.Count - selected.Count
+        );
+    }
+
+    /// <summary>
+    /// Stamps every currently-unreconciled split for the stock as applied at
+    /// <paramref name="appliedTime"/>. Idempotent: already-stamped splits are untouched, so a
+    /// second pass over the same stock stamps nothing. Returns how many splits were stamped.
+    /// </summary>
+    public async Task<int> StampApplied(Guid commonStockId, DateTime appliedTime)
+    {
+        var pending = await _splitRepository
+            .GetByStock(commonStockId)
+            .Where(s => s.PriceAdjustmentAppliedTime == null)
+            .ToListAsync();
+
+        if (pending.Count == 0)
+            return 0;
+
+        foreach (var split in pending)
+            split.PriceAdjustmentAppliedTime = appliedTime;
+
+        await _splitRepository.SaveChanges();
+        return pending.Count;
+    }
+}

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
@@ -57,6 +58,13 @@ public class YahooPriceImportService
         _logger.LogInformation("Starting Yahoo price sync for {Count} stocks", tickerMap.Count);
 
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        // Before the forward-only incremental append: reconcile any stock whose stored history is
+        // on a pre-split basis. GetSyncStartDate only appends, so a split that landed after the
+        // last sync leaves the old rows on the wrong basis (a discontinuity in the series). Re-pull
+        // those stocks' full, fully-adjusted history and overwrite the stored rows (#2879).
+        await ReconcilePendingSplits(today, cancellationToken);
+
         var totalInserted = 0;
 
         foreach (var (ticker, commonStockId) in tickerMap)
@@ -90,6 +98,254 @@ public class YahooPriceImportService
             "Yahoo price sync complete. Inserted {Count} new price records",
             totalInserted
         );
+    }
+
+    // Re-syncs the full price history of every stock that has an unreconciled split, capped per
+    // cycle. Yahoo serves the whole history already split-adjusted, so the fix is to overwrite the
+    // stored rows with a fresh pull rather than doing ratio arithmetic — self-healing, since the
+    // next split re-marks the stock pending and re-syncs it again (#2879).
+    private async Task ReconcilePendingSplits(DateOnly today, CancellationToken cancellationToken)
+    {
+        PendingSplitSelection selection;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var manager =
+                scope.ServiceProvider.GetRequiredService<SplitPriceReconciliationManager>();
+            selection = await manager.SelectPendingStocks(
+                _workerOptions.MaxSplitPriceReconciliationsPerCycle
+            );
+        }
+
+        if (selection.StockIds.Count == 0)
+            return;
+
+        _logger.LogInformation(
+            "Re-syncing split-adjusted price history for {Count} stock(s) with pending splits",
+            selection.StockIds.Count
+        );
+        if (selection.Skipped > 0)
+            _logger.LogInformation(
+                "{Remaining} more stock(s) with pending splits exceed the per-cycle cap "
+                    + "and will be reconciled on a later cycle",
+                selection.Skipped
+            );
+
+        var tickers = await ResolveTickers(selection.StockIds, cancellationToken);
+        var floor = _workerOptions.MinSyncDate.HasValue
+            ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
+            : new DateOnly(2020, 1, 1);
+
+        foreach (var commonStockId in selection.StockIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!tickers.TryGetValue(commonStockId, out var ticker))
+            {
+                _logger.LogWarning(
+                    "No ticker resolved for stock {StockId} with a pending split; leaving it pending",
+                    commonStockId
+                );
+                continue;
+            }
+
+            try
+            {
+                await ReconcileStock(ticker, commonStockId, floor, today, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to fetch split-adjusted history for {Ticker}; leaving its split(s) pending",
+                    ticker
+                );
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error reconciling split-adjusted history for {Ticker}",
+                    ticker
+                );
+                await _errorReporter.Report(
+                    ErrorSource.YahooPriceScraper,
+                    $"ReconcilePendingSplits({ticker})",
+                    ex.Message,
+                    ex.StackTrace
+                );
+            }
+        }
+    }
+
+    private async Task<Dictionary<Guid, string>> ResolveTickers(
+        IReadOnlyList<Guid> stockIds,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        return await stockRepo
+            .GetByIds(stockIds)
+            .ToDictionaryAsync(s => s.Id, s => s.Ticker, cancellationToken);
+    }
+
+    private async Task ReconcileStock(
+        string ticker,
+        Guid commonStockId,
+        DateOnly floor,
+        DateOnly today,
+        CancellationToken cancellationToken
+    )
+    {
+        var chartData = await _yahooClient.GetChart(ticker, floor, today);
+
+        // A delisted/unresolved ticker returns no prices. Do NOT wipe the existing series in that
+        // case — leave the split pending so a later run or another source can handle it.
+        if (chartData.Prices.Count == 0)
+        {
+            _logger.LogWarning(
+                "Yahoo returned no prices for {Ticker}; keeping existing rows and leaving its split(s) pending",
+                ticker
+            );
+            return;
+        }
+
+        var replaced = await ReplaceStoredPrices(
+            ticker,
+            commonStockId,
+            floor,
+            today,
+            chartData.Prices,
+            cancellationToken
+        );
+        if (!replaced)
+            return;
+
+        // Refresh the authoritative current share count + market cap by refetch, not arithmetic —
+        // this is #2879's shares-outstanding requirement.
+        await SyncKeyStatistics(ticker, commonStockId, cancellationToken);
+
+        using var scope = _scopeFactory.CreateScope();
+        var manager = scope.ServiceProvider.GetRequiredService<SplitPriceReconciliationManager>();
+        var stamped = await manager.StampApplied(commonStockId, DateTime.UtcNow);
+        _logger.LogInformation(
+            "Reconciled {Ticker}: replaced stored price history and stamped {Count} split(s) applied",
+            ticker,
+            stamped
+        );
+    }
+
+    // Transactionally swaps a stock's stored rows in [floor, today] for the fresh fully-adjusted
+    // series. Returns false without touching the stored rows when there is nothing usable to store
+    // (all rows overflowed the numeric ceiling, or the parent CommonStock was removed) so a stock
+    // is never left with an empty series.
+    private async Task<bool> ReplaceStoredPrices(
+        string ticker,
+        Guid commonStockId,
+        DateOnly floor,
+        DateOnly today,
+        List<HistoricalPrice> prices,
+        CancellationToken cancellationToken
+    )
+    {
+        var freshRows = MapFreshRows(commonStockId, prices, ticker);
+        if (freshRows.Count == 0)
+        {
+            _logger.LogWarning(
+                "No storable prices for {Ticker} after the numeric range guard; keeping existing rows",
+                ticker
+            );
+            return false;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        // Same GH-1591 guard as the incremental flush: the parent CommonStock can be removed
+        // between selection and now, which would trip the FK on insert.
+        var stockExists = await stockRepo.GetAll().AnyAsync(s => s.Id == commonStockId, cancellationToken);
+        if (!stockExists)
+        {
+            _logger.LogWarning(
+                "Skipping reconcile for CommonStock {Id}: parent row was removed",
+                commonStockId
+            );
+            return false;
+        }
+
+        var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+        await ReplacePriceRows(repo, commonStockId, floor, today, freshRows, cancellationToken);
+        return true;
+    }
+
+    // The transactional core of the replacement: delete the stock's rows in [floor, today], then
+    // bulk-insert the fresh rows in batches, all in one transaction so the stock is never left with
+    // a partial series on failure. Takes the repo so it is unit-testable without a live worker.
+    private static async Task ReplacePriceRows(
+        DailyStockPriceRepository repo,
+        Guid commonStockId,
+        DateOnly floor,
+        DateOnly today,
+        List<DailyStockPrice> freshRows,
+        CancellationToken cancellationToken
+    )
+    {
+        // Never delete the stored series when there is nothing to replace it with. The caller
+        // already guards empty fetches upstream; keeping the invariant local too means the
+        // transaction (and its delete) is never opened for an empty replacement.
+        if (freshRows.Count == 0)
+            return;
+
+        await using var transaction = await repo.CreateTransaction(
+            IsolationLevel.ReadCommitted,
+            cancellationToken
+        );
+        try
+        {
+            var existing = await repo.GetByStocks([commonStockId], floor, today)
+                .ToListAsync(cancellationToken);
+            if (existing.Count > 0)
+            {
+                repo.Delete(existing);
+                await repo.SaveChanges();
+            }
+
+            foreach (var batch in freshRows.Chunk(InsertBatchSize))
+            {
+                repo.AddRange(batch);
+                await repo.SaveChanges();
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+
+    private List<DailyStockPrice> MapFreshRows(
+        Guid commonStockId,
+        List<HistoricalPrice> prices,
+        string ticker
+    )
+    {
+        var overflowDates = WarnAndCollectOverflowDates(prices, ticker);
+        return prices
+            .Where(p => !overflowDates.Contains(p.Date))
+            .Select(p => new DailyStockPrice
+            {
+                CommonStockId = commonStockId,
+                Date = p.Date,
+                Open = p.Open,
+                High = p.High,
+                Low = p.Low,
+                Close = p.Close,
+                AdjustedClose = p.AdjustedClose,
+                Volume = p.Volume,
+            })
+            .ToList();
     }
 
     private async Task<int> ImportTicker(
@@ -139,21 +395,8 @@ public class YahooPriceImportService
             cancellationToken
         );
 
-        var overflowDates = WarnAndCollectOverflowDates(prices, ticker);
-
-        var newPrices = prices
-            .Where(p => !existingDates.Contains(p.Date) && !overflowDates.Contains(p.Date))
-            .Select(p => new DailyStockPrice
-            {
-                CommonStockId = commonStockId,
-                Date = p.Date,
-                Open = p.Open,
-                High = p.High,
-                Low = p.Low,
-                Close = p.Close,
-                AdjustedClose = p.AdjustedClose,
-                Volume = p.Volume,
-            })
+        var newPrices = MapFreshRows(commonStockId, prices, ticker)
+            .Where(p => !existingDates.Contains(p.Date))
             .ToList();
 
         if (newPrices.Count == 0)

--- a/tests/Equibles.UnitTests/CorporateActions/SplitPriceReconciliationManagerSelectionTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/SplitPriceReconciliationManagerSelectionTests.cs
@@ -1,0 +1,103 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CorporateActions.BusinessLogic;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.CorporateActions;
+
+/// <summary>
+/// Pins the selection half of <see cref="SplitPriceReconciliationManager"/>: the price
+/// back-adjustment pass must pick the DISTINCT stocks that still have an unreconciled split
+/// (PriceAdjustmentAppliedTime == null), cap how many it takes per cycle so the universe backfill
+/// throttles against Yahoo's shared limiter, and report the remainder rather than dropping it.
+/// </summary>
+public class SplitPriceReconciliationManagerSelectionTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static StockSplit PendingSplit(Guid stockId, DateOnly effective) =>
+        new()
+        {
+            CommonStockId = stockId,
+            EffectiveDate = effective,
+            Numerator = 2m,
+            Denominator = 1m,
+            Source = StockSplitSource.Yahoo,
+            PriceAdjustmentAppliedTime = null,
+        };
+
+    [Fact]
+    public async Task SelectPendingStocks_ReturnsEachPendingStockOnce()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        // Two pending splits on the SAME stock must collapse to a single selected stock id.
+        db.AddRange(
+            PendingSplit(stockId, new DateOnly(2021, 1, 4)),
+            PendingSplit(stockId, new DateOnly(2024, 6, 10))
+        );
+        await db.SaveChangesAsync();
+
+        var manager = new SplitPriceReconciliationManager(new StockSplitRepository(db));
+
+        var selection = await manager.SelectPendingStocks(50);
+
+        selection.StockIds.Should().ContainSingle().Which.Should().Be(stockId);
+        selection.TotalPending.Should().Be(1);
+        selection.Skipped.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SelectPendingStocks_CapsSelectionAndReportsRemainder()
+    {
+        await using var db = NewDb();
+        for (var i = 0; i < 5; i++)
+            db.Add(PendingSplit(Guid.NewGuid(), new DateOnly(2024, 1, 1)));
+        await db.SaveChangesAsync();
+
+        var manager = new SplitPriceReconciliationManager(new StockSplitRepository(db));
+
+        var selection = await manager.SelectPendingStocks(2);
+
+        selection.StockIds.Should().HaveCount(2);
+        selection.TotalPending.Should().Be(5);
+        selection.Skipped.Should().Be(3); // 5 pending - 2 taken = 3 deferred, not dropped
+    }
+
+    [Fact]
+    public async Task SelectPendingStocks_IgnoresAlreadyReconciledSplits()
+    {
+        await using var db = NewDb();
+        var stampedOnly = Guid.NewGuid();
+        var stamped = PendingSplit(stampedOnly, new DateOnly(2023, 1, 1));
+        stamped.PriceAdjustmentAppliedTime = DateTime.UtcNow;
+        db.Add(stamped);
+        await db.SaveChangesAsync();
+
+        var manager = new SplitPriceReconciliationManager(new StockSplitRepository(db));
+
+        var selection = await manager.SelectPendingStocks(50);
+
+        selection.StockIds.Should().BeEmpty();
+        selection.TotalPending.Should().Be(0);
+    }
+}

--- a/tests/Equibles.UnitTests/CorporateActions/SplitPriceReconciliationManagerStampingTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/SplitPriceReconciliationManagerStampingTests.cs
@@ -1,0 +1,92 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CorporateActions.BusinessLogic;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.CorporateActions;
+
+/// <summary>
+/// Pins the stamping half of <see cref="SplitPriceReconciliationManager"/>: once a stock's prices
+/// have been re-synced, EVERY pending split for that stock is stamped applied, and the operation is
+/// idempotent — a second pass selects and stamps nothing, so a reconciled split is never reprocessed.
+/// </summary>
+public class SplitPriceReconciliationManagerStampingTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static StockSplit PendingSplit(Guid stockId, DateOnly effective) =>
+        new()
+        {
+            CommonStockId = stockId,
+            EffectiveDate = effective,
+            Numerator = 2m,
+            Denominator = 1m,
+            Source = StockSplitSource.Yahoo,
+            PriceAdjustmentAppliedTime = null,
+        };
+
+    [Fact]
+    public async Task StampApplied_StampsAllPendingSplitsForTheStock()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var other = Guid.NewGuid();
+        db.AddRange(
+            PendingSplit(stockId, new DateOnly(2021, 1, 4)),
+            PendingSplit(stockId, new DateOnly(2024, 6, 10)),
+            PendingSplit(other, new DateOnly(2022, 1, 1)) // a different stock stays untouched
+        );
+        await db.SaveChangesAsync();
+
+        var appliedTime = new DateTime(2026, 6, 30, 12, 0, 0, DateTimeKind.Utc);
+        var manager = new SplitPriceReconciliationManager(new StockSplitRepository(db));
+
+        var stamped = await manager.StampApplied(stockId, appliedTime);
+
+        stamped.Should().Be(2);
+        var repo = new StockSplitRepository(db);
+        (await repo.GetByStock(stockId).ToListAsync())
+            .Should()
+            .OnlyContain(s => s.PriceAdjustmentAppliedTime == appliedTime);
+        (await repo.GetByStock(other).ToListAsync())
+            .Should()
+            .OnlyContain(s => s.PriceAdjustmentAppliedTime == null);
+    }
+
+    [Fact]
+    public async Task StampApplied_IsIdempotent_SecondPassStampsNothingAndSelectsNothing()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        db.Add(PendingSplit(stockId, new DateOnly(2024, 6, 10)));
+        await db.SaveChangesAsync();
+
+        var manager = new SplitPriceReconciliationManager(new StockSplitRepository(db));
+
+        var first = await manager.StampApplied(stockId, DateTime.UtcNow);
+        var second = await manager.StampApplied(stockId, DateTime.UtcNow);
+
+        first.Should().Be(1);
+        second.Should().Be(0); // already reconciled — nothing left to stamp
+        (await manager.SelectPendingStocks(50)).StockIds.Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReplacePriceRowsTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReplacePriceRowsTests.cs
@@ -1,0 +1,154 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data;
+using Equibles.Data;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.HostedService.Services;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Pins <see cref="YahooPriceImportService.ReplacePriceRows"/>, the transactional core of the split
+/// back-adjustment pass: it swaps a stock's stored rows in [floor, today] for the fresh
+/// fully-adjusted series, leaves rows outside that window alone, and — crucially — never deletes the
+/// stored series when the fetch came back empty (a delisted/unresolved ticker), so the split stays
+/// pending for a later run (#2879).
+/// </summary>
+public class YahooPriceImportServiceReplacePriceRowsTests
+{
+    private static readonly DateOnly Floor = new(2020, 1, 1);
+    private static readonly DateOnly Today = new(2026, 6, 30);
+
+    private static readonly MethodInfo ReplacePriceRowsMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "ReplacePriceRows",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static Task ReplacePriceRows(
+        DailyStockPriceRepository repo,
+        Guid commonStockId,
+        DateOnly floor,
+        DateOnly today,
+        List<DailyStockPrice> freshRows
+    ) =>
+        (Task)
+            ReplacePriceRowsMethod.Invoke(
+                null,
+                [repo, commonStockId, floor, today, freshRows, CancellationToken.None]
+            );
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            // The in-memory provider has no real transactions; ReplacePriceRows opens one, so tell
+            // EF the ignored-transaction warning is expected rather than throwing.
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new YahooModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static DailyStockPrice Row(Guid stockId, DateOnly date, decimal close) =>
+        new()
+        {
+            CommonStockId = stockId,
+            Date = date,
+            Open = close,
+            High = close,
+            Low = close,
+            Close = close,
+            AdjustedClose = close,
+            Volume = 1000,
+        };
+
+    [Fact]
+    public async Task ReplacePriceRows_SwapsWindowRowsForTheFreshSeries()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        // Pre-split stored rows carry the old basis (close 400).
+        db.AddRange(
+            Row(stockId, new DateOnly(2024, 1, 2), 400m),
+            Row(stockId, new DateOnly(2024, 1, 3), 404m)
+        );
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        // Fresh fully-adjusted series (10:1 split -> close 40) plus a new day.
+        var fresh = new List<DailyStockPrice>
+        {
+            Row(stockId, new DateOnly(2024, 1, 2), 40m),
+            Row(stockId, new DateOnly(2024, 1, 3), 40.4m),
+            Row(stockId, new DateOnly(2024, 1, 4), 41m),
+        };
+
+        await ReplacePriceRows(new DailyStockPriceRepository(db), stockId, Floor, Today, fresh);
+
+        db.ChangeTracker.Clear();
+        var stored = await db.Set<DailyStockPrice>()
+            .Where(p => p.CommonStockId == stockId)
+            .OrderBy(p => p.Date)
+            .ToListAsync();
+        stored.Should().HaveCount(3);
+        stored.Select(p => p.Close).Should().Equal(40m, 40.4m, 41m); // old 400/404 basis gone
+    }
+
+    [Fact]
+    public async Task ReplacePriceRows_LeavesRowsOutsideTheWindowUntouched()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        // A row before the floor must survive the replacement of the [floor, today] window.
+        db.Add(Row(stockId, new DateOnly(2019, 6, 1), 10m));
+        db.Add(Row(stockId, new DateOnly(2024, 1, 2), 400m));
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var fresh = new List<DailyStockPrice> { Row(stockId, new DateOnly(2024, 1, 2), 40m) };
+
+        await ReplacePriceRows(new DailyStockPriceRepository(db), stockId, Floor, Today, fresh);
+
+        db.ChangeTracker.Clear();
+        var dates = await db.Set<DailyStockPrice>()
+            .Where(p => p.CommonStockId == stockId)
+            .Select(p => p.Date)
+            .OrderBy(d => d)
+            .ToListAsync();
+        dates.Should().Equal(new DateOnly(2019, 6, 1), new DateOnly(2024, 1, 2));
+    }
+
+    [Fact]
+    public async Task ReplacePriceRows_EmptyFreshSeries_DeletesNothing()
+    {
+        // Delisted/unresolved ticker: Yahoo returned no prices. The guard must keep the existing
+        // rows rather than wiping the series to empty, so the split can stay pending for a later run.
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        db.AddRange(
+            Row(stockId, new DateOnly(2024, 1, 2), 400m),
+            Row(stockId, new DateOnly(2024, 1, 3), 404m)
+        );
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        await ReplacePriceRows(new DailyStockPriceRepository(db), stockId, Floor, Today, []);
+
+        db.ChangeTracker.Clear();
+        var count = await db.Set<DailyStockPrice>().CountAsync(p => p.CommonStockId == stockId);
+        count.Should().Be(2); // existing rows preserved
+    }
+}


### PR DESCRIPTION
## Summary

Stored price history was never back-adjusted across splits. `GetSyncStartDate` returns `latestStoredDate + 1`, so the Yahoo importer only appended forward and never rewrote old rows. When a split landed, the pre-split rows kept the old basis, producing a discontinuity in the stored series that breaks charts and every close-based indicator (#2879).

Yahoo already serves the whole history split-adjusted, so the fix re-pulls the full history for any stock with an unreconciled split and overwrites the stored rows — no ratio arithmetic. Self-healing: the next split re-marks the stock pending (`StockSplitCaptureManager` clears `PriceAdjustmentAppliedTime`) and it re-syncs again.

## Code changes

- **`SplitPriceReconciliationManager`** (new, `Equibles.CorporateActions.BusinessLogic`, `[Service]`) — owns the split-side data ops so they are unit-testable without a live worker and kept off the repository:
  - `SelectPendingStocks(maxPerCycle)` → distinct stocks with an unreconciled split, capped, with the deferred remainder reported (`PendingSplitSelection`).
  - `StampApplied(stockId, appliedTime)` → stamps every pending split for the stock; idempotent.
- **`WorkerOptions.MaxSplitPriceReconciliationsPerCycle`** (new, default `50`) — caps reconciliations per cycle so the one-time universe backfill throttles against Yahoo's shared limiter; the over-cap remainder is logged, not dropped.
- **`YahooPriceImportService`** — new `ReconcilePendingSplits` pass at the start of `Import` (before the incremental loop). Per selected stock: resolve ticker, fetch full history `GetChart(ticker, floor, today)` where `floor = MinSyncDate ?? 2020-01-01`, transactionally replace the stored rows in `[floor, today]` (begin tx → delete window → batch-insert fresh → commit; rollback on failure), refresh shares outstanding + market cap via `SyncKeyStatistics`, then stamp the splits applied. The incremental/append path is unchanged.

## Behavior notes

- **Transactional replacement** — delete + batched insert run in one `ReadCommitted` transaction on a single context; on exception it rolls back, so a stock is never left with a partial or empty series. Rows outside `[floor, today]` are untouched.
- **Delisted / empty-fetch guard** — if the fetch returns no prices, the existing rows are kept and the split is left pending (no stamp), so a later run or another source can handle it.

## Tests

8 new unit tests (xUnit, in-memory EF): distinct selection + per-cycle cap + reported remainder; stamping marks all pending splits and is idempotent on a second pass; transactional replacement swaps the window and preserves out-of-window rows; empty-fetch guard deletes nothing.

closes #2879