### PR TITLE
fix(corporate-actions): keep as-filed insider rows consistent and split-adjust cross-sectional holdings MCP tools

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -283,7 +283,13 @@ public class InstitutionalHoldingsTools
                 if (holdings.Count == 0)
                     return $"No holdings found for {holder.Name} as of {FormatDate(targetDate)}.";
 
-                return RenderInstitutionPortfolio(holder, targetDate, holdings);
+                // 13F holdings are shown on today's split basis across the platform (matching the
+                // web and GetTopHolders), so restate each position's share count by its own
+                // stock's post-report-date splits. Value is a paired per-holding dollar figure
+                // and stays as reported.
+                var splitsByStock = await LoadSplitsByStock(holdings.Select(h => h.CommonStockId));
+
+                return RenderInstitutionPortfolio(holder, targetDate, holdings, splitsByStock);
             },
             "GetInstitutionPortfolio",
             $"institution: {institutionName}"
@@ -293,7 +299,8 @@ public class InstitutionalHoldingsTools
     private static string RenderInstitutionPortfolio(
         InstitutionalHolder holder,
         DateOnly targetDate,
-        List<InstitutionalHolding> holdings
+        List<InstitutionalHolding> holdings,
+        IReadOnlyDictionary<Guid, List<StockSplit>> splitsByStock
     )
     {
         var result = MarkdownTable.Start(
@@ -305,9 +312,16 @@ public class InstitutionalHoldingsTools
         result.AppendNumberedRows(
             holdings,
             (rank, h) =>
-                $"| {rank} | {h.CommonStock.Ticker} | {h.CommonStock.Name} | "
-                + $"{McpFormat.WholeNumber(h.Shares)} | "
-                + $"{FormatMillions(h.Value)} |"
+            {
+                var shares = SplitAdjustment.AdjustShareCount(
+                    h.Shares,
+                    targetDate,
+                    SplitsFor(splitsByStock, h.CommonStockId)
+                );
+                return $"| {rank} | {h.CommonStock.Ticker} | {h.CommonStock.Name} | "
+                    + $"{McpFormat.WholeNumber(shares)} | "
+                    + $"{FormatMillions(h.Value)} |";
+            }
         );
 
         return result.ToString();
@@ -638,12 +652,21 @@ public class InstitutionalHoldingsTools
         StringBuilder result
     )
     {
-        var activity = _holdingRepository.GetQuarterlyActivity(targetDate, previousDate);
+        // Materialize the whole quarter's activity, then restate each stock's share counts onto
+        // today's split basis BEFORE bucketing and the Δ Shares column. A split between the two
+        // report dates sits the quarters on different bases, so a flat position would otherwise
+        // read as a phantom buyer/seller. Δ Value is a dollar figure and is split-invariant (it
+        // drives the ordering). The restatement is per-stock, so it cannot translate to SQL.
+        var activity = await _holdingRepository
+            .GetQuarterlyActivity(targetDate, previousDate)
+            .ToListAsync();
+        await RestateActivitySharesToTodaysBasis(activity, targetDate, previousDate);
+
         var movers = activity.Where(a => a.CurrentShares != a.PreviousShares);
         var rows =
             normalizedBucket == "top-buys"
-                ? await movers.TopBuyers().Take(maxResults).ToListAsync()
-                : await movers.TopSellers().Take(maxResults).ToListAsync();
+                ? movers.TopBuyers().Take(maxResults).ToList()
+                : movers.TopSellers().Take(maxResults).ToList();
         if (rows.Count == 0)
             return result + "_No stocks moved in this direction this quarter._";
 
@@ -988,6 +1011,14 @@ public class InstitutionalHoldingsTools
                     previousHoldings
                 );
 
+                // Restate every diffed position onto today's split basis before the buckets are
+                // read. When a split falls between the two quarters they sit on different bases,
+                // so a flat holding would otherwise land in Increased/Reduced as a phantom move.
+                // Initiated/Exited are defined by a zero side that restatement preserves; only
+                // the Increased/Reduced/Unchanged split can flip, so re-bucket those. Δ Value is
+                // split-invariant and drives the ordering — left untouched.
+                await RestateAndRebucketQuarterlyActivity(grouped, targetDate, priorDate.Value);
+
                 return RenderQuarterlyActivity(
                     holder,
                     targetDate,
@@ -1317,6 +1348,102 @@ public class InstitutionalHoldingsTools
 
     private Task<Dictionary<Guid, CommonStock>> LoadStocksByIds(List<Guid> stockIds) =>
         _commonStockRepository.GetByIds(stockIds).ToDictionaryAsync(s => s.Id);
+
+    // Batch-loads the splits for a set of stocks once, grouped by stock, so cross-sectional
+    // tools can restate each row's share counts onto today's basis without an N+1 query.
+    private async Task<Dictionary<Guid, List<StockSplit>>> LoadSplitsByStock(
+        IEnumerable<Guid> stockIds
+    )
+    {
+        var ids = stockIds.Distinct().ToList();
+        if (ids.Count == 0)
+            return new Dictionary<Guid, List<StockSplit>>();
+
+        var splits = await _stockSplitRepository
+            .GetAll()
+            .Where(s => ids.Contains(s.CommonStockId))
+            .ToListAsync();
+        return splits.GroupBy(s => s.CommonStockId).ToDictionary(g => g.Key, g => g.ToList());
+    }
+
+    // A stock with no splits restates by factor 1 (no-op), so an absent key returns an empty set.
+    private static IReadOnlyList<StockSplit> SplitsFor(
+        IReadOnlyDictionary<Guid, List<StockSplit>> splitsByStock,
+        Guid stockId
+    ) => splitsByStock.TryGetValue(stockId, out var splits) ? splits : [];
+
+    // Restates each activity row's current/previous share counts onto today's split basis
+    // (current at the target quarter, previous at the prior quarter) from each row's own
+    // stock's splits. These rows are query projections, not tracked entities, so mutating them
+    // in place is safe; Δ Shares recomputes from the restated counts.
+    private async Task RestateActivitySharesToTodaysBasis(
+        IReadOnlyList<MarketWideStockActivity> activity,
+        DateOnly currentDate,
+        DateOnly previousDate
+    )
+    {
+        var splitsByStock = await LoadSplitsByStock(activity.Select(a => a.CommonStockId));
+        foreach (var a in activity)
+        {
+            var splits = SplitsFor(splitsByStock, a.CommonStockId);
+            a.CurrentShares = SplitAdjustment.AdjustShareCount(a.CurrentShares, currentDate, splits);
+            a.PreviousShares = SplitAdjustment.AdjustShareCount(
+                a.PreviousShares,
+                previousDate,
+                splits
+            );
+        }
+    }
+
+    // Restates the quarterly-activity diff onto today's split basis, then re-classifies the
+    // movement buckets from the restated counts. A zero side is preserved by restatement, so
+    // Initiated/Exited stay put; only Increased/Reduced/Unchanged can flip.
+    private async Task RestateAndRebucketQuarterlyActivity(
+        Dictionary<StockPositionChangeType, List<StockPositionChange>> grouped,
+        DateOnly currentDate,
+        DateOnly previousDate
+    )
+    {
+        var splitsByStock = await LoadSplitsByStock(
+            grouped.Values.SelectMany(rows => rows).Select(r => r.CommonStockId)
+        );
+
+        foreach (var rows in grouped.Values)
+        {
+            foreach (var r in rows)
+            {
+                var splits = SplitsFor(splitsByStock, r.CommonStockId);
+                r.CurrentShares = SplitAdjustment.AdjustShareCount(
+                    r.CurrentShares,
+                    currentDate,
+                    splits
+                );
+                r.PreviousShares = SplitAdjustment.AdjustShareCount(
+                    r.PreviousShares,
+                    previousDate,
+                    splits
+                );
+            }
+        }
+
+        var movement = new List<StockPositionChange>();
+        movement.AddRange(grouped[StockPositionChangeType.Increased]);
+        movement.AddRange(grouped[StockPositionChangeType.Reduced]);
+        movement.AddRange(grouped[StockPositionChangeType.Unchanged]);
+        grouped[StockPositionChangeType.Increased] = [];
+        grouped[StockPositionChangeType.Reduced] = [];
+        grouped[StockPositionChangeType.Unchanged] = [];
+
+        foreach (var r in movement)
+        {
+            var type =
+                r.CurrentShares == r.PreviousShares ? StockPositionChangeType.Unchanged
+                : r.CurrentShares > r.PreviousShares ? StockPositionChangeType.Increased
+                : StockPositionChangeType.Reduced;
+            r.ChangeType = type;
+            grouped[type].Add(r);
+        }
+    }
 
     private static (string Ticker, string Name) ResolveStockCells(
         IDictionary<Guid, CommonStock> stocks,

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -73,9 +73,12 @@ public class InsiderTradingTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                // Restate the transaction and post-transaction share counts onto today's
-                // split basis so figures are comparable across dates. Value (Shares × Price)
-                // and the per-share Price are split-invariant and computed from raw figures.
+                // Each row is an as-filed record: the per-row Shares, Price, and Value stay
+                // exactly as reported so Shares × Price = Value holds within the row (the total
+                // value is split-invariant, and a filed quantity is only ever read next to its
+                // own price/value — never compared across dates). Only the running
+                // post-transaction balance (Owned After) is compared across dates and insiders,
+                // so it alone is restated onto today's split basis.
                 var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
 
                 return MarkdownTable.Render(
@@ -97,17 +100,12 @@ public class InsiderTradingTools
                         };
 
                         var value = t.Shares * t.PricePerShare;
-                        var shares = SplitAdjustment.AdjustShareCount(
-                            t.Shares,
-                            t.TransactionDate,
-                            splits
-                        );
                         var ownedAfter = SplitAdjustment.AdjustShareCount(
                             t.SharesOwnedAfter,
                             t.TransactionDate,
                             splits
                         );
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(ownedAfter)} |";
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(ownedAfter)} |";
                     }
                 );
             },
@@ -211,11 +209,10 @@ public class InsiderTradingTools
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
-                // Restate the proposed share count onto today's split basis so notices filed
-                // before a split are comparable with later ones. Aggregate market value is a
-                // dollar figure and is split-invariant — left as reported.
-                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
-
+                // Each Form 144 is an as-filed notice: the proposed Shares pair with the
+                // notice's own Aggregate Market Value, so both stay exactly as reported. The
+                // list is ordered by filing date, not by an adjusted quantity, so a filed share
+                // count is never compared across a split here.
                 return MarkdownTable.Render(
                     filings,
                     $"No Form 144 proposed sales found for {ticker}.",
@@ -228,12 +225,7 @@ public class InsiderTradingTools
                         var approxSaleDate =
                             f.ApproxSaleDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
                             ?? "-";
-                        var sharesToBeSold = SplitAdjustment.AdjustShareCount(
-                            f.SharesToBeSold,
-                            f.FilingDate,
-                            splits
-                        );
-                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(sharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {approxSaleDate} | {f.BrokerName} |";
+                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {approxSaleDate} | {f.BrokerName} |";
                     }
                 );
             },

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjustmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjustmentTests.cs
@@ -1,0 +1,116 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the split adjustment on <c>GetInstitutionQuarterlyActivity</c>. The tool diffs a
+/// holder's positions across two report dates; when a split falls between them the two share
+/// counts sit on different bases, so an economically FLAT position reads as a phantom
+/// Increased move unless each side is restated onto today's basis before bucketing. This is
+/// an integration test because the tool resolves the holder via a Postgres ILike name search
+/// (GH-2879).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjustmentTests
+    : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjustmentTests(
+        ParadeDbFixture fixture
+    )
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetInstitutionQuarterlyActivity_FlatPositionAcrossSplit_IsNotClassifiedIncreased()
+    {
+        var apple = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var microsoft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var holder = new InstitutionalHolder { Cik = "1", Name = "Fund One Capital" };
+        DbContext.AddRange(apple, microsoft, holder);
+
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+
+        // Apple did a 2:1 split between the quarters; the fund's economic position is flat
+        // (1,000 pre-split → 2,000 post-split) with a flat dollar value.
+        DbContext.Add(
+            new StockSplit
+            {
+                CommonStockId = apple.Id,
+                EffectiveDate = new DateOnly(2024, 11, 15),
+                Numerator = 2,
+                Denominator = 1,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        DbContext.Add(MakeHolding(holder, apple, prior, shares: 1_000, value: 100_000));
+        DbContext.Add(MakeHolding(holder, apple, current, shares: 2_000, value: 100_000));
+
+        // Microsoft has no split and a genuine share increase (1,000 → 3,000).
+        DbContext.Add(MakeHolding(holder, microsoft, prior, shares: 1_000, value: 100_000));
+        DbContext.Add(MakeHolding(holder, microsoft, current, shares: 3_000, value: 300_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetInstitutionQuarterlyActivity("Fund One Capital");
+
+        // The genuine Microsoft increase is bucketed as Increased with its real +2,000 delta.
+        output.Should().Contain("## Increased");
+        output.Should().Contain("MSFT");
+        output.Should().Contain("+2,000");
+        // The flat Apple position restates to Unchanged and is dropped — never Increased,
+        // never a phantom +1,000.
+        output.Should().NotContain("Apple");
+        output.Should().NotContain("+1,000");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        InstitutionalHolder holder,
+        CommonStock stock,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            FilingType = FilingType.Form13F,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stock.Ticker}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Reflection;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 
@@ -51,7 +52,10 @@ public class InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarian
             },
         };
         var targetDate = new DateOnly(2024, 12, 31);
-        object[] args = [holder, targetDate, holdings];
+        // No splits for this stock → shares render as reported; the pin is about culture, not
+        // split adjustment (RenderInstitutionPortfolio gained a splits-by-stock parameter).
+        var splitsByStock = new Dictionary<Guid, List<StockSplit>>();
+        object[] args = [holder, targetDate, holdings, splitsByStock];
 
         var original = CultureInfo.CurrentCulture;
         string invariantOutput;

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsSplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsSplitAdjustmentTests.cs
@@ -1,0 +1,143 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins the split adjustment on the cross-sectional / per-holder 13F activity tools. These
+/// diff share counts across two report dates; when a split falls between the quarters the two
+/// counts sit on different bases, so an economically FLAT position reads as a phantom buyer /
+/// Increased move unless each side is restated onto today's basis first. Δ Value is a dollar
+/// figure and is split-invariant, so ranking by it is left alone (GH-2879).
+/// </summary>
+public class InstitutionalHoldingsToolsSplitAdjustmentTests
+{
+    private static readonly DateOnly Prior = new(2024, 9, 30);
+    private static readonly DateOnly Current = new(2024, 12, 31);
+
+    // 2:1 forward split effective between the two report dates.
+    private static readonly DateOnly SplitDate = new(2024, 11, 15);
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+                new HoldingsModuleConfiguration(),
+                new ErrorsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static InstitutionalHoldingsTools Sut(EquiblesFinancialDbContext db) =>
+        new(
+            new InstitutionalHoldingRepository(db),
+            new InstitutionalHolderRepository(db),
+            new CommonStockRepository(db),
+            new StockSplitRepository(db),
+            new ErrorManager(new ErrorRepository(db)),
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    [Fact]
+    public async Task GetMarketWide13FActivity_FlatPositionAcrossSplit_IsNotAPhantomTopBuyer()
+    {
+        await using var db = NewDb();
+
+        var apple = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var microsoft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var holder = new InstitutionalHolder { Cik = "1", Name = "Fund One" };
+        db.AddRange(apple, microsoft, holder);
+
+        // Apple did a 2:1 split between the quarters; the fund's economic position is flat
+        // (1,000 pre-split → 2,000 post-split) with a flat dollar value.
+        db.Add(
+            new StockSplit
+            {
+                CommonStockId = apple.Id,
+                EffectiveDate = SplitDate,
+                Numerator = 2,
+                Denominator = 1,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        db.Add(MakeHolding(holder, apple, Prior, shares: 1_000, value: 100_000));
+        db.Add(MakeHolding(holder, apple, Current, shares: 2_000, value: 100_000));
+
+        // Microsoft has no split and a genuine share increase (1,000 → 3,000).
+        db.Add(MakeHolding(holder, microsoft, Prior, shares: 1_000, value: 100_000));
+        db.Add(MakeHolding(holder, microsoft, Current, shares: 3_000, value: 300_000));
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetMarketWide13FActivity("top-buys");
+
+        // The genuine Microsoft buyer surfaces with its real +2,000 delta.
+        output.Should().Contain("MSFT");
+        output.Should().Contain("+2,000");
+        // The flat Apple position must not appear as a phantom buyer (its raw +1,000 delta
+        // is a split artifact that restatement cancels).
+        output.Should().NotContain("Apple");
+        output.Should().NotContain("+1,000");
+    }
+
+    // GetInstitutionQuarterlyActivity resolves the holder via a Postgres ILike name search,
+    // so its split-adjustment regression lives in the Docker-backed integration suite
+    // (InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjustmentTests).
+
+    private static InstitutionalHolding MakeHolding(
+        InstitutionalHolder holder,
+        CommonStock stock,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            FilingType = FilingType.Form13F,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stock.Ticker}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsSplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsSplitAdjustmentTests.cs
@@ -1,0 +1,177 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Mcp.Tools;
+using Equibles.InsiderTrading.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Mcp;
+
+/// <summary>
+/// Pins the split-adjustment rule for the insider MCP tools: a per-FILING quantity that is
+/// displayed next to its own price/value is an as-filed record and stays as reported, so the
+/// row is internally consistent (Shares × Price = Value). Only a cross-time RUNNING BALANCE
+/// (post-transaction shares owned) is restated onto today's split basis. A prior regression
+/// adjusted the per-row Shares while leaving Price/Value raw, so 40,000 sh @ $800 rendered a
+/// $32M value beside a 400,000-share count — the row no longer reconciled (GH-2879).
+/// </summary>
+public class InsiderTradingToolsSplitAdjustmentTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+                new InsiderTradingModuleConfiguration(),
+                new ErrorsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static InsiderTradingTools Sut(EquiblesFinancialDbContext db) =>
+        new(
+            new InsiderTransactionRepository(db),
+            new InsiderOwnerRepository(db),
+            new Form144FilingRepository(db),
+            new CommonStockRepository(db),
+            new StockSplitRepository(db),
+            new ErrorManager(new ErrorRepository(db)),
+            Substitute.For<ILogger<InsiderTradingTools>>()
+        );
+
+    [Fact]
+    public async Task GetInsiderTransactions_TransactionBeforeSplit_KeepsRowAsFiledAndRestatesRunningBalance()
+    {
+        await using var db = NewDb();
+
+        var stock = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "0001045810",
+        };
+        var owner = new InsiderOwner
+        {
+            OwnerCik = "0009876543",
+            Name = "Jensen Huang",
+            IsOfficer = true,
+            OfficerTitle = "CEO",
+        };
+        db.AddRange(stock, owner);
+
+        // 10:1 forward split effective AFTER the transaction date, so it restates the
+        // running balance by a factor of 10 but leaves the as-filed row alone.
+        db.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                EffectiveDate = new DateOnly(2024, 6, 10),
+                Numerator = 10,
+                Denominator = 1,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        db.Add(
+            new InsiderTransaction
+            {
+                CommonStockId = stock.Id,
+                CommonStock = stock,
+                InsiderOwnerId = owner.Id,
+                InsiderOwner = owner,
+                TransactionDate = new DateOnly(2024, 6, 1),
+                FilingDate = new DateOnly(2024, 6, 3),
+                TransactionCode = TransactionCode.Sale,
+                Shares = 40_000,
+                PricePerShare = 800.00m,
+                AcquiredDisposed = AcquiredDisposed.Disposed,
+                SharesOwnedAfter = 100_000,
+                OwnershipNature = OwnershipNature.Direct,
+                SecurityTitle = "Common Stock",
+                AccessionNumber = "acc-nvda-1",
+            }
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("NVDA");
+
+        // The per-row Shares / Price / Value are as-filed and reconcile within the row:
+        // 40,000 × $800.00 = $32,000,000.
+        output.Should().Contain("| 40,000 | $800.00 | $32,000,000 |");
+        // The filed quantity is NOT restated to the post-split 400,000 count...
+        output.Should().NotContain("400,000");
+        // ...and the value is never the inconsistent adjusted product ($320,000,000).
+        output.Should().NotContain("320,000,000");
+        // The running post-transaction balance IS restated onto today's 10:1 basis.
+        output.Should().Contain("| 1,000,000 |");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_NoticeBeforeSplit_KeepsSharesAsFiledBesideMarketValue()
+    {
+        await using var db = NewDb();
+
+        var stock = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "0001045810",
+        };
+        db.Add(stock);
+
+        db.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                EffectiveDate = new DateOnly(2024, 6, 10),
+                Numerator = 10,
+                Denominator = 1,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        db.Add(
+            new Form144Filing
+            {
+                CommonStockId = stock.Id,
+                CommonStock = stock,
+                FilingDate = new DateOnly(2024, 6, 1),
+                SellerName = "Jensen Huang",
+                RelationshipToIssuer = "Officer",
+                SharesToBeSold = 40_000,
+                AggregateMarketValue = 32_000_000m,
+                ApproxSaleDate = new DateOnly(2024, 6, 5),
+                BrokerName = "Acme Securities",
+                AccessionNumber = "acc-144-1",
+            }
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetProposedSales("NVDA");
+
+        // Proposed Shares pair with the notice's own Aggregate Market Value; both stay
+        // as filed, so the row is not restated to the post-split 400,000 count.
+        output.Should().Contain("| 40,000 | $32,000,000 |");
+        output.Should().NotContain("400,000");
+    }
+}


### PR DESCRIPTION
## Summary

Two confirmed correctness bugs in the split-adjustment behaviour of the MCP tools:

1. **Insider rows were internally inconsistent.** `GetInsiderTransactions` and `GetProposedSales` rendered a split-adjusted share count next to a raw per-share price and raw total value, so a row no longer reconciled across a split (e.g. NVDA pre-split: `40,000 sh @ $800` with a `$32M` value beside a `400,000`-share count). A per-filing quantity shown next to its own price/value is a self-consistent as-filed record, so it should render as reported — only a cross-time running balance is restated.

2. **Cross-sectional / per-holder holdings tools showed phantom split deltas.** `GetMarketWide13FActivity` movers, `GetInstitutionQuarterlyActivity`, and `GetInstitutionPortfolio` compared/displayed 13F share counts across a split boundary with no factor, so a flat position across a 2:1 split read as *Increased* / a phantom top buyer.

## Code changes

**`InsiderTradingTools`**
- `GetInsiderTransactions`: render the per-row `Shares` as filed (was split-adjusted). `Owned After` (a cross-time running balance) stays restated; Price/Value already raw.
- `GetProposedSales`: render `SharesToBeSold` as filed (it pairs with the notice's own raw Market Value); dropped the now-unused splits load.
- `GetInsiderOwnership`: unchanged — its `Shares Owned` **is** a running holding compared across insiders/time, so it stays adjusted and re-ranked.
- Corrected the misleading "per-share price is split-invariant" comment.

**`InstitutionalHoldingsTools`** — restatement done **after** materializing rows, per-stock splits batch-loaded once:
- `GetMarketWide13FActivity` (top-buys/top-sells): materialize the quarter's activity, restate each row's current/previous shares, then bucket/order in memory (Δ Value ranking is split-invariant).
- `GetInstitutionQuarterlyActivity`: restate the diffed positions and re-bucket the Increased/Reduced/Unchanged split (Initiated/Exited are defined by a zero side that restatement preserves).
- `GetInstitutionPortfolio`: restate each holding's shares to today's basis for consistency with the split-adjusted web and its sibling `GetTopHolders`; the paired per-holding Value stays raw.
- `GetMostHeldStocks`: **no change** — it renders only filer-count and dollar columns (no share column, no share-based sort), so it was already safe.

Dollar values, filer counts, and same-date ratios are split-invariant and left untouched.

## Tests
- Insider (unit, in-memory): a transaction-row `Shares × Price == Value` holds (all raw) while `Owned After` is restated across a 10:1 split; `GetProposedSales` shares stay as filed.
- Holdings market movers (unit, in-memory): a flat position across a 2:1 split is not a phantom top buyer; a real mover still surfaces with its true delta.
- `GetInstitutionQuarterlyActivity` (integration, ParadeDB — resolves the holder via a Postgres ILike search): a flat position across a 2:1 split is classified *Unchanged*, not *Increased*.
- Updated the existing `RenderInstitutionPortfolio` culture-invariance pin for the new splits parameter.

`dotnet build Equibles.sln -c Release` green; new + affected unit/integration tests pass.

refs #2879