### PR TITLE
fix(web): derive statement periods from statement concepts only

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -211,6 +211,16 @@ public class XbrlFactExtractionService
         taxonomy = FactTaxonomy.Custom;
         // Prefix casing follows the filer's whim; lowercase it so the same
         // concept lands on one FinancialConcept row across filings.
+        //
+        // Keying on the PREFIX (not the namespace URI) is a deliberate
+        // trade-off: extension namespace URIs are re-dated every filing
+        // (http://www.adobe.com/20231201 → …/20241129), so a URI key would
+        // split one company's concept history across rows, while the prefix
+        // is stable for a filer. Two filers sharing a generic prefix + local
+        // name would share a concept row — harmless for values (facts are
+        // stock-scoped, and extension concepts carry no SEC label; display
+        // labels are humanized from the local name), so meaning cannot leak
+        // across companies.
         tag = $"{fact.Taxonomy.ToLowerInvariant()}:{fact.Tag}";
         return true;
     }

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -542,12 +542,27 @@ public class StockTabService
 
     private async Task<List<FinancialsPeriodOption>> BuildAvailablePeriods(CommonStock stock)
     {
+        // Only periods with an actual STATEMENT fact qualify: filer-extension
+        // (Custom) KPI facts also live in the consolidated context now, and a
+        // KPI-only (year, period) would otherwise offer a dropdown option whose
+        // statement table renders empty.
+        var statementLines = Enum.GetValues<FinancialStatementType>()
+            .SelectMany(FinancialStatementConcepts.For)
+            .ToList();
+        var statementTaxonomies = statementLines.Select(l => l.Taxonomy).Distinct().ToList();
+        var statementTags = statementLines.Select(l => l.Tag).Distinct().ToList();
+        var statementConceptIds = await _financialConceptRepository
+            .GetMatching(statementTaxonomies, statementTags)
+            .Select(c => c.Id)
+            .ToListAsync();
+
         // Distinct (year, period) pairs the company actually reported. This is a
         // separate round trip from the per-period fact query below — both are
         // covered by the [CommonStockId, FiscalYear, FiscalPeriod] index, and
         // keeping them separate avoids loading every fact just to list periods.
         var periodKeys = await _financialFactRepository
             .GetConsolidatedByStock(stock)
+            .Where(f => statementConceptIds.Contains(f.FinancialConceptId))
             .Select(f => new { f.FiscalYear, f.FiscalPeriod })
             .Distinct()
             .ToListAsync();


### PR DESCRIPTION
## Summary
Follow-up to #4083. Consolidated filer-extension (Custom) KPI facts now persist, so `StockTabService.BuildAvailablePeriods`'s unfiltered consolidated scan could offer a (year, period) dropdown option backed only by KPI facts — a statement table that renders empty. Period discovery now restricts to concepts in the shared statement catalog, matching the per-period fact query (and the same filter the downstream consumers already apply).

Also documents the deliberate prefix-vs-namespace-URI keying trade-off for Custom concept tags (URIs are re-dated every filing, so a URI key would split a company's history; prefix collisions across filers cannot leak meaning because facts are stock-scoped and extension concepts carry no SEC label).

## Code changes
- `Equibles.Web/Services/StockTabService.cs` — resolve statement-concept ids up front and filter the period-key scan by them.
- `Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs` — comment-only: rationale for prefix-keyed Custom tags.