### PR TITLE
fix(sec): gate the filing-items idle signal on selection, not completion

### DIFF
--- a/src/Equibles.Sec.HostedService/FilingItemsBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/FilingItemsBackfillWorker.cs
@@ -76,24 +76,29 @@ public class FilingItemsBackfillWorker : BaseScraperWorker
         var result = await backfillService.Backfill(_options.BatchSize, stoppingToken);
 
         Logger.LogInformation(
-            "Filing-items backfill cycle complete. Companies: {Companies}, Stamped: {Stamped}, "
-                + "NotFound: {NotFound}, Failed: {Failed}",
+            "Filing-items backfill cycle complete. Selected: {Selected}, Companies: {Companies}, "
+                + "Stamped: {Stamped}, NotFound: {NotFound}, Failed: {Failed}",
+            result.Selected,
             result.Companies,
             result.Stamped,
             result.NotFound,
             result.Failed
         );
 
-        var drainedNow = result.Companies == 0;
+        // Drained means the sweep SELECTED nothing — not that nothing completed. During
+        // an EDGAR outage every selected company throws and completes zero work; that
+        // cycle must stay on the fast cadence so the backlog resumes when the block
+        // clears, not idle for a day.
+        var drainedNow = result.Selected == 0;
         if (drainedNow && !_drained)
         {
             Logger.LogInformation("Filing-items backfill drained; idling on the daily cadence.");
         }
         _drained = drainedNow;
 
-        // A full batch means a backlog is still queued — burst through it instead of
-        // spending a whole SleepInterval between batch-sized slices.
-        if (!drainedNow && result.Companies >= _options.BatchSize)
+        // A full batch was drawn, so a backlog is still queued — burst through it instead
+        // of spending a whole SleepInterval between batch-sized slices.
+        if (result.Selected >= _options.BatchSize)
         {
             RequestImmediateContinuation();
         }

--- a/src/Equibles.Sec.HostedService/Models/FilingItemsBackfillResult.cs
+++ b/src/Equibles.Sec.HostedService/Models/FilingItemsBackfillResult.cs
@@ -3,6 +3,14 @@ namespace Equibles.Sec.HostedService.Models;
 /// <summary>Per-cycle tally of what the filing-items backfill did, for logging.</summary>
 public class FilingItemsBackfillResult
 {
+    /// <summary>
+    /// Companies drawn from the pending set this cycle, whether or not their fetch then
+    /// succeeded. Zero is the "nothing eligible" signal the worker idles on — distinct
+    /// from "everything selected failed" (an EDGAR outage), where a backlog is still
+    /// pending and the fast cadence must resume.
+    /// </summary>
+    public int Selected { get; set; }
+
     /// <summary>Companies whose submissions feed was fetched and whose 8-Ks were stamped.</summary>
     public int Companies { get; set; }
 

--- a/src/Equibles.Sec.HostedService/Services/FilingItemsBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FilingItemsBackfillService.cs
@@ -71,6 +71,7 @@ public class FilingItemsBackfillService
             .OrderByDescending(x => x.LatestReportingDate)
             .Take(companyBatchSize)
             .ToListAsync(cancellationToken);
+        result.Selected = companies.Count;
 
         foreach (var company in companies)
         {

--- a/tests/Equibles.IntegrationTests/Sec/FilingItemsBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FilingItemsBackfillServiceTests.cs
@@ -219,6 +219,9 @@ public class FilingItemsBackfillServiceTests : ParadeDbMcpTestBase
 
         first.NotFound.Should().Be(1);
         second.Companies.Should().Be(0);
+        second
+            .Selected.Should()
+            .Be(0, "a drained corpus selects nothing — the worker's idle signal");
         await client
             .Received(1)
             .GetCompanyFilings(
@@ -253,6 +256,12 @@ public class FilingItemsBackfillServiceTests : ParadeDbMcpTestBase
 
         result.Failed.Should().Be(1);
         result.Companies.Should().Be(0);
+        result
+            .Selected.Should()
+            .Be(
+                1,
+                "a fully-failed batch still SELECTED work — it must not read as drained, or an EDGAR outage would idle the worker for a day with a backlog pending"
+            );
 
         await using (var verify = Fixture.CreateDbContext())
         {


### PR DESCRIPTION
## Summary
Follow-up to #4106. `FilingItemsBackfillResult.Companies` counts companies that **completed** — per-company feed failures land in `Failed` and never increment it, and `SecEdgarClient.GetCompanyFilings` throws on any fetch error. So during an EDGAR rate-limit block or outage, a full batch fails, the cycle returns `Companies == 0`, and the worker misreads it as drained — parking for 24 hours with a backlog still pending. That's exactly the "stuck on companies whose feed cannot be fetched" case the 5-minute cadence exists for.

## Code changes
- `FilingItemsBackfillResult`: new `Selected` count — companies drawn from the pending set this cycle, regardless of outcome.
- `FilingItemsBackfillService`: stamps `Selected` right after batch selection.
- `FilingItemsBackfillWorker`: drained = `Selected == 0`; the full-batch burst continuation also keys off `Selected` (a fully-drawn batch with one failure previously lost the burst). Cycle log now includes `Selected`.
- Tests: feed-failure test pins `Selected == 1` with `Companies == 0` (the outage shape), terminal-drain test pins `Selected == 0`.

## Verification
- `dotnet csharpier check .` clean; Release build clean.
- Filing-items integration tests 8/8; unit suite 3232/3232.