### PR TITLE
fix(financial-facts): cover zerodash and hyphenated comma-decimal iXBRL formats

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -54,6 +54,11 @@ public class InlineXbrlParser
     private const char NarrowNoBreakSpace = '\u202F';
     private const char ThinSpace = '\u2009';
 
+    // Apostrophe thousands grouping (Swiss style, the TR4+ "-apos" transform
+    // variants); the typographic right single quote is its common rendering.
+    private const char Apostrophe = '\'';
+    private const char RightSingleQuote = '\u2019';
+
     private readonly HtmlParser _parser = new(
         new HtmlParserOptions { IsAcceptingCustomElementsEverywhere = true }
     );
@@ -283,12 +288,14 @@ public class InlineXbrlParser
 
         var format = element.GetAttribute("format") ?? string.Empty;
 
-        // Format hints that the value is a hard-coded zero (numdash → "—",
-        // fixed-zero → literal 0). The Inline XBRL Transformations spec
-        // emits these for placeholders; consumers expect 0, not a parse
-        // failure on the dash glyph.
+        // Format hints that the value is a hard-coded zero (numdash /
+        // zerodash → "—", fixed-zero → literal 0). Every transformation
+        // registry spells it differently (TR1 numdash, TR2/TR3 zerodash,
+        // TR4+ fixed-zero); consumers expect 0, not a parse failure on the
+        // dash glyph.
         if (
             format.EndsWith("numdash", StringComparison.OrdinalIgnoreCase)
+            || format.EndsWith("zerodash", StringComparison.OrdinalIgnoreCase)
             || format.EndsWith("fixed-zero", StringComparison.OrdinalIgnoreCase)
             || format.EndsWith("fixedzero", StringComparison.OrdinalIgnoreCase)
         )
@@ -300,7 +307,13 @@ public class InlineXbrlParser
         if (parenthesised)
             raw = raw.Substring(1, raw.Length - 2).Trim();
 
-        var commaDecimal = format.EndsWith("numcommadecimal", StringComparison.OrdinalIgnoreCase);
+        // European decimal notation: TR2/TR3 call it "numcommadecimal", TR4+
+        // renamed it "num-comma-decimal" (plus the "-apos" grouping variant).
+        // Missing the hyphenated spellings routes "1.234,56" through the
+        // comma-grouping path, silently misreading it as 1.23456.
+        var commaDecimal =
+            format.EndsWith("numcommadecimal", StringComparison.OrdinalIgnoreCase)
+            || format.Contains("num-comma-decimal", StringComparison.OrdinalIgnoreCase);
 
         var cleaned = NormaliseDigits(raw, commaDecimal);
         if (string.IsNullOrEmpty(cleaned))
@@ -333,10 +346,11 @@ public class InlineXbrlParser
 
     private static string NormaliseDigits(string raw, bool commaDecimal)
     {
-        // Strip currency / spacing glyphs filers routinely use ($, NBSP,
-        // narrow NBSP, thin spaces). Then collapse thousands separators
-        // and align the decimal separator to '.' so InvariantCulture
-        // parsing succeeds regardless of the document's locale.
+        // Strip currency / spacing / apostrophe-grouping glyphs filers
+        // routinely use ($, NBSP, narrow NBSP, thin spaces, Swiss-style
+        // apostrophes). Then collapse thousands separators and align the
+        // decimal separator to '.' so InvariantCulture parsing succeeds
+        // regardless of the document's locale.
         var buffer = new System.Text.StringBuilder(raw.Length);
         foreach (var ch in raw)
         {
@@ -346,6 +360,8 @@ public class InlineXbrlParser
                 case NoBreakSpace:
                 case NarrowNoBreakSpace:
                 case ThinSpace:
+                case Apostrophe:
+                case RightSingleQuote:
                 case '$':
                 case '€':
                 case '£':
@@ -372,7 +388,15 @@ public class InlineXbrlParser
     {
         value = 0m;
         var scaleAttribute = element.GetAttribute("scale");
-        if (!string.IsNullOrEmpty(scaleAttribute) && int.TryParse(scaleAttribute, out var scale))
+        if (
+            !string.IsNullOrEmpty(scaleAttribute)
+            && int.TryParse(
+                scaleAttribute,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var scale
+            )
+        )
         {
             // Positive scale shifts the value up; negative shifts down.
             // We use Pow over a literal multiplier so non-trivial scales

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -48,7 +48,9 @@ public class XbrlFactExtractionService
     /// extraction. Bump to reprocess the whole captured corpus after an
     /// extractor behavior change.
     /// </summary>
-    public const int CurrentVersion = 1;
+    // Version 2: TR2/TR3 zerodash + TR4/TR5 num-comma-decimal(-apos) format
+    // coverage in InlineXbrlParser.
+    public const int CurrentVersion = 2;
 
     private const int InsertBatchSize = 1000;
 

--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserHyphenatedCommaDecimalTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserHyphenatedCommaDecimalTests.cs
@@ -1,0 +1,47 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InlineXbrlParserHyphenatedCommaDecimalTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\" "
+        + "><body><div style=\"display:none\"><ix:header><ix:resources>";
+
+    private const string ResourcesEnd = "</ix:resources></ix:header></div>";
+
+    private const string DocClose = "</body></html>";
+
+    // TR4/TR5 renamed the European-notation transform to the hyphenated
+    // "num-comma-decimal" (with an "-apos" variant for Swiss-style apostrophe
+    // grouping). Treating those like the default comma-grouping path strips
+    // the '.' group separators' meaning and misreads "1.234,56" as 1.23456 —
+    // a silent ~1000x corruption, so the hyphenated spellings must route
+    // through the same comma-decimal handling as TR2/TR3's "numcommadecimal".
+    [Theory]
+    [InlineData("ixt:num-comma-decimal", "1.234,56")]
+    [InlineData("ixt:num-comma-decimal-apos", "1'234,56")]
+    [InlineData("ixt:num-comma-decimal-apos", "1’234,56")]
+    public void Parse_HyphenatedCommaDecimalFormats_ReadEuropeanNotation(string format, string text)
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2024-06-30</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:EUR</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<p><ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"C1\" unitRef=\"u\" "
+            + $"format=\"{format}\" decimals=\"2\">{text}</ix:nonFraction></p>"
+            + DocClose;
+
+        var facts = new InlineXbrlParser().Parse(html);
+
+        facts.Should().ContainSingle().Which.Value.Should().Be(1234.56m);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserZeroDashFormatTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserZeroDashFormatTests.cs
@@ -1,0 +1,43 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InlineXbrlParserZeroDashFormatTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\" "
+        + "><body><div style=\"display:none\"><ix:header><ix:resources>";
+
+    private const string ResourcesEnd = "</ix:resources></ix:header></div>";
+
+    private const string DocClose = "</body></html>";
+
+    // TR2/TR3 spell the dash-is-zero transform "zerodash" (TR1 says "numdash",
+    // TR4+ "fixed-zero" — both already covered by sibling tests). A zerodash
+    // placeholder must land as a 0-valued fact, not fail numeric parsing on
+    // the em-dash and vanish: a dropped zero is indistinguishable from
+    // "not reported" downstream.
+    [Fact]
+    public void Parse_ZeroDashFormat_YieldsZeroValuedFact()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2024-06-30</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<p><ix:nonFraction name=\"us-gaap:Goodwill\" contextRef=\"C1\" unitRef=\"u\" "
+            + "format=\"ixt:zerodash\" decimals=\"-6\" scale=\"6\">—</ix:nonFraction></p>"
+            + DocClose;
+
+        var facts = new InlineXbrlParser().Parse(html);
+
+        facts.Should().ContainSingle().Which.Value.Should().Be(0m);
+    }
+}


### PR DESCRIPTION
## Summary

The inline XBRL value decoder missed two transformation-registry format spellings, causing silent data loss and value corruption in dimensional fact extraction:

- **`ixt:zerodash` (TR2/TR3) dropped zeros** — only TR1's `numdash` and TR4's `fixed-zero` were treated as zero placeholders, so a zerodash em-dash failed numeric parsing and the fact was dropped. A dropped zero is indistinguishable from "not reported" downstream.
- **`ixt:num-comma-decimal` (TR4/TR5) corrupted values ~1000x** — only the TR2/TR3 spelling `numcommadecimal` triggered European-notation handling, so hyphenated-format values like `1.234,56` went through the default comma-grouping path and parsed as `1.23456`.

## Code changes

- `InlineXbrlParser.cs` — add `zerodash` to the zero-placeholder formats; route `num-comma-decimal` (incl. the `-apos` apostrophe-grouping variants, stripping both apostrophe glyphs in digit normalisation) through comma-decimal handling; parse the `scale` attribute with `InvariantCulture`.
- `XbrlFactExtractionService.cs` — bump `CurrentVersion` to 2 so the captured corpus is re-extracted with the corrected parser.
- `tests/Equibles.UnitTests/Sec` — new tests: zerodash yields a 0-valued fact; `num-comma-decimal` / `num-comma-decimal-apos` (both apostrophe glyphs) read European notation correctly.

Full unit suite green locally (3235 passed).