### PR TITLE
feat(media): filesystem-backed file storage provider foundation

### DIFF
--- a/src/Equibles.Media.BusinessLogic/Configuration/FileStorageOptions.cs
+++ b/src/Equibles.Media.BusinessLogic/Configuration/FileStorageOptions.cs
@@ -1,0 +1,15 @@
+namespace Equibles.Media.BusinessLogic.Configuration;
+
+/// <summary>
+/// Bound from the "FileStorage" configuration section. When <see cref="Enabled"/> is
+/// false (the default), everything behaves exactly as before — bytes stay in the
+/// database — so the filesystem store is opt-in per deployment.
+/// </summary>
+public class FileStorageOptions
+{
+    /// <summary>Master switch. When false, FileSystem write requests fall back to the database.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Absolute physical root of the store, e.g. "/data/media". Required when <see cref="Enabled"/>.</summary>
+    public string RootPath { get; set; }
+}

--- a/src/Equibles.Media.BusinessLogic/FileManager.cs
+++ b/src/Equibles.Media.BusinessLogic/FileManager.cs
@@ -1,7 +1,10 @@
 using Equibles.Core.AutoWiring;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.BusinessLogic.Storage;
 using Equibles.Media.Data.Models;
 using Equibles.Media.Repositories;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using MimeTypes;
 using File = Equibles.Media.Data.Models.File;
 
@@ -30,10 +33,21 @@ public class FileManager : IFileManager
     }
 
     private readonly FileRepository _fileRepository;
+    private readonly DatabaseFileStorageProvider _databaseProvider;
+    private readonly FileSystemFileStorageProvider _fileSystemProvider;
+    private readonly FileStorageOptions _options;
 
-    public FileManager(FileRepository fileRepository)
+    public FileManager(
+        FileRepository fileRepository,
+        DatabaseFileStorageProvider databaseProvider,
+        FileSystemFileStorageProvider fileSystemProvider,
+        IOptions<FileStorageOptions> options
+    )
     {
         _fileRepository = fileRepository;
+        _databaseProvider = databaseProvider;
+        _fileSystemProvider = fileSystemProvider;
+        _options = options.Value;
     }
 
     /**
@@ -45,7 +59,7 @@ public class FileManager : IFileManager
      * <param name="fileName">The file name</param>
      * <param name="protect">If the file should be protected using a security token for access</param>
      */
-    public Task<File> SaveFile(byte[] content, string fileName, bool protect = false)
+    public async Task<File> SaveFile(byte[] content, string fileName, bool protect = false)
     {
         var fileExtension = Path.GetExtension(fileName)?.TrimStart('.');
         var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
@@ -75,14 +89,14 @@ public class FileManager : IFileManager
         {
             Extension = fileExtension,
             Name = fileNameWithoutExtension,
-            Size = content.Length,
             ContentType = contentType,
         };
 
-        file.FileContent = new FileContent() { File = file, Bytes = content };
+        // User uploads always stay in the database (small, hot, served directly).
+        await _databaseProvider.Save(file, content, FileStorageTiers.Blob);
 
         _fileRepository.Add(file);
-        return Task.FromResult(file);
+        return file;
     }
 
     /// <summary>
@@ -92,29 +106,43 @@ public class FileManager : IFileManager
     /// gzip-compressed XBRL envelope captured during SEC ingest), never for user uploads —
     /// those must go through <see cref="SaveFile"/> so the allowlist is enforced.
     /// </summary>
-    public Task<File> SaveInternalFile(
+    public async Task<File> SaveInternalFile(
         byte[] content,
         string name,
         string extension,
-        string contentType
+        string contentType,
+        StorageProvider storage = null,
+        string tier = null
     )
     {
         var file = new File()
         {
             Extension = extension,
             Name = name,
-            Size = content.Length,
             ContentType = contentType,
         };
 
-        file.FileContent = new FileContent() { File = file, Bytes = content };
+        var provider = ResolveWriteProvider(storage);
+        await provider.Save(file, content, tier ?? FileStorageTiers.Blob);
 
         _fileRepository.Add(file);
-        return Task.FromResult(file);
+        return file;
+    }
+
+    public Task<byte[]> GetContent(File file)
+    {
+        return ResolveProvider(file.StorageProvider).GetContent(file);
+    }
+
+    public Task<Stream> OpenRead(File file)
+    {
+        return ResolveProvider(file.StorageProvider).OpenRead(file);
     }
 
     /// <summary>
-    /// Deletes a file from the database. The db context is not saved.
+    /// Deletes a file from the database. The db context is not saved. Filesystem-stored
+    /// bytes are reclaimed by the orphan sweep, not deleted inline — content addressing
+    /// means another row may reference the same path.
     /// </summary>
     /// <param name="file">The file to delete</param>
     public void DeleteFile(File file)
@@ -122,5 +150,28 @@ public class FileManager : IFileManager
         if (file == null)
             return;
         _fileRepository.Delete(file);
+    }
+
+    // Filesystem writes are opt-in: when the store is disabled, fall back to the database
+    // so a deployment without a configured root keeps working unchanged.
+    private IFileStorageProvider ResolveWriteProvider(StorageProvider requested)
+    {
+        var target = requested ?? StorageProvider.Database;
+        if (target == StorageProvider.FileSystem && !_options.Enabled)
+        {
+            target = StorageProvider.Database;
+        }
+
+        return ResolveProvider(target);
+    }
+
+    private IFileStorageProvider ResolveProvider(StorageProvider provider)
+    {
+        if (provider == StorageProvider.FileSystem)
+        {
+            return _fileSystemProvider;
+        }
+
+        return _databaseProvider;
     }
 }

--- a/src/Equibles.Media.BusinessLogic/IFileManager.cs
+++ b/src/Equibles.Media.BusinessLogic/IFileManager.cs
@@ -1,3 +1,4 @@
+using Equibles.Media.Data.Models;
 using File = Equibles.Media.Data.Models.File;
 
 namespace Equibles.Media.BusinessLogic;
@@ -11,13 +12,25 @@ public interface IFileManager
     /// extension and content type, bypassing the <see cref="FileManager.AcceptedExtensions"/>
     /// upload allowlist. Use only for content the application itself produces — e.g. a
     /// gzip-compressed XBRL envelope captured during SEC ingest — never for inbound files.
+    /// <paramref name="storage"/> selects the backend (default Database preserves the original
+    /// behavior; SEC ingest passes FileSystem). A FileSystem request falls back to Database when
+    /// the store is disabled. <paramref name="tier"/> selects the filesystem durability partition
+    /// (see <see cref="Storage.FileStorageTiers"/>).
     /// </summary>
     public Task<File> SaveInternalFile(
         byte[] content,
         string name,
         string extension,
-        string contentType
+        string contentType,
+        StorageProvider storage = null,
+        string tier = null
     );
+
+    /// <summary>Reads a file's full bytes, dispatching on where it is stored.</summary>
+    public Task<byte[]> GetContent(File file);
+
+    /// <summary>Opens a read stream over a file's bytes, dispatching on where it is stored. The caller disposes it.</summary>
+    public Task<Stream> OpenRead(File file);
 
     public void DeleteFile(File file);
 }

--- a/src/Equibles.Media.BusinessLogic/Storage/ContentAddressedPath.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/ContentAddressedPath.cs
@@ -1,0 +1,45 @@
+using System.Security.Cryptography;
+
+namespace Equibles.Media.BusinessLogic.Storage;
+
+/// <summary>
+/// Builds the content-addressed relative path for a blob and computes its hash.
+/// Layout: <c>&lt;tier&gt;/sha256/&lt;hash[0:2]&gt;/&lt;hash[2:4]&gt;/&lt;hash&gt;</c> — two levels of
+/// 2-hex sharding keep any directory to a few hundred entries even at tens of millions
+/// of files. The path is a pure function of the content, so identical bytes always map
+/// to the same location (free deduplication). Paths use forward slashes so the stored
+/// RelativePath is OS-independent.
+/// </summary>
+public static class ContentAddressedPath
+{
+    public const string Algorithm = "sha256";
+
+    /// <summary>Prefix for the stored <c>File.ContentHash</c>, e.g. "sha256:" — multihash-style so a future algorithm change can coexist.</summary>
+    public const string HashPrefix = Algorithm + ":";
+
+    public static string ComputeSha256Hex(byte[] content)
+    {
+        return Convert.ToHexStringLower(SHA256.HashData(content));
+    }
+
+    public static string Build(string tier, string hashHex)
+    {
+        if (string.IsNullOrEmpty(tier))
+        {
+            throw new ArgumentException("Tier is required.", nameof(tier));
+        }
+
+        if (hashHex == null || hashHex.Length < 4)
+        {
+            throw new ArgumentException("Hash must be at least 4 hex characters.", nameof(hashHex));
+        }
+
+        return $"{tier}/{Algorithm}/{hashHex[..2]}/{hashHex[2..4]}/{hashHex}";
+    }
+
+    /// <summary>Converts a stored forward-slash relative path to the host OS separator.</summary>
+    public static string ToOsPath(string relativePath)
+    {
+        return relativePath.Replace('/', Path.DirectorySeparatorChar);
+    }
+}

--- a/src/Equibles.Media.BusinessLogic/Storage/DatabaseFileStorageProvider.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/DatabaseFileStorageProvider.cs
@@ -1,0 +1,34 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Media.Data.Models;
+using Microsoft.Extensions.DependencyInjection;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.Media.BusinessLogic.Storage;
+
+/// <summary>
+/// Stores bytes inline in the FileContent table — the original behavior. This is the
+/// default backend, so existing rows and callers are unchanged.
+/// </summary>
+[Service(ServiceLifetime.Scoped)]
+public class DatabaseFileStorageProvider : IFileStorageProvider
+{
+    public StorageProvider Provider => StorageProvider.Database;
+
+    public Task Save(File file, byte[] content, string tier)
+    {
+        file.Size = content.Length;
+        file.StorageProvider = StorageProvider.Database;
+        file.FileContent = new FileContent() { File = file, Bytes = content };
+        return Task.CompletedTask;
+    }
+
+    public Task<byte[]> GetContent(File file)
+    {
+        return Task.FromResult(file.FileContent.Bytes);
+    }
+
+    public Task<Stream> OpenRead(File file)
+    {
+        return Task.FromResult<Stream>(new MemoryStream(file.FileContent.Bytes, writable: false));
+    }
+}

--- a/src/Equibles.Media.BusinessLogic/Storage/DurableFileWriter.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/DurableFileWriter.cs
@@ -23,6 +23,17 @@ public static class DurableFileWriter
         }
 
         var directory = Path.GetDirectoryName(fullPath);
+
+        // Record the deepest ancestor that already exists before we create the shard chain,
+        // so afterwards we can fsync every directory whose entries changed — not just the
+        // leaf. Sharding creates fresh <xx>/<yy> dirs; persisting the file's dirent alone
+        // would still lose those parent dirents on a crash, orphaning the fsynced file.
+        var deepestExistingAncestor = directory;
+        while (deepestExistingAncestor != null && !Directory.Exists(deepestExistingAncestor))
+        {
+            deepestExistingAncestor = Path.GetDirectoryName(deepestExistingAncestor);
+        }
+
         Directory.CreateDirectory(directory);
 
         // Temp file lives in the final directory so the rename stays on one filesystem
@@ -57,7 +68,17 @@ public static class DurableFileWriter
                 return;
             }
 
-            FsyncDirectory(directory);
+            // Persist the file's dirent (leaf) and each freshly-created shard directory,
+            // walking up to and including the first pre-existing ancestor (its entry set
+            // also changed by gaining the topmost new child).
+            for (var dir = directory; dir != null; dir = Path.GetDirectoryName(dir))
+            {
+                FsyncDirectory(dir);
+                if (dir == deepestExistingAncestor)
+                {
+                    break;
+                }
+            }
         }
         finally
         {

--- a/src/Equibles.Media.BusinessLogic/Storage/DurableFileWriter.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/DurableFileWriter.cs
@@ -1,0 +1,119 @@
+using System.Runtime.InteropServices;
+
+namespace Equibles.Media.BusinessLogic.Storage;
+
+/// <summary>
+/// Crash-safe, write-once file creation for the content-addressed store. Sequence:
+/// write a temp file on the same filesystem → fsync the file → atomic rename into
+/// place → fsync the containing directory (so the new directory entry survives a
+/// crash). Because the store is content-addressed, a target that already exists holds
+/// identical bytes, so the write is skipped (deduplication). Writing the file before
+/// the caller saves the File row means a crash leaves a harmless orphan file (reclaimed
+/// by the sweep), never a row pointing at nothing.
+/// </summary>
+public static class DurableFileWriter
+{
+    private const int BufferSize = 1 << 16;
+
+    public static async Task WriteIfMissing(string fullPath, byte[] content)
+    {
+        if (System.IO.File.Exists(fullPath))
+        {
+            return; // dedup: identical content already stored
+        }
+
+        var directory = Path.GetDirectoryName(fullPath);
+        Directory.CreateDirectory(directory);
+
+        // Temp file lives in the final directory so the rename stays on one filesystem
+        // (a cross-device rename is not atomic). The leading dot + .tmp suffix let the
+        // orphan sweep recognize and skip in-flight temp files.
+        var tempPath = Path.Combine(directory, "." + Guid.NewGuid().ToString("N") + ".tmp");
+
+        try
+        {
+            await using (
+                var stream = new FileStream(
+                    tempPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None,
+                    BufferSize,
+                    FileOptions.None
+                )
+            )
+            {
+                await stream.WriteAsync(content);
+                stream.Flush(flushToDisk: true); // fsync the file's data + metadata
+            }
+
+            try
+            {
+                System.IO.File.Move(tempPath, fullPath, overwrite: false);
+            }
+            catch (IOException) when (System.IO.File.Exists(fullPath))
+            {
+                // A concurrent writer won the race with identical (content-addressed) bytes.
+                return;
+            }
+
+            FsyncDirectory(directory);
+        }
+        finally
+        {
+            if (System.IO.File.Exists(tempPath))
+            {
+                try
+                {
+                    System.IO.File.Delete(tempPath);
+                }
+                catch (IOException)
+                {
+                    // Best-effort cleanup; the orphan sweep removes any straggler temp files.
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Persists a directory's entries to stable storage. .NET has no built-in directory
+    /// fsync, so on Unix we open the directory and fsync its descriptor. No-op on Windows
+    /// (development only; production runs on Linux), where directory handles can't be fsynced.
+    /// </summary>
+    private static void FsyncDirectory(string directory)
+    {
+        if (
+            !RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+        )
+        {
+            return;
+        }
+
+        var fd = open(directory, O_RDONLY);
+        if (fd < 0)
+        {
+            return; // best-effort
+        }
+
+        try
+        {
+            fsync(fd);
+        }
+        finally
+        {
+            close(fd);
+        }
+    }
+
+    private const int O_RDONLY = 0;
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int open(string pathname, int flags);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int fsync(int fd);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int close(int fd);
+}

--- a/src/Equibles.Media.BusinessLogic/Storage/FileStorageTiers.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/FileStorageTiers.cs
@@ -1,0 +1,17 @@
+namespace Equibles.Media.BusinessLogic.Storage;
+
+/// <summary>
+/// Top-level partition of the filesystem store, chosen for durability placement — a
+/// different disk/dataset can be mounted at <c>&lt;root&gt;/audio</c> so precious audio
+/// gets its own redundancy — NOT for sharding. It never affects deduplication because
+/// bytes of different kinds never collide. Reads use <c>File.RelativePath</c> directly,
+/// so the tier only matters at write time.
+/// </summary>
+public static class FileStorageTiers
+{
+    /// <summary>Re-scrapable bulk content: filings, XBRL envelopes, images, PDFs, text.</summary>
+    public const string Blob = "blob";
+
+    /// <summary>Precious, hard-to-recapture content: earnings-call audio.</summary>
+    public const string Audio = "audio";
+}

--- a/src/Equibles.Media.BusinessLogic/Storage/FileSystemFileStorageProvider.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/FileSystemFileStorageProvider.cs
@@ -1,0 +1,85 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.Data.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.Media.BusinessLogic.Storage;
+
+/// <summary>
+/// Stores bytes on a content-addressed, sharded filesystem tree rooted at the configured
+/// path: <c>&lt;root&gt;/&lt;tier&gt;/sha256/&lt;hash[0:2]&gt;/&lt;hash[2:4]&gt;/&lt;hash&gt;</c>. The path is a
+/// pure function of the content (SHA-256), giving byte-level deduplication. Writes are
+/// crash-safe via <see cref="DurableFileWriter"/> (temp → fsync → atomic rename → fsync dir),
+/// and the File row is persisted by the caller afterwards (blob-before-row).
+/// </summary>
+[Service(ServiceLifetime.Scoped)]
+public class FileSystemFileStorageProvider : IFileStorageProvider
+{
+    private readonly FileStorageOptions _options;
+
+    public FileSystemFileStorageProvider(IOptions<FileStorageOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public StorageProvider Provider => StorageProvider.FileSystem;
+
+    public async Task Save(File file, byte[] content, string tier)
+    {
+        var hashHex = ContentAddressedPath.ComputeSha256Hex(content);
+        var relativePath = ContentAddressedPath.Build(tier, hashHex);
+        var fullPath = Path.Combine(RequireRoot(), ContentAddressedPath.ToOsPath(relativePath));
+
+        await DurableFileWriter.WriteIfMissing(fullPath, content);
+
+        file.Size = content.Length;
+        file.StorageProvider = StorageProvider.FileSystem;
+        file.RelativePath = relativePath;
+        file.ContentHash = ContentAddressedPath.HashPrefix + hashHex;
+        file.FileContent = null;
+    }
+
+    public Task<byte[]> GetContent(File file)
+    {
+        return System.IO.File.ReadAllBytesAsync(ResolvePath(file));
+    }
+
+    public Task<Stream> OpenRead(File file)
+    {
+        Stream stream = new FileStream(
+            ResolvePath(file),
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 1 << 16,
+            FileOptions.Asynchronous | FileOptions.SequentialScan
+        );
+        return Task.FromResult(stream);
+    }
+
+    private string ResolvePath(File file)
+    {
+        if (string.IsNullOrEmpty(file.RelativePath))
+        {
+            throw new InvalidOperationException(
+                $"File {file.Id} is FileSystem-stored but has no RelativePath."
+            );
+        }
+
+        return Path.Combine(RequireRoot(), ContentAddressedPath.ToOsPath(file.RelativePath));
+    }
+
+    private string RequireRoot()
+    {
+        if (string.IsNullOrEmpty(_options.RootPath))
+        {
+            throw new InvalidOperationException(
+                "FileStorage:RootPath is not configured; cannot use the filesystem storage provider."
+            );
+        }
+
+        return _options.RootPath;
+    }
+}

--- a/src/Equibles.Media.BusinessLogic/Storage/IFileStorageProvider.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/IFileStorageProvider.cs
@@ -1,0 +1,29 @@
+using Equibles.Media.Data.Models;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.Media.BusinessLogic.Storage;
+
+/// <summary>
+/// A backend that physically stores and retrieves a <see cref="File"/>'s bytes. One
+/// implementation per <see cref="StorageProvider"/> value; <c>FileManager</c> dispatches
+/// on <c>File.StorageProvider</c>.
+/// </summary>
+public interface IFileStorageProvider
+{
+    /// <summary>The storage backend this implementation handles.</summary>
+    StorageProvider Provider { get; }
+
+    /// <summary>
+    /// Persists content for a newly-created File, stamping the File's storage metadata
+    /// (Size, StorageProvider, and for the filesystem backend RelativePath + ContentHash).
+    /// Does not save the DbContext — the caller does. <paramref name="tier"/> selects the
+    /// durability partition (see <see cref="FileStorageTiers"/>); the database backend ignores it.
+    /// </summary>
+    Task Save(File file, byte[] content, string tier);
+
+    /// <summary>Reads the full content of a stored File.</summary>
+    Task<byte[]> GetContent(File file);
+
+    /// <summary>Opens a read stream over a stored File's content. The caller disposes it.</summary>
+    Task<Stream> OpenRead(File file);
+}

--- a/src/Equibles.Media.Data/MediaModuleConfiguration.cs
+++ b/src/Equibles.Media.Data/MediaModuleConfiguration.cs
@@ -1,5 +1,6 @@
 using Equibles.Media.Data.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equibles.Media.Data;
 
@@ -7,7 +8,24 @@ public class MediaModuleConfiguration : Equibles.Data.IFinancialModule
 {
     public void ConfigureEntities(ModelBuilder builder)
     {
-        builder.Entity<Models.File>();
+        // Store the StorageProvider smart enum as a string; the fallback tolerates
+        // unknown/NULL column values (following the DocumentType convention). The DB
+        // default backfills existing rows to "Database" during the migration.
+        var storageProviderConversion = new ValueConverter<StorageProvider, string>(
+            v => v.Value,
+            v => StorageProvider.FromValue(v) ?? new StorageProvider(v)
+        );
+
+        builder.Entity<Models.File>(b =>
+        {
+            b.Property(e => e.StorageProvider)
+                .HasConversion(storageProviderConversion)
+                .HasMaxLength(16)
+                .HasDefaultValue(StorageProvider.Database);
+
+            // Lets the migration drain worker cheaply find rows still stored in the database.
+            b.HasIndex(e => e.StorageProvider);
+        });
         builder.Entity<FileContent>();
         builder.Entity<Image>();
     }

--- a/src/Equibles.Media.Data/Models/File.cs
+++ b/src/Equibles.Media.Data/Models/File.cs
@@ -19,5 +19,22 @@ public class File
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 
-    public virtual FileContent FileContent { get; set; } = new();
+    // Where the bytes physically live. Defaults to Database so existing rows and callers
+    // are unchanged; FileSystem-stored files carry RelativePath + ContentHash instead of
+    // a FileContent row. Indexed so the migration drain worker can cheaply find un-migrated rows.
+    public StorageProvider StorageProvider { get; set; } = StorageProvider.Database;
+
+    // Relative path within the configured filesystem store root, e.g.
+    // "blob/sha256/a7/f3/a7f3…". Set only when StorageProvider == FileSystem. Always
+    // relative so the store can move between disks without touching rows.
+    [StringLength(128)]
+    public string RelativePath { get; set; }
+
+    // Algorithm-prefixed content hash, e.g. "sha256:a7f3…". Set on filesystem writes;
+    // enables byte-level dedup and integrity checks.
+    [StringLength(80)]
+    public string ContentHash { get; set; }
+
+    // Present only for Database-stored files.
+    public virtual FileContent FileContent { get; set; }
 }

--- a/src/Equibles.Media.Data/Models/StorageProvider.cs
+++ b/src/Equibles.Media.Data/Models/StorageProvider.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+
+namespace Equibles.Media.Data.Models;
+
+/// <summary>
+/// Where a <see cref="File"/>'s bytes physically live. Stored as a string in the
+/// database via a ValueConverter (see MediaModuleConfiguration), following the
+/// DocumentType/ErrorSource smart-enum convention. Extensible via <see cref="Register"/>
+/// so a deployment can add backends (e.g. object storage) without changing this class.
+/// </summary>
+public sealed class StorageProvider
+{
+    public string Value { get; }
+
+    public StorageProvider(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>Bytes stored inline in the FileContent table — the original behavior.</summary>
+    public static readonly StorageProvider Database = new("Database");
+
+    /// <summary>Bytes stored on a content-addressed filesystem tree; the File carries RelativePath + ContentHash.</summary>
+    public static readonly StorageProvider FileSystem = new("FileSystem");
+
+    private static readonly ConcurrentDictionary<string, StorageProvider> AllByValue = new(
+        new[]
+        {
+            new KeyValuePair<string, StorageProvider>(Database.Value, Database),
+            new KeyValuePair<string, StorageProvider>(FileSystem.Value, FileSystem),
+        },
+        StringComparer.OrdinalIgnoreCase
+    );
+
+    public static StorageProvider FromValue(string value)
+    {
+        // The OrdinalIgnoreCase comparer's GetHashCode throws on null, so a null
+        // lookup must short-circuit. FromValue returns null on no match — the EF
+        // value converter relies on this for NULL columns.
+        if (value == null)
+        {
+            return null;
+        }
+
+        return AllByValue.GetValueOrDefault(value);
+    }
+
+    public static IEnumerable<StorageProvider> GetAll() => AllByValue.Values;
+
+    public static void Register(StorageProvider provider)
+    {
+        AllByValue.TryAdd(provider.Value, provider);
+    }
+
+    public override string ToString() => Value;
+
+    public override bool Equals(object obj) => obj is StorageProvider other && Value == other.Value;
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+    public static bool operator ==(StorageProvider left, StorageProvider right) =>
+        Equals(left, right);
+
+    public static bool operator !=(StorageProvider left, StorageProvider right) =>
+        !Equals(left, right);
+}

--- a/src/Equibles.Migrations/Migrations/20260701152914_AddFileStorageProviderColumns.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260701152914_AddFileStorageProviderColumns.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701152914_AddFileStorageProviderColumns")]
+    partial class AddFileStorageProviderColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260701152914_AddFileStorageProviderColumns.cs
+++ b/src/Equibles.Migrations/Migrations/20260701152914_AddFileStorageProviderColumns.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFileStorageProviderColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ContentHash",
+                table: "File",
+                type: "character varying(80)",
+                maxLength: 80,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RelativePath",
+                table: "File",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "StorageProvider",
+                table: "File",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true,
+                defaultValue: "Database");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_File_StorageProvider",
+                table: "File",
+                column: "StorageProvider");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_File_StorageProvider",
+                table: "File");
+
+            migrationBuilder.DropColumn(
+                name: "ContentHash",
+                table: "File");
+
+            migrationBuilder.DropColumn(
+                name: "RelativePath",
+                table: "File");
+
+            migrationBuilder.DropColumn(
+                name: "StorageProvider",
+                table: "File");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Helpers/FileManagerTestFactory.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/FileManagerTestFactory.cs
@@ -1,0 +1,27 @@
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.BusinessLogic.Storage;
+using Equibles.Media.Repositories;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.IntegrationTests;
+
+/// <summary>
+/// Builds a <see cref="FileManager"/> wired with the real storage providers for tests
+/// that exercise the default (database) write path. The filesystem store is left
+/// disabled unless the caller supplies options that enable it. Lives in the root
+/// namespace so tests in any subfolder can use it without an extra using.
+/// </summary>
+internal static class FileManagerTestFactory
+{
+    public static FileManager Create(FileRepository repository, FileStorageOptions options = null)
+    {
+        var wrapped = Options.Create(options ?? new FileStorageOptions());
+        return new FileManager(
+            repository,
+            new DatabaseFileStorageProvider(),
+            new FileSystemFileStorageProvider(wrapped),
+            wrapped
+        );
+    }
+}

--- a/tests/Equibles.IntegrationTests/Media/FileManagerSaveFileExtensionAllowlistTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/FileManagerSaveFileExtensionAllowlistTests.cs
@@ -12,7 +12,7 @@ public class FileManagerSaveFileExtensionAllowlistTests
     public FileManagerSaveFileExtensionAllowlistTests()
     {
         var context = TestDbContextFactory.Create(new MediaModuleConfiguration());
-        _sut = new FileManager(new FileRepository(context));
+        _sut = FileManagerTestFactory.Create(new FileRepository(context));
     }
 
     // Contract: FileManager publishes a curated AcceptedExtensions allowlist

--- a/tests/Equibles.IntegrationTests/Media/FileManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/FileManagerTests.cs
@@ -14,7 +14,7 @@ public class FileManagerTests
     {
         var context = TestDbContextFactory.Create(new MediaModuleConfiguration());
         _repository = new FileRepository(context);
-        _sut = new FileManager(_repository);
+        _sut = FileManagerTestFactory.Create(_repository);
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceReplaceContentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceReplaceContentTests.cs
@@ -48,11 +48,11 @@ public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase
         new(
             new DocumentRepository(DbContext),
             new ChunkRepository(DbContext),
-            new FileManager(new FileRepository(DbContext)),
+            FileManagerTestFactory.Create(new FileRepository(DbContext)),
             new DocumentImageService(
                 new DocumentImageRepository(DbContext),
                 new FileRepository(DbContext),
-                new FileManager(new FileRepository(DbContext))
+                FileManagerTestFactory.Create(new FileRepository(DbContext))
             ),
             Substitute.For<IBus>()
         );

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceXbrlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceXbrlTests.cs
@@ -54,11 +54,11 @@ public class DocumentPersistenceServiceXbrlTests : ParadeDbMcpTestBase
         new(
             new DocumentRepository(DbContext),
             new ChunkRepository(DbContext),
-            new FileManager(new FileRepository(DbContext)),
+            FileManagerTestFactory.Create(new FileRepository(DbContext)),
             new DocumentImageService(
                 new DocumentImageRepository(DbContext),
                 new FileRepository(DbContext),
-                new FileManager(new FileRepository(DbContext))
+                FileManagerTestFactory.Create(new FileRepository(DbContext))
             ),
             Substitute.For<IBus>()
         );

--- a/tests/Equibles.UnitTests/Media/ContentAddressedPathTests.cs
+++ b/tests/Equibles.UnitTests/Media/ContentAddressedPathTests.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using Equibles.Media.BusinessLogic.Storage;
+
+namespace Equibles.UnitTests.Media;
+
+public class ContentAddressedPathTests
+{
+    // The layout must be a pure function of the content hash with two levels of
+    // 2-hex sharding: <tier>/sha256/<hash[0:2]>/<hash[2:4]>/<hash>. Any drift here
+    // (extra segment, wrong shard width) breaks dedup or unbalances directories.
+    [Fact]
+    public void Build_ShardsBySha256Prefix_ProducesTwoLevelPath()
+    {
+        var hash = "a7f3c9d0e1b2a3f4c5d6e7f8091a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f90";
+
+        var path = ContentAddressedPath.Build(FileStorageTiers.Blob, hash);
+
+        path.Should().Be($"blob/sha256/a7/f3/{hash}");
+    }
+
+    // The audio tier lives under its own top-level segment so it can be mounted on a
+    // separate disk; only the leading tier changes, the sharding is identical.
+    [Fact]
+    public void Build_AudioTier_UsesAudioTopLevelSegment()
+    {
+        var hash = "0011223344556677889900112233445566778899001122334455667788990011";
+
+        var path = ContentAddressedPath.Build(FileStorageTiers.Audio, hash);
+
+        path.Should().Be($"audio/sha256/00/11/{hash}");
+    }
+
+    // SHA-256 is the content address; pin the canonical NIST test vector so a hashing
+    // regression (wrong algorithm, encoding, or casing) is caught immediately.
+    [Fact]
+    public void ComputeSha256Hex_KnownVector_MatchesLowercaseHex()
+    {
+        var hex = ContentAddressedPath.ComputeSha256Hex(Encoding.ASCII.GetBytes("abc"));
+
+        hex.Should().Be("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    }
+
+    [Fact]
+    public void Build_HashShorterThanShardWidth_Throws()
+    {
+        var act = () => ContentAddressedPath.Build(FileStorageTiers.Blob, "ab");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Build_MissingTier_Throws()
+    {
+        var act = () => ContentAddressedPath.Build("", "a7f3c9d0e1b2");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Equibles.UnitTests/Media/DatabaseFileStorageProviderTests.cs
+++ b/tests/Equibles.UnitTests/Media/DatabaseFileStorageProviderTests.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using Equibles.Media.BusinessLogic.Storage;
+using Equibles.Media.Data.Models;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.UnitTests.Media;
+
+public class DatabaseFileStorageProviderTests
+{
+    // The database provider preserves the original behavior: bytes go into a FileContent
+    // row and the File is stamped Database with its size — no path/hash.
+    [Fact]
+    public async Task Save_StoresBytesInFileContent_AndStampsDatabaseMetadata()
+    {
+        var provider = new DatabaseFileStorageProvider();
+        var file = new File();
+        var content = Encoding.UTF8.GetBytes("hello database");
+
+        await provider.Save(file, content, FileStorageTiers.Blob);
+
+        file.StorageProvider.Should().Be(StorageProvider.Database);
+        file.Size.Should().Be(content.Length);
+        file.FileContent.Should().NotBeNull();
+        file.FileContent.Bytes.Should().Equal(content);
+        file.RelativePath.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetContent_ReturnsStoredBytes()
+    {
+        var provider = new DatabaseFileStorageProvider();
+        var file = new File();
+        var content = Encoding.UTF8.GetBytes("round trip");
+        await provider.Save(file, content, FileStorageTiers.Blob);
+
+        var read = await provider.GetContent(file);
+
+        read.Should().Equal(content);
+    }
+}

--- a/tests/Equibles.UnitTests/Media/FileManagerSaveFileMissingExtensionTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerSaveFileMissingExtensionTests.cs
@@ -15,7 +15,7 @@ public class FileManagerSaveFileMissingExtensionTests
     public async Task SaveFile_FilenameWithoutExtension_ThrowsArgumentException()
     {
         var repository = Substitute.For<FileRepository>((EquiblesFinancialDbContext)null);
-        var sut = new FileManager(repository);
+        var sut = FileManagerTestFactory.Create(repository);
 
         var act = () => sut.SaveFile("content"u8.ToArray(), "README");
 

--- a/tests/Equibles.UnitTests/Media/FileManagerSaveFileRejectedExtensionTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerSaveFileRejectedExtensionTests.cs
@@ -14,7 +14,7 @@ public class FileManagerSaveFileRejectedExtensionTests
     public async Task SaveFile_DisallowedExtension_ThrowsArgumentException()
     {
         var repository = Substitute.For<FileRepository>((EquiblesFinancialDbContext)null);
-        var sut = new FileManager(repository);
+        var sut = FileManagerTestFactory.Create(repository);
 
         var act = () => sut.SaveFile("malicious"u8.ToArray(), "payload.exe");
 

--- a/tests/Equibles.UnitTests/Media/FileManagerSaveFileTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerSaveFileTests.cs
@@ -16,7 +16,7 @@ public class FileManagerSaveFileTests
     public FileManagerSaveFileTests()
     {
         _repository = Substitute.For<FileRepository>((EquiblesFinancialDbContext)null);
-        _sut = new FileManager(_repository);
+        _sut = FileManagerTestFactory.Create(_repository);
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Media/FileManagerSaveFileUppercaseExtensionTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerSaveFileUppercaseExtensionTests.cs
@@ -17,7 +17,7 @@ public class FileManagerSaveFileUppercaseExtensionTests
     public async Task SaveFile_AcceptedExtensionInUpperCase_ResolvesRealContentType()
     {
         var repository = Substitute.For<FileRepository>((EquiblesFinancialDbContext)null);
-        var sut = new FileManager(repository);
+        var sut = FileManagerTestFactory.Create(repository);
         var content = "fake-pdf-content"u8.ToArray();
 
         var file = await sut.SaveFile(content, "quarterly-report.PDF");

--- a/tests/Equibles.UnitTests/Media/FileManagerSaveInternalFileTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerSaveInternalFileTests.cs
@@ -17,7 +17,7 @@ public class FileManagerSaveInternalFileTests
     public async Task SaveInternalFile_NonAllowlistedExtension_PersistsBlobVerbatim()
     {
         var repository = Substitute.For<FileRepository>((EquiblesFinancialDbContext)null);
-        var sut = new FileManager(repository);
+        var sut = FileManagerTestFactory.Create(repository);
         var content = "gzip-xbrl-bytes"u8.ToArray();
 
         var file = await sut.SaveInternalFile(content, "xbrl-envelope", "gz", "application/gzip");

--- a/tests/Equibles.UnitTests/Media/FileManagerTestFactory.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerTestFactory.cs
@@ -1,0 +1,26 @@
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.BusinessLogic.Storage;
+using Equibles.Media.Repositories;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.UnitTests.Media;
+
+/// <summary>
+/// Builds a <see cref="FileManager"/> wired with the real storage providers for tests
+/// that exercise the default (database) write path. The filesystem store is left
+/// disabled unless the caller supplies options that enable it.
+/// </summary>
+internal static class FileManagerTestFactory
+{
+    public static FileManager Create(FileRepository repository, FileStorageOptions options = null)
+    {
+        var wrapped = Options.Create(options ?? new FileStorageOptions());
+        return new FileManager(
+            repository,
+            new DatabaseFileStorageProvider(),
+            new FileSystemFileStorageProvider(wrapped),
+            wrapped
+        );
+    }
+}

--- a/tests/Equibles.UnitTests/Media/FileSystemFileStorageProviderTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileSystemFileStorageProviderTests.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.BusinessLogic.Storage;
+using Equibles.Media.Data.Models;
+using Microsoft.Extensions.Options;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.UnitTests.Media;
+
+public class FileSystemFileStorageProviderTests : IDisposable
+{
+    private readonly string _root;
+    private readonly FileSystemFileStorageProvider _provider;
+
+    public FileSystemFileStorageProviderTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "eq-blobstore-" + Guid.NewGuid().ToString("N"));
+        _provider = new FileSystemFileStorageProvider(
+            Options.Create(new FileStorageOptions { Enabled = true, RootPath = _root })
+        );
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    // A filesystem write must land the bytes at the content-addressed path and stamp the
+    // File with FileSystem + RelativePath + ContentHash (and clear the DB FileContent).
+    [Fact]
+    public async Task Save_WritesContentAddressedFile_AndStampsMetadata()
+    {
+        var file = new File();
+        var content = Encoding.UTF8.GetBytes("filesystem payload");
+
+        await _provider.Save(file, content, FileStorageTiers.Blob);
+
+        file.StorageProvider.Should().Be(StorageProvider.FileSystem);
+        file.Size.Should().Be(content.Length);
+        file.RelativePath.Should().StartWith("blob/sha256/");
+        file.ContentHash.Should().StartWith("sha256:");
+        file.FileContent.Should().BeNull();
+
+        var onDisk = Path.Combine(_root, ContentAddressedPath.ToOsPath(file.RelativePath));
+        System.IO.File.Exists(onDisk).Should().BeTrue();
+        (await System.IO.File.ReadAllBytesAsync(onDisk)).Should().Equal(content);
+    }
+
+    // Content addressing gives free dedup: identical bytes map to one path and the second
+    // write is a no-op, never an error, even though the target already exists.
+    [Fact]
+    public async Task Save_IdenticalContentTwice_DeduplicatesToSamePath()
+    {
+        var content = Encoding.UTF8.GetBytes("shared exhibit bytes");
+        var first = new File();
+        var second = new File();
+
+        await _provider.Save(first, content, FileStorageTiers.Blob);
+        await _provider.Save(second, content, FileStorageTiers.Blob);
+
+        second.RelativePath.Should().Be(first.RelativePath);
+        var shardDir = Path.GetDirectoryName(
+            Path.Combine(_root, ContentAddressedPath.ToOsPath(first.RelativePath))
+        );
+        Directory.GetFiles(shardDir).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetContentAndOpenRead_RoundTripStoredBytes()
+    {
+        var file = new File();
+        var content = Encoding.UTF8.GetBytes("stream me back");
+        await _provider.Save(file, content, FileStorageTiers.Blob);
+
+        (await _provider.GetContent(file)).Should().Equal(content);
+
+        await using var stream = await _provider.OpenRead(file);
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer);
+        buffer.ToArray().Should().Equal(content);
+    }
+
+    // Guard: a FileSystem file with no path is a corrupt pointer and must fail loudly,
+    // never silently return empty content.
+    [Fact]
+    public async Task GetContent_FileSystemFileWithoutRelativePath_Throws()
+    {
+        var file = new File { StorageProvider = StorageProvider.FileSystem };
+
+        var act = () => _provider.GetContent(file);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/tests/Equibles.UnitTests/Media/StorageProviderTests.cs
+++ b/tests/Equibles.UnitTests/Media/StorageProviderTests.cs
@@ -1,0 +1,42 @@
+using Equibles.Media.Data.Models;
+
+namespace Equibles.UnitTests.Media;
+
+public class StorageProviderTests
+{
+    // The EF value converter round-trips through FromValue, so a known value must map
+    // back to the canonical singleton (case-insensitively, matching the DB collation).
+    [Theory]
+    [InlineData("Database")]
+    [InlineData("database")]
+    [InlineData("FileSystem")]
+    [InlineData("filesystem")]
+    public void FromValue_KnownValue_ReturnsCanonicalInstance(string value)
+    {
+        var provider = StorageProvider.FromValue(value);
+
+        provider.Should().NotBeNull();
+        provider.Value.Should().BeOneOf("Database", "FileSystem");
+    }
+
+    // The converter relies on FromValue returning null for NULL/unknown columns so it
+    // can fall back (FromValue(v) ?? new StorageProvider(v)) — a null lookup must not throw.
+    [Fact]
+    public void FromValue_Null_ReturnsNull()
+    {
+        StorageProvider.FromValue(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void FromValue_Unknown_ReturnsNull()
+    {
+        StorageProvider.FromValue("ObjectStore").Should().BeNull();
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        (StorageProvider.Database == StorageProvider.FromValue("Database")).Should().BeTrue();
+        (StorageProvider.Database != StorageProvider.FileSystem).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

First slice of daniel3303/Equibles#3699 — an **opt-in filesystem storage backend** for the Media module so large cold blobs (zipped filings, XBRL envelopes, images, PDFs, and later audio) can live on disk instead of Postgres `bytea`, while the database keeps only metadata plus a relative path.

**Foundation only — no behavior change.** Everything defaults to `Database`; the filesystem store does nothing until a later slice switches an ingest call site to `FileSystem` and a deployment sets `FileStorage:Enabled`. Safe to ship on its own.

### Design
- **Content-addressed, sharded layout**: `<tier>/sha256/<hash[0:2]>/<hash[2:4]>/<hash>`. Two levels of 2-hex sharding keep any directory to ~hundreds of entries at tens of millions of files; the path is a pure function of the SHA-256, giving byte-level dedup. No date/semantic segment (it would break dedup). Filename is the bare hash — content type comes from `File` metadata on serve.
- **Tier** (`blob` | `audio`) is a top-level segment for **durability placement**, not sharding — a separate disk/dataset can be mounted at `<root>/audio` later with zero row changes. It never affects dedup (bytes of different kinds don't collide).
- **Crash-safe writes**: temp file on the same filesystem → `fsync` → atomic `rename` → **`fsync` the containing directory** (via a small Linux P/Invoke; .NET has no built-in) → then the caller saves the row. A crash leaves a harmless orphan file, never a dangling row.
- `ContentHash` is algorithm-prefixed (`sha256:…`) so a future hash change can coexist.

## Code changes
- **`Equibles.Media.Data`** — `StorageProvider` smart enum (`Database` | `FileSystem`); `File` gains `StorageProvider` (default Database), `RelativePath`, `ContentHash`; `FileContent` nav is now optional. `MediaModuleConfiguration` maps the enum via a string `ValueConverter` (DB default `Database`) + indexes `StorageProvider`.
- **`Equibles.Media.BusinessLogic`** — `IFileStorageProvider` with `DatabaseFileStorageProvider` (original behavior) and `FileSystemFileStorageProvider`; `ContentAddressedPath` (hash + path builder), `DurableFileWriter` (durable write sequence), `FileStorageTiers`, `FileStorageOptions`. `IFileManager` gains `GetContent` / `OpenRead` (dispatch on `StorageProvider`) and an optional storage hint + tier on `SaveInternalFile`; a FileSystem request falls back to Database when the store is disabled.
- **Migration** (`EquiblesFinancialDbContext`) — adds the three columns (existing rows backfill to `Database`) and the index. Scaffolded, not hand-edited.
- **Tests** — unit coverage for path/shard/hash, both provider round-trips, and dedup; existing `FileManager` tests updated for the new constructor via a shared test factory.

## Follow-ups (separate PRs)
1. Switch SEC ingest writes to `FileSystem` + refactor the `FileContent.Bytes` read consumers onto `GetContent`/`OpenRead`.
2. Resumable, self-disabling backfill drain worker + orphan-sweep hosted service (new `Equibles.Media.HostedService`).

Commercial deployment wiring (both-context migration, bind-mounts, drain enablement) tracked in the companion issue.

## Verification
- `dotnet build Equibles.sln` — clean.
- `dotnet csharpier check` on changed paths — clean.
- Media unit tests — 26 passing.

A.L.V.I.S.