### PR TITLE
fix(yahoo): rescale market cap from Yahoo's implied share base, not the quoted class

### DIFF
--- a/src/Equibles.Integrations.Yahoo/Models/KeyStatistics.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/KeyStatistics.cs
@@ -4,5 +4,13 @@ public class KeyStatistics
 {
     public long SharesOutstanding { get; set; }
 
+    /// <summary>
+    /// The entity-wide share count (all classes, converted into the quoted listing's units) that
+    /// Yahoo builds <see cref="MarketCapitalization"/> on, or 0 when Yahoo omits it. For a
+    /// multi-class issuer this exceeds <see cref="SharesOutstanding"/>, which covers only the
+    /// quoted class.
+    /// </summary>
+    public long ImpliedSharesOutstanding { get; set; }
+
     public double MarketCapitalization { get; set; }
 }

--- a/src/Equibles.Integrations.Yahoo/Models/Responses/YahooQuoteSummaryResponse.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/YahooQuoteSummaryResponse.cs
@@ -59,6 +59,12 @@ public class DefaultKeyStatisticsContainer
     [JsonProperty("sharesOutstanding")]
     public YahooRawValue SharesOutstanding { get; set; }
 
+    // The share base Yahoo builds summaryDetail.marketCap on: the entity-wide count with every
+    // share class converted into the quoted listing's units. For a multi-class issuer this is
+    // larger than sharesOutstanding (which covers only the quoted class).
+    [JsonProperty("impliedSharesOutstanding")]
+    public YahooRawValue ImpliedSharesOutstanding { get; set; }
+
     [JsonProperty("enterpriseValue")]
     public YahooRawValue EnterpriseValue { get; set; }
 }

--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -306,6 +306,8 @@ public class YahooFinanceClient : IYahooFinanceClient
         return new KeyStatistics
         {
             SharesOutstanding = result.DefaultKeyStatistics?.SharesOutstanding?.Raw ?? 0,
+            ImpliedSharesOutstanding =
+                result.DefaultKeyStatistics?.ImpliedSharesOutstanding?.Raw ?? 0,
             MarketCapitalization = result.SummaryDetail?.MarketCap?.Raw ?? 0,
         };
     }

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -633,6 +633,7 @@ public class YahooPriceImportService
         var marketCap = ReconcileMarketCap(
             edgarShares,
             stats.SharesOutstanding,
+            stats.ImpliedSharesOutstanding,
             stats.MarketCapitalization,
             currentPrice
         );
@@ -654,17 +655,26 @@ public class YahooPriceImportService
         );
     }
 
-    // Yahoo's market cap is its own (per-share-class / stale) share count times price. When EDGAR
-    // is the authoritative share source the importer keeps EDGAR's SharesOutStanding, so storing
-    // Yahoo's market cap verbatim leaves the two figures on different share bases — they disagree
-    // by the share-count ratio (a reverse-split lag inflates market cap ~20x, COPR #3575; a
-    // multi-class issuer understates Yahoo's shares ~2x, #2503). Rescale Yahoo's market cap onto
-    // the EDGAR base (== EDGAR shares × the same implied price) so market cap stays consistent with
-    // SharesOutStanding and the screener's derived price (market cap ÷ shares) holds. Falls back to
-    // Yahoo's figure when there is no EDGAR count or no usable Yahoo share base to rescale from.
-    // The caller passes edgarShares == null for foreign private issuers (20-F/40-F), whose EDGAR
-    // count is in ordinary shares — a different unit from the US-listed ADR — so they keep Yahoo's
-    // self-consistent ADR market cap rather than being rescaled onto the ordinary base.
+    // When EDGAR is the authoritative share source the importer keeps EDGAR's SharesOutStanding,
+    // so storing Yahoo's market cap verbatim leaves the two figures on different share bases —
+    // they disagree by the share-count ratio (a reverse-split lag inflates market cap ~20x, COPR
+    // #3575; a multi-class issuer understates Yahoo's shares ~2x, #2503). Rescale Yahoo's market
+    // cap onto the EDGAR base (== EDGAR shares × the same implied price) so market cap stays
+    // consistent with SharesOutStanding and the screener's derived price (market cap ÷ shares)
+    // holds. Falls back to Yahoo's figure when there is no EDGAR count or no usable Yahoo share
+    // base to rescale from. The caller passes edgarShares == null for foreign private issuers
+    // (20-F/40-F), whose EDGAR count is in ordinary shares — a different unit from the US-listed
+    // ADR — so they keep Yahoo's self-consistent ADR market cap rather than being rescaled onto
+    // the ordinary base.
+    //
+    // The rescale must divide by the share base Yahoo actually built its market cap on. That is
+    // impliedSharesOutstanding (the entity-wide count, all classes) when Yahoo provides it — NOT
+    // sharesOutstanding, which covers only the quoted class. Dividing a full-company market cap
+    // by a single-class count inflates every multi-class issuer by the class ratio (GOOGL stored
+    // 9.23T against a true ~4.4T, DELL ~2x, UHAL ~10x). Only when Yahoo omits the implied count
+    // is sharesOutstanding assumed to be the base, which keeps the #3575 reverse-split correction:
+    // there the whole Yahoo quote lags the split, so cap ÷ (either stale base) × EDGAR shares
+    // still lands on EDGAR shares × price.
     //
     // Yahoo sometimes returns no market cap at all (summaryDetail.marketCap missing — common for
     // multi-class issuers it hasn't reconciled, #5238): with no Yahoo market cap there is nothing
@@ -674,12 +684,14 @@ public class YahooPriceImportService
     private static double ReconcileMarketCap(
         long? edgarShares,
         long yahooShares,
+        long yahooImpliedShares,
         double yahooMarketCap,
         decimal? currentPrice = null
     )
     {
-        if (edgarShares is > 0 && yahooShares > 0 && yahooMarketCap > 0)
-            return yahooMarketCap * ((double)edgarShares.Value / yahooShares);
+        var yahooShareBase = yahooImpliedShares > 0 ? yahooImpliedShares : yahooShares;
+        if (edgarShares is > 0 && yahooShareBase > 0 && yahooMarketCap > 0)
+            return yahooMarketCap * ((double)edgarShares.Value / yahooShareBase);
         if (edgarShares is > 0 && currentPrice is > 0)
             return (double)edgarShares.Value * (double)currentPrice.Value;
         return yahooMarketCap;

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapImpliedSharesTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapImpliedSharesTests.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Sibling to <see cref="YahooPriceImportServiceReconcileMarketCapTests"/>, pinning the share base
+/// the rescale divides by when Yahoo provides <c>impliedSharesOutstanding</c>. Yahoo's
+/// <c>summaryDetail.marketCap</c> is the ENTITY-WIDE figure (price × implied shares, all classes),
+/// while <c>sharesOutstanding</c> covers only the quoted class — so dividing the market cap by
+/// <c>sharesOutstanding</c> treats a full-company cap as a single-class one and inflates every
+/// multi-class issuer by the class ratio. GOOGL (quoted Class A ≈ 48% of the entity) stored
+/// $9.23T against a true ~$4.44T. The contract: when Yahoo reports an implied count, it — never
+/// the single-class count — is the base the cap is rescaled from.
+/// </summary>
+public class YahooPriceImportServiceReconcileMarketCapImpliedSharesTests
+{
+    private static readonly MethodInfo ReconcileMarketCapMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "ReconcileMarketCap",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static double ReconcileMarketCap(
+        long? edgarShares,
+        long yahooShares,
+        long yahooImpliedShares,
+        double yahooMarketCap
+    ) =>
+        (double)
+            ReconcileMarketCapMethod.Invoke(
+                null,
+                [edgarShares, yahooShares, yahooImpliedShares, yahooMarketCap, null]
+            );
+
+    [Fact]
+    public void ReconcileMarketCap_ImpliedSharesProvided_RescalesFromImpliedBaseNotQuotedClass()
+    {
+        // GOOGL's shape: Yahoo quotes Class A only (5.826B sharesOutstanding) but publishes the
+        // entity-wide market cap ($4.44T = $366.46 × the 12.12B implied count across A+B+C).
+        // EDGAR's cover-page total is 12.116B. Rescaling from the implied base keeps the cap at
+        // ~$4.44T; the pre-fix code divided by the 5.826B quoted-class count and stored $9.23T.
+        const long yahooShares = 5_826_000_000L;
+        const long yahooImpliedShares = 12_120_000_000L;
+        const double yahooMarketCap = 4_440_000_000_000d; // ≈ $366.46 × 12.12B implied
+        const long edgarShares = 12_116_000_000L;
+
+        var reconciled = ReconcileMarketCap(
+            edgarShares,
+            yahooShares,
+            yahooImpliedShares,
+            yahooMarketCap
+        );
+
+        var expected = yahooMarketCap * ((double)edgarShares / yahooImpliedShares); // ≈ $4.439T
+        reconciled.Should().BeApproximately(expected, 1_000_000d);
+        // The regression this guards against: dividing by the quoted-class count would return
+        // ≈ $9.23T — more than double the entity's true market cap.
+        reconciled.Should().BeLessThan(5_000_000_000_000d);
+    }
+
+    [Fact]
+    public void ReconcileMarketCap_ImpliedSharesProvidedButQuotedClassCountMissing_StillRescales()
+    {
+        // Yahoo occasionally omits sharesOutstanding while still publishing the implied count its
+        // market cap is built on. The implied base is usable on its own — the reconcile must not
+        // degrade to the verbatim-Yahoo fallback just because the quoted-class count is missing.
+        const long yahooImpliedShares = 1_000_000_000L;
+        const double yahooMarketCap = 30_000_000_000d; // $30 implied price
+        const long edgarShares = 900_000_000L; // buyback landed on EDGAR before Yahoo caught up
+
+        var reconciled = ReconcileMarketCap(edgarShares, 0L, yahooImpliedShares, yahooMarketCap);
+
+        var expected = yahooMarketCap * ((double)edgarShares / yahooImpliedShares); // == $27.0B
+        reconciled.Should().BeApproximately(expected, 1d);
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapMultiClassTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapMultiClassTests.cs
@@ -19,13 +19,20 @@ public class YahooPriceImportServiceReconcileMarketCapMultiClassTests
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
+    // Pins the legacy feed shape where Yahoo omits impliedSharesOutstanding (0) and its market
+    // cap therefore sits on the sharesOutstanding base. When Yahoo DOES provide the implied
+    // count, that base wins instead — see
+    // YahooPriceImportServiceReconcileMarketCapImpliedSharesTests.
     private static double ReconcileMarketCap(
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
     ) =>
         (double)
-            ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
+            ReconcileMarketCapMethod.Invoke(
+                null,
+                [edgarShares, yahooShares, 0L, yahooMarketCap, null]
+            );
 
     [Fact]
     public void ReconcileMarketCap_EdgarSharesExceedYahoo_ScalesMarketCapUpOntoEdgarBase()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapTests.cs
@@ -24,13 +24,18 @@ public class YahooPriceImportServiceReconcileMarketCapTests
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
+    // Pins the legacy feed shape where Yahoo omits impliedSharesOutstanding (0), so
+    // sharesOutstanding is taken as the market cap's share base.
     private static double ReconcileMarketCap(
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
     ) =>
         (double)
-            ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
+            ReconcileMarketCapMethod.Invoke(
+                null,
+                [edgarShares, yahooShares, 0L, yahooMarketCap, null]
+            );
 
     [Fact]
     public void ReconcileMarketCap_EdgarSharesDifferFromYahoo_RescalesOntoEdgarBase()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests.cs
@@ -20,13 +20,18 @@ public class YahooPriceImportServiceReconcileMarketCapZeroEdgarSharesTests
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
+    // Pins the legacy feed shape where Yahoo omits impliedSharesOutstanding (0), so
+    // sharesOutstanding is the only candidate share base.
     private static double ReconcileMarketCap(
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
     ) =>
         (double)
-            ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
+            ReconcileMarketCapMethod.Invoke(
+                null,
+                [edgarShares, yahooShares, 0L, yahooMarketCap, null]
+            );
 
     [Fact]
     public void ReconcileMarketCap_EdgarShareCountZero_KeepsYahooMarketCap()

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooMarketCapTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooMarketCapTests.cs
@@ -20,6 +20,8 @@ public class YahooPriceImportServiceReconcileMarketCapZeroYahooMarketCapTests
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
+    // Pins the legacy feed shape where Yahoo omits impliedSharesOutstanding (0), so
+    // sharesOutstanding is the only candidate share base.
     private static double ReconcileMarketCap(
         long? edgarShares,
         long yahooShares,
@@ -29,7 +31,7 @@ public class YahooPriceImportServiceReconcileMarketCapZeroYahooMarketCapTests
         (double)
             ReconcileMarketCapMethod.Invoke(
                 null,
-                [edgarShares, yahooShares, yahooMarketCap, currentPrice]
+                [edgarShares, yahooShares, 0L, yahooMarketCap, currentPrice]
             );
 
     [Fact]

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests.cs
@@ -19,13 +19,18 @@ public class YahooPriceImportServiceReconcileMarketCapZeroYahooSharesTests
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
+    // Pins the legacy feed shape where Yahoo omits impliedSharesOutstanding (0), so
+    // sharesOutstanding is the only candidate share base.
     private static double ReconcileMarketCap(
         long? edgarShares,
         long yahooShares,
         double yahooMarketCap
     ) =>
         (double)
-            ReconcileMarketCapMethod.Invoke(null, [edgarShares, yahooShares, yahooMarketCap, null]);
+            ReconcileMarketCapMethod.Invoke(
+                null,
+                [edgarShares, yahooShares, 0L, yahooMarketCap, null]
+            );
 
     [Fact]
     public void ReconcileMarketCap_YahooShareCountZero_KeepsYahooMarketCap()


### PR DESCRIPTION
## Summary

GOOGL showed a **$9.23T market cap** (true ~$4.44T). Yahoo's `summaryDetail.marketCap` is the entity-wide figure — price × `impliedSharesOutstanding` (all share classes) — while `defaultKeyStatistics.sharesOutstanding` covers only the quoted class. `ReconcileMarketCap` divided the full-company cap by the single-class count before rescaling onto the EDGAR share base, inflating every multi-class issuer by its class ratio (GOOGL 2.08×, DELL ~2×, HEI ~2.5×, UHAL and FWONA ~10×).

The fix reads `impliedSharesOutstanding` from the same `defaultKeyStatistics` module (no extra HTTP round-trip) and uses it as the rescale denominator whenever Yahoo provides it, falling back to `sharesOutstanding` when absent. The #3575 reverse-split correction still holds (a stale quote lags on both bases, so cap ÷ stale base × EDGAR shares still lands on EDGAR shares × price), and the #5238 price fallback is untouched.

## Code changes

- `YahooQuoteSummaryResponse` / `KeyStatistics` / `YahooFinanceClient`: carry `impliedSharesOutstanding` through from the quote summary payload.
- `YahooPriceImportService.ReconcileMarketCap`: prefer the implied count as the share base Yahoo's market cap is divided by; single-class count only when implied is absent.
- Tests: new `...ReconcileMarketCapImpliedSharesTests` pins the GOOGL shape (and the implied-only shape); the five existing reconcile test files now explicitly pin the legacy no-implied shape.

## Verification

- `dotnet build Equibles.sln` clean; full `Equibles.UnitTests` suite: 3290 passed.
- csharpier check clean.