### PR TITLE
fix(financial-facts): order concept upserts to prevent deadlocks

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -356,7 +356,14 @@ public class FinancialFactsImportService
             .GroupBy(p => (p.Taxonomy, p.Tag))
             .ToDictionary(g => g.Key, g => g.First().Description);
 
+        // Emit the rows in a stable (Taxonomy, Tag) order so the ON CONFLICT
+        // row locks are taken in the same order as every other writer of this
+        // shared table (notably the XBRL extractor). Without a common order,
+        // two workers upserting an overlapping set of standard concepts lock
+        // the same rows in opposite orders and deadlock (40P01).
         var concepts = pairs
+            .OrderBy(pair => pair.Taxonomy)
+            .ThenBy(pair => pair.Tag, StringComparer.Ordinal)
             .Select(pair => new FinancialConcept
             {
                 Taxonomy = pair.Taxonomy,

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -366,22 +366,34 @@ public class XbrlFactExtractionService
         CancellationToken cancellationToken
     )
     {
+        // Emit the rows in a stable (Taxonomy, Tag) order. Standard concepts
+        // (us-gaap:Revenues, …) recur in nearly every filing, so this extractor
+        // and the Company Facts importer routinely upsert an overlapping set
+        // concurrently. INSERT … ON CONFLICT locks the touched rows in list
+        // order; from an unordered HashSet the two writers would grab the same
+        // shared rows in opposite orders and deadlock (40P01). A single global
+        // order — matched by the importer — makes an ABBA cycle impossible.
         var pairs = persistable.Select(c => (c.Taxonomy, c.Tag)).ToHashSet();
         var concepts = pairs
+            .OrderBy(pair => pair.Item1)
+            .ThenBy(pair => pair.Item2, StringComparer.Ordinal)
             .Select(pair => new FinancialConcept { Taxonomy = pair.Item1, Tag = pair.Item2 })
             .ToList();
 
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
 
+        // Raw XBRL carries no labels, so this path only ever needs the concept
+        // rows to exist — it has nothing to write. DO NOTHING (rather than a
+        // Label = existing.Label no-op update) skips taking write locks on the
+        // hundreds of already-present shared concept rows, shrinking the window
+        // in which this hot table contends with the importer; the importer path
+        // still fills labels/descriptions in.
         await dbContext
             .Set<FinancialConcept>()
             .UpsertRange(concepts)
             .On(c => new { c.Taxonomy, c.Tag })
-            .WhenMatched(
-                (existing, incoming) =>
-                    new FinancialConcept { Label = incoming.Label ?? existing.Label }
-            )
+            .NoUpdate()
             .RunAsync(cancellationToken);
 
         var conceptRepository =


### PR DESCRIPTION
## Summary

Production surfaced recurring `40P01: deadlock detected` errors from `XbrlFactsExtraction.Extract` (`XbrlFactExtractionService.ResolveConcepts`).

**Root cause:** the XBRL fact extractor and the Company Facts importer run as concurrent background workers and both upsert `FinancialConcept` rows. Standard concepts (`us-gaap:Revenues`, `us-gaap:NetIncomeLoss`, …) appear in nearly every filing, so the two writers routinely issue an `INSERT … ON CONFLICT` over an overlapping set of rows at the same time. Each built its concept list from an **unordered `HashSet`**, so the two transactions acquired `ON CONFLICT` row locks in different orders — a classic ABBA cycle — and Postgres killed one with 40P01.

## Code changes

- **`XbrlFactExtractionService.ResolveConcepts`** — order the concepts by `(Taxonomy, Tag)` before the upsert, and switch to `ON CONFLICT DO NOTHING` (`.NoUpdate()`). Raw XBRL carries no labels, so the previous `WhenMatched(Label = incoming.Label ?? existing.Label)` was always a no-op that still took a write lock on every already-present shared row; DO NOTHING inserts only the missing rows and leaves the importer to fill labels, shrinking the contention window.
- **`FinancialFactsImportService.BuildConceptsForUpsert`** — order the concepts by the same `(Taxonomy, Tag)` key before the upsert (keeps its label/description `WhenMatched`).

Both writers now take their `ON CONFLICT` row locks in one identical global order, so an ABBA cycle is impossible.

## Testing

- `dotnet build` clean; csharpier-compliant.
- 209 Sec/FinancialFacts/XBRL/FinancialConcept unit tests pass, including `BuildConceptsForUpsert_DuplicateTagWithDifferentLabels_KeepsFirstEncounteredLabel` (the ordering is applied to the emitted list only, not the label grouping, so the first-label-wins contract is intact).