### PR TITLE
fix(yahoo): stop storing the in-progress trading day as a settled close

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -277,7 +277,7 @@ public class YahooPriceImportService
         CancellationToken cancellationToken
     )
     {
-        var freshRows = MapFreshRows(commonStockId, prices, ticker);
+        var freshRows = MapFreshRows(commonStockId, prices, ticker, today);
         if (freshRows.Count == 0)
         {
             _logger.LogWarning(
@@ -359,12 +359,14 @@ public class YahooPriceImportService
     private List<DailyStockPrice> MapFreshRows(
         Guid commonStockId,
         List<HistoricalPrice> prices,
-        string ticker
+        string ticker,
+        DateOnly today
     )
     {
         var overflowDates = WarnAndCollectOverflowDates(prices, ticker);
         return prices
             .Where(p => !overflowDates.Contains(p.Date))
+            .Where(p => IsSettledDailyBar(p.Date, today))
             .Select(p => new DailyStockPrice
             {
                 CommonStockId = commonStockId,
@@ -378,6 +380,15 @@ public class YahooPriceImportService
             })
             .ToList();
     }
+
+    // Yahoo's daily chart includes the current, still-open trading day as a live candle: a partial
+    // OHLC quartet and partial volume that keep changing until the session closes. Persisting it is
+    // wrong twice over — the "Close" is really an intraday snapshot, and the importer is insert-only
+    // (a date already present is never updated, see PersistPrices), so that partial bar freezes and
+    // the real close never overwrites it. Only store bars strictly before the current UTC date; the
+    // day's settled bar is appended on the next cycle once the date has rolled over (always after a
+    // US market close), so the daily series holds settled closes only.
+    private static bool IsSettledDailyBar(DateOnly barDate, DateOnly today) => barDate < today;
 
     private async Task<int> ImportTicker(
         string ticker,
@@ -399,6 +410,7 @@ public class YahooPriceImportService
             ticker,
             commonStockId,
             chartData.Prices,
+            today,
             cancellationToken
         );
 
@@ -412,6 +424,7 @@ public class YahooPriceImportService
         string ticker,
         Guid commonStockId,
         List<HistoricalPrice> prices,
+        DateOnly today,
         CancellationToken cancellationToken
     )
     {
@@ -428,7 +441,7 @@ public class YahooPriceImportService
             cancellationToken
         );
 
-        var newPrices = MapFreshRows(commonStockId, prices, ticker)
+        var newPrices = MapFreshRows(commonStockId, prices, ticker, today)
             .Where(p => !existingDates.Contains(p.Date))
             .ToList();
 

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSettledBarTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSettledBarTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Pins <c>YahooPriceImportService.IsSettledDailyBar</c>, the guard that keeps the current,
+/// still-open trading day out of the daily series. Yahoo's daily chart returns the in-progress
+/// session as a live candle (partial OHLC + partial volume); the importer is insert-only, so a
+/// stored partial bar freezes and the real close never overwrites it. The guard must admit only
+/// bars strictly before the current date. Both the boundary (today's bar excluded) and the
+/// comparison direction are pinned: a flip to <c>&lt;=</c> re-admits the live candle, and a flip to
+/// <c>&gt;</c> would drop the entire settled history and store only today.
+/// </summary>
+public class YahooPriceImportServiceSettledBarTests
+{
+    private static readonly MethodInfo IsSettledDailyBarMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "IsSettledDailyBar",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static bool IsSettledDailyBar(DateOnly barDate, DateOnly today) =>
+        (bool)IsSettledDailyBarMethod.Invoke(null, [barDate, today]);
+
+    private static readonly DateOnly Today = new(2026, 7, 2);
+
+    [Fact]
+    public void IsSettledDailyBar_CurrentDayBar_IsExcluded()
+    {
+        // The bug this fixes: a bar dated today is the in-progress session — a partial candle whose
+        // "Close" is an intraday snapshot. It must not be persisted as a completed daily close.
+        IsSettledDailyBar(Today, Today).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSettledDailyBar_PriorDayBar_IsKept()
+    {
+        // A bar for any prior date is a settled session and belongs in the series. Pinned alongside
+        // the exclusion case so a regression that flips the comparison to `>` (which would drop the
+        // whole settled history and keep only today) fails here.
+        IsSettledDailyBar(Today.AddDays(-1), Today).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSettledDailyBar_FutureDatedBar_IsExcluded()
+    {
+        // Defensive: a bar dated after today (a clock skew or a bad exchange-offset calculation)
+        // is never a settled bar and must be rejected, not stored ahead of the calendar.
+        IsSettledDailyBar(Today.AddDays(1), Today).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Yahoo's daily chart returns the current, still-open trading day as a live candle — a partial OHLC quartet and partial volume that keep changing until the session closes. The price importer is insert-only (a date already present is never updated), so once that partial bar lands it **freezes**: the real close after the session ends never overwrites it. Every stock synced mid-session ends up with a wrong daily "close" (an intraday snapshot) that pages then label "At close".

Fix: only persist bars strictly before the current UTC date. The day's settled bar is appended on the next sync cycle once the date has rolled over — always after a US market close — so the daily series holds settled closes only.

## Code changes

- `YahooPriceImportService.MapFreshRows` — now filters out the in-progress current day via a new `IsSettledDailyBar(barDate, today)` guard; `today` threaded in from both persist paths (incremental import + split reconcile). The reconcile path already deletes the `[floor, today]` window, so it now also removes any stale partial current-day row it finds.
- `YahooPriceImportServiceSettledBarTests` — pins the guard: today's bar excluded, prior-day kept, future-dated excluded (boundary + comparison direction).