### PR TITLE
fix(tests): register the Media module in fixtures whose entities navigate to File

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsSplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsSplitAdjustmentTests.cs
@@ -12,6 +12,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Mcp.Tools;
 using Equibles.InsiderTrading.Repositories;
+using Equibles.Media.Data;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -44,6 +45,10 @@ public class InsiderTradingToolsSplitAdjustmentTests
                 new CorporateActionsModuleConfiguration(),
                 new InsiderTradingModuleConfiguration(),
                 new ErrorsModuleConfiguration(),
+                // InsiderFiling navigates to Media's File (Content), so the model pulls the File
+                // entity in and needs Media's configuration (the StorageProvider conversion) or
+                // model finalization fails.
+                new MediaModuleConfiguration(),
             }
         );
         ctx.Database.EnsureCreated();

--- a/tests/Equibles.UnitTests/Sec/FilingsWebsiteSourceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FilingsWebsiteSourceTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.BusinessLogic.Websites;
 using Equibles.CommonStocks.Data;
 using Equibles.Data;
+using Equibles.Media.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Data.Models.Chunks;
 using Equibles.Sec.HostedService.Services;
@@ -40,6 +41,10 @@ public class FilingsWebsiteSourceTests
             {
                 new CommonStocksModuleConfiguration(),
                 new DocumentAndChunkModuleConfiguration(),
+                // Document navigates to Media's File (Content/XbrlContent/…), so the model pulls the
+                // File entity in and needs Media's configuration (the StorageProvider conversion) or
+                // model finalization fails.
+                new MediaModuleConfiguration(),
             }
         );
         ctx.Database.EnsureCreated();


### PR DESCRIPTION
## Summary
Main is red since the StorageProvider column shipped: 7 unit tests fail model finalization with `No suitable constructor was found for the type 'StorageProvider'`. `Document` and `InsiderFiling` navigate to Media's `File`, so any partial-module in-memory context including Sec or InsiderTrading pulls `File` (and its `StorageProvider` smart enum) into the model — without `MediaModuleConfiguration`'s value converter EF tries to bind it as an entity and throws. The passing Sec fixtures already register the Media module; these two files just omitted it.

## Code changes
- `FilingsWebsiteSourceTests.cs`, `InsiderTradingToolsSplitAdjustmentTests.cs` — add `new MediaModuleConfiguration()` to the fixture's module set, with a comment explaining the File navigation dependency.