### PR TITLE
feat(holdings): resolve the in-progress 13F quarter as the combined view across MCP and web

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/Equibles.Holdings.BusinessLogic.csproj
+++ b/src/Equibles.Holdings.BusinessLogic/Equibles.Holdings.BusinessLogic.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
     <ProjectReference Include="..\Equibles.Holdings.Repositories\Equibles.Holdings.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
   </ItemGroup>

--- a/src/Equibles.Holdings.BusinessLogic/Models/StockQuarterAnchor.cs
+++ b/src/Equibles.Holdings.BusinessLogic/Models/StockQuarterAnchor.cs
@@ -1,0 +1,25 @@
+namespace Equibles.Holdings.BusinessLogic.Models;
+
+/// <summary>
+/// How a stock's newest 13F quarter should be presented, resolved by
+/// <see cref="StockCombinedQuarterService"/> so every surface (web, MCP, agents) shows the same
+/// picture: the combined view while the filing window is open, the as-filed quarter afterwards.
+/// </summary>
+public class StockQuarterAnchor
+{
+    /// <summary>The stock's newest 13F quarter end.</summary>
+    public DateOnly ReportDate { get; set; }
+
+    /// <summary>The 13F quarter immediately before <see cref="ReportDate"/>, when one exists.</summary>
+    public DateOnly? PreviousReportDate { get; set; }
+
+    /// <summary>True while filings for <see cref="ReportDate"/> are still arriving (45-day window).</summary>
+    public bool FilingWindowOpen { get; set; }
+
+    /// <summary>
+    /// True when positions must be presented as the combined view: the window is open AND a
+    /// previous quarter exists to carry non-filers forward from. An open window with no prior
+    /// quarter degenerates to the as-filed rows.
+    /// </summary>
+    public bool IsCombined => FilingWindowOpen && PreviousReportDate.HasValue;
+}

--- a/src/Equibles.Holdings.BusinessLogic/Models/StockReportedActivity.cs
+++ b/src/Equibles.Holdings.BusinessLogic/Models/StockReportedActivity.cs
@@ -1,0 +1,39 @@
+namespace Equibles.Holdings.BusinessLogic.Models;
+
+/// <summary>
+/// What the funds that have already filed the in-progress quarter did in one stock, plus the
+/// combined-view totals. Every figure is exact over reported filings only — nothing is
+/// extrapolated for funds that have not filed yet (they carry their prior positions).
+/// </summary>
+public class StockReportedActivity
+{
+    /// <summary>Distinct holders in the previous (complete) quarter.</summary>
+    public int PreviousHolderCount { get; set; }
+
+    /// <summary>
+    /// Funds relevant to this stock that have filed the new quarter: its new-quarter filers
+    /// plus previous holders who filed elsewhere (including those who dropped the position).
+    /// </summary>
+    public int ReportedFilerCount { get; set; }
+
+    /// <summary>New-quarter filers of this stock with no position in the previous quarter.</summary>
+    public int NewFilerCount { get; set; }
+
+    /// <summary>Previous holders who filed the new quarter without this stock (proven exits).</summary>
+    public int SoldOutFilerCount { get; set; }
+
+    /// <summary>
+    /// Net share change across the funds that reported: their new-quarter shares (zero for
+    /// proven exits) minus their previous-quarter shares (zero for new positions).
+    /// </summary>
+    public long NetReportedShareDelta { get; set; }
+
+    /// <summary>Distinct holders in the combined view (reported + carried forward).</summary>
+    public int CombinedHolderCount { get; set; }
+
+    /// <summary>Total shares in the combined view.</summary>
+    public long CombinedShares { get; set; }
+
+    /// <summary>Total reported value (USD) in the combined view.</summary>
+    public long CombinedValue { get; set; }
+}

--- a/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
+++ b/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
@@ -1,0 +1,158 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.BusinessLogic.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.BusinessLogic;
+
+/// <summary>
+/// The one place that decides how a stock's newest 13F quarter is presented. While the 45-day
+/// filing window is open the quarter only holds the funds that filed early, so positions are
+/// served as the COMBINED view (new-quarter filings + prior-quarter carry-forward for funds yet
+/// to file; a fund that filed without the stock is a proven exit) and quarter-over-quarter
+/// figures are computed over reported filings only. After the window closes the quarter is
+/// served as filed. Web pages, MCP tools and agent tools all resolve through this service so
+/// "the current quarter" means the same thing everywhere.
+/// </summary>
+[Service]
+public class StockCombinedQuarterService
+{
+    private readonly InstitutionalHoldingRepository _holdingRepository;
+
+    public StockCombinedQuarterService(InstitutionalHoldingRepository holdingRepository)
+    {
+        _holdingRepository = holdingRepository;
+    }
+
+    /// <summary>Resolves the stock's newest 13F quarter and how it must be presented.</summary>
+    public Task<StockQuarterAnchor> Resolve(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return Resolve(stock, DateOnly.FromDateTime(DateTime.UtcNow), cancellationToken);
+    }
+
+    // Explicit-today overload so callers and tests can pin the clock.
+    public async Task<StockQuarterAnchor> Resolve(
+        CommonStock stock,
+        DateOnly today,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var dates = await _holdingRepository
+            .Get13FReportDatesByStock(stock)
+            .Take(2)
+            .ToListAsync(cancellationToken);
+        if (dates.Count == 0)
+            return null;
+
+        return new StockQuarterAnchor
+        {
+            ReportDate = dates[0],
+            PreviousReportDate = dates.Count > 1 ? dates[1] : null,
+            FilingWindowOpen = CombinedQuarterHelper.IsFilingWindowOpen(dates[0], today),
+        };
+    }
+
+    /// <summary>
+    /// The positions to present for the anchored quarter: the combined view while the filing
+    /// window is open, the as-filed 13F rows afterwards.
+    /// </summary>
+    public IQueryable<InstitutionalHolding> GetPresentedPositions(
+        CommonStock stock,
+        StockQuarterAnchor anchor
+    )
+    {
+        return anchor.IsCombined
+            ? _holdingRepository.GetCombinedQuarterByStock(
+                stock,
+                anchor.ReportDate,
+                anchor.PreviousReportDate.Value
+            )
+            : _holdingRepository.Get13FByStock(stock, anchor.ReportDate);
+    }
+
+    /// <summary>Same positions with the holder navigation eagerly loaded for rendering.</summary>
+    public IQueryable<InstitutionalHolding> GetPresentedPositionsWithHolder(
+        CommonStock stock,
+        StockQuarterAnchor anchor
+    )
+    {
+        return anchor.IsCombined
+            ? _holdingRepository.GetCombinedQuarterByStockWithHolder(
+                stock,
+                anchor.ReportDate,
+                anchor.PreviousReportDate.Value
+            )
+            : _holdingRepository.Get13FByStockWithHolder(stock, anchor.ReportDate);
+    }
+
+    /// <summary>
+    /// Reported-so-far activity for a combined anchor: what the funds that already filed the
+    /// new quarter did in this stock, plus the combined-view totals. Only meaningful while
+    /// <see cref="StockQuarterAnchor.IsCombined"/>; three small per-stock reads, aggregated in
+    /// memory.
+    /// </summary>
+    public async Task<StockReportedActivity> LoadReportedActivity(
+        CommonStock stock,
+        StockQuarterAnchor anchor,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var current = await _holdingRepository
+            .Get13FByStock(stock, anchor.ReportDate)
+            .Select(h => new
+            {
+                h.InstitutionalHolderId,
+                h.Shares,
+                h.Value,
+            })
+            .ToListAsync(cancellationToken);
+        var previous = await _holdingRepository
+            .Get13FByStock(stock, anchor.PreviousReportDate.Value)
+            .Select(h => new
+            {
+                h.InstitutionalHolderId,
+                h.Shares,
+                h.Value,
+            })
+            .ToListAsync(cancellationToken);
+
+        var currentHolders = current.Select(h => h.InstitutionalHolderId).ToHashSet();
+        var previousHolders = previous.Select(h => h.InstitutionalHolderId).ToHashSet();
+
+        // Previous holders who filed the new quarter ANYWHERE — present in it or proven exits.
+        var filedPreviousHolders = (
+            await _holdingRepository
+                .GetFiledHolderIdsAmong(anchor.ReportDate, previousHolders.ToList())
+                .ToListAsync(cancellationToken)
+        ).ToHashSet();
+
+        var carried = previous
+            .Where(h => !filedPreviousHolders.Contains(h.InstitutionalHolderId))
+            .ToList();
+
+        return new StockReportedActivity
+        {
+            PreviousHolderCount = previousHolders.Count,
+            ReportedFilerCount = currentHolders.Union(filedPreviousHolders).Count(),
+            NewFilerCount = currentHolders.Count(id => !previousHolders.Contains(id)),
+            SoldOutFilerCount = filedPreviousHolders.Count(id => !currentHolders.Contains(id)),
+            // Net over reporters only: their new shares (zero for exits) minus their previous
+            // shares (zero for new positions). Carried positions contribute nothing.
+            NetReportedShareDelta =
+                current.Sum(h => h.Shares)
+                - previous
+                    .Where(h => filedPreviousHolders.Contains(h.InstitutionalHolderId))
+                    .Sum(h => h.Shares),
+            CombinedHolderCount = currentHolders
+                .Union(carried.Select(h => h.InstitutionalHolderId))
+                .Count(),
+            CombinedShares = current.Sum(h => h.Shares) + carried.Sum(h => h.Shares),
+            CombinedValue = current.Sum(h => h.Value) + carried.Sum(h => h.Value),
+        };
+    }
+}

--- a/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
+++ b/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.BusinessLogic.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
@@ -20,10 +22,15 @@ namespace Equibles.Holdings.BusinessLogic;
 public class StockCombinedQuarterService
 {
     private readonly InstitutionalHoldingRepository _holdingRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
 
-    public StockCombinedQuarterService(InstitutionalHoldingRepository holdingRepository)
+    public StockCombinedQuarterService(
+        InstitutionalHoldingRepository holdingRepository,
+        StockSplitRepository stockSplitRepository
+    )
     {
         _holdingRepository = holdingRepository;
+        _stockSplitRepository = stockSplitRepository;
     }
 
     /// <summary>Resolves the stock's newest 13F quarter and how it must be presented.</summary>
@@ -102,6 +109,12 @@ public class StockCombinedQuarterService
         CancellationToken cancellationToken = default
     )
     {
+        if (!anchor.IsCombined)
+            throw new InvalidOperationException(
+                "Reported activity is only defined for a combined anchor (open filing window "
+                    + "with a previous quarter to compare against)."
+            );
+
         var current = await _holdingRepository
             .Get13FByStock(stock, anchor.ReportDate)
             .Select(h => new
@@ -135,6 +148,33 @@ public class StockCombinedQuarterService
             .Where(h => !filedPreviousHolders.Contains(h.InstitutionalHolderId))
             .ToList();
 
+        // Restate both quarters' share counts onto today's post-split basis before any sum —
+        // a split falling between the two quarters while the window is open would otherwise
+        // read as every continuing filer doubling/halving its position (the same restatement
+        // every other 13F comparison surface applies). Dollar values are split-invariant.
+        var splits = await _stockSplitRepository
+            .GetByStock(stock.Id)
+            .ToListAsync(cancellationToken);
+        var currentFactor = SplitAdjustment.ShareCountFactor(anchor.ReportDate, splits);
+        var previousFactor = SplitAdjustment.ShareCountFactor(
+            anchor.PreviousReportDate.Value,
+            splits
+        );
+        var currentShares = SplitAdjustment.AdjustShareCount(
+            current.Sum(h => h.Shares),
+            currentFactor
+        );
+        var reportedPreviousShares = SplitAdjustment.AdjustShareCount(
+            previous
+                .Where(h => filedPreviousHolders.Contains(h.InstitutionalHolderId))
+                .Sum(h => h.Shares),
+            previousFactor
+        );
+        var carriedShares = SplitAdjustment.AdjustShareCount(
+            carried.Sum(h => h.Shares),
+            previousFactor
+        );
+
         return new StockReportedActivity
         {
             PreviousHolderCount = previousHolders.Count,
@@ -143,15 +183,11 @@ public class StockCombinedQuarterService
             SoldOutFilerCount = filedPreviousHolders.Count(id => !currentHolders.Contains(id)),
             // Net over reporters only: their new shares (zero for exits) minus their previous
             // shares (zero for new positions). Carried positions contribute nothing.
-            NetReportedShareDelta =
-                current.Sum(h => h.Shares)
-                - previous
-                    .Where(h => filedPreviousHolders.Contains(h.InstitutionalHolderId))
-                    .Sum(h => h.Shares),
+            NetReportedShareDelta = currentShares - reportedPreviousShares,
             CombinedHolderCount = currentHolders
                 .Union(carried.Select(h => h.InstitutionalHolderId))
                 .Count(),
-            CombinedShares = current.Sum(h => h.Shares) + carried.Sum(h => h.Shares),
+            CombinedShares = currentShares + carriedShares,
             CombinedValue = current.Sum(h => h.Value) + carried.Sum(h => h.Value),
         };
     }

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -11,6 +11,8 @@ using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.BusinessLogic.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Extensions;
@@ -48,6 +50,7 @@ public class InstitutionalHoldingsTools
     private readonly InstitutionalHolderRepository _holderRepository;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly StockSplitRepository _stockSplitRepository;
+    private readonly StockCombinedQuarterService _combinedQuarterService;
     private readonly McpToolRunner _runner;
 
     public InstitutionalHoldingsTools(
@@ -55,6 +58,7 @@ public class InstitutionalHoldingsTools
         InstitutionalHolderRepository holderRepository,
         CommonStockRepository commonStockRepository,
         StockSplitRepository stockSplitRepository,
+        StockCombinedQuarterService combinedQuarterService,
         ErrorManager errorManager,
         ILogger<InstitutionalHoldingsTools> logger
     )
@@ -63,6 +67,7 @@ public class InstitutionalHoldingsTools
         _holderRepository = holderRepository;
         _commonStockRepository = commonStockRepository;
         _stockSplitRepository = stockSplitRepository;
+        _combinedQuarterService = combinedQuarterService;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -91,7 +96,19 @@ public class InstitutionalHoldingsTools
                 if (!found)
                     return $"No institutional holdings data available for {ticker}.";
 
-                var allHoldings = _holdingRepository.Get13FByStock(stock, targetDate);
+                // While the newest quarter's filing window is open it only holds the early
+                // filers, so it is presented as the combined view (carry-forward for funds
+                // yet to file) — the same rule every web surface applies.
+                var anchor = await _combinedQuarterService.Resolve(stock);
+                var presentCombined =
+                    anchor is { IsCombined: true } && targetDate == anchor.ReportDate;
+                var allHoldings = presentCombined
+                    ? _holdingRepository.GetCombinedQuarterByStock(
+                        stock,
+                        anchor.ReportDate,
+                        anchor.PreviousReportDate.Value
+                    )
+                    : _holdingRepository.Get13FByStock(stock, targetDate);
                 var totalInstitutions = await allHoldings
                     .Select(h => h.InstitutionalHolderId)
                     .Distinct()
@@ -123,13 +140,21 @@ public class InstitutionalHoldingsTools
                     totalSharesAll,
                     totalValueAll,
                     holdings,
-                    shareFactor
+                    shareFactor,
+                    presentCombined ? CombinedViewNote(targetDate, anchor) : null
                 );
             },
             "GetTopHolders",
             $"ticker: {ticker}"
         );
     }
+
+    // The one wording every combined-view tool output carries, so agents and users always see
+    // WHY the newest quarter is presented as a merge of two filing sets.
+    private static string CombinedViewNote(DateOnly targetDate, StockQuarterAnchor anchor) =>
+        $"Note: the {FormatDate(targetDate)} filing window is still open (13Fs are due 45 days "
+        + $"after quarter end). Combined view: funds that have not filed yet carry their "
+        + $"{FormatDate(anchor.PreviousReportDate.Value)} positions.";
 
     private static string RenderTopHoldersTable(
         CommonStock stock,
@@ -139,15 +164,20 @@ public class InstitutionalHoldingsTools
         long totalSharesAll,
         long totalValueAll,
         List<InstitutionalHolding> holdings,
-        decimal shareFactor
+        decimal shareFactor,
+        string combinedNote
     )
     {
         var adjustedTotalShares = SplitAdjustment.AdjustShareCount(totalSharesAll, shareFactor);
+        var subtitle =
+            $"Showing {holdings.Count} of {totalInstitutions} institutions. Total: "
+            + $"{McpFormat.WholeNumber(adjustedTotalShares)} shares, "
+            + $"${FormatMillions(totalValueAll)}M value";
+        if (combinedNote != null)
+            subtitle = $"{subtitle}\n{combinedNote}";
         var result = MarkdownTable.Start(
             $"Top institutional holders of {stock.Name} ({ticker}) as of {FormatDate(targetDate)}:",
-            $"Showing {holdings.Count} of {totalInstitutions} institutions. Total: "
-                + $"{McpFormat.WholeNumber(adjustedTotalShares)} shares, "
-                + $"${FormatMillions(totalValueAll)}M value",
+            subtitle,
             "| # | Institution | Shares | Value ($M) | % of Total |",
             "|---|------------|--------|-----------|-----------|"
         );
@@ -195,7 +225,8 @@ public class InstitutionalHoldingsTools
                 if (reportDates.Count == 0)
                     return $"No institutional holdings history available for {ticker}.";
 
-                return await RenderOwnershipHistory(stock, ticker, reportDates);
+                var anchor = await _combinedQuarterService.Resolve(stock);
+                return await RenderOwnershipHistory(stock, ticker, reportDates, anchor);
             },
             "GetOwnershipHistory",
             $"ticker: {ticker}"
@@ -205,7 +236,8 @@ public class InstitutionalHoldingsTools
     private async Task<string> RenderOwnershipHistory(
         CommonStock stock,
         string ticker,
-        List<DateOnly> reportDates
+        List<DateOnly> reportDates,
+        StockQuarterAnchor anchor
     )
     {
         var result = MarkdownTable.Start(
@@ -220,9 +252,23 @@ public class InstitutionalHoldingsTools
         var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
 
         long previousShares = 0;
+        var combinedRowShown = false;
         foreach (var date in reportDates.OrderBy(d => d))
         {
-            var holdings = await _holdingRepository.Get13FByStock(stock, date).ToListAsync();
+            // The newest quarter is presented as the combined view while its filing window is
+            // open — its as-filed totals would only cover the early filers and the trend would
+            // end on a fabricated collapse.
+            var isCombinedRow = anchor is { IsCombined: true } && date == anchor.ReportDate;
+            var holdings = isCombinedRow
+                ? await _holdingRepository
+                    .GetCombinedQuarterByStock(
+                        stock,
+                        anchor.ReportDate,
+                        anchor.PreviousReportDate.Value
+                    )
+                    .ToListAsync()
+                : await _holdingRepository.Get13FByStock(stock, date).ToListAsync();
+            combinedRowShown |= isCombinedRow;
             var totalShares = SplitAdjustment.AdjustShareCount(
                 holdings.Sum(h => h.Shares),
                 date,
@@ -237,10 +283,16 @@ public class InstitutionalHoldingsTools
                     : "—";
 
             result.AppendLine(
-                $"| {FormatDate(date)} | {McpFormat.WholeNumber(institutionCount)} | {McpFormat.WholeNumber(totalShares)} | {FormatMillions(totalValue)} | {change} |"
+                $"| {FormatDate(date)}{(isCombinedRow ? " \\*" : "")} | {McpFormat.WholeNumber(institutionCount)} | {McpFormat.WholeNumber(totalShares)} | {FormatMillions(totalValue)} | {change} |"
             );
 
             previousShares = totalShares;
+        }
+
+        if (combinedRowShown)
+        {
+            result.AppendLine();
+            result.AppendLine($"\\* {CombinedViewNote(anchor.ReportDate, anchor)}");
         }
 
         return result.ToString();
@@ -425,6 +477,24 @@ public class InstitutionalHoldingsTools
                 var currentByHolder = AggregateByHolder(currentHoldings);
                 var previousByHolder = AggregateByHolder(previousHoldings);
 
+                // While the target quarter's filing window is open, funds that simply have not
+                // filed yet would read as full sellers (previous position → 0). Restrict the
+                // comparison to REPORTERS: the quarter's filers plus previous holders who filed
+                // elsewhere (proven exits). Carried non-filers are excluded.
+                var windowOpen =
+                    previousDate.HasValue
+                    && targetDate == reportDates[0]
+                    && CombinedQuarterHelper.IsFilingWindowOpen(targetDate);
+                HashSet<Guid> filedPreviousHolders = null;
+                if (windowOpen)
+                {
+                    filedPreviousHolders = (
+                        await _holdingRepository
+                            .GetFiledHolderIdsAmong(targetDate, previousByHolder.Keys.ToList())
+                            .ToListAsync()
+                    ).ToHashSet();
+                }
+
                 // Restate each quarter's share counts onto today's split basis (the two
                 // quarters sit on different bases if a split fell between them) so Δ Shares
                 // and the Prior → New column reflect a real position change, not the split.
@@ -435,7 +505,13 @@ public class InstitutionalHoldingsTools
                     ? SplitAdjustment.ShareCountFactor(previousDate.Value, splits)
                     : 1m;
 
-                var allHolderIds = currentByHolder.Keys.Union(previousByHolder.Keys);
+                var allHolderIds = currentByHolder
+                    .Keys.Union(previousByHolder.Keys)
+                    .Where(id =>
+                        filedPreviousHolders == null
+                        || currentByHolder.ContainsKey(id)
+                        || filedPreviousHolders.Contains(id)
+                    );
                 var movers = allHolderIds
                     .Select(id =>
                     {
@@ -479,7 +555,11 @@ public class InstitutionalHoldingsTools
                     targetDate,
                     previousDate,
                     topBuyers,
-                    topSellers
+                    topSellers,
+                    windowOpen
+                        ? $"Note: the {FormatDate(targetDate)} filing window is still open — "
+                            + "movement is computed only across funds that have already filed."
+                        : null
                 );
             },
             "GetTopBuyersSellers",
@@ -505,7 +585,8 @@ public class InstitutionalHoldingsTools
             long PreviousShares,
             long DeltaShares,
             long DeltaValue
-        )> topSellers
+        )> topSellers,
+        string windowNote
     )
     {
         var result = new StringBuilder();
@@ -514,6 +595,8 @@ public class InstitutionalHoldingsTools
         );
         if (previousDate.HasValue)
             result.AppendLine(PriorQuarterSubtitle(previousDate.Value));
+        if (windowNote != null)
+            result.AppendLine(windowNote);
         result.AppendLine();
 
         AppendMoverSection(result, "## Top Buyers", "_No buyers this quarter._", topBuyers);
@@ -572,9 +655,8 @@ public class InstitutionalHoldingsTools
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var (targetDate, previousDate, error) = await ResolveMarketActivityDates(
-                    reportDate
-                );
+                var (targetDate, previousDate, windowOpen, error) =
+                    await ResolveMarketActivityDates(reportDate);
                 if (error != null)
                     return error;
 
@@ -584,6 +666,11 @@ public class InstitutionalHoldingsTools
                     $"Market-wide 13F **{normalizedBucket}** for {FormatDate(targetDate)}"
                 );
                 result.AppendLine(PriorQuarterSubtitle(previousDate));
+                if (windowOpen)
+                    result.AppendLine(
+                        $"Note: the {FormatDate(targetDate)} filing window is still open — "
+                            + "figures cover only the funds that have already filed."
+                    );
                 result.AppendLine();
 
                 if (normalizedBucket is "top-buys" or "top-sells")
@@ -592,6 +679,7 @@ public class InstitutionalHoldingsTools
                         normalizedBucket,
                         targetDate,
                         previousDate,
+                        windowOpen,
                         maxResults,
                         result
                     );
@@ -602,6 +690,7 @@ public class InstitutionalHoldingsTools
                         normalizedBucket,
                         targetDate,
                         previousDate,
+                        windowOpen,
                         maxResults,
                         result
                     );
@@ -615,6 +704,7 @@ public class InstitutionalHoldingsTools
     private async Task<(
         DateOnly Target,
         DateOnly Previous,
+        bool WindowOpen,
         string Error
     )> ResolveMarketActivityDates(string reportDate)
     {
@@ -623,7 +713,7 @@ public class InstitutionalHoldingsTools
         // compare a quarter-end portfolio against a single-day stake.
         var reportDates = await _holdingRepository.Get13FAvailableReportDates().ToListAsync();
         if (reportDates.Count == 0)
-            return (default, default, "No 13F holdings data available.");
+            return (default, default, false, "No 13F holdings data available.");
 
         var targetDate = TryParseReportDate(reportDate, out var parsed) ? parsed : reportDates[0];
         var targetIndex = reportDates.IndexOf(targetDate);
@@ -631,6 +721,7 @@ public class InstitutionalHoldingsTools
             return (
                 default,
                 default,
+                false,
                 $"Report date {FormatDate(targetDate)} not found. Available dates: {string.Join(", ", reportDates.Take(5).Select(d => FormatDate(d)))}{(reportDates.Count > 5 ? "…" : "")}."
             );
 
@@ -638,16 +729,21 @@ public class InstitutionalHoldingsTools
             return (
                 default,
                 default,
+                false,
                 $"No prior quarter to compare against for {FormatDate(targetDate)}."
             );
 
-        return (targetDate, reportDates[targetIndex + 1], null);
+        // While the newest quarter's filing window is open its leaderboards must use the
+        // combined queries, or every fund that has not filed yet reads as a mass seller.
+        var windowOpen = targetIndex == 0 && CombinedQuarterHelper.IsFilingWindowOpen(targetDate);
+        return (targetDate, reportDates[targetIndex + 1], windowOpen, null);
     }
 
     private async Task<string> RenderMarketActivityMovers(
         string normalizedBucket,
         DateOnly targetDate,
         DateOnly previousDate,
+        bool windowOpen,
         int maxResults,
         StringBuilder result
     )
@@ -657,9 +753,13 @@ public class InstitutionalHoldingsTools
         // report dates sits the quarters on different bases, so a flat position would otherwise
         // read as a phantom buyer/seller. Δ Value is a dollar figure and is split-invariant (it
         // drives the ordering). The restatement is per-stock, so it cannot translate to SQL.
-        var activity = await _holdingRepository
-            .GetQuarterlyActivity(targetDate, previousDate)
-            .ToListAsync();
+        // While the filing window is open the combined variant carries non-filers forward at a
+        // zero delta, so only real reported moves rank.
+        var activity = await (
+            windowOpen
+                ? _holdingRepository.GetQuarterlyActivityCombined(targetDate, previousDate)
+                : _holdingRepository.GetQuarterlyActivity(targetDate, previousDate)
+        ).ToListAsync();
         await RestateActivitySharesToTodaysBasis(activity, targetDate, previousDate);
 
         var movers = activity.Where(a => a.CurrentShares != a.PreviousShares);
@@ -689,11 +789,16 @@ public class InstitutionalHoldingsTools
         string normalizedBucket,
         DateOnly targetDate,
         DateOnly previousDate,
+        bool windowOpen,
         int maxResults,
         StringBuilder result
     )
     {
-        var churn = _holdingRepository.GetQuarterlyNewSoldOutPositions(targetDate, previousDate);
+        // Combined while the window is open: the plain variant counts every fund that has not
+        // filed yet as "exited", so sold-out-positions would rank by non-filers, not exits.
+        var churn = windowOpen
+            ? _holdingRepository.GetQuarterlyNewSoldOutPositionsCombined(targetDate, previousDate)
+            : _holdingRepository.GetQuarterlyNewSoldOutPositions(targetDate, previousDate);
         var rows =
             normalizedBucket == "new-positions"
                 ? await churn.NewPositions().Take(maxResults).ToListAsync()
@@ -743,13 +848,16 @@ public class InstitutionalHoldingsTools
                 if (!ValidMostHeldSorts.Contains(normalizedSort))
                     return $"Unknown sort. Use one of: {string.Join(", ", ValidMostHeldSorts)}.";
 
-                var (targetDate, previousDate, error) = await ResolveMarketActivityDates(
-                    reportDate
-                );
+                var (targetDate, previousDate, windowOpen, error) =
+                    await ResolveMarketActivityDates(reportDate);
                 if (error != null)
                     return error;
 
-                var ranking = _holdingRepository.GetMostHeld(targetDate, previousDate);
+                // Combined while the window is open — the as-filed ranking would order the
+                // whole market by which funds happened to file early.
+                var ranking = windowOpen
+                    ? _holdingRepository.GetMostHeldCombined(targetDate, previousDate)
+                    : _holdingRepository.GetMostHeld(targetDate, previousDate);
                 ranking = normalizedSort switch
                 {
                     "filersdelta" => ranking
@@ -766,12 +874,14 @@ public class InstitutionalHoldingsTools
                 if (rows.Count == 0)
                     return $"No stocks were held by 13F filers as of {FormatDate(targetDate)}.";
 
-                var universeFilers = await _holdingRepository
-                    .GetUniqueFilerIds(targetDate)
-                    .CountAsync();
+                var universeFilers = await (
+                    windowOpen
+                        ? _holdingRepository.GetUniqueFilerIdsCombined(targetDate, previousDate)
+                        : _holdingRepository.GetUniqueFilerIds(targetDate)
+                ).CountAsync();
                 var stocks = await LoadStocksByIds(rows.Select(r => r.CommonStockId).ToList());
 
-                return RenderMostHeldStocksTable(
+                var table = RenderMostHeldStocksTable(
                     targetDate,
                     previousDate,
                     normalizedSort,
@@ -779,6 +889,10 @@ public class InstitutionalHoldingsTools
                     rows,
                     stocks
                 );
+                return windowOpen
+                    ? $"{table}\nNote: the {FormatDate(targetDate)} filing window is still open — "
+                        + "funds that have not filed yet carry their prior-quarter positions."
+                    : table;
             },
             "GetMostHeldStocks",
             $"sort: {sort}, max: {maxResults}"

--- a/src/Equibles.Holdings.Repositories/CombinedQuarterHelper.cs
+++ b/src/Equibles.Holdings.Repositories/CombinedQuarterHelper.cs
@@ -1,12 +1,31 @@
 namespace Equibles.Holdings.Repositories;
 
+// The one 13F filing-calendar rule (SEC rule 13f-1: filings are due 45 calendar days after each
+// quarter end). Every surface that decides how to present the newest quarter must go through
+// this helper so "the current quarter" resolves identically everywhere: while the window is
+// open the quarter only holds the funds that filed early, so it must be shown as the COMBINED
+// view (current filings + prior-quarter carry-forward for funds yet to file) — never as a
+// complete quarter.
 public static class CombinedQuarterHelper
 {
     public const int FilingDeadlineDays = 45;
 
     public static bool IsFilingWindowOpen(DateOnly latestReportDate)
     {
-        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        return IsFilingWindowOpen(latestReportDate, DateOnly.FromDateTime(DateTime.UtcNow));
+    }
+
+    // Explicit-today overload so callers and tests can pin the clock.
+    public static bool IsFilingWindowOpen(DateOnly latestReportDate, DateOnly today)
+    {
         return today <= latestReportDate.AddDays(FilingDeadlineDays);
+    }
+
+    // The latest ReportDate whose filing window has fully closed as of `today` (the deadline
+    // plus one day so deadline-day filings have been ingested). Quarter-over-quarter verdicts
+    // and multi-year extremes must only anchor on dates at or before this cutoff.
+    public static DateOnly CompletedReportDateCutoff(DateOnly today)
+    {
+        return today.AddDays(-(FilingDeadlineDays + 1));
     }
 }

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -572,20 +572,34 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             );
     }
 
-    // Combined view scoped to one stock, 13F-only. The global non-filer test stays UNSCOPED on
-    // purpose: a fund that filed this quarter without this stock proved it sold out, so its
-    // prior row must not carry forward. Is13F is applied on top (unlike the market-wide
-    // GetCombinedQuarter) because per-stock holder lists double-count a filer whose 13D/G
-    // event date coincides with the quarter end (GH-4449).
+    // Combined view scoped to one stock, 13F-only on BOTH sides (rows and the has-filed test —
+    // unlike the market-wide GetCombinedQuarter): per-stock holder lists double-count a filer
+    // whose 13D/G event date coincides with the quarter end, and that same coincidence must
+    // not mark the fund as "filed" and drop its carried prior 13F row (GH-4449). The has-filed
+    // test stays UNSCOPED by stock on purpose: a fund that filed this quarter without this
+    // stock proved it sold out, so its prior row must not carry forward.
     public IQueryable<InstitutionalHolding> GetCombinedQuarterByStock(
         CommonStock stock,
         DateOnly current,
         DateOnly previous
     )
     {
-        return GetCombinedQuarter(current, previous)
+        return GetAll()
             .Where(Is13F)
-            .Where(h => h.CommonStockId == stock.Id);
+            .Where(h => h.CommonStockId == stock.Id)
+            .Where(h =>
+                h.ReportDate == current
+                || (
+                    h.ReportDate == previous
+                    && !DbContext
+                        .Set<InstitutionalHolding>()
+                        .Any(c =>
+                            c.ReportDate == current
+                            && c.FilingType == FilingType.Form13F
+                            && c.InstitutionalHolderId == h.InstitutionalHolderId
+                        )
+                )
+            );
     }
 
     // Same combined per-stock view with the holder navigation eagerly loaded for rendering.

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -572,6 +572,47 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             );
     }
 
+    // Combined view scoped to one stock, 13F-only. The global non-filer test stays UNSCOPED on
+    // purpose: a fund that filed this quarter without this stock proved it sold out, so its
+    // prior row must not carry forward. Is13F is applied on top (unlike the market-wide
+    // GetCombinedQuarter) because per-stock holder lists double-count a filer whose 13D/G
+    // event date coincides with the quarter end (GH-4449).
+    public IQueryable<InstitutionalHolding> GetCombinedQuarterByStock(
+        CommonStock stock,
+        DateOnly current,
+        DateOnly previous
+    )
+    {
+        return GetCombinedQuarter(current, previous)
+            .Where(Is13F)
+            .Where(h => h.CommonStockId == stock.Id);
+    }
+
+    // Same combined per-stock view with the holder navigation eagerly loaded for rendering.
+    public IQueryable<InstitutionalHolding> GetCombinedQuarterByStockWithHolder(
+        CommonStock stock,
+        DateOnly current,
+        DateOnly previous
+    )
+    {
+        return GetCombinedQuarterByStock(stock, current, previous)
+            .Include(h => h.InstitutionalHolder);
+    }
+
+    // Distinct holder ids among the given set that filed ANY 13F at reportDate — the "has this
+    // fund reported yet?" test behind the combined view's reported-so-far counts.
+    public IQueryable<Guid> GetFiledHolderIdsAmong(
+        DateOnly reportDate,
+        IReadOnlyCollection<Guid> holderIds
+    )
+    {
+        return GetAll()
+            .Where(Is13F)
+            .Where(h => h.ReportDate == reportDate && holderIds.Contains(h.InstitutionalHolderId))
+            .Select(h => h.InstitutionalHolderId)
+            .Distinct();
+    }
+
     // Combined-quarter variant of GetQuarterlyActivity. The "current" side aggregates
     // the combined view (current filers + previous-quarter fallback for non-filers).
     // The "previous" side uses the actual previous quarter for delta comparison. For

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -74,6 +74,9 @@ public partial class Program
         // Media file access: DocumentTextTools resolves IFileManager to read document
         // content regardless of storage backend.
         builder.Services.AutoWireServicesFrom<Equibles.Media.BusinessLogic.FileManager>();
+        // Holdings tools resolve StockCombinedQuarterService to present the in-progress 13F
+        // quarter as the combined view.
+        builder.Services.AutoWireServicesFrom<Equibles.Holdings.BusinessLogic.StockCombinedQuarterService>();
 
         // Required for RAG search to embed the query at request time; without this
         // bind EmbeddingConfig is default (Enabled=false) and semantic search is inert.

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -120,7 +120,7 @@ public class StocksController : BaseController
     public Task<IActionResult> Holdings(
         string ticker,
         DateOnly? date,
-        bool combined = false,
+        bool? combined = null,
         [FromQuery(Name = "types")] string types = null
     ) =>
         ShowStockTab(
@@ -128,7 +128,12 @@ public class StocksController : BaseController
             "holdings",
             async s =>
             {
-                var vm = combined
+                // No explicit choice → open in the combined view while the newest quarter's
+                // filing window is open, so the tab never presents a half-filed quarter's
+                // early filers as the whole institutional picture.
+                var useCombined =
+                    combined ?? (date == null && await _stockTabService.ShouldDefaultToCombined(s));
+                var vm = useCombined
                     ? await _stockTabService.LoadHoldingsCombinedTab(s)
                     : await _stockTabService.LoadHoldingsTab(s, date);
                 vm.ActiveTypes = ParsePositionTypes(types);

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -100,6 +100,14 @@ public class StockTabService
         _commonStockRepository = commonStockRepository;
     }
 
+    // Whether the holdings tab should OPEN in the combined view: the newest quarter's filing
+    // window is still open and a prior quarter exists to carry non-filers forward from.
+    public async Task<bool> ShouldDefaultToCombined(CommonStock stock)
+    {
+        var reportDates = await LoadClampedReportDates(stock);
+        return reportDates.Count >= 2 && CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
+    }
+
     public async Task<HoldingsTabViewModel> LoadHoldingsTab(CommonStock stock, DateOnly? date)
     {
         var reportDates = await LoadClampedReportDates(stock);

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests.cs
@@ -39,7 +39,10 @@ public class InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests : 
             new InstitutionalHolderRepository(_dbContext),
             new CommonStockRepository(_dbContext),
             new StockSplitRepository(_dbContext),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(_dbContext)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(_dbContext),
+                new StockSplitRepository(_dbContext)
+            ),
             errorManager: null,
             NullLogger<InstitutionalHoldingsTools>.Instance
         );

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -38,6 +39,7 @@ public class InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests : 
             new InstitutionalHolderRepository(_dbContext),
             new CommonStockRepository(_dbContext),
             new StockSplitRepository(_dbContext),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(_dbContext)),
             errorManager: null,
             NullLogger<InstitutionalHoldingsTools>.Instance
         );

--- a/tests/Equibles.IntegrationTests/Holdings/StockCombinedQuarterServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/StockCombinedQuarterServiceTests.cs
@@ -1,0 +1,184 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins the combined-quarter semantics every surface now resolves through
+/// <see cref="StockCombinedQuarterService"/>. Scenario: previous quarter has holders A/B/C;
+/// during the open filing window A re-files (resized), D files new, C files elsewhere without
+/// the stock (a PROVEN exit), and B has not filed at all (carried forward). The presented
+/// positions, reported-so-far figures, and split restatement must all read from that one story
+/// — a carried non-filer must never count as a seller, a proven exit must.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class StockCombinedQuarterServiceTests : ParadeDbMcpTestBase
+{
+    public StockCombinedQuarterServiceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static readonly DateOnly Previous = new(2026, 3, 31);
+    private static readonly DateOnly Current = new(2026, 6, 30);
+
+    // Inside Current's 45-day filing window.
+    private static readonly DateOnly InsideWindow = new(2026, 7, 15);
+
+    // Past Current's deadline (Aug 14).
+    private static readonly DateOnly AfterWindow = new(2026, 9, 1);
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            CommonStock = stock,
+            InstitutionalHolderId = holder.Id,
+            InstitutionalHolder = holder,
+            FilingDate = reportDate.AddDays(20),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            FilingType = FilingType.Form13F,
+        };
+
+    private async Task<(CommonStock Stock, StockCombinedQuarterService Service)> Seed()
+    {
+        var stock = new CommonStock { Ticker = "ARE", Name = "Alexandria Real Estate" };
+        var other = new CommonStock { Ticker = "OTHR", Name = "Other Co" };
+        var continuing = new InstitutionalHolder { Cik = "1", Name = "Continuing Fund" };
+        var carried = new InstitutionalHolder { Cik = "2", Name = "Carried Fund" };
+        var exited = new InstitutionalHolder { Cik = "3", Name = "Exited Fund" };
+        var newcomer = new InstitutionalHolder { Cik = "4", Name = "Newcomer Fund" };
+        DbContext.AddRange(stock, other, continuing, carried, exited, newcomer);
+
+        // Previous quarter: A=100, B=200, C=300.
+        DbContext.Add(MakeHolding(stock, continuing, Previous, shares: 100, value: 1_000));
+        DbContext.Add(MakeHolding(stock, carried, Previous, shares: 200, value: 2_000));
+        DbContext.Add(MakeHolding(stock, exited, Previous, shares: 300, value: 3_000));
+
+        // Current quarter so far: A resized to 150, D new with 50; C filed — but only for the
+        // OTHER stock, proving it dropped this one; B has not filed anything yet.
+        DbContext.Add(MakeHolding(stock, continuing, Current, shares: 150, value: 1_500));
+        DbContext.Add(MakeHolding(stock, newcomer, Current, shares: 50, value: 500));
+        DbContext.Add(MakeHolding(other, exited, Current, shares: 999, value: 9_990));
+
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var service = new StockCombinedQuarterService(
+            new InstitutionalHoldingRepository(DbContext),
+            new StockSplitRepository(DbContext)
+        );
+        return (stock, service);
+    }
+
+    [Fact]
+    public async Task Resolve_InsideAndAfterTheFilingWindow_FlipsIsCombined()
+    {
+        var (stock, service) = await Seed();
+
+        var open = await service.Resolve(stock, InsideWindow);
+        open.ReportDate.Should().Be(Current);
+        open.PreviousReportDate.Should().Be(Previous);
+        open.IsCombined.Should().BeTrue("the 45-day window for Jun 30 runs until Aug 14");
+
+        var closed = await service.Resolve(stock, AfterWindow);
+        closed.IsCombined.Should().BeFalse("the window closed — the quarter is as-filed");
+    }
+
+    [Fact]
+    public async Task GetPresentedPositions_WindowOpen_CarriesNonFilersAndDropsProvenExits()
+    {
+        var (stock, service) = await Seed();
+        var anchor = await service.Resolve(stock, InsideWindow);
+
+        var positions = await service.GetPresentedPositions(stock, anchor).ToListAsync();
+
+        // A (current 150) + D (current 50) + B carried from Previous (200); C's prior row must
+        // NOT carry — it filed the current quarter elsewhere, proving the exit.
+        positions.Should().HaveCount(3);
+        positions.Sum(h => h.Shares).Should().Be(400);
+        positions
+            .Where(h => h.ReportDate == Previous)
+            .Should()
+            .ContainSingle("only the non-filer's prior row is carried forward")
+            .Which.Shares.Should()
+            .Be(200);
+    }
+
+    [Fact]
+    public async Task LoadReportedActivity_WindowOpen_CountsReportersOnly()
+    {
+        var (stock, service) = await Seed();
+        var anchor = await service.Resolve(stock, InsideWindow);
+
+        var reported = await service.LoadReportedActivity(stock, anchor);
+
+        reported.PreviousHolderCount.Should().Be(3);
+        // Reporters relevant to the stock: A (re-filed) + D (new) + C (proven exit). B is not
+        // a reporter and must contribute NOTHING to the delta.
+        reported.ReportedFilerCount.Should().Be(3);
+        reported.NewFilerCount.Should().Be(1);
+        reported.SoldOutFilerCount.Should().Be(1);
+        // Net over reporters: (150 + 50) − (A's 100 + C's 300) = −200.
+        reported.NetReportedShareDelta.Should().Be(-200);
+        reported.CombinedHolderCount.Should().Be(3);
+        reported.CombinedShares.Should().Be(400);
+        reported.CombinedValue.Should().Be(4_000);
+    }
+
+    [Fact]
+    public async Task LoadReportedActivity_SplitBetweenTheQuarters_RestatesBothSides()
+    {
+        var (stock, service) = await Seed();
+
+        // 2:1 split between the two report dates: previous-quarter counts sit on the pre-split
+        // basis and must double before they are compared or summed.
+        DbContext.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                EffectiveDate = new DateOnly(2026, 5, 15),
+                Numerator = 2,
+                Denominator = 1,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var anchor = await service.Resolve(stock, InsideWindow);
+        var reported = await service.LoadReportedActivity(stock, anchor);
+
+        // Reporters on today's basis: A went 200 (post-split) → 150 (−50), C exited −600,
+        // D added +50 → net −600. Combined shares: 150 + 50 + B's carried 400 = 600.
+        reported.NetReportedShareDelta.Should().Be(-600);
+        reported.CombinedShares.Should().Be(600);
+    }
+
+    [Fact]
+    public async Task LoadReportedActivity_AsFiledAnchor_Throws()
+    {
+        var (stock, service) = await Seed();
+        var anchor = await service.Resolve(stock, AfterWindow);
+
+        var act = () => service.LoadReportedActivity(stock, anchor);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -21,6 +22,7 @@ public class InstitutionalHoldingsToolsTests : ParadeDbMcpTestBase
             new InstitutionalHolderRepository(DbContext),
             new CommonStockRepository(DbContext),
             new StockSplitRepository(DbContext),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(DbContext)),
             ErrorManager,
             NullLogger<InstitutionalHoldingsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
@@ -22,7 +22,10 @@ public class InstitutionalHoldingsToolsTests : ParadeDbMcpTestBase
             new InstitutionalHolderRepository(DbContext),
             new CommonStockRepository(DbContext),
             new StockSplitRepository(DbContext),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(DbContext)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(DbContext),
+                new StockSplitRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<InstitutionalHoldingsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
@@ -153,7 +153,10 @@ public class InstitutionalHoldingsToolsGetConsensusHoldingsTests : ParadeDbMcpTe
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -152,6 +153,7 @@ public class InstitutionalHoldingsToolsGetConsensusHoldingsTests : ParadeDbMcpTe
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -55,6 +56,7 @@ public class InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTest
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTests.cs
@@ -56,7 +56,10 @@ public class InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTest
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
@@ -143,7 +143,10 @@ public class InstitutionalHoldingsToolsGetFundOverlapTests : ParadeDbMcpTestBase
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -142,6 +143,7 @@ public class InstitutionalHoldingsToolsGetFundOverlapTests : ParadeDbMcpTestBase
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests.cs
@@ -72,7 +72,10 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -71,6 +72,7 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioExcludes13DGTests
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioMalformedDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioMalformedDateTests.cs
@@ -62,7 +62,10 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioMalformedDateTests
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioMalformedDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioMalformedDateTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -61,6 +62,7 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioMalformedDateTests
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -25,6 +26,7 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResults
             new InstitutionalHolderRepository(DbContext),
             new CommonStockRepository(DbContext),
             new StockSplitRepository(DbContext),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(DbContext)),
             ErrorManager,
             NullLogger<InstitutionalHoldingsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
@@ -26,7 +26,10 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResults
             new InstitutionalHolderRepository(DbContext),
             new CommonStockRepository(DbContext),
             new StockSplitRepository(DbContext),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(DbContext)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(DbContext),
+                new StockSplitRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<InstitutionalHoldingsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
@@ -65,7 +65,10 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioTests : ParadeDbMc
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -64,6 +65,7 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioTests : ParadeDbMc
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjustmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjustmentTests.cs
@@ -78,7 +78,10 @@ public class InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjus
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjustmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjustmentTests.cs
@@ -2,6 +2,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -77,6 +78,7 @@ public class InstitutionalHoldingsToolsGetInstitutionQuarterlyActivitySplitAdjus
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests.cs
@@ -173,7 +173,10 @@ public class InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests : Pa
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -172,6 +173,7 @@ public class InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests : Pa
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests.cs
@@ -113,7 +113,10 @@ public class InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests : Par
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests.cs
@@ -2,6 +2,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Models.Taxonomies;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -112,6 +113,7 @@ public class InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests : Par
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
@@ -204,7 +204,10 @@ public class InstitutionalHoldingsToolsGetInstitutionSummaryTests : ParadeDbMcpT
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -203,6 +204,7 @@ public class InstitutionalHoldingsToolsGetInstitutionSummaryTests : ParadeDbMcpT
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvarianceTests.cs
@@ -83,7 +83,10 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvar
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvarianceTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -82,6 +83,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvar
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnNegativeMaxResultsTests.cs
@@ -65,7 +65,10 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityChurnNegativeMaxR
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnNegativeMaxResultsTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -64,6 +65,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityChurnNegativeMaxR
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyChurnTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyChurnTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -53,6 +54,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyChurnTests :
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyChurnTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyChurnTests.cs
@@ -54,7 +54,10 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyChurnTests :
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyMoversTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyMoversTests.cs
@@ -55,7 +55,10 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyMoversTests
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyMoversTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyMoversTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -54,6 +55,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityEmptyMoversTests
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
@@ -58,7 +58,10 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResult
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -57,6 +58,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResult
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -143,6 +144,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityTests : ParadeDbM
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
@@ -144,7 +144,10 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityTests : ParadeDbM
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -184,6 +185,7 @@ public class InstitutionalHoldingsToolsGetMostHeldStocksTests : ParadeDbMcpTestB
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
@@ -185,7 +185,10 @@ public class InstitutionalHoldingsToolsGetMostHeldStocksTests : ParadeDbMcpTestB
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksValueSortTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksValueSortTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -82,6 +83,7 @@ public class InstitutionalHoldingsToolsGetMostHeldStocksValueSortTests : ParadeD
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksValueSortTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksValueSortTests.cs
@@ -83,7 +83,10 @@ public class InstitutionalHoldingsToolsGetMostHeldStocksValueSortTests : ParadeD
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests.cs
@@ -58,7 +58,10 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTest
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(ctx),
+                new StockSplitRepository(ctx)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -57,6 +58,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTest
             new InstitutionalHolderRepository(ctx),
             new CommonStockRepository(ctx),
             new StockSplitRepository(ctx),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(ctx)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -67,6 +68,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -129,6 +131,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -160,6 +163,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -188,6 +192,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -224,6 +229,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -262,6 +268,7 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
@@ -68,7 +68,10 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -131,7 +134,10 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -163,7 +169,10 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -192,7 +201,10 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -229,7 +241,10 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
@@ -268,7 +283,10 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
@@ -56,7 +56,10 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -55,6 +56,7 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -24,6 +25,7 @@ public class InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests :
             new InstitutionalHolderRepository(DbContext),
             new CommonStockRepository(DbContext),
             new StockSplitRepository(DbContext),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(DbContext)),
             ErrorManager,
             NullLogger<InstitutionalHoldingsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
@@ -25,7 +25,10 @@ public class InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests :
             new InstitutionalHolderRepository(DbContext),
             new CommonStockRepository(DbContext),
             new StockSplitRepository(DbContext),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(DbContext)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(DbContext),
+                new StockSplitRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<InstitutionalHoldingsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryTests.cs
@@ -57,7 +57,10 @@ public class InstitutionalHoldingsToolsOwnershipHistoryTests : ParadeDbMcpTestBa
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -56,6 +57,7 @@ public class InstitutionalHoldingsToolsOwnershipHistoryTests : ParadeDbMcpTestBa
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
@@ -56,7 +56,10 @@ public class InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTe
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -55,6 +56,7 @@ public class InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTe
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterTests.cs
@@ -53,7 +53,10 @@ public class InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterT
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -52,6 +53,7 @@ public class InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterT
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNotFoundTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -52,6 +53,7 @@ public class InstitutionalHoldingsToolsResolveMarketActivityDatesNotFoundTests :
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNotFoundTests.cs
@@ -53,7 +53,10 @@ public class InstitutionalHoldingsToolsResolveMarketActivityDatesNotFoundTests :
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsSearchTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
 using Equibles.Holdings.Repositories;
@@ -54,6 +55,7 @@ public class InstitutionalHoldingsToolsSearchTests : ParadeDbMcpTestBase
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsSearchTests.cs
@@ -55,7 +55,10 @@ public class InstitutionalHoldingsToolsSearchTests : ParadeDbMcpTestBase
             new InstitutionalHolderRepository(verify),
             new CommonStockRepository(verify),
             new StockSplitRepository(verify),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(verify)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
             ErrorManager,
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/CombinedQuarterHelperWindowBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/CombinedQuarterHelperWindowBoundaryTests.cs
@@ -1,0 +1,38 @@
+using Equibles.Holdings.Repositories;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// The 45-day 13F filing-window rule every surface resolves the current quarter through. The
+/// two sides must stay exactly complementary: a quarter is presented as the combined view while
+/// IsFilingWindowOpen and may anchor QoQ verdicts only once its date falls at or before
+/// CompletedReportDateCutoff. If the boundaries ever drift apart, a quarter could be both
+/// "still filling in" and "complete" (or neither) on the same day.
+/// </summary>
+public class CombinedQuarterHelperWindowBoundaryTests
+{
+    private static readonly DateOnly QuarterEnd = new(2026, 3, 31);
+
+    [Fact]
+    public void IsFilingWindowOpen_OnTheDeadline_IsStillOpen()
+    {
+        // Deadline day (quarter end + 45): filings are still legally arriving.
+        var deadline = QuarterEnd.AddDays(CombinedQuarterHelper.FilingDeadlineDays);
+
+        Assert.True(CombinedQuarterHelper.IsFilingWindowOpen(QuarterEnd, deadline));
+        Assert.False(CombinedQuarterHelper.IsFilingWindowOpen(QuarterEnd, deadline.AddDays(1)));
+    }
+
+    [Fact]
+    public void CompletedCutoff_AdmitsAQuarterExactlyWhenItsWindowCloses()
+    {
+        // For every day around the boundary: complete ⇔ window no longer open.
+        for (var offset = 43; offset <= 48; offset++)
+        {
+            var today = QuarterEnd.AddDays(offset);
+            var complete = QuarterEnd <= CombinedQuarterHelper.CompletedReportDateCutoff(today);
+
+            Assert.Equal(!CombinedQuarterHelper.IsFilingWindowOpen(QuarterEnd, today), complete);
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
@@ -108,7 +108,10 @@ public class InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
             new StockSplitRepository(db),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(db)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(db),
+                new StockSplitRepository(db)
+            ),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
@@ -7,6 +7,7 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
@@ -107,6 +108,7 @@ public class InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
             new StockSplitRepository(db),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(db)),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests.cs
@@ -104,7 +104,10 @@ public class InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
             new StockSplitRepository(db),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(db)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(db),
+                new StockSplitRepository(db)
+            ),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests.cs
@@ -7,6 +7,7 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
@@ -103,6 +104,7 @@ public class InstitutionalHoldingsToolsOwnershipHistoryExcludes13DGTests
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
             new StockSplitRepository(db),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(db)),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderBuyersSellersTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderBuyersSellersTableCultureInvarianceTests.cs
@@ -54,6 +54,7 @@ public class InstitutionalHoldingsToolsRenderBuyersSellersTableCultureInvariance
             (DateOnly?)new DateOnly(2024, 9, 30),
             buyers,
             sellers,
+            null,
         ];
 
         var original = CultureInfo.CurrentCulture;

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderBuyersSellersTableEmptySellersPlaceholderTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderBuyersSellersTableEmptySellersPlaceholderTests.cs
@@ -46,7 +46,15 @@ public class InstitutionalHoldingsToolsRenderBuyersSellersTableEmptySellersPlace
         var rendered = (string)
             RenderBuyersSellersTableMethod.Invoke(
                 null,
-                [stock, "AAPL", new DateOnly(2024, 9, 30), (DateOnly?)null, topBuyers, topSellers]
+                [
+                    stock,
+                    "AAPL",
+                    new DateOnly(2024, 9, 30),
+                    (DateOnly?)null,
+                    topBuyers,
+                    topSellers,
+                    null,
+                ]
             );
 
         rendered.Should().Contain("_No sellers this quarter._");

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTests.cs
@@ -48,6 +48,7 @@ public class InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTes
             9_876_543_210L,
             holdings,
             1m,
+            null,
         ];
 
         var original = CultureInfo.CurrentCulture;

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests.cs
@@ -45,6 +45,7 @@ public class InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests
             9_876_543_210L,
             holdings,
             1m,
+            null,
         ];
 
         var original = CultureInfo.CurrentCulture;

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests.cs
@@ -38,7 +38,7 @@ public class InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests
         var rendered = (string)
             RenderTopHoldersTableMethod.Invoke(
                 null,
-                [stock, "AAPL", new DateOnly(2024, 9, 30), 1, 0L, 0L, holdings, 1m]
+                [stock, "AAPL", new DateOnly(2024, 9, 30), 1, 0L, 0L, holdings, 1m, null]
             );
 
         rendered.Should().NotContain("NaN");

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsSplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsSplitAdjustmentTests.cs
@@ -8,6 +8,7 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
@@ -61,6 +62,7 @@ public class InstitutionalHoldingsToolsSplitAdjustmentTests
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
             new StockSplitRepository(db),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(db)),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsSplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsSplitAdjustmentTests.cs
@@ -62,7 +62,10 @@ public class InstitutionalHoldingsToolsSplitAdjustmentTests
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
             new StockSplitRepository(db),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(db)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(db),
+                new StockSplitRepository(db)
+            ),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests.cs
@@ -7,6 +7,7 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Mcp.Tools;
@@ -118,6 +119,7 @@ public class InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
             new StockSplitRepository(db),
+            new StockCombinedQuarterService(new InstitutionalHoldingRepository(db)),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests.cs
@@ -119,7 +119,10 @@ public class InstitutionalHoldingsToolsTopBuyersSellersExcludes13DGTests
             new InstitutionalHolderRepository(db),
             new CommonStockRepository(db),
             new StockSplitRepository(db),
-            new StockCombinedQuarterService(new InstitutionalHoldingRepository(db)),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(db),
+                new StockSplitRepository(db)
+            ),
             new ErrorManager(new ErrorRepository(db)),
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );


### PR DESCRIPTION
## Summary
While a quarter's 45-day 13F filing window is open, the newest ReportDate only holds the funds that filed early. Several surfaces still presented it as a complete quarter: per-stock MCP tools served partial holder lists, GetTopBuyersSellers counted every not-yet-filed fund as a full seller, the market-wide leaderboards ranked by whichever funds filed first, and the web holdings tab opened on the partial quarter unless the reader picked "Current Combined" manually. This PR makes the combined view (current filings + prior-quarter carry-forward; a fund that filed without the stock is a proven exit) the single way an in-progress quarter is presented.

## Code changes
- **CombinedQuarterHelper** — explicit-today `IsFilingWindowOpen` overload + `CompletedReportDateCutoff` (deadline + one ingest day, exactly complementary to the window test; boundary pinned by a unit test).
- **StockCombinedQuarterService** (new, Holdings.BusinessLogic) — resolves a stock's newest quarter (`StockQuarterAnchor`), serves the presented positions (combined vs as-filed), and computes `StockReportedActivity` (reported filer count, new/sold-out, net share delta over reporters, combined totals).
- **InstitutionalHoldingRepository** — `GetCombinedQuarterByStock(+WithHolder)` (13F-only, unscoped non-filer test so proven exits don't carry) and `GetFiledHolderIdsAmong`.
- **MCP tools** — GetTopHolders/GetOwnershipHistory serve the combined view with an explicit note; GetTopBuyersSellers compares reporters only; GetMarketWide13FActivity + GetMostHeldStocks switch to the combined aggregates while the window is open (note appended).
- **Web** — the holdings tab now opens in the combined view during the window (`combined` param is now tri-state; explicit choices honoured).
- Tests: boundary tests for the calendar; existing tool tests updated for the new constructor/render parameters. Full unit suite green (3,242).