### PR TITLE
feat(financial-facts): richer statement catalog with tag variants + concept documentation sweep

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260703144330_FinancialConceptDescriptionAndBalance.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260703144330_FinancialConceptDescriptionAndBalance.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703144330_FinancialConceptDescriptionAndBalance")]
+    partial class FinancialConceptDescriptionAndBalance
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1335,7 +1338,7 @@ namespace Equibles.Migrations.Migrations
 
                     b.HasIndex("InstitutionalHolderId", "ReportDate");
 
-                    NpgsqlIndexBuilderExtensions.IncludeProperties(b.HasIndex("InstitutionalHolderId", "ReportDate"), new[] { "CommonStockId", "Value", "Shares", "FilingDate", "FilingType" });
+                    NpgsqlIndexBuilderExtensions.IncludeProperties(b.HasIndex("InstitutionalHolderId", "ReportDate"), new[] { "CommonStockId", "Value", "Shares", "FilingDate" });
 
                     b.HasIndex("ReportDate", "CommonStockId", "InstitutionalHolderId");
 
@@ -1918,8 +1921,6 @@ namespace Equibles.Migrations.Migrations
                         .HasColumnType("character varying(20)");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("CreationTime");
 
                     b.HasIndex("DocumentType");
 

--- a/src/Equibles.Migrations/Migrations/20260703144330_FinancialConceptDescriptionAndBalance.cs
+++ b/src/Equibles.Migrations/Migrations/20260703144330_FinancialConceptDescriptionAndBalance.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class FinancialConceptDescriptionAndBalance : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ConceptMetadataCheckedAt",
+                table: "FinancialFactsSyncStatus",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Balance",
+                table: "FinancialConcept",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "FinancialConcept",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConceptMetadataCheckedAt",
+                table: "FinancialFactsSyncStatus");
+
+            migrationBuilder.DropColumn(
+                name: "Balance",
+                table: "FinancialConcept");
+
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "FinancialConcept");
+        }
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/Enums/ConceptBalance.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Enums/ConceptBalance.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Sec.FinancialFacts.Data.Enums;
+
+/// <summary>
+/// The XBRL balance attribute of a concept — its normal accounting balance.
+/// On an income statement a debit concept is expense-like and a credit concept
+/// income-like; on a balance sheet debit means asset-like and credit means
+/// liability/equity-like. Sourced from the filing's MetaLinks <c>crdr</c>
+/// attribute; null for concepts without a balance (ratios, share counts, …).
+/// </summary>
+public enum ConceptBalance
+{
+    Debit = 1,
+    Credit = 2,
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/Enums/ConceptBalance.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Enums/ConceptBalance.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace Equibles.Sec.FinancialFacts.Data.Enums;
 
 /// <summary>

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialConcept.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialConcept.cs
@@ -30,6 +30,20 @@ public class FinancialConcept
     [MaxLength(512)]
     public string Label { get; set; }
 
+    /// <summary>
+    /// The concept's authoritative documentation text: FASB's definition for
+    /// standard-taxonomy tags, the filer's own documentation label for
+    /// extension (<see cref="FactTaxonomy.Custom"/>) tags. Sourced from SEC
+    /// Company Facts and filings' MetaLinks; null until ingested.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// The concept's normal accounting balance (XBRL <c>crdr</c>); null for
+    /// concepts without one or not yet ingested.
+    /// </summary>
+    public ConceptBalance? Balance { get; set; }
+
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 
     public virtual List<FinancialFact> Facts { get; set; } = [];

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactsSyncStatus.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactsSyncStatus.cs
@@ -24,4 +24,12 @@ public class FinancialFactsSyncStatus
 
     /// <summary>Newest filed date ingested so far; null until the first run.</summary>
     public DateOnly? LastFiledDateSeen { get; set; }
+
+    /// <summary>
+    /// When the concept-metadata sweep (labels, descriptions, balance from the
+    /// company's recent filings' MetaLinks) last ran for this company; null
+    /// until the first run. A <see cref="LastFiledDateSeen"/> newer than this
+    /// marks the company due again — a new filing can introduce new concepts.
+    /// </summary>
+    public DateTime? ConceptMetadataCheckedAt { get; set; }
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -5,10 +5,15 @@ namespace Equibles.Sec.FinancialFacts.Data.Statements;
 /// <summary>
 /// Maps a friendly concept name (e.g. <c>"revenue"</c>, <c>"net-income"</c>) to
 /// the ordered set of XBRL (taxonomy, tag) pairs that express it. Shared by the
-/// FinancialFacts MCP tools so callers need not know SEC tag names. A single
-/// alias can map to several tags because companies switch concepts over time
-/// (e.g. <c>Revenues</c> → <c>RevenueFromContractWithCustomerExcludingAssessedTax</c>
-/// after ASC 606); callers query the union and pick per period.
+/// FinancialFacts MCP tools so callers need not know SEC tag names, and by
+/// <see cref="FinancialStatementConcepts"/> so every statement line resolves the
+/// same tag variants everywhere. A single alias can map to several tags because
+/// companies switch concepts over time (e.g. <c>Revenues</c> →
+/// <c>RevenueFromContractWithCustomerExcludingAssessedTax</c> after ASC 606) or
+/// report a narrower variant (ADBE files R&amp;D under the software-specific
+/// tag); callers query the union and pick per period in declaration order —
+/// earlier tags are the broader/preferred measure, later ones only fill
+/// periods the preferred tags lack.
 /// </summary>
 public static class FinancialConceptAliases
 {
@@ -25,48 +30,210 @@ public static class FinancialConceptAliases
         public string Tag { get; }
     }
 
+    private static ConceptRef G(string tag) => new(FactTaxonomy.UsGaap, tag);
+
     private static readonly Dictionary<string, IReadOnlyList<ConceptRef>> Map = new()
     {
+        // ── Income statement ────────────────────────────────────────────────
         ["revenue"] =
         [
-            new(FactTaxonomy.UsGaap, "Revenues"),
-            new(FactTaxonomy.UsGaap, "RevenueFromContractWithCustomerExcludingAssessedTax"),
+            G("Revenues"),
+            G("RevenueFromContractWithCustomerExcludingAssessedTax"),
             // The dominant pre-ASC 606 total-revenue tag (AAPL, MSFT, … filed it
             // through ~FY2017; deprecated 2018). Last so it only fills periods
             // the modern tags lack — without it those companies' revenue series
             // start mid-history.
-            new(FactTaxonomy.UsGaap, "SalesRevenueNet"),
+            G("SalesRevenueNet"),
         ],
-        ["cost-of-revenue"] = [new(FactTaxonomy.UsGaap, "CostOfRevenue")],
-        ["gross-profit"] = [new(FactTaxonomy.UsGaap, "GrossProfit")],
-        ["operating-expenses"] = [new(FactTaxonomy.UsGaap, "OperatingExpenses")],
-        ["research-and-development"] = [new(FactTaxonomy.UsGaap, "ResearchAndDevelopmentExpense")],
-        ["operating-income"] = [new(FactTaxonomy.UsGaap, "OperatingIncomeLoss")],
-        ["net-income"] = [new(FactTaxonomy.UsGaap, "NetIncomeLoss")],
-        ["eps-basic"] = [new(FactTaxonomy.UsGaap, "EarningsPerShareBasic")],
-        ["eps-diluted"] = [new(FactTaxonomy.UsGaap, "EarningsPerShareDiluted")],
-        ["total-assets"] = [new(FactTaxonomy.UsGaap, "Assets")],
-        ["current-assets"] = [new(FactTaxonomy.UsGaap, "AssetsCurrent")],
-        ["total-liabilities"] = [new(FactTaxonomy.UsGaap, "Liabilities")],
-        ["current-liabilities"] = [new(FactTaxonomy.UsGaap, "LiabilitiesCurrent")],
-        ["stockholders-equity"] = [new(FactTaxonomy.UsGaap, "StockholdersEquity")],
-        ["retained-earnings"] = [new(FactTaxonomy.UsGaap, "RetainedEarningsAccumulatedDeficit")],
-        ["cash"] = [new(FactTaxonomy.UsGaap, "CashAndCashEquivalentsAtCarryingValue")],
+        // Financial-sector top lines: banks, broker-dealers and insurers never
+        // file the operating-company revenue tags above.
+        ["interest-and-dividend-income"] = [G("InterestAndDividendIncomeOperating")],
+        ["net-interest-income"] = [G("InterestIncomeExpenseNet")],
+        ["noninterest-income"] = [G("NoninterestIncome")],
+        ["total-net-revenue"] = [G("RevenuesNetOfInterestExpense")],
+        ["premiums-earned"] = [G("PremiumsEarnedNet")],
+        ["cost-of-revenue"] =
+        [
+            G("CostOfRevenue"),
+            G("CostOfGoodsAndServicesSold"),
+            G("CostOfGoodsSold"),
+        ],
+        ["gross-profit"] = [G("GrossProfit")],
+        ["research-and-development"] =
+        [
+            G("ResearchAndDevelopmentExpense"),
+            // Software companies (ADBE, …) report R&D under the
+            // software-development-cost variant instead of the generic tag.
+            G("ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost"),
+            G("ResearchAndDevelopmentExpenseExcludingAcquiredInProcessCost"),
+        ],
+        ["selling-general-and-administrative"] = [G("SellingGeneralAndAdministrativeExpense")],
+        ["selling-and-marketing"] = [G("SellingAndMarketingExpense")],
+        ["general-and-administrative"] = [G("GeneralAndAdministrativeExpense")],
+        ["amortization-of-intangibles"] = [G("AmortizationOfIntangibleAssets")],
+        ["restructuring"] = [G("RestructuringCharges")],
+        ["operating-expenses"] = [G("OperatingExpenses")],
+        // Companies that present no gross-profit subtotal report this combined
+        // figure instead; it INCLUDES cost of revenue, so it is a separate
+        // line, never a fallback for operating-expenses.
+        ["total-costs-and-expenses"] = [G("CostsAndExpenses")],
+        ["operating-income"] = [G("OperatingIncomeLoss")],
+        ["interest-expense"] = [G("InterestExpense"), G("InterestExpenseNonoperating")],
+        ["interest-income"] = [G("InvestmentIncomeInterest")],
+        ["other-nonoperating-income"] =
+        [
+            G("NonoperatingIncomeExpense"),
+            G("OtherNonoperatingIncomeExpense"),
+        ],
+        ["pretax-income"] =
+        [
+            G(
+                "IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+            ),
+            G(
+                "IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLossFromEquityMethodInvestments"
+            ),
+        ],
+        ["income-tax"] = [G("IncomeTaxExpenseBenefit")],
+        // ProfitLoss (net income including noncontrolling interests) last: it
+        // only fills filers that never report the parent-attributable figure.
+        ["net-income"] = [G("NetIncomeLoss"), G("ProfitLoss")],
+        ["comprehensive-income"] = [G("ComprehensiveIncomeNetOfTax")],
+        ["eps-basic"] = [G("EarningsPerShareBasic")],
+        ["eps-diluted"] = [G("EarningsPerShareDiluted")],
+        ["weighted-average-shares-basic"] = [G("WeightedAverageNumberOfSharesOutstandingBasic")],
+        ["weighted-average-shares-diluted"] =
+        [
+            G("WeightedAverageNumberOfDilutedSharesOutstanding"),
+        ],
+
+        // ── Balance sheet ───────────────────────────────────────────────────
+        ["cash"] =
+        [
+            G("CashAndCashEquivalentsAtCarryingValue"),
+            // Post-ASU 2016-18 filers may only report the restricted-cash-
+            // inclusive total; it fills periods the pure tag lacks.
+            G("CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents"),
+        ],
+        ["short-term-investments"] = [G("ShortTermInvestments"), G("MarketableSecuritiesCurrent")],
+        ["accounts-receivable"] = [G("AccountsReceivableNetCurrent"), G("ReceivablesNetCurrent")],
+        ["inventory"] = [G("InventoryNet")],
+        ["current-assets"] = [G("AssetsCurrent")],
+        ["property-plant-and-equipment"] = [G("PropertyPlantAndEquipmentNet")],
+        ["operating-lease-assets"] = [G("OperatingLeaseRightOfUseAsset")],
+        ["goodwill"] = [G("Goodwill")],
+        ["intangible-assets"] =
+        [
+            G("FiniteLivedIntangibleAssetsNet"),
+            G("IntangibleAssetsNetExcludingGoodwill"),
+        ],
+        ["long-term-investments"] = [G("LongTermInvestments"), G("MarketableSecuritiesNoncurrent")],
+        ["total-assets"] = [G("Assets")],
+        ["accounts-payable"] = [G("AccountsPayableCurrent"), G("AccountsPayableTradeCurrent")],
+        ["accrued-liabilities"] = [G("AccruedLiabilitiesCurrent")],
+        ["deferred-revenue"] =
+        [
+            G("ContractWithCustomerLiabilityCurrent"),
+            G("DeferredRevenueCurrent"),
+        ],
+        ["short-term-debt"] =
+        [
+            G("DebtCurrent"),
+            G("LongTermDebtCurrent"),
+            G("ShortTermBorrowings"),
+        ],
+        ["current-liabilities"] = [G("LiabilitiesCurrent")],
+        // LongTermDebt (the total including the current portion) last: it only
+        // fills filers that never split out the noncurrent portion.
+        ["long-term-debt"] = [G("LongTermDebtNoncurrent"), G("LongTermDebt")],
+        ["operating-lease-liabilities"] =
+        [
+            G("OperatingLeaseLiabilityNoncurrent"),
+            G("OperatingLeaseLiability"),
+        ],
+        ["deferred-revenue-noncurrent"] =
+        [
+            G("ContractWithCustomerLiabilityNoncurrent"),
+            G("DeferredRevenueNoncurrent"),
+        ],
+        ["total-liabilities"] = [G("Liabilities")],
+        ["common-stock-value"] =
+        [
+            G("CommonStockValue"),
+            G("CommonStocksIncludingAdditionalPaidInCapital"),
+        ],
+        ["additional-paid-in-capital"] = [G("AdditionalPaidInCapital")],
+        ["retained-earnings"] = [G("RetainedEarningsAccumulatedDeficit")],
+        ["accumulated-oci"] = [G("AccumulatedOtherComprehensiveIncomeLossNetOfTax")],
+        ["treasury-stock"] = [G("TreasuryStockValue"), G("TreasuryStockCommonValue")],
+        ["stockholders-equity"] =
+        [
+            G("StockholdersEquity"),
+            G("StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest"),
+        ],
+        ["total-liabilities-and-equity"] = [G("LiabilitiesAndStockholdersEquity")],
         // The issuer's cover-page common shares outstanding. Single-class filers report it
         // consolidated (no dimension); multi-class filers report it only per share class, so a
         // consolidated fact is absent and the entity total is the sum across classes.
         ["shares-outstanding"] = [new(FactTaxonomy.Dei, "EntityCommonStockSharesOutstanding")],
+
+        // ── Cash flow ───────────────────────────────────────────────────────
+        ["depreciation-and-amortization"] =
+        [
+            G("DepreciationDepletionAndAmortization"),
+            G("DepreciationAmortizationAndAccretionNet"),
+        ],
+        ["share-based-compensation"] = [G("ShareBasedCompensation")],
+        ["deferred-income-taxes"] =
+        [
+            G("DeferredIncomeTaxExpenseBenefit"),
+            G("DeferredIncomeTaxesAndTaxCredits"),
+        ],
         ["operating-cash-flow"] =
         [
-            new(FactTaxonomy.UsGaap, "NetCashProvidedByUsedInOperatingActivities"),
+            G("NetCashProvidedByUsedInOperatingActivities"),
+            G("NetCashProvidedByUsedInOperatingActivitiesContinuingOperations"),
         ],
+        ["capital-expenditures"] =
+        [
+            G("PaymentsToAcquirePropertyPlantAndEquipment"),
+            G("PaymentsToAcquireProductiveAssets"),
+        ],
+        ["acquisitions"] = [G("PaymentsToAcquireBusinessesNetOfCashAcquired")],
         ["investing-cash-flow"] =
         [
-            new(FactTaxonomy.UsGaap, "NetCashProvidedByUsedInInvestingActivities"),
+            G("NetCashProvidedByUsedInInvestingActivities"),
+            G("NetCashProvidedByUsedInInvestingActivitiesContinuingOperations"),
         ],
+        ["share-repurchases"] = [G("PaymentsForRepurchaseOfCommonStock")],
+        ["dividends-paid"] = [G("PaymentsOfDividends"), G("PaymentsOfDividendsCommonStock")],
+        ["debt-issued"] = [G("ProceedsFromIssuanceOfLongTermDebt")],
+        ["debt-repaid"] = [G("RepaymentsOfLongTermDebt"), G("RepaymentsOfDebt")],
+        ["stock-issued"] = [G("ProceedsFromIssuanceOfCommonStock")],
         ["financing-cash-flow"] =
         [
-            new(FactTaxonomy.UsGaap, "NetCashProvidedByUsedInFinancingActivities"),
+            G("NetCashProvidedByUsedInFinancingActivities"),
+            G("NetCashProvidedByUsedInFinancingActivitiesContinuingOperations"),
+        ],
+        ["fx-effect-on-cash"] =
+        [
+            G(
+                "EffectOfExchangeRateOnCashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents"
+            ),
+            G("EffectOfExchangeRateOnCashAndCashEquivalents"),
+        ],
+        ["net-change-in-cash"] =
+        [
+            // The modern (post-ASU 2016-18) tag first; the pre-2018 tag fills
+            // older periods, the exchange-rate-excluding variant fills filers
+            // that only report that shape.
+            G(
+                "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalentsPeriodIncreaseDecreaseIncludingExchangeRateEffect"
+            ),
+            G("CashAndCashEquivalentsPeriodIncreaseDecrease"),
+            G(
+                "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalentsPeriodIncreaseDecreaseExcludingExchangeRateEffect"
+            ),
         ],
     };
 
@@ -81,6 +248,8 @@ public static class FinancialConceptAliases
         ["rnd"] = "research-and-development",
         ["r-and-d"] = "research-and-development",
         ["r&d"] = "research-and-development",
+        ["sga"] = "selling-general-and-administrative",
+        ["sg&a"] = "selling-general-and-administrative",
         ["operating-profit"] = "operating-income",
         ["net-profit"] = "net-income",
         ["earnings"] = "net-income",
@@ -90,6 +259,18 @@ public static class FinancialConceptAliases
         ["liabilities"] = "total-liabilities",
         ["equity"] = "stockholders-equity",
         ["ocf"] = "operating-cash-flow",
+        ["capex"] = "capital-expenditures",
+        ["buybacks"] = "share-repurchases",
+        ["stock-buybacks"] = "share-repurchases",
+        ["dividends"] = "dividends-paid",
+        ["d-and-a"] = "depreciation-and-amortization",
+        ["d&a"] = "depreciation-and-amortization",
+        ["sbc"] = "share-based-compensation",
+        ["stock-based-compensation"] = "share-based-compensation",
+        ["ppe"] = "property-plant-and-equipment",
+        ["pp&e"] = "property-plant-and-equipment",
+        ["aoci"] = "accumulated-oci",
+        ["apic"] = "additional-paid-in-capital",
     };
 
     public static IReadOnlyCollection<string> SupportedAliases => Map.Keys;

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialStatementConcepts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialStatementConcepts.cs
@@ -4,10 +4,13 @@ namespace Equibles.Sec.FinancialFacts.Data.Statements;
 
 /// <summary>
 /// Curated, ordered catalog mapping each <see cref="FinancialStatementType"/> to
-/// the us-gaap concepts that compose it. Shared by the Web Financials tab and
-/// the MCP GetFinancialStatement tool so both present the same line items in the
-/// same order. Concepts a given company never reports simply render no value —
-/// the catalog is intentionally broad rather than per-company.
+/// the concepts that compose it, each line resolved through
+/// <see cref="FinancialConceptAliases"/> so tag variants (concept transitions,
+/// narrower per-industry tags) stay defined in exactly one place. Shared by the
+/// Web Financials tab and the MCP GetFinancialStatement tool so both present
+/// the same line items in the same order. Concepts a given company never
+/// reports simply render no value — the catalog is intentionally broad rather
+/// than per-company; renderers hide lines the company has never reported.
 ///
 /// Placement note: this is curation policy, not data access, so it would
 /// normally live in a *.BusinessLogic package. It sits in *.Data deliberately
@@ -17,74 +20,103 @@ namespace Equibles.Sec.FinancialFacts.Data.Statements;
 /// </summary>
 public static class FinancialStatementConcepts
 {
+    // Resolves an alias to its ConceptRefs at catalog-construction time; an
+    // unknown alias is a programming error, so it throws immediately rather
+    // than rendering a permanently-empty line.
+    private static StatementLine Line(string alias, string label)
+    {
+        if (!FinancialConceptAliases.TryResolve(alias, out var concepts) || concepts.Count == 0)
+            throw new InvalidOperationException(
+                $"Statement line '{label}' references unknown concept alias '{alias}'."
+            );
+        return new StatementLine(alias, label, concepts);
+    }
+
     private static readonly IReadOnlyList<StatementLine> IncomeStatement =
     [
-        new(FactTaxonomy.UsGaap, "Revenues", "Revenue"),
-        new(
-            FactTaxonomy.UsGaap,
-            "RevenueFromContractWithCustomerExcludingAssessedTax",
-            "Revenue (ASC 606)"
-        ),
+        Line("revenue", "Revenue"),
         // Financial-sector top lines. Banks, broker-dealers and insurers never file the
         // operating-company revenue tags above, so without these their income statement
         // shows no top line at all. Ordered as a financial income statement reads; a given
         // filer reports only the subset that fits it, and unreported lines simply don't render.
-        new(
-            FactTaxonomy.UsGaap,
-            "InterestAndDividendIncomeOperating",
-            "Interest & Dividend Income"
-        ),
-        new(FactTaxonomy.UsGaap, "InterestIncomeExpenseNet", "Net Interest Income"),
-        new(FactTaxonomy.UsGaap, "NoninterestIncome", "Noninterest Income"),
-        new(FactTaxonomy.UsGaap, "RevenuesNetOfInterestExpense", "Total Net Revenue"),
-        new(FactTaxonomy.UsGaap, "PremiumsEarnedNet", "Premiums Earned (Net)"),
-        new(FactTaxonomy.UsGaap, "CostOfRevenue", "Cost of Revenue"),
-        new(FactTaxonomy.UsGaap, "GrossProfit", "Gross Profit"),
-        new(FactTaxonomy.UsGaap, "OperatingExpenses", "Operating Expenses"),
-        new(FactTaxonomy.UsGaap, "ResearchAndDevelopmentExpense", "Research & Development"),
-        new(FactTaxonomy.UsGaap, "OperatingIncomeLoss", "Operating Income"),
-        new(FactTaxonomy.UsGaap, "NetIncomeLoss", "Net Income"),
-        new(FactTaxonomy.UsGaap, "EarningsPerShareBasic", "EPS (Basic)"),
-        new(FactTaxonomy.UsGaap, "EarningsPerShareDiluted", "EPS (Diluted)"),
+        Line("interest-and-dividend-income", "Interest & Dividend Income"),
+        Line("net-interest-income", "Net Interest Income"),
+        Line("noninterest-income", "Noninterest Income"),
+        Line("total-net-revenue", "Total Net Revenue"),
+        Line("premiums-earned", "Premiums Earned (Net)"),
+        Line("cost-of-revenue", "Cost of Revenue"),
+        Line("gross-profit", "Gross Profit"),
+        Line("research-and-development", "Research & Development"),
+        Line("selling-and-marketing", "Selling & Marketing"),
+        Line("general-and-administrative", "General & Administrative"),
+        Line("selling-general-and-administrative", "Selling, General & Administrative"),
+        Line("amortization-of-intangibles", "Amortization of Intangibles"),
+        Line("restructuring", "Restructuring Charges"),
+        Line("operating-expenses", "Total Operating Expenses"),
+        Line("total-costs-and-expenses", "Total Costs & Expenses"),
+        Line("operating-income", "Operating Income"),
+        Line("interest-expense", "Interest Expense"),
+        Line("interest-income", "Interest Income"),
+        Line("other-nonoperating-income", "Other Non-Operating Income"),
+        Line("pretax-income", "Pretax Income"),
+        Line("income-tax", "Income Tax"),
+        Line("net-income", "Net Income"),
+        Line("comprehensive-income", "Comprehensive Income"),
+        Line("eps-basic", "EPS (Basic)"),
+        Line("eps-diluted", "EPS (Diluted)"),
+        Line("weighted-average-shares-basic", "Shares Outstanding (Basic Avg)"),
+        Line("weighted-average-shares-diluted", "Shares Outstanding (Diluted Avg)"),
     ];
 
     private static readonly IReadOnlyList<StatementLine> BalanceSheet =
     [
-        new(
-            FactTaxonomy.UsGaap,
-            "CashAndCashEquivalentsAtCarryingValue",
-            "Cash & Cash Equivalents"
-        ),
-        new(FactTaxonomy.UsGaap, "AssetsCurrent", "Total Current Assets"),
-        new(FactTaxonomy.UsGaap, "Assets", "Total Assets"),
-        new(FactTaxonomy.UsGaap, "LiabilitiesCurrent", "Total Current Liabilities"),
-        new(FactTaxonomy.UsGaap, "Liabilities", "Total Liabilities"),
-        new(FactTaxonomy.UsGaap, "RetainedEarningsAccumulatedDeficit", "Retained Earnings"),
-        new(FactTaxonomy.UsGaap, "StockholdersEquity", "Total Stockholders' Equity"),
+        Line("cash", "Cash & Cash Equivalents"),
+        Line("short-term-investments", "Short-Term Investments"),
+        Line("accounts-receivable", "Accounts Receivable"),
+        Line("inventory", "Inventory"),
+        Line("current-assets", "Total Current Assets"),
+        Line("property-plant-and-equipment", "Property, Plant & Equipment (Net)"),
+        Line("operating-lease-assets", "Operating Lease Assets"),
+        Line("goodwill", "Goodwill"),
+        Line("intangible-assets", "Intangible Assets (Net)"),
+        Line("long-term-investments", "Long-Term Investments"),
+        Line("total-assets", "Total Assets"),
+        Line("accounts-payable", "Accounts Payable"),
+        Line("accrued-liabilities", "Accrued Liabilities"),
+        Line("deferred-revenue", "Deferred Revenue (Current)"),
+        Line("short-term-debt", "Short-Term Debt"),
+        Line("current-liabilities", "Total Current Liabilities"),
+        Line("long-term-debt", "Long-Term Debt"),
+        Line("operating-lease-liabilities", "Operating Lease Liabilities"),
+        Line("deferred-revenue-noncurrent", "Deferred Revenue (Non-Current)"),
+        Line("total-liabilities", "Total Liabilities"),
+        Line("common-stock-value", "Common Stock"),
+        Line("additional-paid-in-capital", "Additional Paid-In Capital"),
+        Line("retained-earnings", "Retained Earnings"),
+        Line("accumulated-oci", "Accumulated Other Comprehensive Income"),
+        Line("treasury-stock", "Treasury Stock"),
+        Line("stockholders-equity", "Total Stockholders' Equity"),
+        Line("total-liabilities-and-equity", "Total Liabilities & Equity"),
     ];
 
     private static readonly IReadOnlyList<StatementLine> CashFlow =
     [
-        new(
-            FactTaxonomy.UsGaap,
-            "NetCashProvidedByUsedInOperatingActivities",
-            "Operating Cash Flow"
-        ),
-        new(
-            FactTaxonomy.UsGaap,
-            "NetCashProvidedByUsedInInvestingActivities",
-            "Investing Cash Flow"
-        ),
-        new(
-            FactTaxonomy.UsGaap,
-            "NetCashProvidedByUsedInFinancingActivities",
-            "Financing Cash Flow"
-        ),
-        new(
-            FactTaxonomy.UsGaap,
-            "CashAndCashEquivalentsPeriodIncreaseDecrease",
-            "Net Change in Cash"
-        ),
+        Line("net-income", "Net Income"),
+        Line("depreciation-and-amortization", "Depreciation & Amortization"),
+        Line("share-based-compensation", "Share-Based Compensation"),
+        Line("deferred-income-taxes", "Deferred Income Taxes"),
+        Line("operating-cash-flow", "Operating Cash Flow"),
+        Line("capital-expenditures", "Capital Expenditures"),
+        Line("acquisitions", "Acquisitions (Net of Cash)"),
+        Line("investing-cash-flow", "Investing Cash Flow"),
+        Line("share-repurchases", "Share Repurchases"),
+        Line("dividends-paid", "Dividends Paid"),
+        Line("debt-issued", "Debt Issued"),
+        Line("debt-repaid", "Debt Repaid"),
+        Line("stock-issued", "Common Stock Issued"),
+        Line("financing-cash-flow", "Financing Cash Flow"),
+        Line("fx-effect-on-cash", "Exchange-Rate Effect on Cash"),
+        Line("net-change-in-cash", "Net Change in Cash"),
     ];
 
     public static IReadOnlyList<StatementLine> For(FinancialStatementType type) =>

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLine.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLine.cs
@@ -3,23 +3,40 @@ using Equibles.Sec.FinancialFacts.Data.Enums;
 namespace Equibles.Sec.FinancialFacts.Data.Statements;
 
 /// <summary>
-/// One line of a financial statement: the XBRL concept to pull
-/// (<see cref="Taxonomy"/> + <see cref="Tag"/>) and the human-readable
-/// <see cref="Label"/> to render for it. Ordering within a statement is the
-/// order these are declared in <see cref="FinancialStatementConcepts"/>.
+/// One line of a financial statement: the ordered XBRL concept variants that
+/// express it (<see cref="Concepts"/>, resolved from an alias in
+/// <see cref="FinancialConceptAliases"/>) and the human-readable
+/// <see cref="Label"/> to render for it. Consumers pick the first variant a
+/// company reported for the requested period — earlier concepts are the
+/// broader/preferred measure, later ones only fill gaps (a tag transition or a
+/// narrower variant like ADBE's software-specific R&amp;D tag). Ordering within
+/// a statement is the order these are declared in
+/// <see cref="FinancialStatementConcepts"/>.
 /// </summary>
 public class StatementLine
 {
-    public StatementLine(FactTaxonomy taxonomy, string tag, string label)
+    public StatementLine(
+        string alias,
+        string label,
+        IReadOnlyList<FinancialConceptAliases.ConceptRef> concepts
+    )
     {
-        Taxonomy = taxonomy;
-        Tag = tag;
+        Alias = alias;
         Label = label;
+        Concepts = concepts;
     }
 
-    public FactTaxonomy Taxonomy { get; }
-
-    public string Tag { get; }
+    /// <summary>The <see cref="FinancialConceptAliases"/> key the line resolves through.</summary>
+    public string Alias { get; }
 
     public string Label { get; }
+
+    /// <summary>Ordered tag variants; the first is the preferred concept.</summary>
+    public IReadOnlyList<FinancialConceptAliases.ConceptRef> Concepts { get; }
+
+    /// <summary>The preferred concept's taxonomy (first variant).</summary>
+    public FactTaxonomy Taxonomy => Concepts[0].Taxonomy;
+
+    /// <summary>The preferred concept's tag (first variant).</summary>
+    public string Tag => Concepts[0].Tag;
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -1,0 +1,49 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.Data.Statements;
+
+/// <summary>
+/// Shared selection helpers for rendering <see cref="StatementLine"/>s, so the
+/// Web tab, the MCP tool and any other statement surface resolve a line's tag
+/// variants identically: the first variant (declaration order) the company
+/// reported wins, later variants only fill the gap.
+/// </summary>
+public static class StatementLineFacts
+{
+    /// <summary>
+    /// Every distinct (taxonomy, tag) pair across the lines' variants — the
+    /// inputs for a FinancialConceptRepository.GetMatching lookup.
+    /// </summary>
+    public static (List<FactTaxonomy> Taxonomies, List<string> Tags) CollectConceptPairs(
+        IEnumerable<StatementLine> lines
+    )
+    {
+        var refs = lines.SelectMany(l => l.Concepts).ToList();
+        return (
+            refs.Select(r => r.Taxonomy).Distinct().ToList(),
+            refs.Select(r => r.Tag).Distinct().ToList()
+        );
+    }
+
+    /// <summary>
+    /// The fact to render for a line: its first variant with a fact for the
+    /// period, or null when the company reported none of them.
+    /// </summary>
+    public static FinancialFact PickFact(
+        StatementLine line,
+        IReadOnlyDictionary<(FactTaxonomy Taxonomy, string Tag), Guid> conceptIdByKey,
+        IReadOnlyDictionary<Guid, FinancialFact> factByConceptId
+    )
+    {
+        foreach (var reference in line.Concepts)
+        {
+            if (
+                conceptIdByKey.TryGetValue((reference.Taxonomy, reference.Tag), out var conceptId)
+                && factByConceptId.TryGetValue(conceptId, out var fact)
+            )
+                return fact;
+        }
+        return null;
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -26,6 +26,49 @@ public static class StatementLineFacts
         );
     }
 
+    // The longest span a discrete fiscal quarter can cover — 13 weeks on a
+    // 4-4-5 calendar plus the occasional 14-week quarter, with headroom.
+    private const int MaxDiscreteQuarterDays = 100;
+
+    // The shortest span a fiscal year can cover — 52 weeks on a 52/53-week
+    // calendar, with headroom for short transition years.
+    private const int MinAnnualSpanDays = 350;
+
+    /// <summary>
+    /// The currently-reported fact among a fiscal period's candidates. A 10-Q
+    /// reports each flow line twice under that identity — the discrete quarter
+    /// and the fiscal year-to-date — and a balance-sheet line carries the
+    /// period-end instant alongside re-stated comparative instants. Prefer the
+    /// span matching the period's granularity (instants span zero days and
+    /// always qualify), then the candidate ending latest so a comparative
+    /// column never stands in for the current one, then the latest restatement
+    /// among same-ending candidates (#1546).
+    /// </summary>
+    public static FinancialFact PickCurrentlyReported(
+        IEnumerable<FinancialFact> facts,
+        SecFiscalPeriod fiscalPeriod
+    )
+    {
+        var candidates = facts.ToList();
+
+        var preferred = candidates
+            .Where(f =>
+            {
+                var spanDays = f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber;
+                return fiscalPeriod == SecFiscalPeriod.FullYear
+                    ? spanDays == 0 || spanDays >= MinAnnualSpanDays
+                    : spanDays <= MaxDiscreteQuarterDays;
+            })
+            .ToList();
+        if (preferred.Count > 0)
+            candidates = preferred;
+
+        return candidates
+            .OrderByDescending(f => f.PeriodEnd)
+            .ThenByDescending(f => f.FiledDate)
+            .First();
+    }
+
     /// <summary>
     /// The fact to render for a line: its first variant with a fact for the
     /// period, or null when the company reported none of them.

--- a/src/Equibles.Sec.FinancialFacts.HostedService/ConceptMetadataWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/ConceptMetadataWorker.cs
@@ -75,13 +75,14 @@ public class ConceptMetadataWorker : BaseScraperWorker
                 .Where(s =>
                     s.ConceptMetadataCheckedAt == null
                     || s.ConceptMetadataCheckedAt < refreshCutoff
+                    // End of the filed DAY, not its midnight: a filing landing
+                    // later on the same calendar day as the last sweep must
+                    // still re-trigger, or its new concepts wait out RefreshDays.
                     || (
                         s.LastFiledDateSeen != null
                         && s.ConceptMetadataCheckedAt
-                            < s.LastFiledDateSeen.Value.ToDateTime(
-                                TimeOnly.MinValue,
-                                DateTimeKind.Utc
-                            )
+                            < s.LastFiledDateSeen.Value.AddDays(1)
+                                .ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)
                     )
                 )
                 // Never-swept companies first, then stalest sweeps.

--- a/src/Equibles.Sec.FinancialFacts.HostedService/ConceptMetadataWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/ConceptMetadataWorker.cs
@@ -1,0 +1,112 @@
+using Equibles.CommonStocks.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Sec.FinancialFacts.HostedService.Configuration;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Sec.FinancialFacts.HostedService;
+
+/// <summary>
+/// Sweeps concept metadata (labels, documentation, debit/credit balance) from
+/// each company's recent filings' MetaLinks artifact. A company is due when it
+/// was never swept, when a newer filing arrived since its last sweep (new
+/// filings introduce new extension concepts), or on the periodic refresh.
+/// </summary>
+public class ConceptMetadataWorker : BaseScraperWorker
+{
+    private readonly IConfiguration _configuration;
+    private readonly ConceptMetadataOptions _options;
+
+    protected override string WorkerName => "Concept metadata sweep";
+    protected override TimeSpan SleepInterval { get; }
+    protected override ErrorSource ErrorSource => ErrorSource.FinancialFactsScraper;
+
+    // Light SEC walker (a few small JSON fetches per due company) — staggered
+    // behind the heavy sweeps so it never competes for the EDGAR budget at boot.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(12);
+
+    public ConceptMetadataWorker(
+        ILogger<ConceptMetadataWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<ConceptMetadataOptions> options,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+        _options = options.Value;
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(
+            _configuration,
+            "Concept metadata sweep",
+            treatWhitespaceAsAbsent: true
+        );
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        List<Guid> dueStockIds;
+        using (var scope = ScopeFactory.CreateScope())
+        {
+            var statusRepository =
+                scope.ServiceProvider.GetRequiredService<FinancialFactsSyncStatusRepository>();
+            var statuses = await statusRepository
+                .GetAll()
+                .Select(s => new
+                {
+                    s.CommonStockId,
+                    s.LastFiledDateSeen,
+                    s.ConceptMetadataCheckedAt,
+                })
+                .ToListAsync(stoppingToken);
+
+            var refreshCutoff = DateTime.UtcNow.AddDays(-_options.RefreshDays);
+            dueStockIds = statuses
+                .Where(s =>
+                    s.ConceptMetadataCheckedAt == null
+                    || s.ConceptMetadataCheckedAt < refreshCutoff
+                    || (
+                        s.LastFiledDateSeen != null
+                        && s.ConceptMetadataCheckedAt
+                            < s.LastFiledDateSeen.Value.ToDateTime(
+                                TimeOnly.MinValue,
+                                DateTimeKind.Utc
+                            )
+                    )
+                )
+                // Never-swept companies first, then stalest sweeps.
+                .OrderBy(s => s.ConceptMetadataCheckedAt ?? DateTime.MinValue)
+                .Select(s => s.CommonStockId)
+                .ToList();
+        }
+
+        if (dueStockIds.Count == 0)
+            return;
+
+        Logger.LogInformation("Concept metadata sweep: {Count} companies due", dueStockIds.Count);
+
+        foreach (var stockId in dueStockIds)
+        {
+            stoppingToken.ThrowIfCancellationRequested();
+
+            using var scope = ScopeFactory.CreateScope();
+            var stockRepository = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+            var stock = await stockRepository.Get(stockId);
+            if (stock == null)
+                continue;
+
+            var service = scope.ServiceProvider.GetRequiredService<ConceptMetadataService>();
+            await service.ProcessStock(stock, stoppingToken);
+        }
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Configuration/ConceptMetadataOptions.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Configuration/ConceptMetadataOptions.cs
@@ -1,0 +1,26 @@
+using Equibles.Worker;
+
+namespace Equibles.Sec.FinancialFacts.HostedService.Configuration;
+
+public class ConceptMetadataOptions : ScraperOptions
+{
+    public ConceptMetadataOptions()
+    {
+        // The sweep is cheap (a few small JSON fetches per due company) and a
+        // new filing should get its concepts documented promptly.
+        SleepIntervalHours = 6;
+    }
+
+    /// <summary>
+    /// How many of the company's most recent filings to read MetaLinks from.
+    /// The latest 10-K + a few 10-Qs cover both annual-only and quarterly
+    /// concepts; older tags keep whatever text an earlier sweep stored.
+    /// </summary>
+    public int RecentFilingsPerStock { get; set; } = 4;
+
+    /// <summary>
+    /// Re-sweep a company after this many days even without a new filing, so
+    /// taxonomy-text refinements eventually propagate.
+    /// </summary>
+    public int RefreshDays { get; set; } = 90;
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ public static class ServiceCollectionExtensions
         // dimensional-fact extraction sweep can resolve them.
         services.AutoWireServicesFrom<InlineXbrlParser>();
         services.AddHostedService<FinancialFactsScraperWorker>();
+        services.AddHostedService<ConceptMetadataWorker>();
         services.AddHostedService<XbrlFactsExtractionWorker>();
         services.AddHostedService<ReportedStatementsCaptureWorker>();
         services.AddHostedService<ReportedStatementsParseWorker>();

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/ConceptMetadataService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/ConceptMetadataService.cs
@@ -1,0 +1,296 @@
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.HostedService.Configuration;
+using Equibles.Sec.FinancialFacts.Repositories;
+using FlexLabs.EntityFrameworkCore.Upsert;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+
+namespace Equibles.Sec.FinancialFacts.HostedService.Services;
+
+/// <summary>
+/// Fills <see cref="FinancialConcept"/> metadata (label, documentation text,
+/// debit/credit balance) for one company from its recent filings' MetaLinks
+/// artifact. MetaLinks carries every tag the filing uses — standard taxonomies
+/// AND the filer's own extension concepts, which the Company Facts API never
+/// covers — so this is the authoritative, no-inference source for describing
+/// company-specific KPIs. Only concepts that already exist (i.e. have facts)
+/// are updated; MetaLinks also lists axes and members we don't ingest, and
+/// creating fact-less concept rows would pollute the catalog.
+/// </summary>
+[Service]
+public class ConceptMetadataService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly ILogger<ConceptMetadataService> _logger;
+    private readonly ConceptMetadataOptions _options;
+
+    public ConceptMetadataService(
+        IServiceScopeFactory scopeFactory,
+        ISecEdgarClient secEdgarClient,
+        ILogger<ConceptMetadataService> logger,
+        IOptions<ConceptMetadataOptions> options
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _secEdgarClient = secEdgarClient;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public async Task ProcessStock(CommonStock stock, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(stock.Cik))
+            return;
+
+        var accessions = await LoadRecentAccessions(stock, cancellationToken);
+        var incoming = new Dictionary<(FactTaxonomy, string), TagMetadata>();
+        foreach (var accession in accessions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            byte[] bytes;
+            try
+            {
+                bytes = await _secEdgarClient.GetDocumentFileBytes(
+                    stock.Cik,
+                    accession,
+                    "MetaLinks.json",
+                    cancellationToken
+                );
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "MetaLinks download failed for {Ticker} {Accession}, skipping",
+                    stock.Ticker,
+                    accession
+                );
+                continue;
+            }
+            // Empty means 404 — pre-2019 filings have no MetaLinks artifact.
+            if (bytes.Length == 0)
+                continue;
+
+            try
+            {
+                // Newest filing first: TryAdd keeps its (current) text when an
+                // older filing re-documents the same tag.
+                foreach (var (pair, metadata) in ParseMetaLinks(bytes))
+                    incoming.TryAdd(pair, metadata);
+            }
+            catch (Exception ex)
+                when (ex is Newtonsoft.Json.JsonException or DecoderFallbackException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "MetaLinks parse failed for {Ticker} {Accession}, skipping",
+                    stock.Ticker,
+                    accession
+                );
+            }
+        }
+
+        if (incoming.Count > 0)
+            await ApplyMetadata(incoming, cancellationToken);
+        await StampChecked(stock, cancellationToken);
+    }
+
+    // The company's newest distinct filings that produced facts, newest first —
+    // the latest 10-K plus recent 10-Qs cover annual-only and quarterly tags.
+    private async Task<List<string>> LoadRecentAccessions(
+        CommonStock stock,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var factRepository = scope.ServiceProvider.GetRequiredService<FinancialFactRepository>();
+        return await factRepository
+            .GetByStock(stock)
+            .GroupBy(f => f.AccessionNumber)
+            .Select(g => new { Accession = g.Key, Filed = g.Max(f => f.FiledDate) })
+            .OrderByDescending(a => a.Filed)
+            .Take(_options.RecentFilingsPerStock)
+            .Select(a => a.Accession)
+            .ToListAsync(cancellationToken);
+    }
+
+    internal sealed record TagMetadata(string Label, string Description, ConceptBalance? Balance);
+
+    // MetaLinks shape: instance → (per source document) → nsprefix (the filer's
+    // own extension prefix) + tag → "{prefix}_{LocalName}" entries carrying the
+    // crdr balance and the en-us label/documentation strings.
+    internal static IEnumerable<((FactTaxonomy, string) Pair, TagMetadata Metadata)> ParseMetaLinks(
+        byte[] bytes
+    )
+    {
+        var root = JObject.Parse(Encoding.UTF8.GetString(bytes));
+        if (root["instance"] is not JObject instances)
+            yield break;
+
+        foreach (var instanceProperty in instances.Properties())
+        {
+            if (instanceProperty.Value is not JObject instance)
+                continue;
+            var filerPrefix = instance["nsprefix"]?.Value<string>();
+            if (instance["tag"] is not JObject tags)
+                continue;
+
+            foreach (var tagProperty in tags.Properties())
+            {
+                var separator = tagProperty.Name.IndexOf('_');
+                if (separator <= 0 || separator >= tagProperty.Name.Length - 1)
+                    continue;
+                var prefix = tagProperty.Name[..separator];
+                var localName = tagProperty.Name[(separator + 1)..];
+                if (!TryMapPrefix(prefix, filerPrefix, out var taxonomy, out var tagPrefix))
+                    continue;
+                if (tagProperty.Value is not JObject tag)
+                    continue;
+
+                var role = tag.SelectToken("lang.en-us.role") as JObject;
+                var label = role?["label"]?.Value<string>();
+                var documentation = role?["documentation"]?.Value<string>();
+                var balance = tag["crdr"]?.Value<string>() switch
+                {
+                    "credit" => ConceptBalance.Credit,
+                    "debit" => ConceptBalance.Debit,
+                    _ => (ConceptBalance?)null,
+                };
+                if (label == null && documentation == null && balance == null)
+                    continue;
+
+                var storedTag = tagPrefix == null ? localName : $"{tagPrefix}:{localName}";
+                yield return (
+                    (taxonomy, storedTag),
+                    new TagMetadata(label, documentation, balance)
+                );
+            }
+        }
+    }
+
+    // Standard taxonomies map to their enum; the filer's own prefix maps to
+    // Custom with the extractor's "{prefix}:{LocalName}" tag shape. Reference
+    // taxonomies we don't ingest facts for (ecd, country, currency, …) are
+    // skipped — there is no concept row to describe.
+    private static bool TryMapPrefix(
+        string prefix,
+        string filerPrefix,
+        out FactTaxonomy taxonomy,
+        out string tagPrefix
+    )
+    {
+        tagPrefix = null;
+        switch (prefix.ToLowerInvariant())
+        {
+            case "us-gaap":
+                taxonomy = FactTaxonomy.UsGaap;
+                return true;
+            case "dei":
+                taxonomy = FactTaxonomy.Dei;
+                return true;
+            case "ifrs-full":
+                taxonomy = FactTaxonomy.IfrsFull;
+                return true;
+            case "srt":
+                taxonomy = FactTaxonomy.Srt;
+                return true;
+            case "invest":
+                taxonomy = FactTaxonomy.Invest;
+                return true;
+        }
+        if (filerPrefix != null && prefix.Equals(filerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            taxonomy = FactTaxonomy.Custom;
+            tagPrefix = prefix.ToLowerInvariant();
+            return true;
+        }
+        taxonomy = default;
+        return false;
+    }
+
+    // Updates only concepts that already exist; text/balance is overwritten
+    // when the incoming value is non-empty (the newest filing carries the
+    // current taxonomy text) and left alone otherwise.
+    private async Task ApplyMetadata(
+        Dictionary<(FactTaxonomy, string), TagMetadata> incoming,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var conceptRepository =
+            scope.ServiceProvider.GetRequiredService<FinancialConceptRepository>();
+        var taxonomies = incoming.Keys.Select(p => p.Item1).Distinct().ToList();
+        var tags = incoming.Keys.Select(p => p.Item2).Distinct().ToList();
+        var concepts = await conceptRepository
+            .GetMatching(taxonomies, tags)
+            .ToListAsync(cancellationToken);
+
+        var updated = 0;
+        foreach (var concept in concepts)
+        {
+            if (!incoming.TryGetValue((concept.Taxonomy, concept.Tag), out var metadata))
+                continue;
+            var changed = false;
+            if (!string.IsNullOrEmpty(metadata.Label) && metadata.Label != concept.Label)
+            {
+                concept.Label =
+                    metadata.Label.Length <= 512 ? metadata.Label : metadata.Label[..512];
+                changed = true;
+            }
+            if (
+                !string.IsNullOrEmpty(metadata.Description)
+                && metadata.Description != concept.Description
+            )
+            {
+                concept.Description = metadata.Description;
+                changed = true;
+            }
+            if (metadata.Balance != null && metadata.Balance != concept.Balance)
+            {
+                concept.Balance = metadata.Balance;
+                changed = true;
+            }
+            if (changed)
+                updated++;
+        }
+        if (updated > 0)
+        {
+            await conceptRepository.SaveChanges();
+            _logger.LogInformation("Concept metadata updated for {Count} concepts", updated);
+        }
+    }
+
+    private async Task StampChecked(CommonStock stock, CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        var status = new FinancialFactsSyncStatus
+        {
+            CommonStockId = stock.Id,
+            LastCheckedAt = DateTime.UtcNow,
+            ConceptMetadataCheckedAt = DateTime.UtcNow,
+        };
+        await dbContext
+            .Set<FinancialFactsSyncStatus>()
+            .UpsertRange(status)
+            .On(s => s.CommonStockId)
+            .WhenMatched(
+                (existing, incoming) =>
+                    new FinancialFactsSyncStatus
+                    {
+                        ConceptMetadataCheckedAt = incoming.ConceptMetadataCheckedAt,
+                    }
+            )
+            .RunAsync(cancellationToken);
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -227,6 +227,7 @@ public class FinancialFactsImportService
                             taxonomy,
                             tag,
                             concept.Label,
+                            concept.Description,
                             unit,
                             value,
                             stock
@@ -243,6 +244,7 @@ public class FinancialFactsImportService
         FactTaxonomy taxonomy,
         string tag,
         string label,
+        string description,
         string unit,
         CompanyFactValue value,
         CommonStock stock
@@ -271,6 +273,7 @@ public class FinancialFactsImportService
             Taxonomy = taxonomy,
             Tag = tag,
             Label = label,
+            Description = description,
             Unit = unit,
             PeriodType = isInstant ? FactPeriodType.Instant : FactPeriodType.Duration,
             PeriodStart = periodStart,
@@ -300,15 +303,19 @@ public class FinancialFactsImportService
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
 
         // Compound write (insert-or-update) — kept out of the repository by
-        // design; only update Label when the incoming one is non-empty so a
-        // later filing with a missing label can't blank a good one.
+        // design; only update Label/Description when the incoming one is
+        // non-empty so a later filing with a missing text can't blank a good one.
         await dbContext
             .Set<FinancialConcept>()
             .UpsertRange(concepts)
             .On(c => new { c.Taxonomy, c.Tag })
             .WhenMatched(
                 (existing, incoming) =>
-                    new FinancialConcept { Label = incoming.Label ?? existing.Label }
+                    new FinancialConcept
+                    {
+                        Label = incoming.Label ?? existing.Label,
+                        Description = incoming.Description ?? existing.Description,
+                    }
             )
             .RunAsync(cancellationToken);
 
@@ -338,12 +345,16 @@ public class FinancialFactsImportService
     {
         var pairs = parsed.Select(p => (p.Taxonomy, p.Tag)).ToHashSet();
 
-        // Pre-index labels in one pass so the per-pair lookup is O(1); the
+        // Pre-index labels/descriptions in one pass so the per-pair lookup is O(1); the
         // prior per-pair scan was O(pairs * parsed) on multi-thousand-fact filings.
         var firstLabelByPair = parsed
             .Where(p => !string.IsNullOrEmpty(p.Label))
             .GroupBy(p => (p.Taxonomy, p.Tag))
             .ToDictionary(g => g.Key, g => g.First().Label);
+        var firstDescriptionByPair = parsed
+            .Where(p => !string.IsNullOrEmpty(p.Description))
+            .GroupBy(p => (p.Taxonomy, p.Tag))
+            .ToDictionary(g => g.Key, g => g.First().Description);
 
         var concepts = pairs
             .Select(pair => new FinancialConcept
@@ -351,6 +362,7 @@ public class FinancialFactsImportService
                 Taxonomy = pair.Taxonomy,
                 Tag = pair.Tag,
                 Label = firstLabelByPair.GetValueOrDefault(pair),
+                Description = firstDescriptionByPair.GetValueOrDefault(pair),
             })
             .ToList();
 
@@ -575,6 +587,7 @@ public class FinancialFactsImportService
         public FactTaxonomy Taxonomy { get; init; }
         public string Tag { get; init; }
         public string Label { get; init; }
+        public string Description { get; init; }
         public string Unit { get; init; }
         public FactPeriodType PeriodType { get; init; }
         public DateOnly PeriodStart { get; init; }

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -370,10 +370,16 @@ public class FinancialFactsTools
         if (preferredSpan.Count > 0)
             candidates = preferredSpan;
 
-        var byPriority = candidates.OrderBy(f => conceptPriority[f.FinancialConceptId]);
+        // Latest period end first: a filing re-reports comparative prior periods (the
+        // prior-year quarter, prior fiscal years, the prior year-end balance instant)
+        // under its own fiscal identity, and those tie the current figure on span and
+        // filed date — ignoring the period end surfaces a comparative column (#1546).
+        var byPeriod = candidates
+            .OrderByDescending(f => f.PeriodEnd)
+            .ThenBy(f => conceptPriority[f.FinancialConceptId]);
         return asOriginallyReported
-            ? byPriority.ThenBy(f => f.FiledDate).ThenBy(f => f.AccessionNumber).First()
-            : byPriority
+            ? byPeriod.ThenBy(f => f.FiledDate).ThenBy(f => f.AccessionNumber).First()
+            : byPeriod
                 .ThenByDescending(f => f.FiledDate)
                 .ThenByDescending(f => f.AccessionNumber)
                 .First();

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -97,8 +97,7 @@ public class FinancialStatementTools
                     return periodError;
 
                 var statementLines = FinancialStatementConcepts.For(statementType);
-                var taxonomies = statementLines.Select(l => l.Taxonomy).Distinct().ToList();
-                var tags = statementLines.Select(l => l.Tag).Distinct().ToList();
+                var (taxonomies, tags) = StatementLineFacts.CollectConceptPairs(statementLines);
 
                 var concepts = await _financialConceptRepository
                     .GetMatching(taxonomies, tags)
@@ -171,10 +170,8 @@ public class FinancialStatementTools
         var rendered = 0;
         foreach (var line in statementLines)
         {
-            if (
-                !conceptIdByKey.TryGetValue((line.Taxonomy, line.Tag), out var conceptId)
-                || !latestByConcept.TryGetValue(conceptId, out var fact)
-            )
+            var fact = StatementLineFacts.PickFact(line, conceptIdByKey, latestByConcept);
+            if (fact == null)
             {
                 result.AppendLine($"| {FactMarkdown.Cell(line.Label)} | — | | | | |");
                 continue;

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -293,27 +293,7 @@ public class FinancialStatementTools
     internal static FinancialFact PickCurrentlyReportedFact(
         IEnumerable<FinancialFact> facts,
         SecFiscalPeriod fiscalPeriod
-    )
-    {
-        var candidates = facts.ToList();
-
-        var preferred = candidates
-            .Where(f =>
-            {
-                var spanDays = f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber;
-                return fiscalPeriod == SecFiscalPeriod.FullYear
-                    ? spanDays == 0 || spanDays >= MinAnnualSpanDays
-                    : spanDays <= MaxDiscreteQuarterDays;
-            })
-            .ToList();
-        if (preferred.Count > 0)
-            candidates = preferred;
-
-        return candidates
-            .OrderByDescending(f => f.PeriodEnd)
-            .ThenByDescending(f => f.FiledDate)
-            .First();
-    }
+    ) => StatementLineFacts.PickCurrentlyReported(facts, fiscalPeriod);
 
     // Chronological order within a fiscal year: Q1 < Q2 < Q3 < Q4 < FullYear.
     private static int ChronologicalRank(SecFiscalPeriod period) =>

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -621,7 +621,25 @@ public class StockTabService
             .LatestPerGroup(f => f.FinancialConceptId, f => f.FiledDate)
             .ToDictionary(f => f.FinancialConceptId);
 
+        // The catalog is deliberately broad (71 lines across sectors); lines
+        // whose concepts the company has NEVER reported are hidden entirely,
+        // while a line reported in other periods keeps its dash for this one.
+        var everReportedConceptIds = (
+            await _financialFactRepository
+                .GetConsolidatedByStock(stock)
+                .Where(f => conceptIds.Contains(f.FinancialConceptId))
+                .Select(f => f.FinancialConceptId)
+                .Distinct()
+                .ToListAsync()
+        ).ToHashSet();
+
         return statementLines
+            .Where(line =>
+                line.Concepts.Any(r =>
+                    conceptIdByKey.TryGetValue((r.Taxonomy, r.Tag), out var id)
+                    && everReportedConceptIds.Contains(id)
+                )
+            )
             .Select(line =>
             {
                 var row = new FinancialsLineViewModel { Label = line.Label };

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -549,8 +549,9 @@ public class StockTabService
         var statementLines = Enum.GetValues<FinancialStatementType>()
             .SelectMany(FinancialStatementConcepts.For)
             .ToList();
-        var statementTaxonomies = statementLines.Select(l => l.Taxonomy).Distinct().ToList();
-        var statementTags = statementLines.Select(l => l.Tag).Distinct().ToList();
+        var (statementTaxonomies, statementTags) = StatementLineFacts.CollectConceptPairs(
+            statementLines
+        );
         var statementConceptIds = await _financialConceptRepository
             .GetMatching(statementTaxonomies, statementTags)
             .Select(c => c.Id)
@@ -591,8 +592,7 @@ public class StockTabService
     )
     {
         var statementLines = FinancialStatementConcepts.For(statementType);
-        var taxonomies = statementLines.Select(l => l.Taxonomy).Distinct().ToList();
-        var tags = statementLines.Select(l => l.Tag).Distinct().ToList();
+        var (taxonomies, tags) = StatementLineFacts.CollectConceptPairs(statementLines);
 
         var concepts = await _financialConceptRepository
             .GetMatching(taxonomies, tags)
@@ -625,10 +625,8 @@ public class StockTabService
             .Select(line =>
             {
                 var row = new FinancialsLineViewModel { Label = line.Label };
-                if (
-                    conceptIdByKey.TryGetValue((line.Taxonomy, line.Tag), out var conceptId)
-                    && latestByConcept.TryGetValue(conceptId, out var fact)
-                )
+                var fact = StatementLineFacts.PickFact(line, conceptIdByKey, latestByConcept);
+                if (fact != null)
                 {
                     row.HasValue = true;
                     row.Value = fact.Value;

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -615,11 +615,16 @@ public class StockTabService
             )
             .ToListAsync();
 
-        // SEC re-emits a concept across filings (restatements); the latest-filed
-        // value is the currently-reported one.
+        // The currently-reported fact per concept: span-aware so a quarter never
+        // shows the 10-Q's year-to-date figure, latest-ending so a comparative
+        // column never stands in for the current one, latest-filed on
+        // restatements — the same pick the MCP statement tool applies (#1546).
         var latestByConcept = facts
-            .LatestPerGroup(f => f.FinancialConceptId, f => f.FiledDate)
-            .ToDictionary(f => f.FinancialConceptId);
+            .GroupBy(f => f.FinancialConceptId)
+            .ToDictionary(
+                g => g.Key,
+                g => StatementLineFacts.PickCurrentlyReported(g, fiscalPeriod)
+            );
 
         // The catalog is deliberately broad (71 lines across sectors); lines
         // whose concepts the company has NEVER reported are hidden entirely,

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -93,6 +93,9 @@ builder.Services.Configure<Equibles.Sec.HostedService.Configuration.FilingItemsB
 builder.Services.Configure<FinancialFactsScraperOptions>(
     builder.Configuration.GetSection("FinancialFactsScraper")
 );
+builder.Services.Configure<Equibles.Sec.FinancialFacts.HostedService.Configuration.ConceptMetadataOptions>(
+    builder.Configuration.GetSection("ConceptMetadata")
+);
 builder.Services.Configure<Equibles.Sec.FinancialFacts.HostedService.Configuration.XbrlFactsExtractionOptions>(
     builder.Configuration.GetSection("XbrlFactsExtraction")
 );

--- a/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
@@ -186,7 +186,10 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
             NullLogger<DocumentManager>()
         );
 
-        var workDone = await sut.GenerateEmbeddingBatch(new BackfillCursor(), CancellationToken.None);
+        var workDone = await sut.GenerateEmbeddingBatch(
+            new BackfillCursor(),
+            CancellationToken.None
+        );
 
         workDone
             .Should()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
@@ -182,9 +182,10 @@ public class StocksControllerFinancialsTabTests : IDisposable
         revenueLine.Value.Should().Be(400_000_000_000m, "the latest-filed restatement wins");
         revenueLine.Unit.Should().Be("USD");
 
-        // A curated concept the company never reported still renders, valueless,
-        // so the statement keeps its shape.
-        tab.Lines.Should().Contain(l => l.Label == "Net Income" && !l.HasValue);
+        // A curated concept the company NEVER reported is hidden entirely — the
+        // catalog spans 71 cross-sector lines, and rendering them all would
+        // drown a software company's statement in bank/insurer dashes.
+        tab.Lines.Should().NotContain(l => l.Label == "Net Income");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
@@ -32,7 +32,9 @@ public class BackfillCursorTests
         var frontier = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
         cursor.Advance(frontier);
 
-        var allowed = cursor.TryStartFullRescan(new DateTime(2026, 7, 3, 13, 0, 0, DateTimeKind.Utc));
+        var allowed = cursor.TryStartFullRescan(
+            new DateTime(2026, 7, 3, 13, 0, 0, DateTimeKind.Utc)
+        );
 
         allowed.Should().BeTrue();
         cursor.Floor.Should().Be(frontier);

--- a/tests/Equibles.UnitTests/Sec/ConceptMetadataServiceParseMetaLinksTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ConceptMetadataServiceParseMetaLinksTests.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// ParseMetaLinks against the real MetaLinks shape (trimmed from an actual ADBE
+/// 10-Q artifact): standard-taxonomy tags map to their enum, the filer's own
+/// extension tags map to Custom with the extractor's "prefix:LocalName" shape,
+/// reference taxonomies we ingest no facts for (ecd, country, …) are skipped,
+/// and the crdr attribute becomes the debit/credit balance.
+/// </summary>
+public class ConceptMetadataServiceParseMetaLinksTests
+{
+    // Faithful subset of a real MetaLinks.json: instance → document → nsprefix + tag map.
+    private const string Sample = """
+        {
+          "version": "2.2",
+          "instance": {
+            "adbe-20260529.htm": {
+              "nsprefix": "adbe",
+              "tag": {
+                "us-gaap_ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost": {
+                  "crdr": "debit",
+                  "lang": { "en-us": { "role": {
+                    "label": "Research and Development Expense, Software (Excluding Acquired in Process Cost)",
+                    "documentation": "Research and development expense during the period related to the costs of developing and achieving technological feasibility of a computer software product."
+                  } } }
+                },
+                "adbe_ExciseTaxPayableCurrent": {
+                  "crdr": "credit",
+                  "lang": { "en-us": { "role": {
+                    "label": "Excise Tax Payable, Current",
+                    "documentation": "Excise Tax Payable, Current"
+                  } } }
+                },
+                "dei_EntityCommonStockSharesOutstanding": {
+                  "lang": { "en-us": { "role": {
+                    "label": "Entity Common Stock, Shares Outstanding",
+                    "documentation": "Indicate number of shares outstanding of each of registrant's classes of common stock."
+                  } } }
+                },
+                "ecd_AllTradingArrangementsMember": {
+                  "lang": { "en-us": { "role": { "label": "All Trading Arrangements" } } }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    private static Dictionary<(FactTaxonomy, string), ConceptMetadataService.TagMetadata> Parse() =>
+        ConceptMetadataService
+            .ParseMetaLinks(Encoding.UTF8.GetBytes(Sample))
+            .ToDictionary(r => r.Pair, r => r.Metadata);
+
+    [Fact]
+    public void ParseMetaLinks_StandardTag_CarriesDocumentationAndBalance()
+    {
+        var parsed = Parse();
+
+        var rd = parsed[
+            (
+                FactTaxonomy.UsGaap,
+                "ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost"
+            )
+        ];
+        rd.Balance.Should().Be(ConceptBalance.Debit);
+        rd.Description.Should().Contain("technological feasibility");
+        rd.Label.Should().StartWith("Research and Development Expense");
+    }
+
+    [Fact]
+    public void ParseMetaLinks_FilerExtensionTag_MapsToCustomWithPrefixedTag()
+    {
+        var parsed = Parse();
+
+        var excise = parsed[(FactTaxonomy.Custom, "adbe:ExciseTaxPayableCurrent")];
+        excise.Balance.Should().Be(ConceptBalance.Credit);
+        excise.Label.Should().Be("Excise Tax Payable, Current");
+    }
+
+    [Fact]
+    public void ParseMetaLinks_DeiTag_MapsToDeiWithoutBalance()
+    {
+        var parsed = Parse();
+
+        var shares = parsed[(FactTaxonomy.Dei, "EntityCommonStockSharesOutstanding")];
+        shares.Balance.Should().BeNull();
+        shares.Description.Should().Contain("shares outstanding");
+    }
+
+    [Fact]
+    public void ParseMetaLinks_ReferenceTaxonomyTag_IsSkipped()
+    {
+        var parsed = Parse();
+
+        parsed.Keys.Should().NotContain(k => k.Item2.Contains("AllTradingArrangementsMember"));
+        parsed.Should().HaveCount(3);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveEarningsSynonymTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveEarningsSynonymTests.cs
@@ -22,8 +22,9 @@ public class FinancialConceptAliasesTryResolveEarningsSynonymTests
         var matched = FinancialConceptAliases.TryResolve("earnings", out var concepts);
 
         matched.Should().BeTrue();
-        var concept = concepts.Should().ContainSingle().Subject;
-        concept.Taxonomy.Should().Be(FactTaxonomy.UsGaap);
-        concept.Tag.Should().Be("NetIncomeLoss");
+        // The preferred (first) concept is the parent-attributable net income;
+        // ProfitLoss trails as a gap-filler for filers that never report it.
+        concepts[0].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
+        concepts[0].Tag.Should().Be("NetIncomeLoss");
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveRdSynonymTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveRdSynonymTests.cs
@@ -18,7 +18,6 @@ public class FinancialConceptAliasesTryResolveRdSynonymTests
         var resolved = FinancialConceptAliases.TryResolve("R&D", out var concepts);
 
         resolved.Should().BeTrue();
-        concepts.Should().ContainSingle();
         concepts[0].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
         concepts[0].Tag.Should().Be("ResearchAndDevelopmentExpense");
     }

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSpacedAmpersandTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSpacedAmpersandTests.cs
@@ -15,7 +15,6 @@ public class FinancialConceptAliasesTryResolveSpacedAmpersandTests
         var resolved = FinancialConceptAliases.TryResolve("R & D", out var concepts);
 
         resolved.Should().BeTrue();
-        concepts.Should().ContainSingle();
         concepts[0].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
         concepts[0].Tag.Should().Be("ResearchAndDevelopmentExpense");
     }

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactDurationPeriodStartTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactDurationPeriodStartTests.cs
@@ -53,7 +53,7 @@ public class FinancialFactsImportServiceTryBuildParsedFactDurationPeriodStartTes
 
         var parsed = method.Invoke(
             null,
-            [FactTaxonomy.UsGaap, "Revenues", "Revenues", "USD", value, stock]
+            [FactTaxonomy.UsGaap, "Revenues", "Revenues", null, "USD", value, stock]
         );
 
         parsed.Should().NotBeNull();

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactFiscalYearFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactFiscalYearFallbackTests.cs
@@ -52,7 +52,7 @@ public class FinancialFactsImportServiceTryBuildParsedFactFiscalYearFallbackTest
 
         var parsed = method.Invoke(
             null,
-            [FactTaxonomy.UsGaap, "Assets", "Assets", "USD", value, stock]
+            [FactTaxonomy.UsGaap, "Assets", "Assets", null, "USD", value, stock]
         );
 
         parsed.Should().NotBeNull();

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactFiscalYearWireFyTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactFiscalYearWireFyTests.cs
@@ -56,7 +56,7 @@ public class FinancialFactsImportServiceTryBuildParsedFactFiscalYearWireFyTests
 
         var parsed = method!.Invoke(
             null,
-            [FactTaxonomy.UsGaap, "Assets", "Assets", "USD", value, stock]
+            [FactTaxonomy.UsGaap, "Assets", "Assets", null, "USD", value, stock]
         );
 
         parsed.Should().NotBeNull();

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactInstantPeriodStartTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactInstantPeriodStartTests.cs
@@ -45,7 +45,7 @@ public class FinancialFactsImportServiceTryBuildParsedFactInstantPeriodStartTest
 
         var parsed = method.Invoke(
             null,
-            [FactTaxonomy.UsGaap, "Assets", "Assets", "USD", value, stock]
+            [FactTaxonomy.UsGaap, "Assets", "Assets", null, "USD", value, stock]
         );
 
         parsed.Should().NotBeNull();

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactUnmappableFpTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactUnmappableFpTests.cs
@@ -79,7 +79,7 @@ public class FinancialFactsImportServiceTryBuildParsedFactUnmappableFpTests
 
         var result = method!.Invoke(
             null,
-            [FactTaxonomy.UsGaap, "Revenues", "Revenues", "USD", value, stock]
+            [FactTaxonomy.UsGaap, "Revenues", "Revenues", null, "USD", value, stock]
         );
 
         result.Should().BeNull();

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactWhitespaceAccnTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactWhitespaceAccnTests.cs
@@ -45,7 +45,7 @@ public class FinancialFactsImportServiceTryBuildParsedFactWhitespaceAccnTests
 
         var result = TryBuildParsedFactMethod.Invoke(
             null,
-            [FactTaxonomy.UsGaap, "Revenues", "Revenues", "USD", value, stock]
+            [FactTaxonomy.UsGaap, "Revenues", "Revenues", null, "USD", value, stock]
         );
 
         result.Should().BeNull();

--- a/tests/Equibles.UnitTests/Sec/FinancialStatementConceptsVariantResolutionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialStatementConceptsVariantResolutionTests.cs
@@ -1,0 +1,57 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Statement lines resolve through FinancialConceptAliases and carry ordered
+/// tag variants. ADBE files R&amp;D under the software-specific tag and never
+/// the generic one, so its Financials tab rendered a permanent dash until the
+/// line learned the variant — pin that the variant stays, ordered after the
+/// generic (preferred) tag so per-period selection favours the broad measure.
+/// </summary>
+public class FinancialStatementConceptsVariantResolutionTests
+{
+    [Fact]
+    public void IncomeStatement_ResearchAndDevelopment_CarriesSoftwareVariantAfterGenericTag()
+    {
+        var income = FinancialStatementConcepts.For(FinancialStatementType.IncomeStatement);
+        var line = income.Single(l => l.Alias == "research-and-development");
+
+        var tags = line.Concepts.Select(c => c.Tag).ToList();
+        tags[0].Should().Be("ResearchAndDevelopmentExpense");
+        tags.Should()
+            .Contain("ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost");
+    }
+
+    [Fact]
+    public void AllStatementLines_ResolveToAtLeastOneConcept()
+    {
+        foreach (var type in Enum.GetValues<FinancialStatementType>())
+        {
+            foreach (var line in FinancialStatementConcepts.For(type))
+            {
+                line.Concepts.Should()
+                    .NotBeEmpty($"line '{line.Label}' ({type}) must resolve its alias");
+                line.Tag.Should().Be(line.Concepts[0].Tag);
+            }
+        }
+    }
+
+    [Fact]
+    public void CashFlow_NetChangeInCash_PrefersModernRestrictedCashTag()
+    {
+        var cashFlow = FinancialStatementConcepts.For(FinancialStatementType.CashFlow);
+        var line = cashFlow.Single(l => l.Alias == "net-change-in-cash");
+
+        // The pre-2018 tag must stay a fallback only: it was deprecated with
+        // ASU 2016-18 and modern filers only report the restricted-cash shape.
+        line.Tag.Should()
+            .Be(
+                "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalentsPeriodIncreaseDecreaseIncludingExchangeRateEffect"
+            );
+        line.Concepts.Select(c => c.Tag)
+            .Should()
+            .Contain("CashAndCashEquivalentsPeriodIncreaseDecrease");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsPickFactTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsPickFactTests.cs
@@ -1,0 +1,97 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// The shared variant-selection rule every statement surface uses: the FIRST
+/// variant (declaration order) with a fact wins, later variants only fill the
+/// gap — so a company reporting both the broad and the narrow tag always shows
+/// the broad one, and a company reporting only the narrow variant (ADBE's
+/// software R&amp;D) still renders a value instead of a dash.
+/// </summary>
+public class StatementLineFactsPickFactTests
+{
+    private static StatementLine RdLine() =>
+        FinancialStatementConcepts
+            .For(FinancialStatementType.IncomeStatement)
+            .Single(l => l.Alias == "research-and-development");
+
+    private static FinancialFact Fact(decimal value) => new() { Value = value };
+
+    [Fact]
+    public void PickFact_PreferredTagReported_WinsOverVariant()
+    {
+        var line = RdLine();
+        var genericId = Guid.NewGuid();
+        var softwareId = Guid.NewGuid();
+        var conceptIdByKey = new Dictionary<(FactTaxonomy, string), Guid>
+        {
+            [(FactTaxonomy.UsGaap, "ResearchAndDevelopmentExpense")] = genericId,
+            [
+                (
+                    FactTaxonomy.UsGaap,
+                    "ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost"
+                )
+            ] = softwareId,
+        };
+        var facts = new Dictionary<Guid, FinancialFact>
+        {
+            [genericId] = Fact(100),
+            [softwareId] = Fact(200),
+        };
+
+        var picked = StatementLineFacts.PickFact(line, conceptIdByKey, facts);
+
+        picked.Value.Should().Be(100);
+    }
+
+    [Fact]
+    public void PickFact_OnlyVariantReported_FillsFromVariant()
+    {
+        var line = RdLine();
+        var softwareId = Guid.NewGuid();
+        var conceptIdByKey = new Dictionary<(FactTaxonomy, string), Guid>
+        {
+            [
+                (
+                    FactTaxonomy.UsGaap,
+                    "ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost"
+                )
+            ] = softwareId,
+        };
+        var facts = new Dictionary<Guid, FinancialFact> { [softwareId] = Fact(200) };
+
+        var picked = StatementLineFacts.PickFact(line, conceptIdByKey, facts);
+
+        picked.Value.Should().Be(200);
+    }
+
+    [Fact]
+    public void PickFact_NothingReported_ReturnsNull()
+    {
+        var line = RdLine();
+
+        var picked = StatementLineFacts.PickFact(
+            line,
+            new Dictionary<(FactTaxonomy, string), Guid>(),
+            new Dictionary<Guid, FinancialFact>()
+        );
+
+        picked.Should().BeNull();
+    }
+
+    [Fact]
+    public void CollectConceptPairs_ReturnsEveryVariantTag()
+    {
+        var (taxonomies, tags) = StatementLineFacts.CollectConceptPairs([RdLine()]);
+
+        taxonomies.Should().Equal(FactTaxonomy.UsGaap);
+        tags.Should()
+            .Contain([
+                "ResearchAndDevelopmentExpense",
+                "ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost",
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary

Two data-completeness gaps in the shared financial-statement layer:

1. **Statement lines missed tag variants.** The curated catalog mapped each line to a single us-gaap tag, so a company filing a narrower variant rendered a permanent dash — e.g. ADBE files R&D as `ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost` and never the generic tag. Lines now resolve through `FinancialConceptAliases` (single source of truth for variants) and consumers pick the first variant reported per period. The catalog also grows from 26 to 71 curated lines (SG&A split, interest, pretax/tax, comprehensive income, working-capital detail, deferred revenue, debt split, equity components, capex/buybacks/dividends, FX effect, …).

2. **Concepts had no documentation.** `FinancialConcept` gains `Description` and `Balance` (debit/credit). Company Facts `description` is now captured on import (it was already deserialized and dropped), and a new `ConceptMetadataWorker` sweeps each company's recent filings' `MetaLinks.json` — the only source that documents filer-extension (company-specific) concepts, which Company Facts never carries. Resumable via `ConceptMetadataCheckedAt` on the per-company sync status; a company is due when never swept, when a newer filing arrived, or on a 90-day refresh.

## Code changes

- `FinancialConceptAliases`: ~45 new alias groups with ordered variants + synonyms (capex, sga, sbc, buybacks, …)
- `StatementLine`: now alias-based with ordered `Concepts`; `Taxonomy`/`Tag` delegate to the preferred variant
- `StatementLineFacts`: shared variant-selection helper (first reported variant wins) used by the Web tab and MCP tool
- `FinancialStatementConcepts`: rebuilt from aliases, 71 lines
- `FinancialFactsImportService`: plumbs Company Facts `description` into the concept upsert
- `ConceptMetadataService`/`ConceptMetadataWorker` (+options, DI, Worker.Host binding): MetaLinks sweep for labels/descriptions/balance, updating only concepts that already have facts
- Migration `FinancialConceptDescriptionAndBalance` (Description, Balance, ConceptMetadataCheckedAt)
- Tests: variant resolution, PickFact ordering, MetaLinks parsing (real-shape fixture incl. custom-prefix mapping and reference-taxonomy skip); updated alias-synonym and reflection-invoked import tests

https://claude.ai/code/session_01BcT9jGEsew9GwApqnk1U8s