### PR TITLE
fix(financial-facts): cap XBRL envelope parse size + ignore shutdown cancellations

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -62,6 +62,19 @@ public class XbrlFactExtractionService
 
     private const int InsertBatchSize = 1000;
 
+    /// <summary>
+    /// Envelopes above this uncompressed size are skipped instead of parsed.
+    /// The parsers materialise the whole document in memory (the DOM costs a
+    /// large multiple of the source size), so a nine-figure envelope — rare
+    /// foreign-issuer filings attach 100+ MB of inline-XBRL exhibits, while
+    /// the p99.9 of successfully parsed envelopes is ~21 MB — can OOM the
+    /// whole worker process under memory pressure. A skipped document
+    /// completes its sweep normally (the caller stamps <see cref="CurrentVersion"/>),
+    /// so it is only revisited on a version bump, where the guard re-skips it
+    /// before any content is loaded.
+    /// </summary>
+    internal const long MaxParseableEnvelopeBytes = 50 * 1024 * 1024;
+
     // Column limits the parsed values must fit (FinancialFact.Unit,
     // FinancialFactDimension.Axis/Member). Facts that exceed them are skipped
     // rather than truncated — a truncated QName would corrupt the key.
@@ -103,6 +116,18 @@ public class XbrlFactExtractionService
         // legacy/paper rows the capture path never marks Captured anyway.
         if (string.IsNullOrEmpty(document.AccessionNumber))
             return 0;
+        if (document.XbrlUncompressedSize > MaxParseableEnvelopeBytes)
+        {
+            _logger.LogWarning(
+                "Skipping dimensional-fact extraction for document {DocumentId} ({Accession}): "
+                    + "envelope is {Size} bytes, above the {Limit}-byte parse ceiling.",
+                document.Id,
+                document.AccessionNumber,
+                document.XbrlUncompressedSize,
+                MaxParseableEnvelopeBytes
+            );
+            return 0;
+        }
 
         var envelope = Encoding.UTF8.GetString(
             GzipCompressor.Decompress(await _fileManager.GetContent(document.XbrlContent))

--- a/src/Equibles.Sec.FinancialFacts.HostedService/XbrlFactsExtractionWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/XbrlFactsExtractionWorker.cs
@@ -88,6 +88,13 @@ public class XbrlFactsExtractionWorker : BaseScraperWorker
                     // the envelope simply carries none worth re-reading.
                     document.XbrlFactsVersion = XbrlFactExtractionService.CurrentVersion;
                 }
+                // Shutdown mid-batch is not a document failure: let it surface
+                // so the base loop winds down quietly instead of burning one of
+                // the document's attempts and landing a phantom row in Errors.
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 // Per-document fault isolation: count the attempt and keep the
                 // cycle going for the rest of the batch.
                 catch (Exception ex)

--- a/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceOversizedEnvelopeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceOversizedEnvelopeTests.cs
@@ -1,0 +1,106 @@
+using Equibles.Media.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// The extractor's parsers materialise the whole envelope in memory, so a
+/// nine-figure envelope can OOM the shared worker process (a 190 MB 6-K did,
+/// repeatedly, under memory pressure). Extract must refuse such envelopes
+/// before loading their content — returning the same "nothing to persist"
+/// result a clean zero-fact parse does, so the sweep stamps the document
+/// terminal instead of retrying the OOM — while envelopes at or under the
+/// ceiling (and legacy rows with no recorded size) still parse.
+/// </summary>
+public class XbrlFactExtractionServiceOversizedEnvelopeTests
+{
+    /// <summary>
+    /// Minimal valid gzipped envelope: parses cleanly to zero facts, so Extract
+    /// returns before it needs a service scope or the database.
+    /// </summary>
+    private sealed class RecordingFileManager : IFileManager
+    {
+        public bool ContentLoaded { get; private set; }
+
+        public Task<byte[]> GetContent(File file)
+        {
+            ContentLoaded = true;
+            return Task.FromResult(GzipCompressor.Compress("<html></html>"u8.ToArray()));
+        }
+
+        public Task<File> SaveFile(byte[] content, string fileName, bool protect = false) =>
+            throw new NotSupportedException();
+
+        public Task<File> SaveInternalFile(
+            byte[] content,
+            string name,
+            string extension,
+            string contentType,
+            string tier = null
+        ) => throw new NotSupportedException();
+
+        public Task<Stream> OpenRead(File file) => throw new NotSupportedException();
+
+        public void DeleteFile(File file) => throw new NotSupportedException();
+    }
+
+    private static (XbrlFactExtractionService Service, RecordingFileManager Files) BuildService()
+    {
+        var files = new RecordingFileManager();
+        var service = new XbrlFactExtractionService(
+            scopeFactory: null,
+            new InlineXbrlParser(),
+            new StandaloneXbrlParser(),
+            files,
+            NullLogger<XbrlFactExtractionService>.Instance
+        );
+        return (service, files);
+    }
+
+    private static Document CapturedDocument(long? uncompressedSize) =>
+        new()
+        {
+            AccessionNumber = "0001493152-24-017248",
+            XbrlStatus = XbrlCaptureStatus.Captured,
+            XbrlContent = new File(),
+            XbrlUncompressedSize = uncompressedSize,
+        };
+
+    [Fact]
+    public async Task Extract_EnvelopeAboveParseCeiling_SkipsWithoutLoadingContent()
+    {
+        var (service, files) = BuildService();
+        var document = CapturedDocument(XbrlFactExtractionService.MaxParseableEnvelopeBytes + 1);
+
+        var persisted = await service.Extract(document, CancellationToken.None);
+
+        persisted.Should().Be(0);
+        files.ContentLoaded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Extract_EnvelopeAtParseCeiling_LoadsContent()
+    {
+        var (service, files) = BuildService();
+        var document = CapturedDocument(XbrlFactExtractionService.MaxParseableEnvelopeBytes);
+
+        await service.Extract(document, CancellationToken.None);
+
+        files.ContentLoaded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Extract_EnvelopeWithUnknownSize_LoadsContent()
+    {
+        var (service, files) = BuildService();
+        var document = CapturedDocument(uncompressedSize: null);
+
+        await service.Extract(document, CancellationToken.None);
+
+        files.ContentLoaded.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Two fixes for the dimensional-fact extraction sweep, both surfaced by production Errors rows on 2026-07-07:

1. **Envelope size cap.** A 190 MB inline-XBRL 6-K (accession 0001493152-24-017248) OOMed `InlineXbrlParser` twice under memory pressure — AngleSharp materialises the whole DOM at a large multiple of the source size, and an `OutOfMemoryException` in the shared worker process endangers every other background service. The backlog holds ~28 more envelopes over 50 MB (largest 201 MB), while the p99.9 of successfully parsed envelopes is ~21 MB. `Extract` now skips envelopes whose stored `XbrlUncompressedSize` exceeds a 50 MB ceiling **before loading any content**; the sweep stamps them with the current extractor version, so they only come back on a version bump, where the guard re-skips them instantly.

2. **Shutdown cancellations are not failures.** A deploy landing mid-batch cancelled the in-flight read, and the per-document catch recorded the `OperationCanceledException` as an extraction failure — burning one of the document's five attempts and filing a phantom error row on every unlucky deploy. The worker now rethrows when the stopping token caused the cancellation, letting the base loop wind down quietly.

## Code changes

- `XbrlFactExtractionService`: new `MaxParseableEnvelopeBytes` ceiling (50 MB) checked before content load; skip logged as a warning with document id, accession, and size.
- `XbrlFactsExtractionWorker`: `catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)` rethrow ahead of the per-document fault isolation catch.
- Tests: `XbrlFactExtractionServiceOversizedEnvelopeTests` — oversized envelope skips without touching `IFileManager`; envelope at the ceiling and envelope with unknown size still load content.

## Verification

- Full OSS unit suite: 3281 passed.
- csharpier clean on touched files.