### PR TITLE
feat(media): route every blob write through a single filesystem chokepoint

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -36,7 +36,6 @@ public class CommonStock
     /// </summary>
     public DateTime? WebsiteCheckedAt { get; set; }
 
-
     public double MarketCapitalization { get; set; }
     public long SharesOutStanding { get; set; }
 

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -368,8 +368,7 @@ public class InsiderFilingReprocessManager
             compressed,
             accession,
             "gz",
-            "application/gzip",
-            storage: Equibles.Media.Data.Models.StorageProvider.FileSystem
+            "application/gzip"
         );
 
         if (filing == null)

--- a/src/Equibles.Media.BusinessLogic/FileManager.cs
+++ b/src/Equibles.Media.BusinessLogic/FileManager.cs
@@ -1,10 +1,8 @@
 using Equibles.Core.AutoWiring;
-using Equibles.Media.BusinessLogic.Configuration;
 using Equibles.Media.BusinessLogic.Storage;
 using Equibles.Media.Data.Models;
 using Equibles.Media.Repositories;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using MimeTypes;
 using File = Equibles.Media.Data.Models.File;
 
@@ -34,23 +32,17 @@ public class FileManager : IFileManager
 
     private readonly FileRepository _fileRepository;
     private readonly PendingBlobDeletionRepository _pendingBlobDeletionRepository;
-    private readonly DatabaseFileStorageProvider _databaseProvider;
-    private readonly FileSystemFileStorageProvider _fileSystemProvider;
-    private readonly FileStorageOptions _options;
+    private readonly FileStorageRouter _storageRouter;
 
     public FileManager(
         FileRepository fileRepository,
         PendingBlobDeletionRepository pendingBlobDeletionRepository,
-        DatabaseFileStorageProvider databaseProvider,
-        FileSystemFileStorageProvider fileSystemProvider,
-        IOptions<FileStorageOptions> options
+        FileStorageRouter storageRouter
     )
     {
         _fileRepository = fileRepository;
         _pendingBlobDeletionRepository = pendingBlobDeletionRepository;
-        _databaseProvider = databaseProvider;
-        _fileSystemProvider = fileSystemProvider;
-        _options = options.Value;
+        _storageRouter = storageRouter;
     }
 
     /**
@@ -95,8 +87,7 @@ public class FileManager : IFileManager
             ContentType = contentType,
         };
 
-        // User uploads always stay in the database (small, hot, served directly).
-        await _databaseProvider.Save(file, content, FileStorageTiers.Blob);
+        await _storageRouter.Save(file, content, FileStorageTiers.Blob);
 
         _fileRepository.Add(file);
         return file;
@@ -114,7 +105,6 @@ public class FileManager : IFileManager
         string name,
         string extension,
         string contentType,
-        StorageProvider storage = null,
         string tier = null
     )
     {
@@ -125,8 +115,7 @@ public class FileManager : IFileManager
             ContentType = contentType,
         };
 
-        var provider = ResolveWriteProvider(storage);
-        await provider.Save(file, content, tier ?? FileStorageTiers.Blob);
+        await _storageRouter.Save(file, content, tier);
 
         _fileRepository.Add(file);
         return file;
@@ -134,12 +123,12 @@ public class FileManager : IFileManager
 
     public Task<byte[]> GetContent(File file)
     {
-        return ResolveProvider(file.StorageProvider).GetContent(file);
+        return _storageRouter.ReadProvider(file.StorageProvider).GetContent(file);
     }
 
     public Task<Stream> OpenRead(File file)
     {
-        return ResolveProvider(file.StorageProvider).OpenRead(file);
+        return _storageRouter.ReadProvider(file.StorageProvider).OpenRead(file);
     }
 
     /// <summary>
@@ -172,28 +161,5 @@ public class FileManager : IFileManager
         }
 
         _fileRepository.Delete(file);
-    }
-
-    // Filesystem writes are opt-in: when the store is disabled, fall back to the database
-    // so a deployment without a configured root keeps working unchanged.
-    private IFileStorageProvider ResolveWriteProvider(StorageProvider requested)
-    {
-        var target = requested ?? StorageProvider.Database;
-        if (target == StorageProvider.FileSystem && !_options.Enabled)
-        {
-            target = StorageProvider.Database;
-        }
-
-        return ResolveProvider(target);
-    }
-
-    private IFileStorageProvider ResolveProvider(StorageProvider provider)
-    {
-        if (provider == StorageProvider.FileSystem)
-        {
-            return _fileSystemProvider;
-        }
-
-        return _databaseProvider;
     }
 }

--- a/src/Equibles.Media.BusinessLogic/IFileManager.cs
+++ b/src/Equibles.Media.BusinessLogic/IFileManager.cs
@@ -1,4 +1,3 @@
-using Equibles.Media.Data.Models;
 using File = Equibles.Media.Data.Models.File;
 
 namespace Equibles.Media.BusinessLogic;
@@ -12,9 +11,9 @@ public interface IFileManager
     /// extension and content type, bypassing the <see cref="FileManager.AcceptedExtensions"/>
     /// upload allowlist. Use only for content the application itself produces — e.g. a
     /// gzip-compressed XBRL envelope captured during SEC ingest — never for inbound files.
-    /// <paramref name="storage"/> selects the backend (default Database preserves the original
-    /// behavior; SEC ingest passes FileSystem). A FileSystem request falls back to Database when
-    /// the store is disabled. <paramref name="tier"/> selects the filesystem durability partition
+    /// The backend is chosen by <see cref="Storage.FileStorageRouter"/>: the filesystem store
+    /// when it is enabled, otherwise the database — a caller cannot request the database while
+    /// the store is enabled. <paramref name="tier"/> selects the filesystem durability partition
     /// (see <see cref="Storage.FileStorageTiers"/>).
     /// </summary>
     public Task<File> SaveInternalFile(
@@ -22,7 +21,6 @@ public interface IFileManager
         string name,
         string extension,
         string contentType,
-        StorageProvider storage = null,
         string tier = null
     );
 

--- a/src/Equibles.Media.BusinessLogic/ImageManager.cs
+++ b/src/Equibles.Media.BusinessLogic/ImageManager.cs
@@ -1,4 +1,5 @@
 using Equibles.Core.AutoWiring;
+using Equibles.Media.BusinessLogic.Storage;
 using Equibles.Media.Data.Models;
 using Equibles.Media.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,10 +13,12 @@ namespace Equibles.Media.BusinessLogic;
 public class ImageManager : IImageManager
 {
     private readonly ImageRepository _imageRepository;
+    private readonly FileStorageRouter _storageRouter;
 
-    public ImageManager(ImageRepository imageRepository)
+    public ImageManager(ImageRepository imageRepository, FileStorageRouter storageRouter)
     {
         _imageRepository = imageRepository;
+        _storageRouter = storageRouter;
     }
 
     /**
@@ -70,13 +73,14 @@ public class ImageManager : IImageManager
         {
             Extension = fileExtension,
             Name = fileNameWithoutExtension,
-            Size = content.Length,
             ContentType = contentType,
             Height = imageProcessor.Height,
             Width = imageProcessor.Width,
         };
 
-        image.FileContent = new FileContent() { File = image, Bytes = content };
+        // Routes to the filesystem store when enabled, otherwise the database — the router
+        // stamps Size/StorageProvider and the content location on the image.
+        await _storageRouter.Save(image, content, FileStorageTiers.Blob);
         _imageRepository.Add(image);
         return image;
     }

--- a/src/Equibles.Media.BusinessLogic/Storage/FileStorageRouter.cs
+++ b/src/Equibles.Media.BusinessLogic/Storage/FileStorageRouter.cs
@@ -1,0 +1,51 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.Data.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.Media.BusinessLogic.Storage;
+
+/// <summary>
+/// The single decision point for where blob bytes live. When the filesystem store is enabled,
+/// every new write goes to the content-addressed filesystem — there is deliberately no code
+/// path that persists new bytes in the database. When it is disabled (a self-hosted deployment
+/// without a configured root), writes fall back to the database so the application keeps
+/// working unchanged. Reads always dispatch on the provider recorded on the row, so blobs
+/// written under either mode stay readable after the setting changes.
+/// </summary>
+[Service(ServiceLifetime.Scoped)]
+public class FileStorageRouter
+{
+    private readonly DatabaseFileStorageProvider _databaseProvider;
+    private readonly FileSystemFileStorageProvider _fileSystemProvider;
+    private readonly FileStorageOptions _options;
+
+    public FileStorageRouter(
+        DatabaseFileStorageProvider databaseProvider,
+        FileSystemFileStorageProvider fileSystemProvider,
+        IOptions<FileStorageOptions> options
+    )
+    {
+        _databaseProvider = databaseProvider;
+        _fileSystemProvider = fileSystemProvider;
+        _options = options.Value;
+    }
+
+    /// <summary>
+    /// The provider new bytes are written through: the filesystem whenever the store is enabled,
+    /// otherwise the database. There is no way for a caller to request the database while the
+    /// store is enabled — that is the point.
+    /// </summary>
+    public IFileStorageProvider WriteProvider =>
+        _options.Enabled ? _fileSystemProvider : _databaseProvider;
+
+    /// <summary>Writes bytes for a new file through the write provider, stamping the row.</summary>
+    public Task Save(File file, byte[] content, string tier = null) =>
+        WriteProvider.Save(file, content, tier ?? FileStorageTiers.Blob);
+
+    /// <summary>Resolves the provider for reading a file by the value recorded when it was written.</summary>
+    public IFileStorageProvider ReadProvider(StorageProvider stored) =>
+        stored == StorageProvider.FileSystem ? _fileSystemProvider : _databaseProvider;
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsCaptureService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsCaptureService.cs
@@ -140,8 +140,7 @@ public class ReportedStatementsCaptureService
             compressed,
             accession,
             "gz",
-            "application/gzip",
-            storage: Equibles.Media.Data.Models.StorageProvider.FileSystem
+            "application/gzip"
         );
 
         document.ReportedStatementsContent = file;

--- a/src/Equibles.Sec.HostedService/Services/DocumentImageService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentImageService.cs
@@ -57,8 +57,7 @@ public class DocumentImageService
                 image.Bytes,
                 FileNameWithoutExtension(image.FileName).TruncateToFit(MaxFileNameLength),
                 Extension(image.FileName).TruncateToFit(MaxExtensionLength),
-                image.ContentType,
-                storage: Equibles.Media.Data.Models.StorageProvider.FileSystem
+                image.ContentType
             );
 
             _documentImageRepository.Add(

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -178,8 +178,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
             content,
             Path.GetFileNameWithoutExtension(fileName),
             extension,
-            "text/plain",
-            storage: Media.Data.Models.StorageProvider.FileSystem
+            "text/plain"
         );
     }
 
@@ -202,8 +201,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
             compressed,
             name,
             "gz",
-            "application/gzip",
-            storage: Equibles.Media.Data.Models.StorageProvider.FileSystem
+            "application/gzip"
         );
 
         document.XbrlContent = xbrlFile;
@@ -242,8 +240,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
             compressed,
             name,
             "gz",
-            "application/gzip",
-            storage: Equibles.Media.Data.Models.StorageProvider.FileSystem
+            "application/gzip"
         );
 
         document.AsFiledHtmlContent = htmlFile;

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -185,8 +185,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             compressed,
             filing.AccessionNumber,
             "gz",
-            "application/gzip",
-            storage: Equibles.Media.Data.Models.StorageProvider.FileSystem
+            "application/gzip"
         );
 
         filingRepository.Add(

--- a/tests/Equibles.IntegrationTests/Helpers/FileManagerTestFactory.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/FileManagerTestFactory.cs
@@ -24,13 +24,16 @@ internal static class FileManagerTestFactory
     )
     {
         var wrapped = Options.Create(options ?? new FileStorageOptions());
+        var router = new FileStorageRouter(
+            new DatabaseFileStorageProvider(),
+            new FileSystemFileStorageProvider(wrapped),
+            wrapped
+        );
         return new FileManager(
             repository,
             pendingBlobDeletionRepository
                 ?? Substitute.For<PendingBlobDeletionRepository>((EquiblesFinancialDbContext)null),
-            new DatabaseFileStorageProvider(),
-            new FileSystemFileStorageProvider(wrapped),
-            wrapped
+            router
         );
     }
 }

--- a/tests/Equibles.IntegrationTests/Helpers/FileStorageRouterTestFactory.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/FileStorageRouterTestFactory.cs
@@ -1,0 +1,28 @@
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.BusinessLogic.Storage;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.IntegrationTests.Helpers;
+
+/// <summary>
+/// Builds a <see cref="FileStorageRouter"/> for tests. With the store disabled (the default)
+/// the router writes to the database, matching tests that assert on inline byte content;
+/// pass a root path to exercise the filesystem write path.
+/// </summary>
+internal static class FileStorageRouterTestFactory
+{
+    public static FileStorageRouter Disabled()
+    {
+        return Create(new FileStorageOptions());
+    }
+
+    public static FileStorageRouter Create(FileStorageOptions options)
+    {
+        var wrapped = Options.Create(options);
+        return new FileStorageRouter(
+            new DatabaseFileStorageProvider(),
+            new FileSystemFileStorageProvider(wrapped),
+            wrapped
+        );
+    }
+}

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFetchedTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFetchedTests.cs
@@ -111,7 +111,6 @@ public class InsiderFilingReprocessManagerFetchedTests : ParadeDbMcpTestBase
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<Equibles.Media.Data.Models.StorageProvider>(),
                 Arg.Any<string>()
             )
             .Returns(ci => new File
@@ -148,7 +147,6 @@ public class InsiderFilingReprocessManagerFetchedTests : ParadeDbMcpTestBase
                 accession,
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Equibles.Media.Data.Models.StorageProvider.FileSystem,
                 Arg.Any<string>()
             );
 

--- a/tests/Equibles.IntegrationTests/Media/ImageManagerFilesystemStoreTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/ImageManagerFilesystemStoreTests.cs
@@ -1,0 +1,57 @@
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.Data;
+using Equibles.Media.Data.Models;
+using Equibles.Media.Repositories;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Media;
+
+/// <summary>
+/// Proves images take the same chokepoint as every other blob: with the filesystem store
+/// enabled, a saved image is written to disk and carries no inline database bytes.
+/// </summary>
+public class ImageManagerFilesystemStoreTests
+{
+    private static byte[] Png(int width, int height)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream);
+        return stream.ToArray();
+    }
+
+    [Fact]
+    public async Task SaveImage_WhenStoreEnabled_WritesToDiskWithNoDatabaseBytes()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "eq-img-fs-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var context = TestDbContextFactory.Create(new MediaModuleConfiguration());
+            var router = FileStorageRouterTestFactory.Create(
+                new FileStorageOptions { Enabled = true, RootPath = root }
+            );
+            var sut = new ImageManager(new ImageRepository(context), router);
+
+            var image = await sut.SaveImage(Png(8, 8), "logo.png", null, null);
+
+            image.StorageProvider.Should().Be(StorageProvider.FileSystem);
+            image.FileContent.Should().BeNull();
+            image.RelativePath.Should().StartWith("blob/sha256/");
+            System
+                .IO.File.Exists(
+                    Path.Combine(root, image.RelativePath.Replace('/', Path.DirectorySeparatorChar))
+                )
+                .Should()
+                .BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
@@ -14,7 +14,10 @@ public class ImageManagerSaveImageMaxBoundsTests
     public ImageManagerSaveImageMaxBoundsTests()
     {
         var context = TestDbContextFactory.Create(new MediaModuleConfiguration());
-        _sut = new ImageManager(new ImageRepository(context));
+        _sut = new ImageManager(
+            new ImageRepository(context),
+            FileStorageRouterTestFactory.Disabled()
+        );
     }
 
     private static byte[] CreateMinimalPng(int width, int height)

--- a/tests/Equibles.IntegrationTests/Media/ImageManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/ImageManagerTests.cs
@@ -16,7 +16,8 @@ public class ImageManagerTests
     {
         var context = TestDbContextFactory.Create(new MediaModuleConfiguration());
         _repository = new ImageRepository(context);
-        _sut = new ImageManager(_repository);
+        // Store disabled → the router persists images in the database, matching these assertions.
+        _sut = new ImageManager(_repository, FileStorageRouterTestFactory.Disabled());
     }
 
     private static byte[] CreateMinimalPng(int width = 10, int height = 10)

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceSaveTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceSaveTests.cs
@@ -85,7 +85,6 @@ public class DocumentPersistenceServiceSaveTests : ParadeDbMcpTestBase
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<Equibles.Media.Data.Models.StorageProvider>(),
                 Arg.Any<string>()
             )
             .Returns(_ => Task.FromResult(savedFile));

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceTests.cs
@@ -99,7 +99,6 @@ public class DocumentPersistenceServiceTests : IDisposable
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<Equibles.Media.Data.Models.StorageProvider>(),
                 Arg.Any<string>()
             )
             .Returns(savedFile);

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
@@ -36,7 +36,6 @@ public class DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests : Parade
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<Equibles.Media.Data.Models.StorageProvider>(),
                 Arg.Any<string>()
             )
             .Returns(ci =>

--- a/tests/Equibles.UnitTests/Media/FileManagerDeleteFileQueueTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerDeleteFileQueueTests.cs
@@ -21,13 +21,12 @@ public class FileManagerDeleteFileQueueTests
         var files = Substitute.For<FileRepository>((EquiblesFinancialDbContext)null);
         var queue = Substitute.For<PendingBlobDeletionRepository>((EquiblesFinancialDbContext)null);
         var options = Options.Create(new FileStorageOptions());
-        var manager = new FileManager(
-            files,
-            queue,
+        var router = new FileStorageRouter(
             new DatabaseFileStorageProvider(),
             new FileSystemFileStorageProvider(options),
             options
         );
+        var manager = new FileManager(files, queue, router);
         return (manager, files, queue);
     }
 

--- a/tests/Equibles.UnitTests/Media/FileManagerTestFactory.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerTestFactory.cs
@@ -18,12 +18,15 @@ internal static class FileManagerTestFactory
     public static FileManager Create(FileRepository repository, FileStorageOptions options = null)
     {
         var wrapped = Options.Create(options ?? new FileStorageOptions());
-        return new FileManager(
-            repository,
-            Substitute.For<PendingBlobDeletionRepository>((EquiblesFinancialDbContext)null),
+        var router = new FileStorageRouter(
             new DatabaseFileStorageProvider(),
             new FileSystemFileStorageProvider(wrapped),
             wrapped
+        );
+        return new FileManager(
+            repository,
+            Substitute.For<PendingBlobDeletionRepository>((EquiblesFinancialDbContext)null),
+            router
         );
     }
 }

--- a/tests/Equibles.UnitTests/Media/FileStorageRouterTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileStorageRouterTests.cs
@@ -1,0 +1,82 @@
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.BusinessLogic.Storage;
+using Equibles.Media.Data.Models;
+using Microsoft.Extensions.Options;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.UnitTests.Media;
+
+public class FileStorageRouterTests
+{
+    private static FileStorageRouter Build(bool enabled, string root = null)
+    {
+        var options = Options.Create(new FileStorageOptions { Enabled = enabled, RootPath = root });
+        return new FileStorageRouter(
+            new DatabaseFileStorageProvider(),
+            new FileSystemFileStorageProvider(options),
+            options
+        );
+    }
+
+    // The whole point of the chokepoint: when the store is enabled there is no way to land
+    // new bytes in the database — the write provider is the filesystem, period.
+    [Fact]
+    public void WriteProvider_WhenStoreEnabled_IsFilesystem()
+    {
+        Build(enabled: true, root: "/tmp/x")
+            .WriteProvider.Provider.Should()
+            .Be(StorageProvider.FileSystem);
+    }
+
+    // Disabled (a self-hosted deployment without a configured root) still writes to the
+    // database, so the app keeps working with no filesystem store.
+    [Fact]
+    public void WriteProvider_WhenStoreDisabled_IsDatabase()
+    {
+        Build(enabled: false).WriteProvider.Provider.Should().Be(StorageProvider.Database);
+    }
+
+    // Enabling the store writes new content to the filesystem and stamps the row — no
+    // FileContent bytes are attached.
+    [Fact]
+    public async Task Save_WhenEnabled_StampsFilesystemAndLeavesNoDatabaseBytes()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "eq-router-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var file = new File
+            {
+                Name = "x",
+                Extension = "gz",
+                ContentType = "application/gzip",
+            };
+            await Build(enabled: true, root: root)
+                .Save(file, "hello"u8.ToArray(), FileStorageTiers.Blob);
+
+            file.StorageProvider.Should().Be(StorageProvider.FileSystem);
+            file.FileContent.Should().BeNull();
+            file.RelativePath.Should().StartWith("blob/sha256/");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    // Reads always follow the provider recorded on the row, independent of the current
+    // setting, so content stored under either mode stays reachable.
+    [Fact]
+    public void ReadProvider_DispatchesOnStoredValue()
+    {
+        var router = Build(enabled: true, root: "/tmp/x");
+        router
+            .ReadProvider(StorageProvider.Database)
+            .Provider.Should()
+            .Be(StorageProvider.Database);
+        router
+            .ReadProvider(StorageProvider.FileSystem)
+            .Provider.Should()
+            .Be(StorageProvider.FileSystem);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last way new blobs could land in Postgres. Previously the filesystem store was opt-in per write: `SaveInternalFile` defaulted to the database and callers had to pass `storage: FileSystem`, `SaveFile` (user uploads) was hardcoded to the database, and `SaveImage` built a `FileContent` inline. Any caller that forgot to opt in slowly re-bloated the database.

Now a single **`FileStorageRouter`** is the one decision point for where bytes live:
- **Store enabled → filesystem, always.** There is no code path — and after this change no *API* — to persist new bytes in the database while the store is on.
- **Store disabled → database** (a self-hosted deployment without a configured root keeps working unchanged).
- **Reads** dispatch on the `StorageProvider` recorded on each row, so blobs written under either mode stay readable after the setting flips.

## Changes
- New `FileStorageRouter` (`Save` / `WriteProvider` / `ReadProvider`), `[Service]`-registered.
- `FileManager.SaveFile` and `SaveInternalFile` write through the router; `GetContent`/`OpenRead` read through it. The `storage` parameter is **removed** from `SaveInternalFile` (and `IFileManager`) — callers can no longer request the database. All OSS call sites updated.
- `ImageManager.SaveImage` writes through the router instead of constructing `FileContent` inline, so images obey the same rule.
- Tests: new `FileStorageRouterTests` (enabled→FS, disabled→DB, stamps row + no inline bytes, read dispatch) and `ImageManagerFilesystemStoreTests` (image saved with the store on lands on disk, no `FileContent`); existing factories/mocks updated for the new ctor and signature.

## Verification
Solution builds clean; csharpier clean; Media unit tests 34 pass; affected integration tests (ImageManager, FileBackfill, BlobDeletionSweep, DocumentPersistence, InsiderFilingReprocess) all pass.

## Rollout note
On the deployment where the store is enabled, the ~few-thousand database rows that accumulated while writes were still opt-in will be migrated to disk by a one-shot re-enable of the existing backfill drain (ops step, not code).

A.L.V.I.S.