### PR TITLE
style(holdings): csharpier-format HoldingsAggregateRefreshService

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -488,8 +488,10 @@ public class HoldingsAggregateRefreshService
             })
             .ToListAsync(cancellationToken);
 
-        var churn = (await BuildChurnQuery(dbContext, reportDate, previousReportDate)
-            .ToListAsync(cancellationToken)).ToDictionary(c => c.CommonStockId);
+        var churn = (
+            await BuildChurnQuery(dbContext, reportDate, previousReportDate)
+                .ToListAsync(cancellationToken)
+        ).ToDictionary(c => c.CommonStockId);
 
         var computedAt = DateTime.UtcNow;
         var rows = activity


### PR DESCRIPTION
Restores a green `lint` check on `main` — `HoldingsAggregateRefreshService.cs` landed unformatted in #4090, failing the csharpier lint job. Formatting only, no behavior change.

A.L.V.I.S.