### PR TITLE
fix(sec): keep the backfill frontier across empty full rescans

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/BackfillCursor.cs
+++ b/src/Equibles.Sec.HostedService/Services/BackfillCursor.cs
@@ -33,9 +33,12 @@ public class BackfillCursor
     }
 
     /// <summary>
-    /// Clears the floor for a full rescan when one hasn't run within the rescan interval.
-    /// Returns false when the fallback is still rate-limited — the caller should treat the
-    /// backfill as drained for this poll.
+    /// Rate-limits the unfloored fallback scan to one per rescan interval. Returns false when
+    /// still rate-limited — the caller should treat the backfill as drained for this poll. The
+    /// floor itself is left untouched: an empty rescan must not discard the frontier, or new
+    /// rows arriving right after it would wait out the full interval instead of being picked
+    /// up by the next floored poll. A rescan that does find stragglers moves the floor back
+    /// via Advance, and the floored path then works itself forward again.
     /// </summary>
     public bool TryStartFullRescan(DateTime utcNow)
     {
@@ -43,7 +46,6 @@ public class BackfillCursor
             return false;
 
         _lastFullScanUtc = utcNow;
-        Floor = null;
         return true;
     }
 }

--- a/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
@@ -24,15 +24,18 @@ public class BackfillCursorTests
     }
 
     [Fact]
-    public void TryStartFullRescan_FirstCall_AllowsAndClearsFloor()
+    public void TryStartFullRescan_FirstCall_AllowsAndKeepsFloor()
     {
+        // The frontier must survive a rescan: an empty full scan that discarded it would leave
+        // rows arriving right afterwards invisible until the next rescan window.
         var cursor = new BackfillCursor();
-        cursor.Advance(new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc));
+        var frontier = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
+        cursor.Advance(frontier);
 
         var allowed = cursor.TryStartFullRescan(new DateTime(2026, 7, 3, 13, 0, 0, DateTimeKind.Utc));
 
         allowed.Should().BeTrue();
-        cursor.Floor.Should().BeNull();
+        cursor.Floor.Should().Be(frontier);
     }
 
     [Fact]
@@ -61,6 +64,5 @@ public class BackfillCursorTests
         var allowed = cursor.TryStartFullRescan(firstScan.AddMinutes(61));
 
         allowed.Should().BeTrue();
-        cursor.Floor.Should().BeNull();
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #4087. The hourly full-rescan fallback cleared the cursor floor before scanning; when the scan found nothing (the drained steady state — nights/weekends for the SEC processor) nothing re-established the floor, so the floored fast path stayed disabled and newly scraped filings waited up to the full rescan interval (1h) to be chunked/embedded instead of being picked up by the next 15s poll.

## Code changes
- `BackfillCursor.TryStartFullRescan` now only rate-limits — it no longer touches the floor. An empty rescan leaves the frontier intact; a rescan that finds stragglers still moves the floor back via `Advance` and the floored path works itself forward again.
- Tests updated: the frontier now survives a rescan grant.