### PR TITLE
perf(sec,holdings): floor backfill polls at the frontier and cover 13F holder rollups

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -59,6 +59,12 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
         // filtered out millions of rows before finding the match and hit the 30s
         // command timeout — a hard 500 on /institutions/{id} and
         // /stocks/{ticker}/holders/{cik} (#3605).
+        //
+        // FilingType rides along so the 13F-only per-holder rollups (Only13F():
+        // quarterly TotalValue/PositionCount trend, distinct report dates) stay
+        // index-only. FilingType is in no holder-leading index, so its filter
+        // forced a heap fetch for every index row — ~5s and 100k+ buffer reads
+        // per trend query for a mega-filer, thousands of times a day.
         builder
             .Entity<InstitutionalHolding>()
             .HasIndex(h => new { h.InstitutionalHolderId, h.ReportDate })
@@ -68,6 +74,7 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
                 h.Value,
                 h.Shares,
                 h.FilingDate,
+                h.FilingType,
             });
 
         // Covering index for the per-stock 13F ranking pages (Most-Held Stocks,

--- a/src/Equibles.Migrations/Migrations/20260703143851_ChunkCreationTimeAndHolderFilingTypeIndexes.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260703143851_ChunkCreationTimeAndHolderFilingTypeIndexes.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703143851_ChunkCreationTimeAndHolderFilingTypeIndexes")]
+    partial class ChunkCreationTimeAndHolderFilingTypeIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260703143851_ChunkCreationTimeAndHolderFilingTypeIndexes.cs
+++ b/src/Equibles.Migrations/Migrations/20260703143851_ChunkCreationTimeAndHolderFilingTypeIndexes.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChunkCreationTimeAndHolderFilingTypeIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding",
+                columns: new[] { "InstitutionalHolderId", "ReportDate" })
+                .Annotation("Npgsql:IndexInclude", new[] { "CommonStockId", "Value", "Shares", "FilingDate", "FilingType" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Chunk_CreationTime",
+                table: "Chunk",
+                column: "CreationTime");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Chunk_CreationTime",
+                table: "Chunk");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding",
+                columns: new[] { "InstitutionalHolderId", "ReportDate" })
+                .Annotation("Npgsql:IndexInclude", new[] { "CommonStockId", "Value", "Shares", "FilingDate" });
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Chunks/Chunk.cs
+++ b/src/Equibles.Sec.Data/Models/Chunks/Chunk.cs
@@ -6,6 +6,7 @@ namespace Equibles.Sec.Data.Models.Chunks;
 
 [Index(nameof(DocumentId), nameof(Index), IsUnique = true)]
 [Index(nameof(DocumentType), IsUnique = false)]
+[Index(nameof(CreationTime))]
 [Bm25Index(
     nameof(Id),
     nameof(Content),

--- a/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
+++ b/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
@@ -20,6 +20,12 @@ public class DocumentProcessorWorker : BaseScraperWorker
     // visibility comes from the System Health probe + activity feed, not these rows.
     protected override int ErrorReportThreshold => 20;
 
+    // Backfill frontiers for the two phases. They live on the worker (a singleton) because the
+    // DocumentManager is re-resolved from a fresh scope per batch; a process restart resets
+    // them, which just costs one full scan before the floored fast path takes over again.
+    private readonly BackfillCursor _chunkCursor = new();
+    private readonly BackfillCursor _embeddingCursor = new();
+
     public DocumentProcessorWorker(
         ILogger<DocumentProcessorWorker> logger,
         IServiceScopeFactory scopeFactory,
@@ -34,7 +40,7 @@ public class DocumentProcessorWorker : BaseScraperWorker
         {
             await using var chunkScope = ScopeFactory.CreateAsyncScope();
             var documentManager = chunkScope.ServiceProvider.GetRequiredService<DocumentManager>();
-            var workDone = await documentManager.ChunkDocumentBatch(stoppingToken);
+            var workDone = await documentManager.ChunkDocumentBatch(_chunkCursor, stoppingToken);
             if (!workDone)
                 break;
         }
@@ -45,7 +51,10 @@ public class DocumentProcessorWorker : BaseScraperWorker
         {
             await using var embedScope = ScopeFactory.CreateAsyncScope();
             var documentManager = embedScope.ServiceProvider.GetRequiredService<DocumentManager>();
-            var workDone = await documentManager.GenerateEmbeddingBatch(stoppingToken);
+            var workDone = await documentManager.GenerateEmbeddingBatch(
+                _embeddingCursor,
+                stoppingToken
+            );
             if (!workDone)
                 break;
         }

--- a/src/Equibles.Sec.HostedService/Services/BackfillCursor.cs
+++ b/src/Equibles.Sec.HostedService/Services/BackfillCursor.cs
@@ -1,0 +1,49 @@
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Tracks how far a CreationTime-ordered backfill has progressed so each poll seeks straight
+/// to the frontier instead of anti-joining the whole table. New rows are always created at the
+/// frontier (CreationTime = insert time), so a floored batch query sees all new work; rows left
+/// behind the frontier (an item that failed to process, or work re-queued by deleting its
+/// output) are caught by a rate-limited full rescan. The cursor is owned by the long-lived
+/// worker — the per-scope manager only reads and advances it — so it survives DI scopes and
+/// resets on process restart, which itself forces a fresh full scan.
+/// </summary>
+public class BackfillCursor
+{
+    // A full (unfloored) scan anti-joins the entire table — minutes on the chunk corpus — so
+    // the drained-frontier fallback is allowed at most once per interval. One hour keeps the
+    // straggler-retry latency bounded without letting the scan dominate idle DB load again.
+    private static readonly TimeSpan FullRescanInterval = TimeSpan.FromHours(1);
+
+    private DateTime _lastFullScanUtc = DateTime.MinValue;
+
+    /// <summary>
+    /// Lower bound for the next batch query, or null when the next query must scan from the
+    /// start. Batches are CreationTime-ordered, so queries use an inclusive floor: rows that
+    /// share the frontier timestamp are re-read, and the ones already processed drop out via
+    /// the query's own not-yet-processed predicate.
+    /// </summary>
+    public DateTime? Floor { get; private set; }
+
+    /// <summary>Moves the frontier to the newest CreationTime the current batch reached.</summary>
+    public void Advance(DateTime lastBatchCreationTime)
+    {
+        Floor = lastBatchCreationTime;
+    }
+
+    /// <summary>
+    /// Clears the floor for a full rescan when one hasn't run within the rescan interval.
+    /// Returns false when the fallback is still rate-limited — the caller should treat the
+    /// backfill as drained for this poll.
+    /// </summary>
+    public bool TryStartFullRescan(DateTime utcNow)
+    {
+        if (utcNow - _lastFullScanUtc < FullRescanInterval)
+            return false;
+
+        _lastFullScanUtc = utcNow;
+        Floor = null;
+        return true;
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
@@ -36,38 +36,67 @@ public class DocumentManager
         _logger = logger;
     }
 
-    public async Task<bool> ChunkDocumentBatch(CancellationToken cancellationToken)
-    {
-        var pendingDocuments = await _documentRepository
-            .GetAll()
-            .Include(d => d.CommonStock)
-            .Include(d => d.Content)
-            .Where(d => !d.Chunks.Any() && d.Content != null)
-            .OrderBy(d => d.CreationTime)
-            .Take(_loadSize)
-            .ToListAsync(cancellationToken);
+    // Both batch loaders anti-join a huge table ("no chunks yet" / "no embeddings yet") ordered
+    // by CreationTime. Unfloored, that anti-join hashes the entire table on every poll — minutes
+    // of I/O each time on the chunk corpus. The caller-owned cursor floors each poll at the
+    // backfill frontier so the CreationTime index seeks straight to the pending rows; the
+    // rate-limited full-rescan fallback in LoadBatch catches rows left behind the frontier.
 
-        if (!pendingDocuments.Any())
+    public async Task<bool> ChunkDocumentBatch(
+        BackfillCursor cursor,
+        CancellationToken cancellationToken
+    )
+    {
+        var pendingDocuments = await LoadBatch(
+            floor =>
+            {
+                var query = _documentRepository
+                    .GetAll()
+                    .Include(d => d.CommonStock)
+                    .Include(d => d.Content)
+                    .Where(d => !d.Chunks.Any() && d.Content != null);
+                if (floor is { } f)
+                    query = query.Where(d => d.CreationTime >= f);
+                return query
+                    .OrderBy(d => d.CreationTime)
+                    .Take(_loadSize)
+                    .ToListAsync(cancellationToken);
+            },
+            cursor
+        );
+
+        if (pendingDocuments.Count == 0)
             return false;
 
         _logger.LogInformation("Chunking {Count} documents", pendingDocuments.Count);
         await _documentProcessor.ProcessDocuments(pendingDocuments, cancellationToken);
+        cursor.Advance(pendingDocuments[^1].CreationTime);
         return true;
     }
 
-    public async Task<bool> GenerateEmbeddingBatch(CancellationToken cancellationToken)
+    public async Task<bool> GenerateEmbeddingBatch(
+        BackfillCursor cursor,
+        CancellationToken cancellationToken
+    )
     {
         if (!_embeddingConfig.IsConfigured)
             return false;
 
-        var chunksWithoutEmbeddings = await _chunkRepository
-            .GetAll()
-            .Where(c => !c.Embeddings.Any())
-            .OrderBy(c => c.CreationTime)
-            .Take(_loadSize)
-            .ToListAsync(cancellationToken);
+        var chunksWithoutEmbeddings = await LoadBatch(
+            floor =>
+            {
+                var query = _chunkRepository.GetAll().Where(c => !c.Embeddings.Any());
+                if (floor is { } f)
+                    query = query.Where(c => c.CreationTime >= f);
+                return query
+                    .OrderBy(c => c.CreationTime)
+                    .Take(_loadSize)
+                    .ToListAsync(cancellationToken);
+            },
+            cursor
+        );
 
-        if (!chunksWithoutEmbeddings.Any())
+        if (chunksWithoutEmbeddings.Count == 0)
             return false;
 
         _logger.LogInformation(
@@ -75,6 +104,27 @@ public class DocumentManager
             chunksWithoutEmbeddings.Count
         );
         await _documentProcessor.GenerateEmbeddings(chunksWithoutEmbeddings, cancellationToken);
+        cursor.Advance(chunksWithoutEmbeddings[^1].CreationTime);
         return true;
+    }
+
+    // Floored batch first; when the frontier drains, at most one rate-limited full scan so
+    // stragglers behind the cursor (failed items, re-queued work) are eventually retried.
+    private static async Task<List<T>> LoadBatch<T>(
+        Func<DateTime?, Task<List<T>>> query,
+        BackfillCursor cursor
+    )
+    {
+        if (cursor.Floor is { } floor)
+        {
+            var batch = await query(floor);
+            if (batch.Count > 0)
+                return batch;
+        }
+
+        if (!cursor.TryStartFullRescan(DateTime.UtcNow))
+            return [];
+
+        return await query(null);
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
@@ -96,7 +96,7 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
             NullLogger<DocumentManager>()
         );
 
-        var workDone = await sut.ChunkDocumentBatch(CancellationToken.None);
+        var workDone = await sut.ChunkDocumentBatch(new BackfillCursor(), CancellationToken.None);
 
         workDone
             .Should()
@@ -186,7 +186,7 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
             NullLogger<DocumentManager>()
         );
 
-        var workDone = await sut.GenerateEmbeddingBatch(CancellationToken.None);
+        var workDone = await sut.GenerateEmbeddingBatch(new BackfillCursor(), CancellationToken.None);
 
         workDone
             .Should()

--- a/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
@@ -1,0 +1,66 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class BackfillCursorTests
+{
+    [Fact]
+    public void Floor_NewCursor_IsNull()
+    {
+        var cursor = new BackfillCursor();
+
+        cursor.Floor.Should().BeNull();
+    }
+
+    [Fact]
+    public void Advance_SetsFloorToBatchFrontier()
+    {
+        var cursor = new BackfillCursor();
+        var frontier = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
+
+        cursor.Advance(frontier);
+
+        cursor.Floor.Should().Be(frontier);
+    }
+
+    [Fact]
+    public void TryStartFullRescan_FirstCall_AllowsAndClearsFloor()
+    {
+        var cursor = new BackfillCursor();
+        cursor.Advance(new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc));
+
+        var allowed = cursor.TryStartFullRescan(new DateTime(2026, 7, 3, 13, 0, 0, DateTimeKind.Utc));
+
+        allowed.Should().BeTrue();
+        cursor.Floor.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryStartFullRescan_WithinRescanInterval_IsRateLimitedAndKeepsFloor()
+    {
+        var cursor = new BackfillCursor();
+        var firstScan = new DateTime(2026, 7, 3, 13, 0, 0, DateTimeKind.Utc);
+        cursor.TryStartFullRescan(firstScan);
+        var frontier = new DateTime(2026, 7, 3, 13, 30, 0, DateTimeKind.Utc);
+        cursor.Advance(frontier);
+
+        var allowed = cursor.TryStartFullRescan(firstScan.AddMinutes(59));
+
+        allowed.Should().BeFalse();
+        cursor.Floor.Should().Be(frontier);
+    }
+
+    [Fact]
+    public void TryStartFullRescan_AfterRescanInterval_AllowsAgain()
+    {
+        var cursor = new BackfillCursor();
+        var firstScan = new DateTime(2026, 7, 3, 13, 0, 0, DateTimeKind.Utc);
+        cursor.TryStartFullRescan(firstScan);
+        cursor.Advance(new DateTime(2026, 7, 3, 13, 30, 0, DateTimeKind.Utc));
+
+        var allowed = cursor.TryStartFullRescan(firstScan.AddMinutes(61));
+
+        allowed.Should().BeTrue();
+        cursor.Floor.Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentManagerTests.cs
@@ -25,7 +25,7 @@ public class DocumentManagerTests
 
         var sut = new DocumentManager(null, null, processor, embeddingConfig, logger);
 
-        var result = await sut.GenerateEmbeddingBatch(CancellationToken.None);
+        var result = await sut.GenerateEmbeddingBatch(new BackfillCursor(), CancellationToken.None);
 
         result.Should().BeFalse();
         await processor
@@ -49,7 +49,7 @@ public class DocumentManagerTests
 
         var sut = new DocumentManager(null, null, processor, embeddingConfig, logger);
 
-        var result = await sut.GenerateEmbeddingBatch(CancellationToken.None);
+        var result = await sut.GenerateEmbeddingBatch(new BackfillCursor(), CancellationToken.None);
 
         result.Should().BeFalse();
     }
@@ -70,7 +70,7 @@ public class DocumentManagerTests
 
         var sut = new DocumentManager(null, null, processor, embeddingConfig, logger);
 
-        var result = await sut.GenerateEmbeddingBatch(CancellationToken.None);
+        var result = await sut.GenerateEmbeddingBatch(new BackfillCursor(), CancellationToken.None);
 
         result.Should().BeFalse();
     }


### PR DESCRIPTION
## Summary
Production profiling (pg_stat_statements over a 20h window) showed two systemic database drains:

- The document-processor worker's batch loaders (documents without chunks, chunks without embeddings) anti-join the **entire table** on every poll — a ~96s parallel seq scan over the 98 GB chunk corpus, 266×/day (~7h of DB time daily), saturating I/O and dragging unrelated portal queries from ~30ms to 30s+ tail latencies.
- The 13F per-holder rollups (quarterly value/position trend, distinct report dates — ~16k + 62k calls/day) filter on `FilingType`, which was in no holder-leading index: every index row forced a heap fetch, ~5s and 100k+ buffer reads per query for a mega-filer.

## Code changes
- `Equibles.Sec.HostedService/Services/BackfillCursor.cs` (new) — worker-owned frontier cursor: floored batch queries seek straight to the pending rows; a rate-limited (hourly) full rescan still catches items left behind the frontier (failed items, re-queued work). Process restart resets it, costing one full scan.
- `Equibles.Sec.HostedService/Services/DocumentManager.cs` — both batch loaders take the cursor, apply the `CreationTime >= floor` bound conditionally (so the unfloored SQL keeps its plan), and advance the cursor past each processed batch.
- `Equibles.Sec.HostedService/DocumentProcessorWorker.cs` — holds the two cursors (singleton lifetime; the manager is re-resolved per scope).
- `Equibles.Sec.Data/Models/Chunks/Chunk.cs` — new `CreationTime` index so the floored, ordered poll is an index seek.
- `Equibles.Holdings.Data/HoldingsModuleConfiguration.cs` — `FilingType` added to the per-holder covering index INCLUDE list so the 13F-only rollups run index-only.
- `Equibles.Migrations` — migration for both index changes.
- Tests: new `BackfillCursorTests`; existing DocumentManager unit + integration tests updated to the new signature. Full unit suite green (3201 passed).