### PR TITLE
test: always configure CorporateActions in TestDbContextFactory

### DIFF
--- a/tests/Equibles.IntegrationTests/Helpers/TestDbContextFactory.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/TestDbContextFactory.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Linq;
+using Equibles.CorporateActions.Data;
 using Equibles.Data;
 using Equibles.Media.Data;
 using Microsoft.EntityFrameworkCore;
@@ -9,21 +11,29 @@ public static class TestDbContextFactory
 {
     public static EquiblesFinancialDbContext Create(params IModuleConfiguration[] modules)
     {
-        // File — with its value-converted StorageProvider property — is referenced by many
-        // modules via navigation, so the Media module must always configure it. Without it,
-        // EF discovers File through another module's nav but never applies the converter, then
-        // treats StorageProvider as an entity and model-building throws. Mirror production and
-        // the ParadeDb fixture, which always include Media.
-        IModuleConfiguration[] withMedia = modules.Any(m => m is MediaModuleConfiguration)
-            ? modules
-            : [.. modules, new MediaModuleConfiguration()];
+        // Two modules must always be present because their entities are referenced across
+        // module boundaries and get pulled into the model transitively:
+        //  - Media: File carries a value-converted StorageProvider; without the converter EF
+        //    treats it as an entity and model-building throws.
+        //  - CorporateActions: StockSplit is queried by split-adjustment used from Finra/Yahoo/
+        //    Holdings/Insider managers; without it the StockSplit DbSet can't be resolved.
+        // Mirror production and the ParadeDb fixture, which always include both.
+        var ensured = new List<IModuleConfiguration>(modules);
+        if (!ensured.Any(m => m is MediaModuleConfiguration))
+        {
+            ensured.Add(new MediaModuleConfiguration());
+        }
+        if (!ensured.Any(m => m is CorporateActionsModuleConfiguration))
+        {
+            ensured.Add(new CorporateActionsModuleConfiguration());
+        }
 
         var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .EnableServiceProviderCaching(false)
             .Options;
 
-        var context = new EquiblesFinancialDbContext(options, withMedia);
+        var context = new EquiblesFinancialDbContext(options, ensured.ToArray());
         context.Database.EnsureCreated();
         return context;
     }


### PR DESCRIPTION
## Summary

Fixes a class of pre-existing `build-and-test` failures (from the split-adjustment work in #4049) where InMemory tests build a DbContext without `CorporateActionsModuleConfiguration` but transitively query `StockSplit` (via `StockSplitRepository`/split-adjustment), throwing `Cannot create a DbSet for 'StockSplit'`.

`TestDbContextFactory` now always includes `CorporateActionsModuleConfiguration` (alongside `MediaModuleConfiguration`), mirroring production and the ParadeDb fixture — both entities (`File`/`StockSplit`) are referenced across module boundaries and get pulled into the model transitively, so their owning modules must always configure them.

## Verification
- Solution/IntegrationTests build clean; csharpier clean.
- 54 previously-failing/affected tests pass locally (ShortSqueezeScoreManager, InsiderTransactionRepository, FormDFilingRepository, ModuleConfiguration).

## Not covered here
The Yahoo `YahooPriceImportServiceTests` failures are a deeper #4049 behavioral regression (the service's split-reconciliation flow changed; the tests' DI scope and mocks weren't updated, yielding a DI miss and then a 0-prices assertion). That needs the split-adjustment author's domain knowledge and mock rework — filed separately.

A.L.V.I.S.