### PR TITLE
feat(sec): resolve trust-series fund tickers from the sec fund-class directory

### DIFF
--- a/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
@@ -6,6 +6,13 @@ namespace Equibles.Integrations.Sec.Contracts;
 public interface ISecEdgarClient
 {
     Task<List<CompanyInfo>> GetActiveCompanies();
+
+    /// <summary>
+    /// Fetches SEC's fund-class ticker directory (company_tickers_mf.json): one row per registered
+    /// fund share class with its series id and trading symbol. The authoritative ticker source for
+    /// mutual funds and ETFs, whose NPORT-P filings carry no trading symbol of their own.
+    /// </summary>
+    Task<List<FundClassTicker>> GetFundClassTickers();
     Task<string> GetEntityType(string cik);
     Task<CompanyMetadata> GetCompanyMetadata(string cik);
     Task<List<FilingData>> GetCompanyFilings(

--- a/src/Equibles.Integrations.Sec/Equibles.Integrations.Sec.csproj
+++ b/src/Equibles.Integrations.Sec/Equibles.Integrations.Sec.csproj
@@ -9,4 +9,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Integrations.Common\Equibles.Integrations.Common.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Equibles.UnitTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Equibles.Integrations.Sec/Models/FundClassTicker.cs
+++ b/src/Equibles.Integrations.Sec/Models/FundClassTicker.cs
@@ -1,0 +1,15 @@
+namespace Equibles.Integrations.Sec.Models;
+
+/// <summary>
+/// One row of SEC's fund-class ticker directory (company_tickers_mf.json): a registered fund
+/// share class with its trading symbol, keyed to the fund series it belongs to. This is the
+/// authoritative ticker source for registered investment companies — their NPORT-P filings carry
+/// series/class ids but no trading symbol.
+/// </summary>
+public class FundClassTicker
+{
+    public string Cik { get; set; }
+    public string SeriesId { get; set; }
+    public string ClassId { get; set; }
+    public string Symbol { get; set; }
+}

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -117,6 +117,68 @@ public class SecEdgarClient : ISecEdgarClient
         }
     }
 
+    public async Task<List<FundClassTicker>> GetFundClassTickers()
+    {
+        try
+        {
+            var url = $"{FilesBaseUrl}/files/company_tickers_mf.json";
+            _logger.LogInformation("Requesting: {Url}", url);
+
+            var content = await FetchStringAsync(url);
+            var response = JsonConvert.DeserializeObject<CompanyTickersResponse>(content);
+            var tickers = ParseFundClassTickers(response);
+
+            _logger.LogInformation(
+                "Successfully retrieved {Count} fund class tickers",
+                tickers.Count
+            );
+            return tickers;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving fund class tickers");
+            throw;
+        }
+    }
+
+    // Expected fields: ["cik","seriesId","classId","symbol"]. Positional like the company file;
+    // a row missing its series id or symbol carries nothing usable and is skipped.
+    internal static List<FundClassTicker> ParseFundClassTickers(CompanyTickersResponse response)
+    {
+        if (response?.Fields == null || response.Data == null)
+            return [];
+
+        var cikIndex = response.Fields.IndexOf("cik");
+        var seriesIndex = response.Fields.IndexOf("seriesId");
+        var classIndex = response.Fields.IndexOf("classId");
+        var symbolIndex = response.Fields.IndexOf("symbol");
+        if (seriesIndex == -1 || symbolIndex == -1)
+            return [];
+
+        var tickers = new List<FundClassTicker>(response.Data.Count);
+        foreach (var row in response.Data)
+        {
+            var seriesId = ValueAt(row, seriesIndex);
+            var symbol = ValueAt(row, symbolIndex);
+            if (string.IsNullOrWhiteSpace(seriesId) || string.IsNullOrWhiteSpace(symbol))
+                continue;
+
+            tickers.Add(
+                new FundClassTicker
+                {
+                    Cik = ValueAt(row, cikIndex),
+                    SeriesId = seriesId.Trim(),
+                    ClassId = ValueAt(row, classIndex),
+                    Symbol = symbol.Trim().ToUpperInvariant(),
+                }
+            );
+        }
+        return tickers;
+    }
+
+    private static string ValueAt(List<object> row, int index) =>
+        index >= 0 && index < row.Count ? row[index]?.ToString() : null;
+
     public async Task<string> GetEntityType(string cik)
     {
         var metadata = await GetCompanyMetadata(cik);

--- a/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
@@ -1,6 +1,8 @@
 using System.Text;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using FlexLabs.EntityFrameworkCore.Upsert;
@@ -80,11 +82,12 @@ public class FundSeriesRefreshService
             .ToListAsync(cancellationToken);
 
         var fundTypeByStock = await LoadFundTypesByStock(dbContext, cancellationToken);
+        var tickerBySeries = await LoadSeriesTickers(scope.ServiceProvider, cancellationToken);
 
         var computedAt = DateTime.UtcNow;
         var rows = aggregates
             .Where(a => a.CommonStockId != null || !string.IsNullOrEmpty(a.RegistrantCik))
-            .Select(a => BuildRow(a, fundTypeByStock, computedAt))
+            .Select(a => BuildRow(a, fundTypeByStock, tickerBySeries, computedAt))
             .ToList();
 
         _logger.LogInformation("Rebuilding fund-series directory: {Count} series", rows.Count);
@@ -155,9 +158,53 @@ public class FundSeriesRefreshService
             );
     }
 
+    // Series → trading symbol from SEC's fund-class ticker directory, kept only where the series
+    // is unambiguous (exactly one distinct symbol across its share classes). ETFs — the funds a
+    // user looks up by ticker — have a single class, so they resolve; a multi-class mutual fund
+    // has no single ticker and honestly stays null. Best-effort: the directory being unreachable
+    // must never fail the rebuild, so a fetch error degrades to no enrichment.
+    private async Task<Dictionary<string, string>> LoadSeriesTickers(
+        IServiceProvider services,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            var edgarClient = services.GetRequiredService<ISecEdgarClient>();
+            var classTickers = await edgarClient.GetFundClassTickers();
+            cancellationToken.ThrowIfCancellationRequested();
+            return BuildSeriesTickerMap(classTickers);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Fund-class ticker directory unavailable; rebuilding without ticker enrichment"
+            );
+            return [];
+        }
+    }
+
+    internal static Dictionary<string, string> BuildSeriesTickerMap(
+        List<FundClassTicker> classTickers
+    )
+    {
+        return classTickers
+            .GroupBy(t => t.SeriesId, StringComparer.OrdinalIgnoreCase)
+            .Where(g =>
+                g.Select(t => t.Symbol).Distinct(StringComparer.OrdinalIgnoreCase).Count() == 1
+            )
+            .ToDictionary(g => g.Key, g => g.First().Symbol, StringComparer.OrdinalIgnoreCase);
+    }
+
     private static FundSeries BuildRow(
         FundSeriesAggregate a,
         Dictionary<Guid, string> fundTypeByStock,
+        Dictionary<string, string> tickerBySeries,
         DateTime computedAt
     )
     {
@@ -180,6 +227,15 @@ public class FundSeriesRefreshService
             fundTypeByStock.TryGetValue(a.CommonStockId.Value, out fundType);
         }
 
+        // A tracked fund's ticker comes from its own stock row; a trust series (null here) gets
+        // the SEC fund-class directory's symbol when the series maps to exactly one. The slug
+        // discriminator above deliberately stays the series id so existing trust URLs never move.
+        var ticker = a.Ticker;
+        if (string.IsNullOrEmpty(ticker) && !string.IsNullOrEmpty(seriesId))
+        {
+            tickerBySeries.TryGetValue(seriesId, out ticker);
+        }
+
         return new FundSeries
         {
             IdentityKey = identityKey,
@@ -189,7 +245,7 @@ public class FundSeriesRefreshService
             SeriesId = seriesId,
             SeriesName = a.SeriesName,
             RegistrantName = a.RegistrantName,
-            Ticker = a.Ticker,
+            Ticker = ticker,
             LatestReportPeriodDate = a.LatestReportPeriodDate,
             LatestFilingDate = a.LatestFilingDate,
             NetAssets = a.NetAssets,

--- a/tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceSeriesTickerMapTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceSeriesTickerMapTests.cs
@@ -1,0 +1,64 @@
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+// BuildSeriesTickerMap turns SEC's fund-class ticker directory into the series → symbol map that
+// fills FundSeries.Ticker for sweep-discovered trust series (an ETF like ProShares Ultra
+// Semiconductors "USD" was unresolvable by ticker because NPORT carries no symbol). The rule under
+// test: a series maps ONLY when all its share classes agree on one symbol — a multi-class mutual
+// fund has no single ticker, and guessing one class's symbol would misattribute the whole series.
+public class FundSeriesRefreshServiceSeriesTickerMapTests
+{
+    private static FundClassTicker Row(string seriesId, string symbol, string classId = "C1") =>
+        new()
+        {
+            Cik = "1174610",
+            SeriesId = seriesId,
+            ClassId = classId,
+            Symbol = symbol,
+        };
+
+    [Fact]
+    public void BuildSeriesTickerMap_SingleClassSeries_MapsItsSymbol()
+    {
+        var map = FundSeriesRefreshService.BuildSeriesTickerMap([Row("S000014258", "USD")]);
+
+        map.Should().ContainKey("S000014258").WhoseValue.Should().Be("USD");
+    }
+
+    [Fact]
+    public void BuildSeriesTickerMap_MultiClassSeriesWithDifferentSymbols_IsExcluded()
+    {
+        var map = FundSeriesRefreshService.BuildSeriesTickerMap([
+            Row("S000001", "VFIAX", "C1"),
+            Row("S000001", "VFFSX", "C2"),
+        ]);
+
+        map.Should().BeEmpty("a multi-class fund has no single ticker — guessing misattributes it");
+    }
+
+    [Fact]
+    public void BuildSeriesTickerMap_MultipleClassesSameSymbol_StillMaps()
+    {
+        var map = FundSeriesRefreshService.BuildSeriesTickerMap([
+            Row("S000002", "spy", "C1"),
+            Row("S000002", "SPY", "C2"),
+        ]);
+
+        map.Should().ContainKey("S000002");
+    }
+
+    [Fact]
+    public void BuildSeriesTickerMap_IndependentSeries_MapIndependently()
+    {
+        var map = FundSeriesRefreshService.BuildSeriesTickerMap([
+            Row("S000014258", "USD"),
+            Row("S000001", "VFIAX", "C1"),
+            Row("S000001", "VFFSX", "C2"),
+        ]);
+
+        map.Should().HaveCount(1);
+        map["S000014258"].Should().Be("USD");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientParseFundClassTickersTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientParseFundClassTickersTests.cs
@@ -1,0 +1,74 @@
+using Equibles.Integrations.Sec;
+using Equibles.Integrations.Sec.Models.Responses;
+using Newtonsoft.Json;
+
+namespace Equibles.UnitTests.Sec;
+
+// ParseFundClassTickers reads SEC's company_tickers_mf.json — positional rows under a "fields"
+// header, like the company file — into FundClassTicker rows. Pins the field-order independence
+// (indices come from the header, not hard-coded positions), symbol normalization to uppercase,
+// and that rows missing a series id or symbol are skipped rather than producing unusable entries.
+public class SecEdgarClientParseFundClassTickersTests
+{
+    private static CompanyTickersResponse Response(string json) =>
+        JsonConvert.DeserializeObject<CompanyTickersResponse>(json);
+
+    [Fact]
+    public void ParseFundClassTickers_ReadsRowsByHeaderPosition()
+    {
+        var response = Response(
+            """
+            {"fields":["cik","seriesId","classId","symbol"],
+             "data":[[1174610,"S000014258","C000038817","usd"]]}
+            """
+        );
+
+        var tickers = SecEdgarClient.ParseFundClassTickers(response);
+
+        var ticker = tickers.Should().ContainSingle().Subject;
+        ticker.Cik.Should().Be("1174610");
+        ticker.SeriesId.Should().Be("S000014258");
+        ticker.ClassId.Should().Be("C000038817");
+        ticker.Symbol.Should().Be("USD", "symbols normalize to uppercase");
+    }
+
+    [Fact]
+    public void ParseFundClassTickers_ReorderedFields_StillParses()
+    {
+        var response = Response(
+            """
+            {"fields":["symbol","seriesId","cik","classId"],
+             "data":[["VOO","S000030356",36405,"C000093459"]]}
+            """
+        );
+
+        var tickers = SecEdgarClient.ParseFundClassTickers(response);
+
+        tickers.Should().ContainSingle().Which.SeriesId.Should().Be("S000030356");
+    }
+
+    [Fact]
+    public void ParseFundClassTickers_RowsMissingSeriesOrSymbol_AreSkipped()
+    {
+        var response = Response(
+            """
+            {"fields":["cik","seriesId","classId","symbol"],
+             "data":[[1,"","C1","ABC"],[2,"S000000002","C2",""],[3,"S000000003","C3","DEF"]]}
+            """
+        );
+
+        var tickers = SecEdgarClient.ParseFundClassTickers(response);
+
+        tickers.Should().ContainSingle().Which.Symbol.Should().Be("DEF");
+    }
+
+    [Fact]
+    public void ParseFundClassTickers_MissingHeaderOrData_YieldsNothing()
+    {
+        SecEdgarClient.ParseFundClassTickers(null).Should().BeEmpty();
+        SecEdgarClient
+            .ParseFundClassTickers(Response("""{"fields":["cik"],"data":[[1]]}"""))
+            .Should()
+            .BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

A sweep-discovered trust series (e.g. ProShares Ultra Semiconductors, S000014258) carries a null ticker — NPORT-P has no trading symbol — so a well-known ETF could not be found or resolved by its ticker (USD) in the fund directory or the MCP fund tools.

## Code changes

- `ISecEdgarClient.GetFundClassTickers` (new): fetches SEC's authoritative fund-class ticker directory (`company_tickers_mf.json`, ~28k rows) with the same positional fields/data parsing as the company file; symbols normalize to uppercase; rows missing a series id or symbol are skipped.
- `FundSeriesRefreshService`: the rebuild enriches trust-series rows with `BuildSeriesTickerMap` — a series maps ONLY when all its share classes agree on one symbol, so single-class ETFs resolve while multi-class mutual funds honestly keep a null ticker (no guessed class symbols). Best-effort: an unreachable directory degrades to no enrichment, never a failed rebuild. Slug discriminators are unchanged, so no trust profile URL moves.
- The MCP fund tools (`SearchFunds` / `GetFundProfile`) already search and resolve by `FundSeries.Ticker`, so they pick the enrichment up with no changes.
- 8 new tests (map rules incl. the multi-class exclusion; header-position parsing, uppercase normalization, skip rules).

Fund/Sec suites green; csharpier clean.