### PR TITLE
feat(corporate-actions): historical cash-dividend backfill

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/CashDividendBackfillManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CashDividendBackfillManager.cs
@@ -1,0 +1,60 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Integrations.Yahoo.Contracts;
+
+namespace Equibles.CorporateActions.BusinessLogic;
+
+// One-time historical cash-dividend backfill for a single stock. The incremental
+// Yahoo price sync only captures dividends going forward from the date it first
+// ran (its chart window starts at the last stored price), so stocks that predate
+// the dividend capture have no history. This manager issues ONE full-range chart
+// request (since -> today, the same events=div|split fetch the price sync uses,
+// sharing its client and therefore its rate limiter) and upserts the returned
+// dividends through the existing idempotent capture path — safe to re-run.
+[Service]
+public class CashDividendBackfillManager
+{
+    private readonly IYahooFinanceClient _yahooClient;
+    private readonly CashDividendCaptureManager _captureManager;
+
+    public CashDividendBackfillManager(
+        IYahooFinanceClient yahooClient,
+        CashDividendCaptureManager captureManager
+    )
+    {
+        _yahooClient = yahooClient;
+        _captureManager = captureManager;
+    }
+
+    // Fetches the stock's dividend events from `since` through today and upserts
+    // them into CashDividend. Returns the number of rows written (new ex-dates
+    // plus restated amounts); a re-run over already-captured history returns 0.
+    public async Task<int> BackfillHistory(
+        CommonStock stock,
+        DateOnly since,
+        CancellationToken cancellationToken
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var chartData = await _yahooClient.GetChart(stock.Ticker, since, today);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Map Yahoo's dividend shape onto the source-neutral capture DTO at this
+        // boundary (mirrors the price sync's CaptureDividends), so the capture
+        // manager stays decoupled from the integration.
+        var captured = chartData
+            .Dividends.Select(d => new CapturedDividend
+            {
+                ExDate = d.Date,
+                AmountPerShare = d.Amount,
+                Source = CashDividendSource.Yahoo,
+            })
+            .ToList();
+
+        return await _captureManager.Capture(stock, captured);
+    }
+}

--- a/src/Equibles.CorporateActions.BusinessLogic/Equibles.CorporateActions.BusinessLogic.csproj
+++ b/src/Equibles.CorporateActions.BusinessLogic/Equibles.CorporateActions.BusinessLogic.csproj
@@ -7,5 +7,6 @@
     <ProjectReference Include="..\Equibles.CorporateActions.Data\Equibles.CorporateActions.Data.csproj" />
     <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
+    <ProjectReference Include="..\Equibles.Integrations.Yahoo\Equibles.Integrations.Yahoo.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Equibles.UnitTests/CorporateActions/CashDividendBackfillManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CashDividendBackfillManagerTests.cs
@@ -1,0 +1,154 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.BusinessLogic;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Integrations.Yahoo.Contracts;
+using Equibles.Integrations.Yahoo.Models;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CorporateActions;
+
+/// <summary>
+/// Pins the contract of <see cref="CashDividendBackfillManager"/>: one full-range chart request
+/// covering [since, today], the returned dividends upserted through the existing idempotent
+/// capture path (stamped as Yahoo-sourced), the written count returned — and a re-run over
+/// already-captured history writes nothing.
+/// </summary>
+public class CashDividendBackfillManagerTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static CashDividendBackfillManager NewManager(
+        EquiblesFinancialDbContext db,
+        IYahooFinanceClient yahooClient
+    ) => new(yahooClient, new CashDividendCaptureManager(new CashDividendRepository(db)));
+
+    private static IYahooFinanceClient ClientReturning(params CashDividendEvent[] dividends)
+    {
+        var client = Substitute.For<IYahooFinanceClient>();
+        client
+            .GetChart(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new YahooChartData { Dividends = dividends.ToList() });
+        return client;
+    }
+
+    [Fact]
+    public async Task BackfillHistory_RequestsOneChartCoveringSinceThroughToday()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var since = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-730);
+        var client = ClientReturning();
+
+        var before = DateOnly.FromDateTime(DateTime.UtcNow);
+        await NewManager(db, client).BackfillHistory(stock, since, CancellationToken.None);
+        var after = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        // The end bound is "today" (UTC); tolerate a run that crosses UTC midnight.
+        await client
+            .Received(1)
+            .GetChart("AAPL", since, Arg.Is<DateOnly>(d => d >= before && d <= after));
+    }
+
+    [Fact]
+    public async Task BackfillHistory_UpsertsReturnedDividendsAsYahooSourced()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var client = ClientReturning(
+            new CashDividendEvent { Date = new DateOnly(2024, 2, 9), Amount = 0.24m },
+            new CashDividendEvent { Date = new DateOnly(2024, 5, 9), Amount = 0.25m }
+        );
+
+        var captured = await NewManager(db, client)
+            .BackfillHistory(
+                stock,
+                DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-730),
+                CancellationToken.None
+            );
+
+        captured.Should().Be(2);
+        var stored = await new CashDividendRepository(db).GetByStock(stock.Id).ToListAsync();
+        stored.Should().HaveCount(2);
+        stored.Single(d => d.ExDate == new DateOnly(2024, 2, 9)).AmountPerShare.Should().Be(0.24m);
+        stored.Should().OnlyContain(d => d.Source == CashDividendSource.Yahoo);
+    }
+
+    [Fact]
+    public async Task BackfillHistory_Rerun_IsIdempotentAndWritesNothing()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var client = ClientReturning(
+            new CashDividendEvent { Date = new DateOnly(2024, 2, 9), Amount = 0.24m }
+        );
+        var since = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-730);
+
+        await NewManager(db, client).BackfillHistory(stock, since, CancellationToken.None);
+        var secondPass = await NewManager(db, client)
+            .BackfillHistory(stock, since, CancellationToken.None);
+
+        secondPass.Should().Be(0);
+        (await new CashDividendRepository(db).GetByStock(stock.Id).CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BackfillHistory_NoDividendsInWindow_WritesNothingAndReturnsZero()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+
+        var captured = await NewManager(db, ClientReturning())
+            .BackfillHistory(
+                stock,
+                DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-730),
+                CancellationToken.None
+            );
+
+        captured.Should().Be(0);
+        (await new CashDividendRepository(db).GetByStock(stock.Id).AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task BackfillHistory_AlreadyCancelled_ThrowsWithoutFetching()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var client = ClientReturning();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () =>
+            await NewManager(db, client)
+                .BackfillHistory(
+                    stock,
+                    DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-730),
+                    cts.Token
+                );
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await client
+            .DidNotReceive()
+            .GetChart(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
+    }
+}


### PR DESCRIPTION
## Summary

#4066 captures cash dividends by piggybacking on the incremental Yahoo price sync, so existing stocks only accumulate dividends going forward — their history stays empty and TTM dividend figures can't populate. This adds a per-stock historical backfill: one full-range `events=div|split` chart request (`since` → today, the same fetch and rate-limited client the price sync uses) whose dividends are upserted through the existing idempotent capture path. Intended to be driven per stock by an operator-facing one-time backfill (e.g. a backoffice button) passing ~2 years of history.

## Code changes

- **`CashDividendBackfillManager`** (new, `Equibles.CorporateActions.BusinessLogic`): `BackfillHistory(CommonStock stock, DateOnly since, CancellationToken)` — issues one `IYahooFinanceClient.GetChart(ticker, since, today)` call, maps the returned dividend events onto the source-neutral `CapturedDividend` DTO (stamped `CashDividendSource.Yahoo`), and upserts via `CashDividendCaptureManager.Capture`; returns the number of rows written. Re-runs over already-captured history write nothing.
- **`Equibles.CorporateActions.BusinessLogic.csproj`**: adds the `Equibles.Integrations.Yahoo` project reference (the domain manager consumes the integration client; sharing the client shares its static rate limiter, so the backfill respects the same Yahoo politeness as the sync).
- **`CashDividendBackfillManagerTests`** (new): mirrors the capture-manager suite on an in-memory context with a substituted `IYahooFinanceClient` — full-range request bounds, Yahoo-sourced upsert + returned count, idempotent re-run, empty window, and pre-cancelled token short-circuits before any fetch.