### PR TITLE
fix(common-stocks): survive Playwright driver crashes and stop wrong-URL IR fall-through

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,10 @@
     <PackageVersion Include="Equibles.Core.AutoWiring" Version="1.0.1" />
     <!-- Browser Automation -->
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
+    <!-- Playwright is pinned at 1.60.0: the 1.61.0 driver dies on a service-worker target attach
+         (unhandled assert in _CRBrowser._onAttachedToTarget), which killed every browser lane in
+         production. Do not bump until a release fixes that crash and soaks against the sidecars. -->
+    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
     <!-- HTML / Markdown -->
     <PackageVersion Include="AngleSharp" Version="1.5.1" />
     <PackageVersion Include="FlexLabs.EntityFrameworkCore.Upsert" Version="10.0.0" />

--- a/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
@@ -117,9 +117,10 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
 
             IBrowser browser = null;
             IBrowserContext context = null;
+            IPlaywright playwright = null;
             try
             {
-                var playwright = await EnsureDriver(opToken);
+                playwright = await EnsureDriver(opToken);
 
                 // cloakserve speaks CDP over WebSocket; connect, work, disconnect. A tighter connect
                 // timeout fails a dead sidecar faster than the overall ceiling.
@@ -153,6 +154,10 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
                 // A navigation/render/connection failure. Classify it: a host that does not exist is a
                 // conclusive miss for this URL, everything else is a transient sidecar-side failure.
                 _logger.LogWarning(ex, "Stealth fetch failed for {Url}", url);
+                // A dead driver process fails every future call instantly and Playwright never
+                // respawns it — without this, the client stays dead until the host restarts.
+                if (IsDriverProcessDead(ex))
+                    await DropDeadDriver(playwright);
                 return ClassifyPlaywrightFailure(ex);
             }
             finally
@@ -291,6 +296,42 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
         {
             _playwright ??= await Playwright.CreateAsync();
             return _playwright;
+        }
+        finally
+        {
+            _driverLock.Release();
+        }
+    }
+
+    // The driver's node process has exited (e.g. an unhandled exception inside the driver, like the
+    // Playwright 1.61 service-worker target-attach assert): every call on the cached IPlaywright then
+    // fails instantly with a "Process exited" TargetClosedException, forever. Message-matched because
+    // no dedicated exception type distinguishes it from an ordinary browser-side target close
+    // ("Target closed" / "Browser closed"), which must NOT drop the driver.
+    private static bool IsDriverProcessDead(PlaywrightException ex) =>
+        ex.Message.Contains("Process exited", StringComparison.OrdinalIgnoreCase);
+
+    // Drops the cached driver so the next EnsureDriver spawns a fresh node process. Identity-guarded:
+    // a concurrent fetch may already have replaced it, and disposing the fresh driver would re-break
+    // the client. Disposing aborts every in-flight render on the dropped driver — an accepted trade:
+    // they were failing against a dead driver anyway, and each folds into a transient miss and
+    // retries on the caller's schedule.
+    private async Task DropDeadDriver(IPlaywright dead)
+    {
+        if (dead == null)
+            return;
+
+        await _driverLock.WaitAsync();
+        try
+        {
+            if (!ReferenceEquals(_playwright, dead))
+                return;
+
+            _logger.LogWarning(
+                "Stealth Playwright driver process died; dropping it so the next fetch respawns a fresh driver"
+            );
+            _playwright.Dispose();
+            _playwright = null;
         }
         finally
         {

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -48,10 +48,13 @@ public class InvestorRelationsProbeClient
     /// Probes <paramref name="website"/> for an investor-relations page and returns a classified
     /// <see cref="IrProbeResult"/>: <c>Found</c> with the validated URL + platform; <c>NoIrPageFound</c>
     /// when every candidate was assessed and none was an IR page; or <c>Inconclusive</c> when the
-    /// stealth engine was unavailable for one or more candidates, so a real IR page may have been
-    /// missed. With no sidecar configured the probe reports <c>Inconclusive</c>: nothing was assessed,
-    /// and a conclusive miss here would stamp the stock checked-at-current-version — a sidecar
-    /// misconfiguration would silently poison the whole backlog.
+    /// stealth engine was unavailable for a candidate, so a real IR page may have been missed.
+    /// Candidates are probed in priority order (subdomains before paths), and a transient miss ends
+    /// the sweep immediately: a lower-priority candidate must never win while a better one is
+    /// unassessed — that is how a dead render engine once stored <c>www.example.com/investor</c> over
+    /// the real <c>investors.example.com</c>. With no sidecar configured the probe reports
+    /// <c>Inconclusive</c>: nothing was assessed, and a conclusive miss here would stamp the stock
+    /// checked-at-current-version — a sidecar misconfiguration would silently poison the whole backlog.
     /// </summary>
     public async Task<IrProbeResult> Discover(
         string website,
@@ -65,10 +68,9 @@ public class InvestorRelationsProbeClient
 
         var candidates = InvestorRelationsCandidateBuilder.Build(website, paths, subdomains);
 
-        // Render each guessed path/subdomain through the sidecar; the first that validates wins. Track
-        // whether any candidate couldn't be assessed (engine unavailable) so a transient failure isn't
-        // reported as a conclusive "no IR page".
-        var anyTransient = false;
+        // Render each guessed path/subdomain through the sidecar; the first that validates wins. A
+        // candidate that couldn't be assessed (engine unavailable) aborts the sweep: any later match
+        // would be a lower-priority URL that only wins because the better candidate went unassessed.
         foreach (var candidate in candidates)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -76,18 +78,19 @@ public class InvestorRelationsProbeClient
             var (page, transient) = await ProbeCandidate(candidate, candidate, cancellationToken);
             if (page != null)
                 return IrProbeResult.Found(page);
-            anyTransient |= transient;
+            if (transient)
+                return IrProbeResult.Inconclusive;
         }
 
-        // None of the guesses validated. Crawl the homepage and follow the investor-relations link it
-        // exposes — the IR page is often at a location guessing can't reach (a Q4 / GCS host, a
-        // regional or locale path, a deeper path), and the homepage URL itself is sometimes the IR site.
+        // Every guess was conclusively assessed and none validated. Crawl the homepage and follow the
+        // investor-relations link it exposes — the IR page is often at a location guessing can't reach
+        // (a Q4 / GCS host, a regional or locale path, a deeper path), and the homepage URL itself is
+        // sometimes the IR site.
         var (homepageResult, homepageTransient) = await CrawlHomepage(website, cancellationToken);
         if (homepageResult != null)
             return IrProbeResult.Found(homepageResult);
-        anyTransient |= homepageTransient;
 
-        return anyTransient ? IrProbeResult.Inconclusive : IrProbeResult.NoIrPage;
+        return homepageTransient ? IrProbeResult.Inconclusive : IrProbeResult.NoIrPage;
     }
 
     // Renders one candidate and classifies it: a validated page; a non-validating render or a
@@ -219,7 +222,9 @@ public class InvestorRelationsProbeClient
         if (self != null && await IsConfirmedIrPage(self.Url, html, cancellationToken))
             return (self, false);
 
-        var anyTransient = false;
+        // Same rule as the guessed sweep: a link that couldn't be assessed ends the crawl as
+        // transient, so a later link can't win only because an earlier (page-order) one went
+        // unassessed — the whole attempt retries on the short backoff instead.
         foreach (var link in InvestorRelationsLinkExtractor.Extract(html, homepage))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -234,10 +239,11 @@ public class InvestorRelationsProbeClient
                 );
                 return (page, false);
             }
-            anyTransient |= transient;
+            if (transient)
+                return (null, true);
         }
 
-        return (null, anyTransient);
+        return (null, false);
     }
 
     // Turns a possibly-scheme-less website into an absolute http(s) URL, or null when it can't be

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -7,12 +7,14 @@ using NSubstitute;
 namespace Equibles.UnitTests.CommonStocks;
 
 /// <summary>
-/// Contract: the IR probe resolves entirely through the stealth sidecar — every candidate (and the
-/// homepage crawl) is rendered, the first that validates as an IR page wins, and the probe reports a
-/// classified outcome: <c>Found</c>, <c>NoIrPageFound</c> (every candidate was assessed and none was an
-/// IR page), or <c>Inconclusive</c> (the engine was unavailable for a candidate, so a real IR page may
-/// have been missed). With no sidecar configured it reports <c>Inconclusive</c> — nothing was
-/// assessed, and a conclusive miss would stamp the backlog as checked. There is no plain-HTTP path.
+/// Contract: the IR probe resolves entirely through the stealth sidecar — candidates are rendered in
+/// priority order, the first that validates as an IR page wins, and the probe reports a classified
+/// outcome: <c>Found</c>, <c>NoIrPageFound</c> (every candidate was assessed and none was an IR
+/// page), or <c>Inconclusive</c> (the engine was unavailable for a candidate, so a real IR page may
+/// have been missed). A transient miss aborts the sweep — a lower-priority candidate must never win
+/// while a higher-priority one is unassessed. With no sidecar configured it reports
+/// <c>Inconclusive</c> — nothing was assessed, and a conclusive miss would stamp the backlog as
+/// checked. There is no plain-HTTP path.
 /// </summary>
 public class InvestorRelationsProbeClientTests
 {
@@ -97,15 +99,20 @@ public class InvestorRelationsProbeClientTests
     }
 
     [Fact]
-    public async Task Discover_ValidPageWinsEvenWhenAnotherCandidateWasTransient()
+    public async Task Discover_TransientOnHigherPriorityCandidate_AbortsInsteadOfStoringLowerPriorityMatch()
     {
-        // A transient failure on one candidate must not prevent a later candidate from validating — a
-        // found page always wins over an inconclusive signal.
+        // Candidates are probed in priority order. When a higher-priority candidate couldn't be
+        // assessed (engine unavailable), a lower-priority candidate that validates must NOT win —
+        // that is how a dead render engine once stored www.example.com/investor over the real
+        // investors.example.com. The sweep aborts as inconclusive and retries on the short backoff.
+        var probed = new List<string>();
         var stealth = EnabledStealthResults(url =>
-            url == "https://acme.com/ir" ? StealthFetchResult.SidecarUnavailable
-            : url == "https://acme.com/investors" ? StealthFetchResult.Rendered(IrPage)
-            : StealthFetchResult.Rendered(NotIr)
-        );
+        {
+            probed.Add(url);
+            return url == "https://acme.com/ir" ? StealthFetchResult.SidecarUnavailable
+                : url == "https://acme.com/investors" ? StealthFetchResult.Rendered(IrPage)
+                : StealthFetchResult.Rendered(NotIr);
+        });
 
         var client = NewClient(stealth);
 
@@ -116,8 +123,36 @@ public class InvestorRelationsProbeClientTests
             CancellationToken.None
         );
 
-        result.Outcome.Should().Be(IrProbeOutcome.Found);
-        result.Page!.Url.Should().Be("https://acme.com/investors");
+        result.Outcome.Should().Be(IrProbeOutcome.Inconclusive);
+        result.Page.Should().BeNull();
+        // The sweep must stop at the unassessed candidate — probing (and possibly persisting) the
+        // rest would be answering with a better candidate still unknown.
+        probed.Should().Equal("https://acme.com/ir");
+    }
+
+    [Fact]
+    public async Task Discover_TransientOnHomepageIrLink_IsInconclusiveNotLaterLinkMatch()
+    {
+        // Same rule inside the homepage crawl: when an earlier IR link couldn't be assessed, a later
+        // link that validates must not be stored — the whole attempt is inconclusive and retries.
+        const string homepage =
+            "<html><head><title>Acme Corp</title></head><body>"
+            + "<a href=\"/investor-relations\">Investor Relations</a>"
+            + "<a href=\"/investors-home\">Investors</a></body></html>";
+
+        var stealth = EnabledStealthResults(url =>
+            url == "https://acme.com" ? StealthFetchResult.Rendered(homepage)
+            : url == "https://acme.com/investor-relations" ? StealthFetchResult.SidecarUnavailable
+            : url == "https://acme.com/investors-home" ? StealthFetchResult.Rendered(IrPage)
+            : StealthFetchResult.Rendered(NotIr)
+        );
+
+        var client = NewClient(stealth);
+
+        var result = await client.Discover("acme.com", ["ir"], [], CancellationToken.None);
+
+        result.Outcome.Should().Be(IrProbeOutcome.Inconclusive);
+        result.Page.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Since June 29 every browser lane in production has been failing in bursts with `TargetClosedException: Process exited`. Root cause: the Playwright **1.61.0** driver dies with an unhandled assert in `_CRBrowser._onAttachedToTarget` whenever a page attaches a **service-worker** target (crash dumps show `youtube.com/sw.js` and `investors.wallbox.com/runtime-service-worker.js`). A dead driver fails every subsequent call instantly, and the stealth client cached it forever — IR discovery and feed scraping stayed dead until the host restarted.

The same outage exposed a discovery-order bug: with the engine failing transiently on the `investors.*` subdomain probe, a lower-priority `www.*/investor` candidate could validate and be persisted as the IR page (observed on EBS).

## Code changes

- **Directory.Packages.props** — pin `Microsoft.Playwright` back to the known-good **1.60.0** (weeks of clean operation, vs. daily crash storms on 1.61.0), with a comment blocking a casual re-bump.
- **CloakBrowserStealthClient** — on a `Process exited` failure, drop the cached `IPlaywright` (identity-guarded under the driver lock) so the next fetch respawns a fresh driver process instead of failing forever.
- **InvestorRelationsProbeClient** — a transient miss on a candidate now aborts the sweep as `Inconclusive` (guessed candidates and homepage-link crawl alike): a lower-priority candidate must never win while a higher-priority one is unassessed. The stock retries on the existing short backoff.
- **Tests** — inverted the test that pinned the old fall-through behavior, added a probe-order assertion and a homepage-link variant. Full unit suite: 3,248 passed.