### PR TITLE
fix(sec): resolve the five follow-ups from the sync review — amendments, dedup batching, cancellation, backfill atomicity, 13D/G date bound

### DIFF
--- a/src/Equibles.Holdings.HostedService/Holdings13DGRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13DGRealtimeWorker.cs
@@ -1,3 +1,4 @@
+using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Holdings.Data.Models;
@@ -29,6 +30,7 @@ public class Holdings13DGRealtimeWorker : BaseScraperWorker
     private const string WorkerStateName = "Holdings13DGRealtime";
 
     private readonly IConfiguration _configuration;
+    private readonly WorkerOptions _workerOptions;
 
     protected override string WorkerName => "13D/13G real-time ingestion";
     protected override TimeSpan SleepInterval => TimeSpan.FromHours(6);
@@ -42,11 +44,13 @@ public class Holdings13DGRealtimeWorker : BaseScraperWorker
         ILogger<Holdings13DGRealtimeWorker> logger,
         IServiceScopeFactory scopeFactory,
         ErrorReporter errorReporter,
-        IConfiguration configuration
+        IConfiguration configuration,
+        IOptions<WorkerOptions> workerOptions
     )
         : base(logger, scopeFactory, errorReporter)
     {
         _configuration = configuration;
+        _workerOptions = workerOptions.Value;
     }
 
     protected override bool ValidateConfiguration() =>
@@ -76,10 +80,21 @@ public class Holdings13DGRealtimeWorker : BaseScraperWorker
             windowStart
         );
 
+        // The event-date floor is the pipeline's general MinSyncDate (matching the
+        // 13F path), NOT the XML-inception date: inception is a property of the
+        // FILING date and is already enforced by the sweep window above. Flooring
+        // the EVENT date at inception dropped any 13D/A restating an event first
+        // reported before 2024-12-18 even though the filing itself is fully
+        // machine-readable — losing a current-stake disclosure with no bulk data
+        // set to recover it from.
+        var minEventDate = DateOnly.FromDateTime(
+            _workerOptions.MinSyncDate ?? new DateTime(2020, 1, 1)
+        );
+
         var result = await ingestionService.IngestRecentFilings(
             today,
             lookbackDays,
-            ScheduleXmlInception,
+            minEventDate,
             stoppingToken
         );
 

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -41,6 +41,7 @@ public static class InsiderFilingParser
         // element, so it applies to every row this filing contributes — stamp it
         // on each as they are added.
         var rule10b5One = ParseRule10b5One(root);
+        var originalFilingDate = isAmendment ? ParseDateOfOriginalSubmission(root) : null;
 
         void AddParsed(InsiderTransaction tx)
         {
@@ -54,6 +55,7 @@ public static class InsiderFilingParser
                 return;
             tx.TransactionOrder = transactions.Count;
             tx.IsRule10b5One = rule10b5One;
+            tx.OriginalFilingDate = originalFilingDate;
             transactions.Add(tx);
         }
 
@@ -123,6 +125,28 @@ public static class InsiderFilingParser
 
     // Form 3 initial statements set <noSecuritiesOwned> to 1 when the reporting owner
     // holds none of the issuer's securities; both ownership tables are then empty.
+    /// <summary>
+    /// The filing date of the original report a Form 4/A or 3/A restates — the
+    /// document-level <c>dateOfOriginalSubmission</c> element (a plain value, not
+    /// wrapped like transaction fields). Null when absent or unparseable, which
+    /// disables supersession for that amendment rather than guessing.
+    /// </summary>
+    public static DateOnly? ParseDateOfOriginalSubmission(XElement root)
+    {
+        var raw = root.Element("dateOfOriginalSubmission")?.Value?.Trim();
+        if (string.IsNullOrEmpty(raw))
+            return null;
+
+        return DateOnly.TryParse(
+            raw,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None,
+            out var date
+        )
+            ? date
+            : null;
+    }
+
     internal static bool DeclaresNoSecuritiesOwned(XElement root) =>
         ParseBool(root.Element("noSecuritiesOwned")?.Value);
 

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -84,6 +84,29 @@ public class InsiderTransaction
     public bool IsAmendment { get; set; }
 
     /// <summary>
+    /// For rows from a Form 4/A or 3/A: the filing date of the ORIGINAL report the
+    /// amendment restates (the XML's <c>dateOfOriginalSubmission</c>). Drives
+    /// supersession — an amendment replaces the original filing's rows, and a
+    /// late-arriving original (or an older chained amendment) is skipped when a row
+    /// referencing its filing date already exists. Null on non-amendment rows and
+    /// on amendments whose XML omits the element.
+    /// </summary>
+    public DateOnly? OriginalFilingDate { get; set; }
+
+    /// <summary>
+    /// For amendment rows: the accession number of the original filing this
+    /// amendment replaced — or claimed, when the original arrived after the
+    /// amendment (EDGAR lists newest-first). Resolved at ingest rather than
+    /// parsed: the XML only names the original's submission DATE, which can trail
+    /// the feed's filing date (an after-17:30 submission indexes the next
+    /// business day), so the accession is the durable link. Also feeds the
+    /// scraper's known-accession prefilter, so a superseded original stops being
+    /// re-fetched from EDGAR every cycle. Null until resolved.
+    /// </summary>
+    [MaxLength(32)]
+    public string SupersededAccessionNumber { get; set; }
+
+    /// <summary>
     /// Whether this row concerns the issuer's actual shares or a derivative
     /// instrument, taken from the Form 4 table it was parsed from (not the
     /// title text). <see cref="InsiderSecurityKind.Unknown"/> for rows ingested

--- a/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
@@ -40,6 +40,86 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
         return GetAll().Where(t => t.CommonStockId == stock.Id);
     }
 
+    /// <summary>
+    /// Rows from any amendment that restates the original report an owner filed for
+    /// this company on <paramref name="originalFilingDate"/> (the filer-entered
+    /// <c>dateOfOriginalSubmission</c>, stable across chained amendments).
+    /// </summary>
+    public IQueryable<InsiderTransaction> GetAmendmentsOfOriginal(
+        InsiderOwner owner,
+        Guid commonStockId,
+        DateOnly originalFilingDate
+    )
+    {
+        return GetAll()
+            .Where(t =>
+                t.InsiderOwnerId == owner.Id
+                && t.CommonStockId == commonStockId
+                && t.OriginalFilingDate == originalFilingDate
+            );
+    }
+
+    /// <summary>
+    /// Rows whose amendment has claimed <paramref name="accessionNumber"/> as the
+    /// original it replaces — the durable guard that stops a late-arriving (or
+    /// re-listed) original from re-inserting rows its amendment already superseded.
+    /// </summary>
+    public IQueryable<InsiderTransaction> GetAmendmentsClaiming(string accessionNumber)
+    {
+        return GetAll().Where(t => t.SupersededAccessionNumber == accessionNumber);
+    }
+
+    /// <summary>
+    /// Amendment rows for this owner+company that have not yet resolved which
+    /// original they replace, whose filer-entered original date falls in
+    /// [<paramref name="windowStart"/>, <paramref name="windowEnd"/>]. The window
+    /// absorbs EDGAR's date shift: an after-17:30 submission is indexed the next
+    /// business day, so the feed FilingDate of the original can trail the
+    /// filer-entered <c>dateOfOriginalSubmission</c> by up to a weekend.
+    /// </summary>
+    public IQueryable<InsiderTransaction> GetUnresolvedAmendments(
+        InsiderOwner owner,
+        Guid commonStockId,
+        DateOnly windowStart,
+        DateOnly windowEnd
+    )
+    {
+        return GetAll()
+            .Where(t =>
+                t.InsiderOwnerId == owner.Id
+                && t.CommonStockId == commonStockId
+                && t.IsAmendment
+                && t.SupersededAccessionNumber == null
+                && t.OriginalFilingDate != null
+                && t.OriginalFilingDate >= windowStart
+                && t.OriginalFilingDate <= windowEnd
+            );
+    }
+
+    /// <summary>
+    /// Candidate original rows an incoming amendment may supersede: the owner's
+    /// non-amendment rows for this company filed in
+    /// [<paramref name="windowStart"/>, <paramref name="windowEnd"/>] (the
+    /// filer-entered original date plus the EDGAR indexing shift). The caller
+    /// resolves the single original accession from these before deleting anything.
+    /// </summary>
+    public IQueryable<InsiderTransaction> GetOriginalCandidates(
+        InsiderOwner owner,
+        Guid commonStockId,
+        DateOnly windowStart,
+        DateOnly windowEnd
+    )
+    {
+        return GetAll()
+            .Where(t =>
+                t.InsiderOwnerId == owner.Id
+                && t.CommonStockId == commonStockId
+                && !t.IsAmendment
+                && t.FilingDate >= windowStart
+                && t.FilingDate <= windowEnd
+            );
+    }
+
     public IQueryable<InsiderTransaction> GetByAccessionNumber(string accessionNumber)
     {
         return GetAll().Where(t => t.AccessionNumber == accessionNumber);

--- a/src/Equibles.Integrations.Common/RateLimiter/IRateLimiter.cs
+++ b/src/Equibles.Integrations.Common/RateLimiter/IRateLimiter.cs
@@ -2,7 +2,10 @@ namespace Equibles.Integrations.Common.RateLimiter;
 
 public interface IRateLimiter
 {
-    Task WaitAsync();
+    // The token matters most during a PauseFor penalty window (SEC blocks run 10
+    // minutes): an uncancellable wait there holds worker shutdown hostage for the
+    // whole pause.
+    Task WaitAsync(CancellationToken cancellationToken = default);
     void PauseFor(TimeSpan duration);
 
     // True while a PauseFor window is still in effect. The single source of truth

--- a/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
+++ b/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
@@ -20,7 +20,7 @@ public class RateLimiter : IRateLimiter
         _requestTimes = new Queue<DateTime>();
     }
 
-    public async Task WaitAsync()
+    public async Task WaitAsync(CancellationToken cancellationToken = default)
     {
         while (true)
         {
@@ -44,7 +44,7 @@ public class RateLimiter : IRateLimiter
                 }
             }
 
-            await Task.Delay(waitTime);
+            await Task.Delay(waitTime, cancellationToken);
         }
     }
 

--- a/src/Equibles.Integrations.Common/Retry/HttpRetry.cs
+++ b/src/Equibles.Integrations.Common/Retry/HttpRetry.cs
@@ -19,12 +19,13 @@ public static class HttpRetry
         int maxRetries,
         string exhaustedMessage,
         Action<int, TimeSpan> onRateLimited,
-        Action<int, int, TimeSpan> onServerError
+        Action<int, int, TimeSpan> onServerError,
+        CancellationToken cancellationToken = default
     )
     {
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            await rateLimiter.WaitAsync();
+            await rateLimiter.WaitAsync(cancellationToken);
 
             var response = await send();
 
@@ -34,7 +35,7 @@ public static class HttpRetry
                 onRateLimited(attempt, delay);
                 rateLimiter.PauseFor(delay);
                 response.Dispose();
-                await Task.Delay(delay);
+                await Task.Delay(delay, cancellationToken);
                 continue;
             }
 
@@ -43,7 +44,7 @@ public static class HttpRetry
                 var delay = RetryBackoff.Exponential(attempt);
                 onServerError((int)response.StatusCode, attempt, delay);
                 response.Dispose();
-                await Task.Delay(delay);
+                await Task.Delay(delay, cancellationToken);
                 continue;
             }
 

--- a/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
+++ b/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
@@ -37,6 +37,12 @@ public enum DocumentTypeFilter
     [Display(Name = "3")]
     FormThree,
 
+    [Display(Name = "4/A")]
+    FormFourA,
+
+    [Display(Name = "3/A")]
+    FormThreeA,
+
     [Display(Name = "144")]
     Form144,
 

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -702,7 +702,7 @@ public class SecEdgarClient : ISecEdgarClient
     {
         for (var attempt = 0; attempt <= MaxRetries; attempt++)
         {
-            await RateLimiter.WaitAsync();
+            await RateLimiter.WaitAsync(cancellationToken);
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
             HttpResponseMessage response;

--- a/src/Equibles.Migrations/Migrations/20260704143813_AddInsiderTransactionAmendmentSupersession.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260704143813_AddInsiderTransactionAmendmentSupersession.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260704143813_AddInsiderTransactionAmendmentSupersession")]
+    partial class AddInsiderTransactionAmendmentSupersession
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260704143813_AddInsiderTransactionAmendmentSupersession.cs
+++ b/src/Equibles.Migrations/Migrations/20260704143813_AddInsiderTransactionAmendmentSupersession.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInsiderTransactionAmendmentSupersession : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "OriginalFilingDate",
+                table: "InsiderTransaction",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SupersededAccessionNumber",
+                table: "InsiderTransaction",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OriginalFilingDate",
+                table: "InsiderTransaction");
+
+            migrationBuilder.DropColumn(
+                name: "SupersededAccessionNumber",
+                table: "InsiderTransaction");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/DocumentType.cs
+++ b/src/Equibles.Sec.Data/Models/DocumentType.cs
@@ -26,6 +26,8 @@ public sealed class DocumentType
     public static readonly DocumentType FortyF = new("FortyF", "40-F");
     public static readonly DocumentType FormFour = new("FormFour", "4");
     public static readonly DocumentType FormThree = new("FormThree", "3");
+    public static readonly DocumentType FormFourA = new("FormFourA", "4/A");
+    public static readonly DocumentType FormThreeA = new("FormThreeA", "3/A");
     public static readonly DocumentType Form144 = new("Form144", "144");
     public static readonly DocumentType FormD = new("FormD", "D");
     public static readonly DocumentType FormDa = new("FormDa", "D/A");
@@ -50,6 +52,8 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(FortyF.Value, FortyF),
             new KeyValuePair<string, DocumentType>(FormFour.Value, FormFour),
             new KeyValuePair<string, DocumentType>(FormThree.Value, FormThree),
+            new KeyValuePair<string, DocumentType>(FormFourA.Value, FormFourA),
+            new KeyValuePair<string, DocumentType>(FormThreeA.Value, FormThreeA),
             new KeyValuePair<string, DocumentType>(Form144.Value, Form144),
             new KeyValuePair<string, DocumentType>(FormD.Value, FormD),
             new KeyValuePair<string, DocumentType>(FormDa.Value, FormDa),
@@ -77,6 +81,8 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(FortyF.DisplayName, FortyF),
             new KeyValuePair<string, DocumentType>(FormFour.DisplayName, FormFour),
             new KeyValuePair<string, DocumentType>(FormThree.DisplayName, FormThree),
+            new KeyValuePair<string, DocumentType>(FormFourA.DisplayName, FormFourA),
+            new KeyValuePair<string, DocumentType>(FormThreeA.DisplayName, FormThreeA),
             new KeyValuePair<string, DocumentType>(Form144.DisplayName, Form144),
             new KeyValuePair<string, DocumentType>(FormD.DisplayName, FormD),
             new KeyValuePair<string, DocumentType>(FormDa.DisplayName, FormDa),

--- a/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
@@ -4,13 +4,22 @@ namespace Equibles.Sec.HostedService.Configuration;
 
 public class DocumentScraperOptions
 {
+    // Amendments are first-class: 10-K/A, 10-Q/A and 8-K/A store as their own
+    // document types, and Form 4/A / 3/A supersede their originals' transactions
+    // in the insider pipeline. Omitting them left corrected filings invisible
+    // while the erroneous originals stayed live.
     public List<DocumentType> DocumentTypesToSync { get; set; } =
     [
         DocumentType.TenK,
         DocumentType.TenQ,
         DocumentType.EightK,
+        DocumentType.TenKa,
+        DocumentType.TenQa,
+        DocumentType.EightKa,
         DocumentType.FormFour,
         DocumentType.FormThree,
+        DocumentType.FormFourA,
+        DocumentType.FormThreeA,
         DocumentType.Form144,
         DocumentType.FormD,
         DocumentType.FormDa,

--- a/src/Equibles.Sec.HostedService/Contracts/IFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Contracts/IFilingProcessor.cs
@@ -13,4 +13,12 @@ public interface IFilingProcessor
 {
     bool CanProcess(DocumentType documentType);
     Task<bool> Process(FilingData filing, CommonStock company);
+
+    /// <summary>
+    /// The subset of <paramref name="accessionNumbers"/> this processor has already
+    /// ingested, resolved in ONE batched query. The scraper prefilters a company's
+    /// filing list through this so re-enumerated history costs one round-trip per
+    /// (company, type) pass instead of one DB query and DI scope per filing.
+    /// </summary>
+    Task<HashSet<string>> FilterKnownAccessions(IReadOnlyCollection<string> accessionNumbers);
 }

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -487,7 +487,16 @@ public class DocumentScraper : IDocumentScraper
             ciks.Count
         );
 
-        return filings;
+        // Oldest first (accession breaks same-day ties — SEC assigns them
+        // monotonically per filer agent): EDGAR lists newest-first, and pipelines
+        // with supersession semantics (a Form 4/A replacing its original's
+        // transactions) want the original ingested before its amendment whenever
+        // both are in one pass — the out-of-order guards then only cover
+        // cross-cycle arrivals.
+        return filings
+            .OrderBy(f => f.FilingDate)
+            .ThenBy(f => f.AccessionNumber, StringComparer.Ordinal)
+            .ToList();
     }
 
     private async Task ProcessFiling(

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -344,7 +344,20 @@ public class DocumentScraper : IDocumentScraper
 
             result.DocumentsFound += filings.Count;
 
-            foreach (var filing in filings)
+            // The filing list re-enumerates history from MinSyncDate every cycle,
+            // so dedup it in one batched lookup instead of one DB round-trip (and,
+            // for processor forms, one DI scope) per already-ingested filing. The
+            // per-filing checks inside ProcessFiling stay as the race guard for
+            // the few filings that survive the prefilter.
+            var newFilings = await FilterAlreadyIngested(
+                company,
+                documentType,
+                filings,
+                persistenceService
+            );
+            result.DocumentsSkipped += filings.Count - newFilings.Count;
+
+            foreach (var filing in newFilings)
             {
                 await ProcessFiling(company, filing, documentType, result, persistenceService);
             }
@@ -364,6 +377,56 @@ public class DocumentScraper : IDocumentScraper
                 $"ticker: {company.Ticker}, type: {documentType}"
             );
         }
+    }
+
+    // Drops the filings this pass has already ingested, using one batched lookup per
+    // (company, type): the processor's known-accession set for processor forms, or the
+    // document store's known accessions + legacy pre-accession keys for plain forms.
+    private async Task<List<FilingData>> FilterAlreadyIngested(
+        CommonStock company,
+        DocumentType documentType,
+        List<FilingData> filings,
+        IDocumentPersistenceService persistenceService
+    )
+    {
+        if (filings.Count == 0)
+            return filings;
+
+        var accessions = filings
+            .Select(f => f.AccessionNumber)
+            .Where(a => !string.IsNullOrEmpty(a))
+            .Distinct()
+            .ToList();
+
+        var processor = _filingProcessors.FirstOrDefault(p => p.CanProcess(documentType));
+        if (processor != null)
+        {
+            var known = await processor.FilterKnownAccessions(accessions) ?? [];
+            return filings
+                .Where(f =>
+                    string.IsNullOrEmpty(f.AccessionNumber) || !known.Contains(f.AccessionNumber)
+                )
+                .ToList();
+        }
+
+        var (knownAccessions, legacyKeys) = await persistenceService.GetKnownFilingKeys(
+            company,
+            documentType,
+            accessions
+        );
+        knownAccessions ??= [];
+        legacyKeys ??= [];
+
+        return filings
+            .Where(f =>
+                !(
+                    (
+                        !string.IsNullOrEmpty(f.AccessionNumber)
+                        && knownAccessions.Contains(f.AccessionNumber)
+                    ) || legacyKeys.Contains((f.FilingDate, f.ReportDate))
+                )
+            )
+            .ToList();
     }
 
     // Subsidiary CIKs share the parent's public ticker (e.g. parent + co-registrant

--- a/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
@@ -19,6 +19,8 @@ public static class DocumentTypeExtensions
             { DocumentType.FortyF, DocumentTypeFilter.FortyF },
             { DocumentType.FormFour, DocumentTypeFilter.FormFour },
             { DocumentType.FormThree, DocumentTypeFilter.FormThree },
+            { DocumentType.FormFourA, DocumentTypeFilter.FormFourA },
+            { DocumentType.FormThreeA, DocumentTypeFilter.FormThreeA },
             { DocumentType.Form144, DocumentTypeFilter.Form144 },
             { DocumentType.FormD, DocumentTypeFilter.FormD },
             { DocumentType.FormDa, DocumentTypeFilter.FormDa },

--- a/src/Equibles.Sec.HostedService/Services/AsFiledHtmlBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/AsFiledHtmlBackfillService.cs
@@ -65,15 +65,23 @@ public class AsFiledHtmlBackfillService
             query = query.Where(d => d.ReportingDate >= minReportingDate.Value);
         }
 
-        var batch = await query
-            .Include(d => d.CommonStock)
+        // Ids only: each document is loaded fresh inside the loop, so a failed capture's
+        // half-applied change-tracker state can be discarded wholesale without detaching
+        // the rest of the batch mid-flight.
+        var batchIds = await query
             .OrderByDescending(d => d.ReportingDate)
             .Take(batchSize)
+            .Select(d => d.Id)
             .ToListAsync(cancellationToken);
 
-        foreach (var document in batch)
+        foreach (var documentId in batchIds)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            var document = await _documentRepository.Get(documentId);
+            if (document == null)
+                continue;
+
             result.Processed++;
             // Count the attempt up front so a fetch/stitch failure still advances the retry
             // ceiling and the document eventually drops out of the working set.
@@ -88,7 +96,7 @@ public class AsFiledHtmlBackfillService
                     document.SourceUrl,
                     document.Id
                 );
-                await PersistAttempt();
+                await RevertAndPersistAttempt(document, cancellationToken);
                 continue;
             }
 
@@ -131,7 +139,7 @@ public class AsFiledHtmlBackfillService
                     document.Id,
                     document.AccessionNumber
                 );
-                await PersistAttempt();
+                await RevertAndPersistAttempt(document, cancellationToken);
             }
         }
 
@@ -149,13 +157,21 @@ public class AsFiledHtmlBackfillService
         return match.Success ? match.Groups[1].Value : null;
     }
 
-    // Saves the bumped attempt count after a failure. Best-effort: a save failure here must not
-    // abort the rest of the batch.
-    private async Task PersistAttempt()
+    // Discards whatever the failed attempt left in the change tracker, then persists ONLY
+    // the attempt bookkeeping. A failed UpdateAsFiledHtml can leave a half-applied capture
+    // tracked (version stamp, added image/file rows) whose paired image-clear rolled back
+    // with its transaction; the previous bare SaveChanges committed that mix and stamped
+    // the document current with stale+new images, never to be retried. Best-effort: a
+    // persistence failure here must not abort the rest of the batch.
+    private async Task RevertAndPersistAttempt(
+        Document document,
+        CancellationToken cancellationToken
+    )
     {
+        _documentRepository.ClearChangeTracker();
         try
         {
-            await _documentRepository.SaveChanges();
+            await _documentRepository.PersistAsFiledHtmlAttempt(document, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -690,6 +690,10 @@ public class CompanySyncService : ICompanySyncService
         return secondaryCikToParent;
     }
 
+    // Test seam: the memo is static (it must outlive the per-cycle service), so
+    // suites that exercise the refill path reset it to stay order-independent.
+    internal static void ClearBlankWebsiteMemoForTests() => BlankWebsiteCheckedAt.Clear();
+
     private static bool ShouldAttemptWebsiteFetch(string cik) =>
         !BlankWebsiteCheckedAt.TryGetValue(cik, out var checkedAt)
         || DateTime.UtcNow - checkedAt >= BlankWebsiteRecheckInterval;

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -54,6 +54,24 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         );
     }
 
+    public Task<(
+        HashSet<string> KnownAccessions,
+        HashSet<(DateOnly FilingDate, DateOnly ReportDate)> LegacyKeys
+    )> GetKnownFilingKeys(
+        CommonStock company,
+        DocumentType documentType,
+        IReadOnlyCollection<string> accessionNumbers,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _documentRepository.GetKnownFilingKeys(
+            company,
+            documentType,
+            accessionNumbers,
+            cancellationToken
+        );
+    }
+
     public async Task Save(
         CommonStock company,
         byte[] content,

--- a/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
@@ -14,6 +14,20 @@ public interface IDocumentPersistenceService
         string accessionNumber = null
     );
 
+    /// <summary>
+    /// Batched form of <see cref="Exists"/> for one (company, type) scrape pass —
+    /// see DocumentRepository.GetKnownFilingKeys.
+    /// </summary>
+    Task<(
+        HashSet<string> KnownAccessions,
+        HashSet<(DateOnly FilingDate, DateOnly ReportDate)> LegacyKeys
+    )> GetKnownFilingKeys(
+        CommonStock company,
+        DocumentType documentType,
+        IReadOnlyCollection<string> accessionNumbers,
+        CancellationToken cancellationToken = default
+    );
+
     Task Save(
         CommonStock company,
         byte[] content,

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -43,7 +43,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
     public bool CanProcess(DocumentType documentType)
     {
-        return documentType == DocumentType.FormFour || documentType == DocumentType.FormThree;
+        return documentType == DocumentType.FormFour
+            || documentType == DocumentType.FormThree
+            || documentType == DocumentType.FormFourA
+            || documentType == DocumentType.FormThreeA;
     }
 
     public async Task<HashSet<string>> FilterKnownAccessions(
@@ -57,15 +60,28 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var transactionRepository =
             scope.ServiceProvider.GetRequiredService<InsiderTransactionRepository>();
 
+        // An accession is "known" both when its own rows exist and when an
+        // amendment has superseded (or claimed) it — a superseded original has
+        // no rows of its own, and without the claim column every sweep would
+        // re-fetch it from EDGAR forever just to re-skip it.
         var candidates = accessionNumbers.ToList();
         var known = await transactionRepository
             .GetAll()
-            .Where(t => candidates.Contains(t.AccessionNumber))
-            .Select(t => t.AccessionNumber)
-            .Distinct()
+            .Where(t =>
+                candidates.Contains(t.AccessionNumber)
+                || candidates.Contains(t.SupersededAccessionNumber)
+            )
+            .Select(t => new { t.AccessionNumber, t.SupersededAccessionNumber })
             .ToListAsync();
 
-        return known.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in known)
+        {
+            result.Add(row.AccessionNumber);
+            if (row.SupersededAccessionNumber != null)
+                result.Add(row.SupersededAccessionNumber);
+        }
+        return result;
     }
 
     public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
@@ -126,6 +142,72 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         var isAmendment = filing.Form.Contains("/A", StringComparison.OrdinalIgnoreCase);
 
+        // A late-arriving original whose amendment already ingested must not
+        // re-insert the rows that amendment replaced (EDGAR lists newest-first,
+        // so during history sweeps the 4/A routinely lands before its Form 4).
+        if (
+            !isAmendment
+            && await TrySkipSupersededOriginal(
+                transactionRepository,
+                owner,
+                companyId,
+                filing,
+                companyTicker
+            )
+        )
+            return false;
+
+        var originalFilingDate = isAmendment
+            ? InsiderFilingParser.ParseDateOfOriginalSubmission(root)
+            : null;
+        string supersededAccession = null;
+
+        if (isAmendment && originalFilingDate.HasValue)
+        {
+            // Stale amendment: a NEWER amendment of the same original already
+            // ingested — its rows are the current truth, so skip this one.
+            // Same-day chains break the tie on accession number (SEC assigns
+            // them monotonically per filer agent).
+            if (
+                await transactionRepository
+                    .GetAmendmentsOfOriginal(owner, companyId, originalFilingDate.Value)
+                    .AnyAsync(t =>
+                        t.FilingDate > filing.FilingDate
+                        || (
+                            t.FilingDate == filing.FilingDate
+                            && string.Compare(t.AccessionNumber, filing.AccessionNumber) > 0
+                        )
+                    )
+            )
+            {
+                _logger.LogInformation(
+                    "Skipping {Form} {AccessionNumber} for {Ticker}: a newer amendment of the same original is already ingested",
+                    filing.Form,
+                    filing.AccessionNumber,
+                    companyTicker
+                );
+                return false;
+            }
+
+            supersededAccession = await SupersedeOriginal(
+                transactionRepository,
+                owner,
+                companyId,
+                filing,
+                originalFilingDate.Value,
+                companyTicker
+            );
+        }
+        else if (isAmendment)
+        {
+            _logger.LogWarning(
+                "{Form} {AccessionNumber} for {Ticker} carries no parseable dateOfOriginalSubmission; ingesting without superseding the original",
+                filing.Form,
+                filing.AccessionNumber,
+                companyTicker
+            );
+        }
+
         // Cache the raw ownership XML so the filing can be re-parsed locally
         // when the parser changes, without re-fetching from EDGAR.
         await CaptureFilingXml(root, filing, filingRepository, fileManager);
@@ -145,7 +227,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 owner,
                 companyId,
                 filing,
-                companyTicker
+                companyTicker,
+                isAmendment,
+                originalFilingDate,
+                supersededAccession
             );
             return true;
         }
@@ -163,6 +248,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         // GetByAccessionNumber(...).AnyAsync() check at the top of Process().
         foreach (var tx in transactions)
         {
+            tx.SupersededAccessionNumber = supersededAccession;
             transactionRepository.Add(tx);
         }
 
@@ -177,6 +263,164 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         );
 
         return true;
+    }
+
+    // EDGAR indexes an after-17:30 submission on the next business day, so the feed
+    // FilingDate of an original can trail the amendment's filer-entered
+    // dateOfOriginalSubmission by a weekend (+ a holiday).
+    private const int OriginalDateShiftToleranceDays = 4;
+
+    // Whether an incoming ORIGINAL was already replaced by an ingested amendment.
+    // Two signals, strongest first: an amendment that explicitly claimed this
+    // accession (re-listed original), or an unresolved amendment whose
+    // filer-entered original date falls within the indexing-shift window of this
+    // filing date — which then claims it, so the scraper's known-accession
+    // prefilter drops the original from every future sweep without a fetch.
+    private async Task<bool> TrySkipSupersededOriginal(
+        InsiderTransactionRepository transactionRepository,
+        InsiderOwner owner,
+        Guid companyId,
+        FilingData filing,
+        string companyTicker
+    )
+    {
+        if (await transactionRepository.GetAmendmentsClaiming(filing.AccessionNumber).AnyAsync())
+        {
+            _logger.LogInformation(
+                "Skipping {Form} {AccessionNumber} for {Ticker}: an amendment already claimed and superseded it",
+                filing.Form,
+                filing.AccessionNumber,
+                companyTicker
+            );
+            return true;
+        }
+
+        var windowStart = filing.FilingDate.AddDays(-OriginalDateShiftToleranceDays);
+        var orphans = await transactionRepository
+            .GetUnresolvedAmendments(owner, companyId, windowStart, filing.FilingDate)
+            .ToListAsync();
+        if (orphans.Count == 0)
+            return false;
+
+        // Several unresolved amendments (of DIFFERENT originals) can sit in the
+        // window; pair this original with exactly one group — the exact-date
+        // match when present, else the closest original date — so a sibling
+        // amendment stays unresolved for ITS original instead of being consumed
+        // by the wrong one.
+        var targetDate = orphans.Any(t => t.OriginalFilingDate == filing.FilingDate)
+            ? filing.FilingDate
+            : orphans.Max(t => t.OriginalFilingDate!.Value);
+        var claimed = orphans.Where(t => t.OriginalFilingDate == targetDate).ToList();
+
+        foreach (var row in claimed)
+        {
+            row.SupersededAccessionNumber = filing.AccessionNumber;
+        }
+        await transactionRepository.SaveChanges();
+
+        _logger.LogInformation(
+            "Skipping {Form} {AccessionNumber} for {Ticker}: claimed by the already-ingested amendment dated {OriginalDate:yyyy-MM-dd}",
+            filing.Form,
+            filing.AccessionNumber,
+            companyTicker,
+            targetDate
+        );
+        return true;
+    }
+
+    // Replaces what an incoming amendment restates: the original filing's rows —
+    // resolved to a SINGLE accession via the filer-entered original date plus the
+    // indexing-shift window — and any older amendment of the same original.
+    // Returns the accession this amendment now supersedes (its own resolution, or
+    // one inherited from a replaced older amendment), or null when the original
+    // is not ingested (pre-MinSyncDate history, or it arrives later and is
+    // claimed by TrySkipSupersededOriginal). Ambiguity (several candidate
+    // accessions) deletes nothing: a visible duplicate beats silently deleting a
+    // legitimate sibling filing.
+    private async Task<string> SupersedeOriginal(
+        InsiderTransactionRepository transactionRepository,
+        InsiderOwner owner,
+        Guid companyId,
+        FilingData filing,
+        DateOnly originalFilingDate,
+        string companyTicker
+    )
+    {
+        var windowEnd = originalFilingDate.AddDays(OriginalDateShiftToleranceDays);
+        var candidates = await transactionRepository
+            .GetOriginalCandidates(owner, companyId, originalFilingDate, windowEnd)
+            .Select(t => new { t.AccessionNumber, t.FilingDate })
+            .Distinct()
+            .ToListAsync();
+
+        var exactAccessions = candidates
+            .Where(c => c.FilingDate == originalFilingDate)
+            .Select(c => c.AccessionNumber)
+            .Distinct()
+            .ToList();
+        var pool =
+            exactAccessions.Count > 0
+                ? exactAccessions
+                : candidates.Select(c => c.AccessionNumber).Distinct().ToList();
+
+        string resolvedAccession = null;
+        if (pool.Count == 1)
+        {
+            resolvedAccession = pool[0];
+            var originalRows = await transactionRepository
+                .GetByAccessionNumber(resolvedAccession)
+                .ToListAsync();
+            transactionRepository.Delete(originalRows);
+            _logger.LogInformation(
+                "Amendment {AccessionNumber} supersedes {Count} transaction(s) of original {OriginalAccession} for {Ticker}",
+                filing.AccessionNumber,
+                originalRows.Count,
+                resolvedAccession,
+                companyTicker
+            );
+        }
+        else if (pool.Count > 1)
+        {
+            _logger.LogWarning(
+                "Amendment {AccessionNumber} for {Ticker} matches {Count} candidate originals around {OriginalDate:yyyy-MM-dd}; superseding none to avoid deleting a sibling filing",
+                filing.AccessionNumber,
+                companyTicker,
+                pool.Count,
+                originalFilingDate
+            );
+        }
+
+        // Chained amendments: an older amendment of the same original is replaced
+        // wholesale, and its resolution (which original accession it consumed or
+        // claimed) is inherited so the prefilter keeps dropping that original.
+        var olderAmendments = await transactionRepository
+            .GetAmendmentsOfOriginal(owner, companyId, originalFilingDate)
+            .Where(t =>
+                t.AccessionNumber != filing.AccessionNumber
+                && (
+                    t.FilingDate < filing.FilingDate
+                    || (
+                        t.FilingDate == filing.FilingDate
+                        && string.Compare(t.AccessionNumber, filing.AccessionNumber) < 0
+                    )
+                )
+            )
+            .ToListAsync();
+        if (olderAmendments.Count > 0)
+        {
+            resolvedAccession ??= olderAmendments
+                .Select(t => t.SupersededAccessionNumber)
+                .FirstOrDefault(a => a != null);
+            transactionRepository.Delete(olderAmendments);
+            _logger.LogInformation(
+                "Amendment {AccessionNumber} replaces {Count} row(s) from older amendment(s) of the same original for {Ticker}",
+                filing.AccessionNumber,
+                olderAmendments.Count,
+                companyTicker
+            );
+        }
+
+        return resolvedAccession;
     }
 
     // Stores the parsed ownership XML as a gzip-compressed internal File so the
@@ -405,7 +649,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         InsiderOwner owner,
         Guid companyId,
         FilingData filing,
-        string companyTicker
+        string companyTicker,
+        bool isAmendment = false,
+        DateOnly? originalFilingDate = null,
+        string supersededAccessionNumber = null
     )
     {
         _logger.LogDebug(
@@ -425,6 +672,9 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 AccessionNumber = filing.AccessionNumber,
                 SecurityTitle = "No Securities Owned",
                 TransactionOrder = 0,
+                IsAmendment = isAmendment,
+                OriginalFilingDate = originalFilingDate,
+                SupersededAccessionNumber = supersededAccessionNumber,
                 // 0-price holding sentinel: nothing to validate or repair.
                 IsPriceValid = true,
                 // No security exists on a noSecuritiesOwned filing, so SecurityKind

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -46,6 +46,28 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         return documentType == DocumentType.FormFour || documentType == DocumentType.FormThree;
     }
 
+    public async Task<HashSet<string>> FilterKnownAccessions(
+        IReadOnlyCollection<string> accessionNumbers
+    )
+    {
+        if (accessionNumbers.Count == 0)
+            return [];
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var transactionRepository =
+            scope.ServiceProvider.GetRequiredService<InsiderTransactionRepository>();
+
+        var candidates = accessionNumbers.ToList();
+        var known = await transactionRepository
+            .GetAll()
+            .Where(t => candidates.Contains(t.AccessionNumber))
+            .Select(t => t.AccessionNumber)
+            .Distinct()
+            .ToListAsync();
+
+        return known.ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
     public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
     {
         // Capture IDs from the outer-scope entity to avoid leaking untracked entities into inner scope

--- a/src/Equibles.Sec.HostedService/Services/IssuerFeedFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/IssuerFeedFilingProcessor.cs
@@ -58,6 +58,29 @@ public abstract class IssuerFeedFilingProcessor<TEntity, TRepository> : IFilingP
 
     protected abstract void LogImported(TEntity entity, string ticker, string accessionNumber);
 
+    public async Task<HashSet<string>> FilterKnownAccessions(
+        IReadOnlyCollection<string> accessionNumbers
+    )
+    {
+        if (accessionNumbers.Count == 0)
+            return [];
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var repository = scope.ServiceProvider.GetRequiredService<TRepository>();
+
+        // Every issuer-feed entity stores the filing's accession number under a
+        // unique index; EF.Property keeps the lookup generic without forcing a
+        // per-form abstract member alongside GetByAccessionNumber.
+        var candidates = accessionNumbers.ToList();
+        var known = await repository
+            .GetAll()
+            .Where(e => candidates.Contains(EF.Property<string>(e, "AccessionNumber")))
+            .Select(e => EF.Property<string>(e, "AccessionNumber"))
+            .ToListAsync();
+
+        return known.ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
     public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
     {
         // Capture IDs from the outer-scope entity to avoid leaking untracked entities into inner scope.

--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -108,6 +108,55 @@ public class DocumentRepository : BaseRepository<Document>
     }
 
     /// <summary>
+    /// One-batch dedup lookup for a (company, type) scrape pass: the subset of
+    /// <paramref name="accessionNumbers"/> already stored, plus the (filing date,
+    /// report date) keys of legacy rows stored before accession stamping. Together
+    /// they answer <see cref="Exists"/> for a whole filing list in two queries
+    /// instead of one round-trip per filing.
+    /// </summary>
+    public async Task<(
+        HashSet<string> KnownAccessions,
+        HashSet<(DateOnly FilingDate, DateOnly ReportDate)> LegacyKeys
+    )> GetKnownFilingKeys(
+        CommonStock company,
+        DocumentType documentType,
+        IReadOnlyCollection<string> accessionNumbers,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var candidates = accessionNumbers.ToList();
+        var knownAccessions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (candidates.Count > 0)
+        {
+            var stored = await GetAll()
+                .Where(d => d.CommonStock == company && candidates.Contains(d.AccessionNumber))
+                .Select(d => d.AccessionNumber)
+                .ToListAsync(cancellationToken);
+            foreach (var accession in stored)
+            {
+                knownAccessions.Add(accession);
+            }
+        }
+
+        var legacyPairs = await GetAll()
+            .Where(d =>
+                d.CommonStock == company
+                && d.DocumentType == documentType
+                && (d.AccessionNumber == null || d.AccessionNumber == "")
+            )
+            .Select(d => new { d.ReportingDate, d.ReportingForDate })
+            .ToListAsync(cancellationToken);
+
+        var legacyKeys = new HashSet<(DateOnly, DateOnly)>();
+        foreach (var pair in legacyPairs)
+        {
+            legacyKeys.Add((pair.ReportingDate, pair.ReportingForDate));
+        }
+
+        return (knownAccessions, legacyKeys);
+    }
+
+    /// <summary>
     /// Persists ONLY the as-filed backfill attempt bookkeeping (attempt count and any
     /// accession derived from the source URL) for one document. Set-based so it can
     /// never flush unrelated tracked changes from the caller's context — the backfill

--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -107,6 +107,27 @@ public class DocumentRepository : BaseRepository<Document>
             );
     }
 
+    /// <summary>
+    /// Persists ONLY the as-filed backfill attempt bookkeeping (attempt count and any
+    /// accession derived from the source URL) for one document. Set-based so it can
+    /// never flush unrelated tracked changes from the caller's context — the backfill
+    /// calls this after a failed capture whose half-applied mutations must be discarded.
+    /// </summary>
+    public Task PersistAsFiledHtmlAttempt(
+        Document document,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return GetAll()
+            .Where(d => d.Id == document.Id)
+            .ExecuteUpdateAsync(
+                s =>
+                    s.SetProperty(x => x.AsFiledHtmlAttempts, document.AsFiledHtmlAttempts)
+                        .SetProperty(x => x.AccessionNumber, document.AccessionNumber),
+                cancellationToken
+            );
+    }
+
     public async Task<Document> GetWithContent(Guid id)
     {
         // The content bytes ride along eagerly: leaving File.FileContent to a lazy load

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
@@ -1,0 +1,274 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+// Form 4/A / 3/A supersession: an amendment restates its original filing in full,
+// so the pipeline must (1) replace the original's transactions when the amendment
+// ingests, (2) skip a late-arriving original whose amendment already ingested
+// (EDGAR lists newest-first, so that order is the COMMON one during history
+// sweeps), and (3) skip an older amendment when a newer one of the same original
+// is already in. Without these, enabling 4/A sync would double count insider
+// trades — the erroneous original and its correction summed together.
+public class InsiderTradingFilingProcessorAmendmentTests
+{
+    private const string OriginalAccession = "0001-24-000100";
+    private const string AmendmentAccession = "0001-24-000200";
+    private static readonly DateOnly OriginalFilingDate = new(2024, 3, 16);
+    private static readonly DateOnly AmendmentFilingDate = new(2024, 4, 2);
+
+    private static readonly string OriginalForm4Xml = BuildOwnershipXml(
+        shares: 1000,
+        dateOfOriginalSubmission: null
+    );
+
+    // The amendment corrects the share count and names its original via
+    // dateOfOriginalSubmission — the document-level element EDGAR requires on /A
+    // ownership filings.
+    private static readonly string AmendmentForm4Xml = BuildOwnershipXml(
+        shares: 250,
+        dateOfOriginalSubmission: OriginalFilingDate
+    );
+
+    private static string BuildOwnershipXml(long shares, DateOnly? dateOfOriginalSubmission)
+    {
+        var originalSubmission = dateOfOriginalSubmission.HasValue
+            ? $"<dateOfOriginalSubmission>{dateOfOriginalSubmission:yyyy-MM-dd}</dateOfOriginalSubmission>"
+            : string.Empty;
+        return $"""
+            <ownershipDocument>
+                {originalSubmission}
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>0001234567</rptOwnerCik>
+                        <rptOwnerName>John Doe</rptOwnerName>
+                    </reportingOwnerId>
+                    <reportingOwnerRelationship>
+                        <isDirector>1</isDirector>
+                    </reportingOwnerRelationship>
+                </reportingOwner>
+                <nonDerivativeTable>
+                    <nonDerivativeTransaction>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <transactionDate><value>2024-03-15</value></transactionDate>
+                        <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+                        <transactionAmounts>
+                            <transactionShares><value>{shares}</value></transactionShares>
+                            <transactionPricePerShare><value>150.50</value></transactionPricePerShare>
+                            <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+                        </transactionAmounts>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>5000</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                        <ownershipNature>
+                            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                        </ownershipNature>
+                    </nonDerivativeTransaction>
+                </nonDerivativeTable>
+            </ownershipDocument>
+            """;
+    }
+
+    private static (
+        InsiderTradingFilingProcessor Processor,
+        InsiderTransactionRepository TxRepo,
+        ISecEdgarClient SecClient
+    ) CreateProcessorWithDeps()
+    {
+        var dbContext = TestDbContextFactory.Create(
+            new InsiderTradingModuleConfiguration(),
+            new CommonStocksModuleConfiguration(),
+            new ErrorsModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+
+        var ownerRepo = new InsiderOwnerRepository(dbContext);
+        var txRepo = new InsiderTransactionRepository(dbContext);
+        var filingRepo = new InsiderFilingRepository(dbContext);
+        var errorManager = new ErrorManager(new ErrorRepository(dbContext));
+        var dailyStockPriceRepo = new DailyStockPriceRepository(dbContext);
+        var secClient = Substitute.For<ISecEdgarClient>();
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ISecEdgarClient), secClient),
+            (typeof(InsiderOwnerRepository), ownerRepo),
+            (typeof(InsiderTransactionRepository), txRepo),
+            (typeof(InsiderFilingRepository), filingRepo),
+            (typeof(IFileManager), Substitute.For<IFileManager>()),
+            (typeof(ErrorManager), errorManager),
+            (typeof(DailyStockPriceRepository), dailyStockPriceRepo),
+            (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator())
+        );
+
+        var processor = new InsiderTradingFilingProcessor(
+            scopeFactory,
+            Substitute.For<ILogger<InsiderTradingFilingProcessor>>(),
+            new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>())
+        );
+
+        return (processor, txRepo, secClient);
+    }
+
+    private static FilingData MakeOriginal() =>
+        new()
+        {
+            AccessionNumber = OriginalAccession,
+            Form = "4",
+            FilingDate = OriginalFilingDate,
+            ReportDate = new DateOnly(2024, 3, 15),
+            Cik = "0000320193",
+        };
+
+    private static FilingData MakeAmendment() =>
+        new()
+        {
+            AccessionNumber = AmendmentAccession,
+            Form = "4/A",
+            FilingDate = AmendmentFilingDate,
+            ReportDate = new DateOnly(2024, 3, 15),
+            Cik = "0000320193",
+        };
+
+    private static CommonStock MakeCompany() =>
+        new()
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+        };
+
+    [Fact]
+    public async Task Process_AmendmentAfterOriginal_ReplacesTheOriginalsTransactions()
+    {
+        var (processor, txRepo, secClient) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        var result = await processor.Process(MakeAmendment(), company);
+
+        result.Should().BeTrue();
+        var transactions = txRepo.GetAll().ToList();
+        transactions
+            .Should()
+            .ContainSingle("the amendment replaces, never sums with, its original");
+        transactions[0].AccessionNumber.Should().Be(AmendmentAccession);
+        transactions[0].Shares.Should().Be(250);
+        transactions[0].IsAmendment.Should().BeTrue();
+        transactions[0].OriginalFilingDate.Should().Be(OriginalFilingDate);
+        transactions[0]
+            .SupersededAccessionNumber.Should()
+            .Be(OriginalAccession, "the amendment records which original it replaced");
+    }
+
+    [Fact]
+    public async Task Process_OriginalAfterItsAmendment_IsSkipped()
+    {
+        // EDGAR's submissions feed lists newest-first, so during a history sweep
+        // the 4/A routinely processes BEFORE its Form 4.
+        var (processor, txRepo, secClient) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        var result = await processor.Process(MakeOriginal(), company);
+
+        result.Should().BeFalse("the original's rows were already superseded");
+        var transactions = txRepo.GetAll().ToList();
+        transactions.Should().ContainSingle();
+        transactions[0].AccessionNumber.Should().Be(AmendmentAccession);
+        transactions[0].Shares.Should().Be(250);
+        transactions[0]
+            .SupersededAccessionNumber.Should()
+            .Be(
+                OriginalAccession,
+                "the orphaned amendment claims the original so future sweeps drop it without a fetch"
+            );
+    }
+
+    [Fact]
+    public async Task Process_AmendmentWithDateShiftedOriginal_StillSupersedesIt()
+    {
+        // EDGAR indexes an after-17:30 submission the NEXT business day, so the
+        // original's feed FilingDate can trail the amendment's filer-entered
+        // dateOfOriginalSubmission. The window resolution must still find and
+        // replace it — exact-date-only matching would leave both rows counted.
+        var (processor, txRepo, secClient) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        var shiftedOriginal = MakeOriginal();
+        shiftedOriginal.FilingDate = OriginalFilingDate.AddDays(3); // Friday 18:00 → Monday index
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(shiftedOriginal, company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        var result = await processor.Process(MakeAmendment(), company);
+
+        result.Should().BeTrue();
+        var transactions = txRepo.GetAll().ToList();
+        transactions.Should().ContainSingle("the date-shifted original must still be replaced");
+        transactions[0].AccessionNumber.Should().Be(AmendmentAccession);
+        transactions[0].SupersededAccessionNumber.Should().Be(OriginalAccession);
+    }
+
+    [Fact]
+    public async Task FilterKnownAccessions_SupersededOriginal_CountsAsKnown()
+    {
+        // A superseded original has no rows of its own; without the claim column
+        // every sweep would pass it through the prefilter and re-fetch it from
+        // EDGAR forever just to re-skip it.
+        var (processor, _, secClient) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var known = await processor.FilterKnownAccessions([
+            OriginalAccession,
+            AmendmentAccession,
+            "0001-24-999999",
+        ]);
+
+        known.Should().BeEquivalentTo([OriginalAccession, AmendmentAccession]);
+    }
+
+    [Fact]
+    public async Task Process_OlderAmendmentAfterNewer_IsSkipped()
+    {
+        var (processor, txRepo, secClient) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var olderAmendment = MakeAmendment();
+        olderAmendment.AccessionNumber = "0001-24-000150";
+        olderAmendment.FilingDate = new DateOnly(2024, 3, 20);
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(shares: 999, dateOfOriginalSubmission: OriginalFilingDate));
+        var result = await processor.Process(olderAmendment, company);
+
+        result.Should().BeFalse("a newer amendment of the same original is already ingested");
+        var transactions = txRepo.GetAll().ToList();
+        transactions.Should().ContainSingle();
+        transactions[0].Shares.Should().Be(250);
+    }
+}

--- a/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
+++ b/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
@@ -144,13 +144,18 @@ public class ConfigurationTests
         options
             .DocumentTypesToSync.Should()
             .NotBeNull()
-            .And.HaveCount(13)
+            .And.HaveCount(18)
             .And.ContainInOrder(
                 DocumentType.TenK,
                 DocumentType.TenQ,
                 DocumentType.EightK,
+                DocumentType.TenKa,
+                DocumentType.TenQa,
+                DocumentType.EightKa,
                 DocumentType.FormFour,
                 DocumentType.FormThree,
+                DocumentType.FormFourA,
+                DocumentType.FormThreeA,
                 DocumentType.Form144,
                 DocumentType.FormD,
                 DocumentType.FormDa,

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingWebsiteRefillTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingWebsiteRefillTests.cs
@@ -28,6 +28,13 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class CompanySyncServiceUpdateExistingWebsiteRefillTests
 {
+    public CompanySyncServiceUpdateExistingWebsiteRefillTests()
+    {
+        // The blank-website memo is static process state; earlier tests sharing a
+        // CIK would otherwise suppress the refill fetch these tests pin.
+        CompanySyncService.ClearBlankWebsiteMemoForTests();
+    }
+
     private static EquiblesFinancialDbContext NewDb()
     {
         var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -162,6 +162,76 @@ public class DocumentScraperTests
     }
 
     [Fact]
+    public async Task ScrapeDocuments_FilingKnownToBatchPrefilter_SkipsWithoutPerFilingChecks()
+    {
+        // Covers: FilterAlreadyIngested's plain-document branch. The batched
+        // GetKnownFilingKeys lookup reports the filing's accession as already stored, so
+        // the filing must be counted skipped WITHOUT reaching the per-filing Exists check
+        // or the ingest flow — that per-filing round-trip is exactly what the prefilter
+        // exists to remove for re-enumerated history.
+        var harness = new Harness();
+        await using var dbContext = harness.CreateDbContext();
+        SeedCompany(dbContext, ticker: "ACME", cik: "0000123456");
+
+        harness
+            .SecEdgarClient.GetCompanyFilings("0000123456", DocumentTypeFilter.TenK, null)
+            .Returns([
+                new FilingData
+                {
+                    Cik = "0000123456",
+                    AccessionNumber = "0000123456-25-000001",
+                    FilingDate = FilingDateAlpha,
+                    ReportDate = ReportDateAlpha,
+                    Form = "10-K",
+                    PrimaryDocument = "acme-10k.htm",
+                    DocumentUrl = "https://sec.gov/acme-10k.htm",
+                },
+            ]);
+        harness
+            .Persistence.GetKnownFilingKeys(
+                Arg.Any<CommonStock>(),
+                Arg.Any<DocumentType>(),
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(
+                (
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        "0000123456-25-000001",
+                    },
+                    new HashSet<(DateOnly, DateOnly)>()
+                )
+            );
+
+        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
+
+        result.DocumentsFound.Should().Be(1);
+        result.DocumentsSkipped.Should().Be(1);
+        result.DocumentsAdded.Should().Be(0);
+        await harness
+            .Persistence.DidNotReceiveWithAnyArgs()
+            .Exists(default, default, default, default, default);
+        await harness
+            .Persistence.DidNotReceiveWithAnyArgs()
+            .Save(
+                default,
+                default,
+                default,
+                default,
+                default,
+                default,
+                default,
+                default,
+                default,
+                default,
+                default,
+                default
+            );
+    }
+
+    [Fact]
     public async Task ScrapeDocuments_FilingHandledByCustomProcessor_DelegatesToProcessorAndSkipsDefaultFlow()
     {
         // Covers: ProcessFiling's specialized-processor branch. The InsiderTrading filing


### PR DESCRIPTION
## Summary

Resolves all five follow-up issues filed from the SEC sync review. Closes #4098, closes #4099, closes #4100, closes #4101, closes #4102.

## Code changes

**Amendment filings (#4098)** — 10-K/A, 10-Q/A and 8-K/A join the default sync list as their own document types. Form 4/A and 3/A get the full path: new `DocumentType`/`DocumentTypeFilter` values, insider-processor routing, and supersession — an amendment restates its original in full, so ingesting one deletes the original filing's transactions (and older amendments of the same original). The original is resolved from the XML's `dateOfOriginalSubmission` plus a small window (EDGAR indexes after-17:30 submissions the next business day) to a SINGLE accession before anything is deleted; ambiguity deletes nothing. The resolved accession persists as `InsiderTransaction.SupersededAccessionNumber` (new column + migration), making the guards order-independent against EDGAR's newest-first feed — a late-arriving original is claimed and skipped, a stale amendment behind a newer one is skipped (same-day chains tie-broken on accession) — and feeding the scraper's known-accession prefilter so superseded originals stop being re-fetched every cycle. Five DB-backed tests pin replace/claim/stale/date-shift/prefilter semantics.

**Batched dedup prefilter (#4099)** — the scraper re-enumerates history from `MinSyncDate` every ~15s cycle and deduped one filing at a time (a DB round-trip per plain filing; a DI scope + point query per processor filing). Each (company, type) pass now prefilters through one batched lookup — `IFilingProcessor.FilterKnownAccessions` for processor forms, known accessions + legacy pre-accession keys for plain documents — with the per-filing checks retained as race guards.

**Rate-limited wait cancellation (#4100)** — `IRateLimiter.WaitAsync` accepts an optional token (SEC retry core and shared `HttpRetry` pass theirs), so a 10-minute throttle pause no longer holds worker shutdown hostage.

**As-filed backfill atomicity (#4101)** — a failed capture used to commit its half-applied mutations (version stamp, image/file rows) via the bare attempt-count save, stamping a stale+new mix terminal. The batch now loads ids, fetches each document fresh, and a failure clears the tracker and persists only the attempt bookkeeping set-based.

**13D/G date bound (#4102)** — the sweep floored the EVENT date at the XML-inception date, dropping any 13D/A restating a pre-inception event; inception is a filing-date property already enforced by the sweep window, so the event-date floor is now the pipeline's general `MinSyncDate`.

All 3,232 unit and 2,009 integration tests pass; the commercial repo needs the matching `InsiderTransaction` migration, which ships with the pin bump.