### PR TITLE
fix(common-stocks): keep IR discovery re-sweepable through transient misses and sidecar outages

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
@@ -52,6 +52,17 @@ public class InvestorRelationsDiscoveryService : IImporter
     /// </summary>
     public async Task<bool> DiscoverBatch(CancellationToken cancellationToken)
     {
+        // Without a stealth sidecar nothing can be assessed (every probe is Inconclusive), so don't
+        // load a batch at all — probing would only churn transient-miss stamps across the backlog.
+        // Loud on purpose: in a deployment that expects a sidecar this is a misconfiguration.
+        if (!_probeClient.IsEnabled)
+        {
+            _logger.LogWarning(
+                "Investor relations discovery skipped: no stealth browser sidecar is configured"
+            );
+            return false;
+        }
+
         var batch = await LoadCandidates(cancellationToken);
         if (batch.Count == 0)
         {
@@ -104,6 +115,17 @@ public class InvestorRelationsDiscoveryService : IImporter
         CancellationToken cancellationToken
     )
     {
+        // Same no-sidecar guard as the batch sweep; the periodic sweep picks the stock up once a
+        // sidecar is configured (its InvestorRelationsUrl stays null, so it stays pending).
+        if (!_probeClient.IsEnabled)
+        {
+            _logger.LogWarning(
+                "Investor relations discovery for stock {StockId} skipped: no stealth browser sidecar is configured",
+                commonStockId
+            );
+            return false;
+        }
+
         var candidate = await LoadCandidate(commonStockId, cancellationToken);
         if (candidate == null)
             return false;
@@ -267,7 +289,9 @@ public class InvestorRelationsDiscoveryService : IImporter
     // IR page may have been missed. Stamp a short, fixed cooldown — long enough not to re-occupy a batch
     // slot every cycle, short enough that a stock with a reachable IR page isn't exiled on the escalating
     // conclusive-miss schedule over one bad sidecar moment. Deliberately does NOT advance the exponential
-    // schedule.
+    // schedule, and deliberately does NOT stamp the discovery version: the stock was never assessed
+    // under this generation, so a version bump must still be able to re-sweep it. PendingDiscovery
+    // keeps the short cooldown from being bypassed by that version clause.
     private async Task MarkTransientMiss(Guid commonStockId)
     {
         using var scope = _scopeFactory.CreateScope();
@@ -282,7 +306,6 @@ public class InvestorRelationsDiscoveryService : IImporter
             Math.Max(1, _options.RetryTransientBackoffHours)
         );
         stock.InvestorRelationsCheckedAt = now;
-        stock.InvestorRelationsDiscoveryVersion = InvestorRelationsDiscoveryVersion.Current;
         await repo.SaveChanges();
     }
 
@@ -315,12 +338,25 @@ public class InvestorRelationsDiscoveryService : IImporter
     }
 
     /// <summary>
+    /// Ceiling separating a short transient (engine-unavailable) cooldown from a conclusive-miss
+    /// backoff, measured as the RetryAfter−CheckedAt gap. Sits above the default transient cooldown
+    /// (<see cref="InvestorRelationsDiscoveryOptions.RetryTransientBackoffHours"/>, 6h) and below the
+    /// smallest conclusive backoff (<see cref="InvestorRelationsDiscoveryOptions.RetryInitialBackoffDays"/>,
+    /// 1 day). The version-bump clause in <see cref="PendingDiscovery"/> bypasses only backoffs longer
+    /// than this: a transient miss keeps the stock's old version stamp, so without the ceiling every
+    /// old-version stock in a transient cooldown would be re-eligible immediately and a saturated
+    /// sidecar would livelock the sweep on the same top-priority stocks.
+    /// </summary>
+    public const double TransientCooldownCeilingHours = 12;
+
+    /// <summary>
     /// Stocks eligible for an IR discovery probe: a known website, no discovered IR page yet, and one
     /// of — never probed; due for a re-probe (its exponential miss-backoff has elapsed, or it predates
     /// the backoff field and so re-probes once); probed under an older discovery version
-    /// (<paramref name="currentVersion"/> — our probe improved, re-sweep the backlog now); or probed
-    /// before the website was found (<c>InvestorRelationsCheckedAt &lt; WebsiteCheckedAt</c> — the
-    /// input changed; the reconciliation backstop for a website-discovered event lost to a crash).
+    /// (<paramref name="currentVersion"/> — our probe improved, re-sweep the backlog now) unless it is
+    /// sitting out a short transient cooldown (see <see cref="TransientCooldownCeilingHours"/>); or
+    /// probed before the website was found (<c>InvestorRelationsCheckedAt &lt; WebsiteCheckedAt</c> —
+    /// the input changed; the reconciliation backstop for a website-discovered event lost to a crash).
     /// </summary>
     public static Expression<Func<CommonStock, bool>> PendingDiscovery(
         DateTime now,
@@ -335,7 +371,11 @@ public class InvestorRelationsDiscoveryService : IImporter
                 s.InvestorRelationsCheckedAt == null
                 || s.InvestorRelationsRetryAfter == null
                 || s.InvestorRelationsRetryAfter <= now
-                || s.InvestorRelationsDiscoveryVersion < currentVersion
+                || (
+                    s.InvestorRelationsDiscoveryVersion < currentVersion
+                    && s.InvestorRelationsRetryAfter
+                        > s.InvestorRelationsCheckedAt.Value.AddHours(TransientCooldownCeilingHours)
+                )
                 || s.InvestorRelationsCheckedAt < s.WebsiteCheckedAt
             );
     }

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryVersion.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryVersion.cs
@@ -21,10 +21,15 @@ namespace Equibles.CommonStocks.HostedService.Services;
 public static class InvestorRelationsDiscoveryVersion
 {
     /// <summary>
-    /// v1: the discovery logic as it stands today (plain-HTTP-first with stealth fallback, path +
-    /// subdomain guessing, homepage crawl, platform classification). The column defaults the
+    /// v1: the discovery logic as it stood at introduction (plain-HTTP-first with stealth fallback,
+    /// path + subdomain guessing, homepage crawl, platform classification). The column defaults the
     /// pre-existing corpus to 0, so every stock probed before this generation is reconsidered once
     /// against it.
+    ///
+    /// v2: subdomain-first candidate ordering, press-release (<c>og:type=article</c>) rejection, and
+    /// the second-pass page confirmers all shipped without a bump, so the backlog of misses was never
+    /// re-examined against them — this bump re-sweeps it. Also the first generation where a transient
+    /// (engine-unavailable) miss leaves the stamped version untouched.
     /// </summary>
-    public const int Current = 1;
+    public const int Current = 2;
 }

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -7,8 +7,10 @@ namespace Equibles.CommonStocks.HostedService.Services;
 /// validated IR page. All fetches go through the stealth sidecar (<see cref="IStealthBrowserClient"/>):
 /// virtually every IR host is bot-protected, so a plain-HTTP pass only ever returned a challenge page
 /// that failed validation — it found nothing while adding ~100s of dead-host timeouts per stock before
-/// the stealth pass even started. With no sidecar configured the client is a no-op (a build without a
-/// stealth browser can't get past the bot walls anyway), so discovery simply finds nothing.
+/// the stealth pass even started. With no sidecar configured the probe reports every stock
+/// <c>Inconclusive</c> (nothing was assessed), never a conclusive miss — a sidecar misconfiguration
+/// must not stamp the whole backlog as checked. Callers should skip the sweep entirely via
+/// <see cref="IsEnabled"/>.
 /// </summary>
 public class InvestorRelationsProbeClient
 {
@@ -37,12 +39,19 @@ public class InvestorRelationsProbeClient
     }
 
     /// <summary>
+    /// Whether a stealth sidecar is configured. When false every probe is <c>Inconclusive</c>, so
+    /// callers should skip the sweep (loudly) instead of burning batch slots on unassessable stocks.
+    /// </summary>
+    public bool IsEnabled => _stealthClient.IsEnabled;
+
+    /// <summary>
     /// Probes <paramref name="website"/> for an investor-relations page and returns a classified
     /// <see cref="IrProbeResult"/>: <c>Found</c> with the validated URL + platform; <c>NoIrPageFound</c>
     /// when every candidate was assessed and none was an IR page; or <c>Inconclusive</c> when the
     /// stealth engine was unavailable for one or more candidates, so a real IR page may have been
-    /// missed. With no sidecar configured the probe reports <c>NoIrPageFound</c> (it can't get past bot
-    /// walls anyway, and re-probing won't help).
+    /// missed. With no sidecar configured the probe reports <c>Inconclusive</c>: nothing was assessed,
+    /// and a conclusive miss here would stamp the stock checked-at-current-version — a sidecar
+    /// misconfiguration would silently poison the whole backlog.
     /// </summary>
     public async Task<IrProbeResult> Discover(
         string website,
@@ -52,7 +61,7 @@ public class InvestorRelationsProbeClient
     )
     {
         if (!_stealthClient.IsEnabled)
-            return IrProbeResult.NoIrPage;
+            return IrProbeResult.Inconclusive;
 
         var candidates = InvestorRelationsCandidateBuilder.Build(website, paths, subdomains);
 

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsDiscoveryServicePendingDiscoveryTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsDiscoveryServicePendingDiscoveryTests.cs
@@ -69,19 +69,48 @@ public class InvestorRelationsDiscoveryServicePendingDiscoveryTests
     public void PendingDiscovery_OlderVersion_IsEligibleWhileBackingOff(int version, bool expected)
     {
         // Contract: a probe-logic improvement (version bump) re-opens the backlog of misses
-        // immediately, bypassing the backoff — even a stock still mid-backoff is reconsidered when it
-        // was probed under an older version.
+        // immediately, bypassing the multi-day conclusive backoff — even a stock still mid-backoff is
+        // reconsidered when it was probed under an older version.
         var stock = new CommonStock
         {
             Website = "https://acme.com",
             InvestorRelationsCheckedAt = Utc("2026-06-14"),
-            InvestorRelationsRetryAfter = Utc("2026-06-20"), // still backing off
+            InvestorRelationsRetryAfter = Utc("2026-06-20"), // 6-day conclusive backoff, mid-flight
             WebsiteCheckedAt = Utc("2026-06-14"),
             InvestorRelationsDiscoveryVersion = version,
         };
 
         var eligible = InvestorRelationsDiscoveryService
             .PendingDiscovery(Now, CurrentVersion)
+            .Compile();
+
+        eligible(stock).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("2026-06-14T20:00:00Z", false)] // 6h transient cooldown still running → hold
+    [InlineData("2026-06-16T00:00:00Z", true)] // 34h gap is a conclusive backoff → bypass now
+    public void PendingDiscovery_OlderVersionInTransientCooldown_WaitsOutTheCooldown(
+        string retryAfter,
+        bool expected
+    )
+    {
+        // Contract: a transient (engine-unavailable) miss keeps the stock's OLD version stamp so a
+        // version bump can still re-sweep it — but the bump must not bypass the short transient
+        // cooldown itself, or a saturated sidecar would make every old-version stock immediately
+        // re-eligible and livelock the sweep on the same top-priority names. Only a standing backoff
+        // longer than the transient ceiling (a conclusive miss) is bypassed.
+        var stock = new CommonStock
+        {
+            Website = "https://acme.com",
+            InvestorRelationsCheckedAt = Utc("2026-06-14T14:00:00Z"),
+            InvestorRelationsRetryAfter = Utc(retryAfter), // both still in the future at Now
+            WebsiteCheckedAt = Utc("2026-06-01"),
+            InvestorRelationsDiscoveryVersion = CurrentVersion - 1,
+        };
+
+        var eligible = InvestorRelationsDiscoveryService
+            .PendingDiscovery(Utc("2026-06-14T15:00:00Z"), CurrentVersion)
             .Compile();
 
         eligible(stock).Should().Be(expected);

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -11,8 +11,8 @@ namespace Equibles.UnitTests.CommonStocks;
 /// homepage crawl) is rendered, the first that validates as an IR page wins, and the probe reports a
 /// classified outcome: <c>Found</c>, <c>NoIrPageFound</c> (every candidate was assessed and none was an
 /// IR page), or <c>Inconclusive</c> (the engine was unavailable for a candidate, so a real IR page may
-/// have been missed). With no sidecar configured it reports <c>NoIrPageFound</c>. There is no
-/// plain-HTTP path.
+/// have been missed). With no sidecar configured it reports <c>Inconclusive</c> — nothing was
+/// assessed, and a conclusive miss would stamp the backlog as checked. There is no plain-HTTP path.
 /// </summary>
 public class InvestorRelationsProbeClientTests
 {
@@ -121,10 +121,12 @@ public class InvestorRelationsProbeClientTests
     }
 
     [Fact]
-    public async Task Discover_NoSidecar_IsNoOpConclusiveMiss()
+    public async Task Discover_NoSidecar_IsInconclusiveNoOp()
     {
-        // No stealth browser configured: the probe can't get past bot walls, so it finds nothing (there
-        // is no plain-HTTP fallback) and re-probing won't help — report a conclusive miss.
+        // No stealth browser configured: nothing can be assessed, so the probe must NOT report a
+        // conclusive miss — that would stamp the stock checked-at-current-version and a sidecar
+        // misconfiguration would silently poison the whole backlog. It reports Inconclusive without
+        // touching the sidecar, and exposes IsEnabled=false so callers skip the sweep entirely.
         var stealth = Substitute.For<IStealthBrowserClient>();
         stealth.IsEnabled.Returns(false);
 
@@ -132,7 +134,8 @@ public class InvestorRelationsProbeClientTests
 
         var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
 
-        result.Outcome.Should().Be(IrProbeOutcome.NoIrPageFound);
+        client.IsEnabled.Should().BeFalse();
+        result.Outcome.Should().Be(IrProbeOutcome.Inconclusive);
         await stealth.DidNotReceive().TryFetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## Summary
Three related reliability fixes for investor-relations page discovery, aimed at making sure the sweep never silently stops or poisons its own backlog:

1. **No-sidecar runs no longer stamp conclusive misses.** With no stealth sidecar configured the probe used to report `NoIrPageFound`, which stamped every swept stock checked-at-current-version with a multi-day backoff — a sidecar misconfiguration silently exiled the whole backlog. The probe now reports `Inconclusive`, and the discovery service skips the sweep entirely with a warning when `InvestorRelationsProbeClient.IsEnabled` is false.
2. **Transient misses no longer forfeit version-bump eligibility.** `MarkTransientMiss` stamped `InvestorRelationsDiscoveryVersion = Current`, so a stock that merely hit a bad sidecar moment was excluded from the next version-bump re-sweep. It now leaves the version untouched. To keep a saturated sidecar from livelocking the sweep (old-version stocks would otherwise be re-eligible immediately through the version clause), `PendingDiscovery`'s version clause now bypasses only backoffs longer than a 12h ceiling — conclusive misses — and holds short transient cooldowns.
3. **Discovery version bumped 1 → 2.** Subdomain-first candidate ordering, press-release (`og:type=article`) rejection, and the second-pass page confirmers all shipped without a bump, so the existing backlog of misses was never re-examined against them. In production this re-sweeps ~2,800 backed-off misses on deploy.

## Code changes
- `InvestorRelationsProbeClient.cs` — early return changed to `Inconclusive`; new `IsEnabled` property; doc updates.
- `InvestorRelationsDiscoveryService.cs` — no-sidecar guard in `DiscoverBatch`/`DiscoverForStock`; `MarkTransientMiss` no longer stamps the version; `PendingDiscovery` version clause holds transient cooldowns (`TransientCooldownCeilingHours`).
- `InvestorRelationsDiscoveryVersion.cs` — `Current = 2` with the v2 rationale.
- Tests: probe-client no-sidecar contract updated; new `PendingDiscovery` cases for the transient-cooldown hold vs conclusive-backoff bypass.