### PR TITLE
perf(insider-trading): index SupersededAccessionNumber for the known-accession prefilter

### DIFF
--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -7,6 +7,10 @@ namespace Equibles.InsiderTrading.Data.Models;
 [Index(nameof(CommonStockId), nameof(TransactionDate))]
 [Index(nameof(InsiderOwnerId), nameof(TransactionDate))]
 [Index(nameof(AccessionNumber), nameof(TransactionOrder), IsUnique = true)]
+// The scraper's known-accession prefilter probes SupersededAccessionNumber with the same
+// candidate list as AccessionNumber; without its own index that arm falls back to a
+// sequential scan of the table on every sweep batch.
+[Index(nameof(SupersededAccessionNumber))]
 [Index(nameof(FilingDate))]
 [Index(nameof(TransactionDate))]
 [Index(nameof(IsPriceValid), nameof(TransactionDate))]

--- a/src/Equibles.Migrations/Migrations/20260705012910_IndexInsiderTransactionSupersededAccessionNumber.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260705012910_IndexInsiderTransactionSupersededAccessionNumber.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260705012910_IndexInsiderTransactionSupersededAccessionNumber")]
+    partial class IndexInsiderTransactionSupersededAccessionNumber
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260705012910_IndexInsiderTransactionSupersededAccessionNumber.cs
+++ b/src/Equibles.Migrations/Migrations/20260705012910_IndexInsiderTransactionSupersededAccessionNumber.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class IndexInsiderTransactionSupersededAccessionNumber : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_SupersededAccessionNumber",
+                table: "InsiderTransaction",
+                column: "SupersededAccessionNumber");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_SupersededAccessionNumber",
+                table: "InsiderTransaction");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The insider scraper's known-accession prefilter checks each sweep batch with `candidates.Contains(AccessionNumber) || candidates.Contains(SupersededAccessionNumber)`. `AccessionNumber` is covered by the unique `(AccessionNumber, TransactionOrder)` index, but `SupersededAccessionNumber` had no index, so its arm degraded the probe to a sequential scan — 526 ms mean over 15k+ calls in production `pg_stat_statements`, the single largest DB time consumer. The amendment lookup `GetBySupersededAccession` benefits from the same index.

## Code changes
- `InsiderTransaction`: added `[Index(nameof(SupersededAccessionNumber))]`.
- `Equibles.Migrations`: `IndexInsiderTransactionSupersededAccessionNumber` migration (plain `CreateIndex`, generated via `dotnet ef`).

## Verification
- `dotnet csharpier check .` clean; Release build clean.
- InsiderTrading-scoped integration tests 162/162 (schema materialises from the model, covering the new index).