### PR TITLE
feat(corporate-actions): capture cash dividends from the Yahoo chart events payload

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
@@ -1,0 +1,65 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CorporateActions.BusinessLogic;
+
+// Upserts captured cash-dividend events into CashDividend. Idempotent by
+// (stock, ExDate): a re-run with the same events writes nothing. A changed
+// amount for an existing ex-date is updated in place (Yahoo occasionally
+// restates a dividend after declaration).
+[Service]
+public class CashDividendCaptureManager
+{
+    private readonly CashDividendRepository _dividendRepository;
+
+    public CashDividendCaptureManager(CashDividendRepository dividendRepository)
+    {
+        _dividendRepository = dividendRepository;
+    }
+
+    public async Task<int> Capture(
+        CommonStock stock,
+        IReadOnlyCollection<CapturedDividend> dividends
+    )
+    {
+        if (dividends == null || dividends.Count == 0)
+            return 0;
+
+        var existing = await _dividendRepository.GetByStock(stock.Id).ToListAsync();
+        var changes = 0;
+
+        foreach (var dividend in dividends)
+        {
+            if (dividend.AmountPerShare <= 0)
+                continue;
+
+            var match = existing.FirstOrDefault(d => d.ExDate == dividend.ExDate);
+            if (match == null)
+            {
+                _dividendRepository.Add(
+                    new CashDividend
+                    {
+                        CommonStockId = stock.Id,
+                        ExDate = dividend.ExDate,
+                        AmountPerShare = dividend.AmountPerShare,
+                        Source = dividend.Source,
+                    }
+                );
+                changes++;
+            }
+            else if (match.AmountPerShare != dividend.AmountPerShare)
+            {
+                match.AmountPerShare = dividend.AmountPerShare;
+                changes++;
+            }
+        }
+
+        if (changes > 0)
+            await _dividendRepository.SaveChanges();
+
+        return changes;
+    }
+}

--- a/src/Equibles.CorporateActions.Data/CorporateActionsModuleConfiguration.cs
+++ b/src/Equibles.CorporateActions.Data/CorporateActionsModuleConfiguration.cs
@@ -8,5 +8,6 @@ public class CorporateActionsModuleConfiguration : Equibles.Data.IFinancialModul
     public void ConfigureEntities(ModelBuilder builder)
     {
         builder.Entity<StockSplit>().Property(s => s.Source).HasConversion<string>();
+        builder.Entity<CashDividend>().Property(d => d.Source).HasConversion<string>();
     }
 }

--- a/src/Equibles.CorporateActions.Data/Models/CapturedDividend.cs
+++ b/src/Equibles.CorporateActions.Data/Models/CapturedDividend.cs
@@ -1,0 +1,12 @@
+namespace Equibles.CorporateActions.Data.Models;
+
+// A source-neutral cash-dividend observation handed to
+// CashDividendCaptureManager for upsert. Each capturing source maps its own
+// payload to this DTO at its worker boundary (mirrors CapturedSplit), so the
+// manager stays decoupled from any one integration.
+public class CapturedDividend
+{
+    public DateOnly ExDate { get; set; }
+    public decimal AmountPerShare { get; set; }
+    public CashDividendSource Source { get; set; }
+}

--- a/src/Equibles.CorporateActions.Data/Models/CashDividend.cs
+++ b/src/Equibles.CorporateActions.Data/Models/CashDividend.cs
@@ -1,0 +1,28 @@
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CorporateActions.Data.Models;
+
+/// <summary>
+/// An as-reported cash dividend for a <see cref="CommonStock"/>.
+/// <see cref="ExDate"/> is the ex-dividend date (the first trading day the
+/// stock trades without the dividend) and <see cref="AmountPerShare"/> is the
+/// declared cash amount per share. The (stock, ex-date) pair is unique — it is
+/// the idempotency guard for the capture upsert.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(ExDate), IsUnique = true)]
+public class CashDividend
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    public DateOnly ExDate { get; set; }
+
+    public decimal AmountPerShare { get; set; }
+
+    public CashDividendSource Source { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.CorporateActions.Data/Models/CashDividendSource.cs
+++ b/src/Equibles.CorporateActions.Data/Models/CashDividendSource.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.CorporateActions.Data.Models;
+
+public enum CashDividendSource
+{
+    [Display(Name = "Yahoo")]
+    Yahoo,
+
+    [Display(Name = "Manual")]
+    Manual,
+}

--- a/src/Equibles.CorporateActions.Repositories/CashDividendRepository.cs
+++ b/src/Equibles.CorporateActions.Repositories/CashDividendRepository.cs
@@ -1,0 +1,16 @@
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Data;
+using Equibles.Data.Extensions;
+
+namespace Equibles.CorporateActions.Repositories;
+
+public class CashDividendRepository : BaseRepository<CashDividend>
+{
+    public CashDividendRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<CashDividend> GetByStock(Guid commonStockId)
+    {
+        return GetAll().Where(d => d.CommonStockId == commonStockId);
+    }
+}

--- a/src/Equibles.Integrations.Yahoo/Models/CashDividendEvent.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/CashDividendEvent.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Integrations.Yahoo.Models;
+
+// A cash-dividend corporate action parsed from the chart endpoint's events
+// node (events=div). Date is the ex-dividend date on the exchange-local
+// calendar; Amount is the declared cash amount per share.
+public class CashDividendEvent
+{
+    public DateOnly Date { get; set; }
+    public decimal Amount { get; set; }
+}

--- a/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
@@ -38,6 +38,19 @@ public class ChartEvents
     // Keyed by the split's epoch-second string (e.g. "1718022600").
     [JsonProperty("splits")]
     public Dictionary<string, ChartSplit> Splits { get; set; } = [];
+
+    // Keyed by the dividend's epoch-second string, like splits.
+    [JsonProperty("dividends")]
+    public Dictionary<string, ChartDividend> Dividends { get; set; } = [];
+}
+
+public class ChartDividend
+{
+    [JsonProperty("date")]
+    public long Date { get; set; }
+
+    [JsonProperty("amount")]
+    public decimal Amount { get; set; }
 }
 
 public class ChartSplit

--- a/src/Equibles.Integrations.Yahoo/Models/YahooChartData.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/YahooChartData.cs
@@ -1,10 +1,11 @@
 namespace Equibles.Integrations.Yahoo.Models;
 
 // The full payload of a single chart fetch: the daily price bars plus any
-// split events the same request returned (events=split), so callers get both
-// without a second HTTP round-trip.
+// split and dividend events the same request returned (events=div|split), so
+// callers get all three without a second HTTP round-trip.
 public class YahooChartData
 {
     public List<HistoricalPrice> Prices { get; set; } = [];
     public List<StockSplitEvent> Splits { get; set; } = [];
+    public List<CashDividendEvent> Dividends { get; set; } = [];
 }

--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -57,9 +57,10 @@ public class YahooFinanceClient : IYahooFinanceClient
     ) => (await GetChart(ticker, startDate, endDate)).Prices;
 
     // Single chart fetch that parses BOTH the daily price bars and any split
-    // events Yahoo returns for the window (events=split). Callers that need
-    // only prices go through GetHistoricalPrices; the split capture piggybacks
-    // on this same request so it costs no extra HTTP round-trip.
+    // and dividend events Yahoo returns for the window (events=div|split).
+    // Callers that need only prices go through GetHistoricalPrices; the split
+    // and dividend captures piggyback on this same request so they cost no
+    // extra HTTP round-trip.
     public async Task<YahooChartData> GetChart(string ticker, DateOnly startDate, DateOnly endDate)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ticker);
@@ -74,7 +75,7 @@ public class YahooFinanceClient : IYahooFinanceClient
 
         var url =
             $"{ChartBaseUrl}/{Uri.EscapeDataString(ticker)}"
-            + $"?period1={period1}&period2={period2}&interval=1d&events=split";
+            + $"?period1={period1}&period2={period2}&interval=1d&events=div%7Csplit";
 
         var content = await SendWithRetry(url);
         var response = JsonConvert.DeserializeObject<YahooChartResponse>(content);
@@ -92,6 +93,7 @@ public class YahooFinanceClient : IYahooFinanceClient
         {
             Prices = BuildPrices(result, ticker, offsetSeconds, startDate, endDate),
             Splits = BuildSplits(result.Events?.Splits, offsetSeconds, startDate, endDate),
+            Dividends = BuildDividends(result.Events?.Dividends, offsetSeconds, startDate, endDate),
         };
     }
 
@@ -179,6 +181,37 @@ public class YahooFinanceClient : IYahooFinanceClient
                     Denominator = split.Denominator,
                 }
             );
+        }
+
+        return events;
+    }
+
+    // Parse the dividend events into the requested window. Dividend timestamps
+    // are dated on the same exchange-local calendar as the price bars (offset
+    // added to the UTC epoch), trimmed to [startDate, endDate], and a dividend
+    // with a non-positive amount is dropped as unusable (a cash dividend is a
+    // strictly-positive payout).
+    private static List<CashDividendEvent> BuildDividends(
+        Dictionary<string, ChartDividend> dividends,
+        long offsetSeconds,
+        DateOnly startDate,
+        DateOnly endDate
+    )
+    {
+        var events = new List<CashDividendEvent>();
+        if (dividends == null)
+            return events;
+
+        foreach (var dividend in dividends.Values)
+        {
+            if (dividend.Amount <= 0)
+                continue;
+
+            var date = FromUnixTimestamp(dividend.Date + offsetSeconds);
+            if (date < startDate || date > endDate)
+                continue;
+
+            events.Add(new CashDividendEvent { Date = date, Amount = dividend.Amount });
         }
 
         return events;

--- a/src/Equibles.Migrations/Migrations/20260701221801_AddCashDividends.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260701221801_AddCashDividends.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701221801_AddCashDividends")]
+    partial class AddCashDividends
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260701221801_AddCashDividends.cs
+++ b/src/Equibles.Migrations/Migrations/20260701221801_AddCashDividends.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCashDividends : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CashDividend",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ExDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    AmountPerShare = table.Column<decimal>(type: "numeric", nullable: false),
+                    Source = table.Column<string>(type: "text", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CashDividend", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CashDividend_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CashDividend_CommonStockId_ExDate",
+                table: "CashDividend",
+                columns: new[] { "CommonStockId", "ExDate" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CashDividend");
+        }
+    }
+}

--- a/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -14,10 +14,11 @@ public static class ServiceCollectionExtensions
         services.AutoWireServicesFrom<YahooPriceImportService>();
         services.AutoWireServicesFrom<Equibles.Integrations.Yahoo.YahooFinanceClient>();
 
-        // The price import piggybacks split capture on its chart fetch; register
-        // the capture manager so it resolves in the import scope. Its
-        // StockSplitRepository is picked up by AddAllRepositories (PluginLoader
-        // loads Equibles.CorporateActions.Repositories.dll from the output dir).
+        // The price import piggybacks split and dividend capture on its chart
+        // fetch; auto-wire the CorporateActions.BusinessLogic assembly (both
+        // capture managers) so they resolve in the import scope. Their
+        // repositories are picked up by AddAllRepositories (PluginLoader loads
+        // Equibles.CorporateActions.Repositories.dll from the output dir).
         services.AutoWireServicesFrom<StockSplitCaptureManager>();
 
         // Yahoo is the OSS source of stock prices for Holdings valuation.

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -361,8 +361,9 @@ public class YahooPriceImportService
         if (startDate >= today)
             return 0;
 
-        // One chart fetch yields both the price bars and any split events for the
-        // window — capture the splits off the same response, no extra HTTP.
+        // One chart fetch yields the price bars plus any split and dividend
+        // events for the window — capture both off the same response, no extra
+        // HTTP.
         var chartData = await _yahooClient.GetChart(ticker, startDate, today);
 
         var inserted = await PersistPrices(
@@ -373,6 +374,7 @@ public class YahooPriceImportService
         );
 
         await CaptureSplits(commonStockId, chartData.Splits);
+        await CaptureDividends(commonStockId, chartData.Dividends);
 
         return inserted;
     }
@@ -446,6 +448,46 @@ public class YahooPriceImportService
         if (count > 0)
             _logger.LogInformation(
                 "Captured {Count} stock split(s) for {StockId}",
+                count,
+                commonStockId
+            );
+    }
+
+    // Upserts the dividend events Yahoo returned for this ticker into
+    // CashDividend via the CorporateActions capture manager. Mirrors
+    // CaptureSplits: its own scope, and skipped when there are no dividends so
+    // the common no-dividend path costs nothing.
+    private async Task CaptureDividends(
+        Guid commonStockId,
+        IReadOnlyCollection<CashDividendEvent> dividends
+    )
+    {
+        if (dividends.Count == 0)
+            return;
+
+        // Map Yahoo's dividend shape onto the source-neutral capture DTO at the
+        // worker boundary, stamping Yahoo as the source, so the domain manager
+        // stays decoupled from this integration.
+        var captured = dividends
+            .Select(d => new CapturedDividend
+            {
+                ExDate = d.Date,
+                AmountPerShare = d.Amount,
+                Source = CashDividendSource.Yahoo,
+            })
+            .ToList();
+
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var stock = await stockRepo.Get(commonStockId);
+        if (stock == null)
+            return;
+
+        var captureManager = scope.ServiceProvider.GetRequiredService<CashDividendCaptureManager>();
+        var count = await captureManager.Capture(stock, captured);
+        if (count > 0)
+            _logger.LogInformation(
+                "Captured {Count} cash dividend(s) for {StockId}",
                 count,
                 commonStockId
             );

--- a/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
@@ -3,6 +3,7 @@ using Equibles.Cboe.Data;
 using Equibles.Cftc.Data;
 using Equibles.CommonStocks.Data;
 using Equibles.Congress.Data;
+using Equibles.CorporateActions.Data;
 using Equibles.Data;
 using Equibles.Errors.Data;
 using Equibles.FdaCatalysts.Data;
@@ -206,6 +207,7 @@ public class McpServerAppFixture : IAsyncLifetime
             new YahooModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration(),
+            new CorporateActionsModuleConfiguration(),
             new FdaCatalystsModuleConfiguration(),
             new GovernmentContractsModuleConfiguration(),
             new SecModuleConfiguration(),

--- a/tests/Equibles.UnitTests/CorporateActions/CashDividendCaptureManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CashDividendCaptureManagerTests.cs
@@ -1,0 +1,129 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.BusinessLogic;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.CorporateActions;
+
+/// <summary>
+/// Pins the upsert contract of <see cref="CashDividendCaptureManager"/>, mirroring the split
+/// capture manager: idempotent by (stock, ExDate) — a re-run with the same events writes nothing —
+/// a restated amount for an existing ex-date is updated in place, and a non-positive amount is
+/// dropped as unusable.
+/// </summary>
+public class CashDividendCaptureManagerTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static CapturedDividend Dividend(DateOnly exDate, decimal amount) =>
+        new()
+        {
+            ExDate = exDate,
+            AmountPerShare = amount,
+            Source = CashDividendSource.Yahoo,
+        };
+
+    [Fact]
+    public async Task Capture_NewDividends_InsertsOneRowPerExDate()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid() };
+        var manager = new CashDividendCaptureManager(new CashDividendRepository(db));
+
+        var changes = await manager.Capture(
+            stock,
+            [Dividend(new DateOnly(2024, 2, 9), 0.24m), Dividend(new DateOnly(2024, 5, 9), 0.25m)]
+        );
+
+        changes.Should().Be(2);
+        var stored = await new CashDividendRepository(db).GetByStock(stock.Id).ToListAsync();
+        stored.Should().HaveCount(2);
+        stored.Single(d => d.ExDate == new DateOnly(2024, 2, 9)).AmountPerShare.Should().Be(0.24m);
+        stored.Should().OnlyContain(d => d.Source == CashDividendSource.Yahoo);
+    }
+
+    [Fact]
+    public async Task Capture_SameEventsRerun_IsIdempotentAndWritesNothing()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid() };
+        var events = new[] { Dividend(new DateOnly(2024, 2, 9), 0.24m) };
+
+        await new CashDividendCaptureManager(new CashDividendRepository(db)).Capture(stock, events);
+        var secondPass = await new CashDividendCaptureManager(
+            new CashDividendRepository(db)
+        ).Capture(stock, events);
+
+        secondPass.Should().Be(0);
+        (await new CashDividendRepository(db).GetByStock(stock.Id).CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Capture_RestatedAmountForExistingExDate_UpdatesInPlace()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid() };
+        var exDate = new DateOnly(2024, 2, 9);
+
+        await new CashDividendCaptureManager(new CashDividendRepository(db)).Capture(
+            stock,
+            [Dividend(exDate, 0.24m)]
+        );
+        var changes = await new CashDividendCaptureManager(new CashDividendRepository(db)).Capture(
+            stock,
+            [Dividend(exDate, 0.26m)]
+        );
+
+        changes.Should().Be(1);
+        var stored = await new CashDividendRepository(db).GetByStock(stock.Id).ToListAsync();
+        stored.Should().HaveCount(1);
+        stored[0].AmountPerShare.Should().Be(0.26m);
+    }
+
+    [Fact]
+    public async Task Capture_NonPositiveAmount_IsDropped()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid() };
+        var manager = new CashDividendCaptureManager(new CashDividendRepository(db));
+
+        var changes = await manager.Capture(
+            stock,
+            [Dividend(new DateOnly(2024, 2, 9), 0m), Dividend(new DateOnly(2024, 5, 9), -0.1m)]
+        );
+
+        changes.Should().Be(0);
+        (await new CashDividendRepository(db).GetByStock(stock.Id).AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Capture_NullOrEmpty_ReturnsZero()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid() };
+        var manager = new CashDividendCaptureManager(new CashDividendRepository(db));
+
+        (await manager.Capture(stock, null)).Should().Be(0);
+        (await manager.Capture(stock, [])).Should().Be(0);
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooDividendParsingTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooDividendParsingTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using Equibles.Integrations.Yahoo;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Yahoo;
+
+// Contract: the chart endpoint fetched with events=div|split carries a
+// chart.result[0].events.dividends object keyed by epoch-string. GetChart must
+// parse every in-window dividend — dated on the exchange-local calendar, with
+// the declared cash amount per share — alongside the price bars, drop
+// non-positive amounts as unusable, and trim events outside the requested
+// window. Fixture mirrors real AAPL-style data: $0.24 ex 2024-02-09 and $0.25
+// ex 2024-05-09 in-window (gmtoffset 0), one 2023 dividend outside the window,
+// and one zero-amount junk row, plus two price bars.
+public class YahooDividendParsingTests
+{
+    private const string DividendCassette = """
+        {
+          "chart": {
+            "result": [
+              {
+                "meta": { "gmtoffset": 0, "exchangeTimezoneName": "UTC" },
+                "timestamp": [1704153600, 1704240000],
+                "events": {
+                  "dividends": {
+                    "1707486600": { "date": 1707486600, "amount": 0.24 },
+                    "1715261400": { "date": 1715261400, "amount": 0.25 },
+                    "1691760600": { "date": 1691760600, "amount": 0.23 },
+                    "1723123800": { "date": 1723123800, "amount": 0.0 }
+                  }
+                },
+                "indicators": {
+                  "quote": [
+                    {
+                      "open": [184.0, 183.0],
+                      "high": [186.0, 185.0],
+                      "low": [183.0, 182.0],
+                      "close": [185.5, 184.5],
+                      "volume": [1000, 2000]
+                    }
+                  ]
+                }
+              }
+            ],
+            "error": null
+          }
+        }
+        """;
+
+    private static readonly DateOnly WindowStart = new(2024, 1, 1);
+    private static readonly DateOnly WindowEnd = new(2024, 12, 31);
+
+    [Fact]
+    public async Task GetChart_DividendEventsInWindow_ParsesBothWithCorrectDatesAndAmounts()
+    {
+        var client = new SessionStubbedYahooClient(
+            new HttpClient(new CassetteHandler(DividendCassette))
+        );
+
+        var chart = await client.GetChart("AAPL", WindowStart, WindowEnd);
+
+        chart.Dividends.Should().HaveCount(2);
+
+        var february = chart.Dividends.Single(d => d.Date == new DateOnly(2024, 2, 9));
+        february.Amount.Should().Be(0.24m);
+
+        var may = chart.Dividends.Single(d => d.Date == new DateOnly(2024, 5, 9));
+        may.Amount.Should().Be(0.25m);
+    }
+
+    [Fact]
+    public async Task GetChart_OutOfWindowAndZeroAmountDividends_AreDropped()
+    {
+        var client = new SessionStubbedYahooClient(
+            new HttpClient(new CassetteHandler(DividendCassette))
+        );
+
+        var chart = await client.GetChart("AAPL", WindowStart, WindowEnd);
+
+        chart.Dividends.Should().NotContain(d => d.Date.Year == 2023);
+        chart.Dividends.Should().NotContain(d => d.Amount <= 0);
+    }
+
+    [Fact]
+    public async Task GetChart_SameResponse_StillReturnsPriceBarsAndNoSplits()
+    {
+        var client = new SessionStubbedYahooClient(
+            new HttpClient(new CassetteHandler(DividendCassette))
+        );
+
+        var chart = await client.GetChart("AAPL", WindowStart, WindowEnd);
+
+        chart.Prices.Should().HaveCount(2);
+        chart.Prices.Should().Contain(p => p.Date == new DateOnly(2024, 1, 2) && p.Close == 185.5m);
+        chart.Prices.Should().Contain(p => p.Date == new DateOnly(2024, 1, 3) && p.Close == 184.5m);
+        chart.Splits.Should().BeEmpty();
+    }
+
+    // Overrides the documented protected-virtual session seam so the data fetch
+    // skips the live cookie/crumb bootstrap and runs entirely against the stub.
+    private sealed class SessionStubbedYahooClient(HttpClient httpClient)
+        : YahooFinanceClient(httpClient, NullLogger<YahooFinanceClient>.Instance)
+    {
+        protected override Task<(string Crumb, string CookieHeader)> EnsureSession() =>
+            Task.FromResult<(string Crumb, string CookieHeader)>(("test-crumb", "A=1"));
+    }
+
+    private sealed class CassetteHandler(string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

Adds cash-dividend capture to the CorporateActions module by piggybacking on the same Yahoo chart fetch that already captures stock splits: the request now asks for `events=div|split` and the returned `events.dividends` map is upserted into a new `CashDividend` entity, idempotent by (stock, ex-date). No extra HTTP round-trip and the same cadence/window as the split capture.

## Code changes

- **`CashDividend` entity** (`Equibles.CorporateActions.Data`): `CommonStockId` + nav, `ExDate` (DateOnly), `AmountPerShare`, `Source` (`CashDividendSource` enum, stored as string) and `CreationTime`, with a unique index on (CommonStockId, ExDate) — mirrors `StockSplit`'s provenance pattern. Registered in `CorporateActionsModuleConfiguration`.
- **`CapturedDividend` DTO** — source-neutral capture shape, mirroring `CapturedSplit`.
- **`CashDividendRepository`** — `BaseRepository<CashDividend>` with `GetByStock`, mirroring `StockSplitRepository`.
- **`CashDividendCaptureManager`** (`[Service]`) — idempotent upsert by (stock, ExDate); a restated amount for an existing ex-date is updated in place; non-positive amounts are dropped. Mirrors `StockSplitCaptureManager`.
- **`YahooFinanceClient`** — chart URL now requests `events=div%7Csplit`; new `BuildDividends` parses `events.dividends` on the exchange-local calendar with the same window trim as splits. New `CashDividendEvent` model + `YahooChartData.Dividends`; `ChartEvents.Dividends`/`ChartDividend` response models.
- **`YahooPriceImportService`** — `CaptureDividends` runs right after `CaptureSplits` off the same chart response (own scope, skipped when empty). The manager auto-registers via the existing `AutoWireServicesFrom<StockSplitCaptureManager>()` assembly scan.
- **Migration** `AddCashDividends` — creates the `CashDividend` table with the unique (CommonStockId, ExDate) index and FK cascade to `CommonStock`.
- **Tests** — `YahooDividendParsingTests` (cassette-based, mirrors `YahooSplitParsingTests`: in-window parse, out-of-window + zero-amount drops, prices unaffected) and `CashDividendCaptureManagerTests` (in-memory DB, mirrors the reconciliation-manager test style: insert, idempotent re-run, restated amount, non-positive drop, null/empty).