### PR TITLE
fix(sec): resolve the residual impossible shares-outstanding records + guard the squeeze board

### DIFF
--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -22,13 +22,25 @@ namespace Equibles.Finra.BusinessLogic;
 /// The composite is the equal-weight mean of the factor percentiles a stock has data
 /// for — weights are deliberate and documented rather than tuned. The universe is every
 /// stock reporting short interest at the latest settlement date with a known
-/// shares-outstanding count.
+/// shares-outstanding count and a physically credible short-interest ratio (see
+/// <see cref="MaxCredibleShortInterestRatio"/>).
 /// </summary>
 [Service]
 public class ShortSqueezeScoreManager
 {
     /// <summary>Each trend window pools two calendar weeks of daily short-volume rows.</summary>
     public const int TrendWindowDays = 14;
+
+    /// <summary>
+    /// Highest short-interest-to-shares-outstanding ratio accepted as a real measurement. No
+    /// genuine reading has ever approached this bound (the January 2021 GameStop peak, the most
+    /// extreme on record, was ~1.4x); a ratio beyond it proves the inputs are inconsistent — a
+    /// wrong shares-outstanding record (e.g. a listed note's issuer whose common stock is one
+    /// share held by its parent), a cover-page filing artifact, or a short position and share
+    /// count on different split bases — so the stock is dropped from the scored universe, the
+    /// same treatment as an unknown share count, rather than ranked on a meaningless figure.
+    /// </summary>
+    public const decimal MaxCredibleShortInterestRatio = 2m;
 
     private readonly ShortInterestRepository _shortInterestRepository;
     private readonly DailyShortVolumeRepository _dailyShortVolumeRepository;
@@ -132,18 +144,26 @@ public class ShortSqueezeScoreManager
                     / (decimal)shortInterest.AverageDailyVolume.Value;
             }
 
+            var shortInterestPercentOfShares = ShortInterestPercentOfShares(
+                shortInterest.CurrentShortPosition,
+                stock.SharesOutStanding,
+                settlementDate,
+                splitsByStock.TryGetValue(stock.Id, out var stockSplits) ? stockSplits : []
+            );
+            if (shortInterestPercentOfShares > MaxCredibleShortInterestRatio)
+            {
+                // Physically impossible reading — the share count or split basis is wrong for
+                // this listing, so no honest score exists for it (see the constant's doc).
+                continue;
+            }
+
             scores.Add(
                 new ShortSqueezeScore
                 {
                     CommonStockId = stock.Id,
                     Ticker = stock.Ticker,
                     SettlementDate = settlementDate,
-                    ShortInterestPercentOfShares = ShortInterestPercentOfShares(
-                        shortInterest.CurrentShortPosition,
-                        stock.SharesOutStanding,
-                        settlementDate,
-                        splitsByStock.TryGetValue(stock.Id, out var stockSplits) ? stockSplits : []
-                    ),
+                    ShortInterestPercentOfShares = shortInterestPercentOfShares,
                     DaysToCover = daysToCover,
                     // TryGetValue, not GetValueOrDefault: a stock with no volume data
                     // must carry a null trend (factor drops out), never a zero trend.

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
@@ -38,7 +38,11 @@ public interface ISharesOutstandingProvider
     /// per-class reporting — the stale consolidated value must not win, so the figure from the
     /// most recent filing is used. The us-gaap:CommonStockSharesOutstanding balance-sheet count
     /// (frequently a nominal placeholder for shells and multi-class filers) is used only as a
-    /// fallback when the issuer never reported the cover-page tag. Null when neither is on record.
+    /// fallback when the issuer never reported the cover-page tag. Null when neither is on
+    /// record, or when the latest cover-page count is a filing artifact — contradicted as a
+    /// collapse by both the issuer's previous cover-page count and the same filing's
+    /// balance-sheet count — in which case EDGAR abstains and the caller's fallback source (the
+    /// price feed's listed-security count) stands.
     /// </summary>
     Task<long?> GetCurrentSharesOutstanding(
         CommonStock stock,
@@ -46,11 +50,13 @@ public interface ISharesOutstandingProvider
     );
 
     /// <summary>
-    /// True when the authoritative shares-outstanding fact comes from a foreign-private-issuer
-    /// annual form (20-F or 40-F). Such issuers report the cover-page count in <em>ordinary</em>
-    /// shares, a different unit from the US-listed ADR a price feed quotes, so the reported count
-    /// must not be reconciled against an ADR market cap / price (it would inflate it by the ADR
-    /// ratio). False for domestic 10-K/10-Q filers and when no shares fact is on record.
+    /// True when the fact backing <see cref="GetCurrentSharesOutstanding"/> — the latest
+    /// consolidated cover-page fact or the latest per-class filing, whichever wins the pick —
+    /// comes from a foreign-private-issuer annual form (20-F or 40-F). Such issuers report the
+    /// cover-page count in <em>ordinary</em> shares, a different unit from the US-listed ADR a
+    /// price feed quotes, so the reported count must not be reconciled against an ADR market cap
+    /// / price (it would inflate it by the ADR ratio). False for domestic 10-K/10-Q filers and
+    /// when no shares fact is on record.
     /// </summary>
     Task<bool> IsForeignPrivateIssuer(
         CommonStock stock,

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -14,7 +14,7 @@ namespace Equibles.Sec.FinancialFacts.BusinessLogic;
 // than the per-share-class figure Yahoo returns (which understates multi-class issuers ~2x and
 // lags corporate actions like reverse splits). A single-class issuer reports a consolidated fact,
 // read by GetReportedSharesOutstanding, giving the current entity total (#3575). A multi-class
-// issuer reports the count only per share class (dimensional facts on the class-of-stock axis,
+// issuer reports the count only per share class (dimensional facts on a class-of-stock axis,
 // no consolidated fact), so GetSummedPerClassSharesOutstanding sums those classes into the entity
 // total (#2503).
 [Service(ServiceLifetime.Scoped, typeof(ISharesOutstandingProvider))]
@@ -22,11 +22,26 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
 {
     private const string SharesUnit = "shares";
 
-    // XBRL axis that distinguishes a per-share-class cover-page count (e.g. Class A vs Class C)
-    // from the consolidated total. Multi-class issuers report
-    // dei:EntityCommonStockSharesOutstanding dimensioned on this axis and carry no consolidated
-    // fact, so the entity total is the sum across its members.
-    private const string ClassOfStockAxis = "us-gaap:StatementClassOfStockAxis";
+    // XBRL axes that mark a per-share-class cover-page count (e.g. Class A vs Class C) as opposed
+    // to the consolidated total. Multi-class issuers report dei:EntityCommonStockSharesOutstanding
+    // dimensioned on one of these axes and carry no consolidated fact, so the entity total is the
+    // sum across the axis members. Domestic filers use the us-gaap statement axis; IFRS filers
+    // (20-F) report the same semantic on the ifrs-full share-capital axes — without them a
+    // multi-class IFRS filer's per-class counts are invisible and a stale consolidated fact wins.
+    private static readonly string[] ClassOfStockAxes =
+    [
+        "us-gaap:StatementClassOfStockAxis",
+        "ifrs-full:ClassesOfShareCapitalAxis",
+        "ifrs-full:ClassesOfOrdinarySharesAxis",
+    ];
+
+    // A cover-page count this many times smaller than BOTH the issuer's previous cover-page count
+    // and the same filing's balance-sheet count is treated as a filing artifact (see
+    // IsCollapsedCoverPageCount). Observed artifacts are 10x-1000x off (a dropped digit or a
+    // thousands-scaled entry); a genuine reduction this large inside one filing window is a
+    // reverse split or going-private event, for which abstaining — letting the price feed's
+    // listed-security count stand — is also the correct outcome.
+    private const decimal CoverPageCollapseFactor = 5m;
 
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
@@ -39,6 +54,14 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
     }
+
+    // The current entity share count together with the filing that stated it.
+    private sealed record SharesFact(
+        long Shares,
+        DateOnly Filed,
+        DocumentType Form,
+        string AccessionNumber
+    );
 
     // The shares on the most-recently-filed consolidated cover-page fact, or null when the issuer
     // has none on record (e.g. a multi-class filer that reports the count only per share class).
@@ -56,7 +79,7 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
 
     // The entity-wide share count for a multi-class issuer, summed across its share classes from
     // the latest filing's per-class cover-page facts, or null when the issuer reports no per-class
-    // count on the class-of-stock axis (a single-class filer's consolidated fact is read by
+    // count on a class-of-stock axis (a single-class filer's consolidated fact is read by
     // GetReportedSharesOutstanding instead). Sourced straight from the issuer's per-class cover-page
     // tags — no heuristic, no MarketCap / Price shortcut.
     public async Task<long?> GetSummedPerClassSharesOutstanding(
@@ -87,9 +110,40 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     // leaving a stale consolidated fact alongside current per-class facts — so the figure from the
     // most recent filing wins; a same-filing tie keeps the consolidated total, which is the entity
     // figure directly (#5158).
+    //
+    // Null when nothing is on record, or when the latest cover-page count is a filing artifact
+    // (see IsCollapsedCoverPageCount): EDGAR abstains rather than propagate a count its own filing
+    // contradicts, and the caller's fallback source (the price feed's listed-security count) stands.
     public async Task<long?> GetCurrentSharesOutstanding(
         CommonStock stock,
         CancellationToken cancellationToken = default
+    ) => (await ResolveCurrentSharesFact(stock, cancellationToken))?.Shares;
+
+    // True when the fact backing GetCurrentSharesOutstanding — the latest consolidated cover-page
+    // fact or the latest per-class filing, whichever wins the pick — is a foreign-private-issuer
+    // annual form (20-F/40-F). Those cover-page counts are in the issuer's ordinary shares, which
+    // are a different unit from the US-listed ADR a price feed quotes; the Yahoo importer uses this
+    // to skip reconciling Yahoo's (correct, self-consistent) ADR market cap / shares onto that
+    // ordinary base, which would otherwise inflate market cap by the ADR ratio (e.g. Latam Airlines
+    // ~2000x), and the financial-facts importer uses it to leave the stored ADR share base alone.
+    // Keyed to the same pick so a multi-class 20-F filer (per-class facts only) is recognized, not
+    // just one with a consolidated fact. Authoritative — the SEC form, not a ticker/name heuristic.
+    public async Task<bool> IsForeignPrivateIssuer(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var fact = await ResolveCurrentSharesFact(stock, cancellationToken);
+        return fact != null
+            && (fact.Form == DocumentType.TwentyF || fact.Form == DocumentType.FortyF);
+    }
+
+    // The single source of truth for "the issuer's current share count and the filing that stated
+    // it", shared by GetCurrentSharesOutstanding and IsForeignPrivateIssuer so the two can never
+    // disagree about which fact is authoritative.
+    private async Task<SharesFact> ResolveCurrentSharesFact(
+        CommonStock stock,
+        CancellationToken cancellationToken
     )
     {
         var coverPageConceptIds = await ResolveConceptIds(cancellationToken, FactTaxonomy.Dei);
@@ -100,37 +154,90 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         );
         var perClass = await GetLatestPerClass(stock, coverPageConceptIds, cancellationToken);
 
-        var coverPageTotal = PickEntityTotal(consolidated, perClass);
-        if (coverPageTotal != null)
-            return coverPageTotal;
+        // The more-recently-filed figure wins; a same-filing tie keeps the consolidated total,
+        // which is the entity figure directly (#5158).
+        if (perClass != null && (consolidated == null || perClass.Filed > consolidated.Filed))
+            return perClass;
+
+        if (consolidated != null)
+        {
+            var collapsed = await IsCollapsedCoverPageCount(
+                stock,
+                consolidated,
+                coverPageConceptIds,
+                cancellationToken
+            );
+            return collapsed ? null : consolidated;
+        }
 
         // No dei cover-page fact on record — fall back to the balance-sheet consolidated count,
         // the best available for an issuer that never reported the authoritative cover-page tag.
         var fallbackConceptIds = await ResolveConceptIds(cancellationToken);
-        return (await GetLatestConsolidated(stock, fallbackConceptIds, cancellationToken))?.Shares;
+        return await GetLatestConsolidated(stock, fallbackConceptIds, cancellationToken);
     }
 
-    // Picks the entity total from the latest consolidated cover-page fact and the latest per-class
-    // sum: the more-recently-filed wins, and a same-filing tie keeps the consolidated total (the
-    // entity figure directly). Null when neither is present.
-    private static long? PickEntityTotal(
-        (long Shares, DateOnly Filed)? consolidated,
-        (long Shares, DateOnly Filed)? perClass
+    // True when the latest consolidated cover-page count is contradicted as a collapse artifact by
+    // BOTH of the filer's own other statements of the same measure: the previous cover-page count
+    // (an earlier filing) and the same filing's us-gaap balance-sheet count, each at least
+    // CoverPageCollapseFactor times larger. Real filings show this exact shape when the filer drops
+    // a digit or types the count in thousands (observed: 36,710 vs 36.4M; 161,489 vs 17.0M;
+    // 8,294,933 vs 82.9M) — the artifact then poisons every downstream ratio until the next filing.
+    // Requiring both anchors keeps the check one-sided and conservative: a garbage-LARGE
+    // balance-sheet figure alone (the mis-scaled inverse artifact) does not fire because history
+    // still confirms the cover-page count, and a genuinely tiny issuer (e.g. a wholly-owned
+    // subsidiary with 1 share) has a tiny prior count, so it does not fire either.
+    private async Task<bool> IsCollapsedCoverPageCount(
+        CommonStock stock,
+        SharesFact latest,
+        IReadOnlyCollection<Guid> coverPageConceptIds,
+        CancellationToken cancellationToken
     )
     {
-        if (consolidated == null)
-            return perClass?.Shares;
-        if (perClass == null)
-            return consolidated.Value.Shares;
+        var collapseThreshold = latest.Shares * CoverPageCollapseFactor;
 
-        return perClass.Value.Filed > consolidated.Value.Filed
-            ? perClass.Value.Shares
-            : consolidated.Value.Shares;
+        var priorCoverPage = await _financialFactRepository
+            .GetConsolidatedByStock(stock)
+            .Where(f =>
+                coverPageConceptIds.Contains(f.FinancialConceptId)
+                && f.Unit == SharesUnit
+                && f.FiledDate < latest.Filed
+                && f.Value > 0
+            )
+            .OrderByDescending(f => f.FiledDate)
+            .ThenByDescending(f => f.PeriodEnd)
+            .Select(f => (decimal?)f.Value)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (priorCoverPage == null || priorCoverPage < collapseThreshold)
+            return false;
+
+        // The same filing's balance-sheet count at its most recent as-of date. Same-accession so a
+        // later filing can never masquerade as the corroborating anchor.
+        var balanceSheetConceptIds = await ResolveConceptIds(
+            cancellationToken,
+            FactTaxonomy.UsGaap
+        );
+        if (balanceSheetConceptIds.Count == 0)
+            return false;
+
+        var sameFilingBalanceSheet = await _financialFactRepository
+            .GetConsolidatedByStock(stock)
+            .Where(f =>
+                balanceSheetConceptIds.Contains(f.FinancialConceptId)
+                && f.Unit == SharesUnit
+                && f.AccessionNumber == latest.AccessionNumber
+                && f.Value > 0
+            )
+            .OrderByDescending(f => f.PeriodEnd)
+            .Select(f => (decimal?)f.Value)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return sameFilingBalanceSheet != null && sameFilingBalanceSheet >= collapseThreshold;
     }
 
-    // The latest-filed consolidated (classless) cover-page count and the date it was filed, or null
-    // when the issuer has no consolidated fact on record or the count is unrepresentable as Int64.
-    private async Task<(long Shares, DateOnly Filed)?> GetLatestConsolidated(
+    // The latest-filed consolidated (classless) cover-page count and the filing it came from, or
+    // null when the issuer has no consolidated fact on record or the count is unrepresentable as
+    // Int64.
+    private async Task<SharesFact> GetLatestConsolidated(
         CommonStock stock,
         IReadOnlyCollection<Guid> conceptIds,
         CancellationToken cancellationToken
@@ -140,13 +247,20 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
             return null;
 
         // The latest filing wins (FiledDate), then the most recent as-of date within it; the value
-        // is a whole share count.
+        // is a whole share count. FromValue round-trips Form back to the cached DocumentType
+        // statics, so reference equality holds after materialization.
         var match = await _financialFactRepository
             .GetConsolidatedByStock(stock)
             .Where(f => conceptIds.Contains(f.FinancialConceptId) && f.Unit == SharesUnit)
             .OrderByDescending(f => f.FiledDate)
             .ThenByDescending(f => f.PeriodEnd)
-            .Select(f => new { f.Value, f.FiledDate })
+            .Select(f => new
+            {
+                f.Value,
+                f.FiledDate,
+                f.Form,
+                f.AccessionNumber,
+            })
             .FirstOrDefaultAsync(cancellationToken);
         if (match == null)
             return null;
@@ -155,14 +269,14 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         // decimal->long cast would throw, crashing the caller. Treat an unrepresentable figure as
         // none on record (null), matching how every other decimal->long cast here is range-checked.
         return match.Value >= long.MinValue && match.Value <= long.MaxValue
-            ? ((long)match.Value, match.FiledDate)
-            : ((long, DateOnly)?)null;
+            ? new SharesFact((long)match.Value, match.FiledDate, match.Form, match.AccessionNumber)
+            : null;
     }
 
     // The entity total summed across the latest filing's per-class cover-page facts and that
-    // filing's filed date, or null when the issuer reports no per-class count on the class-of-stock
-    // axis or the sum is unrepresentable as Int64.
-    private async Task<(long Shares, DateOnly Filed)?> GetLatestPerClass(
+    // filing, or null when the issuer reports no per-class count on a class-of-stock axis or the
+    // sum is unrepresentable as Int64.
+    private async Task<SharesFact> GetLatestPerClass(
         CommonStock stock,
         IReadOnlyCollection<Guid> conceptIds,
         CancellationToken cancellationToken
@@ -171,7 +285,7 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         if (conceptIds.Count == 0)
             return null;
 
-        // Per-share-class cover-page facts only: a single explicit dimension, on the class-of-stock
+        // Per-share-class cover-page facts only: a single explicit dimension, on a class-of-stock
         // axis. A fact dimensioned otherwise (segment/geography), on several axes, or with none is
         // excluded so only genuine per-class counts are summed.
         var perClassFacts = await _financialFactRepository
@@ -180,16 +294,17 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
                 conceptIds.Contains(f.FinancialConceptId)
                 && f.Unit == SharesUnit
                 && f.Dimensions.Count == 1
-                && f.Dimensions.Any(d => d.Axis == ClassOfStockAxis)
+                && f.Dimensions.Any(d => ClassOfStockAxes.Contains(d.Axis))
             )
             .Include(f => f.Dimensions)
             .ToListAsync(cancellationToken);
         if (perClassFacts.Count == 0)
             return null;
 
-        // Sum across share classes from the latest filing only — pinned to that one accession and
-        // as-of date so classes are never mixed across filings, and grouped by class member so a
-        // restated row never double-counts a class.
+        // Sum across share classes from the latest filing only — pinned to that one accession,
+        // as-of date and axis (a filer double-tagging the same classes on two axes must not be
+        // double-counted), and grouped by class member so a restated row never double-counts a
+        // class.
         var latest = perClassFacts
             .OrderByDescending(f => f.FiledDate)
             .ThenByDescending(f => f.PeriodEnd)
@@ -197,7 +312,9 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
 
         var total = perClassFacts
             .Where(f =>
-                f.AccessionNumber == latest.AccessionNumber && f.PeriodEnd == latest.PeriodEnd
+                f.AccessionNumber == latest.AccessionNumber
+                && f.PeriodEnd == latest.PeriodEnd
+                && f.Dimensions[0].Axis == latest.Dimensions[0].Axis
             )
             .GroupBy(f => f.Dimensions[0].Member)
             .Sum(g => g.First().Value);
@@ -205,38 +322,8 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         // Same range-check: a corrupt per-class count can push the sum past Int64; degrade to null
         // rather than let the decimal->long cast throw.
         return total > 0 && total <= long.MaxValue
-            ? ((long)total, latest.FiledDate)
-            : ((long, DateOnly)?)null;
-    }
-
-    // True when the latest-filed consolidated shares fact — the one GetReportedSharesOutstanding
-    // reconciles against — was filed on a foreign-private-issuer annual form (20-F/40-F). Those
-    // cover-page counts are in the issuer's ordinary shares, which are a different unit from the
-    // US-listed ADR a price feed quotes; the Yahoo importer uses this to skip reconciling Yahoo's
-    // (correct, self-consistent) ADR market cap / shares onto that ordinary base, which would
-    // otherwise inflate market cap by the ADR ratio (e.g. Latam Airlines ~2000x). Authoritative —
-    // keyed off the SEC form, not a ticker/name heuristic.
-    public async Task<bool> IsForeignPrivateIssuer(
-        CommonStock stock,
-        CancellationToken cancellationToken = default
-    )
-    {
-        var conceptIds = await ResolveConceptIds(cancellationToken);
-        if (conceptIds.Count == 0)
-            return false;
-
-        // Same fact selection as GetReportedSharesOutstanding (latest FiledDate, then PeriodEnd),
-        // so the gate matches the count that would be reconciled. FromValue round-trips Form back to
-        // the cached DocumentType statics, so reference equality holds after materialization.
-        var form = await _financialFactRepository
-            .GetConsolidatedByStock(stock)
-            .Where(f => conceptIds.Contains(f.FinancialConceptId) && f.Unit == SharesUnit)
-            .OrderByDescending(f => f.FiledDate)
-            .ThenByDescending(f => f.PeriodEnd)
-            .Select(f => f.Form)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        return form == DocumentType.TwentyF || form == DocumentType.FortyF;
+            ? new SharesFact((long)total, latest.FiledDate, latest.Form, latest.AccessionNumber)
+            : null;
     }
 
     // The financial-concept ids the "shares-outstanding" alias resolves to, or an empty list when

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -38,9 +38,10 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     // A cover-page count this many times smaller than BOTH the issuer's previous cover-page count
     // and the same filing's balance-sheet count is treated as a filing artifact (see
     // IsCollapsedCoverPageCount). Observed artifacts are 10x-1000x off (a dropped digit or a
-    // thousands-scaled entry); a genuine reduction this large inside one filing window is a
-    // reverse split or going-private event, for which abstaining — letting the price feed's
-    // listed-security count stand — is also the correct outcome.
+    // thousands-scaled entry). A genuine reduction this large in one filing window (a reverse
+    // split, going private) resolves safely either way: a balance sheet stated on the new share
+    // basis agrees with the reduced cover page and the count is kept, while a contradicted one
+    // abstains and the price feed's listed-security count stands.
     private const decimal CoverPageCollapseFactor = 5m;
 
     private readonly FinancialFactRepository _financialFactRepository;
@@ -140,8 +141,25 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
 
     // The single source of truth for "the issuer's current share count and the filing that stated
     // it", shared by GetCurrentSharesOutstanding and IsForeignPrivateIssuer so the two can never
-    // disagree about which fact is authoritative.
+    // disagree about which fact is authoritative. Callers pair the two accessors on the same
+    // stock and the resolution costs several queries, so the result (including an abstention) is
+    // memoized per stock for this scoped instance's lifetime — one import scope, single consumer.
+    private readonly Dictionary<Guid, SharesFact> _currentFactByStock = [];
+
     private async Task<SharesFact> ResolveCurrentSharesFact(
+        CommonStock stock,
+        CancellationToken cancellationToken
+    )
+    {
+        if (_currentFactByStock.TryGetValue(stock.Id, out var cached))
+            return cached;
+
+        var resolved = await ResolveCurrentSharesFactUncached(stock, cancellationToken);
+        _currentFactByStock[stock.Id] = resolved;
+        return resolved;
+    }
+
+    private async Task<SharesFact> ResolveCurrentSharesFactUncached(
         CommonStock stock,
         CancellationToken cancellationToken
     )
@@ -308,6 +326,9 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         var latest = perClassFacts
             .OrderByDescending(f => f.FiledDate)
             .ThenByDescending(f => f.PeriodEnd)
+            // Deterministic axis pick when a filer double-tags the same filing's classes on two
+            // class axes — without it the pinned axis depends on list order among equal keys.
+            .ThenBy(f => Array.IndexOf(ClassOfStockAxes, f.Dimensions[0].Axis))
             .First();
 
         var total = perClassFacts

--- a/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
@@ -171,6 +171,29 @@ public class ShortSqueezeScoreManagerTests : IDisposable
         scores.Select(s => s.Ticker).Should().Equal("KNOWN");
     }
 
+    [Fact]
+    public async Task Compute_ImpossibleShortInterestRatio_ExcludesStockFromUniverse()
+    {
+        // A listing whose issuer's common-stock record cannot back the reported short
+        // position — e.g. exchange-traded notes whose issuer's common stock is a nominal
+        // one-share count held by its parent — yields a ratio no real stock has ever had.
+        // Such a stock must drop out of the universe (the unknown-share-count treatment),
+        // not rank as top squeeze risk on a meaningless figure, while an extreme-but-genuine
+        // reading (the 2021 GameStop peak was ~1.4x) is still scored.
+        var typical = SeedStock("TYP", sharesOutstanding: 1_000_000);
+        var extreme = SeedStock("EXTR", sharesOutstanding: 1_000_000);
+        var impossible = SeedStock("NOTE", sharesOutstanding: 1);
+        SeedShortInterest(typical, shortPosition: 100_000, daysToCover: 2m);
+        SeedShortInterest(extreme, shortPosition: 1_400_000, daysToCover: 8m);
+        SeedShortInterest(impossible, shortPosition: 15_566, daysToCover: 1m);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Select(s => s.Ticker).Should().BeEquivalentTo(["EXTR", "TYP"]);
+        scores.Should().OnlyContain(s => s.ShortInterestPercentOfShares <= 2m);
+    }
+
     private CommonStock SeedStock(string ticker, long sharesOutstanding)
     {
         var stock = new CommonStock

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderCoverPageIntegrityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderCoverPageIntegrityTests.cs
@@ -1,0 +1,373 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.Data;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+// Pins the integrity rules SharesOutstandingProvider applies to the cover-page count, each taken
+// from a real production defect:
+// - an IFRS filer's per-class cover-page facts live on the ifrs-full share-capital axis, not the
+//   us-gaap class-of-stock axis, and must still be summed (Quantum Biopharma reported 12 shares
+//   because its per-class facts were invisible and a stale consolidated fact won);
+// - IsForeignPrivateIssuer keys off the SAME fact GetCurrentSharesOutstanding picks, so a
+//   multi-class 20-F filer with no current consolidated fact is still recognized;
+// - a cover-page count contradicted as a collapse by BOTH the issuer's previous cover-page count
+//   and the same filing's balance-sheet count is a filing artifact (a dropped digit or a
+//   thousands-scaled entry: Armata 36,710 vs 36.4M; FB Bancorp 161,489 vs 17.0M; PTC Therapeutics
+//   8,294,933 vs 82.9M) — the provider abstains (null) so the price feed's listed-security count
+//   stands, instead of poisoning market cap and short-interest ratios until the next filing.
+public class SharesOutstandingProviderCoverPageIntegrityTests
+{
+    private const string IfrsClassAxis = "ifrs-full:ClassesOfShareCapitalAxis";
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new FinancialFactsTestModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static SharesOutstandingProvider NewProvider(EquiblesFinancialDbContext db) =>
+        new(new FinancialFactRepository(db), new FinancialConceptRepository(db));
+
+    private static CommonStock Stock(string ticker) =>
+        new()
+        {
+            Ticker = ticker,
+            Name = ticker,
+            Cik = "0001000001",
+        };
+
+    private static FinancialConcept CoverPageConcept() =>
+        new() { Taxonomy = FactTaxonomy.Dei, Tag = "EntityCommonStockSharesOutstanding" };
+
+    private static FinancialConcept BalanceSheetConcept() =>
+        new() { Taxonomy = FactTaxonomy.UsGaap, Tag = "CommonStockSharesOutstanding" };
+
+    private static FinancialFact Fact(
+        CommonStock stock,
+        FinancialConcept concept,
+        decimal value,
+        DateOnly filed,
+        DateOnly asOf,
+        string accession,
+        DocumentType form = null
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Unit = "shares",
+            PeriodType = FactPeriodType.Instant,
+            PeriodStart = asOf,
+            PeriodEnd = asOf,
+            Value = value,
+            FiscalYear = asOf.Year,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = form ?? DocumentType.TenQ,
+            FiledDate = filed,
+            AccessionNumber = accession,
+            DimensionsKey = "",
+        };
+
+    private static FinancialFact ClassFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        decimal value,
+        DateOnly filed,
+        DateOnly asOf,
+        string accession,
+        string member,
+        string axis,
+        DocumentType form = null
+    )
+    {
+        var fact = Fact(stock, concept, value, filed, asOf, accession, form);
+        fact.DimensionsKey = $"{axis}={member}";
+        fact.Dimensions.Add(new FinancialFactDimension { Axis = axis, Member = member });
+        return fact;
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_IfrsClassAxisPerClassFacts_SumsThemOverStaleConsolidated()
+    {
+        await using var db = NewDb();
+        // Quantum Biopharma: the 2026 20-F reports the entity count only per share class on the
+        // IFRS share-capital axis (Class A multiple voting 42 + Class B subordinate 3,887,729),
+        // while the last consolidated cover-page fact is a stale 12 from an older filing. The
+        // per-class sum must win.
+        var stock = Stock("QNTM");
+        var coverPage = CoverPageConcept();
+        db.AddRange(stock, coverPage);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                12m,
+                new(2025, 3, 31),
+                new(2024, 12, 31),
+                "0001654954-25-003693",
+                DocumentType.Other
+            )
+        );
+        const string acc = "0001185185-26-001069";
+        db.Add(
+            ClassFact(
+                stock,
+                coverPage,
+                42m,
+                new(2026, 3, 26),
+                new(2025, 12, 31),
+                acc,
+                "qntm:ClassAMultipleVotingMember",
+                IfrsClassAxis,
+                DocumentType.TwentyF
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                coverPage,
+                3_887_729m,
+                new(2026, 3, 26),
+                new(2025, 12, 31),
+                acc,
+                "qntm:ClassBSubordinateVotingMember",
+                IfrsClassAxis,
+                DocumentType.TwentyF
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(3_887_771);
+    }
+
+    [Fact]
+    public async Task IsForeignPrivateIssuer_PerClassPickFromTwentyF_ReturnsTrue()
+    {
+        await using var db = NewDb();
+        // Same shape: the pick is the per-class sum from a 20-F, while the stale consolidated
+        // fact is on a non-annual form. The gate must follow the pick, not the consolidated fact,
+        // or the importer treats the filer as domestic and overwrites the listed-security count.
+        var stock = Stock("QNTM");
+        var coverPage = CoverPageConcept();
+        db.AddRange(stock, coverPage);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                12m,
+                new(2025, 3, 31),
+                new(2024, 12, 31),
+                "0001654954-25-003693",
+                DocumentType.Other
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                coverPage,
+                3_887_729m,
+                new(2026, 3, 26),
+                new(2025, 12, 31),
+                "0001185185-26-001069",
+                "qntm:ClassBSubordinateVotingMember",
+                IfrsClassAxis,
+                DocumentType.TwentyF
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var isForeign = await NewProvider(db).IsForeignPrivateIssuer(stock);
+
+        isForeign.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_ThousandsScaledCoverPage_ReturnsNull()
+    {
+        await using var db = NewDb();
+        // Armata: the latest 10-Q cover page says 36,710 — the count typed in thousands — while
+        // the previous cover-page fact says 36,632,775 and the SAME filing's balance sheet says
+        // 36,431,444. Both anchors contradict the collapse, so the provider must abstain.
+        var stock = Stock("ARMP");
+        var coverPage = CoverPageConcept();
+        var balanceSheet = BalanceSheetConcept();
+        db.AddRange(stock, coverPage, balanceSheet);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                36_632_775m,
+                new(2026, 3, 25),
+                new(2026, 3, 20),
+                "0001628280-26-011111",
+                DocumentType.TenK
+            )
+        );
+        const string acc = "0001628280-26-022222";
+        db.Add(Fact(stock, coverPage, 36_710m, new(2026, 5, 13), new(2026, 5, 12), acc));
+        db.Add(Fact(stock, balanceSheet, 36_431_444m, new(2026, 5, 13), new(2026, 3, 31), acc));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().BeNull("a cover-page count both anchors contradict is a filing artifact");
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_DroppedDigitJustUnderTenfold_ReturnsNull()
+    {
+        await using var db = NewDb();
+        // PTC Therapeutics: the filer dropped a digit — 8,294,933 against 82,882,024 on the same
+        // filing's balance sheet and 82,774,730 on the previous cover page. The discrepancy is
+        // 9.99x, so a threshold of 10 would miss it; the collapse factor must catch it.
+        var stock = Stock("PTCT");
+        var coverPage = CoverPageConcept();
+        var balanceSheet = BalanceSheetConcept();
+        db.AddRange(stock, coverPage, balanceSheet);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                82_774_730m,
+                new(2026, 2, 19),
+                new(2026, 2, 13),
+                "0000950170-26-011111",
+                DocumentType.TenK
+            )
+        );
+        const string acc = "0000950170-26-022222";
+        db.Add(Fact(stock, coverPage, 8_294_933m, new(2026, 5, 7), new(2026, 5, 1), acc));
+        db.Add(Fact(stock, balanceSheet, 82_882_024m, new(2026, 5, 7), new(2026, 3, 31), acc));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_BalanceSheetGarbageButHistoryConfirms_KeepsCoverPageCount()
+    {
+        await using var db = NewDb();
+        // The inverse artifact: the balance-sheet count is mis-scaled 1000x LARGE (Regeneron 2012
+        // filed 93.9 BILLION) while the cover-page count is continuous with the issuer's history.
+        // Only one anchor contradicts, so the cover-page count must stand — abstaining here would
+        // hand a correct figure to the fallback source for no reason.
+        var stock = Stock("REGN");
+        var coverPage = CoverPageConcept();
+        var balanceSheet = BalanceSheetConcept();
+        db.AddRange(stock, coverPage, balanceSheet);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                93_900_000m,
+                new(2012, 4, 25),
+                new(2012, 4, 20),
+                "0000872589-12-011111"
+            )
+        );
+        const string acc = "0000872589-12-022222";
+        db.Add(Fact(stock, coverPage, 93_955_110m, new(2012, 7, 25), new(2012, 7, 20), acc));
+        db.Add(Fact(stock, balanceSheet, 93_941_788_000m, new(2012, 7, 25), new(2012, 6, 30), acc));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(93_955_110);
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_ConsistentTinyCount_IsKept()
+    {
+        await using var db = NewDb();
+        // QVC, Inc.: a wholly-owned subsidiary whose common stock is genuinely one share held by
+        // its parent — every filing agrees. A tiny count is not an artifact when the issuer's own
+        // history and balance sheet state the same figure.
+        var stock = Stock("QVCCQ");
+        var coverPage = CoverPageConcept();
+        var balanceSheet = BalanceSheetConcept();
+        db.AddRange(stock, coverPage, balanceSheet);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                1m,
+                new(2026, 4, 15),
+                new(2026, 4, 10),
+                "0000950170-26-033333",
+                DocumentType.TenK
+            )
+        );
+        const string acc = "0000950170-26-044444";
+        db.Add(Fact(stock, coverPage, 1m, new(2026, 5, 15), new(2026, 5, 12), acc));
+        db.Add(Fact(stock, balanceSheet, 1m, new(2026, 5, 15), new(2026, 3, 31), acc));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_CollapseWithoutBalanceSheetAnchor_KeepsCoverPageCount()
+    {
+        await using var db = NewDb();
+        // A large drop against history alone is not enough: without the same filing's
+        // balance-sheet count as a second anchor it can be a genuine event (going private, a
+        // reverse split), so the authoritative cover-page tag stands.
+        var stock = Stock("GONE");
+        var coverPage = CoverPageConcept();
+        db.AddRange(stock, coverPage);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                20_490_501m,
+                new(2025, 11, 14),
+                new(2025, 11, 10),
+                "0001628280-25-055555"
+            )
+        );
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                100m,
+                new(2026, 4, 15),
+                new(2026, 4, 10),
+                "0001628280-26-066666",
+                DocumentType.TenK
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(100);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #4115. After the cover-page fix and the foreign-issuer guard, seven listings still showed impossible short-interest-percent-of-shares on the squeeze board. Root causes, confirmed against the production facts, fall into three classes; each is addressed here.

### 1. IFRS filers' per-class facts were invisible

`GetLatestPerClass` only accepted `us-gaap:StatementClassOfStockAxis`, but IFRS (20-F) filers report per-class cover-page counts on `ifrs-full:ClassesOfShareCapitalAxis` / `ifrs-full:ClassesOfOrdinarySharesAxis` (139 stocks in production). Quantum Biopharma's per-class facts (42 + 3,887,729) were invisible, so a stale consolidated `12` won and was written as the share count. The per-class query now accepts the IFRS axes, and the sum is pinned to a single axis so a filer double-tagging the same classes on two axes is never double-counted.

`IsForeignPrivateIssuer` now keys off the same fact `GetCurrentSharesOutstanding` picks (shared resolution via `ResolveCurrentSharesFact`), so a multi-class 20-F filer with no current consolidated fact is recognized as foreign and the importers leave its listed-security count alone. Previously it only looked at the latest consolidated fact.

### 2. Cover-page filer typos poisoned the count until the next filing

Armata's latest 10-Q cover page says 36,710 (typed in thousands; its own balance sheet in the same filing says 36,431,444). FB Bancorp filed 161,489 vs 17.0M; PTC Therapeutics dropped a digit (8,294,933 vs 82,882,024 — a 9.99× discrepancy, which pins the threshold below 10×). Because the importer re-sources the count every cycle, the artifact was rewritten daily and could not be repaired.

`GetCurrentSharesOutstanding` now abstains (returns null) when the picked consolidated cover-page count is contradicted as a collapse by BOTH the issuer's previous cover-page count and the same filing's us-gaap balance-sheet count, each ≥5× larger. On abstention the financial-facts importer keeps the stored value and the Yahoo importer's listed-security count stands (the existing `edgarShares == null` branch), so these stocks self-heal. Requiring both anchors keeps the check one-sided and conservative:

- a mis-scaled LARGE balance-sheet figure alone (Regeneron 2012 filed 93.9 **billion**) does not fire — history confirms the cover page;
- a genuinely tiny issuer (QVC, Inc.: one share, held by its parent, stated consistently in every filing) never fires;
- a production survey of same-filing ≥10× disagreements found 48 stocks, ~40 of which have the placeholder on the us-gaap side — direction-excluded by construction.

### 3. Some listings can never have an honest ratio

QVC, Inc.'s baby-bond ticker (QVCCQ) carries FINRA short interest against an issuer whose common stock is genuinely one share; Sotherly went private (100 common shares, correctly filed) while its preferreds still trade; UTime's short position and Yahoo share count sit on different split bases. No share-count fix can make these rows meaningful. `ShortSqueezeScoreManager` now drops a stock from the scored universe when its split-adjusted ratio exceeds `MaxCredibleShortInterestRatio` (2×) — well above the most extreme genuine reading on record (GameStop's 2021 peak ≈1.4×) — the same treatment as an unknown share count.

## Code changes

- `SharesOutstandingProvider` — IFRS class axes; single-axis per-class sum; `ResolveCurrentSharesFact` shared by `GetCurrentSharesOutstanding`/`IsForeignPrivateIssuer`; `IsCollapsedCoverPageCount` dual-anchor abstention; contract docs updated on `ISharesOutstandingProvider`.
- `ShortSqueezeScoreManager` — `MaxCredibleShortInterestRatio` guard excluding impossible rows before scoring.

## Tests

- `SharesOutstandingProviderCoverPageIntegrityTests` (new): IFRS-axis per-class sum; FPI keyed to the per-class pick; thousands-scale abstention; 9.99× dropped-digit abstention; inverse (balance-sheet-garbage) non-abstention; consistent tiny count kept; single-anchor restraint.
- `ShortSqueezeScoreManagerTests`: impossible ratio excluded, extreme-but-genuine 1.4× still scored.
- All existing provider/importer/Yahoo/squeeze suites green locally (24 + 7 unit, 37 integration).