### PR TITLE
fix(financial-facts): cover the plain DepreciationAndAmortization tag in the cash-flow d&a alias

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -218,6 +218,9 @@ public static class FinancialConceptAliases
         [
             G("DepreciationDepletionAndAmortization"),
             G("DepreciationAmortizationAndAccretionNet"),
+            // Capital-heavy filers (REITs) tag the cash-flow add-back with the
+            // plain income-statement element instead of the DD&A variants.
+            G("DepreciationAndAmortization"),
         ],
         ["share-based-compensation"] = [G("ShareBasedCompensation")],
         ["deferred-income-taxes"] =


### PR DESCRIPTION
## Summary
REITs and other capital-heavy filers (ARE is the reproducing case) tag the cash-flow D&A add-back with the plain `DepreciationAndAmortization` element instead of `DepreciationDepletionAndAmortization`/`DepreciationAmortizationAndAccretionNet`, so the curated Cash Flow statement's D&A line rendered blank even though the fact is extracted and stored. One covered-tag addition; declaration order keeps the DD&A variants preferred, the new tag only fills periods they lack.

## Code changes
- `FinancialConceptAliases.cs`: add `DepreciationAndAmortization` to the `depreciation-and-amortization` alias family.