### PR TITLE
fix(sec): tiered backfill rescans with persisted cursor state

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260707011429_AddBackfillState.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260707011429_AddBackfillState.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260707011429_AddBackfillState")]
+    partial class AddBackfillState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260707011429_AddBackfillState.cs
+++ b/src/Equibles.Migrations/Migrations/20260707011429_AddBackfillState.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBackfillState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BackfillState",
+                columns: table => new
+                {
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Floor = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastFullRescanAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BackfillState", x => x.Name);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BackfillState");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/BackfillState.cs
+++ b/src/Equibles.Sec.Data/Models/BackfillState.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// One row per backfill cursor, keyed by the worker-assigned cursor name. Persists the
+/// frontier and the last unfloored-rescan stamp so a process restart neither re-scans the
+/// corpus to find its position nor forgets when the full rescan last ran — deploy bursts
+/// would otherwise repeat the minutes-long corpus scan on every boot, or dodge the daily
+/// backstop indefinitely.
+/// </summary>
+public class BackfillState
+{
+    [Key]
+    [MaxLength(100)]
+    public string Name { get; set; }
+
+    /// <summary>Backfill frontier (mirrors BackfillCursor.Floor); null until a batch advances it.</summary>
+    public DateTime? Floor { get; set; }
+
+    /// <summary>When the last unfloored full rescan started; null until the first one runs.</summary>
+    public DateTime? LastFullRescanAt { get; set; }
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -38,6 +38,7 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
+        builder.Entity<BackfillState>();
         builder.Entity<FailToDeliver>();
         builder.Entity<FormAdvAdviser>();
         builder.Entity<FormDFiling>();

--- a/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
+++ b/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
@@ -21,10 +21,11 @@ public class DocumentProcessorWorker : BaseScraperWorker
     protected override int ErrorReportThreshold => 20;
 
     // Backfill frontiers for the two phases. They live on the worker (a singleton) because the
-    // DocumentManager is re-resolved from a fresh scope per batch; a process restart resets
-    // them, which just costs one full scan before the floored fast path takes over again.
-    private readonly BackfillCursor _chunkCursor = new();
-    private readonly BackfillCursor _embeddingCursor = new();
+    // DocumentManager is re-resolved from a fresh scope per batch; each hydrates from its
+    // persisted BackfillState row on first use, so a process restart resumes at the frontier
+    // instead of paying the unfloored corpus scan.
+    private readonly BackfillCursor _chunkCursor = new("document-chunking");
+    private readonly BackfillCursor _embeddingCursor = new("chunk-embedding");
 
     public DocumentProcessorWorker(
         ILogger<DocumentProcessorWorker> logger,

--- a/src/Equibles.Sec.HostedService/Services/BackfillCursor.cs
+++ b/src/Equibles.Sec.HostedService/Services/BackfillCursor.cs
@@ -3,20 +3,39 @@ namespace Equibles.Sec.HostedService.Services;
 /// <summary>
 /// Tracks how far a CreationTime-ordered backfill has progressed so each poll seeks straight
 /// to the frontier instead of anti-joining the whole table. New rows are always created at the
-/// frontier (CreationTime = insert time), so a floored batch query sees all new work; rows left
-/// behind the frontier (an item that failed to process, or work re-queued by deleting its
-/// output) are caught by a rate-limited full rescan. The cursor is owned by the long-lived
-/// worker — the per-scope manager only reads and advances it — so it survives DI scopes and
-/// resets on process restart, which itself forces a fresh full scan.
+/// frontier (CreationTime = insert time), so a floored batch query sees all new work. Rows left
+/// behind the frontier are caught by two rescan tiers: an hourly rescan bounded to
+/// <see cref="BoundedRescanLookback"/> behind the floor (stragglers are read-skew commits or
+/// partially processed batches, always near the frontier — an index-range anti-join, not a
+/// corpus scan), and an unfloored full scan at most once per day as the backstop for re-queued
+/// work older than the bounded window. The cursor is owned by the long-lived worker — the
+/// per-scope manager only reads and advances it — and hydrates its floor and full-rescan stamp
+/// from the persisted BackfillState row, so a process restart resumes at the frontier instead
+/// of paying the minutes-long corpus scan on every boot (deploy bursts used to pay it several
+/// times in a row).
 /// </summary>
 public class BackfillCursor
 {
-    // A full (unfloored) scan anti-joins the entire table — minutes on the chunk corpus — so
-    // the drained-frontier fallback is allowed at most once per interval. One hour keeps the
-    // straggler-retry latency bounded without letting the scan dominate idle DB load again.
-    private static readonly TimeSpan FullRescanInterval = TimeSpan.FromHours(1);
+    // Stragglers surface close behind the frontier: a long transaction committing rows whose
+    // CreationTime predates an already-advanced floor, or a batch whose processing partially
+    // skipped items. An hourly rescan floored a week back catches both through the
+    // CreationTime index without touching the rest of the corpus.
+    private static readonly TimeSpan BoundedRescanInterval = TimeSpan.FromHours(1);
+    public static readonly TimeSpan BoundedRescanLookback = TimeSpan.FromDays(7);
 
-    private DateTime _lastFullScanUtc = DateTime.MinValue;
+    // A full (unfloored) scan anti-joins the entire table — minutes on the chunk corpus — so it
+    // runs at most daily, purely as the backstop for work re-queued behind the bounded window
+    // (output deleted to force re-processing). The stamp is persisted via BackfillState, so
+    // deploy bursts neither repeat the scan per boot nor dodge it indefinitely.
+    private static readonly TimeSpan FullRescanInterval = TimeSpan.FromDays(1);
+
+    private DateTime _lastBoundedScanUtc = DateTime.MinValue;
+
+    /// <summary>The BackfillState row key this cursor hydrates from and persists to.</summary>
+    public string Name { get; }
+
+    /// <summary>True once <see cref="Hydrate"/> ran; the manager hydrates on first use per process.</summary>
+    public bool IsHydrated { get; private set; }
 
     /// <summary>
     /// Lower bound for the next batch query, or null when the next query must scan from the
@@ -26,6 +45,32 @@ public class BackfillCursor
     /// </summary>
     public DateTime? Floor { get; private set; }
 
+    /// <summary>
+    /// When the last unfloored full rescan started (UTC); null until the first one runs, which
+    /// admits the rescan immediately — a fresh install backfills without waiting out a day.
+    /// </summary>
+    public DateTime? LastFullRescanAt { get; private set; }
+
+    public BackfillCursor(string name)
+    {
+        Name = name;
+    }
+
+    /// <summary>
+    /// Seeds the floor and full-rescan stamp from the persisted BackfillState row. The first
+    /// call wins; later calls are ignored so live cursor state is never regressed by a stale
+    /// re-read.
+    /// </summary>
+    public void Hydrate(DateTime? floor, DateTime? lastFullRescanAt)
+    {
+        if (IsHydrated)
+            return;
+
+        IsHydrated = true;
+        Floor = floor;
+        LastFullRescanAt = lastFullRescanAt;
+    }
+
     /// <summary>Moves the frontier to the newest CreationTime the current batch reached.</summary>
     public void Advance(DateTime lastBatchCreationTime)
     {
@@ -33,19 +78,38 @@ public class BackfillCursor
     }
 
     /// <summary>
+    /// Rate-limits the bounded straggler rescan (a query floored at Floor −
+    /// <see cref="BoundedRescanLookback"/>) to one per interval. False when still rate-limited
+    /// or when there is no floor to bound from — a floorless cursor has never processed
+    /// anything, so only the full scan applies. The floor itself is left untouched: a rescan
+    /// that finds stragglers moves it back via <see cref="Advance"/>, and the floored path then
+    /// works itself forward again.
+    /// </summary>
+    public bool TryStartBoundedRescan(DateTime utcNow)
+    {
+        if (Floor is null)
+            return false;
+
+        if (utcNow - _lastBoundedScanUtc < BoundedRescanInterval)
+            return false;
+
+        _lastBoundedScanUtc = utcNow;
+        return true;
+    }
+
+    /// <summary>
     /// Rate-limits the unfloored fallback scan to one per rescan interval. Returns false when
     /// still rate-limited — the caller should treat the backfill as drained for this poll. The
-    /// floor itself is left untouched: an empty rescan must not discard the frontier, or new
-    /// rows arriving right after it would wait out the full interval instead of being picked
-    /// up by the next floored poll. A rescan that does find stragglers moves the floor back
-    /// via Advance, and the floored path then works itself forward again.
+    /// floor is left untouched: an empty rescan must not discard the frontier, or new rows
+    /// arriving right after it would wait out the full interval instead of being picked up by
+    /// the next floored poll.
     /// </summary>
     public bool TryStartFullRescan(DateTime utcNow)
     {
-        if (utcNow - _lastFullScanUtc < FullRescanInterval)
+        if (LastFullRescanAt is { } last && utcNow - last < FullRescanInterval)
             return false;
 
-        _lastFullScanUtc = utcNow;
+        LastFullRescanAt = utcNow;
         return true;
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
@@ -2,6 +2,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -15,6 +16,7 @@ public class DocumentManager
 
     private readonly DocumentRepository _documentRepository;
     private readonly ChunkRepository _chunkRepository;
+    private readonly BackfillStateRepository _backfillStateRepository;
     private readonly IDocumentProcessor _documentProcessor;
     private readonly EmbeddingConfig _embeddingConfig;
     private readonly int _loadSize;
@@ -23,6 +25,7 @@ public class DocumentManager
     public DocumentManager(
         DocumentRepository documentRepository,
         ChunkRepository chunkRepository,
+        BackfillStateRepository backfillStateRepository,
         IDocumentProcessor documentProcessor,
         IOptions<EmbeddingConfig> embeddingConfig,
         ILogger<DocumentManager> logger
@@ -30,6 +33,7 @@ public class DocumentManager
     {
         _documentRepository = documentRepository;
         _chunkRepository = chunkRepository;
+        _backfillStateRepository = backfillStateRepository;
         _documentProcessor = documentProcessor;
         _embeddingConfig = embeddingConfig.Value;
         _loadSize = Math.Max(DefaultLoadSize, _embeddingConfig.BatchSize);
@@ -71,6 +75,7 @@ public class DocumentManager
         _logger.LogInformation("Chunking {Count} documents", pendingDocuments.Count);
         await _documentProcessor.ProcessDocuments(pendingDocuments, cancellationToken);
         cursor.Advance(pendingDocuments[^1].CreationTime);
+        await PersistCursor(cursor);
         return true;
     }
 
@@ -105,16 +110,22 @@ public class DocumentManager
         );
         await _documentProcessor.GenerateEmbeddings(chunksWithoutEmbeddings, cancellationToken);
         cursor.Advance(chunksWithoutEmbeddings[^1].CreationTime);
+        await PersistCursor(cursor);
         return true;
     }
 
-    // Floored batch first; when the frontier drains, at most one rate-limited full scan so
-    // stragglers behind the cursor (failed items, re-queued work) are eventually retried.
-    private static async Task<List<T>> LoadBatch<T>(
+    // Floored batch first; when the frontier drains, an hourly rescan bounded a week behind the
+    // floor catches near-frontier stragglers cheaply, and an unfloored corpus scan runs at most
+    // daily as the backstop for re-queued work older than the bounded window. The cursor
+    // hydrates from its persisted BackfillState row on first use per process, so a restart
+    // resumes at the frontier instead of paying the corpus scan.
+    private async Task<List<T>> LoadBatch<T>(
         Func<DateTime?, Task<List<T>>> query,
         BackfillCursor cursor
     )
     {
+        await HydrateCursor(cursor);
+
         if (cursor.Floor is { } floor)
         {
             var batch = await query(floor);
@@ -122,9 +133,44 @@ public class DocumentManager
                 return batch;
         }
 
-        if (!cursor.TryStartFullRescan(DateTime.UtcNow))
+        var utcNow = DateTime.UtcNow;
+        if (cursor.Floor is { } drainedFloor && cursor.TryStartBoundedRescan(utcNow))
+        {
+            var batch = await query(drainedFloor - BackfillCursor.BoundedRescanLookback);
+            if (batch.Count > 0)
+                return batch;
+        }
+
+        if (!cursor.TryStartFullRescan(utcNow))
             return [];
 
+        // Stamp before scanning: an interrupted scan then waits out the interval instead of a
+        // crash-loop re-running the minutes-long scan on every boot; fresh work still flows
+        // through the floored and bounded tiers regardless.
+        await PersistCursor(cursor);
         return await query(null);
+    }
+
+    private async Task HydrateCursor(BackfillCursor cursor)
+    {
+        if (cursor.IsHydrated)
+            return;
+
+        var state = await _backfillStateRepository.GetByName(cursor.Name);
+        cursor.Hydrate(state?.Floor, state?.LastFullRescanAt);
+    }
+
+    private async Task PersistCursor(BackfillCursor cursor)
+    {
+        var state = await _backfillStateRepository.GetByName(cursor.Name);
+        if (state == null)
+        {
+            state = new BackfillState { Name = cursor.Name };
+            _backfillStateRepository.Add(state);
+        }
+
+        state.Floor = cursor.Floor;
+        state.LastFullRescanAt = cursor.LastFullRescanAt;
+        await _backfillStateRepository.SaveChanges();
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
@@ -163,14 +163,20 @@ public class DocumentManager
     private async Task PersistCursor(BackfillCursor cursor)
     {
         var state = await _backfillStateRepository.GetByName(cursor.Name);
-        if (state == null)
-        {
+        var isNew = state == null;
+        if (isNew)
             state = new BackfillState { Name = cursor.Name };
-            _backfillStateRepository.Add(state);
-        }
 
         state.Floor = cursor.Floor;
         state.LastFullRescanAt = cursor.LastFullRescanAt;
+
+        // Mark the write explicitly rather than leaning on change tracking: a floor advance
+        // that silently failed to persist would re-hydrate the stale floor on the next restart
+        // and re-run the corpus scan this fix exists to prevent, with no test catching it.
+        if (isNew)
+            _backfillStateRepository.Add(state);
+        else
+            _backfillStateRepository.Update(state);
         await _backfillStateRepository.SaveChanges();
     }
 }

--- a/src/Equibles.Sec.Repositories/BackfillStateRepository.cs
+++ b/src/Equibles.Sec.Repositories/BackfillStateRepository.cs
@@ -1,0 +1,16 @@
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Repositories;
+
+public class BackfillStateRepository : BaseRepository<BackfillState>
+{
+    public BackfillStateRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public async Task<BackfillState> GetByName(string name)
+    {
+        return await GetAll().FirstOrDefaultAsync(s => s.Name == name);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
@@ -7,6 +7,7 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.Data.Models.Chunks;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Pgvector;
@@ -225,6 +226,115 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
         state.Should().NotBeNull();
         state!.Floor.Should().Be(pendingChunk.CreationTime);
     }
+
+    [Fact]
+    public async Task GenerateEmbeddingBatch_RestartAfterAdvance_ResumesFromPersistedFloorAndUpdatesInPlace()
+    {
+        // Simulates a worker restart between two batches: the second batch runs on a FRESH
+        // cursor that must hydrate the persisted frontier, resume via the floored path (no
+        // corpus re-scan), and persist the next advance as an in-place UPDATE of the single
+        // BackfillState row. Reverting PersistCursor to lean on implicit change tracking, or
+        // dropping hydration, would fail this — the floor would stay stale and the daily scan
+        // would re-run on every restart, the exact regression this fix prevents.
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+        };
+        var file = MakeFile();
+        var document = MakeDocument(
+            stock,
+            file,
+            contentId: file.Id,
+            createdAt: DateTime.UtcNow.AddMinutes(-10)
+        );
+        var firstChunk = MakeChunk(
+            document,
+            content: "first",
+            index: 0,
+            createdAt: DateTime.UtcNow.AddMinutes(-5)
+        );
+
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<File>().Add(file);
+        DbContext.Set<Document>().Add(document);
+        DbContext.Set<Chunk>().Add(firstChunk);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        // First batch on a fresh cursor: no state row yet, so it full-scans, processes the
+        // chunk, and persists floor = firstChunk.CreationTime.
+        await NewEmbeddingManager()
+            .GenerateEmbeddingBatch(new BackfillCursor("chunk-embedding"), CancellationToken.None);
+
+        var afterFirst = await new BackfillStateRepository(DbContext).GetByName("chunk-embedding");
+        afterFirst.Should().NotBeNull();
+        afterFirst!.Floor.Should().Be(firstChunk.CreationTime);
+        var stampAfterFirst = afterFirst.LastFullRescanAt;
+        stampAfterFirst.Should().NotBeNull("the first drained-frontier scan stamped the cursor");
+        DbContext.ChangeTracker.Clear();
+
+        // Mark the first chunk embedded so it leaves the pending filter, then seed a newer
+        // pending chunk that only a floored resume from the persisted frontier will reach.
+        DbContext
+            .Set<Embedding>()
+            .Add(
+                new Embedding
+                {
+                    Id = Guid.NewGuid(),
+                    ChunkId = firstChunk.Id,
+                    Model = "test-model",
+                    Vector = new Vector(new ReadOnlyMemory<float>(new[] { 1f, 0f, 0f })),
+                    VectorDimension = 3,
+                }
+            );
+        var secondChunk = MakeChunk(
+            document,
+            content: "second",
+            index: 1,
+            createdAt: DateTime.UtcNow.AddMinutes(-2)
+        );
+        DbContext.Set<Chunk>().Add(secondChunk);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        // Second batch on a brand-new cursor (the restart): hydrate → floored resume → advance.
+        await NewEmbeddingManager()
+            .GenerateEmbeddingBatch(new BackfillCursor("chunk-embedding"), CancellationToken.None);
+
+        var rows = await new BackfillStateRepository(DbContext)
+            .GetAll()
+            .Where(s => s.Name == "chunk-embedding")
+            .ToListAsync();
+        rows.Should().ContainSingle("the advance is an in-place UPDATE, never a second row");
+        rows[0]
+            .Floor.Should()
+            .Be(secondChunk.CreationTime, "the UPDATE persisted the new frontier");
+        rows[0]
+            .LastFullRescanAt.Should()
+            .Be(
+                stampAfterFirst,
+                "the restart hydrated the frontier and resumed via the floored path, so no new full scan ran"
+            );
+    }
+
+    private DocumentManager NewEmbeddingManager() =>
+        new(
+            new DocumentRepository(DbContext),
+            new ChunkRepository(DbContext),
+            new BackfillStateRepository(DbContext),
+            _processor,
+            Options.Create(
+                new EmbeddingConfig
+                {
+                    Enabled = true,
+                    BaseUrl = "http://localhost:11434",
+                    ModelName = "test-model",
+                }
+            ),
+            NullLogger<DocumentManager>()
+        );
 
     private static Chunk MakeChunk(
         Document document,

--- a/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
@@ -91,12 +91,16 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
         var sut = new DocumentManager(
             new DocumentRepository(DbContext),
             new ChunkRepository(DbContext),
+            new BackfillStateRepository(DbContext),
             _processor,
             Options.Create(new EmbeddingConfig { Enabled = false }),
             NullLogger<DocumentManager>()
         );
 
-        var workDone = await sut.ChunkDocumentBatch(new BackfillCursor(), CancellationToken.None);
+        var workDone = await sut.ChunkDocumentBatch(
+            new BackfillCursor("document-chunking"),
+            CancellationToken.None
+        );
 
         workDone
             .Should()
@@ -172,6 +176,7 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
         var sut = new DocumentManager(
             new DocumentRepository(DbContext),
             new ChunkRepository(DbContext),
+            new BackfillStateRepository(DbContext),
             _processor,
             // IsConfigured is computed from Enabled + BaseUrl + ModelName; without these
             // the guard returns false before the query runs and the test pins nothing.
@@ -187,7 +192,7 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
         );
 
         var workDone = await sut.GenerateEmbeddingBatch(
-            new BackfillCursor(),
+            new BackfillCursor("chunk-embedding"),
             CancellationToken.None
         );
 
@@ -213,6 +218,12 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
                 id => id == pendingChunk.Id,
                 "only the embedding-less chunk survives the !c.Embeddings.Any() filter"
             );
+
+        // The advance is persisted so a restarted worker hydrates this frontier instead of
+        // re-running the unfloored corpus scan.
+        var state = await new BackfillStateRepository(DbContext).GetByName("chunk-embedding");
+        state.Should().NotBeNull();
+        state!.Floor.Should().Be(pendingChunk.CreationTime);
     }
 
     private static Chunk MakeChunk(

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorWorkerDoWorkTests.cs
@@ -35,6 +35,7 @@ public class DocumentProcessorWorkerDoWorkTests : ParadeDbMcpTestBase
         var documentManager = new DocumentManager(
             new DocumentRepository(DbContext),
             new ChunkRepository(DbContext),
+            new BackfillStateRepository(DbContext),
             Substitute.For<IDocumentProcessor>(),
             Options.Create(new EmbeddingConfig { Enabled = false }),
             Substitute.For<ILogger<DocumentManager>>()

--- a/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
@@ -4,18 +4,22 @@ namespace Equibles.UnitTests.Sec;
 
 public class BackfillCursorTests
 {
+    private static readonly DateTime Now = new(2026, 7, 7, 12, 0, 0, DateTimeKind.Utc);
+
     [Fact]
     public void Floor_NewCursor_IsNull()
     {
-        var cursor = new BackfillCursor();
+        var cursor = new BackfillCursor("test");
 
         cursor.Floor.Should().BeNull();
+        cursor.IsHydrated.Should().BeFalse();
+        cursor.LastFullRescanAt.Should().BeNull();
     }
 
     [Fact]
     public void Advance_SetsFloorToBatchFrontier()
     {
-        var cursor = new BackfillCursor();
+        var cursor = new BackfillCursor("test");
         var frontier = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
 
         cursor.Advance(frontier);
@@ -24,32 +28,60 @@ public class BackfillCursorTests
     }
 
     [Fact]
-    public void TryStartFullRescan_FirstCall_AllowsAndKeepsFloor()
+    public void Hydrate_SeedsFloorAndFullRescanStamp()
+    {
+        var cursor = new BackfillCursor("test");
+        var floor = Now.AddDays(-2);
+        var lastFullRescan = Now.AddHours(-3);
+
+        cursor.Hydrate(floor, lastFullRescan);
+
+        cursor.IsHydrated.Should().BeTrue();
+        cursor.Floor.Should().Be(floor);
+        cursor.LastFullRescanAt.Should().Be(lastFullRescan);
+    }
+
+    [Fact]
+    public void Hydrate_SecondCall_IsIgnored()
+    {
+        // The manager hydrates on first use per process; a later stale re-read must never
+        // regress live cursor state (an advanced floor, a fresh rescan stamp).
+        var cursor = new BackfillCursor("test");
+        cursor.Hydrate(Now.AddDays(-2), Now.AddHours(-3));
+        cursor.Advance(Now.AddDays(-1));
+
+        cursor.Hydrate(Now.AddDays(-30), null);
+
+        cursor.Floor.Should().Be(Now.AddDays(-1));
+        cursor.LastFullRescanAt.Should().Be(Now.AddHours(-3));
+    }
+
+    [Fact]
+    public void TryStartFullRescan_NoStamp_AllowsAndKeepsFloor()
     {
         // The frontier must survive a rescan: an empty full scan that discarded it would leave
-        // rows arriving right afterwards invisible until the next rescan window.
-        var cursor = new BackfillCursor();
+        // rows arriving right afterwards invisible until the next rescan window. A null stamp
+        // (fresh install, no BackfillState row yet) admits the scan immediately.
+        var cursor = new BackfillCursor("test");
         var frontier = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
         cursor.Advance(frontier);
 
-        var allowed = cursor.TryStartFullRescan(
-            new DateTime(2026, 7, 3, 13, 0, 0, DateTimeKind.Utc)
-        );
+        var allowed = cursor.TryStartFullRescan(Now);
 
         allowed.Should().BeTrue();
         cursor.Floor.Should().Be(frontier);
+        cursor.LastFullRescanAt.Should().Be(Now);
     }
 
     [Fact]
     public void TryStartFullRescan_WithinRescanInterval_IsRateLimitedAndKeepsFloor()
     {
-        var cursor = new BackfillCursor();
-        var firstScan = new DateTime(2026, 7, 3, 13, 0, 0, DateTimeKind.Utc);
-        cursor.TryStartFullRescan(firstScan);
-        var frontier = new DateTime(2026, 7, 3, 13, 30, 0, DateTimeKind.Utc);
+        var cursor = new BackfillCursor("test");
+        cursor.TryStartFullRescan(Now);
+        var frontier = Now.AddMinutes(30);
         cursor.Advance(frontier);
 
-        var allowed = cursor.TryStartFullRescan(firstScan.AddMinutes(59));
+        var allowed = cursor.TryStartFullRescan(Now.AddHours(23));
 
         allowed.Should().BeFalse();
         cursor.Floor.Should().Be(frontier);
@@ -58,13 +90,88 @@ public class BackfillCursorTests
     [Fact]
     public void TryStartFullRescan_AfterRescanInterval_AllowsAgain()
     {
-        var cursor = new BackfillCursor();
-        var firstScan = new DateTime(2026, 7, 3, 13, 0, 0, DateTimeKind.Utc);
-        cursor.TryStartFullRescan(firstScan);
-        cursor.Advance(new DateTime(2026, 7, 3, 13, 30, 0, DateTimeKind.Utc));
+        var cursor = new BackfillCursor("test");
+        cursor.TryStartFullRescan(Now);
 
-        var allowed = cursor.TryStartFullRescan(firstScan.AddMinutes(61));
+        var allowed = cursor.TryStartFullRescan(Now.AddHours(25));
 
         allowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryStartFullRescan_HydratedRecentStamp_IsRateLimited()
+    {
+        // The stamp survives restarts via BackfillState precisely so a deploy burst cannot
+        // re-run the minutes-long corpus scan on every boot.
+        var cursor = new BackfillCursor("test");
+        cursor.Hydrate(null, Now.AddHours(-2));
+
+        var allowed = cursor.TryStartFullRescan(Now);
+
+        allowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryStartFullRescan_HydratedExpiredStamp_Allows()
+    {
+        var cursor = new BackfillCursor("test");
+        cursor.Hydrate(null, Now.AddDays(-2));
+
+        var allowed = cursor.TryStartFullRescan(Now);
+
+        allowed.Should().BeTrue();
+        cursor.LastFullRescanAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void TryStartBoundedRescan_NoFloor_IsRefused()
+    {
+        // A floorless cursor has never processed anything — there is no frontier to look
+        // behind, so only the unfloored full scan applies.
+        var cursor = new BackfillCursor("test");
+
+        cursor.TryStartBoundedRescan(Now).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryStartBoundedRescan_WithFloor_AllowsAndKeepsFloor()
+    {
+        var cursor = new BackfillCursor("test");
+        var frontier = Now.AddDays(-1);
+        cursor.Advance(frontier);
+
+        var allowed = cursor.TryStartBoundedRescan(Now);
+
+        allowed.Should().BeTrue();
+        cursor.Floor.Should().Be(frontier);
+    }
+
+    [Fact]
+    public void TryStartBoundedRescan_WithinInterval_IsRateLimited()
+    {
+        var cursor = new BackfillCursor("test");
+        cursor.Advance(Now.AddDays(-1));
+        cursor.TryStartBoundedRescan(Now);
+
+        cursor.TryStartBoundedRescan(Now.AddMinutes(59)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryStartBoundedRescan_AfterInterval_AllowsAgain()
+    {
+        var cursor = new BackfillCursor("test");
+        cursor.Advance(Now.AddDays(-1));
+        cursor.TryStartBoundedRescan(Now);
+
+        cursor.TryStartBoundedRescan(Now.AddMinutes(61)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void BoundedRescanLookback_CoversAWeekBehindTheFloor()
+    {
+        // LoadBatch floors the bounded rescan at Floor − lookback; a week comfortably covers
+        // the realistic stragglers (read-skew commits, partially processed batches) while
+        // keeping the rescan an index-range query instead of a corpus scan.
+        BackfillCursor.BoundedRescanLookback.Should().Be(TimeSpan.FromDays(7));
     }
 }

--- a/tests/Equibles.UnitTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentManagerTests.cs
@@ -23,9 +23,12 @@ public class DocumentManagerTests
         var logger = Substitute.For<ILogger<DocumentManager>>();
         var processor = Substitute.For<IDocumentProcessor>();
 
-        var sut = new DocumentManager(null, null, processor, embeddingConfig, logger);
+        var sut = new DocumentManager(null, null, null, processor, embeddingConfig, logger);
 
-        var result = await sut.GenerateEmbeddingBatch(new BackfillCursor(), CancellationToken.None);
+        var result = await sut.GenerateEmbeddingBatch(
+            new BackfillCursor("test"),
+            CancellationToken.None
+        );
 
         result.Should().BeFalse();
         await processor
@@ -47,9 +50,12 @@ public class DocumentManagerTests
         var logger = Substitute.For<ILogger<DocumentManager>>();
         var processor = Substitute.For<IDocumentProcessor>();
 
-        var sut = new DocumentManager(null, null, processor, embeddingConfig, logger);
+        var sut = new DocumentManager(null, null, null, processor, embeddingConfig, logger);
 
-        var result = await sut.GenerateEmbeddingBatch(new BackfillCursor(), CancellationToken.None);
+        var result = await sut.GenerateEmbeddingBatch(
+            new BackfillCursor("test"),
+            CancellationToken.None
+        );
 
         result.Should().BeFalse();
     }
@@ -68,9 +74,12 @@ public class DocumentManagerTests
         var logger = Substitute.For<ILogger<DocumentManager>>();
         var processor = Substitute.For<IDocumentProcessor>();
 
-        var sut = new DocumentManager(null, null, processor, embeddingConfig, logger);
+        var sut = new DocumentManager(null, null, null, processor, embeddingConfig, logger);
 
-        var result = await sut.GenerateEmbeddingBatch(new BackfillCursor(), CancellationToken.None);
+        var result = await sut.GenerateEmbeddingBatch(
+            new BackfillCursor("test"),
+            CancellationToken.None
+        );
 
         result.Should().BeFalse();
     }


### PR DESCRIPTION
## Summary

The document-chunking and chunk-embedding backfills fall back to an **unfloored anti-join over the whole corpus** — minutes of parallel scan on the chunk table — in two situations: once per hour whenever the frontier drains (worst-case cost exactly when there is nothing to find), and on **every process start** because the cursor was in-memory only. In production, deploy bursts recreated the worker several times within minutes and paid the ~2-minute corpus scan on each boot, starving concurrent queries past their command timeouts.

This PR:

- **Tiers the rescan.** When the frontier drains, an hourly rescan bounded to `Floor − 7d` catches the realistic stragglers — read-skew commits (long transactions committing rows whose `CreationTime` predates an already-advanced floor) and partially processed batches, both always near the frontier — via the CreationTime index instead of a corpus scan. The unfloored full scan is demoted to **at most daily**, purely as the backstop for work re-queued behind the bounded window (output deleted to force re-processing).
- **Persists cursor state.** New additive `BackfillState` table (`Name` PK, `Floor`, `LastFullRescanAt`), one row per cursor. Cursors hydrate on first use per process and persist on every advance, so a restart resumes at the frontier, and the daily-scan stamp survives deploy bursts (which could otherwise either repeat the scan per boot or dodge it indefinitely). The stamp is written before the scan starts so an interrupted scan waits out the interval instead of crash-looping the corpus scan at boot.
- Preserves the existing invariants: inclusive floors, rescans never discard the frontier (a rescan that finds stragglers moves the floor back via `Advance`), a fresh install (no state row) full-scans immediately.

## Code changes

- `src/Equibles.Sec.HostedService/Services/BackfillCursor.cs` — named cursor with `Hydrate` (first call wins), `TryStartBoundedRescan` (hourly, requires a floor), `TryStartFullRescan` (daily, stamp-persisted), public `BoundedRescanLookback`.
- `src/Equibles.Sec.HostedService/Services/DocumentManager.cs` — `LoadBatch` gains the bounded tier and hydrates/persists cursor state via the new repository; both batch methods persist after `Advance`.
- `src/Equibles.Sec.Data/Models/BackfillState.cs` + registration in `SecModuleConfiguration` + `src/Equibles.Sec.Repositories/BackfillStateRepository.cs`.
- `src/Equibles.Migrations` — `AddBackfillState` (additive table only).
- `src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs` — named cursors (`document-chunking`, `chunk-embedding`).
- Tests: `BackfillCursorTests` rewritten for the tiered/hydration semantics (15 tests); integration `DocumentManagerTests` now also pins that the advanced frontier lands in `BackfillState` against real Postgres; construction sites updated for the new ctor param.

Verified: full OSS unit suite (3257 passed), Sec integration tests against the ParadeDB container (3 passed, migration applied by the fixture), solution builds clean, csharpier run on changed files.