### PR TITLE
fix(financial-facts): map REIT top-line revenue tags and add rental-income line

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -39,11 +39,19 @@ public static class FinancialConceptAliases
         [
             G("Revenues"),
             G("RevenueFromContractWithCustomerExcludingAssessedTax"),
+            // Some filers (REITs like ARE) tag their total-revenue line with the
+            // assessed-tax-inclusive ASC 606 variant and never file the excluding
+            // form; it only fills periods the preferred tags lack.
+            G("RevenueFromContractWithCustomerIncludingAssessedTax"),
             // The dominant pre-ASC 606 total-revenue tag (AAPL, MSFT, … filed it
             // through ~FY2017; deprecated 2018). Last so it only fills periods
             // the modern tags lack — without it those companies' revenue series
             // start mid-history.
             G("SalesRevenueNet"),
+            // Pre-2019 real-estate total revenue (deprecated with ASC 842):
+            // REITs filed it instead of SalesRevenueNet, so without it their
+            // revenue series starts at the ASC 606 transition.
+            G("RealEstateRevenueNet"),
         ],
         // Financial-sector top lines: banks, broker-dealers and insurers never
         // file the operating-company revenue tags above.
@@ -52,6 +60,17 @@ public static class FinancialConceptAliases
         ["noninterest-income"] = [G("NoninterestIncome")],
         ["total-net-revenue"] = [G("RevenuesNetOfInterestExpense")],
         ["premiums-earned"] = [G("PremiumsEarnedNet")],
+        // REIT top-line detail: lessors report rental revenue under the lease
+        // tags, not the contract-with-customer tags. LeaseIncome (operating +
+        // sales-type/direct-financing income) is the broadest; the operating
+        // component fills filers that never report the total; the pre-ASC 842
+        // tag covers history before 2019.
+        ["rental-income"] =
+        [
+            G("LeaseIncome"),
+            G("OperatingLeaseLeaseIncome"),
+            G("OperatingLeasesIncomeStatementLeaseRevenue"),
+        ],
         ["cost-of-revenue"] =
         [
             G("CostOfRevenue"),

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialStatementConcepts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialStatementConcepts.cs
@@ -44,6 +44,9 @@ public static class FinancialStatementConcepts
         Line("noninterest-income", "Noninterest Income"),
         Line("total-net-revenue", "Total Net Revenue"),
         Line("premiums-earned", "Premiums Earned (Net)"),
+        // REIT top-line detail: lessors report rental revenue under the lease-income
+        // tags; renders alongside Revenue (the total) for real-estate filers only.
+        Line("rental-income", "Rental Income"),
         Line("cost-of-revenue", "Cost of Revenue"),
         Line("gross-profit", "Gross Profit"),
         Line("research-and-development", "Research & Development"),

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesRevenuePreAsc606Tests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesRevenuePreAsc606Tests.cs
@@ -7,18 +7,23 @@ namespace Equibles.UnitTests.Sec;
 /// The revenue alias must reach back past the ASC 606 transition: large filers
 /// (AAPL, MSFT) reported total revenue as <c>SalesRevenueNet</c> through
 /// ~FY2017, so a series built from the modern tags alone starts mid-history.
-/// The legacy tag sits LAST so it only fills periods the modern tags lack —
-/// per-period selection prefers lower-index refs.
+/// The legacy tag sits AFTER the modern tags so it only fills periods they
+/// lack — per-period selection prefers lower-index refs.
 /// </summary>
 public class FinancialConceptAliasesRevenuePreAsc606Tests
 {
     [Fact]
-    public void TryResolve_Revenue_IncludesLegacySalesRevenueNetLast()
+    public void TryResolve_Revenue_IncludesLegacySalesRevenueNetAfterModernTags()
     {
         FinancialConceptAliases.TryResolve("revenue", out var refs).Should().BeTrue();
 
-        refs[^1].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
-        refs[^1].Tag.Should().Be("SalesRevenueNet");
         refs[0].Tag.Should().Be("Revenues");
+        var tags = refs.Select(r => r.Tag).ToList();
+        var legacyIndex = tags.IndexOf("SalesRevenueNet");
+        legacyIndex.Should().BePositive();
+        legacyIndex
+            .Should()
+            .BeGreaterThan(tags.IndexOf("RevenueFromContractWithCustomerExcludingAssessedTax"));
+        refs[legacyIndex].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesRevenueReitTopLineTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesRevenueReitTopLineTests.cs
@@ -1,0 +1,40 @@
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// REITs never file the operating-company revenue tags the alias preferred:
+/// ARE tags its total-revenue line with the assessed-tax-inclusive ASC 606
+/// variant (2016+) and filed <c>RealEstateRevenueNet</c> before that — without
+/// both, a REIT's income statement renders no Revenue row at all. The
+/// inclusive variant must stay behind the excluding form so filers reporting
+/// both keep the cleaner measure per period.
+/// </summary>
+public class FinancialConceptAliasesRevenueReitTopLineTests
+{
+    [Fact]
+    public void TryResolve_Revenue_CoversReitTopLineTags()
+    {
+        FinancialConceptAliases.TryResolve("revenue", out var refs).Should().BeTrue();
+
+        var tags = refs.Select(r => r.Tag).ToList();
+        tags.Should().Contain("RevenueFromContractWithCustomerIncludingAssessedTax");
+        tags.Should().Contain("RealEstateRevenueNet");
+        tags.IndexOf("RevenueFromContractWithCustomerIncludingAssessedTax")
+            .Should()
+            .BeGreaterThan(tags.IndexOf("RevenueFromContractWithCustomerExcludingAssessedTax"));
+    }
+
+    [Fact]
+    public void TryResolve_RentalIncome_PrefersBroadLeaseIncomeTotal()
+    {
+        FinancialConceptAliases.TryResolve("rental-income", out var refs).Should().BeTrue();
+
+        var tags = refs.Select(r => r.Tag).ToList();
+        // LeaseIncome (operating + sales-type/direct-financing) leads so the
+        // operating-only component never shadows a reported total.
+        tags[0].Should().Be("LeaseIncome");
+        tags.Should().Contain("OperatingLeaseLeaseIncome");
+        tags.Should().Contain("OperatingLeasesIncomeStatementLeaseRevenue");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialStatementConceptsIncomeReitRentalIncomeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialStatementConceptsIncomeReitRentalIncomeTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialStatementConceptsIncomeReitRentalIncomeTests
+{
+    // REITs report rental revenue under the lease-income tags, which no
+    // operating-company or financial-sector line resolves — without this line
+    // a lessor's income statement shows no rental detail. Pin the catalog so a
+    // future trim can't silently drop the REIT top-line block.
+    [Theory]
+    [InlineData("LeaseIncome")]
+    [InlineData("OperatingLeaseLeaseIncome")]
+    [InlineData("OperatingLeasesIncomeStatementLeaseRevenue")]
+    public void IncomeStatement_IncludesReitRentalIncomeVariant(string tag)
+    {
+        var income = FinancialStatementConcepts.For(FinancialStatementType.IncomeStatement);
+
+        var line = income.Should().ContainSingle(l => l.Alias == "rental-income").Subject;
+        line.Concepts.Should().Contain(r => r.Tag == tag && r.Taxonomy == FactTaxonomy.UsGaap);
+    }
+}


### PR DESCRIPTION
## Summary
REITs never file the operating-company revenue tags (`Revenues` / `RevenueFromContractWithCustomerExcludingAssessedTax` / `SalesRevenueNet`), so a REIT's income statement rendered no Revenue row at all — ARE's statement collapsed to 7 lines with no top line. Same defect class as the earlier bank/insurer fix, for the real-estate sector.

## Code changes
- `FinancialConceptAliases`: the `revenue` alias gains `RevenueFromContractWithCustomerIncludingAssessedTax` (ARE tags its total-revenue line with the assessed-tax-inclusive ASC 606 variant, 2016+; verified equal to the reported $3.116B FY2024 total) ordered behind the excluding form, and `RealEstateRevenueNet` (pre-ASC 842 REIT total, deprecated 2018) as the legacy fallback — both only fill periods the preferred tags lack.
- New `rental-income` alias + "Rental Income" income-statement line (`LeaseIncome` → `OperatingLeaseLeaseIncome` → `OperatingLeasesIncomeStatementLeaseRevenue`) so lessors show rental top-line detail; renders only for filers of those tags.
- Tests: reworked the pre-ASC-606 ordering pin (SalesRevenueNet is no longer last), added REIT alias-coverage and statement-line pins.

Full unit suite: 3,228 passed.