### PR TITLE
fix(congress): strip the pdf checkbox artifact from asset names

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -224,6 +224,9 @@ public static partial class DisclosureParsingHelper
         if (string.IsNullOrEmpty(ticker) && string.IsNullOrEmpty(assetName))
             return null;
 
+        // The House PDF checkbox artifact must go before the name is stored or mined for a ticker.
+        assetName = CleanAssetName(assetName);
+
         // Fall back to extracting ticker from asset name (parentheses pattern)
         if (string.IsNullOrEmpty(ticker) && !string.IsNullOrEmpty(assetName))
             ticker = ExtractTickerFromAssetName(assetName);
@@ -304,6 +307,19 @@ public static partial class DisclosureParsingHelper
         )
             return d;
         return null;
+    }
+
+    // Strips the PDF checkbox artifact from an asset name. The House disclosure PDFs draw each
+    // row's checkboxes with a symbol font whose glyphs extract as the letter runs "gfedc" /
+    // "gfedcb"; the text extractor glues those tokens onto the asset name ("Weyerhaeuser Company
+    // (WY) gfedcb"). Case-sensitive on purpose — the artifact is always lowercase, and a real
+    // uppercase word must never be eaten. Collapses the whitespace the removal leaves behind.
+    public static string CleanAssetName(string assetName)
+    {
+        if (string.IsNullOrEmpty(assetName))
+            return assetName;
+        var cleaned = CheckboxArtifactRegex().Replace(assetName, " ");
+        return RepeatedWhitespaceRegex().Replace(cleaned, " ").Trim();
     }
 
     public static string ExtractTickerFromAssetName(string assetName)
@@ -397,6 +413,14 @@ public static partial class DisclosureParsingHelper
     // Matches href attribute in anchor tags
     [GeneratedRegex(@"href=[""']([^""']+)[""']")]
     public static partial Regex HrefRegex();
+
+    // The PDF checkbox glyph runs ("gfedc", "gfedcb") that leak into House asset names — see
+    // CleanAssetName. Word-bounded so a legitimate word containing the letters is never touched.
+    [GeneratedRegex(@"\bgfedcb?\b")]
+    private static partial Regex CheckboxArtifactRegex();
+
+    [GeneratedRegex(@"\s{2,}")]
+    private static partial Regex RepeatedWhitespaceRegex();
 
     private record ColumnIndices(
         int Date,

--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -390,6 +390,10 @@ public partial class HouseDisclosureClient
         // mistaken for a ticker when the asset has no parenthesised symbol.
         assetText = AssetTypeCodeRegex().Replace(assetText, " ").Trim();
 
+        // The PDF's row checkboxes extract as "gfedc"/"gfedcb" glued onto the asset name — strip
+        // them before the name is stored or mined for a ticker (see CleanAssetName).
+        assetText = CleanAssetName(assetText);
+
         var ticker = ExtractTickerFromAssetName(assetText);
         if (string.IsNullOrEmpty(assetText) && string.IsNullOrEmpty(ticker))
             return null;

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperCleanAssetNameTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperCleanAssetNameTests.cs
@@ -1,0 +1,51 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+// CleanAssetName strips the PDF checkbox artifact from House asset names. The House disclosure
+// PDFs draw each row's checkboxes with a symbol font whose glyphs extract as the letter runs
+// "gfedc" / "gfedcb"; the text extractor glues those onto the asset name, and ~9k production
+// rows shipped like "Weyerhaeuser Company (WY) gfedcb" before this cleanup existed. The strip
+// must be word-bounded and case-sensitive so real asset-name words are never eaten, and must
+// collapse the whitespace the removal leaves so names don't keep double spaces.
+public class DisclosureParsingHelperCleanAssetNameTests
+{
+    [Theory]
+    [InlineData("Weyerhaeuser Company (WY) gfedcb", "Weyerhaeuser Company (WY)")]
+    [InlineData("Kimco Realty Corporation (KIM)  gfedc", "Kimco Realty Corporation (KIM)")]
+    [InlineData(
+        "International Business Machines gfedc Corporation (IBM)",
+        "International Business Machines Corporation (IBM)"
+    )]
+    [InlineData("Starbucks Corporation (SBuX) gfedcb", "Starbucks Corporation (SBuX)")]
+    public void CleanAssetName_StripsCheckboxArtifacts(string raw, string expected)
+    {
+        DisclosureParsingHelper.CleanAssetName(raw).Should().Be(expected);
+    }
+
+    [Fact]
+    public void CleanAssetName_CleanName_IsUnchanged()
+    {
+        DisclosureParsingHelper
+            .CleanAssetName("Apple Inc. (AAPL)")
+            .Should()
+            .Be("Apple Inc. (AAPL)");
+    }
+
+    // Word-bounded and case-sensitive: the artifact letters inside a real word, or uppercased,
+    // must never be eaten.
+    [Theory]
+    [InlineData("Gfedc Industries (GF)")]
+    [InlineData("Kingfedcorp Holdings (KFC)")]
+    public void CleanAssetName_NeverEatsRealWords(string name)
+    {
+        DisclosureParsingHelper.CleanAssetName(name).Should().Be(name);
+    }
+
+    [Fact]
+    public void CleanAssetName_NullOrEmpty_PassesThrough()
+    {
+        DisclosureParsingHelper.CleanAssetName(null).Should().BeNull();
+        DisclosureParsingHelper.CleanAssetName("").Should().Be("");
+    }
+}


### PR DESCRIPTION
## Summary

The House disclosure PDFs draw each row's checkboxes with a symbol font whose glyphs extract as the letter runs `gfedc` / `gfedcb`; the text extractor glues them onto the asset name — about 9k rows in a production deployment carry names like `Weyerhaeuser Company (WY) gfedcb`.

## Code changes

- `DisclosureParsingHelper.CleanAssetName` (new): strips the word-bounded, lowercase-only artifact tokens and collapses the whitespace the removal leaves. Case-sensitive and word-bounded on purpose so a real asset-name word can never be eaten.
- Applied in both ingestion paths before the name is stored or mined for a ticker: `HouseDisclosureClient.BuildTransaction` (the PDF path where the artifact originates) and `DisclosureParsingHelper.ParseTransactionRow`.
- 8 new tests (production shapes, mid-name artifact, never-eats-real-words guards, null/empty passthrough).

Note for deployments: the trade upsert identity includes AssetName, so existing dirty rows should be cleaned with the same transformation (deduping post-clean collisions) or future scrapes of the same disclosures will insert clean-named duplicates.

Congress suite 261/261; csharpier clean.