### PR TITLE
feat(media): route file reads through IFileManager.GetContent

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -335,7 +335,7 @@ public class InsiderFilingReprocessManager
 
         if (filing is { CaptureStatus: InsiderFilingCaptureStatus.Captured, ContentId: not null })
         {
-            var raw = GzipCompressor.Decompress(filing.Content.FileContent.Bytes);
+            var raw = GzipCompressor.Decompress(await _fileManager.GetContent(filing.Content));
             var cachedRoot = InsiderFilingParser.TryGetOwnershipRoot(Encoding.UTF8.GetString(raw));
             if (cachedRoot != null)
                 return cachedRoot;

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -77,6 +77,9 @@ public partial class Program
         builder.Services.Configure<Equibles.Sec.BusinessLogic.Embeddings.EmbeddingConfig>(
             builder.Configuration.GetSection("Embedding")
         );
+        builder.Services.Configure<Equibles.Media.BusinessLogic.Configuration.FileStorageOptions>(
+            builder.Configuration.GetSection("FileStorage")
+        );
 
         builder.Services.AddEquiblesMcp(mcp =>
         {

--- a/src/Equibles.Media.BusinessLogic/Storage/DatabaseFileStorageProvider.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/DatabaseFileStorageProvider.cs
@@ -24,7 +24,10 @@ public class DatabaseFileStorageProvider : IFileStorageProvider
 
     public Task<byte[]> GetContent(File file)
     {
-        return Task.FromResult(file.FileContent.Bytes);
+        // Null-tolerant: a File indexed but never downloaded has a FileContent row with
+        // null Bytes, and callers treat null as "no content" — matching the pre-refactor
+        // `file.Content?.FileContent?.Bytes` semantics exactly.
+        return Task.FromResult(file.FileContent?.Bytes);
     }
 
     public Task<Stream> OpenRead(File file)

--- a/src/Equibles.Sec.BusinessLogic/Equibles.Sec.BusinessLogic.csproj
+++ b/src/Equibles.Sec.BusinessLogic/Equibles.Sec.BusinessLogic.csproj
@@ -24,5 +24,6 @@
     <ProjectReference Include="..\Equibles.Sec.Repositories\Equibles.Sec.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Search.Abstractions\Equibles.Search.Abstractions.csproj" />
+    <ProjectReference Include="..\Equibles.Media.BusinessLogic\Equibles.Media.BusinessLogic.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Equibles.Core.AutoWiring;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Data.Models.Chunks;
@@ -19,6 +20,7 @@ public class DocumentProcessor : IDocumentProcessor
     private readonly IEmbeddingClient _embeddingClient;
     private readonly ChunkingStrategy _chunkingStrategy;
     private readonly EmbeddingConfig _embeddingConfig;
+    private readonly IFileManager _fileManager;
     private readonly ILogger<DocumentProcessor> _logger;
 
     public DocumentProcessor(
@@ -27,6 +29,7 @@ public class DocumentProcessor : IDocumentProcessor
         IEmbeddingClient embeddingClient,
         ChunkingStrategy chunkingStrategy,
         IOptions<EmbeddingConfig> embeddingConfig,
+        IFileManager fileManager,
         ILogger<DocumentProcessor> logger
     )
     {
@@ -35,6 +38,7 @@ public class DocumentProcessor : IDocumentProcessor
         _embeddingClient = embeddingClient;
         _chunkingStrategy = chunkingStrategy;
         _embeddingConfig = embeddingConfig.Value;
+        _fileManager = fileManager;
         _logger = logger;
     }
 
@@ -140,7 +144,7 @@ public class DocumentProcessor : IDocumentProcessor
             document.CommonStock.Ticker
         );
 
-        var content = GetDocumentContent(document);
+        var content = await GetDocumentContent(document);
         if (string.IsNullOrWhiteSpace(content))
         {
             _logger.LogWarning("Document {DocumentId} has no content", document.Id);
@@ -155,14 +159,14 @@ public class DocumentProcessor : IDocumentProcessor
         );
     }
 
-    private string GetDocumentContent(Document document)
+    private async Task<string> GetDocumentContent(Document document)
     {
         if (document.Content == null)
         {
             throw new Exception("Document content is null");
         }
 
-        return Encoding.UTF8.GetString(document.Content.FileContent.Bytes);
+        return Encoding.UTF8.GetString(await _fileManager.GetContent(document.Content));
     }
 
     private async Task<List<Chunk>> CreateChunks(Document document, string content)

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsParseService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsParseService.cs
@@ -1,4 +1,5 @@
 using Equibles.Core.AutoWiring;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.BusinessLogic.ReportedStatements;
 using Equibles.Sec.FinancialFacts.Data.Models;
@@ -22,10 +23,15 @@ public class ReportedStatementsParseService
     private const string FilingSummaryFileName = "FilingSummary.xml";
 
     private readonly ReportedFinancialStatementRepository _statementRepository;
+    private readonly IFileManager _fileManager;
 
-    public ReportedStatementsParseService(ReportedFinancialStatementRepository statementRepository)
+    public ReportedStatementsParseService(
+        ReportedFinancialStatementRepository statementRepository,
+        IFileManager fileManager
+    )
     {
         _statementRepository = statementRepository;
+        _fileManager = fileManager;
     }
 
     /// <summary>
@@ -35,7 +41,12 @@ public class ReportedStatementsParseService
     /// </summary>
     public async Task<int> Parse(Document document, CancellationToken cancellationToken)
     {
-        var bytes = document.ReportedStatementsContent?.FileContent?.Bytes;
+        if (document.ReportedStatementsContent == null)
+        {
+            return 0;
+        }
+
+        var bytes = await _fileManager.GetContent(document.ReportedStatementsContent);
         if (bytes is not { Length: > 0 })
         {
             return 0;

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -61,18 +61,21 @@ public class XbrlFactExtractionService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly InlineXbrlParser _inlineParser;
     private readonly StandaloneXbrlParser _standaloneParser;
+    private readonly IFileManager _fileManager;
     private readonly ILogger<XbrlFactExtractionService> _logger;
 
     public XbrlFactExtractionService(
         IServiceScopeFactory scopeFactory,
         InlineXbrlParser inlineParser,
         StandaloneXbrlParser standaloneParser,
+        IFileManager fileManager,
         ILogger<XbrlFactExtractionService> logger
     )
     {
         _scopeFactory = scopeFactory;
         _inlineParser = inlineParser;
         _standaloneParser = standaloneParser;
+        _fileManager = fileManager;
         _logger = logger;
     }
 
@@ -92,7 +95,7 @@ public class XbrlFactExtractionService
             return 0;
 
         var envelope = Encoding.UTF8.GetString(
-            GzipCompressor.Decompress(document.XbrlContent.FileContent.Bytes)
+            GzipCompressor.Decompress(await _fileManager.GetContent(document.XbrlContent))
         );
 
         var parsed =

--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -6,6 +6,7 @@ using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Mcp.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Microsoft.Extensions.Logging;
@@ -17,15 +18,18 @@ namespace Equibles.Sec.Mcp.Tools;
 public class DocumentTextTools
 {
     private readonly DocumentRepository _documentRepository;
+    private readonly IFileManager _fileManager;
     private readonly McpToolRunner _runner;
 
     public DocumentTextTools(
         DocumentRepository documentRepository,
         ErrorManager errorManager,
+        IFileManager fileManager,
         ILogger<DocumentTextTools> logger
     )
     {
         _documentRepository = documentRepository;
+        _fileManager = fileManager;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -144,10 +148,14 @@ public class DocumentTextTools
         var document = await _documentRepository.GetWithContent(documentId);
         if (document == null)
             return (null, null, $"Document {documentId} not found.");
-        if (document.Content?.FileContent?.Bytes == null)
+        if (document.Content == null)
             return (null, null, $"Document {documentId} has no content.");
 
-        var text = Encoding.UTF8.GetString(document.Content.FileContent.Bytes);
+        var bytes = await _fileManager.GetContent(document.Content);
+        if (bytes == null)
+            return (null, null, $"Document {documentId} has no content.");
+
+        var text = Encoding.UTF8.GetString(bytes);
         return (document, text.Split('\n'), null);
     }
 

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Repositories;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers.Abstract;
@@ -22,6 +23,7 @@ public class StocksController : BaseController
     private readonly InstitutionalHoldingRepository _institutionalHoldingRepository;
     private readonly DocumentRepository _documentRepository;
     private readonly StockTabService _stockTabService;
+    private readonly IFileManager _fileManager;
 
     public StocksController(
         CommonStockRepository commonStockRepository,
@@ -29,6 +31,7 @@ public class StocksController : BaseController
         InstitutionalHoldingRepository institutionalHoldingRepository,
         DocumentRepository documentRepository,
         StockTabService stockTabService,
+        IFileManager fileManager,
         ILogger<StocksController> logger
     )
         : base(logger)
@@ -38,6 +41,7 @@ public class StocksController : BaseController
         _institutionalHoldingRepository = institutionalHoldingRepository;
         _documentRepository = documentRepository;
         _stockTabService = stockTabService;
+        _fileManager = fileManager;
     }
 
     [HttpGet]
@@ -296,10 +300,13 @@ public class StocksController : BaseController
             return NotFound();
         }
 
-        var content =
-            document.Content?.FileContent?.Bytes != null
-                ? Encoding.UTF8.GetString(document.Content.FileContent.Bytes)
-                : string.Empty;
+        var content = string.Empty;
+        if (document.Content != null)
+        {
+            var bytes = await _fileManager.GetContent(document.Content);
+            if (bytes != null)
+                content = Encoding.UTF8.GetString(bytes);
+        }
 
         var viewModel = new DocumentViewModel
         {

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -86,6 +86,9 @@ public partial class Program
         builder.Services.Configure<Equibles.Sec.BusinessLogic.Embeddings.EmbeddingConfig>(
             builder.Configuration.GetSection("Embedding")
         );
+        builder.Services.Configure<Equibles.Media.BusinessLogic.Configuration.FileStorageOptions>(
+            builder.Configuration.GetSection("FileStorage")
+        );
 
         var authSettings =
             builder.Configuration.GetSection("Auth").Get<AuthSettings>() ?? new AuthSettings();

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -138,6 +138,9 @@ builder.Services.Configure<GovernmentContractsScraperOptions>(
 builder.Services.Configure<Equibles.Sec.BusinessLogic.Embeddings.EmbeddingConfig>(
     builder.Configuration.GetSection("Embedding")
 );
+builder.Services.Configure<Equibles.Media.BusinessLogic.Configuration.FileStorageOptions>(
+    builder.Configuration.GetSection("FileStorage")
+);
 
 builder.Services.AddHttpClient();
 

--- a/tests/Equibles.IntegrationTests/Mcp/DocumentTextToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/DocumentTextToolsTests.cs
@@ -1,10 +1,12 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
 using Equibles.Sec.Repositories;
+using NSubstitute;
 using Xunit;
 using File = Equibles.Media.Data.Models.File;
 
@@ -16,8 +18,17 @@ public class DocumentTextToolsTests : ParadeDbMcpTestBase
     public DocumentTextToolsTests(ParadeDbFixture fixture)
         : base(fixture) { }
 
-    private DocumentTextTools Sut() =>
-        new(new DocumentRepository(DbContext), ErrorManager, NullLogger<DocumentTextTools>());
+    private DocumentTextTools Sut()
+    {
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
+        return new(
+            new DocumentRepository(DbContext),
+            ErrorManager,
+            fileManager,
+            NullLogger<DocumentTextTools>()
+        );
+    }
 
     private async Task<Document> SeedDocument(
         string content,

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorChunkDocumentGuardTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorChunkDocumentGuardTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.BusinessLogic.Processing;
 using Equibles.Sec.BusinessLogic.Tokenization;
@@ -30,15 +31,20 @@ public class DocumentProcessorChunkDocumentGuardTests : ParadeDbMcpTestBase
     public DocumentProcessorChunkDocumentGuardTests(ParadeDbFixture fixture)
         : base(fixture) { }
 
-    private DocumentProcessor BuildProcessor() =>
-        new(
+    private DocumentProcessor BuildProcessor()
+    {
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
+        return new(
             new ChunkRepository(DbContext),
             new EmbeddingRepository(DbContext),
             Substitute.For<IEmbeddingClient>(),
             new ChunkingStrategy(new TokenCounter()),
             Options.Create(new EmbeddingConfig()),
+            fileManager,
             Substitute.For<ILogger<DocumentProcessor>>()
         );
+    }
 
     private static Task InvokeChunk(DocumentProcessor sut, Document document)
     {

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorCreateChunksTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorCreateChunksTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.BusinessLogic.Processing;
 using Equibles.Sec.BusinessLogic.Tokenization;
@@ -59,12 +60,15 @@ public class DocumentProcessorCreateChunksTests
         var chunkRepository = Substitute.For<ChunkRepository>(
             (Equibles.Data.EquiblesFinancialDbContext)null
         );
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         var sut = new DocumentProcessor(
             chunkRepository,
             Substitute.For<EmbeddingRepository>((Equibles.Data.EquiblesFinancialDbContext)null),
             Substitute.For<IEmbeddingClient>(),
             new ChunkingStrategy(new TokenCounter()),
             Options.Create(new EmbeddingConfig { ModelName = "test-model" }),
+            fileManager,
             Substitute.For<ILogger<DocumentProcessor>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorGenerateEmbeddingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorGenerateEmbeddingsTests.cs
@@ -1,3 +1,4 @@
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.BusinessLogic.Processing;
 using Equibles.Sec.BusinessLogic.Tokenization;
@@ -53,6 +54,7 @@ public class DocumentProcessorGenerateEmbeddingsTests
             embeddingClient,
             new ChunkingStrategy(new TokenCounter()),
             Options.Create(new EmbeddingConfig { ModelName = "nomic-embed-text" }),
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<DocumentProcessor>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorPerDocumentIsolationTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorPerDocumentIsolationTests.cs
@@ -1,3 +1,4 @@
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.BusinessLogic.Processing;
 using Equibles.Sec.BusinessLogic.Tokenization;
@@ -46,6 +47,7 @@ public class DocumentProcessorPerDocumentIsolationTests
             embeddingClient,
             new ChunkingStrategy(new TokenCounter()),
             Options.Create(new EmbeddingConfig { ModelName = "nomic-embed-text" }),
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<DocumentProcessor>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorSystemicFailureBackoffTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorSystemicFailureBackoffTests.cs
@@ -1,3 +1,4 @@
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.BusinessLogic.Processing;
 using Equibles.Sec.BusinessLogic.Tokenization;
@@ -48,6 +49,7 @@ public class DocumentProcessorSystemicFailureBackoffTests
             embeddingClient,
             new ChunkingStrategy(new TokenCounter()),
             Options.Create(new EmbeddingConfig { ModelName = "nomic-embed-text" }),
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<DocumentProcessor>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Data.Models;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.BusinessLogic.Processing;
 using Equibles.Sec.BusinessLogic.Tokenization;
@@ -24,6 +25,7 @@ public class DocumentProcessorTests
             embeddingClient,
             new ChunkingStrategy(new TokenCounter()),
             Options.Create(new EmbeddingConfig { ModelName = "test-model" }),
+            Substitute.For<IFileManager>(),
             logger ?? Substitute.For<ILogger<DocumentProcessor>>()
         );
     }
@@ -119,6 +121,7 @@ public class DocumentProcessorTests
             embeddingClient,
             new ChunkingStrategy(new TokenCounter()),
             Options.Create(new EmbeddingConfig { ModelName = "test-model" }),
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<DocumentProcessor>>()
         );
         return (sut, embeddingRepository);

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadDocumentLinesCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadDocumentLinesCultureInvarianceTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
@@ -54,9 +55,12 @@ public class DocumentTextToolsReadDocumentLinesCultureInvarianceTests : ParadeDb
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         var sut = new DocumentTextTools(
             new DocumentRepository(DbContext),
             ErrorManager,
+            fileManager,
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesErrorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesErrorTests.cs
@@ -1,5 +1,6 @@
 using Equibles.Errors.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.Mcp.Tools;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -32,6 +33,7 @@ public class DocumentTextToolsReadLinesErrorTests : ParadeDbMcpTestBase
         var sut = new DocumentTextTools(
             new DocumentRepository(disposedContext),
             ErrorManager,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesInvalidRangeTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesInvalidRangeTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
@@ -53,9 +54,12 @@ public class DocumentTextToolsReadLinesInvalidRangeTests : ParadeDbMcpTestBase
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         var sut = new DocumentTextTools(
             new DocumentRepository(DbContext),
             ErrorManager,
+            fileManager,
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesNoContentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesNoContentTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
@@ -52,9 +53,12 @@ public class DocumentTextToolsReadLinesNoContentTests : ParadeDbMcpTestBase
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         var sut = new DocumentTextTools(
             new DocumentRepository(DbContext),
             ErrorManager,
+            fileManager,
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
@@ -53,9 +54,12 @@ public class DocumentTextToolsReadLinesTests : ParadeDbMcpTestBase
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         var sut = new DocumentTextTools(
             new DocumentRepository(DbContext),
             ErrorManager,
+            fileManager,
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordErrorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordErrorTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
@@ -54,9 +55,12 @@ public class DocumentTextToolsSearchKeywordErrorTests : ParadeDbMcpTestBase
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         var sut = new DocumentTextTools(
             new DocumentRepository(DbContext),
             ErrorManager,
+            fileManager,
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordNoContentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordNoContentTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
@@ -54,9 +55,12 @@ public class DocumentTextToolsSearchKeywordNoContentTests : ParadeDbMcpTestBase
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         var sut = new DocumentTextTools(
             new DocumentRepository(DbContext),
             ErrorManager,
+            fileManager,
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
@@ -58,9 +59,12 @@ public class DocumentTextToolsSearchKeywordTests : ParadeDbMcpTestBase
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         var sut = new DocumentTextTools(
             new DocumentRepository(DbContext),
             ErrorManager,
+            fileManager,
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceExtractTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceExtractTests.cs
@@ -9,6 +9,7 @@ using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.HostedService.Services;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Xunit;
 using File = Equibles.Media.Data.Models.File;
 
@@ -89,10 +90,13 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
             (typeof(EquiblesFinancialDbContext), DbContext),
             (typeof(FinancialConceptRepository), new FinancialConceptRepository(DbContext))
         );
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         return new XbrlFactExtractionService(
             scopeFactory,
             new InlineXbrlParser(),
             new StandaloneXbrlParser(),
+            fileManager,
             NullLogger<XbrlFactExtractionService>()
         );
     }

--- a/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
@@ -22,6 +22,7 @@ using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
@@ -333,6 +334,7 @@ public class StocksControllerTests : IDisposable
             _institutionalHoldingRepository,
             _documentRepository,
             _stockTabService,
+            Substitute.For<IFileManager>(),
             _logger
         );
         controller.ControllerContext = new ControllerContext

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
@@ -11,6 +11,7 @@ using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -87,6 +88,7 @@ public class StocksControllerCongressionalTradesTabTests : IDisposable
             new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerDocumentsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerDocumentsTabTests.cs
@@ -11,6 +11,7 @@ using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -87,6 +88,7 @@ public class StocksControllerDocumentsTabTests : IDisposable
             new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
@@ -11,6 +11,7 @@ using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data;
@@ -144,6 +145,7 @@ public class StocksControllerFinancialsTabTests : IDisposable
             new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerFtdTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerFtdTabTests.cs
@@ -11,6 +11,7 @@ using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -86,6 +87,7 @@ public class StocksControllerFtdTabTests : IDisposable
             new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerHoldingsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerHoldingsTabTests.cs
@@ -11,6 +11,7 @@ using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -88,6 +89,7 @@ public class StocksControllerHoldingsTabTests : IDisposable
             new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerInsiderTradingTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerInsiderTradingTabTests.cs
@@ -11,6 +11,7 @@ using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -87,6 +88,7 @@ public class StocksControllerInsiderTradingTabTests : IDisposable
             new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerLoadStockTurkishCultureTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerLoadStockTurkishCultureTests.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
@@ -52,6 +53,7 @@ public class StocksControllerLoadStockTurkishCultureTests
             institutionalHoldingRepository: null!,
             new DocumentRepository(ctx),
             stockTabService: null!,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerPriceNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerPriceNotFoundTests.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Data;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Web.Controllers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -46,6 +47,7 @@ public class StocksControllerPriceNotFoundTests : IDisposable
             // Must 404 before any tab load — a dropped null-stock guard would
             // NRE here instead of returning NotFound.
             stockTabService: null!,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShortInterestTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShortInterestTabTests.cs
@@ -11,6 +11,7 @@ using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -87,6 +88,7 @@ public class StocksControllerShortInterestTabTests : IDisposable
             new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShortVolumeTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShortVolumeTabTests.cs
@@ -11,6 +11,7 @@ using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -87,6 +88,7 @@ public class StocksControllerShortVolumeTabTests : IDisposable
             new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentCrossTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentCrossTickerTests.cs
@@ -2,6 +2,7 @@ using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
@@ -64,6 +65,7 @@ public class StocksControllerShowDocumentCrossTickerTests
             institutionalHoldingRepository: null!,
             new DocumentRepository(ctx),
             stockTabService: null!,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentHappyTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentHappyTests.cs
@@ -2,6 +2,7 @@ using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
@@ -68,12 +69,15 @@ public class StocksControllerShowDocumentHappyTests
         ctx.Set<Document>().Add(document);
         await ctx.SaveChangesAsync();
 
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         var sut = new StocksController(
             new CommonStockRepository(ctx),
             institutionalHolderRepository: null!,
             institutionalHoldingRepository: null!,
             new DocumentRepository(ctx),
             stockTabService: null!,
+            fileManager,
             Substitute.For<ILogger<StocksController>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentNotFoundTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
@@ -37,6 +38,7 @@ public class StocksControllerShowDocumentNotFoundTests
             institutionalHoldingRepository: null!,
             new DocumentRepository(ctx),
             stockTabService: null!,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowHolderNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowHolderNotFoundTests.cs
@@ -5,6 +5,7 @@ using Equibles.Data;
 using Equibles.Holdings.Data;
 using Equibles.Holdings.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
 using Microsoft.AspNetCore.Http;
@@ -52,6 +53,7 @@ public class StocksControllerShowHolderNotFoundTests : IDisposable
             // service is intentionally null — a regression that dropped the
             // holder guard would NRE here instead of returning NotFound.
             stockTabService: null!,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         )
         {

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowHolderUnknownCikTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowHolderUnknownCikTests.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Data;
 using Equibles.Holdings.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
@@ -55,6 +56,7 @@ public class StocksControllerShowHolderUnknownCikTests
             institutionalHoldingRepository: null!,
             documentRepository: null!,
             stockTabService: null!,
+            Substitute.For<IFileManager>(),
             Substitute.For<ILogger<StocksController>>()
         );
 


### PR DESCRIPTION
## Summary

Second slice of daniel3303/Equibles#3699. Makes every Media `File` reader **storage-agnostic** by replacing direct `FileContent.Bytes` dereferences with `await fileManager.GetContent(file)` (dispatches on `File.StorageProvider`; for database-stored files it returns `FileContent.Bytes` exactly as before). This is the prerequisite for turning the filesystem store on — without it, a `FileSystem`-stored file (whose `FileContent` is null) would NPE on read.

**Strictly behavior-preserving.** No write path changes; no functional change for database-stored files (which is everything today).

## Code changes
- **Readers → `GetContent`** in `DocumentProcessor` (`GetDocumentContent` now async, caller awaited), `XbrlFactExtractionService`, `ReportedStatementsParseService`, `DocumentTextTools`, `StocksController.ShowDocument`, and `InsiderFilingReprocessManager` (read only; its write is untouched). Null-conditional chains were rewritten to guard the `File` nav before calling `GetContent` and to preserve the original null/empty branches (e.g. the MCP "has no content" message, the `string.Empty` viewer fallback, the 0-count parse path).
- **`IFileManager` injected** into the five readers that lacked it (`Equibles.Sec.BusinessLogic` gained a `Equibles.Media.BusinessLogic` project reference).
- **Options binding**: `Configure<FileStorageOptions>(GetSection("FileStorage"))` added to the worker, web, and MCP hosts so the store is configurable per deployment.
- **Tests**: ~31 construction sites updated for the new ctor param — read-path tests use a returning substitute (`GetContent(...)` returns the file's bytes, identical to the DB provider); non-read tests get a bare `Substitute.For<IFileManager>()`.

## Follow-up (PR 3)
Switch SEC ingest writes to `FileSystem` + the resumable backfill drain worker and orphan-sweep hosted service (new `Equibles.Media.HostedService`) — the slice that actually populates the disk.

## Verification
- `dotnet build Equibles.sln` — clean.
- `dotnet csharpier check .` (whole tree) — clean.
- Media unit tests — 26 passing. (Reader integration tests require Testcontainers; compile-verified and behavior-preserved via the returning substitute.)

A.L.V.I.S.