### PR TITLE
Fold redundant share-count tags into their aliases

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -101,10 +101,20 @@ public static class FinancialConceptAliases
         ["comprehensive-income"] = [G("ComprehensiveIncomeNetOfTax")],
         ["eps-basic"] = [G("EarningsPerShareBasic")],
         ["eps-diluted"] = [G("EarningsPerShareDiluted")],
-        ["weighted-average-shares-basic"] = [G("WeightedAverageNumberOfSharesOutstandingBasic")],
+        ["weighted-average-shares-basic"] =
+        [
+            G("WeightedAverageNumberOfSharesOutstandingBasic"),
+            // Filers whose basic and diluted share counts are equal (no dilutive
+            // securities) report only the combined tag; it fills the basic series
+            // where the split-out basic tag is absent.
+            G("WeightedAverageNumberOfShareOutstandingBasicAndDiluted"),
+        ],
         ["weighted-average-shares-diluted"] =
         [
             G("WeightedAverageNumberOfDilutedSharesOutstanding"),
+            // The same combined tag fills the diluted series for those filers, so
+            // the basic-and-diluted vintage never lists as its own picker entry.
+            G("WeightedAverageNumberOfShareOutstandingBasicAndDiluted"),
         ],
 
         // ── Balance sheet ───────────────────────────────────────────────────
@@ -172,10 +182,17 @@ public static class FinancialConceptAliases
             G("StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest"),
         ],
         ["total-liabilities-and-equity"] = [G("LiabilitiesAndStockholdersEquity")],
-        // The issuer's cover-page common shares outstanding. Single-class filers report it
-        // consolidated (no dimension); multi-class filers report it only per share class, so a
-        // consolidated fact is absent and the entity total is the sum across classes.
-        ["shares-outstanding"] = [new(FactTaxonomy.Dei, "EntityCommonStockSharesOutstanding")],
+        // The issuer's common shares outstanding at a point in time. The dei cover-page
+        // count (as of the filing date) leads; the us-gaap balance-sheet count fills the
+        // periods the cover-page tag lacks. Both name the same measure — one line, not two
+        // near-duplicate picker entries. Single-class filers report the cover-page tag
+        // consolidated (no dimension); multi-class filers report it only per share class,
+        // so a consolidated fact is absent and the entity total is the sum across classes.
+        ["shares-outstanding"] =
+        [
+            new(FactTaxonomy.Dei, "EntityCommonStockSharesOutstanding"),
+            G("CommonStockSharesOutstanding"),
+        ],
 
         // ── Cash flow ───────────────────────────────────────────────────────
         ["depreciation-and-amortization"] =

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesShareCountMergeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesShareCountMergeTests.cs
@@ -1,0 +1,51 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Redundant share-count tag vintages fold into their canonical alias instead of
+/// listing as separate near-duplicate metrics. The preferred tag leads; the
+/// vintage sits LAST so per-period selection only reaches for it where the
+/// preferred tag is absent (companies that never split basic from diluted, or
+/// only file the balance-sheet share count).
+/// </summary>
+public class FinancialConceptAliasesShareCountMergeTests
+{
+    [Fact]
+    public void TryResolve_WeightedAverageSharesBasic_FallsBackToCombinedTagLast()
+    {
+        FinancialConceptAliases
+            .TryResolve("weighted-average-shares-basic", out var refs)
+            .Should()
+            .BeTrue();
+
+        refs[0].Tag.Should().Be("WeightedAverageNumberOfSharesOutstandingBasic");
+        refs[^1].Tag.Should().Be("WeightedAverageNumberOfShareOutstandingBasicAndDiluted");
+    }
+
+    [Fact]
+    public void TryResolve_WeightedAverageSharesDiluted_FallsBackToCombinedTagLast()
+    {
+        FinancialConceptAliases
+            .TryResolve("weighted-average-shares-diluted", out var refs)
+            .Should()
+            .BeTrue();
+
+        refs[0].Tag.Should().Be("WeightedAverageNumberOfDilutedSharesOutstanding");
+        refs[^1].Tag.Should().Be("WeightedAverageNumberOfShareOutstandingBasicAndDiluted");
+    }
+
+    [Fact]
+    public void TryResolve_SharesOutstanding_PrefersCoverPageThenBalanceSheetTag()
+    {
+        FinancialConceptAliases.TryResolve("shares-outstanding", out var refs).Should().BeTrue();
+
+        // The dei cover-page count (as of the filing date) leads.
+        refs[0].Taxonomy.Should().Be(FactTaxonomy.Dei);
+        refs[0].Tag.Should().Be("EntityCommonStockSharesOutstanding");
+        // The us-gaap balance-sheet count fills periods the cover-page tag lacks.
+        refs[^1].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
+        refs[^1].Tag.Should().Be("CommonStockSharesOutstanding");
+    }
+}


### PR DESCRIPTION
## Summary

The chart-builder picker listed **five overlapping "shares outstanding" metrics** where only three distinct measures exist (period-end outstanding, weighted-average basic, weighted-average diluted). The extras are redundant XBRL tag vintages that were never merged into their canonical alias, so each surfaced as its own near-duplicate entry.

This folds the vintages into the existing aliases (superset-only — the preferred tag stays first, the vintage sits last so per-period selection only reaches for it where the preferred tag is absent):

- `shares-outstanding` += `us-gaap:CommonStockSharesOutstanding` (the balance-sheet count fills periods the dei cover-page count lacks — same measure, one line).
- `weighted-average-shares-basic` and `weighted-average-shares-diluted` += `us-gaap:WeightedAverageNumberOfShareOutstandingBasicAndDiluted` (the combined tag that filers with no dilutive securities report instead of the split tags).

The merge flows through every consumer automatically: the `GetFinancialFact` MCP tool gains coverage, and the commercial chart-builder/statement-matrix collapse the duplicates.

## Code changes

- `FinancialConceptAliases.cs` — three alias entries gain a trailing fallback tag; comments explain the ordering.
- `FinancialConceptAliasesShareCountMergeTests.cs` — asserts preferred-tag-first ordering and the merged fallback for each of the three aliases.

All 11 alias-resolution tests pass.