### PR TITLE
fix(sec): correct impossible shares-outstanding counts feeding short-interest %, market cap, ownership

### DIFF
--- a/src/Equibles.Integrations.Sec/Equibles.Integrations.Sec.csproj
+++ b/src/Equibles.Integrations.Sec/Equibles.Integrations.Sec.csproj
@@ -12,5 +12,4 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Equibles.UnitTests" />
   </ItemGroup>
-
 </Project>

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
@@ -29,13 +29,16 @@ public interface ISharesOutstandingProvider
     );
 
     /// <summary>
-    /// The issuer's current entity-wide share count: the more-recently-filed of the latest
+    /// The issuer's current entity-wide share count, taken from the authoritative
+    /// dei:EntityCommonStockSharesOutstanding cover-page tag: the more-recently-filed of the latest
     /// consolidated cover-page fact and the latest per-class sum. A single-class issuer (only a
     /// consolidated fact) or a multi-class issuer that never reported a consolidated count (only
     /// per-class facts) returns that one figure. When an issuer reports <em>both</em> — e.g. a
     /// dual-class filer whose classless cover-page series ended years ago when it switched to
     /// per-class reporting — the stale consolidated value must not win, so the figure from the
-    /// most recent filing is used. Null when the issuer has neither on record.
+    /// most recent filing is used. The us-gaap:CommonStockSharesOutstanding balance-sheet count
+    /// (frequently a nominal placeholder for shells and multi-class filers) is used only as a
+    /// fallback when the issuer never reported the cover-page tag. Null when neither is on record.
     /// </summary>
     Task<long?> GetCurrentSharesOutstanding(
         CommonStock stock,

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Statements;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -44,7 +45,14 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     public async Task<long?> GetReportedSharesOutstanding(
         CommonStock stock,
         CancellationToken cancellationToken = default
-    ) => (await GetLatestConsolidated(stock, cancellationToken))?.Shares;
+    ) =>
+        (
+            await GetLatestConsolidated(
+                stock,
+                await ResolveConceptIds(cancellationToken),
+                cancellationToken
+            )
+        )?.Shares;
 
     // The entity-wide share count for a multi-class issuer, summed across its share classes from
     // the latest filing's per-class cover-page facts, or null when the issuer reports no per-class
@@ -54,23 +62,62 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     public async Task<long?> GetSummedPerClassSharesOutstanding(
         CommonStock stock,
         CancellationToken cancellationToken = default
-    ) => (await GetLatestPerClass(stock, cancellationToken))?.Shares;
+    ) =>
+        (
+            await GetLatestPerClass(
+                stock,
+                await ResolveConceptIds(cancellationToken),
+                cancellationToken
+            )
+        )?.Shares;
 
-    // The issuer's current entity total: the more-recently-filed of the latest consolidated fact
-    // and the latest per-class sum. Most issuers have only one of the two, in which case that one
-    // is returned. A dual-class filer (e.g. Mastercard, Visa) can have BOTH — its classless
-    // dei:EntityCommonStockSharesOutstanding series ended years ago when it moved to per-class
-    // reporting, leaving a stale consolidated fact alongside current per-class facts — so the
-    // figure from the most recent filing wins; a same-filing tie keeps the consolidated total,
-    // which is the entity figure directly (#5158).
+    // The issuer's current entity total. The authoritative source is the dei:EntityCommonStock
+    // SharesOutstanding COVER-PAGE figure: the latest consolidated cover-page fact, or — for a
+    // multi-class issuer that reports the count only per share class — the sum across those classes.
+    // The us-gaap:CommonStockSharesOutstanding BALANCE-SHEET tag the shares-outstanding alias also
+    // maps is NOT an entity total: shells and multi-class filers routinely carry a nominal placeholder
+    // there (1, 100, 1000 shares) alongside the real per-class cover-page counts, filed the same day.
+    // Resolving both tags together let that placeholder win the same-filing tie, pinning
+    // SharesOutStanding to 1 and blowing up every ratio built on it (short interest % of shares,
+    // market cap, ownership %). So the cover-page (dei) figure is resolved first; the balance-sheet
+    // count is used only as a last-resort fallback for an issuer that never reported the dei tag.
+    //
+    // A dual-class filer (e.g. Mastercard, Visa) can report BOTH a consolidated cover-page fact and
+    // per-class ones — its classless series ended years ago when it moved to per-class reporting,
+    // leaving a stale consolidated fact alongside current per-class facts — so the figure from the
+    // most recent filing wins; a same-filing tie keeps the consolidated total, which is the entity
+    // figure directly (#5158).
     public async Task<long?> GetCurrentSharesOutstanding(
         CommonStock stock,
         CancellationToken cancellationToken = default
     )
     {
-        var consolidated = await GetLatestConsolidated(stock, cancellationToken);
-        var perClass = await GetLatestPerClass(stock, cancellationToken);
+        var coverPageConceptIds = await ResolveConceptIds(cancellationToken, FactTaxonomy.Dei);
+        var consolidated = await GetLatestConsolidated(
+            stock,
+            coverPageConceptIds,
+            cancellationToken
+        );
+        var perClass = await GetLatestPerClass(stock, coverPageConceptIds, cancellationToken);
 
+        var coverPageTotal = PickEntityTotal(consolidated, perClass);
+        if (coverPageTotal != null)
+            return coverPageTotal;
+
+        // No dei cover-page fact on record — fall back to the balance-sheet consolidated count,
+        // the best available for an issuer that never reported the authoritative cover-page tag.
+        var fallbackConceptIds = await ResolveConceptIds(cancellationToken);
+        return (await GetLatestConsolidated(stock, fallbackConceptIds, cancellationToken))?.Shares;
+    }
+
+    // Picks the entity total from the latest consolidated cover-page fact and the latest per-class
+    // sum: the more-recently-filed wins, and a same-filing tie keeps the consolidated total (the
+    // entity figure directly). Null when neither is present.
+    private static long? PickEntityTotal(
+        (long Shares, DateOnly Filed)? consolidated,
+        (long Shares, DateOnly Filed)? perClass
+    )
+    {
         if (consolidated == null)
             return perClass?.Shares;
         if (perClass == null)
@@ -85,10 +132,10 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     // when the issuer has no consolidated fact on record or the count is unrepresentable as Int64.
     private async Task<(long Shares, DateOnly Filed)?> GetLatestConsolidated(
         CommonStock stock,
+        IReadOnlyCollection<Guid> conceptIds,
         CancellationToken cancellationToken
     )
     {
-        var conceptIds = await ResolveConceptIds(cancellationToken);
         if (conceptIds.Count == 0)
             return null;
 
@@ -117,10 +164,10 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     // axis or the sum is unrepresentable as Int64.
     private async Task<(long Shares, DateOnly Filed)?> GetLatestPerClass(
         CommonStock stock,
+        IReadOnlyCollection<Guid> conceptIds,
         CancellationToken cancellationToken
     )
     {
-        var conceptIds = await ResolveConceptIds(cancellationToken);
         if (conceptIds.Count == 0)
             return null;
 
@@ -193,14 +240,25 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     }
 
     // The financial-concept ids the "shares-outstanding" alias resolves to, or an empty list when
-    // the alias is unmapped or no matching concept has been ingested yet.
-    private async Task<List<Guid>> ResolveConceptIds(CancellationToken cancellationToken)
+    // the alias is unmapped or no matching concept has been ingested yet. Pass a taxonomy to narrow
+    // to that source: FactTaxonomy.Dei isolates the authoritative EntityCommonStockSharesOutstanding
+    // cover-page tag from the us-gaap CommonStockSharesOutstanding balance-sheet tag the alias also
+    // maps.
+    private async Task<List<Guid>> ResolveConceptIds(
+        CancellationToken cancellationToken,
+        FactTaxonomy? taxonomy = null
+    )
     {
         if (!FinancialConceptAliases.TryResolve("shares-outstanding", out var refs))
             return [];
 
-        var taxonomies = refs.Select(r => r.Taxonomy).Distinct().ToList();
-        var tags = refs.Select(r => r.Tag).ToList();
+        IReadOnlyList<FinancialConceptAliases.ConceptRef> selected =
+            taxonomy == null ? refs : refs.Where(r => r.Taxonomy == taxonomy.Value).ToList();
+        if (selected.Count == 0)
+            return [];
+
+        var taxonomies = selected.Select(r => r.Taxonomy).Distinct().ToList();
+        var tags = selected.Select(r => r.Tag).ToList();
         return await _financialConceptRepository
             .GetMatching(taxonomies, tags)
             .Select(c => c.Id)

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -155,6 +155,17 @@ public class FinancialFactsImportService
         if (shares == null)
             return;
 
+        // A foreign private issuer (20-F/40-F filer) reports its cover-page count in ordinary
+        // shares — a different unit from the US-listed ADR that price feeds quote and that FINRA
+        // reports short interest against. Writing that count here would overwrite the correct ADR
+        // share base the Yahoo importer maintains (which drops the EDGAR figure for these issuers
+        // for exactly this reason, #3575/#2503) with an ordinary count off by the ADR ratio —
+        // inflating shares outstanding e.g. ~2000x for Latam Airlines and burying (or exploding)
+        // every ratio derived from it. Leave the ADR figure in place; the reconciliation stays in
+        // force for domestic 10-K/10-Q filers.
+        if (await sharesProvider.IsForeignPrivateIssuer(stock, cancellationToken))
+            return;
+
         var stockRepository = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var tracked = await stockRepository
             .GetByIds([stock.Id])

--- a/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
@@ -224,7 +224,9 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
         // re-running the unfloored corpus scan.
         var state = await new BackfillStateRepository(DbContext).GetByName("chunk-embedding");
         state.Should().NotBeNull();
-        state!.Floor.Should().Be(pendingChunk.CreationTime);
+        // Postgres timestamp keeps microsecond precision, so the persisted floor matches the
+        // chunk's 100ns-tick CreationTime only within a microsecond — assert with that tolerance.
+        state!.Floor.Should().BeCloseTo(pendingChunk.CreationTime, TimeSpan.FromMicroseconds(1));
     }
 
     [Fact]
@@ -270,7 +272,7 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
 
         var afterFirst = await new BackfillStateRepository(DbContext).GetByName("chunk-embedding");
         afterFirst.Should().NotBeNull();
-        afterFirst!.Floor.Should().Be(firstChunk.CreationTime);
+        afterFirst!.Floor.Should().BeCloseTo(firstChunk.CreationTime, TimeSpan.FromMicroseconds(1));
         var stampAfterFirst = afterFirst.LastFullRescanAt;
         stampAfterFirst.Should().NotBeNull("the first drained-frontier scan stamped the cursor");
         DbContext.ChangeTracker.Clear();
@@ -310,11 +312,16 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
         rows.Should().ContainSingle("the advance is an in-place UPDATE, never a second row");
         rows[0]
             .Floor.Should()
-            .Be(secondChunk.CreationTime, "the UPDATE persisted the new frontier");
+            .BeCloseTo(
+                secondChunk.CreationTime,
+                TimeSpan.FromMicroseconds(1),
+                "the UPDATE persisted the new frontier"
+            );
         rows[0]
             .LastFullRescanAt.Should()
-            .Be(
-                stampAfterFirst,
+            .BeCloseTo(
+                stampAfterFirst!.Value,
+                TimeSpan.FromMicroseconds(1),
                 "the restart hydrated the frontier and resumed via the floored path, so no new full scan ran"
             );
     }

--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceForeignIssuerSharesTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceForeignIssuerSharesTests.cs
@@ -1,0 +1,197 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models.Responses;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins the foreign-private-issuer guard in FinancialFactsImportService.UpdateSharesOutstanding.
+/// A 20-F/40-F filer reports its cover-page count in ordinary shares — a different unit from the
+/// US-listed ADR the Yahoo importer maintains — so the financial-facts importer must NOT overwrite
+/// the stored ADR share base with it. Without the guard the importer wrote e.g. Latam Airlines'
+/// ~574B ordinary shares over Yahoo's correct ADR count, off by the ADR ratio and blowing up every
+/// ratio built on it (short interest % of shares, market cap, ownership %). Domestic filers still
+/// have their share count refreshed from the cover page as before.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FinancialFactsImportServiceForeignIssuerSharesTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public FinancialFactsImportServiceForeignIssuerSharesTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    // Every scope shares the one caller-configured shares provider so the test controls the
+    // GetCurrentSharesOutstanding / IsForeignPrivateIssuer answers the import path sees.
+    private IServiceScopeFactory CreateScopeFactory(ISharesOutstandingProvider sharesProvider)
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                sp.GetService(typeof(FinancialConceptRepository))
+                    .Returns(new FinancialConceptRepository(ctx));
+                sp.GetService(typeof(FinancialFactsSyncStatusRepository))
+                    .Returns(new FinancialFactsSyncStatusRepository(ctx));
+                sp.GetService(typeof(DocumentRepository)).Returns(new DocumentRepository(ctx));
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(ISharesOutstandingProvider)).Returns(sharesProvider);
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    // A minimal, single-value payload: one ParsedFact so the import reaches the share-count refresh
+    // without exercising the within-batch dedup path.
+    private static CompanyFactsResponse RevenueFacts() =>
+        new()
+        {
+            Cik = 320193,
+            EntityName = "Issuer",
+            Facts = new()
+            {
+                ["us-gaap"] = new()
+                {
+                    ["Revenues"] = new CompanyFactConcept
+                    {
+                        Label = "Revenues",
+                        Units = new()
+                        {
+                            ["USD"] =
+                            [
+                                new CompanyFactValue
+                                {
+                                    Start = new DateOnly(2023, 1, 1),
+                                    End = new DateOnly(2023, 12, 31),
+                                    Val = 100m,
+                                    Accn = "0000320193-24-000001",
+                                    Fy = 2023,
+                                    Fp = "FY",
+                                    Form = "10-K",
+                                    Filed = new DateOnly(2024, 1, 15),
+                                    Frame = "CY2023",
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+
+    private FinancialFactsImportService BuildService(ISharesOutstandingProvider sharesProvider)
+    {
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient.GetCompanyFacts("0000320193").Returns(RevenueFacts());
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+        return new FinancialFactsImportService(
+            CreateScopeFactory(sharesProvider),
+            secEdgarClient,
+            Substitute.For<ILogger<FinancialFactsImportService>>(),
+            errorReporter
+        );
+    }
+
+    private async Task<CommonStock> Seed(long sharesOutstanding, string ticker)
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = ticker,
+            Cik = "0000320193",
+            SharesOutStanding = sharesOutstanding,
+        };
+        await using var seed = _fixture.CreateDbContext();
+        seed.Set<CommonStock>().Add(stock);
+        await seed.SaveChangesAsync(CancellationToken.None);
+        return stock;
+    }
+
+    private async Task<long> StoredShares(Guid stockId)
+    {
+        await using var verify = _fixture.CreateDbContext();
+        var tracked = await verify.Set<CommonStock>().FirstAsync(s => s.Id == stockId);
+        return tracked.SharesOutStanding;
+    }
+
+    [Fact]
+    public async Task Import_ForeignPrivateIssuer_LeavesStoredAdrShareCountUntouched()
+    {
+        // The ADR count the Yahoo importer already maintains for this 20-F filer.
+        var stock = await Seed(606_407_693, "LTM");
+
+        var sharesProvider = Substitute.For<ISharesOutstandingProvider>();
+        // The EDGAR ordinary-share cover-page count — the wrong unit for the US-listed ADR.
+        sharesProvider
+            .GetCurrentSharesOutstanding(Arg.Any<CommonStock>(), Arg.Any<CancellationToken>())
+            .Returns(574_215_983_709L);
+        sharesProvider
+            .IsForeignPrivateIssuer(Arg.Any<CommonStock>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await BuildService(sharesProvider).Import(stock, CancellationToken.None);
+
+        (await StoredShares(stock.Id))
+            .Should()
+            .Be(606_407_693, "a 20-F filer's ordinary count must not overwrite the ADR share base");
+    }
+
+    [Fact]
+    public async Task Import_DomesticIssuer_RefreshesSharesOutstandingFromCoverPage()
+    {
+        // Same harness, domestic filer: the cover-page refresh still runs and corrects the count.
+        var stock = await Seed(1, "AAPL");
+
+        var sharesProvider = Substitute.For<ISharesOutstandingProvider>();
+        sharesProvider
+            .GetCurrentSharesOutstanding(Arg.Any<CommonStock>(), Arg.Any<CancellationToken>())
+            .Returns(14_687_356_000L);
+        sharesProvider
+            .IsForeignPrivateIssuer(Arg.Any<CommonStock>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        await BuildService(sharesProvider).Import(stock, CancellationToken.None);
+
+        (await StoredShares(stock.Id)).Should().Be(14_687_356_000L);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
@@ -615,6 +615,102 @@ public class SharesOutstandingProviderTests
         isForeign.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_UsGaapBalanceSheetPlaceholder_PrefersDeiPerClassSum()
+    {
+        await using var db = NewDb();
+        // A multi-class filer (e.g. XNDU, BRUN) whose latest 10-Q reports the real count only per
+        // share class via the dei cover-page tag, while the us-gaap balance-sheet
+        // CommonStockSharesOutstanding line carries a nominal placeholder of 1 — filed the SAME day.
+        // The placeholder must never be chosen as the entity total; the per-class cover-page sum is
+        // authoritative, else SharesOutStanding is pinned to 1 and short interest % of shares explodes.
+        var stock = new CommonStock
+        {
+            Ticker = "BRUN",
+            Name = "Boost Run Inc.",
+            Cik = "0001999001",
+        };
+        var deiCoverPage = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        var usGaapBalanceSheet = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "CommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, deiCoverPage, usGaapBalanceSheet);
+
+        const string acc = "0001493152-26-026667";
+        db.Add(
+            ClassFact(
+                stock,
+                deiCoverPage,
+                31_895_656m,
+                new(2026, 6, 1),
+                new(2026, 6, 1),
+                acc,
+                "us-gaap:CommonClassAMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                deiCoverPage,
+                29_533_018m,
+                new(2026, 6, 1),
+                new(2026, 6, 1),
+                acc,
+                "us-gaap:CommonClassBMember"
+            )
+        );
+        // The balance-sheet placeholder: consolidated (no class dimension), same filing date.
+        db.Add(Fact(stock, usGaapBalanceSheet, 1m, new(2026, 6, 1), new(2026, 6, 1)));
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(61_428_674);
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_OnlyUsGaapBalanceSheetConsolidated_FallsBackToIt()
+    {
+        await using var db = NewDb();
+        // An issuer that reports no dei cover-page count at all — only the us-gaap balance-sheet
+        // CommonStockSharesOutstanding consolidated line. With no authoritative cover-page figure to
+        // prefer, the balance-sheet count is the best available and must still be returned.
+        var stock = new CommonStock
+        {
+            Ticker = "OLD",
+            Name = "Legacy Filer",
+            Cik = "0007777001",
+        };
+        var usGaapBalanceSheet = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "CommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, usGaapBalanceSheet);
+        db.Add(Fact(stock, usGaapBalanceSheet, 5_000_000m, new(2026, 5, 1), new(2026, 4, 26)));
+        await db.SaveChangesAsync();
+
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db)
+        );
+
+        var shares = await provider.GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(5_000_000);
+    }
+
     private static FinancialFact ClassFact(
         CommonStock stock,
         FinancialConcept concept,


### PR DESCRIPTION
## Summary

The squeeze-risk board and other pages showed impossible short-interest-percent-of-shares values (XNDU 434,684,900%, BRUN 315,095,700%, HQ 37,015,500%, …) because `CommonStock.SharesOutStanding` was being set to tiny garbage values (1, 7, 12, 100, 1000) for ~30 US-listed stocks. Every affected stock's stored value exactly matched a placeholder shares-outstanding fact while the real count was large. The same bad denominator also corrupts market cap and ownership percentages everywhere they are shown.

Two independent root causes fed the garbage; each is fixed here.

### 1. Balance-sheet placeholder beat the per-class cover-page sum

The `shares-outstanding` alias maps two XBRL tags — the authoritative dei `EntityCommonStockSharesOutstanding` cover-page count and the us-gaap `CommonStockSharesOutstanding` balance-sheet count. A multi-class filer reports the real entity count only per share class via the dei tag, while carrying a nominal placeholder (1, 100, 1000) on the us-gaap balance-sheet line — filed the same day. Resolving both tags together let the consolidated placeholder win the same-filing tie over the per-class sum.

Fix: `GetCurrentSharesOutstanding` now resolves the dei cover-page figure first (consolidated fact, or per-class sum for a multi-class issuer) and uses the us-gaap balance-sheet count only as a fallback for an issuer that never reported the cover-page tag. The stale-consolidated vs current-per-class tie-break (#5158, Mastercard/Visa) is unchanged. Affects the domestic multi-class filers (BRUN, MAIR, YSWY, AVAT, AVEX, HMH, RMIX, …).

### 2. Financial-facts importer overwrote foreign issuers' ADR share counts

A 20-F/40-F filer reports its cover-page count in ordinary shares — a different unit from the US-listed ADR that price feeds quote and FINRA reports short interest against. The Yahoo importer already drops the EDGAR count for these issuers and keeps the ADR base, but the financial-facts importer refreshed shares outstanding with no such guard, overwriting the ADR base with the ordinary count (e.g. Latam Airlines ~574B ordinary shares). Fix: mirror the Yahoo importer's foreign-private-issuer guard in `FinancialFactsImportService.UpdateSharesOutstanding`. Affects the foreign filers (XNDU, HQ, AVAL, GENI, NTCL, …).

## Code changes

- `SharesOutstandingProvider` — `GetCurrentSharesOutstanding` resolves the dei cover-page tag first with a us-gaap balance-sheet fallback; `ResolveConceptIds` takes an optional taxonomy filter; the consolidated/per-class query helpers take the concept-id set; tie-break extracted to `PickEntityTotal`. The public `GetReportedSharesOutstanding`/`GetSummedPerClassSharesOutstanding` keep their existing full-alias behavior.
- `ISharesOutstandingProvider` — updated the `GetCurrentSharesOutstanding` contract doc.
- `FinancialFactsImportService.UpdateSharesOutstanding` — skip the refresh for foreign private issuers, mirroring the Yahoo importer.

## Tests

- `SharesOutstandingProviderTests` — a us-gaap consolidated placeholder must not beat the dei per-class sum; the us-gaap balance-sheet count is still used when no dei fact exists.
- `FinancialFactsImportServiceForeignIssuerSharesTests` (new) — a 20-F filer's ordinary count does not overwrite the stored ADR base; a domestic filer's count is still refreshed.

All affected suites green locally (provider unit tests, Yahoo importer integration tests, new integration tests).