### PR TITLE
chore(deps): block Playwright bumps while 1.61's driver crash is unfixed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,12 @@ updates:
       # 9.0.x patches are still allowed.
       - dependency-name: "Microsoft.Bcl.Memory"
         update-types: ["version-update:semver-major"]
+      # Microsoft.Playwright is deliberately pinned at 1.60.0: the 1.61.0 driver
+      # dies on a service-worker target attach (unhandled assert in
+      # _CRBrowser._onAttachedToTarget), which killed every production browser
+      # lane. Block all bumps until a release fixes that crash and is soaked
+      # against the cloakbrowser sidecars, then remove this ignore.
+      - dependency-name: "Microsoft.Playwright"
     groups:
       microsoft-extensions:
         patterns:


### PR DESCRIPTION
## Summary

Companion to #4072: `Microsoft.Playwright` is pinned at 1.60.0 because the 1.61.0 driver dies on a service-worker target attach. The weekly testing-group bump would re-open a PR to 1.61+ — ignore the dependency in dependabot so the pin can't be silently undone. Remove the ignore once an upstream release fixes the crash and has been soaked against the cloakbrowser sidecars.

## Code changes

- **.github/dependabot.yml** — add `Microsoft.Playwright` to the nuget ignore list (all update types), with the reason and the removal condition in a comment.