### PR TITLE
fix(financial-facts): don't count shutdown cancellations as reported-statements failures

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsCaptureWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsCaptureWorker.cs
@@ -95,6 +95,13 @@ public class ReportedStatementsCaptureWorker : BaseScraperWorker
                     captured++;
                 }
             }
+            // Shutdown mid-batch is not a document failure: let it surface so the
+            // base loop winds down quietly instead of burning one of the document's
+            // attempts and landing a phantom row in Errors.
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                throw;
+            }
             // Per-document fault isolation: count the attempt and keep the cycle going.
             catch (Exception ex)
             {

--- a/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsParseWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsParseWorker.cs
@@ -77,6 +77,13 @@ public class ReportedStatementsParseWorker : BaseScraperWorker
                     document.ReportedStatementsParseVersion =
                         Document.ReportedStatementsParserVersion;
                 }
+                // Shutdown mid-batch is not a document failure: let it surface so the
+                // base loop winds down quietly instead of burning one of the document's
+                // attempts and landing a phantom row in Errors.
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 // Per-document fault isolation: count the attempt and keep the cycle going.
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary

Completes the sweep started in #4116. An audit of every worker with a per-item catch-all (both repos) found exactly two remaining instances of the shutdown-cancellation defect, both here: `ReportedStatementsCaptureWorker` and `ReportedStatementsParseWorker` bump the document's attempt counter and file an Errors row when a deploy cancels their in-flight document — a `ReportedStatementsCapture.Capture | The operation was canceled.` row landed during today's 14:32 deploy. Every other worker already rethrows or filters the stopping-token cancellation.

## Code changes

- `ReportedStatementsCaptureWorker` / `ReportedStatementsParseWorker`: `catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { throw; }` ahead of the per-document catch-all, identical to #4116. The rethrow skips only the in-flight document's stamp; earlier documents' stamps were already saved by the per-iteration SaveChanges.

## Verification

- Full OSS unit suite: 3281 passed.
- csharpier clean on the touched project.