### PR TITLE
feat(media): staged, reversible deletion of filesystem blobs

### DIFF
--- a/src/Equibles.Media.BusinessLogic/FileManager.cs
+++ b/src/Equibles.Media.BusinessLogic/FileManager.cs
@@ -33,18 +33,21 @@ public class FileManager : IFileManager
     }
 
     private readonly FileRepository _fileRepository;
+    private readonly PendingBlobDeletionRepository _pendingBlobDeletionRepository;
     private readonly DatabaseFileStorageProvider _databaseProvider;
     private readonly FileSystemFileStorageProvider _fileSystemProvider;
     private readonly FileStorageOptions _options;
 
     public FileManager(
         FileRepository fileRepository,
+        PendingBlobDeletionRepository pendingBlobDeletionRepository,
         DatabaseFileStorageProvider databaseProvider,
         FileSystemFileStorageProvider fileSystemProvider,
         IOptions<FileStorageOptions> options
     )
     {
         _fileRepository = fileRepository;
+        _pendingBlobDeletionRepository = pendingBlobDeletionRepository;
         _databaseProvider = databaseProvider;
         _fileSystemProvider = fileSystemProvider;
         _options = options.Value;
@@ -141,14 +144,33 @@ public class FileManager : IFileManager
 
     /// <summary>
     /// Deletes a file from the database. The db context is not saved. Filesystem-stored
-    /// bytes are reclaimed by the orphan sweep, not deleted inline — content addressing
-    /// means another row may reference the same path.
+    /// bytes are not deleted inline — content addressing means another row may reference
+    /// the same path, and an inline unlink can race an identical re-upload that dedup-skips
+    /// onto the existing blob. Instead the blob is queued and the deletion sweep retires it
+    /// after re-checking references, in the same SaveChanges as the row delete so the mark
+    /// can never outlive a rolled-back delete.
     /// </summary>
     /// <param name="file">The file to delete</param>
     public void DeleteFile(File file)
     {
         if (file == null)
             return;
+
+        if (
+            file.StorageProvider == StorageProvider.FileSystem
+            && file.ContentHash != null
+            && file.RelativePath != null
+        )
+        {
+            _pendingBlobDeletionRepository.Add(
+                new PendingBlobDeletion
+                {
+                    ContentHash = file.ContentHash,
+                    RelativePath = file.RelativePath,
+                }
+            );
+        }
+
         _fileRepository.Delete(file);
     }
 

--- a/src/Equibles.Media.BusinessLogic/Storage/IBlobReferenceChecker.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/IBlobReferenceChecker.cs
@@ -1,0 +1,19 @@
+namespace Equibles.Media.BusinessLogic.Storage;
+
+/// <summary>
+/// Answers whether any live File row still references a stored blob by its
+/// algorithm-prefixed content hash. The deletion sweep resolves every registered
+/// checker and only retires a blob when ALL of them report it unreferenced — a
+/// deployment that binds the Media module into more than one database registers one
+/// checker per context so the sweep stays conservative.
+/// </summary>
+public interface IBlobReferenceChecker
+{
+    Task<bool> IsReferenced(string contentHash, CancellationToken cancellationToken);
+
+    /// <summary>Returns the subset of <paramref name="contentHashes"/> that ARE referenced.</summary>
+    Task<IReadOnlySet<string>> GetReferenced(
+        IReadOnlyCollection<string> contentHashes,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/Equibles.Media.Data/MediaModuleConfiguration.cs
+++ b/src/Equibles.Media.Data/MediaModuleConfiguration.cs
@@ -25,8 +25,13 @@ public class MediaModuleConfiguration : Equibles.Data.IFinancialModule
 
             // Lets the migration drain worker cheaply find rows still stored in the database.
             b.HasIndex(e => e.StorageProvider);
+
+            // The deletion sweep checks whether any live row still references a queued
+            // blob by its content hash, and the reconciliation pass does the same in bulk.
+            b.HasIndex(e => e.ContentHash);
         });
         builder.Entity<FileContent>();
         builder.Entity<Image>();
+        builder.Entity<PendingBlobDeletion>();
     }
 }

--- a/src/Equibles.Media.Data/Models/PendingBlobDeletion.cs
+++ b/src/Equibles.Media.Data/Models/PendingBlobDeletion.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Media.Data.Models;
+
+/// <summary>
+/// A filesystem blob whose owning <see cref="File"/> row was deleted, queued for the
+/// deletion sweep. The blob cannot be unlinked inline: the store is content-addressed,
+/// so another File row may share the same bytes, and a delete can race an identical
+/// re-upload that dedup-skips onto the existing file. The sweep re-checks references
+/// after a grace period and retires the blob through a reversible trash phase.
+/// Duplicate rows for the same hash are allowed — the sweep is idempotent.
+/// </summary>
+public class PendingBlobDeletion
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>The deleted row's algorithm-prefixed content hash, e.g. "sha256:…".</summary>
+    [Required]
+    [StringLength(80)]
+    public string ContentHash { get; set; }
+
+    /// <summary>The deleted row's store-relative blob path, e.g. "blob/sha256/a7/f3/…".</summary>
+    [Required]
+    [StringLength(128)]
+    public string RelativePath { get; set; }
+
+    public DateTime QueuedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Media.HostedService/BlobDeletionSweepWorker.cs
+++ b/src/Equibles.Media.HostedService/BlobDeletionSweepWorker.cs
@@ -46,6 +46,11 @@ public class BlobDeletionSweepWorker : BackgroundService
     protected virtual TimeSpan StartupDelay => TimeSpan.FromMinutes(10);
     protected virtual TimeSpan TickInterval => TimeSpan.FromHours(24);
 
+    // A misconfigured tiny grace (e.g. 0) would let the sweep race blobs whose rows are
+    // still inside an uncommitted write window, causing hours-long read outages until the
+    // purge restores them. Clamp to a floor no configuration can go below.
+    internal const int MinimumGraceHours = 6;
+
     public BlobDeletionSweepWorker(
         IServiceScopeFactory scopeFactory,
         IOptions<FileStorageOptions> storageOptions,
@@ -59,6 +64,8 @@ public class BlobDeletionSweepWorker : BackgroundService
         _logger = logger;
     }
 
+    private int EffectiveGraceHours => Math.Max(_sweepOptions.GraceHours, MinimumGraceHours);
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (!_sweepOptions.Enabled || !_storageOptions.Enabled)
@@ -71,11 +78,19 @@ public class BlobDeletionSweepWorker : BackgroundService
             return;
         }
 
+        try
+        {
+            await Task.Delay(StartupDelay, stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
-                await Task.Delay(StartupDelay, stoppingToken);
                 await SweepOnce(stoppingToken);
             }
             catch (OperationCanceledException)
@@ -150,7 +165,7 @@ public class BlobDeletionSweepWorker : BackgroundService
         CancellationToken cancellationToken
     )
     {
-        var cutoff = now.AddHours(-_sweepOptions.GraceHours);
+        var cutoff = now.AddHours(-EffectiveGraceHours);
         var due = await dbContext
             .Set<PendingBlobDeletion>()
             .Where(p => p.QueuedAt < cutoff)
@@ -161,27 +176,34 @@ public class BlobDeletionSweepWorker : BackgroundService
         }
 
         var trashed = 0;
-        // Duplicate queue rows for the same hash collapse into one decision.
+        // Duplicate queue rows for the same hash collapse into one reference decision;
+        // every distinct path is still processed, since identical bytes could in
+        // principle have been stored under more than one tier.
         foreach (var group in due.GroupBy(p => p.ContentHash))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var relativePath = group.First().RelativePath;
-            if (
-                !await IsReferencedByAny(checkers, group.Key, cancellationToken)
-                && TryTrashBlob(root, relativePath, now)
-            )
+            if (!await IsReferencedByAny(checkers, group.Key, cancellationToken))
             {
-                // A row may have committed between the check and the rename (an identical
-                // re-upload that dedup-skipped just before the blob moved). The rename made
-                // later writes self-sufficient; restore covers the one that raced us.
-                if (await IsReferencedByAny(checkers, group.Key, cancellationToken))
+                foreach (var relativePath in group.Select(p => p.RelativePath).Distinct())
                 {
-                    RestoreBlob(root, relativePath);
-                }
-                else
-                {
-                    trashed++;
+                    if (!TryTrashBlob(root, relativePath, now))
+                    {
+                        continue;
+                    }
+
+                    // A row may have committed between the check and the rename (an
+                    // identical re-upload that dedup-skipped just before the blob moved).
+                    // The rename made later writes self-sufficient; restore covers the
+                    // one that raced us.
+                    if (await IsReferencedByAny(checkers, group.Key, cancellationToken))
+                    {
+                        RestoreBlob(root, relativePath);
+                    }
+                    else
+                    {
+                        trashed++;
+                    }
                 }
             }
 
@@ -251,11 +273,14 @@ public class BlobDeletionSweepWorker : BackgroundService
         CancellationToken cancellationToken
     )
     {
-        var graceCutoff = now.AddHours(-_sweepOptions.GraceHours);
+        var graceCutoff = now.AddHours(-EffectiveGraceHours);
         var todaySlot = (int)now.DayOfWeek;
         var trashed = 0;
 
-        foreach (var tier in new[] { FileStorageTiers.Blob, FileStorageTiers.Audio })
+        var tiers = _sweepOptions.ReconciliationIncludesAudioTier
+            ? new[] { FileStorageTiers.Blob, FileStorageTiers.Audio }
+            : new[] { FileStorageTiers.Blob };
+        foreach (var tier in tiers)
         {
             var algorithmRoot = Path.Combine(root, tier, ContentAddressedPath.Algorithm);
             if (!Directory.Exists(algorithmRoot))
@@ -364,11 +389,44 @@ public class BlobDeletionSweepWorker : BackgroundService
     }
 
     /// <summary>
+    /// Rejects any relative path that resolves outside the store root or does not name a
+    /// 64-hex digest. Queue paths are self-produced, but this worker moves and deletes
+    /// files — a corrupted row must never let it reach outside the store.
+    /// </summary>
+    private bool IsSafeStorePath(string root, string relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath) || !HexName.IsMatch(Path.GetFileName(relativePath)))
+        {
+            return false;
+        }
+
+        var rootFull = Path.GetFullPath(root) + Path.DirectorySeparatorChar;
+        var resolved = Path.GetFullPath(
+            Path.Combine(root, ContentAddressedPath.ToOsPath(relativePath))
+        );
+        if (!resolved.StartsWith(rootFull, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "Refusing to touch blob path {RelativePath} outside the store root",
+                relativePath
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Atomically moves a blob into the mirrored trash tree and stamps its trash time.
     /// Returns false when the blob is already gone (queued twice, or removed earlier).
     /// </summary>
     private bool TryTrashBlob(string root, string relativePath, DateTime now)
     {
+        if (!IsSafeStorePath(root, relativePath))
+        {
+            return false;
+        }
+
         var source = Path.Combine(root, ContentAddressedPath.ToOsPath(relativePath));
         if (!System.IO.File.Exists(source))
         {
@@ -407,6 +465,11 @@ public class BlobDeletionSweepWorker : BackgroundService
     /// </summary>
     private void RestoreBlob(string root, string relativePath)
     {
+        if (!IsSafeStorePath(root, relativePath))
+        {
+            return;
+        }
+
         var trashPath = Path.Combine(
             root,
             TrashDirectoryName,

--- a/src/Equibles.Media.HostedService/BlobDeletionSweepWorker.cs
+++ b/src/Equibles.Media.HostedService/BlobDeletionSweepWorker.cs
@@ -1,0 +1,433 @@
+using System.Text.RegularExpressions;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.BusinessLogic.Storage;
+using Equibles.Media.Data.Models;
+using Equibles.Media.HostedService.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Media.HostedService;
+
+/// <summary>
+/// Retires filesystem blobs whose File rows are gone. Inline deletion is unsafe in a
+/// content-addressed store (a blob can be shared by several rows, and an unlink can race
+/// an identical re-upload that dedup-skips onto the existing file), so deletion is a
+/// staged, reversible pipeline instead:
+///
+///   1. Queue — deletes mark the blob in PendingBlobDeletion (same transaction as the row).
+///   2. Sweep (daily) — for marks past the grace window, re-check every registered
+///      reference checker; unreferenced blobs are RENAMED into a mirrored .trash tree
+///      (atomic and reversible — a racing identical write now writes fresh bytes), then
+///      references are re-checked and the blob restored if a row appeared in the gap.
+///   3. Purge — trash older than the retention window is deleted permanently after one
+///      final reference check (restore instead if a row reappeared).
+///   4. Reconciliation (rolling) — cascades and direct repository deletes never hit the
+///      queue, so each daily run also diffs one seventh of the shard space against the
+///      database and trashes unreferenced blobs; the whole store is covered weekly.
+///
+/// Only files named as a 64-hex digest inside the store root are ever touched; temp files
+/// and anything else are ignored. Runs only when the store and the sweep are enabled.
+/// </summary>
+public class BlobDeletionSweepWorker : BackgroundService
+{
+    private static readonly Regex HexName = new("^[0-9a-f]{64}$", RegexOptions.Compiled);
+    private const string TrashDirectoryName = ".trash";
+    private const int ReconciliationQueryChunkSize = 2000;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly FileStorageOptions _storageOptions;
+    private readonly BlobSweepOptions _sweepOptions;
+    private readonly ILogger<BlobDeletionSweepWorker> _logger;
+
+    // Virtual seams so tests can collapse the waits.
+    protected virtual TimeSpan StartupDelay => TimeSpan.FromMinutes(10);
+    protected virtual TimeSpan TickInterval => TimeSpan.FromHours(24);
+
+    public BlobDeletionSweepWorker(
+        IServiceScopeFactory scopeFactory,
+        IOptions<FileStorageOptions> storageOptions,
+        IOptions<BlobSweepOptions> sweepOptions,
+        ILogger<BlobDeletionSweepWorker> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _storageOptions = storageOptions.Value;
+        _sweepOptions = sweepOptions.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_sweepOptions.Enabled || !_storageOptions.Enabled)
+        {
+            _logger.LogInformation(
+                "Blob deletion sweep is disabled (sweep: {Sweep}, store: {Store}); worker idle.",
+                _sweepOptions.Enabled,
+                _storageOptions.Enabled
+            );
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(StartupDelay, stoppingToken);
+                await SweepOnce(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Blob deletion sweep failed; will retry on next interval");
+            }
+
+            try
+            {
+                await Task.Delay(TickInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    internal async Task<(int Trashed, int Purged, int Restored)> SweepOnce(
+        CancellationToken cancellationToken
+    )
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext =
+            scope.ServiceProvider.GetRequiredService<Equibles.Data.EquiblesFinancialDbContext>();
+        var checkers = scope.ServiceProvider.GetServices<IBlobReferenceChecker>().ToList();
+        if (checkers.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "No IBlobReferenceChecker is registered; refusing to sweep without a reference check."
+            );
+        }
+
+        var root = _storageOptions.RootPath;
+        if (string.IsNullOrEmpty(root) || !Directory.Exists(root))
+        {
+            _logger.LogWarning("Blob store root {Root} is missing; skipping sweep.", root);
+            return (0, 0, 0);
+        }
+
+        var now = DateTime.UtcNow;
+        var trashed = await SweepQueue(dbContext, checkers, root, now, cancellationToken);
+        var (purged, restored) = await PurgeTrash(checkers, root, now, cancellationToken);
+
+        var reconciled = 0;
+        if (_sweepOptions.ReconciliationEnabled)
+        {
+            reconciled = await ReconcileShards(checkers, root, now, cancellationToken);
+        }
+
+        _logger.LogInformation(
+            "Blob sweep done: {Trashed} queued blob(s) trashed, {Reconciled} reconciled "
+                + "blob(s) trashed, {Purged} purged, {Restored} restored",
+            trashed,
+            reconciled,
+            purged,
+            restored
+        );
+        return (trashed + reconciled, purged, restored);
+    }
+
+    // Phase 1+2: process queued deletions past the grace window.
+    private async Task<int> SweepQueue(
+        Equibles.Data.EquiblesFinancialDbContext dbContext,
+        IReadOnlyList<IBlobReferenceChecker> checkers,
+        string root,
+        DateTime now,
+        CancellationToken cancellationToken
+    )
+    {
+        var cutoff = now.AddHours(-_sweepOptions.GraceHours);
+        var due = await dbContext
+            .Set<PendingBlobDeletion>()
+            .Where(p => p.QueuedAt < cutoff)
+            .ToListAsync(cancellationToken);
+        if (due.Count == 0)
+        {
+            return 0;
+        }
+
+        var trashed = 0;
+        // Duplicate queue rows for the same hash collapse into one decision.
+        foreach (var group in due.GroupBy(p => p.ContentHash))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var relativePath = group.First().RelativePath;
+            if (
+                !await IsReferencedByAny(checkers, group.Key, cancellationToken)
+                && TryTrashBlob(root, relativePath, now)
+            )
+            {
+                // A row may have committed between the check and the rename (an identical
+                // re-upload that dedup-skipped just before the blob moved). The rename made
+                // later writes self-sufficient; restore covers the one that raced us.
+                if (await IsReferencedByAny(checkers, group.Key, cancellationToken))
+                {
+                    RestoreBlob(root, relativePath);
+                }
+                else
+                {
+                    trashed++;
+                }
+            }
+
+            dbContext.RemoveRange(group);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return trashed;
+    }
+
+    // Phase 3: permanently delete trash past retention, restoring anything re-referenced.
+    private async Task<(int Purged, int Restored)> PurgeTrash(
+        IReadOnlyList<IBlobReferenceChecker> checkers,
+        string root,
+        DateTime now,
+        CancellationToken cancellationToken
+    )
+    {
+        var trashRoot = Path.Combine(root, TrashDirectoryName);
+        if (!Directory.Exists(trashRoot))
+        {
+            return (0, 0);
+        }
+
+        var purged = 0;
+        var restored = 0;
+        var cutoff = now.AddHours(-_sweepOptions.TrashRetentionHours);
+        foreach (
+            var trashPath in Directory.EnumerateFiles(trashRoot, "*", SearchOption.AllDirectories)
+        )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var name = Path.GetFileName(trashPath);
+            if (!HexName.IsMatch(name) || System.IO.File.GetLastWriteTimeUtc(trashPath) >= cutoff)
+            {
+                continue;
+            }
+
+            if (
+                await IsReferencedByAny(
+                    checkers,
+                    ContentAddressedPath.HashPrefix + name,
+                    cancellationToken
+                )
+            )
+            {
+                RestoreBlob(root, Path.GetRelativePath(trashRoot, trashPath));
+                restored++;
+            }
+            else
+            {
+                System.IO.File.Delete(trashPath);
+                purged++;
+            }
+        }
+
+        return (purged, restored);
+    }
+
+    // Phase 4: rolling disk-vs-database diff over one seventh of the shard space per run,
+    // catching deletions that never hit the queue (cascades, direct repository deletes).
+    private async Task<int> ReconcileShards(
+        IReadOnlyList<IBlobReferenceChecker> checkers,
+        string root,
+        DateTime now,
+        CancellationToken cancellationToken
+    )
+    {
+        var graceCutoff = now.AddHours(-_sweepOptions.GraceHours);
+        var todaySlot = (int)now.DayOfWeek;
+        var trashed = 0;
+
+        foreach (var tier in new[] { FileStorageTiers.Blob, FileStorageTiers.Audio })
+        {
+            var algorithmRoot = Path.Combine(root, tier, ContentAddressedPath.Algorithm);
+            if (!Directory.Exists(algorithmRoot))
+            {
+                continue;
+            }
+
+            foreach (var shardDir in Directory.EnumerateDirectories(algorithmRoot))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var shard = Path.GetFileName(shardDir);
+                if (
+                    shard.Length != 2
+                    || !int.TryParse(
+                        shard,
+                        System.Globalization.NumberStyles.HexNumber,
+                        null,
+                        out var shardByte
+                    )
+                    || shardByte % 7 != todaySlot
+                )
+                {
+                    continue;
+                }
+
+                // Old enough that any owning row has long committed; young files are skipped.
+                var candidates = Directory
+                    .EnumerateFiles(shardDir, "*", SearchOption.AllDirectories)
+                    .Where(p =>
+                        HexName.IsMatch(Path.GetFileName(p))
+                        && System.IO.File.GetLastWriteTimeUtc(p) < graceCutoff
+                    )
+                    .ToList();
+
+                foreach (var chunk in candidates.Chunk(ReconciliationQueryChunkSize))
+                {
+                    var byHash = chunk.ToDictionary(
+                        p => ContentAddressedPath.HashPrefix + Path.GetFileName(p),
+                        p => p
+                    );
+                    var referenced = await GetReferencedByAny(
+                        checkers,
+                        byHash.Keys.ToList(),
+                        cancellationToken
+                    );
+
+                    foreach (var (hash, fullPath) in byHash)
+                    {
+                        if (referenced.Contains(hash))
+                        {
+                            continue;
+                        }
+
+                        var relativePath = Path.GetRelativePath(root, fullPath)
+                            .Replace(Path.DirectorySeparatorChar, '/');
+                        if (TryTrashBlob(root, relativePath, now))
+                        {
+                            if (await IsReferencedByAny(checkers, hash, cancellationToken))
+                            {
+                                RestoreBlob(root, relativePath);
+                            }
+                            else
+                            {
+                                trashed++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return trashed;
+    }
+
+    private static async Task<bool> IsReferencedByAny(
+        IReadOnlyList<IBlobReferenceChecker> checkers,
+        string contentHash,
+        CancellationToken cancellationToken
+    )
+    {
+        foreach (var checker in checkers)
+        {
+            if (await checker.IsReferenced(contentHash, cancellationToken))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<HashSet<string>> GetReferencedByAny(
+        IReadOnlyList<IBlobReferenceChecker> checkers,
+        IReadOnlyCollection<string> contentHashes,
+        CancellationToken cancellationToken
+    )
+    {
+        var referenced = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var checker in checkers)
+        {
+            referenced.UnionWith(await checker.GetReferenced(contentHashes, cancellationToken));
+        }
+
+        return referenced;
+    }
+
+    /// <summary>
+    /// Atomically moves a blob into the mirrored trash tree and stamps its trash time.
+    /// Returns false when the blob is already gone (queued twice, or removed earlier).
+    /// </summary>
+    private bool TryTrashBlob(string root, string relativePath, DateTime now)
+    {
+        var source = Path.Combine(root, ContentAddressedPath.ToOsPath(relativePath));
+        if (!System.IO.File.Exists(source))
+        {
+            return false;
+        }
+
+        var target = Path.Combine(
+            root,
+            TrashDirectoryName,
+            ContentAddressedPath.ToOsPath(relativePath)
+        );
+        Directory.CreateDirectory(Path.GetDirectoryName(target));
+        try
+        {
+            System.IO.File.Move(source, target, overwrite: true);
+            // The rename preserves the original write time; the purge ages trash entries
+            // by when they were trashed, so restamp.
+            System.IO.File.SetLastWriteTimeUtc(target, now);
+            return true;
+        }
+        catch (IOException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not trash blob {RelativePath}; leaving in place",
+                relativePath
+            );
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Moves a trashed blob back to its live path. If an identical blob was re-created in
+    /// the meantime the trash copy is redundant (same bytes by content addressing) and is
+    /// deleted instead.
+    /// </summary>
+    private void RestoreBlob(string root, string relativePath)
+    {
+        var trashPath = Path.Combine(
+            root,
+            TrashDirectoryName,
+            ContentAddressedPath.ToOsPath(relativePath)
+        );
+        var livePath = Path.Combine(root, ContentAddressedPath.ToOsPath(relativePath));
+        if (!System.IO.File.Exists(trashPath))
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(livePath));
+        try
+        {
+            System.IO.File.Move(trashPath, livePath, overwrite: false);
+            _logger.LogInformation("Restored re-referenced blob {RelativePath}", relativePath);
+        }
+        catch (IOException) when (System.IO.File.Exists(livePath))
+        {
+            // An identical write already re-created the live path; the trash copy is redundant.
+            System.IO.File.Delete(trashPath);
+        }
+    }
+}

--- a/src/Equibles.Media.HostedService/Configuration/BlobSweepOptions.cs
+++ b/src/Equibles.Media.HostedService/Configuration/BlobSweepOptions.cs
@@ -1,0 +1,31 @@
+namespace Equibles.Media.HostedService.Configuration;
+
+/// <summary>
+/// Bound from the "BlobSweep" configuration section. Controls the deletion sweep that
+/// retires filesystem blobs whose File rows are gone. Disabled by default.
+/// </summary>
+public class BlobSweepOptions
+{
+    /// <summary>Master switch for the deletion sweep worker.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// How old a queued deletion (and a blob's last write) must be before the sweep will
+    /// touch it. Protects blobs whose rows are still inside an uncommitted write window.
+    /// </summary>
+    public int GraceHours { get; set; } = 48;
+
+    /// <summary>
+    /// How long a trashed blob is retained before permanent deletion. The purge re-checks
+    /// references one final time and restores the blob if a row reappeared — the window
+    /// that makes retiring a shared, content-addressed blob reversible.
+    /// </summary>
+    public int TrashRetentionHours { get; set; } = 24;
+
+    /// <summary>
+    /// Enables the rolling disk-vs-database reconciliation that catches deletions the
+    /// queue cannot see (database-level cascades, direct repository deletes). Each daily
+    /// run covers one seventh of the shard space, so the whole store is reconciled weekly.
+    /// </summary>
+    public bool ReconciliationEnabled { get; set; } = true;
+}

--- a/src/Equibles.Media.HostedService/Configuration/BlobSweepOptions.cs
+++ b/src/Equibles.Media.HostedService/Configuration/BlobSweepOptions.cs
@@ -28,4 +28,11 @@ public class BlobSweepOptions
     /// run covers one seventh of the shard space, so the whole store is reconciled weekly.
     /// </summary>
     public bool ReconciliationEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Whether reconciliation also covers the audio tier. Audio is the one content class
+    /// that cannot be re-captured, so a deployment can exclude it and rely on the delete
+    /// queue alone for audio while reconciliation handles the re-scrapable bulk tiers.
+    /// </summary>
+    public bool ReconciliationIncludesAudioTier { get; set; } = true;
 }

--- a/src/Equibles.Media.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Media.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
+using Equibles.Media.BusinessLogic.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Equibles.Media.HostedService.Extensions;
 
@@ -6,7 +8,14 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddMediaWorker(this IServiceCollection services)
     {
+        // TryAddEnumerable so a host registering additional checkers (e.g. a second
+        // database context) composes with this default instead of duplicating it.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<IBlobReferenceChecker, FinancialBlobReferenceChecker>()
+        );
+
         services.AddHostedService<FileBackfillWorker>();
+        services.AddHostedService<BlobDeletionSweepWorker>();
         return services;
     }
 }

--- a/src/Equibles.Media.HostedService/FinancialBlobReferenceChecker.cs
+++ b/src/Equibles.Media.HostedService/FinancialBlobReferenceChecker.cs
@@ -1,0 +1,42 @@
+using Equibles.Data;
+using Equibles.Media.BusinessLogic.Storage;
+using Microsoft.EntityFrameworkCore;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.Media.HostedService;
+
+/// <summary>
+/// Reference checker over the financial context's File table — the context every
+/// filesystem-stored blob is tracked in. Registered scoped by AddMediaWorker; the
+/// sweep resolves all registered checkers so a multi-context deployment can add more.
+/// </summary>
+public class FinancialBlobReferenceChecker : IBlobReferenceChecker
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+
+    public FinancialBlobReferenceChecker(EquiblesFinancialDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<bool> IsReferenced(string contentHash, CancellationToken cancellationToken)
+    {
+        return _dbContext
+            .Set<File>()
+            .AnyAsync(f => f.ContentHash == contentHash, cancellationToken);
+    }
+
+    public async Task<IReadOnlySet<string>> GetReferenced(
+        IReadOnlyCollection<string> contentHashes,
+        CancellationToken cancellationToken
+    )
+    {
+        var referenced = await _dbContext
+            .Set<File>()
+            .Where(f => f.ContentHash != null && contentHashes.Contains(f.ContentHash))
+            .Select(f => f.ContentHash)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+        return referenced.ToHashSet(StringComparer.Ordinal);
+    }
+}

--- a/src/Equibles.Media.Repositories/PendingBlobDeletionRepository.cs
+++ b/src/Equibles.Media.Repositories/PendingBlobDeletionRepository.cs
@@ -1,0 +1,10 @@
+using Equibles.Data;
+using Equibles.Media.Data.Models;
+
+namespace Equibles.Media.Repositories;
+
+public class PendingBlobDeletionRepository : BaseRepository<PendingBlobDeletion>
+{
+    public PendingBlobDeletionRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+}

--- a/src/Equibles.Migrations/Migrations/20260702164355_AddPendingBlobDeletionAndContentHashIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260702164355_AddPendingBlobDeletionAndContentHashIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702164355_AddPendingBlobDeletionAndContentHashIndex")]
+    partial class AddPendingBlobDeletionAndContentHashIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260702164355_AddPendingBlobDeletionAndContentHashIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260702164355_AddPendingBlobDeletionAndContentHashIndex.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPendingBlobDeletionAndContentHashIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PendingBlobDeletion",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContentHash = table.Column<string>(type: "character varying(80)", maxLength: 80, nullable: false),
+                    RelativePath = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    QueuedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PendingBlobDeletion", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_File_ContentHash",
+                table: "File",
+                column: "ContentHash");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PendingBlobDeletion");
+
+            migrationBuilder.DropIndex(
+                name: "IX_File_ContentHash",
+                table: "File");
+        }
+    }
+}

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -145,6 +145,9 @@ builder.Services.Configure<Equibles.Media.BusinessLogic.Configuration.FileStorag
 builder.Services.Configure<Equibles.Media.HostedService.Configuration.FileBackfillOptions>(
     builder.Configuration.GetSection("FileBackfill")
 );
+builder.Services.Configure<Equibles.Media.HostedService.Configuration.BlobSweepOptions>(
+    builder.Configuration.GetSection("BlobSweep")
+);
 
 builder.Services.AddHttpClient();
 

--- a/tests/Equibles.IntegrationTests/Helpers/FileManagerTestFactory.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/FileManagerTestFactory.cs
@@ -1,8 +1,10 @@
+using Equibles.Data;
 using Equibles.Media.BusinessLogic;
 using Equibles.Media.BusinessLogic.Configuration;
 using Equibles.Media.BusinessLogic.Storage;
 using Equibles.Media.Repositories;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 
 namespace Equibles.IntegrationTests;
 
@@ -10,15 +12,22 @@ namespace Equibles.IntegrationTests;
 /// Builds a <see cref="FileManager"/> wired with the real storage providers for tests
 /// that exercise the default (database) write path. The filesystem store is left
 /// disabled unless the caller supplies options that enable it. Lives in the root
-/// namespace so tests in any subfolder can use it without an extra using.
+/// namespace so tests in any subfolder can use it without an extra using. Pass a real
+/// <see cref="PendingBlobDeletionRepository"/> when a test exercises the delete queue.
 /// </summary>
 internal static class FileManagerTestFactory
 {
-    public static FileManager Create(FileRepository repository, FileStorageOptions options = null)
+    public static FileManager Create(
+        FileRepository repository,
+        FileStorageOptions options = null,
+        PendingBlobDeletionRepository pendingBlobDeletionRepository = null
+    )
     {
         var wrapped = Options.Create(options ?? new FileStorageOptions());
         return new FileManager(
             repository,
+            pendingBlobDeletionRepository
+                ?? Substitute.For<PendingBlobDeletionRepository>((EquiblesFinancialDbContext)null),
             new DatabaseFileStorageProvider(),
             new FileSystemFileStorageProvider(wrapped),
             wrapped

--- a/tests/Equibles.IntegrationTests/Media/BlobDeletionSweepWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/BlobDeletionSweepWorkerTests.cs
@@ -1,0 +1,205 @@
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.BusinessLogic.Storage;
+using Equibles.Media.Data.Models;
+using Equibles.Media.HostedService;
+using Equibles.Media.HostedService.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Media;
+
+/// <summary>
+/// Exercises the full deletion-sweep pipeline against real Postgres and a real store
+/// tree: queued blobs are trashed only when unreferenced, still-referenced queue entries
+/// are dropped without touching the blob, aged trash is purged unless a row reappeared
+/// (then restored), and the rolling reconciliation trashes on-disk blobs that no row
+/// references even though they were never queued (the cascade-delete case).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class BlobDeletionSweepWorkerTests : ParadeDbMcpTestBase
+{
+    public BlobDeletionSweepWorkerTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private sealed class TestSweepWorker : BlobDeletionSweepWorker
+    {
+        public TestSweepWorker(
+            IServiceScopeFactory scopeFactory,
+            IOptions<FileStorageOptions> storageOptions,
+            IOptions<BlobSweepOptions> sweepOptions
+        )
+            : base(
+                scopeFactory,
+                storageOptions,
+                sweepOptions,
+                NullLogger<BlobDeletionSweepWorker>()
+            ) { }
+    }
+
+    private static string WriteBlob(string root, string relativePath, byte[] bytes)
+    {
+        var fullPath = Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+        System.IO.File.WriteAllBytes(fullPath, bytes);
+        return fullPath;
+    }
+
+    private static string HexHash(string firstByteHex)
+    {
+        return firstByteHex + new string('0', 58) + "abcd";
+    }
+
+    [Fact]
+    public async Task SweepOnce_RunsTheFullQueueTrashPurgeAndReconciliationPipeline()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "eq-sweep-it-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var now = DateTime.UtcNow;
+
+            // A — queued, row deleted, blob on disk → must be trashed.
+            var hashA = HexHash("aa");
+            var pathA = $"blob/sha256/aa/00/{hashA}";
+            var fullA = WriteBlob(root, pathA, "blob-a"u8.ToArray());
+
+            // B — queued, but a live row still references the hash (dedup / re-created)
+            // → queue entry dropped, blob untouched.
+            var hashB = HexHash("bb");
+            var pathB = $"blob/sha256/bb/00/{hashB}";
+            var fullB = WriteBlob(root, pathB, "blob-b"u8.ToArray());
+            var rowB = new File
+            {
+                Name = "kept",
+                Extension = "gz",
+                ContentType = "application/gzip",
+                StorageProvider = StorageProvider.FileSystem,
+                ContentHash = "sha256:" + hashB,
+                RelativePath = pathB,
+            };
+
+            // D — on disk, old, never queued, no row (a cascade-deleted file); its shard
+            // is chosen so today's rolling reconciliation slice covers it → trashed.
+            var todaySlot = (int)now.DayOfWeek;
+            var shardD = Enumerable.Range(0, 256).First(b => b % 7 == todaySlot).ToString("x2");
+            var hashD = HexHash(shardD);
+            var pathD = $"blob/sha256/{shardD}/00/{hashD}";
+            var fullD = WriteBlob(root, pathD, "blob-d"u8.ToArray());
+            System.IO.File.SetLastWriteTimeUtc(fullD, now.AddDays(-3));
+
+            // E — already in trash, aged past retention, but a live row references it
+            // → the purge must RESTORE it instead of deleting.
+            var hashE = HexHash("ee");
+            var pathE = $"audio/sha256/ee/00/{hashE}";
+            var trashE = WriteBlob(root, $".trash/{pathE}", "blob-e"u8.ToArray());
+            System.IO.File.SetLastWriteTimeUtc(trashE, now.AddHours(-2));
+            var rowE = new File
+            {
+                Name = "restored",
+                Extension = "m4a",
+                ContentType = "audio/mp4",
+                StorageProvider = StorageProvider.FileSystem,
+                ContentHash = "sha256:" + hashE,
+                RelativePath = pathE,
+            };
+
+            DbContext.AddRange(rowB, rowE);
+            DbContext.Add(
+                new PendingBlobDeletion
+                {
+                    ContentHash = "sha256:" + hashA,
+                    RelativePath = pathA,
+                    QueuedAt = now.AddDays(-3),
+                }
+            );
+            DbContext.Add(
+                new PendingBlobDeletion
+                {
+                    ContentHash = "sha256:" + hashB,
+                    RelativePath = pathB,
+                    QueuedAt = now.AddDays(-3),
+                }
+            );
+            await DbContext.SaveChangesAsync();
+            DbContext.ChangeTracker.Clear();
+
+            var storageOptions = Options.Create(
+                new FileStorageOptions { Enabled = true, RootPath = root }
+            );
+            var services = new ServiceCollection();
+            services.AddScoped<EquiblesFinancialDbContext>(_ => Fixture.CreateDbContext());
+            services.AddScoped<IBlobReferenceChecker, FinancialBlobReferenceChecker>();
+            await using var provider = services.BuildServiceProvider();
+
+            var worker = new TestSweepWorker(
+                provider.GetRequiredService<IServiceScopeFactory>(),
+                storageOptions,
+                Options.Create(
+                    new BlobSweepOptions
+                    {
+                        Enabled = true,
+                        GraceHours = 0,
+                        TrashRetentionHours = 1,
+                    }
+                )
+            );
+
+            await worker.SweepOnce(CancellationToken.None);
+
+            // A: moved to trash, not yet purged (retention window).
+            System.IO.File.Exists(fullA).Should().BeFalse();
+            System
+                .IO.File.Exists(
+                    Path.Combine(root, ".trash", pathA.Replace('/', Path.DirectorySeparatorChar))
+                )
+                .Should()
+                .BeTrue();
+
+            // B: still live, untouched.
+            System.IO.File.Exists(fullB).Should().BeTrue();
+
+            // D: reconciliation caught the never-queued orphan.
+            System.IO.File.Exists(fullD).Should().BeFalse();
+            System
+                .IO.File.Exists(
+                    Path.Combine(root, ".trash", pathD.Replace('/', Path.DirectorySeparatorChar))
+                )
+                .Should()
+                .BeTrue();
+
+            // E: purge found it re-referenced and restored it to its live path.
+            System
+                .IO.File.Exists(Path.Combine(root, pathE.Replace('/', Path.DirectorySeparatorChar)))
+                .Should()
+                .BeTrue();
+            System.IO.File.Exists(trashE).Should().BeFalse();
+
+            // Queue is fully drained.
+            await using var verify = Fixture.CreateDbContext();
+            (await verify.Set<PendingBlobDeletion>().CountAsync()).Should().Be(0);
+
+            // Second run: age A's trash entry past retention → permanently purged
+            // (still unreferenced).
+            var trashA = Path.Combine(
+                root,
+                ".trash",
+                pathA.Replace('/', Path.DirectorySeparatorChar)
+            );
+            System.IO.File.SetLastWriteTimeUtc(trashA, DateTime.UtcNow.AddHours(-2));
+            await worker.SweepOnce(CancellationToken.None);
+            System.IO.File.Exists(trashA).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Media/BlobDeletionSweepWorkerDisabledTests.cs
+++ b/tests/Equibles.UnitTests/Media/BlobDeletionSweepWorkerDisabledTests.cs
@@ -1,0 +1,31 @@
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.HostedService;
+using Equibles.Media.HostedService.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Media;
+
+public class BlobDeletionSweepWorkerDisabledTests
+{
+    // The sweep deletes data; it must be strictly opt-in. When either flag is off the
+    // worker exits immediately without ever creating a DB scope.
+    [Fact]
+    public async Task StartAsync_WhenSweepDisabled_DoesNoWork()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        var worker = new BlobDeletionSweepWorker(
+            scopeFactory,
+            Options.Create(new FileStorageOptions { Enabled = true, RootPath = "/tmp/x" }),
+            Options.Create(new BlobSweepOptions { Enabled = false }),
+            NullLogger<BlobDeletionSweepWorker>.Instance
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await worker.StopAsync(CancellationToken.None);
+
+        scopeFactory.DidNotReceive().CreateScope();
+    }
+}

--- a/tests/Equibles.UnitTests/Media/FileManagerDeleteFileQueueTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerDeleteFileQueueTests.cs
@@ -1,0 +1,73 @@
+using Equibles.Data;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.BusinessLogic.Storage;
+using Equibles.Media.Data.Models;
+using Equibles.Media.Repositories;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.UnitTests.Media;
+
+public class FileManagerDeleteFileQueueTests
+{
+    private static (
+        FileManager Manager,
+        FileRepository Files,
+        PendingBlobDeletionRepository Queue
+    ) CreateSut()
+    {
+        var files = Substitute.For<FileRepository>((EquiblesFinancialDbContext)null);
+        var queue = Substitute.For<PendingBlobDeletionRepository>((EquiblesFinancialDbContext)null);
+        var options = Options.Create(new FileStorageOptions());
+        var manager = new FileManager(
+            files,
+            queue,
+            new DatabaseFileStorageProvider(),
+            new FileSystemFileStorageProvider(options),
+            options
+        );
+        return (manager, files, queue);
+    }
+
+    // A filesystem-stored file's blob can't be unlinked inline (shared by dedup, racy),
+    // so the delete must leave a mark the sweep can act on — carrying both the hash for
+    // the reference re-check and the path to locate the blob.
+    [Fact]
+    public void DeleteFile_FileSystemFile_QueuesBlobDeletionAndDeletesRow()
+    {
+        var (manager, files, queue) = CreateSut();
+        var file = new File
+        {
+            StorageProvider = StorageProvider.FileSystem,
+            ContentHash = "sha256:abc123",
+            RelativePath = "blob/sha256/ab/c1/abc123",
+        };
+
+        manager.DeleteFile(file);
+
+        files.Received(1).Delete(file);
+        queue
+            .Received(1)
+            .Add(
+                Arg.Is<PendingBlobDeletion>(p =>
+                    p.ContentHash == "sha256:abc123" && p.RelativePath == "blob/sha256/ab/c1/abc123"
+                )
+            );
+    }
+
+    // Database-stored files have no blob on disk; their FileContent row cascades away
+    // with the delete, so nothing must be queued.
+    [Fact]
+    public void DeleteFile_DatabaseFile_DoesNotQueue()
+    {
+        var (manager, files, queue) = CreateSut();
+        var file = new File { StorageProvider = StorageProvider.Database };
+
+        manager.DeleteFile(file);
+
+        files.Received(1).Delete(file);
+        queue.DidNotReceive().Add(Arg.Any<PendingBlobDeletion>());
+    }
+}

--- a/tests/Equibles.UnitTests/Media/FileManagerTestFactory.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerTestFactory.cs
@@ -1,8 +1,10 @@
+using Equibles.Data;
 using Equibles.Media.BusinessLogic;
 using Equibles.Media.BusinessLogic.Configuration;
 using Equibles.Media.BusinessLogic.Storage;
 using Equibles.Media.Repositories;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 
 namespace Equibles.UnitTests.Media;
 
@@ -18,6 +20,7 @@ internal static class FileManagerTestFactory
         var wrapped = Options.Create(options ?? new FileStorageOptions());
         return new FileManager(
             repository,
+            Substitute.For<PendingBlobDeletionRepository>((EquiblesFinancialDbContext)null),
             new DatabaseFileStorageProvider(),
             new FileSystemFileStorageProvider(wrapped),
             wrapped


### PR DESCRIPTION
## Summary

Closes the last lifecycle gap in the filesystem blob store: deleting a `File` left its blob on disk forever. Inline unlink is unsafe in a content-addressed store — a blob can be shared by several rows (dedup), and an unlink races an identical re-upload that dedup-skips onto the existing file. Deletion is now a staged, reversible pipeline (the mark-and-sweep pattern every content-addressed store uses — git gc, restic prune, registry GC):

1. **Queue** — `DeleteFile` marks filesystem blobs in a new `PendingBlobDeletion` table (hash + relative path), in the same `SaveChanges` as the row delete.
2. **Sweep (daily)** — marks past a grace window (default 48 h) are re-checked against every registered `IBlobReferenceChecker`; unreferenced blobs are **renamed into a mirrored `.trash` tree** — atomic and reversible: a racing identical write now writes fresh bytes, and if a row appears in the gap the blob is renamed back.
3. **Purge** — trash older than the retention window (default 24 h) is deleted after one final reference check (restored instead if re-referenced).
4. **Rolling reconciliation** — DB-level `ON DELETE CASCADE` paths (e.g. `Document → File.ContentId`) and direct repository deletes never hit the queue, so each daily run also diffs one seventh of the shard space against the database (hex-prefix mod 7 by day of week); the whole store is covered weekly with bounded per-run cost.

## Code changes
- `Equibles.Media.Data` — `PendingBlobDeletion` entity; `File.ContentHash` index (the reference checks need it); registered in `MediaModuleConfiguration` + migration.
- `Equibles.Media.BusinessLogic` — `FileManager.DeleteFile` queues filesystem blobs; `IBlobReferenceChecker` (single + bulk check), resolved as a set so multi-context deployments register one checker per database and the sweep stays conservative.
- `Equibles.Media.HostedService` — `BlobDeletionSweepWorker` (the pipeline above), `FinancialBlobReferenceChecker` (default, `TryAddEnumerable` so hosts can add more), `BlobSweepOptions` (`BlobSweep:*`, **off by default**), wired via `AddMediaWorker`; options bound in Worker.Host.
- Safety rails: only 64-hex-named files inside the store root are ever touched; `.tmp`/foreign files ignored; the sweep refuses to run with zero registered checkers.

## Verification
- Solution builds clean; csharpier clean; 30 Media unit tests pass (incl. the new delete-queues-mark and disabled-gate pins).
- New Postgres integration test runs the full pipeline end to end: queued blob trashed; still-referenced queue entry dropped with blob untouched; never-queued orphan caught by reconciliation; re-referenced trash restored on purge; aged trash permanently purged; queue drained.

A.L.V.I.S.