### PR TITLE
fix(sec): widen the embedding request timeout and aggregate per-chunk failure logging

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
+++ b/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
@@ -28,7 +28,7 @@ public class EmbeddingClient : IEmbeddingClient
         if (_config.IsConfigured)
         {
             _httpClient.BaseAddress = new Uri(_config.BaseUrl);
-            _httpClient.Timeout = TimeSpan.FromSeconds(30);
+            _httpClient.Timeout = TimeSpan.FromSeconds(Math.Max(1, _config.RequestTimeoutSeconds));
 
             if (!string.IsNullOrEmpty(_config.ApiKey))
             {
@@ -106,6 +106,20 @@ public class EmbeddingClient : IEmbeddingClient
         var embeddings = await Task.WhenAll(
             batch.Select(text => EmbedSingle(text, cancellationToken))
         );
+
+        // One aggregated line per batch instead of one warning per failed chunk: under a saturated
+        // or restarting server every chunk fails, and per-chunk warnings flooded the log by the
+        // hundreds of thousands, burying real errors. Per-chunk detail stays at Debug.
+        var failed = embeddings.Count(e => e == null);
+        if (failed > 0)
+        {
+            _logger.LogWarning(
+                "Skipped {Failed} of {Total} chunks that failed to embed (continuing with the rest)",
+                failed,
+                embeddings.Length
+            );
+        }
+
         return embeddings.ToList();
     }
 
@@ -173,10 +187,8 @@ public class EmbeddingClient : IEmbeddingClient
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(
-                ex,
-                "Skipping a chunk that failed to embed (continuing with the rest)"
-            );
+            // Per-chunk failures are aggregated into one warning per batch by ProcessBatch.
+            _logger.LogDebug(ex, "Chunk failed to embed (continuing with the rest)");
             return null;
         }
     }

--- a/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingConfig.cs
+++ b/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingConfig.cs
@@ -13,6 +13,12 @@ public class EmbeddingConfig
     public string ApiKey { get; set; }
     public int BatchSize { get; set; } = 10;
 
+    // A continuous-batching server (vLLM) queues requests under backfill load, so a whole-array
+    // request can legitimately wait well beyond the old 30s HttpClient default before its forward
+    // pass starts. A too-tight timeout aborts the batch, and the per-text fallback then times out
+    // the same way — wasting the server's work and flooding the log with per-chunk failures.
+    public int RequestTimeoutSeconds { get; set; } = 120;
+
     public bool IsConfigured =>
         Enabled && !string.IsNullOrEmpty(BaseUrl) && !string.IsNullOrEmpty(ModelName);
 }

--- a/tests/Equibles.UnitTests/Sec/EmbeddingClientBatchFailureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EmbeddingClientBatchFailureTests.cs
@@ -1,0 +1,50 @@
+using Equibles.Sec.BusinessLogic.Embeddings;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+public class EmbeddingClientBatchFailureTests
+{
+    [Fact]
+    public async Task GenerateEmbeddings_ServerUnreachable_ReturnsPositionalNullsWithoutThrowing()
+    {
+        // Contract: one bad chunk (or a whole unreachable server) must never abort the batch — the
+        // caller relies on a positionally-aligned list with null entries for the failures so the
+        // backfill keeps draining and re-attempts them next cycle. The batched OpenAI request fails,
+        // the per-text fallback fails per text, and the client still returns one entry per input.
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(new ThrowingHandler()));
+
+        var client = new EmbeddingClient(
+            factory,
+            Options.Create(
+                new EmbeddingConfig
+                {
+                    Enabled = true,
+                    BaseUrl = "http://embedding-server:11434",
+                    ModelName = "qwen3-embedding:0.6b",
+                    Provider = EmbeddingProvider.OpenAI,
+                }
+            ),
+            NullLogger<EmbeddingClient>.Instance
+        );
+
+        var result = await client.GenerateEmbeddings(["a", "b", "c"]);
+
+        result.Should().HaveCount(3);
+        result.Should().OnlyContain(e => e == null);
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromException<HttpResponseMessage>(
+                new HttpRequestException("Resource temporarily unavailable")
+            );
+    }
+}


### PR DESCRIPTION
## Summary
Two resilience fixes for the embedding client, prompted by a production log flood (219k warnings in one day) while the vLLM embedding server was saturated during backfill:

1. **Request timeout 30s → configurable, default 120s.** A continuous-batching server queues requests under load, so a whole-array `/v1/embeddings` request can legitimately wait past 30s before its forward pass starts. The hard-coded timeout aborted the batch and the per-text fallback then timed out the same way — wasting the server's completed work and failing chunks that would have succeeded. New `EmbeddingConfig.RequestTimeoutSeconds` (default 120).
2. **One aggregated warning per batch instead of one per failed chunk.** Under a saturated or restarting server every chunk fails; per-chunk warnings buried real errors. `ProcessBatch` now counts failures and logs a single `Skipped {Failed} of {Total} chunks` warning; per-chunk exceptions move to Debug.

Failed chunks still return positional nulls, so the backfill skips and re-attempts them next cycle (unchanged contract, now pinned by a test).

## Code changes
- `EmbeddingConfig.cs` — new `RequestTimeoutSeconds` (default 120) with rationale.
- `EmbeddingClient.cs` — timeout wired from config; aggregated batch warning; per-chunk log demoted to Debug.
- `EmbeddingClientBatchFailureTests.cs` — pins the never-throw / positional-nulls contract when the server is unreachable.