### PR TITLE
fix(common-stocks): block service workers in stealth contexts — the driver dies on their target attach

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,11 +33,12 @@ updates:
       # 9.0.x patches are still allowed.
       - dependency-name: "Microsoft.Bcl.Memory"
         update-types: ["version-update:semver-major"]
-      # Microsoft.Playwright is deliberately pinned at 1.60.0: the 1.61.0 driver
-      # dies on a service-worker target attach (unhandled assert in
-      # _CRBrowser._onAttachedToTarget), which killed every production browser
-      # lane. Block all bumps until a release fixes that crash and is soaked
-      # against the cloakbrowser sidecars, then remove this ignore.
+      # Microsoft.Playwright is held at 1.60.0 as the known production
+      # baseline. The driver (1.60 and 1.61 alike) dies on a service-worker
+      # target attach (unhandled assert in _CRBrowser._onAttachedToTarget);
+      # the code blocks service workers and respawns dead drivers, but bumps
+      # stay blocked until an upstream release fixes the assert and is soaked
+      # against the cloakbrowser sidecars. Then remove this ignore.
       - dependency-name: "Microsoft.Playwright"
     groups:
       microsoft-extensions:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,10 @@
     <PackageVersion Include="Equibles.Core.AutoWiring" Version="1.0.1" />
     <!-- Browser Automation -->
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
-    <!-- Playwright is pinned at 1.60.0: the 1.61.0 driver dies on a service-worker target attach
-         (unhandled assert in _CRBrowser._onAttachedToTarget), which killed every browser lane in
-         production. Do not bump until a release fixes that crash and soaks against the sidecars. -->
+    <!-- Playwright is held at 1.60.0 as the known production baseline. Its driver (1.60 and 1.61
+         alike) dies on a service-worker target attach (unhandled assert in
+         _CRBrowser._onAttachedToTarget); contexts block service workers to remove the trigger and
+         the stealth client respawns a dead driver. Bump only after upstream fixes the assert. -->
     <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
     <!-- HTML / Markdown -->
     <PackageVersion Include="AngleSharp" Version="1.5.1" />

--- a/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
@@ -127,7 +127,17 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
                 browser = await playwright
                     .Chromium.ConnectOverCDPAsync(_options.SidecarUrl)
                     .WaitAsync(TimeSpan.FromSeconds(_options.ConnectTimeoutSeconds), opToken);
-                context = await browser.NewContextAsync().WaitAsync(opToken);
+                // Service workers are blocked: a page that registers one attaches a service_worker
+                // target, and the Playwright driver (1.60 and 1.61 alike) dies on that attach with an
+                // unhandled assert in _CRBrowser._onAttachedToTarget — one news page with a service
+                // worker killed the driver for every lane sharing it. Scraping never needs offline
+                // caching or push, so blocking removes the crash trigger outright; the driver-respawn
+                // in RunInStealthPage remains the backstop for any other driver death.
+                context = await browser
+                    .NewContextAsync(
+                        new BrowserNewContextOptions { ServiceWorkers = ServiceWorkerPolicy.Block }
+                    )
+                    .WaitAsync(opToken);
                 var page = await context.NewPageAsync().WaitAsync(opToken);
                 var html = await action(page).WaitAsync(opToken);
                 return StealthFetchResult.Rendered(html);


### PR DESCRIPTION
## Summary

Follow-up to #4072 with new production evidence: after deploying the 1.60.0 pin, the driver crashed again with the SAME service-worker assert (`Node.js v24.15.0`, the 1.60 driver) — the bug is not 1.61-specific. The June 29 regression was really an exposure change (fetching full press-release bodies through the stealth browser visits pages that register service workers), and the #4072 driver-respawn absorbed the crash in production exactly as designed (one transient miss, fresh driver, lane kept working).

This removes the crash trigger outright: stealth contexts are created with `ServiceWorkers = ServiceWorkerPolicy.Block` — a blocked page can't register a service worker, so no `service_worker` target ever attaches to the driver. Scraping has no use for offline caching or push. The respawn remains as the backstop for any other driver death.

## Code changes

- **CloakBrowserStealthClient** — `NewContextAsync(new BrowserNewContextOptions { ServiceWorkers = ServiceWorkerPolicy.Block })` with a comment explaining the crash.
- **Directory.Packages.props / .github/dependabot.yml** — correct the pin comments: 1.60.0 is the known baseline, not a fix; bumps stay blocked until upstream fixes the assert.

Build clean; unit suite 3,248 passed.