### PR TITLE
perf(media): parallel blob loads and writes in the backfill drain

### DIFF
--- a/src/Equibles.Media.BusinessLogic/Storage/FileSystemFileStorageProvider.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/FileSystemFileStorageProvider.cs
@@ -39,8 +39,30 @@ public class FileSystemFileStorageProvider : IFileStorageProvider
     /// </summary>
     public async Task SaveBuffered(File file, byte[] content, string tier)
     {
-        var fullPath = StampAndResolve(file, content, tier);
+        var stamp = await WriteBuffered(content, tier);
+        file.Size = content.Length;
+        file.StorageProvider = StorageProvider.FileSystem;
+        file.RelativePath = stamp.RelativePath;
+        file.ContentHash = stamp.ContentHash;
+        file.FileContent = null;
+    }
+
+    /// <summary>
+    /// Entity-free buffered write for bulk migration: stores the bytes at their
+    /// content-addressed path (no fsync — pair with <see cref="SyncStore"/>) and returns the
+    /// values to stamp on the row later. Lets parallel workers write blobs without sharing a
+    /// DbContext; the caller applies the row changes after the durability barrier.
+    /// </summary>
+    public async Task<(string RelativePath, string ContentHash)> WriteBuffered(
+        byte[] content,
+        string tier
+    )
+    {
+        var hashHex = ContentAddressedPath.ComputeSha256Hex(content);
+        var relativePath = ContentAddressedPath.Build(tier, hashHex);
+        var fullPath = Path.Combine(RequireRoot(), ContentAddressedPath.ToOsPath(relativePath));
         await DurableFileWriter.WriteIfMissingBuffered(fullPath, content);
+        return (relativePath, ContentAddressedPath.HashPrefix + hashHex);
     }
 
     /// <summary>Flushes the whole store's filesystem to stable storage (batch durability barrier).</summary>

--- a/src/Equibles.Media.HostedService/Configuration/FileBackfillOptions.cs
+++ b/src/Equibles.Media.HostedService/Configuration/FileBackfillOptions.cs
@@ -10,8 +10,16 @@ public class FileBackfillOptions
     public bool Enabled { get; set; }
 
     /// <summary>
-    /// Rows claimed per tick. Each tick loads the full bytes of the whole batch into memory,
-    /// and filing/XBRL blobs are multi-MB, so keep this modest; tune via config for the corpus.
+    /// Rows claimed per pass. Memory is bounded by <see cref="Concurrency"/> (blobs in
+    /// flight), not by the batch size, so this mainly amortizes the claim query and the
+    /// per-batch commit.
     /// </summary>
-    public int BatchSize { get; set; } = 25;
+    public int BatchSize { get; set; } = 1000;
+
+    /// <summary>
+    /// How many blobs are loaded and written concurrently within a batch. Peak memory is
+    /// roughly this many blobs (audio runs tens of MB each); it also sets the database
+    /// read parallelism, so keep it well below the connection pool size.
+    /// </summary>
+    public int Concurrency { get; set; } = 8;
 }

--- a/src/Equibles.Media.HostedService/FileBackfillWorker.cs
+++ b/src/Equibles.Media.HostedService/FileBackfillWorker.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Equibles.Data;
 using Equibles.Media.BusinessLogic.Configuration;
 using Equibles.Media.BusinessLogic.Storage;
@@ -16,12 +17,14 @@ namespace Equibles.Media.HostedService;
 /// One-off, resumable drain of database-stored blobs onto the filesystem store. Each pass
 /// claims a batch of Database-provider File rows (excluding small Image rows — headshots /
 /// web images stay in the DB) that still hold bytes, writes them to the content-addressed
-/// store, flips the row to FileSystem, and deletes the FileContent row. Progress is durable
-/// in File.StorageProvider, so it resumes for free. While full batches keep coming the worker
-/// drains continuously (no inter-tick delay); memory stays bounded because blobs are loaded
-/// one at a time and released as soon as they are written. Self-disabling: after a few
-/// consecutive empty passes it stops, and since new writes now go straight to FileSystem the
-/// backlog never regrows. Runs only when both the store and the backfill are enabled in config.
+/// store, flips the rows to FileSystem, and deletes the FileContent rows. Progress is durable
+/// in File.StorageProvider, so it resumes for free. Within a batch, blobs are loaded and
+/// written by <see cref="FileBackfillOptions.Concurrency"/> parallel tasks (bounding both
+/// memory and DB read parallelism); the rows commit only after a single per-batch durability
+/// barrier, so no row ever points at volatile bytes. While full batches keep coming the worker
+/// drains continuously (no inter-tick delay). Self-disabling: after a few consecutive empty
+/// passes it stops, and since new writes now go straight to FileSystem the backlog never
+/// regrows. Runs only when both the store and the backfill are enabled in config.
 /// </summary>
 public class FileBackfillWorker : BackgroundService
 {
@@ -152,51 +155,105 @@ public class FileBackfillWorker : BackgroundService
             return (0, 0);
         }
 
-        var moved = 0;
-        foreach (var fileId in batchIds)
+        // Phase 1 — parallel: each task loads one blob untracked in its own scope, hashes it,
+        // and writes it buffered (no per-file fsync — seek-bound on a spinning disk). No
+        // database state changes yet; the values to stamp on the row are collected instead.
+        // Concurrency bounds both peak memory (that many blobs in flight) and DB parallelism.
+        var written = new ConcurrentBag<MovedBlob>();
+        var parallelOptions = new ParallelOptions
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var file = await dbContext
-                .Set<File>()
-                .Include(f => f.FileContent)
-                .FirstOrDefaultAsync(f => f.Id == fileId, cancellationToken);
-            var content = file?.FileContent;
-            if (content?.Bytes == null)
+            MaxDegreeOfParallelism = Math.Max(1, _backfillOptions.Concurrency),
+            CancellationToken = cancellationToken,
+        };
+        await Parallel.ForEachAsync(
+            batchIds,
+            parallelOptions,
+            async (fileId, taskCancellation) =>
             {
-                continue;
+                await using var taskScope = _scopeFactory.CreateAsyncScope();
+                var taskDb =
+                    taskScope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+
+                var blob = await taskDb
+                    .Set<File>()
+                    .AsNoTracking()
+                    .Where(f => f.Id == fileId && f.FileContent != null)
+                    .Select(f => new
+                    {
+                        f.Id,
+                        f.ContentType,
+                        ContentId = f.FileContent.Id,
+                        f.FileContent.Bytes,
+                    })
+                    .FirstOrDefaultAsync(taskCancellation);
+                if (blob?.Bytes == null)
+                {
+                    return;
+                }
+
+                // Audio goes to its own durability tier so a future mirrored mount at
+                // <root>/audio covers the precious, hard-to-recapture recordings; everything
+                // else is re-scrapable and lands on the bulk blob tier.
+                var tier = IsAudio(blob.ContentType)
+                    ? FileStorageTiers.Audio
+                    : FileStorageTiers.Blob;
+                var stamp = await fileSystemProvider.WriteBuffered(blob.Bytes, tier);
+                written.Add(
+                    new MovedBlob(
+                        blob.Id,
+                        blob.ContentId,
+                        stamp.RelativePath,
+                        stamp.ContentHash,
+                        blob.Bytes.Length
+                    )
+                );
             }
+        );
 
-            // Buffered write (no per-file fsync — seek-bound on a spinning disk); the whole
-            // batch is made durable by the single SyncStore below, BEFORE the rows commit.
-            // Audio goes to its own durability tier so a future mirrored mount at
-            // <root>/audio covers the precious, hard-to-recapture recordings; everything
-            // else is re-scrapable and lands on the bulk blob tier.
-            var tier = IsAudio(file) ? FileStorageTiers.Audio : FileStorageTiers.Blob;
-            await fileSystemProvider.SaveBuffered(file, content.Bytes, tier);
-            dbContext.Remove(content);
-
-            // Release the blob reference immediately — the row is being deleted, and the
-            // tracked entity would otherwise pin every batch blob in memory until SaveChanges.
-            content.Bytes = null;
-            moved++;
+        if (written.IsEmpty)
+        {
+            return (batchIds.Count, 0);
         }
 
         // Batch durability barrier: flush every buffered blob to stable storage before the
         // database rows flip to FileSystem — a crash before this point leaves all rows
         // Database-stored (bytes intact in the DB), never a row pointing at volatile bytes.
         fileSystemProvider.SyncStore();
+
+        // Phase 2 — apply the row changes via attached stubs (no bytes re-read) in a single
+        // commit: flip each File to FileSystem and delete its FileContent row.
+        foreach (var blob in written)
+        {
+            var file = new File { Id = blob.FileId };
+            dbContext.Attach(file);
+            file.Size = blob.Size;
+            file.StorageProvider = StorageProvider.FileSystem;
+            file.RelativePath = blob.RelativePath;
+            file.ContentHash = blob.ContentHash;
+
+            dbContext.Entry(new FileContent { Id = blob.ContentId, FileId = blob.FileId }).State =
+                EntityState.Deleted;
+        }
+
         await dbContext.SaveChangesAsync(cancellationToken);
         _logger.LogInformation(
             "File backfill moved {Moved} blob(s) to the filesystem store",
-            moved
+            written.Count
         );
-        return (batchIds.Count, moved);
+        return (batchIds.Count, written.Count);
     }
 
-    private static bool IsAudio(File file)
+    private static bool IsAudio(string contentType)
     {
-        return file.ContentType != null
-            && file.ContentType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase);
+        return contentType != null
+            && contentType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase);
     }
+
+    private sealed record MovedBlob(
+        Guid FileId,
+        Guid ContentId,
+        string RelativePath,
+        string ContentHash,
+        long Size
+    );
 }


### PR DESCRIPTION
## Summary

After #4062 removed the per-file fsyncs, the drain's remaining serialization is the per-blob DB round-trip + hash + write happening one at a time. Parallelize within the batch.

## Code changes
- `FileBackfillOptions.Concurrency` (default 8): blobs loaded + written concurrently inside a batch. Bounds peak memory (≈ that many blobs in flight; audio runs tens of MB) and DB read parallelism.
- `FileBackfillWorker.DrainOnce` is two-phase: **phase 1** `Parallel.ForEachAsync` — each task uses its own DI scope, loads one blob untracked (projection, no proxies), hashes + buffered-writes it, and records the stamp values; **barrier** — one `SyncStore()` per batch; **phase 2** — one context applies all row flips + `FileContent` deletes via attached stubs, single `SaveChanges`. The blob-before-row invariant is unchanged: rows can only commit after their bytes are durable.
- `FileSystemFileStorageProvider.WriteBuffered(content, tier)` — entity-free buffered write returning the stamp values (RelativePath, ContentHash); `SaveBuffered` delegates to it.
- `BatchSize` default aligned to 1000 (memory no longer scales with it).
- A task failure fails the batch before any row commits (rows stay Database-stored; orphaned content-addressed files are harmlessly reused on retry).

## Verification
- Builds clean, csharpier clean, 27 Media unit tests pass.
- The Postgres drain integration test exercises both phases, the stub updates/deletes, and tier routing in CI.

A.L.V.I.S.