### PR TITLE
feat(financial-facts): persist filer-extension (company-specific) XBRL concepts

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -36,7 +36,6 @@ public class CommonStock
     /// </summary>
     public DateTime? WebsiteCheckedAt { get; set; }
 
-
     public double MarketCapitalization { get; set; }
     public long SharesOutStanding { get; set; }
 

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedXbrlFact.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedXbrlFact.cs
@@ -21,6 +21,15 @@ public class ParsedXbrlFact
     public string Tag { get; init; }
 
     /// <summary>
+    /// Namespace URI the concept's prefix resolves to (e.g.
+    /// <c>http://fasb.org/us-gaap/2023</c>, <c>http://www.apple.com/20230930</c>);
+    /// null when the source document does not declare the prefix. Lets consumers
+    /// classify filer-extension concepts by namespace ownership instead of
+    /// guessing from the prefix spelling.
+    /// </summary>
+    public string Namespace { get; init; }
+
+    /// <summary>
     /// Resolved unit string — single measures collapse to their local name
     /// (<c>iso4217:USD</c> → <c>USD</c>); divide units are emitted as
     /// <c>numerator/denominator</c> (e.g. <c>USD/shares</c>).

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -74,14 +74,41 @@ public class InlineXbrlParser
 
         var contexts = BuildContextMap(document);
         var units = BuildUnitMap(document);
+        var namespaces = BuildNamespaceMap(document);
 
         var facts = new List<ParsedXbrlFact>();
         foreach (var element in FindByLocalName(document, NonFractionLocalName))
         {
-            if (TryParseFact(element, contexts, units, out var fact))
+            if (TryParseFact(element, contexts, units, namespaces, out var fact))
                 facts.Add(fact);
         }
         return facts;
+    }
+
+    /// <summary>
+    /// Prefix → namespace URI map from every <c>xmlns:*</c> declaration in the
+    /// document (filers declare them on <c>html</c>, but nothing forbids deeper
+    /// placement). Case-insensitive because the HTML parser lowercases attribute
+    /// names while <c>name</c> attribute values keep the author's prefix casing.
+    /// Duplicate declarations keep the first URI seen — scoped redefinition of a
+    /// taxonomy prefix does not occur in EDGAR filings.
+    /// </summary>
+    private static Dictionary<string, string> BuildNamespaceMap(IDocument document)
+    {
+        var namespaces = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var element in document.All)
+        {
+            foreach (var attribute in element.Attributes)
+            {
+                if (!attribute.Name.StartsWith("xmlns:", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                var prefix = attribute.Name.Substring("xmlns:".Length);
+                if (prefix.Length == 0 || string.IsNullOrEmpty(attribute.Value))
+                    continue;
+                namespaces.TryAdd(prefix, attribute.Value.Trim());
+            }
+        }
+        return namespaces;
     }
 
     private static IEnumerable<IElement> FindByLocalName(IParentNode root, string localName) =>
@@ -227,6 +254,7 @@ public class InlineXbrlParser
         IElement element,
         Dictionary<string, ParsedContext> contexts,
         Dictionary<string, string> units,
+        Dictionary<string, string> namespaces,
         out ParsedXbrlFact fact
     )
     {
@@ -267,6 +295,7 @@ public class InlineXbrlParser
         {
             Taxonomy = taxonomy,
             Tag = tag,
+            Namespace = namespaces.GetValueOrDefault(taxonomy),
             Unit = unit,
             Value = value,
             IsInstant = context.IsInstant,

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
@@ -259,6 +259,7 @@ public class StandaloneXbrlParser
         {
             Taxonomy = taxonomy,
             Tag = element.Name.LocalName,
+            Namespace = element.Name.NamespaceName,
             Unit = unit,
             Value = value,
             IsInstant = context.IsInstant,

--- a/src/Equibles.Sec.FinancialFacts.Data/Enums/FactTaxonomy.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Enums/FactTaxonomy.cs
@@ -3,10 +3,14 @@ using System.ComponentModel.DataAnnotations;
 namespace Equibles.Sec.FinancialFacts.Data.Enums;
 
 /// <summary>
-/// The XBRL taxonomy a financial concept belongs to. Maps to the top-level
-/// keys under <c>facts</c> in SEC's Company Facts API
+/// The XBRL taxonomy a financial concept belongs to. The first five map to the
+/// top-level keys under <c>facts</c> in SEC's Company Facts API
 /// (<c>us-gaap</c>, <c>dei</c>, <c>ifrs-full</c>, <c>srt</c>, <c>invest</c>).
-/// Facts in taxonomies outside this set are skipped on import.
+/// <see cref="Custom"/> holds filer-extension concepts — the company's own
+/// namespace tags (KPIs like subscriber counts, ARR, deliveries) that only the
+/// raw-XBRL extraction path can supply; the Company Facts API never carries
+/// them. Facts in reference taxonomies outside this set (country, currency,
+/// exch, …) are skipped on import.
 /// </summary>
 public enum FactTaxonomy
 {
@@ -24,4 +28,13 @@ public enum FactTaxonomy
 
     [Display(Name = "INVEST")]
     Invest,
+
+    /// <summary>
+    /// A filer-extension concept from the company's own taxonomy. The
+    /// <c>FinancialConcept.Tag</c> keeps the QName shape
+    /// (<c>adbe:AnnualizedRecurringRevenue</c>) so concepts from different
+    /// companies never collide on the (Taxonomy, Tag) unique index.
+    /// </summary>
+    [Display(Name = "Company-specific")]
+    Custom,
 }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -25,13 +25,19 @@ namespace Equibles.Sec.FinancialFacts.HostedService.Services;
 /// the SEC Company Facts API drops (see #877).
 ///
 /// <para>
-/// The API stays authoritative for the consolidated (no-dimension) context:
-/// this extractor persists facts that carry at least one explicit dimension,
-/// so its rows (non-empty <see cref="FinancialFact.DimensionsKey"/>) can never
-/// collide with API-sourced rows (empty key) on the natural-key unique index.
-/// Filer-extension <em>members</em> ride through as QName strings; facts whose
-/// <em>concept</em> lives in a filer-extension taxonomy are skipped until
-/// <see cref="FinancialConcept"/> can represent them (follow-up to #877).
+/// The API stays authoritative for the consolidated (no-dimension) context of
+/// <em>standard-taxonomy</em> concepts: for those this extractor persists only
+/// facts carrying at least one explicit dimension, so its rows (non-empty
+/// <see cref="FinancialFact.DimensionsKey"/>) can never collide with
+/// API-sourced rows (empty key) on the natural-key unique index.
+/// <em>Filer-extension</em> concepts (<see cref="FactTaxonomy.Custom"/> — the
+/// company's own KPI tags like subscriber counts or ARR) never appear in the
+/// API at all, so they are persisted at every dimensionality, consolidated
+/// context included; classification is by namespace ownership (a concept
+/// namespace not hosted by a standards body is the filer's), never by prefix
+/// spelling. Their stored tag keeps the QName shape (<c>adbe:Subscribers</c>)
+/// so extension concepts from different companies never share a
+/// <see cref="FinancialConcept"/> row.
 /// </para>
 ///
 /// <para>
@@ -50,7 +56,9 @@ public class XbrlFactExtractionService
     /// </summary>
     // Version 2: TR2/TR3 zerodash + TR4/TR5 num-comma-decimal(-apos) format
     // coverage in InlineXbrlParser.
-    public const int CurrentVersion = 2;
+    // Version 3: filer-extension (company-specific) concepts persisted under
+    // FactTaxonomy.Custom, consolidated contexts included.
+    public const int CurrentVersion = 3;
 
     private const int InsertBatchSize = 1000;
 
@@ -118,9 +126,7 @@ public class XbrlFactExtractionService
         );
         foreach (var candidate in persistable)
         {
-            if (
-                !conceptIds.TryGetValue((candidate.Taxonomy, candidate.Fact.Tag), out var conceptId)
-            )
+            if (!conceptIds.TryGetValue((candidate.Taxonomy, candidate.Tag), out var conceptId))
                 continue;
             facts.Add(BuildFact(document, stock, candidate, conceptId));
             dimensionsByKey.TryAdd(candidate.DimensionsKey, candidate.Fact.Dimensions);
@@ -133,22 +139,24 @@ public class XbrlFactExtractionService
     }
 
     /// <summary>
-    /// Keeps the facts this extractor is allowed to persist: at least one
-    /// explicit dimension (the API owns the consolidated context), a concept
-    /// in a known taxonomy, and values that fit their columns.
+    /// Keeps the facts this extractor is allowed to persist: a concept in a
+    /// standard taxonomy with at least one explicit dimension (the API owns
+    /// standard concepts' consolidated context) or a filer-extension concept at
+    /// any dimensionality (the API never carries those), and values that fit
+    /// their columns.
     /// </summary>
     internal static List<PersistableXbrlFact> SelectPersistable(List<ParsedXbrlFact> parsed)
     {
         var selected = new List<PersistableXbrlFact>();
         foreach (var fact in parsed)
         {
-            if (fact.Dimensions.Count == 0)
+            if (!TryResolveConcept(fact, out var taxonomy, out var tag))
                 continue;
-            if (!TryMapTaxonomy(fact.Taxonomy, out var taxonomy))
+            if (taxonomy != FactTaxonomy.Custom && fact.Dimensions.Count == 0)
                 continue;
             if (string.IsNullOrEmpty(fact.Unit) || fact.Unit.Length > UnitMaxLength)
                 continue;
-            if (string.IsNullOrEmpty(fact.Tag) || fact.Tag.Length > QNameMaxLength)
+            if (tag.Length > QNameMaxLength)
                 continue;
             if (
                 fact.Dimensions.Any(d =>
@@ -165,11 +173,81 @@ public class XbrlFactExtractionService
                 {
                     Fact = fact,
                     Taxonomy = taxonomy,
+                    Tag = tag,
                     DimensionsKey = XbrlDimensionsKey.Compute(fact.Dimensions),
                 }
             );
         }
         return selected;
+    }
+
+    /// <summary>
+    /// Resolves a parsed fact's concept identity: standard-taxonomy prefixes
+    /// map to their enum arm with the tag as-is; anything else is a
+    /// filer-extension concept (<see cref="FactTaxonomy.Custom"/>, tag stored
+    /// as <c>prefix:Tag</c>) when its namespace URI is owned by neither a
+    /// standards body nor the SEC — namespace ownership is authoritative, the
+    /// prefix spelling is not. Facts whose prefix is undeclared or whose
+    /// namespace belongs to a reference taxonomy (country, currency, exch, …,
+    /// all standards-body-hosted) resolve to nothing and are skipped.
+    /// </summary>
+    internal static bool TryResolveConcept(
+        ParsedXbrlFact fact,
+        out FactTaxonomy taxonomy,
+        out string tag
+    )
+    {
+        tag = fact.Tag;
+        if (string.IsNullOrEmpty(fact.Tag) || string.IsNullOrEmpty(fact.Taxonomy))
+        {
+            taxonomy = default;
+            return false;
+        }
+        if (TryMapTaxonomy(fact.Taxonomy, out taxonomy))
+            return true;
+        if (!IsFilerExtensionNamespace(fact.Namespace))
+            return false;
+
+        taxonomy = FactTaxonomy.Custom;
+        // Prefix casing follows the filer's whim; lowercase it so the same
+        // concept lands on one FinancialConcept row across filings.
+        tag = $"{fact.Taxonomy.ToLowerInvariant()}:{fact.Tag}";
+        return true;
+    }
+
+    // Registrable domains that host the standard and reference XBRL
+    // taxonomies (FASB us-gaap/srt, SEC dei/country/currency/exch/…, IFRS,
+    // XBRL spec/utility namespaces, legacy xbrl.us, W3C schema machinery).
+    // A concept namespace under any other domain is, per the EDGAR filer
+    // manual, the registrant's own extension taxonomy.
+    private static readonly string[] StandardsBodyDomains =
+    [
+        "fasb.org",
+        "sec.gov",
+        "xbrl.org",
+        "ifrs.org",
+        "xbrl.us",
+        "w3.org",
+    ];
+
+    /// <summary>
+    /// True when the namespace URI parses and its host is owned by none of the
+    /// standards bodies. Unparseable or missing namespaces return false — a
+    /// concept that cannot be attributed is skipped, never misfiled.
+    /// </summary>
+    internal static bool IsFilerExtensionNamespace(string namespaceUri)
+    {
+        if (string.IsNullOrWhiteSpace(namespaceUri))
+            return false;
+        if (!Uri.TryCreate(namespaceUri, UriKind.Absolute, out var uri))
+            return false;
+        var host = uri.Host;
+        if (string.IsNullOrEmpty(host))
+            return false;
+        return !StandardsBodyDomains.Any(domain =>
+            host.Equals(domain, StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith("." + domain, StringComparison.OrdinalIgnoreCase)
+        );
     }
 
     /// <summary>
@@ -185,7 +263,7 @@ public class XbrlFactExtractionService
             .GroupBy(c =>
                 (
                     c.Taxonomy,
-                    c.Fact.Tag,
+                    c.Tag,
                     c.Fact.Unit,
                     c.Fact.PeriodStart,
                     c.Fact.PeriodEnd,
@@ -278,7 +356,7 @@ public class XbrlFactExtractionService
         CancellationToken cancellationToken
     )
     {
-        var pairs = persistable.Select(c => (c.Taxonomy, c.Fact.Tag)).ToHashSet();
+        var pairs = persistable.Select(c => (c.Taxonomy, c.Tag)).ToHashSet();
         var concepts = pairs
             .Select(pair => new FinancialConcept { Taxonomy = pair.Item1, Tag = pair.Item2 })
             .ToList();
@@ -431,11 +509,16 @@ public class XbrlFactExtractionService
         }
     }
 
-    /// <summary>A parsed fact admitted for persistence, with its resolved taxonomy and canonical dimensions key.</summary>
+    /// <summary>
+    /// A parsed fact admitted for persistence, with its resolved taxonomy, its
+    /// storage tag (the raw tag for standard concepts, <c>prefix:Tag</c> for
+    /// filer-extension ones) and canonical dimensions key.
+    /// </summary>
     internal sealed class PersistableXbrlFact
     {
         public ParsedXbrlFact Fact { get; init; }
         public FactTaxonomy Taxonomy { get; init; }
+        public string Tag { get; init; }
         public string DimensionsKey { get; init; }
     }
 }

--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserNamespaceResolutionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserNamespaceResolutionTests.cs
@@ -1,0 +1,61 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// The inline parser resolves each fact's concept prefix to the namespace URI
+/// the document declares for it, so downstream classification can tell a
+/// filer-extension concept (company-owned namespace) from a reference
+/// taxonomy. Prefix lookup is case-insensitive because the HTML parser
+/// lowercases attribute names while fact names keep the author's casing; an
+/// undeclared prefix yields a null namespace, never a guess.
+/// </summary>
+public class InlineXbrlParserNamespaceResolutionTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\" "
+        + "xmlns:ADBE=\"http://www.adobe.com/20231201\" "
+        + "><body><div style=\"display:none\"><ix:header><ix:resources>"
+        + "<xbrli:context id=\"C1\">"
+        + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+        + "  <xbrli:period><xbrli:instant>2024-06-30</xbrli:instant></xbrli:period>"
+        + "</xbrli:context>"
+        + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+        + "</ix:resources></ix:header></div>";
+
+    private const string DocClose = "</body></html>";
+
+    [Fact]
+    public void Parse_DeclaredPrefixes_ResolveToTheirNamespaceUris()
+    {
+        var html =
+            DocOpen
+            + "<p><ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"C1\" unitRef=\"u\">100</ix:nonFraction></p>"
+            + "<p><ix:nonFraction name=\"ADBE:Subscribers\" contextRef=\"C1\" unitRef=\"u\">7</ix:nonFraction></p>"
+            + DocClose;
+
+        var facts = new InlineXbrlParser().Parse(html);
+
+        facts.Should().HaveCount(2);
+        facts[0].Namespace.Should().Be("http://fasb.org/us-gaap/2018-01-31");
+        facts[1].Namespace.Should().Be("http://www.adobe.com/20231201");
+    }
+
+    [Fact]
+    public void Parse_UndeclaredPrefix_YieldsNullNamespace()
+    {
+        var html =
+            DocOpen
+            + "<p><ix:nonFraction name=\"mystery:Metric\" contextRef=\"C1\" unitRef=\"u\">5</ix:nonFraction></p>"
+            + DocClose;
+
+        var facts = new InlineXbrlParser().Parse(html);
+
+        facts.Should().ContainSingle();
+        facts[0].Namespace.Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceSelectPersistableTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceSelectPersistableTests.cs
@@ -6,11 +6,12 @@ namespace Equibles.UnitTests.Sec;
 
 /// <summary>
 /// SelectPersistable enforces the extractor's contract boundary with the
-/// Company Facts API: only facts carrying at least one explicit dimension are
-/// persisted (the API owns the consolidated context — admitting a
-/// no-dimension fact here would fight the API import over the same
-/// unique-index slot), concepts must belong to a known taxonomy, and values
-/// must fit their columns rather than being truncated into corrupt keys.
+/// Company Facts API: standard-taxonomy facts are persisted only when they
+/// carry at least one explicit dimension (the API owns their consolidated
+/// context — admitting a no-dimension fact here would fight the API import
+/// over the same unique-index slot), filer-extension concepts are persisted
+/// at any dimensionality (the API never carries them), and values must fit
+/// their columns rather than being truncated into corrupt keys.
 /// </summary>
 public class XbrlFactExtractionServiceSelectPersistableTests
 {
@@ -18,12 +19,14 @@ public class XbrlFactExtractionServiceSelectPersistableTests
         string taxonomy = "us-gaap",
         string tag = "RevenueFromContractWithCustomerExcludingAssessedTax",
         string unit = "USD",
+        string ns = "http://fasb.org/us-gaap/2023",
         List<ParsedXbrlDimension> dimensions = null
     ) =>
         new()
         {
             Taxonomy = taxonomy,
             Tag = tag,
+            Namespace = ns,
             Unit = unit,
             Value = 1_000m,
             IsInstant = false,
@@ -52,17 +55,86 @@ public class XbrlFactExtractionServiceSelectPersistableTests
     }
 
     [Fact]
-    public void SelectPersistable_ConsolidatedFact_IsDropped()
+    public void SelectPersistable_ConsolidatedStandardTaxonomyFact_IsDropped()
     {
         XbrlFactExtractionService.SelectPersistable([Fact(dimensions: [])]).Should().BeEmpty();
     }
 
     [Fact]
-    public void SelectPersistable_FilerExtensionConcept_IsDropped()
+    public void SelectPersistable_FilerExtensionConcept_IsKeptWithQNameTag()
     {
-        // The concept itself lives in a filer-extension namespace; FactTaxonomy
-        // cannot represent it yet, so it must be skipped, not misfiled.
-        var fact = Fact(taxonomy: "aapl", dimensions: IPhoneCut());
+        // The concept lives in the company's own namespace — the Company Facts
+        // API never carries it, so this extractor is its only source. Even the
+        // consolidated (no-dimension) context is persisted, and the storage tag
+        // keeps the prefix so extension concepts never collide across filers.
+        var fact = Fact(
+            taxonomy: "aapl",
+            tag: "SubscriberCount",
+            ns: "http://www.apple.com/20230930",
+            dimensions: []
+        );
+
+        var selected = XbrlFactExtractionService.SelectPersistable([fact]);
+
+        selected.Should().ContainSingle();
+        selected[0].Taxonomy.Should().Be(FactTaxonomy.Custom);
+        selected[0].Tag.Should().Be("aapl:SubscriberCount");
+        selected[0].DimensionsKey.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectPersistable_DimensionalFilerExtensionConcept_IsKept()
+    {
+        var fact = Fact(
+            taxonomy: "aapl",
+            tag: "SubscriberCount",
+            ns: "http://www.apple.com/20230930",
+            dimensions: IPhoneCut()
+        );
+
+        var selected = XbrlFactExtractionService.SelectPersistable([fact]);
+
+        selected.Should().ContainSingle();
+        selected[0].Taxonomy.Should().Be(FactTaxonomy.Custom);
+        selected[0].DimensionsKey.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void SelectPersistable_UnknownPrefixWithoutNamespace_IsDropped()
+    {
+        // A prefix the document never declares cannot be attributed to anyone —
+        // skip it rather than misfile it as a company concept.
+        var fact = Fact(taxonomy: "aapl", ns: null, dimensions: IPhoneCut());
+
+        XbrlFactExtractionService.SelectPersistable([fact]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectPersistable_ReferenceTaxonomyConcept_IsDropped()
+    {
+        // SEC-hosted reference taxonomies (country, currency, exch, …) are not
+        // company concepts; their namespace ownership keeps them out of Custom.
+        var fact = Fact(
+            taxonomy: "ecd",
+            tag: "PeoTotalCompAmt",
+            ns: "http://xbrl.sec.gov/ecd/2023",
+            dimensions: []
+        );
+
+        XbrlFactExtractionService.SelectPersistable([fact]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectPersistable_FilerExtensionTagExceedingColumnAfterPrefixing_IsDropped()
+    {
+        // The stored tag is "prefix:Tag" — the length gate must apply to that
+        // composed value, not the raw local name.
+        var fact = Fact(
+            taxonomy: "adbe",
+            tag: new string('X', 253),
+            ns: "http://www.adobe.com/20231201",
+            dimensions: []
+        );
 
         XbrlFactExtractionService.SelectPersistable([fact]).Should().BeEmpty();
     }

--- a/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceTryResolveConceptTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceTryResolveConceptTests.cs
@@ -1,0 +1,109 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// TryResolveConcept decides a parsed fact's persisted identity: the five
+/// standard prefixes map to their enum arm with the tag untouched; everything
+/// else is a filer-extension concept only when its namespace URI is owned by
+/// neither a standards body nor the SEC. Ownership is the classifier — the
+/// prefix spelling never is, so a company must not be misfiled because its
+/// prefix happens to collide with a reference taxonomy and a reference
+/// taxonomy must never leak into Custom.
+/// </summary>
+public class XbrlFactExtractionServiceTryResolveConceptTests
+{
+    private static ParsedXbrlFact Fact(string taxonomy, string tag, string ns) =>
+        new()
+        {
+            Taxonomy = taxonomy,
+            Tag = tag,
+            Namespace = ns,
+            Unit = "USD",
+            Value = 1m,
+            IsInstant = true,
+            PeriodStart = new DateOnly(2025, 12, 27),
+            PeriodEnd = new DateOnly(2025, 12, 27),
+        };
+
+    [Fact]
+    public void TryResolveConcept_StandardPrefix_MapsWithRawTag()
+    {
+        var resolved = XbrlFactExtractionService.TryResolveConcept(
+            Fact("us-gaap", "Revenues", "http://fasb.org/us-gaap/2023"),
+            out var taxonomy,
+            out var tag
+        );
+
+        resolved.Should().BeTrue();
+        taxonomy.Should().Be(FactTaxonomy.UsGaap);
+        tag.Should().Be("Revenues");
+    }
+
+    [Fact]
+    public void TryResolveConcept_CompanyNamespace_MapsToCustomWithPrefixedTag()
+    {
+        var resolved = XbrlFactExtractionService.TryResolveConcept(
+            Fact("adbe", "AnnualizedRecurringRevenue", "http://www.adobe.com/20231201"),
+            out var taxonomy,
+            out var tag
+        );
+
+        resolved.Should().BeTrue();
+        taxonomy.Should().Be(FactTaxonomy.Custom);
+        tag.Should().Be("adbe:AnnualizedRecurringRevenue");
+    }
+
+    [Fact]
+    public void TryResolveConcept_UppercasePrefix_IsLoweredInStoredTag()
+    {
+        // Prefix casing follows the filer; the stored tag must not split one
+        // concept across FinancialConcept rows by casing alone.
+        XbrlFactExtractionService.TryResolveConcept(
+            Fact("ADBE", "Subscribers", "http://www.adobe.com/20231201"),
+            out _,
+            out var tag
+        );
+
+        tag.Should().Be("adbe:Subscribers");
+    }
+
+    [Theory]
+    [InlineData("country", "http://xbrl.sec.gov/country/2023")]
+    [InlineData("ecd", "http://xbrl.sec.gov/ecd/2023")]
+    [InlineData("us-types", "http://xbrl.us/us-types/2009-01-31")]
+    [InlineData("ifrs", "https://xbrl.ifrs.org/taxonomy/2023-03-23/ifrs")]
+    [InlineData("xbrli", "http://www.xbrl.org/2003/instance")]
+    public void TryResolveConcept_StandardsBodyNamespace_IsRejected(string prefix, string ns)
+    {
+        XbrlFactExtractionService
+            .TryResolveConcept(Fact(prefix, "Anything", ns), out _, out _)
+            .Should()
+            .BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not a uri")]
+    public void TryResolveConcept_MissingOrUnparseableNamespace_IsRejected(string ns)
+    {
+        XbrlFactExtractionService
+            .TryResolveConcept(Fact("acme", "Metric", ns), out _, out _)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void IsFilerExtensionNamespace_LookalikeDomainSuffix_IsNotAStandardsBody()
+    {
+        // "notsec.gov"-style hosts must not pass by substring accident; only an
+        // exact registrable-domain match (or a true subdomain) is standard.
+        XbrlFactExtractionService
+            .IsFilerExtensionNamespace("http://mycompanyfasb.org/2024")
+            .Should()
+            .BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
The raw-XBRL extraction sweep dropped every concept from a filer's own extension taxonomy, so company-specific KPIs (Adobe's ARR/subscription metrics, subscriber counts, deliveries, …) never reached `FinancialFact` — the Company Facts API cannot supply them either, as it only carries standard taxonomies. This closes the gap that was documented as the follow-up to #877.

- New `FactTaxonomy.Custom` arm for filer-extension concepts; stored tags keep the QName shape (`adbe:AnnualizedRecurringRevenue`) so extension concepts from different filers never collide on the `(Taxonomy, Tag)` unique index (enum append-only — no migration needed).
- Both parsers (`InlineXbrlParser`, `StandaloneXbrlParser`) now resolve each fact's prefix to the namespace URI the document declares; classification is by **namespace ownership** (a concept namespace hosted by neither a standards body — FASB/SEC/XBRL/IFRS/W3C/xbrl.us — nor the SEC is the registrant's own), never by prefix spelling.
- `SelectPersistable` admits extension concepts at **any** dimensionality, consolidated context included (the API owns only *standard* concepts' consolidated context, so the natural-key invariant holds); reference taxonomies (country, currency, ecd, …) remain skipped, as do undeclared/unparseable-namespace prefixes (skipped, never misfiled).
- Extractor `CurrentVersion` 2 → 3 so `XbrlFactsExtractionWorker` re-sweeps the captured corpus (newest filings first, purely local re-parse of stored envelopes).

## Code changes
- `Equibles.Sec.FinancialFacts.Data/Enums/FactTaxonomy.cs` — `Custom` arm + docs.
- `Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedXbrlFact.cs` — new `Namespace` property.
- `Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs` — document-wide `xmlns:*` prefix→URI map (case-insensitive), stamped on parsed facts.
- `Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs` — namespace from the element's `XName`.
- `Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs` — `TryResolveConcept`/`IsFilerExtensionNamespace` classification, custom-aware `SelectPersistable`, resolved-tag plumbing through `CollapseToNaturalKey`/`ResolveConcepts`/`BuildFact`, version 3.
- Tests: updated `SelectPersistable` suite (extension concepts now kept, reference taxonomies still dropped, post-prefix length gate) + new `TryResolveConcept` and inline-parser namespace-resolution suites.