### PR TITLE
fix(yahoo): stop recording shutdown cancellations as phantom scraper errors

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -89,6 +89,12 @@ public class YahooPriceImportService
             {
                 _logger.LogWarning(ex, "Failed to fetch data for {Ticker}, skipping", ticker);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Shutdown, not a per-ticker fault — rethrow so the worker's cancellation
+                // handling sees it instead of recording a phantom error row per deploy.
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error importing data for {Ticker}", ticker);
@@ -188,6 +194,12 @@ public class YahooPriceImportService
                     "Failed to fetch split-adjusted history for {Ticker}; leaving its split(s) pending",
                     ticker
                 );
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Shutdown, not a per-stock fault — rethrow so the worker's cancellation
+                // handling sees it instead of recording a phantom error row per deploy.
+                throw;
             }
             catch (Exception ex)
             {

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -488,6 +488,81 @@ public class YahooPriceImportServiceTests : IDisposable
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
+    [Fact]
+    public async Task Import_CancelledMidTicker_RethrowsWithoutReportingPhantomError()
+    {
+        // A deploy's SIGTERM cancels the stopping token while a ticker is mid-import. The
+        // per-ticker catch-all must NOT record that OperationCanceledException as an error
+        // row ("The operation was canceled.") — it rethrows so the worker's cancellation
+        // handling sees an orderly shutdown instead of a phantom per-deploy error.
+        var apple = CreateStock("AAPL", "Apple Inc.");
+        await SeedStocks(apple);
+
+        var cts = new CancellationTokenSource();
+        _yahooClient
+            .GetChart("AAPL", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Throws(_ =>
+            {
+                cts.Cancel();
+                return new OperationCanceledException(cts.Token);
+            });
+
+        var act = () => _service.Import(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await _errorReporter
+            .DidNotReceive()
+            .Report(
+                Arg.Any<ErrorSource>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            );
+    }
+
+    [Fact]
+    public async Task Import_CancelledMidSplitReconcile_RethrowsWithoutReportingPhantomError()
+    {
+        // Same shutdown-cancellation contract for the split-reconciliation pass (the loop
+        // that produced the prod "ReconcilePendingSplits(JILL)" phantom): cancellation
+        // mid-reconcile propagates instead of landing in the per-stock error report.
+        var apple = CreateStock("AAPL", "Apple Inc.");
+        await SeedStocks(apple);
+
+        _splitRepo.Add(
+            new StockSplit
+            {
+                CommonStockId = apple.Id,
+                EffectiveDate = new DateOnly(2026, 3, 24),
+                Numerator = 4m,
+                Denominator = 1m,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        await _splitRepo.SaveChanges();
+
+        var cts = new CancellationTokenSource();
+        _yahooClient
+            .GetChart("AAPL", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Throws(_ =>
+            {
+                cts.Cancel();
+                return new OperationCanceledException(cts.Token);
+            });
+
+        var act = () => _service.Import(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await _errorReporter
+            .DidNotReceive()
+            .Report(
+                Arg.Any<ErrorSource>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            );
+    }
+
     // ── MinSyncDate configuration ─────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Every deploy that lands while the Yahoo price import is mid-cycle records a phantom `"The operation was canceled."` row to the Errors table (latest occurrence: `ReconcilePendingSplits(JILL)` during a worker shutdown). The per-ticker loop in `Import` and the per-stock loop in `ReconcilePendingSplits` catch the shutdown `OperationCanceledException` in their generic catch-alls and report it as if it were a real per-stock fault.

This is the same shutdown-cancellation phantom fixed across the other workers in #4116/#4118 — these two loops were missed.

## Code changes

- `YahooPriceImportService.cs`: add `catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }` ahead of the catch-alls in both the `Import` per-ticker loop and the `ReconcilePendingSplits` per-stock loop, so an orderly shutdown propagates to `BaseScraperWorker`'s cancellation handling instead of being recorded.
- `YahooPriceImportServiceTests.cs` (integration): two regression tests pinning that a cancellation raised mid-ticker / mid-split-reconcile rethrows and reports nothing to the error reporter.