### PR TITLE
fix(sec): stamp 8-K/A items in the backfill and idle the drained sweep

### DIFF
--- a/src/Equibles.Sec.HostedService/FilingItemsBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/FilingItemsBackfillWorker.cs
@@ -11,21 +11,30 @@ using Microsoft.Extensions.Options;
 namespace Equibles.Sec.HostedService;
 
 /// <summary>
-/// Backfills <c>Document.Items</c> for 8-Ks ingested before item capture was enabled. Runs
-/// alongside the live scraper (sharing the EDGAR request budget) and is gated on an opt-in
-/// switch, so the historical sweep only runs when an operator asks for it.
+/// Backfills <c>Document.Items</c> for 8-Ks and 8-K/As ingested before item capture was
+/// enabled. Runs alongside the live scraper (sharing the EDGAR request budget) and is gated
+/// on an opt-in switch, so the historical sweep only runs when an operator asks for it.
 /// </summary>
 public class FilingItemsBackfillWorker : BaseScraperWorker
 {
     private readonly IConfiguration _configuration;
     private readonly FilingItemsBackfillOptions _options;
 
+    // Set when a cycle finds no eligible company (the sweep is drained, or the switch is
+    // off). The historical corpus is finite and every checked document gets a terminal
+    // value, so once drained the 5-minute cadence only re-runs an empty scan of the 8-K
+    // corpus — idle daily instead. A rare new pending row (a feed entry without items) is
+    // picked up on the next daily tick or worker restart, and any non-empty cycle drops
+    // straight back to the fast cadence.
+    private bool _drained;
+
     protected override string WorkerName => "Filing items backfill";
 
     // A historical sweep, not a latency-sensitive job: a longer interval keeps it from
-    // re-querying and re-spending the shared EDGAR budget when the queue is drained or
-    // stuck on companies whose feed cannot be fetched.
-    protected override TimeSpan SleepInterval => TimeSpan.FromMinutes(5);
+    // re-querying and re-spending the shared EDGAR budget when the queue is stuck on
+    // companies whose feed cannot be fetched.
+    protected override TimeSpan SleepInterval =>
+        _drained ? TimeSpan.FromHours(24) : TimeSpan.FromMinutes(5);
     protected override ErrorSource ErrorSource => ErrorSource.DocumentScraper;
 
     // Yield to the live SEC scrapers at deploy time before spending the shared EDGAR budget
@@ -57,6 +66,7 @@ public class FilingItemsBackfillWorker : BaseScraperWorker
         if (!_options.Enabled)
         {
             Logger.LogDebug("Filing-items backfill disabled; skipping cycle.");
+            _drained = true;
             return;
         }
 
@@ -73,5 +83,19 @@ public class FilingItemsBackfillWorker : BaseScraperWorker
             result.NotFound,
             result.Failed
         );
+
+        var drainedNow = result.Companies == 0;
+        if (drainedNow && !_drained)
+        {
+            Logger.LogInformation("Filing-items backfill drained; idling on the daily cadence.");
+        }
+        _drained = drainedNow;
+
+        // A full batch means a backlog is still queued — burst through it instead of
+        // spending a whole SleepInterval between batch-sized slices.
+        if (!drainedNow && result.Companies >= _options.BatchSize)
+        {
+            RequestImmediateContinuation();
+        }
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/FilingItemsBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FilingItemsBackfillService.cs
@@ -10,11 +10,12 @@ using Microsoft.Extensions.Logging;
 namespace Equibles.Sec.HostedService.Services;
 
 /// <summary>
-/// Stamps <c>Document.Items</c> onto 8-K rows ingested before item capture went live, so the
-/// earnings-release consumers (Item 2.02) can match historical filings. Each cycle picks the
-/// companies with pending 8-Ks (newest filings first), re-fetches each company's submissions
-/// feed once — <see cref="ISecEdgarClient.GetCompanyFilings"/> already walks the archive pages,
-/// so the whole filing history is covered — and stamps every pending 8-K by accession number.
+/// Stamps <c>Document.Items</c> onto 8-K and 8-K/A rows ingested before item capture went
+/// live, so the earnings-release consumers (Item 2.02) can match historical filings. Each
+/// cycle picks the companies with pending documents (newest filings first), re-fetches each
+/// company's submissions feed once — <see cref="ISecEdgarClient.GetCompanyFilings"/> already
+/// walks the archive pages, so the whole filing history is covered — and stamps every pending
+/// document by accession number.
 /// </summary>
 /// <remarks>
 /// A document whose accession is absent from the feed (or carries no items there) is stamped
@@ -111,7 +112,9 @@ public class FilingItemsBackfillService
         }
 
         var stock = documents[0].CommonStock;
-        var filings = await _secEdgarClient.GetCompanyFilings(stock.Cik, DocumentTypeFilter.EightK);
+        // Unfiltered on purpose: the exact-form filter would drop 8-K/A rows (form "8-K/A"),
+        // and the accession lookup below only ever matches the 8-K-family rows anyway.
+        var filings = await _secEdgarClient.GetCompanyFilings(stock.Cik);
         var itemsByAccession = filings
             .Where(f => !string.IsNullOrEmpty(f.AccessionNumber))
             .DistinctBy(f => f.AccessionNumber)
@@ -157,8 +160,12 @@ public class FilingItemsBackfillService
 
     private IQueryable<Document> PendingEightKs() =>
         _documentRepository
-            .GetByDocumentType(DocumentType.EightK)
-            .Where(d => d.Items == null && d.CommonStock.Cik != null);
+            .GetAll()
+            .Where(d =>
+                (d.DocumentType == DocumentType.EightK || d.DocumentType == DocumentType.EightKa)
+                && d.Items == null
+                && d.CommonStock.Cik != null
+            );
 
     private static string DeriveAccessionNumber(string sourceUrl)
     {

--- a/tests/Equibles.IntegrationTests/Sec/FilingItemsBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FilingItemsBackfillServiceTests.cs
@@ -45,7 +45,8 @@ public class FilingItemsBackfillServiceTests : ParadeDbMcpTestBase
         string accessionNumber,
         DateOnly reportingDate,
         string sourceUrl = null,
-        string items = null
+        string items = null,
+        DocumentType documentType = null
     )
     {
         await using var seed = Fixture.CreateDbContext();
@@ -64,7 +65,7 @@ public class FilingItemsBackfillServiceTests : ParadeDbMcpTestBase
             Id = Guid.NewGuid(),
             CommonStockId = companyId,
             Content = content,
-            DocumentType = DocumentType.EightK,
+            DocumentType = documentType ?? DocumentType.EightK,
             ReportingDate = reportingDate,
             ReportingForDate = reportingDate,
             AccessionNumber = accessionNumber,
@@ -97,12 +98,16 @@ public class FilingItemsBackfillServiceTests : ParadeDbMcpTestBase
         return client;
     }
 
-    private static FilingData EightKFiling(string accessionNumber, string items) =>
+    private static FilingData EightKFiling(
+        string accessionNumber,
+        string items,
+        string form = "8-K"
+    ) =>
         new()
         {
             Cik = "0000320193",
             AccessionNumber = accessionNumber,
-            Form = "8-K",
+            Form = form,
             Items = items,
             FilingDate = new DateOnly(2024, 2, 1),
             ReportDate = new DateOnly(2024, 2, 1),
@@ -135,6 +140,43 @@ public class FilingItemsBackfillServiceTests : ParadeDbMcpTestBase
             .SingleAsync(d => d.AccessionNumber == "0000320193-24-000002");
         stampedDoc.Items.Should().Be("2.02,9.01");
         feedlessDoc.Items.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public async Task Backfill_StampsPendingEightKAmendmentsFromTheUnfilteredFeed()
+    {
+        // 8-K/A rows carry form "8-K/A" in the submissions feed, so an exact-form
+        // "8-K" filter would drop them and the amendment would be stamped not-found.
+        // The sweep must select pending amendments AND walk the feed unfiltered.
+        var company = await SeedCompany("ITMA", "0000320193");
+        var documentId = await SeedEightK(
+            company.Id,
+            "0000320193-24-000003",
+            new DateOnly(2024, 3, 1),
+            documentType: DocumentType.EightKa
+        );
+        DbContext.ChangeTracker.Clear();
+
+        var client = StubClient(EightKFiling("0000320193-24-000003", "2.02,9.01", form: "8-K/A"));
+        var result = await BuildSut(client).Backfill(companyBatchSize: 10);
+
+        result.Companies.Should().Be(1);
+        result.Stamped.Should().Be(1);
+
+        await using var verify = Fixture.CreateDbContext();
+        var document = await verify.Set<Document>().SingleAsync(d => d.Id == documentId);
+        document.Items.Should().Be("2.02,9.01");
+
+        // Pin the unfiltered walk itself — a form-filtered stub would still return the
+        // amendment row above, so assert the service passed no document-type filter.
+        await client
+            .Received(1)
+            .GetCompanyFilings(
+                Arg.Any<string>(),
+                Arg.Is<DocumentTypeFilter?>(f => f == null),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Two defects in the filing-items backfill:

1. **8-K/A rows never got items.** The pending set only selected plain 8-Ks, so ~7.6k amendments ingested before item capture went live keep `Items = null` forever — invisible to the Item-2.02 consumers (earnings-release linking, KPI / guidance / non-GAAP-bridge extraction). Worse, just widening the query wouldn't have been enough: the per-company feed walk passed an exact-form `8-K` filter, which drops form `8-K/A` rows and would have stamped every amendment with the not-found terminal marker.
2. **The drained sweep polled forever.** Once the corpus drains (every checked document gets a terminal value), the worker kept re-running an empty grouped scan of the 8-K corpus every 5 minutes, indefinitely.

## Code changes
- `FilingItemsBackfillService`: pending set now covers `EightK` + `EightKa`; the company feed walk is unfiltered (accession lookup only ever matches 8-K-family rows anyway, and the submissions JSON is fetched once and cached).
- `FilingItemsBackfillWorker`: a cycle that finds no eligible company switches the cadence to daily (rare stragglers are picked up on the next tick or a restart; any non-empty cycle drops back to 5 minutes); a full batch requests immediate continuation so a backlog drains in bursts.
- `FilingItemsBackfillServiceTests`: new test seeding a pending 8-K/A stamped from a form-`8-K/A` feed row, also pinning that the feed walk passes no document-type filter.

## Verification
- `dotnet csharpier check .` clean; Release build clean.
- Unit suite 3232/3232; filing-items + document-scraper integration tests 9/9.