### PR TITLE
perf(media): batch-level durability for the backfill drain

### DIFF
--- a/src/Equibles.Media.BusinessLogic/Storage/DurableFileWriter.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/DurableFileWriter.cs
@@ -97,6 +97,86 @@ public static class DurableFileWriter
     }
 
     /// <summary>
+    /// Like <see cref="WriteIfMissing"/> but WITHOUT any fsync — temp file + atomic rename
+    /// only, leaving the data in the page cache. For bulk migration where the caller makes a
+    /// whole batch durable at once via <see cref="SyncFileSystem"/> before committing the
+    /// matching database rows: per-file fsyncs on a spinning disk are seek-bound (a few
+    /// dozen per second), while buffered writes stream at full disk bandwidth.
+    /// </summary>
+    public static async Task WriteIfMissingBuffered(string fullPath, byte[] content)
+    {
+        if (System.IO.File.Exists(fullPath))
+        {
+            return; // dedup: identical content already stored
+        }
+
+        var directory = Path.GetDirectoryName(fullPath);
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(directory, "." + Guid.NewGuid().ToString("N") + ".tmp");
+        try
+        {
+            await System.IO.File.WriteAllBytesAsync(tempPath, content);
+            try
+            {
+                System.IO.File.Move(tempPath, fullPath, overwrite: false);
+            }
+            catch (IOException) when (System.IO.File.Exists(fullPath))
+            {
+                // A concurrent writer won the race with identical (content-addressed) bytes.
+            }
+        }
+        finally
+        {
+            if (System.IO.File.Exists(tempPath))
+            {
+                try
+                {
+                    System.IO.File.Delete(tempPath);
+                }
+                catch (IOException)
+                {
+                    // Best-effort cleanup; the orphan sweep removes any straggler temp files.
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Flushes every dirty page of the filesystem containing <paramref name="directory"/> to
+    /// stable storage (Linux syncfs). The batch-durability counterpart of
+    /// <see cref="WriteIfMissingBuffered"/>: call once after writing a batch, before
+    /// committing the database rows that point at it. Falls back to a global sync elsewhere.
+    /// </summary>
+    public static void SyncFileSystem(string directory)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            var fd = open(directory, O_RDONLY);
+            if (fd >= 0)
+            {
+                try
+                {
+                    syncfs(fd);
+                }
+                finally
+                {
+                    close(fd);
+                }
+                return;
+            }
+        }
+
+        if (
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+        )
+        {
+            sync();
+        }
+    }
+
+    /// <summary>
     /// Persists a directory's entries to stable storage. .NET has no built-in directory
     /// fsync, so on Unix we open the directory and fsync its descriptor. No-op on Windows
     /// (development only; production runs on Linux), where directory handles can't be fsynced.
@@ -134,6 +214,12 @@ public static class DurableFileWriter
 
     [DllImport("libc", SetLastError = true)]
     private static extern int fsync(int fd);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int syncfs(int fd);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern void sync();
 
     [DllImport("libc", SetLastError = true)]
     private static extern int close(int fd);

--- a/src/Equibles.Media.BusinessLogic/Storage/FileSystemFileStorageProvider.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/FileSystemFileStorageProvider.cs
@@ -28,17 +28,39 @@ public class FileSystemFileStorageProvider : IFileStorageProvider
 
     public async Task Save(File file, byte[] content, string tier)
     {
+        var fullPath = StampAndResolve(file, content, tier);
+        await DurableFileWriter.WriteIfMissing(fullPath, content);
+    }
+
+    /// <summary>
+    /// Bulk-migration variant of <see cref="Save"/>: writes buffered (no per-file fsync).
+    /// The caller MUST call <see cref="SyncStore"/> after the batch, before committing the
+    /// database rows, so bytes are durable before any row points at them.
+    /// </summary>
+    public async Task SaveBuffered(File file, byte[] content, string tier)
+    {
+        var fullPath = StampAndResolve(file, content, tier);
+        await DurableFileWriter.WriteIfMissingBuffered(fullPath, content);
+    }
+
+    /// <summary>Flushes the whole store's filesystem to stable storage (batch durability barrier).</summary>
+    public void SyncStore()
+    {
+        DurableFileWriter.SyncFileSystem(RequireRoot());
+    }
+
+    private string StampAndResolve(File file, byte[] content, string tier)
+    {
         var hashHex = ContentAddressedPath.ComputeSha256Hex(content);
         var relativePath = ContentAddressedPath.Build(tier, hashHex);
         var fullPath = Path.Combine(RequireRoot(), ContentAddressedPath.ToOsPath(relativePath));
-
-        await DurableFileWriter.WriteIfMissing(fullPath, content);
 
         file.Size = content.Length;
         file.StorageProvider = StorageProvider.FileSystem;
         file.RelativePath = relativePath;
         file.ContentHash = ContentAddressedPath.HashPrefix + hashHex;
         file.FileContent = null;
+        return fullPath;
     }
 
     public Task<byte[]> GetContent(File file)

--- a/src/Equibles.Media.HostedService/FileBackfillWorker.cs
+++ b/src/Equibles.Media.HostedService/FileBackfillWorker.cs
@@ -133,6 +133,8 @@ public class FileBackfillWorker : BackgroundService
         // never downloaded) have nothing to move and are excluded so they don't stall the drain.
         // Only ids are claimed here — bytes are loaded one file at a time below so peak memory
         // is a single blob regardless of batch size (audio blobs run tens of MB each).
+        // Deliberately unordered: an ORDER BY would sort every remaining row on every claim
+        // (millions of rows, once per batch), and drain order carries no meaning.
         var batchIds = await dbContext
             .Set<File>()
             .Where(f =>
@@ -141,7 +143,6 @@ public class FileBackfillWorker : BackgroundService
                 && f.FileContent != null
                 && f.FileContent.Bytes != null
             )
-            .OrderBy(f => f.CreationTime)
             .Take(_backfillOptions.BatchSize)
             .Select(f => f.Id)
             .ToListAsync(cancellationToken);
@@ -166,12 +167,13 @@ public class FileBackfillWorker : BackgroundService
                 continue;
             }
 
-            // Write to disk first (durable), then flip the row and drop the DB bytes.
+            // Buffered write (no per-file fsync — seek-bound on a spinning disk); the whole
+            // batch is made durable by the single SyncStore below, BEFORE the rows commit.
             // Audio goes to its own durability tier so a future mirrored mount at
             // <root>/audio covers the precious, hard-to-recapture recordings; everything
             // else is re-scrapable and lands on the bulk blob tier.
             var tier = IsAudio(file) ? FileStorageTiers.Audio : FileStorageTiers.Blob;
-            await fileSystemProvider.Save(file, content.Bytes, tier);
+            await fileSystemProvider.SaveBuffered(file, content.Bytes, tier);
             dbContext.Remove(content);
 
             // Release the blob reference immediately — the row is being deleted, and the
@@ -180,6 +182,10 @@ public class FileBackfillWorker : BackgroundService
             moved++;
         }
 
+        // Batch durability barrier: flush every buffered blob to stable storage before the
+        // database rows flip to FileSystem — a crash before this point leaves all rows
+        // Database-stored (bytes intact in the DB), never a row pointing at volatile bytes.
+        fileSystemProvider.SyncStore();
         await dbContext.SaveChangesAsync(cancellationToken);
         _logger.LogInformation(
             "File backfill moved {Moved} blob(s) to the filesystem store",


### PR DESCRIPTION
## Summary

The production drain measured ~4 blobs/s — per-file durability (2-3 fsyncs each) is seek-bound on the HDD, and the claim's `ORDER BY CreationTime` re-sorts all ~3M remaining rows every batch. At that rate the backlog takes ~9 days.

## Code changes
- `DurableFileWriter.WriteIfMissingBuffered` — temp + atomic rename, **no fsync** (data stays in page cache); and `SyncFileSystem` — one `syncfs()` for the store's filesystem (global `sync()` fallback off-Linux).
- `FileSystemFileStorageProvider.SaveBuffered`/`SyncStore` — bulk-migration variants; `Save` (live ingest) keeps the per-file durable path unchanged.
- `FileBackfillWorker`: buffered writes per file, then **one durability barrier per batch** (`SyncStore`) *before* `SaveChanges`. The blob-before-row invariant holds at batch granularity — a crash before the barrier leaves every row `Database`-stored with bytes intact in the DB; nothing can commit a row pointing at volatile bytes. Claim is now unordered (drain order carries no meaning; the `StorageProvider` index serves it directly).

Expected effect: the HDD streams buffered writes instead of seeking per fsync — throughput bounded by DB reads + disk bandwidth (order of 100+ blobs/s).

## Verification
- Media projects + both test projects build clean; csharpier clean; 27 Media unit tests pass.
- The Postgres drain integration test (moves, tier routing, skips) exercises the buffered path + barrier in CI.

A.L.V.I.S.