### PR TITLE
style: apply csharpier formatting to unformatted files

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/IInvestorRelationsPageConfirmer.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IInvestorRelationsPageConfirmer.cs
@@ -29,5 +29,9 @@ public interface IInvestorRelationsPageConfirmer
     /// outage then degrades discovery to keyword-only behavior rather than wrongly writing a real IR
     /// page off as absent and exiling the stock on the miss back-off.
     /// </summary>
-    Task<bool> IsInvestorRelationsPage(string url, string html, CancellationToken cancellationToken);
+    Task<bool> IsInvestorRelationsPage(
+        string url,
+        string html,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsPageValidator.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsPageValidator.cs
@@ -107,7 +107,9 @@ public static class InvestorRelationsPageValidator
         {
             var key = (
                 meta.GetAttributeValue("property", null) ?? meta.GetAttributeValue("name", "")
-            ).Trim().ToLowerInvariant();
+            )
+                .Trim()
+                .ToLowerInvariant();
 
             if (ArticleTimestampProperties.Contains(key))
                 return true;

--- a/src/Equibles.CorporateActions.BusinessLogic/PendingSplitSelection.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/PendingSplitSelection.cs
@@ -6,8 +6,4 @@ namespace Equibles.CorporateActions.BusinessLogic;
 /// is how many distinct stocks had unreconciled splits before the cap, and
 /// <see cref="Skipped"/> is the remainder deferred to a later cycle.
 /// </summary>
-public record PendingSplitSelection(
-    IReadOnlyList<Guid> StockIds,
-    int TotalPending,
-    int Skipped
-);
+public record PendingSplitSelection(IReadOnlyList<Guid> StockIds, int TotalPending, int Skipped);

--- a/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
@@ -48,9 +48,7 @@ public class StockSplitCaptureManager
                 );
                 changes++;
             }
-            else if (
-                match.Numerator != split.Numerator || match.Denominator != split.Denominator
-            )
+            else if (match.Numerator != split.Numerator || match.Denominator != split.Denominator)
             {
                 match.Numerator = split.Numerator;
                 match.Denominator = split.Denominator;

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1386,7 +1386,11 @@ public class InstitutionalHoldingsTools
         foreach (var a in activity)
         {
             var splits = SplitsFor(splitsByStock, a.CommonStockId);
-            a.CurrentShares = SplitAdjustment.AdjustShareCount(a.CurrentShares, currentDate, splits);
+            a.CurrentShares = SplitAdjustment.AdjustShareCount(
+                a.CurrentShares,
+                currentDate,
+                splits
+            );
             a.PreviousShares = SplitAdjustment.AdjustShareCount(
                 a.PreviousShares,
                 previousDate,

--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -60,11 +60,7 @@ public class YahooFinanceClient : IYahooFinanceClient
     // events Yahoo returns for the window (events=split). Callers that need
     // only prices go through GetHistoricalPrices; the split capture piggybacks
     // on this same request so it costs no extra HTTP round-trip.
-    public async Task<YahooChartData> GetChart(
-        string ticker,
-        DateOnly startDate,
-        DateOnly endDate
-    )
+    public async Task<YahooChartData> GetChart(string ticker, DateOnly startDate, DateOnly endDate)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ticker);
         // Yahoo stamps daily bars in the exchange's local time, but the

--- a/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
 using Equibles.CommonStocks.BusinessLogic.Websites;
-using Equibles.CorporateActions.BusinessLogic;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Contracts;
+using Equibles.CorporateActions.BusinessLogic;
 using Equibles.Yahoo.HostedService.Services;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -263,7 +263,9 @@ public class YahooPriceImportService
 
         // Same GH-1591 guard as the incremental flush: the parent CommonStock can be removed
         // between selection and now, which would trip the FK on insert.
-        var stockExists = await stockRepo.GetAll().AnyAsync(s => s.Id == commonStockId, cancellationToken);
+        var stockExists = await stockRepo
+            .GetAll()
+            .AnyAsync(s => s.Id == commonStockId, cancellationToken);
         if (!stockExists)
         {
             _logger.LogWarning(
@@ -439,8 +441,7 @@ public class YahooPriceImportService
         if (stock == null)
             return;
 
-        var captureManager =
-            scope.ServiceProvider.GetRequiredService<StockSplitCaptureManager>();
+        var captureManager = scope.ServiceProvider.GetRequiredService<StockSplitCaptureManager>();
         var count = await captureManager.Capture(stock, captured);
         if (count > 0)
             _logger.LogInformation(

--- a/tests/Equibles.UnitTests/Yahoo/YahooSplitParsingTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooSplitParsingTests.cs
@@ -77,7 +77,9 @@ public class YahooSplitParsingTests
         var chart = await client.GetChart("NVDA", WindowStart, WindowEnd);
 
         chart.Prices.Should().HaveCount(2);
-        chart.Prices.Should().Contain(p => p.Date == new DateOnly(2024, 6, 28) && p.Close == 120.5m);
+        chart
+            .Prices.Should()
+            .Contain(p => p.Date == new DateOnly(2024, 6, 28) && p.Close == 120.5m);
         chart.Prices.Should().Contain(p => p.Date == new DateOnly(2024, 7, 1) && p.Close == 122.5m);
     }
 
@@ -91,7 +93,8 @@ public class YahooSplitParsingTests
         var prices = await client.GetHistoricalPrices("NVDA", WindowStart, WindowEnd);
 
         prices.Should().HaveCount(2);
-        prices.Select(p => p.Date)
+        prices
+            .Select(p => p.Date)
             .Should()
             .BeEquivalentTo([new DateOnly(2024, 6, 28), new DateOnly(2024, 7, 1)]);
     }


### PR DESCRIPTION
## Summary

Runs the repo-pinned csharpier (1.3.0) over nine files that merged without reformatting, which had left the CI `Format check (CSharpier)` red on `main` for every open PR. Whitespace/line-wrapping only — no logic changes.

## Files
CorporateActions (StockSplitCaptureManager, PendingSplitSelection), CommonStocks.HostedService (IInvestorRelationsPageConfirmer, InvestorRelationsPageValidator), Holdings.Mcp (InstitutionalHoldingsTools), Integrations.Yahoo (YahooFinanceClient), Yahoo.HostedService (ServiceCollectionExtensions, YahooPriceImportService), and one test (YahooSplitParsingTests).

A.L.V.I.S.