### PR TITLE
fix(hosts): register Media business logic in the web and MCP hosts

### DIFF
--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -71,6 +71,9 @@ public partial class Program
 
         builder.Services.AutoWireServicesFrom<Equibles.Errors.BusinessLogic.ErrorManager>();
         builder.Services.AutoWireServicesFrom<Equibles.Sec.BusinessLogic.Search.RagManager>();
+        // Media file access: DocumentTextTools resolves IFileManager to read document
+        // content regardless of storage backend.
+        builder.Services.AutoWireServicesFrom<Equibles.Media.BusinessLogic.FileManager>();
 
         // Required for RAG search to embed the query at request time; without this
         // bind EmbeddingConfig is default (Enabled=false) and semantic search is inert.

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -74,6 +74,9 @@ public partial class Program
 
         builder.Services.AutoWireServicesFrom<Equibles.Errors.BusinessLogic.ErrorManager>();
         builder.Services.AutoWireServicesFrom<Equibles.Web.Services.StockTabService>();
+        // Media file access: readers (DocumentProcessor, the document viewer) resolve
+        // IFileManager to load blob content regardless of storage backend.
+        builder.Services.AutoWireServicesFrom<Equibles.Media.BusinessLogic.FileManager>();
         // Holdings business-logic services the portal consumes directly (e.g. the smart-money
         // index manager). Repositories these depend on are registered by AddAllRepositories.
         builder.Services.AutoWireServicesFrom<Equibles.Holdings.BusinessLogic.SmartMoneyIndexManager>();

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCancellationTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCancellationTests.cs
@@ -100,7 +100,7 @@ public class InsiderFilingReprocessManagerCancellationTests : ParadeDbMcpTestBas
                 cts.Cancel();
                 return ownershipXml;
             });
-        var fileManager = Substitute.For<IFileManager>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
         fileManager
             .SaveInternalFile(
                 Arg.Any<byte[]>(),

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerConcurrentInsertTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerConcurrentInsertTests.cs
@@ -124,7 +124,7 @@ public class InsiderFilingReprocessManagerConcurrentInsertTests : ParadeDbMcpTes
                 }
                 return ownershipXml;
             });
-        var fileManager = Substitute.For<IFileManager>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
         fileManager
             .SaveInternalFile(
                 Arg.Any<byte[]>(),

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCorruptCacheTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCorruptCacheTests.cs
@@ -125,7 +125,7 @@ public class InsiderFilingReprocessManagerCorruptCacheTests : ParadeDbMcpTestBas
 
         // Mirror the real file manager: it tracks the new File as Added on the same
         // context the manager saves, so the re-cache write satisfies the ContentId FK.
-        var fileManager = Substitute.For<IFileManager>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
         fileManager
             .SaveInternalFile(
                 Arg.Any<byte[]>(),

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
@@ -122,7 +122,7 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
         DbContext.ChangeTracker.Clear();
 
         var edgar = Substitute.For<ISecEdgarClient>();
-        var fileManager = Substitute.For<IFileManager>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
 
         await using var runCtx = Fixture.CreateDbContext();
         var manager = new InsiderFilingReprocessManager(

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFailureTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFailureTests.cs
@@ -78,7 +78,7 @@ public class InsiderFilingReprocessManagerFailureTests : ParadeDbMcpTestBase
         // No cached InsiderFiling exists, and the EDGAR client returns null (default substitute),
         // so neither source yields parseable ownership XML.
         var edgar = Substitute.For<ISecEdgarClient>();
-        var fileManager = Substitute.For<IFileManager>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
 
         await using var runCtx = Fixture.CreateDbContext();
         var manager = new InsiderFilingReprocessManager(

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFetchedTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFetchedTests.cs
@@ -104,12 +104,14 @@ public class InsiderFilingReprocessManagerFetchedTests : ParadeDbMcpTestBase
         // ownership XML and the file manager stands in for the cache write.
         var edgar = Substitute.For<ISecEdgarClient>();
         edgar.GetDocumentContent(accession, Arg.Any<string>()).Returns(ownershipXml);
-        var fileManager = Substitute.For<IFileManager>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
         fileManager
             .SaveInternalFile(
                 Arg.Any<byte[]>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<Equibles.Media.Data.Models.StorageProvider>(),
                 Arg.Any<string>()
             )
             .Returns(ci => new File
@@ -137,9 +139,18 @@ public class InsiderFilingReprocessManagerFetchedTests : ParadeDbMcpTestBase
         result.Reclassified.Should().Be(1);
         result.Failed.Should().Be(0);
         await edgar.Received().GetDocumentContent(accession, Arg.Any<string>());
+        // The re-fetched cache blob is written through the filesystem store request
+        // (falls back to the database while the store is disabled).
         await fileManager
             .Received()
-            .SaveInternalFile(Arg.Any<byte[]>(), accession, Arg.Any<string>(), Arg.Any<string>());
+            .SaveInternalFile(
+                Arg.Any<byte[]>(),
+                accession,
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Equibles.Media.Data.Models.StorageProvider.FileSystem,
+                Arg.Any<string>()
+            );
 
         await using var verify = Fixture.CreateDbContext();
         var row = await verify.Set<InsiderTransaction>().FindAsync(stale.Id);

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerReclassifyTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerReclassifyTests.cs
@@ -124,7 +124,7 @@ public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
         DbContext.ChangeTracker.Clear();
 
         var edgar = Substitute.For<ISecEdgarClient>();
-        var fileManager = Substitute.For<IFileManager>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
 
         await using var runCtx = Fixture.CreateDbContext();
         var manager = new InsiderFilingReprocessManager(

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRepairTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRepairTests.cs
@@ -116,7 +116,7 @@ public class InsiderFilingReprocessManagerRepairTests : ParadeDbMcpTestBase
         DbContext.ChangeTracker.Clear();
 
         var edgar = Substitute.For<ISecEdgarClient>();
-        var fileManager = Substitute.For<IFileManager>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
 
         await using var runCtx = Fixture.CreateDbContext();
         var manager = new InsiderFilingReprocessManager(

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRetagHoldingTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRetagHoldingTests.cs
@@ -119,7 +119,7 @@ public class InsiderFilingReprocessManagerRetagHoldingTests : ParadeDbMcpTestBas
         DbContext.ChangeTracker.Clear();
 
         var edgar = Substitute.For<ISecEdgarClient>();
-        var fileManager = Substitute.For<IFileManager>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
 
         await using var runCtx = Fixture.CreateDbContext();
         var manager = new InsiderFilingReprocessManager(

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderReprocessTestSupport.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderReprocessTestSupport.cs
@@ -1,0 +1,24 @@
+using Equibles.Media.BusinessLogic;
+using NSubstitute;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+internal static class InsiderReprocessTestSupport
+{
+    /// <summary>
+    /// An <see cref="IFileManager"/> substitute whose <c>GetContent</c> mirrors the
+    /// database storage provider (returns the file's seeded <c>FileContent</c> bytes).
+    /// The reprocess manager reads its cached filing blob through the manager, so a bare
+    /// substitute would intercept the read and return garbage — making every seeded cache
+    /// look corrupt and silently changing the Processed/Fetched counts these tests pin.
+    /// </summary>
+    public static IFileManager NewFileManager()
+    {
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager
+            .GetContent(Arg.Any<File>())
+            .Returns(callInfo => ((File)callInfo[0]).FileContent?.Bytes);
+        return fileManager;
+    }
+}


### PR DESCRIPTION
## Summary

#4052 injected `IFileManager` into `DocumentProcessor` and `DocumentTextTools`, but only the worker host auto-wires `Equibles.Media.BusinessLogic`. The web and MCP hosts fail service-provider validation at startup (`Unable to resolve service for type 'Equibles.Media.BusinessLogic.IFileManager'`) — this is what turned ~200 web-host integration tests red on `main`.

## Code changes
- `Equibles.Web/Program.cs` + `Equibles.Mcp.Server/Program.cs`: add `AutoWireServicesFrom<Equibles.Media.BusinessLogic.FileManager>()` alongside the existing business-logic registrations (registers `IFileManager` + both storage providers; `FileStorageOptions` was already bound in both hosts).

## Verification
- Both host projects build clean; csharpier clean.
- The ~200 `Equibles.IntegrationTests.Web.*` failures on main are all this DI validation error; CI on this PR should flip them green.

A.L.V.I.S.