### PR TITLE
fix(yahoo): crawl the daily price sync stalest-first

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -67,7 +67,14 @@ public class YahooPriceImportService
 
         var totalInserted = 0;
 
-        foreach (var (ticker, commonStockId) in tickerMap)
+        // Crawl stalest-first: the ticker map's DB order is stable across cycles, so with a
+        // multi-hour crawl any interruption (deploy, crash, rate-limit stall) starves the same
+        // tail stocks for days while head stocks re-sync every cycle. Ordering by each stock's
+        // last stored price date spends every partial cycle on the most out-of-date stocks;
+        // never-synced stocks lead.
+        var crawlOrder = await OrderByStalestPrice(tickerMap, cancellationToken);
+
+        foreach (var (ticker, commonStockId) in crawlOrder)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -98,6 +105,28 @@ public class YahooPriceImportService
             "Yahoo price sync complete. Inserted {Count} new price records",
             totalInserted
         );
+    }
+
+    // Orders the ticker map by each stock's most recent stored price date, oldest first (stocks
+    // with no prices at all lead). One grouped MAX(Date) query over the price table per cycle.
+    private async Task<List<KeyValuePair<string, Guid>>> OrderByStalestPrice(
+        Dictionary<string, Guid> tickerMap,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var priceRepo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+        var lastDates = await priceRepo
+            .GetAll()
+            .GroupBy(p => p.CommonStockId)
+            .Select(g => new { StockId = g.Key, LastDate = g.Max(p => p.Date) })
+            .ToDictionaryAsync(x => x.StockId, x => x.LastDate, cancellationToken);
+
+        return tickerMap
+            .OrderBy(kv =>
+                lastDates.TryGetValue(kv.Value, out var lastDate) ? lastDate : DateOnly.MinValue
+            )
+            .ToList();
     }
 
     // Re-syncs the full price history of every stock that has an unreconciled split, capped per


### PR DESCRIPTION
## Summary
The Yahoo price import iterates the ticker map in stable DB order, and one cycle over ~8k stocks takes hours (chart + key-stats + profile calls per ticker). Any interruption — a deploy, a crash, a rate-limit stall — restarts the crawl from the same head, so the same tail stocks go days without a price row while head stocks re-sync every cycle (observed in production: a large-cap stock's daily close lagging 3+ days while ~70% of the universe was current).

## Code changes
- `YahooPriceImportService.Import` now orders the crawl by each stock's most recent stored price date, oldest first, with never-synced stocks leading — one grouped `MAX(Date)` query per cycle.
- New `OrderByStalestPrice` helper resolves the last price date per stock via `DailyStockPriceRepository` in its own scope.

A partial cycle now always spends its budget on the most out-of-date prices, so interruptions no longer starve the same stocks repeatedly.