### PR TITLE
fix(sec): scope the r-file scale note to the money segment and parse the iso currency

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ReportedStatements/RFileStatement.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ReportedStatements/RFileStatement.cs
@@ -24,7 +24,7 @@ public class RFileStatement
     /// <summary>Reporting currency, e.g. <c>USD</c>; null if not stated in the title.</summary>
     public string Currency { get; set; }
 
-    /// <summary>The "$ in Thousands/Millions" presentation multiplier (1 / 1000 / 1000000) from the title.</summary>
+    /// <summary>The money presentation multiplier (1 / 1000 / 1000000) from the title's "$ in Thousands/Millions" segment; share and per-share scales are separate.</summary>
     public long Scale { get; set; } = 1;
 
     /// <summary>True when no statement table or no data rows were found — the R-file carried nothing usable.</summary>

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ReportedStatements/RFileStatementParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ReportedStatements/RFileStatementParser.cs
@@ -31,6 +31,20 @@ public static class RFileStatementParser
         RegexOptions.Compiled | RegexOptions.IgnoreCase
     );
 
+    // One "<subject> in <magnitude>" segment of the scale note; segments are
+    // comma-separated, so the subject is everything since the last comma.
+    private static readonly Regex ScaleSegmentPattern = new(
+        @"([^,]*?)\s*\bin\s+(Thousands|Millions|Billions)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
+
+    // The note's leading ISO currency code, rendered as "<code> (<symbol>)" —
+    // "USD ($)", "EUR (€)", "CAD ($)".
+    private static readonly Regex CurrencyCodePattern = new(
+        @"^([A-Za-z]{3})\s*\(",
+        RegexOptions.Compiled
+    );
+
     public static RFileStatement Parse(string html)
     {
         var result = new RFileStatement();
@@ -80,17 +94,36 @@ public static class RFileStatementParser
         var note = dash >= 0 ? title[(dash + 3)..].Trim() : null;
         var haystack = note ?? title;
 
-        var currency = haystack.Contains("USD", StringComparison.OrdinalIgnoreCase) ? "USD" : null;
-        var scale = haystack switch
+        return (note, ParseCurrency(haystack), ParseMoneyScale(haystack));
+    }
+
+    private static string ParseCurrency(string haystack)
+    {
+        var match = CurrencyCodePattern.Match(haystack);
+        return match.Success ? match.Groups[1].Value.ToUpperInvariant() : null;
+    }
+
+    // The note scales each unit family in its own segment — "$ in Thousands",
+    // "shares in Millions", "$ / shares in Thousands" — and only the money segment may
+    // set the statement scale: "USD ($) shares in Thousands" presents dollars UNSCALED,
+    // so treating any "in Thousands" as the money scale inflates every money cell 1000×
+    // downstream. A subject-less "(In Thousands)" (old-style title) applies to money.
+    private static long ParseMoneyScale(string haystack)
+    {
+        foreach (Match match in ScaleSegmentPattern.Matches(haystack))
         {
-            _ when haystack.Contains("in Billions", StringComparison.OrdinalIgnoreCase) =>
-                1_000_000_000L,
-            _ when haystack.Contains("in Millions", StringComparison.OrdinalIgnoreCase) =>
-                1_000_000L,
-            _ when haystack.Contains("in Thousands", StringComparison.OrdinalIgnoreCase) => 1_000L,
-            _ => 1L,
-        };
-        return (note, currency, scale);
+            if (match.Groups[1].Value.Contains("share", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            return match.Groups[2].Value.ToLowerInvariant() switch
+            {
+                "billions" => 1_000_000_000L,
+                "millions" => 1_000_000L,
+                _ => 1_000L,
+            };
+        }
+        return 1L;
     }
 
     // Columns come from the header rows: the row of period-end dates is the column set; an earlier

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/ReportedFinancialStatement.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/ReportedFinancialStatement.cs
@@ -95,9 +95,10 @@ public class ReportedFinancialStatement
     public string Currency { get; set; }
 
     /// <summary>
-    /// The "$ in Thousands/Millions" multiplier SEC noted on the statement (1, 1000, 1000000).
-    /// The values in <see cref="Payload"/> are already de-scaled to whole units; this is kept
-    /// for reference and to round-trip the issuer's stated presentation scale.
+    /// The MONEY multiplier from SEC's scale note ("$ in Thousands/Millions" → 1000 / 1000000;
+    /// 1 when money is presented unscaled). Values in <see cref="Payload"/> stay exactly as
+    /// filed, so a consumer needing whole-unit figures multiplies money cells by this. Share
+    /// counts and per-share amounts scale independently and are NOT covered by it.
     /// </summary>
     public long Scale { get; set; } = 1;
 

--- a/tests/Equibles.UnitTests/Sec/RFileStatementParserScaleNoteTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RFileStatementParserScaleNoteTests.cs
@@ -1,0 +1,63 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.ReportedStatements;
+
+namespace Equibles.UnitTests.Sec;
+
+// The R-file scale note scales each unit family in its own segment — "$ in Thousands",
+// "shares in Millions", "$ / shares in Thousands" — and only the money segment may set
+// the statement Scale. The production corpus hit every shape below; "USD ($) shares in
+// Thousands" filings (dollars UNSCALED, only share counts in thousands) were inflated
+// 1000× downstream when any "in Thousands" was read as the money scale.
+public class RFileStatementParserScaleNoteTests
+{
+    // The smallest R-file the parser accepts: a title cell, one dated column and one
+    // tagged data row (Parse discards metadata when no data rows survive).
+    private static string RFile(string title) =>
+        $"""
+            <html><body><table class="report">
+            <tr><th class="tl">{title}</th><th class="th">Mar. 28, 2026</th></tr>
+            <tr class="re"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_us-gaap_Revenues', window );">Revenues</a></td><td class="num">1,234</td></tr>
+            </table></body></html>
+            """;
+
+    [Theory]
+    // A money segment sets the scale, whatever the shares segment says.
+    [InlineData("STATEMENT - USD ($) $ in Thousands", 1_000L, "USD")]
+    [InlineData("STATEMENT - USD ($) $ in Millions", 1_000_000L, "USD")]
+    [InlineData("STATEMENT - USD ($) $ in Billions", 1_000_000_000L, "USD")]
+    [InlineData("STATEMENT - USD ($) shares in Thousands, $ in Thousands", 1_000L, "USD")]
+    [InlineData("STATEMENT - USD ($) shares in Thousands, $ in Millions", 1_000_000L, "USD")]
+    [InlineData("STATEMENT - USD ($) $ in Thousands, shares in Millions", 1_000L, "USD")]
+    [InlineData("STATEMENT - USD ($) $ / shares in Thousands, $ in Thousands", 1_000L, "USD")]
+    // Shares-only and per-share-only scales leave money unscaled.
+    [InlineData("STATEMENT - USD ($) shares in Thousands", 1L, "USD")]
+    [InlineData("STATEMENT - USD ($) shares in Millions", 1L, "USD")]
+    [InlineData("STATEMENT - USD ($) $ / shares in Thousands", 1L, "USD")]
+    [InlineData("STATEMENT - $ / shares shares in Thousands", 1L, null)]
+    [InlineData("STATEMENT - shares shares in Millions", 1L, null)]
+    // No scale segments at all.
+    [InlineData("STATEMENT - USD ($)", 1L, "USD")]
+    [InlineData("STATEMENT - Futures Contracts", 1L, null)]
+    // Foreign reporting currencies carry their ISO code before the symbol.
+    [InlineData("STATEMENT - EUR (€) € in Thousands", 1_000L, "EUR")]
+    [InlineData("STATEMENT - CAD ($) $ in Millions", 1_000_000L, "CAD")]
+    [InlineData("STATEMENT - BRL (R$) R$ in Thousands", 1_000L, "BRL")]
+    // Old-style titles without a " - " note: a subject-less "(In Thousands)" is money.
+    [InlineData("CONSOLIDATED BALANCE SHEETS (In Thousands, except per share data)", 1_000L, null)]
+    [InlineData(
+        "STATEMENTS OF OPERATIONS (In Millions, except share and per share amounts)",
+        1_000_000L,
+        null
+    )]
+    public void Parse_ScaleNote_YieldsMoneyScaleAndCurrency(
+        string title,
+        long expectedScale,
+        string expectedCurrency
+    )
+    {
+        var statement = RFileStatementParser.Parse(RFile(title));
+
+        statement.IsEmpty.Should().BeFalse();
+        statement.Scale.Should().Be(expectedScale);
+        statement.Currency.Should().Be(expectedCurrency);
+    }
+}


### PR DESCRIPTION
## Summary
The R-file title's scale note scales each unit family in its own comma-separated segment — `$ in Thousands`, `shares in Millions`, `$ / shares in Thousands` — but `RFileStatementParser.ParseTitle` took **any** `in Thousands/Millions/Billions` occurrence as the money multiplier. Filings noted `USD ($) shares in Thousands` present dollar amounts **unscaled** (only share counts are in thousands), yet got `Scale = 1000`; consumers that multiply money cells by `Scale` then inflate every figure 1000× (1e6× for `shares in Millions`, and `$ in Thousands, shares in Millions` even resolved to 1e6 because the switch tested Millions first). This produced ~28k false value-mismatch findings in the downstream financials reconciliation audit.

Currency was also assumed USD-or-null; the note's leading ISO code (`CAD ($)`, `EUR (€)`, `BRL (R$)`) is now parsed so foreign-currency statements stop comparing against USD facts.

## Code changes
- `RFileStatementParser`: `ParseTitle` now derives the money scale segment-aware (`ParseMoneyScale`) — only a segment whose subject is not shares/per-share sets `Scale`; subject-less old-style `(In Thousands)` titles still count as money. `ParseCurrency` reads the leading ISO code.
- `ReportedFinancialStatement.Scale` / `RFileStatement.Scale` XML docs corrected: payload values are stored **as filed** (the old doc claimed they were de-scaled) and `Scale` covers money only.
- New `RFileStatementParserScaleNoteTests` covering all 19 note shapes observed in the production corpus.