### PR TITLE
perf(sec): probe known insider accessions per column instead of a cross-column or

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -64,18 +64,32 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         // amendment has superseded (or claimed) it — a superseded original has
         // no rows of its own, and without the claim column every sweep would
         // re-fetch it from EDGAR forever just to re-skip it.
+        //
+        // Deliberately TWO single-column probes instead of one cross-column OR:
+        // EF translates the OR (plus null-compensation branches for the nullable
+        // columns) into a shape Postgres plans as a bitmap heap scan — ~230 ms
+        // per call at the sweep's batch rate, the single largest query cost on
+        // the box — while each single-column ANY probe walks its own index in
+        // well under a millisecond. The union is semantically identical: feed
+        // accession numbers are never null, so the dropped null-match branches
+        // could never fire.
         var candidates = accessionNumbers.ToList();
-        var known = await transactionRepository
+        var knownByOwnRows = await transactionRepository
+            .GetAll()
+            .Where(t => candidates.Contains(t.AccessionNumber))
+            .Select(t => new { t.AccessionNumber, t.SupersededAccessionNumber })
+            .ToListAsync();
+        var knownBySupersededClaim = await transactionRepository
             .GetAll()
             .Where(t =>
-                candidates.Contains(t.AccessionNumber)
-                || candidates.Contains(t.SupersededAccessionNumber)
+                t.SupersededAccessionNumber != null
+                && candidates.Contains(t.SupersededAccessionNumber)
             )
             .Select(t => new { t.AccessionNumber, t.SupersededAccessionNumber })
             .ToListAsync();
 
         var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var row in known)
+        foreach (var row in knownByOwnRows.Concat(knownBySupersededClaim))
         {
             result.Add(row.AccessionNumber);
             if (row.SupersededAccessionNumber != null)


### PR DESCRIPTION
## Summary

- `FilterKnownAccessions` checked each feed batch with a single `Contains(AccessionNumber) || Contains(SupersededAccessionNumber)` query. EF's translation (cross-column OR plus null-compensation branches for the nullable columns) plans as a bitmap heap scan: ~230 ms mean per call and the single largest query cost on the production box (~8 CPU-hours of Postgres per day at the sweep's call rate).
- Split into two single-column `= ANY(...)` probes unioned in memory — each walks its own index. Verified with `EXPLAIN ANALYZE` against production data: 0.11 ms + 0.45 ms versus 27–230 ms for the old shape. Semantics are identical: feed accession numbers are never null, so the dropped null-match branches could never fire, and the OR of the two predicates equals the union of the two result sets.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — `FilterKnownAccessions` runs one indexed probe per column and unions the pairs before building the known set; comment records the measured plans so the shape isn't "simplified" back.