### PR TITLE
fix(financial-facts): revenue alias reaches back past ASC 606 via SalesRevenueNet

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -31,6 +31,11 @@ public static class FinancialConceptAliases
         [
             new(FactTaxonomy.UsGaap, "Revenues"),
             new(FactTaxonomy.UsGaap, "RevenueFromContractWithCustomerExcludingAssessedTax"),
+            // The dominant pre-ASC 606 total-revenue tag (AAPL, MSFT, … filed it
+            // through ~FY2017; deprecated 2018). Last so it only fills periods
+            // the modern tags lack — without it those companies' revenue series
+            // start mid-history.
+            new(FactTaxonomy.UsGaap, "SalesRevenueNet"),
         ],
         ["cost-of-revenue"] = [new(FactTaxonomy.UsGaap, "CostOfRevenue")],
         ["gross-profit"] = [new(FactTaxonomy.UsGaap, "GrossProfit")],

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesRevenuePreAsc606Tests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesRevenuePreAsc606Tests.cs
@@ -1,0 +1,24 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// The revenue alias must reach back past the ASC 606 transition: large filers
+/// (AAPL, MSFT) reported total revenue as <c>SalesRevenueNet</c> through
+/// ~FY2017, so a series built from the modern tags alone starts mid-history.
+/// The legacy tag sits LAST so it only fills periods the modern tags lack —
+/// per-period selection prefers lower-index refs.
+/// </summary>
+public class FinancialConceptAliasesRevenuePreAsc606Tests
+{
+    [Fact]
+    public void TryResolve_Revenue_IncludesLegacySalesRevenueNetLast()
+    {
+        FinancialConceptAliases.TryResolve("revenue", out var refs).Should().BeTrue();
+
+        refs[^1].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
+        refs[^1].Tag.Should().Be("SalesRevenueNet");
+        refs[0].Tag.Should().Be("Revenues");
+    }
+}


### PR DESCRIPTION
## Summary
Revenue series built from the `revenue` alias start mid-history for AAPL/MSFT-style filers: they reported total revenue as `SalesRevenueNet` through ~FY2017 (tag deprecated 2018), which the alias didn't include. Every alias consumer (Trends/metric series, MCP `GetFinancialFact`, dimensional revenue breakdown) gained only `Revenues` + the ASC 606 tag.

`SalesRevenueNet` joins the alias **last**, so per-period selection (which prefers lower-index refs) only uses it for periods the modern tags lack — no behavior change where modern tags exist.

## Code changes
- `Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs` — append `SalesRevenueNet` to `revenue`.
- New test pinning the ref order (legacy tag last).