### PR TITLE
fix(holdings): gate the boot backfill on 13F-only quarter coverage

### DIFF
--- a/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
+++ b/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
@@ -121,12 +121,19 @@ public class AumSnapshotRebuildWorker : BackgroundService
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
 
-        var holdingQuarters = await dbContext
+        // Coverage is measured against distinct Form-13F quarters only — the
+        // same set RebuildAllAsync enumerates. Schedule 13D/G rows carry
+        // per-day event dates that inflate the all-types distinct count but
+        // can never produce a snapshot row, so a gate comparing against it
+        // could never be satisfied and would re-run the full backfill on
+        // every boot, forever.
+        var form13FQuarters = await dbContext
             .Set<InstitutionalHolding>()
+            .Where(h => h.FilingType == FilingType.Form13F)
             .Select(h => h.ReportDate)
             .Distinct()
             .CountAsync(cancellationToken);
-        if (holdingQuarters == 0)
+        if (form13FQuarters == 0)
         {
             return;
         }
@@ -134,23 +141,13 @@ public class AumSnapshotRebuildWorker : BackgroundService
         var snapshotQuarters = await dbContext
             .Set<AumQuarterlySnapshot>()
             .CountAsync(cancellationToken);
-        // RebuildQuarter also materialises StockQuarterlyActivity, so a quarter
-        // isn't fully covered until both snapshots exist for it — otherwise a
-        // newly-added activity table would never backfill once AUM is complete.
+        // RebuildQuarter also materialises StockQuarterlyActivity and
+        // HolderQuarterlySnapshot, so a quarter isn't fully covered until all
+        // three snapshots exist for it — otherwise a newly-added snapshot
+        // table would never backfill once AUM is complete.
         var activityQuarters = await dbContext
             .Set<StockQuarterlyActivity>()
             .Select(s => s.ReportDate)
-            .Distinct()
-            .CountAsync(cancellationToken);
-        // HolderQuarterlySnapshot is Form-13F-only, so its coverage is measured
-        // against distinct 13F quarters — Schedule 13D/G event dates inflate
-        // holdingQuarters but can never produce a holder snapshot row, and
-        // comparing against the all-types count would re-trigger the backfill
-        // on every boot.
-        var holder13FQuarters = await dbContext
-            .Set<InstitutionalHolding>()
-            .Where(h => h.FilingType == FilingType.Form13F)
-            .Select(h => h.ReportDate)
             .Distinct()
             .CountAsync(cancellationToken);
         var holderQuarters = await dbContext
@@ -159,21 +156,20 @@ public class AumSnapshotRebuildWorker : BackgroundService
             .Distinct()
             .CountAsync(cancellationToken);
         if (
-            snapshotQuarters >= holdingQuarters
-            && activityQuarters >= holdingQuarters
-            && holderQuarters >= holder13FQuarters
+            snapshotQuarters >= form13FQuarters
+            && activityQuarters >= form13FQuarters
+            && holderQuarters >= form13FQuarters
         )
         {
             return;
         }
 
         _logger.LogInformation(
-            "Holdings snapshot coverage incomplete (AUM {Snapshots}, activity {Activity} of {Holdings} quarters; holder {HolderQuarters} of {Holder13FQuarters} 13F quarters) — running backfill with {Timeout}s command timeout",
+            "Holdings snapshot coverage incomplete (AUM {Snapshots}, activity {Activity}, holder {HolderQuarters} of {Form13FQuarters} 13F quarters) — running backfill with {Timeout}s command timeout",
             snapshotQuarters,
             activityQuarters,
-            holdingQuarters,
             holderQuarters,
-            holder13FQuarters,
+            form13FQuarters,
             BackfillCommandTimeout.TotalSeconds
         );
 

--- a/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
@@ -288,6 +288,134 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ExecuteAsync_Schedule13DGEventDates_DoNotRetriggerFullBackfill()
+    {
+        // Schedule 13D/G rows carry per-day EVENT dates as ReportDate, so the
+        // all-types distinct-quarter count always exceeds what the rebuild can
+        // ever materialise (it enumerates 13F quarters only). The coverage
+        // gate must ignore them — otherwise every boot re-runs the full
+        // backfill forever. Five fully-covered 13F quarters are seeded so the
+        // oldest lies beyond the 4-quarter daily safety-net: a sentinel there
+        // survives iff the full backfill did NOT run.
+        var quarters = Enumerable
+            .Range(0, 5)
+            .Select(i => new DateOnly(2023, 12, 31).AddMonths(3 * i))
+            .ToList();
+        var oldest = quarters[0];
+        var recent = quarters.Skip(1).ToList();
+        InstitutionalHolder holder;
+        CommonStock aapl;
+        await using (var seed = FreshContext())
+        {
+            var tech = new Sector { Name = "Technology" };
+            seed.Add(tech);
+            await seed.SaveChangesAsync();
+            var industry = new Industry { Name = "Software", SectorId = tech.Id };
+            seed.Add(industry);
+            await seed.SaveChangesAsync();
+            aapl = new CommonStock
+            {
+                Ticker = "AAPL",
+                Name = "Apple",
+                Cik = "C0000320193",
+                IndustryId = industry.Id,
+            };
+            seed.Add(aapl);
+            holder = new InstitutionalHolder { Cik = "H001", Name = "Holder H001" };
+            seed.Add(holder);
+            await seed.SaveChangesAsync();
+            foreach (var quarter in quarters)
+            {
+                seed.Add(MakeHolding(aapl, holder, quarter, 100_000, $"acc-{quarter}"));
+                seed.Add(
+                    new AumQuarterlySnapshot
+                    {
+                        ReportDate = quarter,
+                        TotalValue = 999_999_999, // sentinel — only the safety-net window may overwrite it
+                        FilerCount = 1,
+                        PositionCount = 1,
+                        StockCount = 1,
+                        FilingCount = 1,
+                    }
+                );
+                seed.Add(
+                    new StockQuarterlyActivity
+                    {
+                        CommonStockId = aapl.Id,
+                        ReportDate = quarter,
+                        CurrentShares = 1_000,
+                        CurrentValue = 100_000,
+                        CurrentFilerCount = 1,
+                    }
+                );
+                seed.Add(
+                    new HolderQuarterlySnapshot
+                    {
+                        InstitutionalHolderId = holder.Id,
+                        ReportDate = quarter,
+                        FilingDate = quarter.AddDays(45),
+                        Aum = 100_000,
+                        PositionCount = 1,
+                        StockCount = 1,
+                    }
+                );
+            }
+            // 13D/G event dates that are not 13F quarter ends — these must not
+            // count towards the coverage the gate expects the rebuild to reach.
+            seed.Add(
+                MakeHolding(
+                    aapl,
+                    holder,
+                    new DateOnly(2024, 2, 14),
+                    50_000,
+                    "acc-13d",
+                    FilingType.Schedule13D
+                )
+            );
+            seed.Add(
+                MakeHolding(
+                    aapl,
+                    holder,
+                    new DateOnly(2024, 11, 15),
+                    60_000,
+                    "acc-13g",
+                    FilingType.Schedule13G
+                )
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = ScopeFactory();
+        var refreshService = new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+        var worker = new InstantTickWorker(scopeFactory, refreshService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await worker.StartAsync(cts.Token);
+        // Wait until the daily safety-net has rebuilt the 4 recent quarters
+        // (their sentinels replaced by the true 100k total) so "the backfill
+        // didn't run" is asserted after the worker has demonstrably cycled.
+        await WaitForSnapshots(async ctx =>
+            await ctx.Set<AumQuarterlySnapshot>()
+                .CountAsync(s => recent.Contains(s.ReportDate) && s.TotalValue == 100_000)
+            >= recent.Count
+        );
+        await worker.StopAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var oldestSnapshot = await read.Set<AumQuarterlySnapshot>()
+            .SingleAsync(s => s.ReportDate == oldest);
+        oldestSnapshot
+            .TotalValue.Should()
+            .Be(
+                999_999_999,
+                "the oldest quarter is outside the safety-net window, so only the full backfill could rewrite it — and full coverage of the 13F quarters means it must not have run"
+            );
+    }
+
+    [Fact]
     public async Task ExecuteAsync_NoHoldings_DoesNotCreatePhantomSnapshotRows()
     {
         // No holdings seeded — the worker should not invent rows out of nothing.
@@ -339,12 +467,14 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
         InstitutionalHolder holder,
         DateOnly reportDate,
         long value,
-        string accession
+        string accession,
+        FilingType filingType = FilingType.Form13F
     ) =>
         new()
         {
             CommonStockId = stock.Id,
             InstitutionalHolderId = holder.Id,
+            FilingType = filingType,
             FilingDate = reportDate.AddDays(45),
             ReportDate = reportDate,
             Shares = value / 100,


### PR DESCRIPTION
## Summary
The first-boot backfill gate in `AumSnapshotRebuildWorker` compared AUM and activity snapshot coverage against the **all-types** distinct `ReportDate` count in `InstitutionalHolding`. Schedule 13D/G rows carry per-day event dates (hundreds of distinct dates from a few thousand rows), so that count sits far above the Form-13F quarter set `RebuildAllAsync` actually enumerates — the gate could never be satisfied, and **every worker boot re-ran the full all-quarters rebuild** (~5 minutes of heavy aggregation over the 31M-row holdings table), forever. The holder-snapshot check already measured against 13F-only quarters; the AUM and activity checks now do the same.

## Code changes
- `AumSnapshotRebuildWorker.TryBackfillIfNeeded`: all three coverage checks now compare against distinct Form-13F quarters (the set the rebuild can materialise); log message updated accordingly.
- `AumSnapshotRebuildWorkerTests`: new regression test seeding fully-covered 13F quarters plus 13D/G event-date rows — asserts the full backfill does not re-trigger (verified failing against the previous gate). `MakeHolding` gains an optional `FilingType`.

## Verification
- `dotnet csharpier check .` clean; Release build clean.
- Unit suite 3232/3232, Holdings-scoped integration tests 384/384.