### PR TITLE
feat(corporate-actions): split-adjust MCP holdings/short/insider tools and short-squeeze score

### DIFF
--- a/src/Equibles.CorporateActions.Data/SplitAdjustment.cs
+++ b/src/Equibles.CorporateActions.Data/SplitAdjustment.cs
@@ -31,6 +31,31 @@ public static class SplitAdjustment
     }
 
     /// <summary>
+    /// Restates a share COUNT observed as-of <paramref name="asOf"/> onto today's
+    /// basis by multiplying it by <see cref="ShareCountFactor"/> and rounding to the
+    /// nearest whole share. A no-op (returns <paramref name="count"/> unchanged) when
+    /// the factor is 1 — i.e. the stock has no splits after <paramref name="asOf"/> —
+    /// so an unsplit stock is never perturbed by rounding.
+    /// </summary>
+    public static long AdjustShareCount(
+        long count,
+        DateOnly asOf,
+        IEnumerable<StockSplit> splits
+    ) => AdjustShareCount(count, ShareCountFactor(asOf, splits));
+
+    /// <summary>
+    /// Restates a share COUNT by an already-computed <paramref name="shareCountFactor"/>
+    /// (see <see cref="ShareCountFactor"/>), rounding to the nearest whole share. A no-op
+    /// when the factor is 1. Sign is preserved, so a negative count (e.g. a change/delta)
+    /// restates correctly. Kept as a separate overload so callers that render many rows for
+    /// a single as-of date compute the factor once and reuse it.
+    /// </summary>
+    public static long AdjustShareCount(long count, decimal shareCountFactor) =>
+        shareCountFactor == 1m
+            ? count
+            : (long)Math.Round(count * shareCountFactor, MidpointRounding.AwayFromZero);
+
+    /// <summary>
     /// Factor that converts a PRICE observed as-of <paramref name="asOf"/> onto
     /// today's basis — the inverse of <see cref="ShareCountFactor"/>, since a
     /// split moves price opposite to share count. Returns 1 when the share-count

--- a/src/Equibles.Finra.BusinessLogic/Equibles.Finra.BusinessLogic.csproj
+++ b/src/Equibles.Finra.BusinessLogic/Equibles.Finra.BusinessLogic.csproj
@@ -6,5 +6,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Finra.Repositories\Equibles.Finra.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -1,5 +1,8 @@
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic.Models;
 using Equibles.Finra.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -30,16 +33,19 @@ public class ShortSqueezeScoreManager
     private readonly ShortInterestRepository _shortInterestRepository;
     private readonly DailyShortVolumeRepository _dailyShortVolumeRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
 
     public ShortSqueezeScoreManager(
         ShortInterestRepository shortInterestRepository,
         DailyShortVolumeRepository dailyShortVolumeRepository,
-        CommonStockRepository commonStockRepository
+        CommonStockRepository commonStockRepository,
+        StockSplitRepository stockSplitRepository
     )
     {
         _shortInterestRepository = shortInterestRepository;
         _dailyShortVolumeRepository = dailyShortVolumeRepository;
         _commonStockRepository = commonStockRepository;
+        _stockSplitRepository = stockSplitRepository;
     }
 
     public async Task<List<ShortSqueezeScore>> Compute(
@@ -88,6 +94,20 @@ public class ShortSqueezeScoreManager
 
         var trends = await LoadShortVolumeTrends(stockIds, settlementDate, cancellationToken);
 
+        // Load every scored stock's splits once so the short position — a share COUNT
+        // observed as-of the settlement date — can be restated onto today's basis before
+        // it is divided by the CURRENT shares outstanding. Without this a stock that split
+        // after the settlement date reports a short-interest-percent-of-shares off by the
+        // split factor (e.g. a 10:1 split makes the raw ratio 10× too small).
+        var splitsByStock = (
+            await _stockSplitRepository
+                .GetAll()
+                .Where(s => stockIds.Contains(s.CommonStockId))
+                .ToListAsync(cancellationToken)
+        )
+            .GroupBy(s => s.CommonStockId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<StockSplit>)g.ToList());
+
         var scores = new List<ShortSqueezeScore>();
         foreach (var shortInterest in shortInterests)
         {
@@ -118,8 +138,12 @@ public class ShortSqueezeScoreManager
                     CommonStockId = stock.Id,
                     Ticker = stock.Ticker,
                     SettlementDate = settlementDate,
-                    ShortInterestPercentOfShares =
-                        shortInterest.CurrentShortPosition / (decimal)stock.SharesOutStanding,
+                    ShortInterestPercentOfShares = ShortInterestPercentOfShares(
+                        shortInterest.CurrentShortPosition,
+                        stock.SharesOutStanding,
+                        settlementDate,
+                        splitsByStock.TryGetValue(stock.Id, out var stockSplits) ? stockSplits : []
+                    ),
                     DaysToCover = daysToCover,
                     // TryGetValue, not GetValueOrDefault: a stock with no volume data
                     // must carry a null trend (factor drops out), never a zero trend.
@@ -180,6 +204,25 @@ public class ShortSqueezeScoreManager
         }
 
         return trends;
+    }
+
+    /// <summary>
+    /// Short interest as a fraction of shares outstanding, with the short position
+    /// restated onto today's split basis first. The short position is a share COUNT
+    /// as-of <paramref name="settlementDate"/>; the shares-outstanding denominator is
+    /// the CURRENT count, so the two must sit on the same basis before dividing. When
+    /// the stock has no splits after the settlement date the factor is 1 and the ratio
+    /// is unchanged.
+    /// </summary>
+    private static decimal ShortInterestPercentOfShares(
+        long currentShortPosition,
+        long sharesOutstanding,
+        DateOnly settlementDate,
+        IReadOnlyList<StockSplit> splits
+    )
+    {
+        var factor = SplitAdjustment.ShareCountFactor(settlementDate, splits);
+        return currentShortPosition * factor / sharesOutstanding;
     }
 
     private static void ApplyPercentiles(List<ShortSqueezeScore> scores)

--- a/src/Equibles.Finra.Mcp/Equibles.Finra.Mcp.csproj
+++ b/src/Equibles.Finra.Mcp/Equibles.Finra.Mcp.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\Equibles.Finra.Repositories\Equibles.Finra.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Finra.BusinessLogic\Equibles.Finra.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
   </ItemGroup>

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -24,6 +27,7 @@ public class ShortDataTools
     private readonly ShortInterestRepository _shortInterestRepository;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly ShortSqueezeScoreManager _shortSqueezeScoreManager;
+    private readonly StockSplitRepository _stockSplitRepository;
     private readonly McpToolRunner _runner;
 
     public ShortDataTools(
@@ -31,6 +35,7 @@ public class ShortDataTools
         ShortInterestRepository shortInterestRepository,
         CommonStockRepository commonStockRepository,
         ShortSqueezeScoreManager shortSqueezeScoreManager,
+        StockSplitRepository stockSplitRepository,
         ErrorManager errorManager,
         ILogger<ShortDataTools> logger
     )
@@ -39,6 +44,7 @@ public class ShortDataTools
         _shortInterestRepository = shortInterestRepository;
         _commonStockRepository = commonStockRepository;
         _shortSqueezeScoreManager = shortSqueezeScoreManager;
+        _stockSplitRepository = stockSplitRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -80,13 +86,24 @@ public class ShortDataTools
                     .Take(maxResults)
                     .ToListAsync();
 
+                // Restate each day's volumes onto today's split basis so the series is
+                // continuous across a split (a raw pre-split day would otherwise show a
+                // phantom step against post-split days). The same-day Short % is a ratio of
+                // two counts on the same date, so it is split-invariant and left as-is.
+                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+
                 return MarkdownTable.Render(
                     records.OrderBy(r => r.Date).ToList(),
                     $"No short volume data found for {stock.Ticker} in the specified date range.",
                     $"Daily short volume for {stock.Ticker} ({stock.Name}):",
                     "| Date | Short Volume | Exempt | Total Volume | Short % |",
                     "|------|-------------|--------|-------------|---------|",
-                    r => RenderShortVolumeRow($"{r.Date:yyyy-MM-dd}", r)
+                    r =>
+                        RenderShortVolumeRow(
+                            $"{r.Date:yyyy-MM-dd}",
+                            r,
+                            SplitAdjustment.ShareCountFactor(r.Date, splits)
+                        )
                 );
             },
             "GetShortVolume",
@@ -132,13 +149,25 @@ public class ShortDataTools
                     .Take(maxResults)
                     .ToListAsync();
 
+                // Restate each settlement's share counts (short position, change, average
+                // daily volume) onto today's split basis so the series is continuous across a
+                // split. Days to cover is a same-settlement ratio (position ÷ ADV) and is left
+                // as reported — restating the numerator and denominator by the same factor
+                // leaves it unchanged anyway.
+                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+
                 return MarkdownTable.Render(
                     records.OrderBy(r => r.SettlementDate).ToList(),
                     $"No short interest data found for {stock.Ticker} in the specified date range.",
                     $"Short interest for {stock.Ticker} ({stock.Name}):",
                     "| Settlement Date | Short Position | Change | Avg Daily Volume | Days to Cover |",
                     "|----------------|---------------|--------|-----------------|---------------|",
-                    r => RenderShortInterestRow($"{r.SettlementDate:yyyy-MM-dd}", r)
+                    r =>
+                        RenderShortInterestRow(
+                            $"{r.SettlementDate:yyyy-MM-dd}",
+                            r,
+                            SplitAdjustment.ShareCountFactor(r.SettlementDate, splits)
+                        )
                 );
             },
             "GetShortInterest",
@@ -244,21 +273,45 @@ public class ShortDataTools
     }
 
     // Render with InvariantCulture so the MCP markdown does not fork the separators by host
-    // locale (e.g. de-DE would render 5.000.000 / 62,5%).
-    private static string RenderShortVolumeRow(string leadCell, DailyShortVolume r)
+    // locale (e.g. de-DE would render 5.000.000 / 62,5%). `shareFactor` restates the volume
+    // counts onto today's split basis (1 = no adjustment, the single-date snapshot tools).
+    private static string RenderShortVolumeRow(
+        string leadCell,
+        DailyShortVolume r,
+        decimal shareFactor = 1m
+    )
     {
+        // Short % is computed from raw counts — it is a same-day ratio and split-invariant,
+        // so the factor cancels; adjusting only the displayed absolute volumes.
         var shortPct = r.TotalVolume > 0 ? (double)r.ShortVolume / r.TotalVolume * 100 : 0;
-        return $"| {leadCell} | {McpFormat.WholeNumber(r.ShortVolume)} | {McpFormat.WholeNumber(r.ShortExemptVolume)} | {McpFormat.WholeNumber(r.TotalVolume)} | {McpFormat.Invariant(shortPct, "F1")}% |";
+        var shortVolume = SplitAdjustment.AdjustShareCount(r.ShortVolume, shareFactor);
+        var exemptVolume = SplitAdjustment.AdjustShareCount(r.ShortExemptVolume, shareFactor);
+        var totalVolume = SplitAdjustment.AdjustShareCount(r.TotalVolume, shareFactor);
+        return $"| {leadCell} | {McpFormat.WholeNumber(shortVolume)} | {McpFormat.WholeNumber(exemptVolume)} | {McpFormat.WholeNumber(totalVolume)} | {McpFormat.Invariant(shortPct, "F1")}% |";
     }
 
     // Render with InvariantCulture so the MCP markdown does not fork the separators by host
-    // locale (e.g. de-DE would render 1.234.567 / 12,3).
-    private static string RenderShortInterestRow(string leadCell, ShortInterest r)
+    // locale (e.g. de-DE would render 1.234.567 / 12,3). `shareFactor` restates the share
+    // counts onto today's split basis (1 = no adjustment, the single-date snapshot tools).
+    private static string RenderShortInterestRow(
+        string leadCell,
+        ShortInterest r,
+        decimal shareFactor = 1m
+    )
     {
-        var changeStr = FormatSignedChange(r.ChangeInShortPosition);
-        var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
+        var position = SplitAdjustment.AdjustShareCount(r.CurrentShortPosition, shareFactor);
+        var changeStr = FormatSignedChange(
+            SplitAdjustment.AdjustShareCount(r.ChangeInShortPosition, shareFactor)
+        );
+        // Average daily volume is a share count as-of the settlement; restate it too so the
+        // row stays self-consistent (position ÷ ADV still reconciles to Days to Cover).
+        var adv = r.AverageDailyVolume.HasValue
+            ? SplitAdjustment.AdjustShareCount(r.AverageDailyVolume.Value, shareFactor)
+            : (long?)null;
+        var advStr = McpFormat.OrDash(adv, "N0");
+        // Days to cover is a same-settlement ratio — left as reported (split-invariant).
         var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
-        return $"| {leadCell} | {McpFormat.WholeNumber(r.CurrentShortPosition)} | {changeStr} | {advStr} | {dtcStr} |";
+        return $"| {leadCell} | {McpFormat.WholeNumber(position)} | {changeStr} | {advStr} | {dtcStr} |";
     }
 
     private static string FormatSignedChange(long change) =>

--- a/src/Equibles.Holdings.Mcp/Equibles.Holdings.Mcp.csproj
+++ b/src/Equibles.Holdings.Mcp/Equibles.Holdings.Mcp.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\Equibles.Holdings.BusinessLogic\Equibles.Holdings.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Holdings.Repositories\Equibles.Holdings.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -5,6 +5,9 @@ using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -44,12 +47,14 @@ public class InstitutionalHoldingsTools
     private readonly InstitutionalHoldingRepository _holdingRepository;
     private readonly InstitutionalHolderRepository _holderRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
     private readonly McpToolRunner _runner;
 
     public InstitutionalHoldingsTools(
         InstitutionalHoldingRepository holdingRepository,
         InstitutionalHolderRepository holderRepository,
         CommonStockRepository commonStockRepository,
+        StockSplitRepository stockSplitRepository,
         ErrorManager errorManager,
         ILogger<InstitutionalHoldingsTools> logger
     )
@@ -57,6 +62,7 @@ public class InstitutionalHoldingsTools
         _holdingRepository = holdingRepository;
         _holderRepository = holderRepository;
         _commonStockRepository = commonStockRepository;
+        _stockSplitRepository = stockSplitRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -103,6 +109,12 @@ public class InstitutionalHoldingsTools
                 if (holdings.Count == 0)
                     return $"No institutional holdings found for {ticker} as of {FormatDate(targetDate)}.";
 
+                // All rows share the target report date, so a single factor restates every
+                // share count onto today's basis (matching the web). The % of Total is a
+                // same-date ratio and is split-invariant (the factor cancels top and bottom).
+                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var shareFactor = SplitAdjustment.ShareCountFactor(targetDate, splits);
+
                 return RenderTopHoldersTable(
                     stock,
                     ticker,
@@ -110,7 +122,8 @@ public class InstitutionalHoldingsTools
                     totalInstitutions,
                     totalSharesAll,
                     totalValueAll,
-                    holdings
+                    holdings,
+                    shareFactor
                 );
             },
             "GetTopHolders",
@@ -125,13 +138,15 @@ public class InstitutionalHoldingsTools
         int totalInstitutions,
         long totalSharesAll,
         long totalValueAll,
-        List<InstitutionalHolding> holdings
+        List<InstitutionalHolding> holdings,
+        decimal shareFactor
     )
     {
+        var adjustedTotalShares = SplitAdjustment.AdjustShareCount(totalSharesAll, shareFactor);
         var result = MarkdownTable.Start(
             $"Top institutional holders of {stock.Name} ({ticker}) as of {FormatDate(targetDate)}:",
             $"Showing {holdings.Count} of {totalInstitutions} institutions. Total: "
-                + $"{McpFormat.WholeNumber(totalSharesAll)} shares, "
+                + $"{McpFormat.WholeNumber(adjustedTotalShares)} shares, "
                 + $"${FormatMillions(totalValueAll)}M value",
             "| # | Institution | Shares | Value ($M) | % of Total |",
             "|---|------------|--------|-----------|-----------|"
@@ -141,9 +156,12 @@ public class InstitutionalHoldingsTools
             holdings,
             (rank, h) =>
             {
+                // Ratio computed from raw shares (split-invariant); only the displayed
+                // absolute share count is restated onto today's basis.
                 var pct = Percentage.Of(h.Shares, totalSharesAll);
+                var adjustedShares = SplitAdjustment.AdjustShareCount(h.Shares, shareFactor);
                 return $"| {rank} | {h.InstitutionalHolder.Name} | "
-                    + $"{McpFormat.WholeNumber(h.Shares)} | "
+                    + $"{McpFormat.WholeNumber(adjustedShares)} | "
                     + $"{FormatMillions(h.Value)} | "
                     + $"{McpFormat.Invariant(pct, "F2")}% |";
             }
@@ -196,11 +214,20 @@ public class InstitutionalHoldingsTools
             "|------------|-------------|-------------|-----------------|--------|"
         );
 
+        // Restate each quarter's total shares onto today's split basis before the
+        // quarter-over-quarter change so a split between two report dates does not read as a
+        // real change in institutional ownership (a 2:1 split would otherwise show +100%).
+        var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+
         long previousShares = 0;
         foreach (var date in reportDates.OrderBy(d => d))
         {
             var holdings = await _holdingRepository.Get13FByStock(stock, date).ToListAsync();
-            var totalShares = holdings.Sum(h => h.Shares);
+            var totalShares = SplitAdjustment.AdjustShareCount(
+                holdings.Sum(h => h.Shares),
+                date,
+                splits
+            );
             var totalValue = holdings.Sum(h => h.Value);
             var institutionCount = holdings.Select(h => h.InstitutionalHolderId).Distinct().Count();
 
@@ -384,17 +411,35 @@ public class InstitutionalHoldingsTools
                 var currentByHolder = AggregateByHolder(currentHoldings);
                 var previousByHolder = AggregateByHolder(previousHoldings);
 
+                // Restate each quarter's share counts onto today's split basis (the two
+                // quarters sit on different bases if a split fell between them) so Δ Shares
+                // and the Prior → New column reflect a real position change, not the split.
+                // Δ Value is a dollar figure and is split-invariant — left as reported.
+                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var currentFactor = SplitAdjustment.ShareCountFactor(targetDate, splits);
+                var previousFactor = previousDate.HasValue
+                    ? SplitAdjustment.ShareCountFactor(previousDate.Value, splits)
+                    : 1m;
+
                 var allHolderIds = currentByHolder.Keys.Union(previousByHolder.Keys);
                 var movers = allHolderIds
                     .Select(id =>
                     {
                         currentByHolder.TryGetValue(id, out var c);
                         previousByHolder.TryGetValue(id, out var p);
+                        var currentShares = SplitAdjustment.AdjustShareCount(
+                            c?.Shares ?? 0,
+                            currentFactor
+                        );
+                        var previousShares = SplitAdjustment.AdjustShareCount(
+                            p?.Shares ?? 0,
+                            previousFactor
+                        );
                         return (
                             Name: c?.Name ?? p?.Name ?? "Unknown",
-                            CurrentShares: c?.Shares ?? 0,
-                            PreviousShares: p?.Shares ?? 0,
-                            DeltaShares: (c?.Shares ?? 0) - (p?.Shares ?? 0),
+                            CurrentShares: currentShares,
+                            PreviousShares: previousShares,
+                            DeltaShares: currentShares - previousShares,
                             DeltaValue: (c?.Value ?? 0) - (p?.Value ?? 0)
                         );
                     })

--- a/src/Equibles.InsiderTrading.Mcp/Equibles.InsiderTrading.Mcp.csproj
+++ b/src/Equibles.InsiderTrading.Mcp/Equibles.InsiderTrading.Mcp.csproj
@@ -7,6 +7,7 @@
     <ProjectReference Include="..\Equibles.Mcp\Equibles.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.InsiderTrading.Repositories\Equibles.InsiderTrading.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -24,6 +27,7 @@ public class InsiderTradingTools
     private readonly InsiderOwnerRepository _ownerRepository;
     private readonly Form144FilingRepository _form144Repository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
     private readonly McpToolRunner _runner;
 
     public InsiderTradingTools(
@@ -31,6 +35,7 @@ public class InsiderTradingTools
         InsiderOwnerRepository ownerRepository,
         Form144FilingRepository form144Repository,
         CommonStockRepository commonStockRepository,
+        StockSplitRepository stockSplitRepository,
         ErrorManager errorManager,
         ILogger<InsiderTradingTools> logger
     )
@@ -39,6 +44,7 @@ public class InsiderTradingTools
         _ownerRepository = ownerRepository;
         _form144Repository = form144Repository;
         _commonStockRepository = commonStockRepository;
+        _stockSplitRepository = stockSplitRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -67,6 +73,11 @@ public class InsiderTradingTools
                     .Take(maxResults)
                     .ToListAsync();
 
+                // Restate the transaction and post-transaction share counts onto today's
+                // split basis so figures are comparable across dates. Value (Shares × Price)
+                // and the per-share Price are split-invariant and computed from raw figures.
+                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+
                 return MarkdownTable.Render(
                     transactions,
                     $"No insider transactions found for {ticker}.",
@@ -86,7 +97,17 @@ public class InsiderTradingTools
                         };
 
                         var value = t.Shares * t.PricePerShare;
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(t.SharesOwnedAfter)} |";
+                        var shares = SplitAdjustment.AdjustShareCount(
+                            t.Shares,
+                            t.TransactionDate,
+                            splits
+                        );
+                        var ownedAfter = SplitAdjustment.AdjustShareCount(
+                            t.SharesOwnedAfter,
+                            t.TransactionDate,
+                            splits
+                        );
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(ownedAfter)} |";
                     }
                 );
             },
@@ -127,18 +148,38 @@ public class InsiderTradingTools
                     .Take(30)
                     .ToListAsync();
 
+                // Each insider's most recent position is reported as-of its own transaction
+                // date, so different rows sit on different split bases; restate them all onto
+                // today's basis and re-rank by the adjusted holding so the ordering is correct.
+                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var ranked = latestTransactions
+                    .OrderByDescending(t =>
+                        SplitAdjustment.AdjustShareCount(
+                            t.SharesOwnedAfter,
+                            t.TransactionDate,
+                            splits
+                        )
+                    )
+                    .ToList();
+
                 return MarkdownTable.Render(
-                    latestTransactions,
+                    ranked,
                     $"No insider ownership data found for {ticker}.",
                     $"Insider ownership summary for {stock.Name} ({ticker}):",
-                    $"Showing {latestTransactions.Count} insiders with most recent data",
+                    $"Showing {ranked.Count} insiders with most recent data",
                     "| Insider | Role | Shares Owned | Last Transaction | Last Date |",
                     "|---------|------|-------------|-----------------|-----------|",
                     t =>
                     {
                         var role = GetRole(t.InsiderOwner);
                         var lastType = t.TransactionCode.ToString();
-                        var sharesOwned = McpFormat.WholeNumber(t.SharesOwnedAfter);
+                        var sharesOwned = McpFormat.WholeNumber(
+                            SplitAdjustment.AdjustShareCount(
+                                t.SharesOwnedAfter,
+                                t.TransactionDate,
+                                splits
+                            )
+                        );
                         return $"| {t.InsiderOwner.Name} | {role} | {sharesOwned} | {lastType} | {t.TransactionDate:yyyy-MM-dd} |";
                     }
                 );
@@ -170,6 +211,11 @@ public class InsiderTradingTools
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
+                // Restate the proposed share count onto today's split basis so notices filed
+                // before a split are comparable with later ones. Aggregate market value is a
+                // dollar figure and is split-invariant — left as reported.
+                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+
                 return MarkdownTable.Render(
                     filings,
                     $"No Form 144 proposed sales found for {ticker}.",
@@ -182,7 +228,12 @@ public class InsiderTradingTools
                         var approxSaleDate =
                             f.ApproxSaleDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
                             ?? "-";
-                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {approxSaleDate} | {f.BrokerName} |";
+                        var sharesToBeSold = SplitAdjustment.AdjustShareCount(
+                            f.SharesToBeSold,
+                            f.FilingDate,
+                            splits
+                        );
+                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(sharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {approxSaleDate} | {f.BrokerName} |";
                     }
                 );
             },

--- a/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data;
@@ -28,7 +29,8 @@ public class ShortSqueezeScoreManagerTests : IDisposable
         _manager = new ShortSqueezeScoreManager(
             new ShortInterestRepository(_dbContext),
             new DailyShortVolumeRepository(_dbContext),
-            new CommonStockRepository(_dbContext)
+            new CommonStockRepository(_dbContext),
+            new StockSplitRepository(_dbContext)
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
@@ -2,6 +2,7 @@ using Equibles.Cboe.Data;
 using Equibles.Cftc.Data;
 using Equibles.CommonStocks.Data;
 using Equibles.Congress.Data;
+using Equibles.CorporateActions.Data;
 using Equibles.Data;
 using Equibles.Errors.Data;
 using Equibles.FdaCatalysts.Data;
@@ -121,6 +122,7 @@ public class ParadeDbFixture : IAsyncLifetime
         IModuleConfiguration[] modules =
         [
             new CommonStocksModuleConfiguration(),
+            new CorporateActionsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),
             new CongressModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Holdings.Data;
 using Equibles.Holdings.Mcp.Tools;
@@ -36,6 +37,7 @@ public class InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests : 
             new InstitutionalHoldingRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
             new CommonStockRepository(_dbContext),
+            new StockSplitRepository(_dbContext),
             errorManager: null,
             NullLogger<InstitutionalHoldingsTools>.Instance
         );

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTradingToolsResolveStockByTickerNormalizationTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTradingToolsResolveStockByTickerNormalizationTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Mcp.Tools;
@@ -34,6 +35,7 @@ public class InsiderTradingToolsResolveStockByTickerNormalizationTests : IDispos
             new InsiderOwnerRepository(_dbContext),
             new Form144FilingRepository(_dbContext),
             new CommonStockRepository(_dbContext),
+            new StockSplitRepository(_dbContext),
             errorManager: null,
             NullLogger<InsiderTradingTools>.Instance
         );

--- a/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Data.Models;
@@ -27,6 +28,7 @@ public class Form144ProposedSalesToolTests : IDisposable
             new InsiderOwnerRepository(_dbContext),
             new Form144FilingRepository(_dbContext),
             new CommonStockRepository(_dbContext),
+            new StockSplitRepository(_dbContext),
             errorManager: null,
             NullLogger<InsiderTradingTools>.Instance
         );

--- a/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -19,6 +20,7 @@ public class InstitutionalHoldingsToolsTests : ParadeDbMcpTestBase
             new InstitutionalHoldingRepository(DbContext),
             new InstitutionalHolderRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<InstitutionalHoldingsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Mcp.Tools;
 using Equibles.InsiderTrading.Repositories;
@@ -21,6 +22,7 @@ public class InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests : Para
             new InsiderOwnerRepository(DbContext),
             new Form144FilingRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<InsiderTradingTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Mcp.Tools;
 using Equibles.InsiderTrading.Repositories;
@@ -21,6 +22,7 @@ public class InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests : P
             new InsiderOwnerRepository(DbContext),
             new Form144FilingRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<InsiderTradingTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetProposedSalesCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetProposedSalesCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Mcp.Tools;
 using Equibles.InsiderTrading.Repositories;
@@ -79,6 +80,7 @@ public class InsiderTradingToolsGetProposedSalesCultureInvarianceTests : ParadeD
             new InsiderOwnerRepository(DbContext),
             new Form144FilingRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<InsiderTradingTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetProposedSalesTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetProposedSalesTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Mcp.Tools;
 using Equibles.InsiderTrading.Repositories;
@@ -20,6 +21,7 @@ public class InsiderTradingToolsGetProposedSalesTests : ParadeDbMcpTestBase
             new InsiderOwnerRepository(DbContext),
             new Form144FilingRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<InsiderTradingTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetRoleOfficerBlankTitleTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetRoleOfficerBlankTitleTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Mcp.Tools;
 using Equibles.InsiderTrading.Repositories;
@@ -73,6 +74,7 @@ public class InsiderTradingToolsGetRoleOfficerBlankTitleTests : ParadeDbMcpTestB
             new InsiderOwnerRepository(DbContext),
             new Form144FilingRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<InsiderTradingTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Mcp.Tools;
 using Equibles.InsiderTrading.Repositories;
@@ -20,6 +21,7 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
             new InsiderOwnerRepository(DbContext),
             new Form144FilingRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<InsiderTradingTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -150,6 +151,7 @@ public class InstitutionalHoldingsToolsGetConsensusHoldingsTests : ParadeDbMcpTe
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -53,6 +54,7 @@ public class InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTest
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -140,6 +141,7 @@ public class InstitutionalHoldingsToolsGetFundOverlapTests : ParadeDbMcpTestBase
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -69,6 +70,7 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioMalformedDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioMalformedDateTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -59,6 +60,7 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioMalformedDateTests
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -23,6 +24,7 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResults
             new InstitutionalHoldingRepository(DbContext),
             new InstitutionalHolderRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<InstitutionalHoldingsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -62,6 +63,7 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioTests : ParadeDbMc
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -170,6 +171,7 @@ public class InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests : Pa
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Models.Taxonomies;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -110,6 +111,7 @@ public class InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests : Par
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -201,6 +202,7 @@ public class InstitutionalHoldingsToolsGetInstitutionSummaryTests : ParadeDbMcpT
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -80,6 +81,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvar
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnNegativeMaxResultsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -62,6 +63,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityChurnNegativeMaxR
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyChurnTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyChurnTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -51,6 +52,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyChurnTests :
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyMoversTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyMoversTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -52,6 +53,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyMoversTests
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -55,6 +56,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResult
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -141,6 +142,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityTests : ParadeDbM
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -182,6 +183,7 @@ public class InstitutionalHoldingsToolsGetMostHeldStocksTests : ParadeDbMcpTestB
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksValueSortTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksValueSortTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -80,6 +81,7 @@ public class InstitutionalHoldingsToolsGetMostHeldStocksValueSortTests : ParadeD
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -55,6 +56,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTest
             new InstitutionalHoldingRepository(ctx),
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
+            new StockSplitRepository(ctx),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -65,6 +66,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -126,6 +128,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -156,6 +159,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -183,6 +187,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -218,6 +223,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -255,6 +261,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -53,6 +54,7 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -22,6 +23,7 @@ public class InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests :
             new InstitutionalHoldingRepository(DbContext),
             new InstitutionalHolderRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<InstitutionalHoldingsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -54,6 +55,7 @@ public class InstitutionalHoldingsToolsOwnershipHistoryTests : ParadeDbMcpTestBa
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -53,6 +54,7 @@ public class InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTe
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -50,6 +51,7 @@ public class InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterT
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNotFoundTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -50,6 +51,7 @@ public class InstitutionalHoldingsToolsResolveMarketActivityDatesNotFoundTests :
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsSearchTests.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -52,6 +53,7 @@ public class InstitutionalHoldingsToolsSearchTests : ParadeDbMcpTestBase
             new InstitutionalHoldingRepository(verify),
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
@@ -21,8 +22,10 @@ public class ShortDataToolsGetLargestShortVolumeCultureInvarianceTests : ParadeD
             new ShortSqueezeScoreManager(
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
-                new CommonStockRepository(DbContext)
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext)
             ),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
@@ -22,8 +23,10 @@ public class ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests
             new ShortSqueezeScoreManager(
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
-                new CommonStockRepository(DbContext)
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext)
             ),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
@@ -21,8 +22,10 @@ public class ShortDataToolsGetShortInterestCultureInvarianceTests : ParadeDbMcpT
             new ShortSqueezeScoreManager(
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
-                new CommonStockRepository(DbContext)
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext)
             ),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
@@ -21,8 +22,10 @@ public class ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests : Para
             new ShortSqueezeScoreManager(
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
-                new CommonStockRepository(DbContext)
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext)
             ),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
@@ -30,8 +31,10 @@ public class ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTes
             new ShortSqueezeScoreManager(
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
-                new CommonStockRepository(DbContext)
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext)
             ),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
@@ -21,8 +22,10 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
             new ShortSqueezeScoreManager(
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
-                new CommonStockRepository(DbContext)
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext)
             ),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
@@ -21,8 +22,10 @@ public class ShortDataToolsGetShortVolumeCultureInvarianceTests : ParadeDbMcpTes
             new ShortSqueezeScoreManager(
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
-                new CommonStockRepository(DbContext)
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext)
             ),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
@@ -20,8 +21,10 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
             new ShortSqueezeScoreManager(
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
-                new CommonStockRepository(DbContext)
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext)
             ),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
@@ -32,8 +33,10 @@ public class ShortDataToolsZeroChangeTests : ParadeDbMcpTestBase
             new ShortSqueezeScoreManager(
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
-                new CommonStockRepository(DbContext)
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext)
             ),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.UnitTests/CorporateActions/SplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/SplitAdjustmentTests.cs
@@ -94,4 +94,79 @@ public class SplitAdjustmentTests
 
         SplitAdjustment.ShareCountFactor(new DateOnly(2023, 1, 1), splits).Should().Be(1m);
     }
+
+    [Fact]
+    public void AdjustShareCount_NoSplits_ReturnsCountUnchanged()
+    {
+        SplitAdjustment.AdjustShareCount(1_000, new DateOnly(2020, 1, 1), []).Should().Be(1_000);
+    }
+
+    [Fact]
+    public void AdjustShareCount_BeforeBothSplits_RestatesOntoTodaysBasis()
+    {
+        // 100 pre-split shares × 40 (NVDA 4:1 then 10:1) = 4,000 on today's basis.
+        SplitAdjustment
+            .AdjustShareCount(100, new DateOnly(2021, 1, 1), NvdaSplits)
+            .Should()
+            .Be(4_000);
+    }
+
+    [Fact]
+    public void AdjustShareCount_ReverseSplit_ShrinksAndRoundsToNearestShare()
+    {
+        StockSplit[] splits =
+        [
+            new()
+            {
+                EffectiveDate = new DateOnly(2024, 1, 1),
+                Numerator = 1m,
+                Denominator = 3m,
+            },
+        ];
+
+        // 100 / 3 = 33.33… → rounds to the nearest whole share.
+        SplitAdjustment.AdjustShareCount(100, new DateOnly(2023, 1, 1), splits).Should().Be(33);
+    }
+
+    [Fact]
+    public void AdjustShareCount_NegativeCount_PreservesSign()
+    {
+        // A change/delta can be negative; the 4:1 split still restates it correctly.
+        SplitAdjustment
+            .AdjustShareCount(-250, new DateOnly(2022, 1, 1), NvdaSplits)
+            .Should()
+            .Be(-2_500);
+    }
+
+    [Fact]
+    public void AdjustShareCount_QuarterOverQuarterAcrossASplit_ShowsNoPhantomChange()
+    {
+        // A 2:1 split falls between two 13F report dates. 1,000 shares held before the split
+        // and 2,000 after are the SAME economic position; once both are restated onto today's
+        // basis the quarter-over-quarter change must be zero, not +100%.
+        StockSplit[] splits =
+        [
+            new()
+            {
+                EffectiveDate = new DateOnly(2024, 3, 1),
+                Numerator = 2m,
+                Denominator = 1m,
+            },
+        ];
+
+        var priorQuarter = SplitAdjustment.AdjustShareCount(
+            1_000,
+            new DateOnly(2024, 2, 15),
+            splits
+        );
+        var currentQuarter = SplitAdjustment.AdjustShareCount(
+            2_000,
+            new DateOnly(2024, 3, 31),
+            splits
+        );
+
+        priorQuarter.Should().Be(2_000);
+        currentQuarter.Should().Be(2_000);
+        (currentQuarter - priorQuarter).Should().Be(0, "the split is not a real ownership change");
+    }
 }

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerShortInterestPercentSplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerShortInterestPercentSplitAdjustmentTests.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Finra.BusinessLogic;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Pins that ShortSqueezeScoreManager restates the short position — a share COUNT observed
+/// as-of the FINRA settlement date — onto today's split basis before dividing it by the
+/// CURRENT shares outstanding. A stock that split after the settlement date must report its
+/// short interest as a fraction of shares on the same basis as the denominator; without the
+/// restatement a 10:1 split makes the raw ratio 10× too small (and the peer-relative rank
+/// collapses the stock out of the squeeze board).
+/// </summary>
+public class ShortSqueezeScoreManagerShortInterestPercentSplitAdjustmentTests
+{
+    private static readonly StockSplit TenForOne = new()
+    {
+        EffectiveDate = new DateOnly(2024, 6, 10),
+        Numerator = 10m,
+        Denominator = 1m,
+    };
+
+    [Fact]
+    public void ShortInterestPercentOfShares_SplitAfterSettlement_RestatedOntoCurrentBasis()
+    {
+        // 1,000,000 shares short as-of a settlement BEFORE a 10:1 split, against today's
+        // 100,000,000 shares outstanding. The position must be scaled ×10 to 10,000,000
+        // before dividing, giving 10% — not the un-restated 1%.
+        var settlementDate = new DateOnly(2024, 5, 15);
+
+        var result = InvokeShortInterestPercentOfShares(
+            currentShortPosition: 1_000_000,
+            sharesOutstanding: 100_000_000,
+            settlementDate,
+            [TenForOne]
+        );
+
+        result.Should().Be(0.10m);
+    }
+
+    [Fact]
+    public void ShortInterestPercentOfShares_NoSplits_LeavesRatioUnchanged()
+    {
+        var result = InvokeShortInterestPercentOfShares(
+            currentShortPosition: 5_000_000,
+            sharesOutstanding: 100_000_000,
+            new DateOnly(2024, 5, 15),
+            []
+        );
+
+        result.Should().Be(0.05m);
+    }
+
+    [Fact]
+    public void ShortInterestPercentOfShares_SettlementAfterSplit_NoAdjustment()
+    {
+        // A settlement dated after the split already reports the post-split count, so the
+        // factor is 1 and the ratio is the raw one.
+        var result = InvokeShortInterestPercentOfShares(
+            currentShortPosition: 10_000_000,
+            sharesOutstanding: 100_000_000,
+            new DateOnly(2024, 7, 1),
+            [TenForOne]
+        );
+
+        result.Should().Be(0.10m);
+    }
+
+    private static decimal InvokeShortInterestPercentOfShares(
+        long currentShortPosition,
+        long sharesOutstanding,
+        DateOnly settlementDate,
+        IReadOnlyList<StockSplit> splits
+    )
+    {
+        var method = typeof(ShortSqueezeScoreManager).GetMethod(
+            "ShortInterestPercentOfShares",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.Should().NotBeNull("the split-adjusted short-interest-percent helper should exist");
+        return (decimal)
+            method!.Invoke(null, [currentShortPosition, sharesOutstanding, settlementDate, splits]);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
@@ -1,6 +1,8 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
@@ -41,6 +43,7 @@ public class InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests
             new IModuleConfiguration[]
             {
                 new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
                 new HoldingsModuleConfiguration(),
                 new ErrorsModuleConfiguration(),
             }
@@ -103,6 +106,7 @@ public class InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests
             new InstitutionalHoldingRepository(db),
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
+            new StockSplitRepository(db),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests.cs
@@ -1,6 +1,8 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
@@ -38,6 +40,7 @@ public class InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests
             new IModuleConfiguration[]
             {
                 new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
                 new HoldingsModuleConfiguration(),
                 new ErrorsModuleConfiguration(),
             }
@@ -99,6 +102,7 @@ public class InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests
             new InstitutionalHoldingRepository(db),
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
+            new StockSplitRepository(db),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTests.cs
@@ -47,6 +47,7 @@ public class InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTes
             9_876_543L,
             9_876_543_210L,
             holdings,
+            1m,
         ];
 
         var original = CultureInfo.CurrentCulture;

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests.cs
@@ -44,6 +44,7 @@ public class InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests
             9_876_543L,
             9_876_543_210L,
             holdings,
+            1m,
         ];
 
         var original = CultureInfo.CurrentCulture;

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests.cs
@@ -38,7 +38,7 @@ public class InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests
         var rendered = (string)
             RenderTopHoldersTableMethod.Invoke(
                 null,
-                [stock, "AAPL", new DateOnly(2024, 9, 30), 1, 0L, 0L, holdings]
+                [stock, "AAPL", new DateOnly(2024, 9, 30), 1, 0L, 0L, holdings, 1m]
             );
 
         rendered.Should().NotContain("NaN");

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests.cs
@@ -1,6 +1,8 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
@@ -39,6 +41,7 @@ public class InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests
             new IModuleConfiguration[]
             {
                 new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
                 new HoldingsModuleConfiguration(),
                 new ErrorsModuleConfiguration(),
             }
@@ -114,6 +117,7 @@ public class InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests
             new InstitutionalHoldingRepository(db),
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
+            new StockSplitRepository(db),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );


### PR DESCRIPTION
## Summary

Applies split-adjustment to the OSS library consumers that run inside the commercial MCP host and workers: the holdings, short-data and insider MCP tools, and the one persisted short metric (short-squeeze score). A raw share/position/volume COUNT tied to a date — when compared across time or divided by the CURRENT `SharesOutStanding` — is restated onto today's basis via `SplitAdjustment.ShareCountFactor(date, splits)`. Dollar values and same-date ratios are split-invariant and left untouched. When a stock has no splits, everything is a no-op.

Read-time adjustment everywhere it is possible; the persisted `ShortSqueezeScore.ShortInterestPercentOfShares` is fixed at compute time (the factor is relative to today, which is correct at write time and refreshed when the score recomputes).

## Code changes

- **`SplitAdjustment.AdjustShareCount`** (new helper, `Equibles.CorporateActions.Data`): restates a share count by factor(asOf, splits), rounding to the nearest whole share, sign-preserving; plus a factor-based overload so a tool computes the factor once per as-of date.
- **`ShortSqueezeScoreManager`** (persisted metric): loads each scored stock's splits once and restates `CurrentShortPosition` by factor(settlementDate) before dividing by current `SharesOutStanding`.
- **`ShortDataTools`** — `GetShortInterest`/`GetShortVolume`: restate each row's short position, change, ADV and volumes by that settlement/date's factor so the series is continuous across a split. Same-settlement Days to Cover and same-day Short % left as reported (split-invariant). The single-date snapshot tools (`GetShortInterestSnapshot`, `GetLargestShortVolume`) render with factor 1.
- **`InstitutionalHoldingsTools`** — `GetOwnershipHistory` (restate each quarter's total before the QoQ change), `GetTopHolders` (displayed Shares + total; the same-date % of Total is invariant), `GetTopBuyersSellers` (both quarters before the delta and the Prior → New column). Dollar figures left as reported. The market-wide tools read the persisted `StockQuarterlyActivity` snapshot and are intentionally left as-filed (see below).
- **`InsiderTradingTools`** — `GetInsiderTransactions` and `GetInsiderOwnership` restate `Shares`/`SharesOwnedAfter` by factor(transactionDate) (ownership summary re-ranked by the adjusted holding); `GetProposedSales` restates Form 144 `SharesToBeSold` by factor(filingDate). Dollar `Value`/`PricePerShare`/`AggregateMarketValue` left as reported.
- Added the `Equibles.CorporateActions.Repositories` project reference to each MCP/BusinessLogic csproj touched; registered `CorporateActionsModuleConfiguration` in the integration-test DB fixture so the model maps `StockSplit`.

## Left split-invariant (with reason)

- Dollar values (`Shares × Price`, `Value`, `AggregateMarketValue`, all `$M` columns) — a split does not change a dollar amount.
- Same-date ratios: `% of Total` (one date's total), `Short %` (same day), `Days to Cover` (position ÷ ADV within one settlement).
- Filer **counts** in `GetMostHeldStocks` (a count of institutions, not shares).
- The market-wide `GetMarketWide13FActivity` / `GetMostHeldStocks` Δ Shares: these render the persisted `StockQuarterlyActivity` snapshot, which this change deliberately leaves as-filed (per the issue scope, commercial consumers adjust that snapshot on read); they are also cross-sectional over the whole market rather than the single-stock "load a stock's splits once" pattern.

## Insider MCP tool

Yes — an insider MCP tool exists (`Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs`) and was adjusted as above.

## Tests

- `SplitAdjustmentTests`: `AdjustShareCount` no-op / NVDA restatement / reverse-split rounding / negative-sign / QoQ-across-a-split-shows-no-phantom-change.
- `ShortSqueezeScoreManagerShortInterestPercentSplitAdjustmentTests`: short-interest-percent-of-shares for a stock that split after settlement comes out on the current basis (10:1 → 10% not 1%), no-op without splits, and no adjustment when the settlement post-dates the split.
- All existing MCP-tool call sites updated for the new `StockSplitRepository` dependency; reflection-based render tests updated for the new signature.

`dotnet build Equibles.sln -c Release` green (pre-existing CS8632 warnings only); the full `Equibles.UnitTests` project passes (3198 tests). Integration suites (Testcontainers/ParadeDB) run in the pipeline.

refs #2879