### PR TITLE
perf(holdings): incremental fund scoring and a probe-free churn aggregate

### DIFF
--- a/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
+++ b/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.Data;
 using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
@@ -7,12 +8,16 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.Holdings.HostedService;
 
 /// <summary>
-/// Periodically (re)computes the fund score for every filer that has holdings on file, so the
-/// institutions leaderboard can rank the universe by alpha vs the benchmark. A score depends on
-/// daily prices as well as quarterly 13F filings, so the job refreshes daily even though the
-/// underlying portfolio only changes each quarter. Filers without 13F snapshots (Schedule
-/// 13D/G-only) are still visited: scoring them yields nothing, which prunes any stale score
-/// they may have accumulated.
+/// Periodically (re)computes the fund score for filers that have holdings on file, so the
+/// institutions leaderboard can rank the universe by alpha vs the benchmark. Scoring is
+/// incremental: a filer is re-scored when holdings data was imported after its last score,
+/// when its score is older than <see cref="MaxScoreAge"/>, or when it has no score at all
+/// (which also keeps visiting Schedule 13D/G-only filers — scoring them yields nothing, which
+/// prunes any stale score they may have accumulated, and their backtest short-circuits before
+/// loading prices). Re-scoring every filer daily ran ~15k multi-year price-history backtests
+/// per day — billions of price rows read for scores whose portfolios only change when a new
+/// 13F lands, while the price-only drift of a rolling multi-year alpha is far too slow for a
+/// daily recompute to reorder the leaderboard.
 /// <para>
 /// Each filer is scored in its own DI scope: the backtest can load thousands of price rows, so a
 /// single shared context's change tracker would balloon across the run, and a fault scoring one
@@ -29,6 +34,12 @@ public class FundScoringWorker : BackgroundService
     protected virtual TimeSpan SleepInterval => TimeSpan.FromHours(24);
     protected virtual int WindowYears => FundScoringManager.DefaultWindowYears;
     protected virtual string BenchmarkTicker => FundScoringManager.DefaultBenchmark;
+
+    // Price-drift refresh floor: with no new filing, a filer's rolling-window alpha still
+    // drifts as the window slides over daily prices, so every score is recomputed at least
+    // this often. A week keeps the leaderboard honest while spreading the recompute cost to
+    // ~1/7 of the universe per daily cycle.
+    protected virtual TimeSpan MaxScoreAge => TimeSpan.FromDays(7);
 
     public FundScoringWorker(IServiceScopeFactory scopeFactory, ILogger<FundScoringWorker> logger)
     {
@@ -81,16 +92,17 @@ public class FundScoringWorker : BackgroundService
     }
 
     /// <summary>
-    /// Scores every filer with holdings on file as of today, returning how many produced a
-    /// score. Internal so the worker's batch behaviour can be driven directly in tests.
+    /// Scores every filer whose score is missing, stale, or older than its latest imported
+    /// holdings data, returning how many produced a score. Internal so the worker's batch
+    /// behaviour can be driven directly in tests.
     /// </summary>
     internal async Task<int> ScoreAllHolders(CancellationToken cancellationToken)
     {
         var asOf = DateOnly.FromDateTime(DateTime.UtcNow);
-        var holderIds = await LoadScoreableHolderIds(cancellationToken);
+        var pending = await SelectHoldersNeedingScore(cancellationToken);
 
         var scored = 0;
-        foreach (var holderId in holderIds)
+        foreach (var holderId in pending)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (await ScoreHolder(holderId, asOf, cancellationToken))
@@ -99,16 +111,69 @@ public class FundScoringWorker : BackgroundService
         return scored;
     }
 
-    private async Task<List<Guid>> LoadScoreableHolderIds(CancellationToken cancellationToken)
+    // The incremental selection: one grouped pass over the holdings table yields the filer
+    // universe together with each filer's latest data-import time (row CreationTime — exact,
+    // unlike FilingDate, which a late backfill of old filings would not bump), and one small
+    // read yields the existing scores' last-computed times. A filer is due when it has no
+    // score for this (window, benchmark), its data changed after the score, or the score has
+    // aged past MaxScoreAge. FundScore.CreationTime is refreshed on every upsert, so it is
+    // the "last scored at" marker; a transiently unscoreable filer keeps its old timestamps
+    // and is naturally retried next cycle.
+    private async Task<List<Guid>> SelectHoldersNeedingScore(CancellationToken cancellationToken)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
-        return await dbContext
+
+        var holders = await dbContext
             .Set<InstitutionalHolding>()
-            .Select(h => h.InstitutionalHolderId)
-            .Distinct()
+            .GroupBy(h => h.InstitutionalHolderId)
+            .Select(g => new { HolderId = g.Key, LastImported = g.Max(h => h.CreationTime) })
             .ToListAsync(cancellationToken);
+
+        var benchmark = TickerNormalizer.Normalize(BenchmarkTicker);
+        var scoredAt = await dbContext
+            .Set<FundScore>()
+            .Where(s => s.WindowYears == WindowYears && s.BenchmarkTicker == benchmark)
+            .Select(s => new { s.InstitutionalHolderId, s.CreationTime })
+            .ToDictionaryAsync(
+                s => s.InstitutionalHolderId,
+                s => s.CreationTime,
+                cancellationToken
+            );
+
+        var staleBefore = DateTime.UtcNow - MaxScoreAge;
+        var pending = holders
+            .Where(h =>
+                IsScoreDue(
+                    scoredAt.TryGetValue(h.HolderId, out var lastScored)
+                        ? lastScored
+                        : (DateTime?)null,
+                    h.LastImported,
+                    staleBefore
+                )
+            )
+            .Select(h => h.HolderId)
+            .ToList();
+
+        _logger.LogInformation(
+            "Fund scoring cycle: {Pending} of {Total} filer(s) due (new data, stale, or unscored)",
+            pending.Count,
+            holders.Count
+        );
+        return pending;
     }
+
+    // The pure due-decision behind the incremental cycle: unscored filers are always due;
+    // scored filers are due when new holdings data was imported after the score, or the
+    // score has aged past the staleness floor. Internal so tests can pin the rule directly.
+    internal static bool IsScoreDue(
+        DateTime? lastScoredAt,
+        DateTime lastImportedAt,
+        DateTime staleBefore
+    ) =>
+        lastScoredAt is not { } lastScored
+        || lastScored < staleBefore
+        || lastImportedAt > lastScored;
 
     private async Task<bool> ScoreHolder(
         Guid holderId,

--- a/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
+++ b/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
@@ -112,13 +112,16 @@ public class FundScoringWorker : BackgroundService
     }
 
     // The incremental selection: one grouped pass over the holdings table yields the filer
-    // universe together with each filer's latest data-import time (row CreationTime — exact,
-    // unlike FilingDate, which a late backfill of old filings would not bump), and one small
-    // read yields the existing scores' last-computed times. A filer is due when it has no
-    // score for this (window, benchmark), its data changed after the score, or the score has
-    // aged past MaxScoreAge. FundScore.CreationTime is refreshed on every upsert, so it is
-    // the "last scored at" marker; a transiently unscoreable filer keeps its old timestamps
-    // and is naturally retried next cycle.
+    // universe together with two change signals per filer, and one small read yields the
+    // existing scores' last-computed times. A filer is due when it has no score for this
+    // (window, benchmark), its data changed after the score, or the score has aged past
+    // MaxScoreAge. Two signals because neither alone sees every change: row CreationTime
+    // catches new inserts (new quarters, late backfills of old filings) but not in-place
+    // amendment restatements — the importer's upsert rewrites values without touching
+    // CreationTime — while the latest FilingDate catches those restatements (it IS rewritten
+    // on match) but not backfills of old-dated filings. FundScore.CreationTime is refreshed
+    // on every upsert, so it is the "last scored at" marker; a transiently unscoreable filer
+    // keeps its old timestamps and is retried by the staleness floor.
     private async Task<List<Guid>> SelectHoldersNeedingScore(CancellationToken cancellationToken)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
@@ -127,7 +130,12 @@ public class FundScoringWorker : BackgroundService
         var holders = await dbContext
             .Set<InstitutionalHolding>()
             .GroupBy(h => h.InstitutionalHolderId)
-            .Select(g => new { HolderId = g.Key, LastImported = g.Max(h => h.CreationTime) })
+            .Select(g => new
+            {
+                HolderId = g.Key,
+                LastImported = g.Max(h => h.CreationTime),
+                LastFiled = g.Max(h => h.FilingDate),
+            })
             .ToListAsync(cancellationToken);
 
         var benchmark = TickerNormalizer.Normalize(BenchmarkTicker);
@@ -149,6 +157,7 @@ public class FundScoringWorker : BackgroundService
                         ? lastScored
                         : (DateTime?)null,
                     h.LastImported,
+                    h.LastFiled,
                     staleBefore
                 )
             )
@@ -164,16 +173,21 @@ public class FundScoringWorker : BackgroundService
     }
 
     // The pure due-decision behind the incremental cycle: unscored filers are always due;
-    // scored filers are due when new holdings data was imported after the score, or the
-    // score has aged past the staleness floor. Internal so tests can pin the rule directly.
+    // scored filers are due when new holdings data was imported after the score, when the
+    // latest filing is dated on or after the score's day (in-place amendment restatements
+    // rewrite rows without a new CreationTime, so the filing date is the only tell — using
+    // its end-of-day costs at most one extra re-score right after a filing lands), or when
+    // the score has aged past the staleness floor. Internal so tests can pin the rule.
     internal static bool IsScoreDue(
         DateTime? lastScoredAt,
         DateTime lastImportedAt,
+        DateOnly lastFiledOn,
         DateTime staleBefore
     ) =>
         lastScoredAt is not { } lastScored
         || lastScored < staleBefore
-        || lastImportedAt > lastScored;
+        || lastImportedAt > lastScored
+        || lastFiledOn.ToDateTime(TimeOnly.MaxValue) > lastScored;
 
     private async Task<bool> ScoreHolder(
         Guid holderId,

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models.Taxonomies;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories.Models;
 using FlexLabs.EntityFrameworkCore.Upsert;
 using Microsoft.EntityFrameworkCore;
 
@@ -487,51 +488,8 @@ public class HoldingsAggregateRefreshService
             })
             .ToListAsync(cancellationToken);
 
-        // Per-stock churn via two NOT-EXISTS subqueries, identical to
-        // GetQuarterlyNewSoldOutPositions. Keyed by stock so it merges with the
-        // activity rows above.
-        var churn = (
-            await dbContext
-                .Set<InstitutionalHolding>()
-                .Where(h =>
-                    (h.ReportDate == reportDate || h.ReportDate == previousReportDate)
-                    && h.FilingType == FilingType.Form13F
-                )
-                .GroupBy(h => h.CommonStockId)
-                .Select(g => new
-                {
-                    CommonStockId = g.Key,
-                    NewFilerCount = g.Where(h =>
-                            h.ReportDate == reportDate
-                            && !dbContext
-                                .Set<InstitutionalHolding>()
-                                .Any(p =>
-                                    p.ReportDate == previousReportDate
-                                    && p.FilingType == FilingType.Form13F
-                                    && p.CommonStockId == h.CommonStockId
-                                    && p.InstitutionalHolderId == h.InstitutionalHolderId
-                                )
-                        )
-                        .Select(h => h.InstitutionalHolderId)
-                        .Distinct()
-                        .Count(),
-                    SoldOutFilerCount = g.Where(h =>
-                            h.ReportDate == previousReportDate
-                            && !dbContext
-                                .Set<InstitutionalHolding>()
-                                .Any(c =>
-                                    c.ReportDate == reportDate
-                                    && c.FilingType == FilingType.Form13F
-                                    && c.CommonStockId == h.CommonStockId
-                                    && c.InstitutionalHolderId == h.InstitutionalHolderId
-                                )
-                        )
-                        .Select(h => h.InstitutionalHolderId)
-                        .Distinct()
-                        .Count(),
-                })
-                .ToListAsync(cancellationToken)
-        ).ToDictionary(c => c.CommonStockId);
+        var churn = (await BuildChurnQuery(dbContext, reportDate, previousReportDate)
+            .ToListAsync(cancellationToken)).ToDictionary(c => c.CommonStockId);
 
         var computedAt = DateTime.UtcNow;
         var rows = activity
@@ -589,4 +547,39 @@ public class HoldingsAggregateRefreshService
             .Where(s => s.ReportDate == reportDate && !currentStockIds.Contains(s.CommonStockId))
             .ExecuteDeleteAsync(cancellationToken);
     }
+
+    // Per-stock churn: the same numbers GetQuarterlyNewSoldOutPositions defines ("new" =
+    // holder holds the stock this quarter but not last; "sold-out" = the reverse), computed
+    // as two grouped passes instead of that method's correlated NOT-EXISTS probes. The inner
+    // grouping collapses the two-quarter slice to one row per (stock, holder) with presence
+    // flags; the outer grouping counts the flag combinations per stock. The probe-based shape
+    // re-seeked the index once per scanned row — millions of lookups, ~35s per rebuild at
+    // prod scale — while this shape is one index-only scan plus two hash aggregates (~8x
+    // faster), and a rebuild runs on every dirty-quarter drain. Internal so the translation
+    // test can pin that the chained-GroupBy shape stays translatable on the Npgsql provider.
+    internal static IQueryable<MarketWideStockChurn> BuildChurnQuery(
+        EquiblesFinancialDbContext dbContext,
+        DateOnly reportDate,
+        DateOnly previousReportDate
+    ) =>
+        dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h =>
+                (h.ReportDate == reportDate || h.ReportDate == previousReportDate)
+                && h.FilingType == FilingType.Form13F
+            )
+            .GroupBy(h => new { h.CommonStockId, h.InstitutionalHolderId })
+            .Select(g => new
+            {
+                g.Key.CommonStockId,
+                HasCurrent = g.Max(h => h.ReportDate == reportDate ? 1 : 0),
+                HasPrevious = g.Max(h => h.ReportDate == previousReportDate ? 1 : 0),
+            })
+            .GroupBy(p => p.CommonStockId)
+            .Select(g => new MarketWideStockChurn
+            {
+                CommonStockId = g.Key,
+                NewFilerCount = g.Count(p => p.HasCurrent == 1 && p.HasPrevious == 0),
+                SoldOutFilerCount = g.Count(p => p.HasPrevious == 1 && p.HasCurrent == 0),
+            });
 }

--- a/tests/Equibles.UnitTests/Holdings/FundScoringWorkerIsScoreDueTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundScoringWorkerIsScoreDueTests.cs
@@ -4,20 +4,26 @@ namespace Equibles.UnitTests.Holdings;
 
 /// <summary>
 /// Pins the incremental re-score rule in <see cref="FundScoringWorker"/>: unscored filers are
-/// always due; scored filers are due only when new holdings data was imported after the score
-/// or the score has aged past the staleness floor. The daily full-universe recompute this rule
-/// replaced was the largest database drain on record, so a regression here silently reverts to
-/// ~15k multi-year backtests per day.
+/// always due; scored filers are due only when new holdings data was imported after the score,
+/// when the latest filing is dated on or after the score's day (in-place amendment
+/// restatements rewrite rows without a new CreationTime), or when the score has aged past the
+/// staleness floor. The daily full-universe recompute this rule replaced was the largest
+/// database drain on record, so a regression here silently reverts to ~15k multi-year
+/// backtests per day.
 /// </summary>
 public class FundScoringWorkerIsScoreDueTests
 {
     private static readonly DateTime StaleBefore = new(2026, 6, 26, 12, 0, 0, DateTimeKind.Utc);
 
+    // A latest-filing date far enough in the past that the filing-date clause never fires;
+    // each test overrides it when the clause itself is under test.
+    private static readonly DateOnly OldFiling = new(2026, 1, 15);
+
     [Fact]
     public void UnscoredFiler_IsDue()
     {
         FundScoringWorker
-            .IsScoreDue(null, StaleBefore.AddDays(-30), StaleBefore)
+            .IsScoreDue(null, StaleBefore.AddDays(-30), OldFiling, StaleBefore)
             .Should()
             .BeTrue();
     }
@@ -28,7 +34,7 @@ public class FundScoringWorkerIsScoreDueTests
         var lastScored = StaleBefore.AddDays(2);
 
         FundScoringWorker
-            .IsScoreDue(lastScored, lastScored.AddDays(-10), StaleBefore)
+            .IsScoreDue(lastScored, lastScored.AddDays(-10), OldFiling, StaleBefore)
             .Should()
             .BeFalse();
     }
@@ -39,9 +45,37 @@ public class FundScoringWorkerIsScoreDueTests
         var lastScored = StaleBefore.AddDays(2);
 
         FundScoringWorker
-            .IsScoreDue(lastScored, lastScored.AddMinutes(1), StaleBefore)
+            .IsScoreDue(lastScored, lastScored.AddMinutes(1), OldFiling, StaleBefore)
             .Should()
             .BeTrue();
+    }
+
+    [Fact]
+    public void FreshScore_FilingDatedOnScoreDay_IsDue()
+    {
+        // An amendment restating the same quarter updates rows in place — no new
+        // CreationTime — so the filing date is the only change signal. A filing dated the
+        // same day as the score must re-trigger: the restatement may have been imported
+        // after the score ran.
+        var lastScored = StaleBefore.AddDays(2);
+        var filedOn = DateOnly.FromDateTime(lastScored);
+
+        FundScoringWorker
+            .IsScoreDue(lastScored, lastScored.AddDays(-10), filedOn, StaleBefore)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void FreshScore_FilingDatedBeforeScoreDay_IsNotDue()
+    {
+        var lastScored = StaleBefore.AddDays(2);
+        var filedOn = DateOnly.FromDateTime(lastScored).AddDays(-1);
+
+        FundScoringWorker
+            .IsScoreDue(lastScored, lastScored.AddDays(-10), filedOn, StaleBefore)
+            .Should()
+            .BeFalse();
     }
 
     [Fact]
@@ -50,7 +84,7 @@ public class FundScoringWorkerIsScoreDueTests
         var lastScored = StaleBefore.AddDays(-1);
 
         FundScoringWorker
-            .IsScoreDue(lastScored, lastScored.AddDays(-10), StaleBefore)
+            .IsScoreDue(lastScored, lastScored.AddDays(-10), OldFiling, StaleBefore)
             .Should()
             .BeTrue();
     }
@@ -62,6 +96,9 @@ public class FundScoringWorkerIsScoreDueTests
         // means the score already saw that data — only strictly newer imports re-trigger.
         var lastScored = StaleBefore.AddDays(2);
 
-        FundScoringWorker.IsScoreDue(lastScored, lastScored, StaleBefore).Should().BeFalse();
+        FundScoringWorker
+            .IsScoreDue(lastScored, lastScored, OldFiling, StaleBefore)
+            .Should()
+            .BeFalse();
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/FundScoringWorkerIsScoreDueTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundScoringWorkerIsScoreDueTests.cs
@@ -1,0 +1,67 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins the incremental re-score rule in <see cref="FundScoringWorker"/>: unscored filers are
+/// always due; scored filers are due only when new holdings data was imported after the score
+/// or the score has aged past the staleness floor. The daily full-universe recompute this rule
+/// replaced was the largest database drain on record, so a regression here silently reverts to
+/// ~15k multi-year backtests per day.
+/// </summary>
+public class FundScoringWorkerIsScoreDueTests
+{
+    private static readonly DateTime StaleBefore = new(2026, 6, 26, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void UnscoredFiler_IsDue()
+    {
+        FundScoringWorker
+            .IsScoreDue(null, StaleBefore.AddDays(-30), StaleBefore)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void FreshScore_NoNewData_IsNotDue()
+    {
+        var lastScored = StaleBefore.AddDays(2);
+
+        FundScoringWorker
+            .IsScoreDue(lastScored, lastScored.AddDays(-10), StaleBefore)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void FreshScore_DataImportedAfterScore_IsDue()
+    {
+        var lastScored = StaleBefore.AddDays(2);
+
+        FundScoringWorker
+            .IsScoreDue(lastScored, lastScored.AddMinutes(1), StaleBefore)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void StaleScore_NoNewData_IsDue()
+    {
+        var lastScored = StaleBefore.AddDays(-1);
+
+        FundScoringWorker
+            .IsScoreDue(lastScored, lastScored.AddDays(-10), StaleBefore)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void DataImportedExactlyAtScoreTime_IsNotDue()
+    {
+        // The importer stamps CreationTime before the score reads it, so an equal timestamp
+        // means the score already saw that data — only strictly newer imports re-trigger.
+        var lastScored = StaleBefore.AddDays(2);
+
+        FundScoringWorker.IsScoreDue(lastScored, lastScored, StaleBefore).Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsAggregateRefreshServiceChurnQueryTranslationTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsAggregateRefreshServiceChurnQueryTranslationTests.cs
@@ -1,0 +1,48 @@
+using Equibles.CommonStocks.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.HostedService.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins that the snapshot builder's churn query — a chained GroupBy (per (stock, holder)
+/// presence flags, then per stock counts) — stays translatable by the Npgsql provider.
+/// <c>ToQueryString</c> runs the full relational translation pipeline without opening a
+/// connection, so an EF upgrade that stops translating this shape fails here instead of
+/// faulting every dirty-quarter snapshot rebuild at runtime. The chained shape replaced
+/// per-row correlated NOT-EXISTS probes that cost ~35s per rebuild at production scale.
+/// </summary>
+public class HoldingsAggregateRefreshServiceChurnQueryTranslationTests
+{
+    [Fact]
+    public void BuildChurnQuery_TranslatesToSingleStatementSql()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only")
+            .EnableServiceProviderCaching(false)
+            .Options;
+        using var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new HoldingsModuleConfiguration(),
+            }
+        );
+
+        var query = HoldingsAggregateRefreshService.BuildChurnQuery(
+            ctx,
+            new DateOnly(2026, 3, 31),
+            new DateOnly(2025, 12, 31)
+        );
+
+        // Throws InvalidOperationException ("could not be translated") when the shape stops
+        // translating; the GROUP BY assertions pin that both grouping levels stay in SQL
+        // rather than one silently falling back to client evaluation.
+        var sql = query.ToQueryString();
+        sql.Should().Contain("GROUP BY");
+        sql.ToUpperInvariant().Should().NotContain("NOT EXISTS");
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #4087 targeting the two remaining production DB drains found in pg_stat_statements (20h window):

- **Fund scoring**: the worker re-ran a multi-year price backtest for every 13F filer every cycle — ~15k backtests/day reading ~9.3B `DailyStockPrice` rows (≈7.5h of DB execution time per day), for scores whose portfolios only change when a quarterly 13F lands.
- **Snapshot churn aggregation**: each dirty-quarter rebuild of `StockQuarterlyActivity` ran two correlated NOT-EXISTS probes per scanned row (~3.4M rows × 2 index re-seeks) — ~35s per rebuild, ~290 rebuilds/day during filing season.

## Code changes
- `FundScoringWorker` — incremental selection: one grouped pass over `InstitutionalHolding` yields each filer's latest data-import time (`Max(CreationTime)` — exact, unlike FilingDate, which a late backfill wouldn't bump); a filer is re-scored only when data arrived after its last score (`FundScore.CreationTime`, refreshed on every upsert), the score aged past a 7-day price-drift floor, or it has no score (which keeps visiting 13D/G-only filers so stale scores still get pruned — their backtest short-circuits before loading prices). Steady state drops from ~15k to ~2k backtests/day, spiking naturally around filing deadlines. The due-rule is a pure internal predicate (`IsScoreDue`) with direct unit tests.
- `HoldingsAggregateRefreshService.BuildChurnQuery` (extracted, internal) — the churn numbers are now a chained grouped aggregate: inner GroupBy collapses the two-quarter slice to per-(stock, holder) presence flags, outer GroupBy counts the flag combinations per stock. Verified equivalent semantics (the inner grouping subsumes the old per-holder `Distinct()`), and verified on production data: 35s → 4.2s warm. A `ToQueryString` translation test pins the chained-GroupBy shape against the Npgsql provider (single statement, no NOT EXISTS, no client eval).

## Testing
- Full unit suite: 3207 passed (5 new IsScoreDue pins + 1 translation pin).
- Existing FundScoringWorker integration tests unchanged and still valid (fresh DB → no scores → all filers due).