### PR TITLE
fix(holdings): issuer-scoped 13D/G deletes, aggregate isolation, and 13F sync fixes

### DIFF
--- a/src/Equibles.Holdings.Data/Models/AumQuarterlySnapshot.cs
+++ b/src/Equibles.Holdings.Data/Models/AumQuarterlySnapshot.cs
@@ -9,12 +9,14 @@ namespace Equibles.Holdings.Data.Models;
 // quarter on each 13F import and the request path scans this small table in
 // quarter order.
 //
-// DirtyAt is the coalescing signal between Filings13FImportedConsumer (sets it
-// on every import) and AumSnapshotDrainWorker (rebuilds the quarter once the
-// cooldown has elapsed since the first event of a wave, then clears it).
-// Holding the timestamp instead of a bool lets the drain worker clear the
-// flag via optimistic concurrency (clear only if DirtyAt still matches the
-// value seen at claim time), so an event that lands mid-rebuild isn't lost.
+// DirtyAt is the coalescing signal between Filings13FImportedConsumer (stamps
+// it only when currently null, preserving the wave's first-event timestamp)
+// and AumSnapshotDrainWorker (claims — clears — the flag once the cooldown has
+// elapsed, then rebuilds). The claim happens BEFORE the rebuild: an import
+// landing mid-rebuild finds the flag null and re-dirties the row, so its
+// signal triggers another rebuild instead of being lost. Holding a timestamp
+// instead of a bool lets the claim use optimistic concurrency (clear only if
+// DirtyAt still matches the value seen when the drain selected the row).
 // The partial index on DirtyAt is declared in HoldingsModuleConfiguration —
 // the attribute form can't express the WHERE filter.
 public class AumQuarterlySnapshot

--- a/src/Equibles.Holdings.HostedService/AumSnapshotDrainWorker.cs
+++ b/src/Equibles.Holdings.HostedService/AumSnapshotDrainWorker.cs
@@ -13,11 +13,14 @@ namespace Equibles.Holdings.HostedService;
 /// <c>DirtyAt = UtcNow</c> on each import — many events for the same quarter
 /// in the same cooldown window coalesce into a single rebuild here.
 ///
-/// Clearing the dirty flag uses optimistic concurrency: we capture the
-/// <c>DirtyAt</c> value at claim time and clear it only if it still matches
-/// after the rebuild finishes. If a new event arrived mid-rebuild it updated
-/// <c>DirtyAt</c> to a different (more recent) timestamp; the conditional
-/// clear is a no-op and the next tick rebuilds again, so no signal is lost.
+/// The dirty flag is CLAIMED (cleared) before the rebuild runs, not after.
+/// The consumer only stamps <c>DirtyAt</c> when it is currently null, so a
+/// clear-after-rebuild could never observe a mid-rebuild import — the flag
+/// would test unchanged and the signal be silently dropped. Clearing first
+/// means an import landing mid-rebuild finds the flag null, re-dirties the
+/// row with a fresh timestamp, and the next cooldown rebuilds again — no
+/// signal lost. If the rebuild fails, the claim is re-armed with the original
+/// timestamp so the next tick retries immediately.
 /// </summary>
 public class AumSnapshotDrainWorker : BackgroundService
 {
@@ -111,10 +114,19 @@ public class AumSnapshotDrainWorker : BackgroundService
         foreach (var entry in due)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            // Claim BEFORE rebuilding: the consumer only stamps DirtyAt when it
+            // is null, so an import landing mid-rebuild can only be observed if
+            // the flag is already cleared — it then re-dirties the row with a
+            // fresh timestamp and the next cooldown rebuilds again. A skipped
+            // claim means another racer (or a fresh event) moved the flag;
+            // leave this entry for the next tick.
+            if (!await TryClaimDirtyFlag(entry, cancellationToken))
+                continue;
+
             try
             {
                 await _refreshService.RebuildQuarterAsync(entry.ReportDate, cancellationToken);
-                await ClearDirtyFlag(entry, cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -127,20 +139,22 @@ public class AumSnapshotDrainWorker : BackgroundService
                     "Failed to drain dirty AUM snapshot for {ReportDate}; will retry on next tick",
                     entry.ReportDate
                 );
+                await RearmDirtyFlag(entry, cancellationToken);
             }
         }
     }
 
-    private async Task ClearDirtyFlag(DueRebuild entry, CancellationToken cancellationToken)
+    // Clears DirtyAt only if it still matches the claim-time value, returning
+    // whether this worker won the claim.
+    private async Task<bool> TryClaimDirtyFlag(
+        DueRebuild entry,
+        CancellationToken cancellationToken
+    )
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
 
-        // Optimistic concurrency clear: only nullify DirtyAt if it still
-        // matches the timestamp we captured at claim time. If a new event
-        // landed mid-rebuild, DirtyAt was overwritten and this is a no-op,
-        // so the next tick rebuilds again — no signal lost.
-        var cleared = await dbContext
+        var claimed = await dbContext
             .Set<AumQuarterlySnapshot>()
             .Where(s => s.ReportDate == entry.ReportDate && s.DirtyAt == entry.DirtyAt)
             .ExecuteUpdateAsync(
@@ -148,10 +162,34 @@ public class AumSnapshotDrainWorker : BackgroundService
                 cancellationToken
             );
 
-        if (cleared == 0)
+        return claimed > 0;
+    }
+
+    // Restores the original claim timestamp after a failed rebuild — unless an
+    // import already re-dirtied the row (a fresh timestamp supersedes ours).
+    // The restored value is already past the cooldown, so the retry is immediate.
+    private async Task RearmDirtyFlag(DueRebuild entry, CancellationToken cancellationToken)
+    {
+        try
         {
-            _logger.LogDebug(
-                "DirtyAt for {ReportDate} changed during rebuild; leaving it set for the next drain tick",
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+
+            await dbContext
+                .Set<AumQuarterlySnapshot>()
+                .Where(s => s.ReportDate == entry.ReportDate && s.DirtyAt == null)
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(x => x.DirtyAt, entry.DirtyAt),
+                    cancellationToken
+                );
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Losing the re-arm only delays this quarter until its next import
+            // event or the daily safety-net rebuild; never abort the drain loop.
+            _logger.LogWarning(
+                ex,
+                "Failed to re-arm DirtyAt for {ReportDate} after a failed rebuild",
                 entry.ReportDate
             );
         }

--- a/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
+++ b/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
@@ -19,6 +19,12 @@ public class ImportContext
     // Other managers: AccessionNumber → (SequenceNumber → ManagerName)
     public Dictionary<string, Dictionary<int, string>> OtherManagers { get; set; } = [];
 
+    // For Schedule 13D/13G submissions only: AccessionNumber → tracked stock ids
+    // of the issuer(s) the filing reports. A 13D/G covers a single issuer, so its
+    // amendment delete must be scoped to that issuer rather than the holder's
+    // whole (reportDate, filingType) slice.
+    public Dictionary<string, HashSet<Guid>> ScheduleAccessionStockIds { get; set; } = [];
+
     // Yahoo stock prices: (CommonStockId, ReportDate) → closing price
     public Dictionary<(Guid, DateOnly), decimal> StockPrices { get; set; } = [];
 }

--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -59,8 +59,13 @@ public class Filing13FXmlParser
             ),
         };
 
-        var otherManagersScope = coverPage ?? root;
-        foreach (var otherManager2 in Descendants(otherManagersScope, "otherManager2"))
+        // otherManager2 entries live under formData/summaryPage/otherManagers2Info,
+        // NOT under coverPage (which only carries the sequence-less otherManagersInfo
+        // list). Scan from the root: the local name is unique to the summary page, so
+        // a root-wide scan can never grab a wrong element, while a coverPage-scoped
+        // scan finds nothing on every real filing and silently drops all co-manager
+        // names from the realtime path.
+        foreach (var otherManager2 in Descendants(root, "otherManager2"))
         {
             var seqText = Value(Child(otherManager2, "sequenceNumber"));
             if (!int.TryParse(seqText, out var seq))

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -127,8 +127,13 @@ public class HoldingsAggregateRefreshService
             dbContext.Database.SetCommandTimeout(commandTimeout.Value);
         }
 
+        // 13F quarter ends only: Schedule 13D/G rows carry per-day event dates,
+        // so without the filter the "N most recent report dates" the daily
+        // safety net rebuilds are the last N business days of 13D/G activity —
+        // not the recent 13F quarters it exists to protect.
         var distinctDates = dbContext
             .Set<InstitutionalHolding>()
+            .Where(h => h.FilingType == FilingType.Form13F)
             .Select(h => h.ReportDate)
             .Distinct();
         return await orderAndLimit(distinctDates).ToListAsync(cancellationToken);
@@ -292,10 +297,14 @@ public class HoldingsAggregateRefreshService
         // Filtering by ReportDate first narrows the scan via the existing
         // [Index(ReportDate)] btree, so the multi-distinct aggregate only
         // touches one quarter's slice. GroupBy on the same column then folds
-        // to a single output row.
+        // to a single output row. Form 13F only: a 13G/A whose event date lands
+        // exactly on a 13F quarter end (the common annual-amendment case)
+        // stores a Schedule row alongside the same holder+stock's 13F row, and
+        // without the filter that overlapping stake double counts into the
+        // market-wide totals.
         var aggregate = await dbContext
             .Set<InstitutionalHolding>()
-            .Where(h => h.ReportDate == reportDate)
+            .Where(h => h.ReportDate == reportDate && h.FilingType == FilingType.Form13F)
             .GroupBy(h => h.ReportDate)
             .Select(g => new
             {
@@ -359,10 +368,11 @@ public class HoldingsAggregateRefreshService
     {
         // Same quarter-bounded shape: filter holdings first, then join the
         // stock/industry/sector taxonomy. The aggregate produces one row per
-        // (ReportDate, SectorId).
+        // (ReportDate, SectorId). Form 13F only — see UpsertAumSnapshot for the
+        // quarter-end 13G/A double-count this filter prevents.
         var rows = await dbContext
             .Set<InstitutionalHolding>()
-            .Where(h => h.ReportDate == reportDate)
+            .Where(h => h.ReportDate == reportDate && h.FilingType == FilingType.Form13F)
             .Join(
                 dbContext.Set<CommonStock>(),
                 h => h.CommonStockId,

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -106,6 +106,13 @@ public class HoldingsImportService
         var byQuarter = new Dictionary<DateOnly, int>();
         foreach (var submission in context.Submissions.Values)
         {
+            // 13F submissions only: a Schedule 13D/G carries an event DATE, not a
+            // quarter end. Publishing it would seed a stub AumQuarterlySnapshot
+            // (and downstream sector/activity snapshot rows) keyed to that
+            // arbitrary day, polluting every market-wide quarterly surface.
+            if (submission.FormType.ToHoldingsFilingType() != FilingType.Form13F)
+                continue;
+
             if (TryParseDateOnly(submission.PeriodOfReport, out var reportDate))
             {
                 byQuarter[reportDate] = byQuarter.GetValueOrDefault(reportDate) + 1;
@@ -316,16 +323,32 @@ public class HoldingsImportService
             return CusipMappingOutcome.NoInfoTable;
 
         var uniqueCusips = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var scheduleCusipsByAccession = new Dictionary<string, HashSet<string>>(
+            StringComparer.OrdinalIgnoreCase
+        );
         await foreach (var row in context.TsvParser.ParseEntry(infoTableEntry))
         {
             var accession = GetValue(row, AccessionNumberColumn);
-            if (!context.Submissions.ContainsKey(accession))
+            if (!context.Submissions.TryGetValue(accession, out var submission))
                 continue;
 
             var cusip = GetValue(row, "CUSIP");
-            if (!string.IsNullOrEmpty(cusip))
+            if (string.IsNullOrEmpty(cusip))
+                continue;
+
+            uniqueCusips.Add(cusip);
+
+            // Remember which issuer(s) each Schedule 13D/G filing reports —
+            // HandleAmendments scopes those filings' restatement delete to them.
+            var filingType = submission.FormType.ToHoldingsFilingType();
+            if (filingType is FilingType.Schedule13D or FilingType.Schedule13G)
             {
-                uniqueCusips.Add(cusip);
+                if (!scheduleCusipsByAccession.TryGetValue(accession, out var cusips))
+                {
+                    cusips = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    scheduleCusipsByAccession[accession] = cusips;
+                }
+                cusips.Add(cusip);
             }
         }
 
@@ -366,6 +389,18 @@ public class HoldingsImportService
         }
 
         context.CusipMapping = cusipMapping;
+
+        foreach (var (accession, cusips) in scheduleCusipsByAccession)
+        {
+            var stockIds = new HashSet<Guid>();
+            foreach (var cusip in cusips)
+            {
+                if (cusipMapping.TryGetValue(cusip, out var stockId))
+                    stockIds.Add(stockId);
+            }
+            context.ScheduleAccessionStockIds[accession] = stockIds;
+        }
+
         return CusipMappingOutcome.Mapped;
     }
 
@@ -430,23 +465,58 @@ public class HoldingsImportService
     }
 
     // Refresh the confidential-treatment flag on holders we already track from
-    // the current filing's cover page; their identity columns stay as first seen.
+    // their latest filing's cover page; their identity columns stay as first seen.
+    // Keyed by CIK up front: a linear scan per holder is O(holders × submissions),
+    // which a quarterly bulk data set (~8k of each) turns into tens of millions of
+    // comparisons — and its first-match pick was import-order-arbitrary when a
+    // filer has several submissions (multiple quarters) in one data set.
     private void RefreshExistingHolderConfidentialTreatment(
         ImportContext context,
         List<InstitutionalHolder> existingHolders
     )
     {
+        var latestByCik = BuildLatestSubmissionByCik(context.Submissions.Values);
+
         foreach (var holder in existingHolders)
         {
-            var submission = context.Submissions.Values.FirstOrDefault(s =>
-                string.Equals(s.Cik, holder.Cik, StringComparison.OrdinalIgnoreCase)
-            );
-            if (submission == null)
+            if (!latestByCik.TryGetValue(holder.Cik, out var submission))
                 continue;
             context.CoverPages.TryGetValue(submission.AccessionNumber, out var cp);
             if (cp != null)
                 holder.ConfidentialTreatmentRequested = IsYes(cp.ConfidentialTreatment);
         }
+    }
+
+    // The most recently filed submission per CIK — same ordering contract as
+    // DeduplicateSubmissions (parsed FilingDate, accession breaks same-day ties).
+    internal static Dictionary<string, SubmissionRow> BuildLatestSubmissionByCik(
+        IEnumerable<SubmissionRow> submissions
+    )
+    {
+        var latestByCik = new Dictionary<string, SubmissionRow>(StringComparer.OrdinalIgnoreCase);
+        foreach (var submission in submissions)
+        {
+            if (string.IsNullOrEmpty(submission.Cik))
+                continue;
+            if (
+                !latestByCik.TryGetValue(submission.Cik, out var current)
+                || CompareByFilingDateThenAccession(submission, current) > 0
+            )
+            {
+                latestByCik[submission.Cik] = submission;
+            }
+        }
+        return latestByCik;
+    }
+
+    private static int CompareByFilingDateThenAccession(SubmissionRow left, SubmissionRow right)
+    {
+        TryParseDateOnly(left.FilingDate, out var leftDate);
+        TryParseDateOnly(right.FilingDate, out var rightDate);
+        var byDate = leftDate.CompareTo(rightDate);
+        return byDate != 0
+            ? byDate
+            : string.CompareOrdinal(left.AccessionNumber, right.AccessionNumber);
     }
 
     // Submissions whose CIK has no holder row yet become new InstitutionalHolder
@@ -609,28 +679,53 @@ public class HoldingsImportService
             // let a 13G/A restatement wipe the entire 13F-HR portfolio at that
             // quarter (#3738), so a $5T filer vanished from the AUM rankings.
             // Restatements only ever replace their own form's rows.
-            var existingHoldings = await holdingRepo
+            var existingQuery = holdingRepo
                 .GetAll()
                 .Where(h =>
                     h.InstitutionalHolderId == holderId
                     && h.ReportDate == reportDate
                     && h.FilingType == filingType
-                )
-                .ToListAsync(cancellationToken);
+                );
 
-            if (existingHoldings.Count > 0)
+            // A 13F restatement replaces the holder's whole portfolio for the
+            // quarter, but a Schedule 13D/G filing covers a SINGLE issuer — its
+            // delete must be scoped to the issuer(s) the amendment itself
+            // reports. Passive filers amend many issuers with the same event
+            // date (year/quarter end); an unscoped delete let each 13G/A wipe
+            // every other issuer's stake at that date, and since the wiped
+            // accessions stay recorded as processed and no bulk data set exists
+            // for 13D/G, the loss was permanent and silent.
+            if (filingType != FilingType.Form13F)
             {
-                holdingRepo.Delete(existingHoldings);
+                if (
+                    !context.ScheduleAccessionStockIds.TryGetValue(accession, out var issuerStocks)
+                    || issuerStocks.Count == 0
+                )
+                    continue;
+
+                var issuerStockIds = issuerStocks.ToList();
+                existingQuery = existingQuery.Where(h =>
+                    issuerStockIds.Contains(h.CommonStockId)
+                );
+            }
+
+            // Set-based delete: materialising a large filer's whole portfolio
+            // into the change tracker (and deleting row-by-id) accumulated
+            // hundreds of thousands of tracked entities across a bulk data
+            // set's restatements; one DELETE statement per amendment does the
+            // same work with zero materialisation.
+            var deleted = await existingQuery.ExecuteDeleteAsync(cancellationToken);
+
+            if (deleted > 0)
+            {
                 _logger.LogInformation(
                     "Deleted {Count} {FilingType} holdings for RESTATEMENT amendment {Accession}",
-                    existingHoldings.Count,
+                    deleted,
                     filingType,
                     accession
                 );
             }
         }
-
-        await holdingRepo.SaveChanges();
     }
 
     private static bool IsNewHoldingsAmendment(string accession, ImportContext context)

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -704,9 +704,7 @@ public class HoldingsImportService
                     continue;
 
                 var issuerStockIds = issuerStocks.ToList();
-                existingQuery = existingQuery.Where(h =>
-                    issuerStockIds.Contains(h.CommonStockId)
-                );
+                existingQuery = existingQuery.Where(h => issuerStockIds.Contains(h.CommonStockId));
             }
 
             // Set-based delete: materialising a large filer's whole portfolio

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13DGIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13DGIngestionService.cs
@@ -149,6 +149,27 @@ public class Realtime13DGIngestionService
             if (!importResult.IsComplete)
                 continue;
 
+            // A filing that imported "complete" yet inserted zero holdings is
+            // suspect: recording it would consume the accession forever even
+            // though we hold none of its position (e.g. a blank filer CIK made
+            // the holder upsert skip it). Unlike 13F there is no quarterly bulk
+            // data set to reconcile the loss, so retry instead — and every
+            // 13D/G archive row carries the issuer position (an amendment
+            // re-reports it, a final exit reports zero shares), so zero inserts
+            // is never legitimate here, amendments included.
+            if (importResult.InsertedHoldings == 0)
+            {
+                _logger.LogWarning(
+                    "{Form} {Accession} (CIK {Cik}) imported as complete but inserted no holdings; not recording so a later cycle retries",
+                    filing.SubmissionType,
+                    entry.AccessionNumber,
+                    entry.Cik
+                );
+                if (earliestRetryDate == null || entry.DateFiled < earliestRetryDate)
+                    earliestRetryDate = entry.DateFiled;
+                continue;
+            }
+
             await RecordProcessed([entry.AccessionNumber], cancellationToken);
             totalImported++;
         }

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -402,8 +402,12 @@ public class HoldingsActivityController : BaseController
         return View(viewModel);
     }
 
+    // 13F quarter ends only: including Schedule 13D/G event dates makes the
+    // newest "quarter" an arbitrary business day where almost nothing has a
+    // holding, so the default selection (and the quarter-over-quarter compare)
+    // silently degrades to quarter-vs-single-day.
     private Task<List<DateOnly>> LoadAvailableReportDates() =>
-        _holdingRepository.GetAvailableReportDates().ToListAsync();
+        _holdingRepository.Get13FAvailableReportDates().ToListAsync();
 
     private Task<Dictionary<Guid, StockLabel>> LoadStockLabels(List<Guid> stockIds) =>
         _commonStockRepository

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -167,7 +167,9 @@ public class HoldingsExportController : BaseController
     [HttpGet("~/holdings/export/activity")]
     public async Task<IActionResult> Activity(DateOnly? date)
     {
-        var reportDates = await _holdingRepository.GetAvailableReportDates().ToListAsync();
+        // 13F quarter ends only — a 13D/G event date as the default "quarter"
+        // degrades the exported movers to quarter-vs-single-day.
+        var reportDates = await _holdingRepository.Get13FAvailableReportDates().ToListAsync();
         if (reportDates.Count < 2)
             return NotFound();
 

--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -177,7 +177,9 @@ public class HoldingsScreenerController : BaseController
         DateOnly? Comparison
     )> ResolveScreenerDates(DateOnly? date, DateOnly? compareDate)
     {
-        var reportDates = await _holdingRepository.GetAvailableReportDates().ToListAsync();
+        // 13F quarter ends only — a 13D/G event date as the default "quarter"
+        // degrades the screener's comparison to quarter-vs-single-day.
+        var reportDates = await _holdingRepository.Get13FAvailableReportDates().ToListAsync();
         if (reportDates.Count < 2)
             return (reportDates, null, null);
         var selected = reportDates.ResolveSelectedDateOrFirst(date);

--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserOtherManagersNoCoverPageFallbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserOtherManagersNoCoverPageFallbackTests.cs
@@ -4,14 +4,13 @@ namespace Equibles.IntegrationTests.Holdings;
 
 public class Filing13FXmlParserOtherManagersNoCoverPageFallbackTests
 {
-    // ParseCoverPage scopes otherManager2 lookups via `coverPage ?? root` — the
-    // null-coalescing fallback (line 58) is uncovered. A malformed primary_doc
-    // that omits the <coverPage> wrapper but still ships <otherManagers2Info>
-    // (e.g., a partial filing or future schema variant) must still pick up
-    // the manager seq → name pairs by widening the scope to the root.
-    // A regression that hard-coded `Descendants(coverPage, "otherManager2")`
-    // would compile, pass every cover-page test, and silently lose every
-    // co-manager for filings missing the coverPage wrapper.
+    // ParseCoverPage scans otherManager2 from the document root, because real
+    // filings carry them under formData/summaryPage while a malformed or
+    // future-variant primary_doc may omit wrappers entirely. A regression that
+    // re-scopes the scan to coverPage would compile and pass any test that
+    // co-locates the managers with the cover page, yet silently lose every
+    // co-manager on real filings — this pin (managers with no coverPage at
+    // all) fails for any scope narrower than the root.
     [Fact]
     public void ParseCoverPage_OtherManagers2InfoSiblingOfCoverPageAbsent_FallsBackToRootScope()
     {

--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserOtherManagersSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserOtherManagersSkipTests.cs
@@ -7,7 +7,6 @@ public class Filing13FXmlParserOtherManagersSkipTests
     [Fact]
     public void ParseCoverPage_OtherManager2WithNonNumericSequence_IsSkippedNotPoisoningTheMap()
     {
-        // The existing cover-page pin only feeds a well-formed otherManager2.
         // ParseCoverPage keys OtherManagers by the parsed integer sequence and
         // skips entries whose sequenceNumber isn't an int. One malformed block
         // must not abort cover-page parsing (dropping the whole filing) nor
@@ -25,6 +24,8 @@ public class Filing13FXmlParserOtherManagersSkipTests
                   <isAmendment>false</isAmendment>
                   <filingManager><name>BIG FUND</name></filingManager>
                   <form13FFileNumber>028-1</form13FFileNumber>
+                </coverPage>
+                <summaryPage>
                   <otherManagers2Info>
                     <otherManager2>
                       <sequenceNumber>ABC</sequenceNumber>
@@ -35,7 +36,7 @@ public class Filing13FXmlParserOtherManagersSkipTests
                       <otherManager><cik>0008888888</cik><name>GOOD ADVISORS</name></otherManager>
                     </otherManager2>
                   </otherManagers2Info>
-                </coverPage>
+                </summaryPage>
               </formData>
             </edgarSubmission>
             """;

--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
@@ -34,13 +34,15 @@ public class Filing13FXmlParserParseCoverPageTests
                     </address>
                   </filingManager>
                   <form13FFileNumber>028-12345</form13FFileNumber>
+                </coverPage>
+                <summaryPage>
                   <otherManagers2Info>
                     <otherManager2>
                       <sequenceNumber>1</sequenceNumber>
                       <otherManager><cik>0009999999</cik><name>DECOY ADVISORS LLC</name></otherManager>
                     </otherManager2>
                   </otherManagers2Info>
-                </coverPage>
+                </summaryPage>
               </formData>
             </edgarSubmission>
             """;

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
@@ -722,10 +722,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
 
         var sut = CreateImporter(
             PriceProviderReturning(
-                new Dictionary<(Guid, DateOnly), decimal>
-                {
-                    [(stockAmended.Id, eventDate)] = 200m,
-                }
+                new Dictionary<(Guid, DateOnly), decimal> { [(stockAmended.Id, eventDate)] = 200m }
             )
         );
 
@@ -737,9 +734,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
             .Where(h => h.InstitutionalHolderId == holder.Id && h.ReportDate == eventDate)
             .ToListAsync();
 
-        holdings
-            .Should()
-            .HaveCount(2, "the 13G/A must replace only its own issuer's stake");
+        holdings.Should().HaveCount(2, "the 13G/A must replace only its own issuer's stake");
         var meta = holdings.Single(h => h.CommonStockId == stockAmended.Id);
         meta.Shares.Should().Be(42);
         meta.AccessionNumber.Should().Be("ACC-13G-META-A");

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
@@ -630,6 +630,124 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
         holdings[0].IsAmendment.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task ImportDataSet_Schedule13GAmendment_DeletesOnlyTheAmendedIssuersHoldings()
+    {
+        // A Schedule 13D/G filing covers a SINGLE issuer, unlike a 13F-HR which
+        // covers the whole portfolio. Passive filers submit many 13G/As whose
+        // event dates collide on the same year/quarter end, one per issuer. The
+        // restatement delete must therefore be scoped to the issuer(s) the
+        // amendment itself reports — an unscoped (holder, reportDate,
+        // filingType) delete lets each 13G/A wipe every OTHER issuer's stake at
+        // that event date, and because the wiped filings stay recorded as
+        // processed (and 13D/G has no quarterly bulk data set), the loss is
+        // permanent and silent.
+        var stockAmended = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "META",
+            Name = "Meta",
+            Cik = "0001326801",
+            Cusip = "30303M102",
+        };
+        var stockOther = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Cik = "1067983",
+            Name = "Passive Fund Advisors",
+        };
+        var eventDate = new DateOnly(2024, 12, 31);
+        var amendedIssuerHolding = new InstitutionalHolding
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stockAmended.Id,
+            InstitutionalHolderId = holder.Id,
+            ReportDate = eventDate,
+            FilingDate = new DateOnly(2025, 1, 10),
+            Shares = 999,
+            Value = 99_900,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            FilingType = FilingType.Schedule13G,
+            AccessionNumber = "ACC-13G-META",
+            Cusip = "30303M102",
+        };
+        var otherIssuerHolding = new InstitutionalHolding
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stockOther.Id,
+            InstitutionalHolderId = holder.Id,
+            ReportDate = eventDate,
+            FilingDate = new DateOnly(2025, 1, 11),
+            Shares = 555,
+            Value = 55_500,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            FilingType = FilingType.Schedule13G,
+            AccessionNumber = "ACC-13G-AAPL",
+            Cusip = "037833100",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().AddRange(stockAmended, stockOther);
+            seed.Set<InstitutionalHolder>().Add(holder);
+            seed.Set<InstitutionalHolding>().AddRange(amendedIssuerHolding, otherIssuerHolding);
+            await seed.SaveChangesAsync();
+        }
+
+        // A 13G/A restating ONLY the META stake at the same event date.
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "SC 13G/A\tACC-13G-META-A\t2025-02-14\t2024-12-31\t0001067983\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\n"
+            + "ACC-13G-META-A\tY\tPassive Fund Advisors\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tINVESTMENTDISCRETION\n"
+            + "ACC-13G-META-A\t30303M102\t42\tSH\tSOLE\n";
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+
+        var sut = CreateImporter(
+            PriceProviderReturning(
+                new Dictionary<(Guid, DateOnly), decimal>
+                {
+                    [(stockAmended.Id, eventDate)] = 200m,
+                }
+            )
+        );
+
+        await sut.ImportDataSet(archive, new DateOnly(2024, 1, 1), CancellationToken.None);
+
+        using var verify = FreshContext();
+        var holdings = await verify
+            .Set<InstitutionalHolding>()
+            .Where(h => h.InstitutionalHolderId == holder.Id && h.ReportDate == eventDate)
+            .ToListAsync();
+
+        holdings
+            .Should()
+            .HaveCount(2, "the 13G/A must replace only its own issuer's stake");
+        var meta = holdings.Single(h => h.CommonStockId == stockAmended.Id);
+        meta.Shares.Should().Be(42);
+        meta.AccessionNumber.Should().Be("ACC-13G-META-A");
+        var aapl = holdings.Single(h => h.CommonStockId == stockOther.Id);
+        aapl.Shares.Should().Be(555, "the other issuer's stake must survive the amendment");
+        aapl.AccessionNumber.Should().Be("ACC-13G-AAPL");
+    }
+
     // ── Resilience / parser-branch coverage ─────────────────────────────
 
     [Fact]

--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
@@ -30,15 +30,21 @@ public class Filing13FXmlParserParseCoverPageTests
             + "    </filingManager>"
             + "    <form13FFileNumber>028-00338</form13FFileNumber>"
             + "    <crdNumber>314159</crdNumber>"
-            + "    <otherManager2>"
-            + "      <sequenceNumber>1</sequenceNumber>"
-            + "      <otherManager><name>General Re-New England Asset Mgmt</name></otherManager>"
-            + "    </otherManager2>"
-            + "    <otherManager2>"
-            + "      <sequenceNumber>3</sequenceNumber>"
-            + "      <otherManager><name>New England Asset Management</name></otherManager>"
-            + "    </otherManager2>"
             + "  </coverPage>"
+            // Real filings carry otherManager2 under summaryPage/otherManagers2Info,
+            // outside coverPage — the parser must find them there.
+            + "  <summaryPage>"
+            + "    <otherManagers2Info>"
+            + "      <otherManager2>"
+            + "        <sequenceNumber>1</sequenceNumber>"
+            + "        <otherManager><name>General Re-New England Asset Mgmt</name></otherManager>"
+            + "      </otherManager2>"
+            + "      <otherManager2>"
+            + "        <sequenceNumber>3</sequenceNumber>"
+            + "        <otherManager><name>New England Asset Management</name></otherManager>"
+            + "      </otherManager2>"
+            + "    </otherManagers2Info>"
+            + "  </summaryPage>"
             + "</edgarSubmission>";
 
         var result = _sut.ParseCoverPage(

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildLatestSubmissionByCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildLatestSubmissionByCikTests.cs
@@ -1,0 +1,57 @@
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceBuildLatestSubmissionByCikTests
+{
+    // A bulk data set carries several submissions per filer (late filings for older
+    // quarters land in the same archive). The confidential-treatment refresh must
+    // read the LATEST-filed cover page per CIK — parsed FilingDate first (the raw
+    // strings are SEC dd-MMM-yyyy, where an ordinal sort misorders month spans),
+    // accession breaking same-day ties — never an arbitrary first match.
+    [Fact]
+    public void BuildLatestSubmissionByCik_MultipleSubmissionsPerCik_PicksLatestFiled()
+    {
+        var older = Submission("0000000000-25-000001", "29-JAN-2025", "1000");
+        var latest = Submission("0000000000-25-000002", "14-FEB-2025", "1000");
+        var otherCik = Submission("0000000000-25-000003", "01-JAN-2025", "2000");
+
+        var result = HoldingsImportService.BuildLatestSubmissionByCik(
+            [latest, older, otherCik]
+        );
+
+        result.Should().HaveCount(2);
+        result["1000"].Should().BeSameAs(latest);
+        result["2000"].Should().BeSameAs(otherCik);
+    }
+
+    [Fact]
+    public void BuildLatestSubmissionByCik_SameDayAmendment_HigherAccessionWins()
+    {
+        var original = Submission("0000000000-25-000010", "14-FEB-2025", "1000");
+        var amendment = Submission("0000000000-25-000011", "14-FEB-2025", "1000");
+
+        var result = HoldingsImportService.BuildLatestSubmissionByCik([amendment, original]);
+
+        result["1000"].Should().BeSameAs(amendment);
+    }
+
+    [Fact]
+    public void BuildLatestSubmissionByCik_MissingCik_IsIgnored()
+    {
+        var noCik = Submission("0000000000-25-000020", "14-FEB-2025", null);
+
+        var result = HoldingsImportService.BuildLatestSubmissionByCik([noCik]);
+
+        result.Should().BeEmpty();
+    }
+
+    private static SubmissionRow Submission(string accession, string filingDate, string cik) =>
+        new()
+        {
+            AccessionNumber = accession,
+            FilingDate = filingDate,
+            Cik = cik,
+        };
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildLatestSubmissionByCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildLatestSubmissionByCikTests.cs
@@ -17,9 +17,7 @@ public class HoldingsImportServiceBuildLatestSubmissionByCikTests
         var latest = Submission("0000000000-25-000002", "14-FEB-2025", "1000");
         var otherCik = Submission("0000000000-25-000003", "01-JAN-2025", "2000");
 
-        var result = HoldingsImportService.BuildLatestSubmissionByCik(
-            [latest, older, otherCik]
-        );
+        var result = HoldingsImportService.BuildLatestSubmissionByCik([latest, older, otherCik]);
 
         result.Should().HaveCount(2);
         result["1000"].Should().BeSameAs(latest);


### PR DESCRIPTION
## Summary

Review of the SEC 13F/13D-G sync pipeline surfaced one critical data-loss bug, several confirmed correctness defects, and two hot-path performance problems. All are fixed here; every fix is pinned by a unit or ParadeDB-backed pipeline test.

## Code changes

**`Filing13FXmlParser`** — real EDGAR filings carry `otherManager2` under `formData/summaryPage`, never under `coverPage`; the coverPage-scoped scan found nothing on every real filing, so realtime-ingested 13Fs silently lost all co-manager names (verified against Berkshire's live filing). The scan now runs from the document root, and the parser tests pin the real schema shape instead of the wrong one they encoded.

**`HoldingsImportService.HandleAmendments`** — a Schedule 13D/G covers a single issuer, but a restatement amendment deleted the holder's entire (reportDate, filingType) slice: each 13G/A wiped every other issuer's stake sharing the event date, permanently (accessions stay recorded as processed and 13D/G has no quarterly bulk data set to reconcile from). Deletes for schedule filings are now scoped to the issuer stock ids the amendment itself reports (collected during CUSIP mapping). New pipeline test seeds two 13G positions and proves a 13G/A replaces only its own issuer.

**Quarterly aggregate isolation** — 13D/G event dates leaked into every market-wide quarterly surface: imports published `Filings13FImported` for schedule submissions (stub AUM snapshots at arbitrary business days), the daily safety-net rebuild resolved "recent quarters" to event dates, the AUM/sector snapshots double counted quarter-end 13G/A stakes, and the activity/screener/export pages defaulted their quarter-over-quarter comparison to the newest event date (quarter-vs-single-day). All now filter to Form 13F.

**`AumSnapshotDrainWorker`** — the consumer only stamps `DirtyAt` when null, so the drain's clear-after-rebuild could never observe a mid-rebuild import; the optimistic compare always matched and the signal was dropped. The drain now claims (clears) the flag before rebuilding and re-arms it on failure; a mid-rebuild import re-dirties the row and triggers another rebuild.

**`Realtime13DGIngestionService`** — a 13D/G import that completed with zero inserted holdings (e.g. blank filer CIK) was recorded processed forever; it is now retried with the watermark held back, mirroring the 13F guard.

**Performance** — the confidential-treatment refresh was an O(holders × submissions) scan (~64M string comparisons per quarterly data set), now a CIK-keyed dictionary that also deterministically prefers the latest-filed cover page; restatement deletes now run as one `DELETE` statement per amendment instead of materialising whole portfolios into the change tracker.