### PR TITLE
fix(yahoo): detect ordinary-vs-ADS share-unit mismatches the FPI guard can't see

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ShareBasisPlausibility.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ShareBasisPlausibility.cs
@@ -1,0 +1,72 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic;
+
+/// <summary>
+/// Decides whether two share counts for the same issuer can be statements of the same unit, and
+/// whether a stored (market cap, share count) pair credibly sits on the listed-security basis.
+/// Shared by the Yahoo key-stats sync and the financial-facts importer so the two writers of
+/// <c>CommonStock.SharesOutStanding</c> apply one definition of "these figures are on different
+/// bases" and can never fight each other across the same threshold.
+///
+/// The problem this solves: an issuer can list one security while its EDGAR cover page counts
+/// another unit entirely. The form-based foreign-private-issuer guard catches 20-F/40-F filers,
+/// but a former FPI that lost the status keeps filing 10-K/10-Q while its US listing is still an
+/// ADS — AKTX files 10-Q covers of 91.6B ordinary shares against ~1.1M listed ADSs (80,000
+/// ordinary per ADS since 2026-03-31). No API the importers ingest exposes the registered
+/// security's title (the SEC companyfacts endpoint serves numeric facts only, and the submissions
+/// feed has no security section), so the mismatch is detected from the figures themselves.
+/// </summary>
+public static class ShareBasisPlausibility
+{
+    /// <summary>
+    /// The largest ratio two same-unit statements of an issuer's share count have ever been
+    /// observed apart. Legitimate divergences are corporate-action lags — a price feed trailing a
+    /// reverse split (COPR ~20x; even the most extreme real reverse splits stay around 1:100 to
+    /// 1:250) or a merger/issuance one source has and the other hasn't. Different-unit pairs sit
+    /// far above: ordinary-shares-vs-ADS bases run 458x to 80,000x (ABTC, CNDA, Latam Airlines,
+    /// AKTX). 300 splits the two regimes with margin on both sides.
+    /// </summary>
+    public const double MaxPlausibleSameUnitRatio = 300;
+
+    // A stored pair whose implied per-share price (market cap ÷ shares) falls inside these bounds
+    // is credibly a real listed quote: the lower bound excludes a garbage-large stored count
+    // against a sane market cap (implied price collapses to fractions of a cent), the upper bound
+    // excludes a nominal-placeholder count — shells file cover pages of 1/100/1000 shares, so the
+    // implied price explodes to millions per share. BRK.A, the most expensive real listing, is
+    // ~$780k/share, an order of magnitude inside the upper bound. Sub-penny OTC listings fall
+    // outside the lower bound and simply don't get the protection (unchanged behavior for them).
+    private const double MinPlausibleSharePrice = 0.01;
+    private const double MaxPlausibleSharePrice = 10_000_000;
+
+    /// <summary>
+    /// True when the two counts are too far apart to be statements of the same unit — one is an
+    /// ordinary-share count against an ADS count, or one is garbage (dropped digit,
+    /// thousands-scaled entry, nominal placeholder). Direction-agnostic: either count may be the
+    /// larger. False when either count is missing (zero or negative) — absence is not evidence of
+    /// a unit mismatch.
+    /// </summary>
+    public static bool IsUnitMismatch(long countA, long countB)
+    {
+        if (countA <= 0 || countB <= 0)
+            return false;
+
+        var ratio = (double)countA / countB;
+        return ratio >= MaxPlausibleSameUnitRatio || ratio <= 1d / MaxPlausibleSameUnitRatio;
+    }
+
+    /// <summary>
+    /// True when a stored (market cap, share count) pair implies a per-share price a real listed
+    /// security could trade at — evidence the pair sits on the listed-security basis and deserves
+    /// protection from an overwrite in a different unit. False for a missing market cap or share
+    /// count, for the implied sub-cent price of a garbage-large count, and for the implied
+    /// millions-per-share price of a nominal-placeholder count (1/100/1000 shares), all of which
+    /// should be repaired by the authoritative EDGAR figure, not protected from it.
+    /// </summary>
+    public static bool ImpliesPlausibleSharePrice(double marketCapitalization, long shares)
+    {
+        if (marketCapitalization <= 0 || shares <= 0)
+            return false;
+
+        var impliedPrice = marketCapitalization / shares;
+        return impliedPrice >= MinPlausibleSharePrice && impliedPrice <= MaxPlausibleSharePrice;
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -173,6 +173,28 @@ public class FinancialFactsImportService
         if (tracked == null || tracked.SharesOutStanding == shares.Value)
             return;
 
+        // The FPI guard above can't see a DOMESTIC filer whose US listing is still an ADS (a
+        // former FPI that lost the status files 10-K/10-Q while its cover page keeps counting
+        // ordinary shares — AKTX: 91.6B ordinary against ~1.1M listed ADSs). Writing that count
+        // would put the share count back on the ordinary base while the market cap the Yahoo
+        // importer maintains stays on the ADS base, re-breaking the pair every facts cycle. So
+        // when the stored figures credibly sit on the listed-security basis (their implied
+        // per-share price is one a real listing could trade at) and the cover-page count is too
+        // far from the stored count to be the same unit, leave the stored count alone. A stored
+        // count that is itself garbage (nominal 1/100/1000-share placeholder, or a count whose
+        // implied price collapses to fractions of a cent) fails the plausibility test and is
+        // still repaired here, and a refusal that goes stale after a large legitimate issuance is
+        // corrected by the Yahoo importer, which writes the EDGAR count once Yahoo's own share
+        // base confirms it plausible.
+        if (
+            ShareBasisPlausibility.IsUnitMismatch(shares.Value, tracked.SharesOutStanding)
+            && ShareBasisPlausibility.ImpliesPlausibleSharePrice(
+                tracked.MarketCapitalization,
+                tracked.SharesOutStanding
+            )
+        )
+            return;
+
         tracked.SharesOutStanding = shares.Value;
         await stockRepository.SaveChanges();
     }

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -615,6 +615,26 @@ public class YahooPriceImportService
         )
             edgarShares = null;
 
+        // The form-based guard above can't see a DOMESTIC filer whose US listing is still an ADS:
+        // a former foreign private issuer that lost FPI status files 10-K/10-Q while its cover
+        // page keeps counting ordinary shares — AKTX filed 10-Q covers of 91.6B ordinary shares
+        // against ~1.1M listed ADSs (80,000 ordinary per ADS). Rescaling onto that base inflates
+        // market cap by the full ADS ratio, and the damage is undetectable downstream because the
+        // stored pair stays self-consistent (cap ÷ shares == the close). No ingested API exposes
+        // the registered security's title to flag these issuers authoritatively, so detect the
+        // unit mismatch from the figures themselves: when the EDGAR count and Yahoo's own share
+        // base are too far apart to be statements of the same unit, keep Yahoo's self-consistent
+        // listed-security figures verbatim, exactly like the FPI path. Also stops a garbage EDGAR
+        // count (ABTC 458x, CNDA 768x off any real basis) from poisoning the rescale. The
+        // threshold is deliberately far above any corporate-action lag (see
+        // MaxPlausibleSameUnitRatio), so a lagging reverse split — where EDGAR is right and the
+        // rescale must proceed (#3575) — cannot trip it.
+        if (
+            edgarShares is > 0
+            && ShareBasisPlausibility.IsUnitMismatch(edgarShares.Value, YahooShareBase(stats))
+        )
+            edgarShares = null;
+
         // Per-field conservative writes: only update on actual change, and never
         // overwrite a known value with 0 (treated as Yahoo "unknown" by the rest of
         // the codebase).
@@ -626,6 +646,19 @@ public class YahooPriceImportService
         )
         {
             stock.SharesOutStanding = stats.SharesOutstanding;
+            changed = true;
+        }
+        // When the EDGAR count is the authoritative base (not dropped above), store it here too —
+        // not only in the financial-facts importer — so the share count and the market cap
+        // rescaled onto it below always land together and the stored pair is never split across
+        // two bases between worker cycles. This is also the arbiter behind the facts importer's
+        // own unit-mismatch guard: that guard refuses to overwrite a stored count that is credibly
+        // on the listed-security basis, and when such a refusal goes stale (a large legitimate
+        // issuance moved the true count), it is corrected here, where Yahoo's agreeing share base
+        // proves the EDGAR count plausible.
+        if (edgarShares is > 0 && stock.SharesOutStanding != edgarShares.Value)
+        {
+            stock.SharesOutStanding = edgarShares.Value;
             changed = true;
         }
         // Reconcile Yahoo's market cap onto the authoritative EDGAR share base so it never
@@ -677,7 +710,9 @@ public class YahooPriceImportService
     // base to rescale from. The caller passes edgarShares == null for foreign private issuers
     // (20-F/40-F), whose EDGAR count is in ordinary shares — a different unit from the US-listed
     // ADR — so they keep Yahoo's self-consistent ADR market cap rather than being rescaled onto
-    // the ordinary base.
+    // the ordinary base, and likewise whenever the EDGAR count and Yahoo's share base are too far
+    // apart to be statements of the same unit (a domestic filer still listing ADSs, a garbage
+    // cover-page count — see ShareBasisPlausibility).
     //
     // The rescale must divide by the share base Yahoo actually built its market cap on. That is
     // impliedSharesOutstanding (the entity-wide count, all classes) when Yahoo provides it — NOT
@@ -701,13 +736,23 @@ public class YahooPriceImportService
         decimal? currentPrice = null
     )
     {
-        var yahooShareBase = yahooImpliedShares > 0 ? yahooImpliedShares : yahooShares;
+        var yahooShareBase = YahooShareBase(yahooImpliedShares, yahooShares);
         if (edgarShares is > 0 && yahooShareBase > 0 && yahooMarketCap > 0)
             return yahooMarketCap * ((double)edgarShares.Value / yahooShareBase);
         if (edgarShares is > 0 && currentPrice is > 0)
             return (double)edgarShares.Value * (double)currentPrice.Value;
         return yahooMarketCap;
     }
+
+    private static long YahooShareBase(KeyStatistics stats) =>
+        YahooShareBase(stats.ImpliedSharesOutstanding, stats.SharesOutstanding);
+
+    // The share base Yahoo built its published market cap on: the entity-wide implied count when
+    // provided, else the quoted-class count. The single definition shared by the unit-mismatch
+    // guard and ReconcileMarketCap — the base the guard vets must always be the base the rescale
+    // divides by, or a mismatch could be vetted against one figure and rescaled from another.
+    private static long YahooShareBase(long yahooImpliedShares, long yahooShares) =>
+        yahooImpliedShares > 0 ? yahooImpliedShares : yahooShares;
 
     private async Task SyncCompanyProfile(
         string ticker,

--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceAdsShareBasisTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceAdsShareBasisTests.cs
@@ -1,0 +1,224 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models.Responses;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Sibling to <see cref="FinancialFactsImportServiceForeignIssuerSharesTests"/>, pinning the
+/// unit-mismatch guard in FinancialFactsImportService.UpdateSharesOutstanding for issuers the
+/// form-based FPI guard can't see: a former foreign private issuer that lost FPI status files
+/// 10-K/10-Q while its US listing is still an ADS, so its cover page counts ordinary shares —
+/// AKTX: 91.57B ordinary against ~2.5M listed ADSs (80,000 ordinary per ADS). Writing that count
+/// would put the share count back on the ordinary base while the market cap the Yahoo importer
+/// maintains stays on the ADS base, re-breaking the pair every facts cycle. A stored count that is
+/// itself garbage (nominal placeholder, or one whose implied price is nothing a listing could
+/// trade at) must still be repaired by the cover-page figure.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FinancialFactsImportServiceAdsShareBasisTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public FinancialFactsImportServiceAdsShareBasisTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    // Every scope shares the one caller-configured shares provider so the test controls the
+    // GetCurrentSharesOutstanding / IsForeignPrivateIssuer answers the import path sees.
+    private IServiceScopeFactory CreateScopeFactory(ISharesOutstandingProvider sharesProvider)
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                sp.GetService(typeof(FinancialConceptRepository))
+                    .Returns(new FinancialConceptRepository(ctx));
+                sp.GetService(typeof(FinancialFactsSyncStatusRepository))
+                    .Returns(new FinancialFactsSyncStatusRepository(ctx));
+                sp.GetService(typeof(DocumentRepository)).Returns(new DocumentRepository(ctx));
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(ISharesOutstandingProvider)).Returns(sharesProvider);
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    // A minimal, single-value payload: one ParsedFact so the import reaches the share-count refresh
+    // without exercising the within-batch dedup path.
+    private static CompanyFactsResponse RevenueFacts() =>
+        new()
+        {
+            Cik = 1541157,
+            EntityName = "Issuer",
+            Facts = new()
+            {
+                ["us-gaap"] = new()
+                {
+                    ["Revenues"] = new CompanyFactConcept
+                    {
+                        Label = "Revenues",
+                        Units = new()
+                        {
+                            ["USD"] =
+                            [
+                                new CompanyFactValue
+                                {
+                                    Start = new DateOnly(2025, 1, 1),
+                                    End = new DateOnly(2025, 12, 31),
+                                    Val = 100m,
+                                    Accn = "0001541157-26-000001",
+                                    Fy = 2025,
+                                    Fp = "FY",
+                                    Form = "10-K",
+                                    Filed = new DateOnly(2026, 3, 30),
+                                    Frame = "CY2025",
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+
+    private FinancialFactsImportService BuildService(ISharesOutstandingProvider sharesProvider)
+    {
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient.GetCompanyFacts("0001541157").Returns(RevenueFacts());
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+        return new FinancialFactsImportService(
+            CreateScopeFactory(sharesProvider),
+            secEdgarClient,
+            Substitute.For<ILogger<FinancialFactsImportService>>(),
+            errorReporter
+        );
+    }
+
+    private async Task<CommonStock> Seed(
+        long sharesOutstanding,
+        double marketCapitalization,
+        string ticker
+    )
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = ticker,
+            Cik = "0001541157",
+            SharesOutStanding = sharesOutstanding,
+            MarketCapitalization = marketCapitalization,
+        };
+        await using var seed = _fixture.CreateDbContext();
+        seed.Set<CommonStock>().Add(stock);
+        await seed.SaveChangesAsync(CancellationToken.None);
+        return stock;
+    }
+
+    private async Task<long> StoredShares(Guid stockId)
+    {
+        await using var verify = _fixture.CreateDbContext();
+        var tracked = await verify.Set<CommonStock>().FirstAsync(s => s.Id == stockId);
+        return tracked.SharesOutStanding;
+    }
+
+    private static ISharesOutstandingProvider DomesticProviderReturning(long coverPageCount)
+    {
+        var sharesProvider = Substitute.For<ISharesOutstandingProvider>();
+        sharesProvider
+            .GetCurrentSharesOutstanding(Arg.Any<CommonStock>(), Arg.Any<CancellationToken>())
+            .Returns(coverPageCount);
+        sharesProvider
+            .IsForeignPrivateIssuer(Arg.Any<CommonStock>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        return sharesProvider;
+    }
+
+    [Fact]
+    public async Task Import_DomesticAdsIssuer_LeavesStoredListedSecurityCountUntouched()
+    {
+        // AKTX steady state after the Yahoo importer healed the pair: ~2.5M ADSs against a ~$27M
+        // market cap (implied ~$10.90 — a real quote). The 10-K cover page counts 91.57B ordinary
+        // shares; a domestic-form filer, so the FPI guard is blind and only the unit-mismatch
+        // guard stands between the ordinary count and the stored ADS base.
+        var stock = await Seed(2_477_000, 27_000_000d, "AKTX");
+
+        await BuildService(DomesticProviderReturning(91_567_009_533L))
+            .Import(stock, CancellationToken.None);
+
+        (await StoredShares(stock.Id))
+            .Should()
+            .Be(
+                2_477_000,
+                "a domestic filer's ordinary-share cover-page count must not overwrite the listed ADS base"
+            );
+    }
+
+    [Fact]
+    public async Task Import_NominalPlaceholderCount_IsStillRepairedFromCoverPage()
+    {
+        // A stock pinned to a 1-share nominal placeholder alongside a real market cap: the
+        // implied price (billions per share) proves the stored count is NOT on the listed basis,
+        // so the plausibility gate keeps the guard out and the cover-page repair proceeds even
+        // though the two counts diverge far beyond the unit-mismatch threshold.
+        var stock = await Seed(1, 2_000_000_000d, "SHEL");
+
+        await BuildService(DomesticProviderReturning(14_687_356_000L))
+            .Import(stock, CancellationToken.None);
+
+        (await StoredShares(stock.Id)).Should().Be(14_687_356_000L);
+    }
+
+    [Fact]
+    public async Task Import_SameUnitDivergence_RefreshesSharesFromCoverPage()
+    {
+        // An ordinary refresh: stored pair on the listed basis (implied ~$3/share) and a
+        // cover-page count 5% away — a buyback landing on EDGAR before Yahoo catches up. Same
+        // unit, so the guard stays out and the authoritative count is written.
+        var stock = await Seed(14_000_000_000, 42_000_000_000d, "AAPL");
+
+        await BuildService(DomesticProviderReturning(14_687_356_000L))
+            .Import(stock, CancellationToken.None);
+
+        (await StoredShares(stock.Id)).Should().Be(14_687_356_000L);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -836,6 +836,108 @@ public class YahooPriceImportServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Import_DomesticAdsIssuer_KeepsYahooPairInsteadOfRescalingOntoOrdinaryBase()
+    {
+        // AKTX: a former foreign private issuer that lost FPI status — it files 10-K/10-Q, so the
+        // form-based guard says "domestic" — while its US listing is still an ADS. EDGAR's cover
+        // page counts 91.57B *ordinary* shares against ~2.5M listed ADSs (80,000 ordinary per
+        // ADS). Rescaling Yahoo's correct ~$27M cap onto that base stored $998B, and the damage
+        // was invisible downstream because the pair stayed self-consistent. The unit-mismatch
+        // guard must keep Yahoo's listed-security figures verbatim, exactly like the FPI path.
+        var stock = CreateStock("AKTX", "Akari Therapeutics Plc");
+        await SeedStocks(stock);
+
+        _sharesProvider.GetCurrentSharesOutstanding(stock).Returns(91_567_009_533L);
+        _sharesProvider.IsForeignPrivateIssuer(stock).Returns(false);
+
+        _yahooClient
+            .GetChart("AKTX", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new YahooChartData());
+        _yahooClient
+            .GetKeyStatistics("AKTX")
+            .Returns(
+                new KeyStatistics
+                {
+                    SharesOutstanding = 2_477_000,
+                    ImpliedSharesOutstanding = 2_477_000,
+                    MarketCapitalization = 27_000_000d,
+                }
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "AKTX");
+        updated.MarketCapitalization.Should().Be(27_000_000d);
+        updated.SharesOutStanding.Should().Be(2_477_000);
+    }
+
+    [Fact]
+    public async Task Import_GarbageSmallEdgarCount_KeepsYahooPairInsteadOfRescaling()
+    {
+        // ABTC's shape: the EDGAR-side count is orders of magnitude below any real basis (a
+        // dropped digit / thousands-scaled cover-page entry). Rescaling Yahoo's cap onto it
+        // collapses market cap by the same factor; the guard is direction-agnostic and keeps
+        // Yahoo's self-consistent pair.
+        var stock = CreateStock("ABTC", "Garbage Count Co.");
+        await SeedStocks(stock);
+
+        _sharesProvider.GetCurrentSharesOutstanding(stock).Returns(1_000L);
+        _sharesProvider.IsForeignPrivateIssuer(stock).Returns(false);
+
+        _yahooClient
+            .GetChart("ABTC", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new YahooChartData());
+        _yahooClient
+            .GetKeyStatistics("ABTC")
+            .Returns(
+                new KeyStatistics
+                {
+                    SharesOutstanding = 458_000_000,
+                    MarketCapitalization = 45_800_000d,
+                }
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "ABTC");
+        updated.MarketCapitalization.Should().Be(45_800_000d);
+        updated.SharesOutStanding.Should().Be(458_000_000);
+    }
+
+    [Fact]
+    public async Task Import_DomesticIssuer_StoresEdgarShareCountAlongsideRescaledCap()
+    {
+        // When the EDGAR count is the authoritative base, the key-stats sync stores it together
+        // with the market cap rescaled onto it, so the stored pair always moves as one — the
+        // share count can't sit on Yahoo's base for a cycle while the cap is already on EDGAR's.
+        var stock = CreateStock("PAIR", "Paired Write Co.");
+        stock.SharesOutStanding = 5_000_000;
+        await SeedStocks(stock);
+
+        _sharesProvider.GetCurrentSharesOutstanding(stock).Returns(10_000_000L);
+        _sharesProvider.IsForeignPrivateIssuer(stock).Returns(false);
+
+        _yahooClient
+            .GetChart("PAIR", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new YahooChartData());
+        _yahooClient
+            .GetKeyStatistics("PAIR")
+            .Returns(
+                new KeyStatistics
+                {
+                    SharesOutstanding = 5_000_000,
+                    MarketCapitalization = 1_000_000_000d,
+                }
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "PAIR");
+        updated.SharesOutStanding.Should().Be(10_000_000L);
+        updated.MarketCapitalization.Should().Be(2_000_000_000d);
+    }
+
+    [Fact]
     public async Task Import_KeyStatisticsBothZero_LeavesStockUntouched()
     {
         var stock = CreateStock("ZERO", "All Zero Co.");

--- a/tests/Equibles.UnitTests/Sec/ShareBasisPlausibilitySharePriceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ShareBasisPlausibilitySharePriceTests.cs
@@ -1,0 +1,65 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the listed-security-basis test the financial-facts importer gates its unit-mismatch guard
+/// on. The guard must protect a stored (market cap, shares) pair the Yahoo importer maintains on
+/// the listed-security basis (implied per-share price is a real quote), while still letting the
+/// EDGAR cover-page count repair stored garbage: a nominal 1/100/1000-share placeholder implies
+/// millions per share, a garbage-large count implies fractions of a cent — neither is a price a
+/// listed security trades at, so neither deserves protection.
+/// </summary>
+public class ShareBasisPlausibilitySharePriceTests
+{
+    [Fact]
+    public void ImpliesPlausibleSharePrice_ListedSecurityPair_True()
+    {
+        // AKTX's healed pair: ~$27M cap over ~2.5M ADSs implies ~$10.90 — a real quote.
+        ShareBasisPlausibility
+            .ImpliesPlausibleSharePrice(27_000_000d, 2_477_000L)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void ImpliesPlausibleSharePrice_MostExpensiveRealListing_True()
+    {
+        // BRK.A trades around $780k/share — the extreme real quote must stay inside the band.
+        ShareBasisPlausibility
+            .ImpliesPlausibleSharePrice(1_140_000_000_000d, 1_460_000L)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void ImpliesPlausibleSharePrice_NominalPlaceholderCount_False()
+    {
+        // A shell pinned to a 1-share cover-page placeholder implies $2B per share; the stored
+        // count is garbage and must remain repairable by the EDGAR figure.
+        ShareBasisPlausibility.ImpliesPlausibleSharePrice(2_000_000_000d, 1L).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ImpliesPlausibleSharePrice_GarbageLargeCount_False()
+    {
+        // A garbage-large stored count against a sane cap implies fractions of a cent per share;
+        // it is not on the listed-security basis and must remain repairable.
+        ShareBasisPlausibility
+            .ImpliesPlausibleSharePrice(27_000_000d, 91_567_009_533L)
+            .Should()
+            .BeFalse();
+    }
+
+    [Theory]
+    [InlineData(0d, 1_000_000L)]
+    [InlineData(-1d, 1_000_000L)]
+    [InlineData(1_000_000d, 0L)]
+    [InlineData(1_000_000d, -1L)]
+    public void ImpliesPlausibleSharePrice_MissingFigure_False(double marketCap, long shares)
+    {
+        // With either figure missing there is no evidence the stored pair is on the listed
+        // basis, so it gets no protection and the EDGAR write proceeds.
+        ShareBasisPlausibility.ImpliesPlausibleSharePrice(marketCap, shares).Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/ShareBasisPlausibilityUnitMismatchTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ShareBasisPlausibilityUnitMismatchTests.cs
@@ -1,0 +1,77 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the unit-mismatch predicate both writers of CommonStock.SharesOutStanding share. It must
+/// separate two regimes: legitimate same-unit divergences (corporate-action lags, at most a few
+/// hundred x) where the EDGAR cover-page count must stay authoritative, and different-unit pairs
+/// (ordinary shares vs ADSs, garbage counts — observed 458x to 80,000x) where reconciling onto the
+/// EDGAR count inflates market cap by the full ratio while leaving the stored pair self-consistent,
+/// invisible to the derived-price scan (AKTX stored $998B against a true ~$27M).
+/// </summary>
+public class ShareBasisPlausibilityUnitMismatchTests
+{
+    [Fact]
+    public void IsUnitMismatch_OrdinarySharesAgainstAdsCount_Fires()
+    {
+        // AKTX's shape: the 10-Q cover page counts 91.57B ordinary shares while Yahoo's base is
+        // the ~2.5M listed ADSs (80,000 ordinary per ADS) — a ~37,000x disagreement.
+        ShareBasisPlausibility.IsUnitMismatch(91_567_009_533L, 2_477_000L).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUnitMismatch_GarbageSmallEdgarCount_FiresInTheOtherDirection()
+    {
+        // ABTC's shape: a stored cover-page count ~458x SMALLER than the listed-security base.
+        // The predicate is direction-agnostic — either side may hold the larger figure.
+        ShareBasisPlausibility.IsUnitMismatch(1_000_000L, 458_000_000L).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUnitMismatch_ReverseSplitLag_DoesNotFire()
+    {
+        // COPR's shape (#3575): Yahoo lags a 1-for-20 reverse split, so its base is 20x the
+        // EDGAR count. EDGAR is RIGHT here — the rescale must proceed, the guard must stay out.
+        ShareBasisPlausibility.IsUnitMismatch(5_000_000L, 100_000_000L).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsUnitMismatch_MultiClassQuotedClassBase_DoesNotFire()
+    {
+        // GOOGL's shape: EDGAR's entity total vs Yahoo's quoted-class count differ ~2x. Same
+        // unit, different scopes — the rescale handles this; the guard must not interfere.
+        ShareBasisPlausibility.IsUnitMismatch(12_116_000_000L, 5_826_000_000L).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsUnitMismatch_ExactThreshold_Fires()
+    {
+        // The boundary is inclusive: at exactly MaxPlausibleSameUnitRatio the pair is treated as
+        // different units.
+        var threshold = (long)ShareBasisPlausibility.MaxPlausibleSameUnitRatio;
+        ShareBasisPlausibility.IsUnitMismatch(threshold * 1_000_000L, 1_000_000L).Should().BeTrue();
+        ShareBasisPlausibility.IsUnitMismatch(1_000_000L, threshold * 1_000_000L).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUnitMismatch_JustUnderThreshold_DoesNotFire()
+    {
+        var justUnder = (long)ShareBasisPlausibility.MaxPlausibleSameUnitRatio - 1;
+        ShareBasisPlausibility
+            .IsUnitMismatch(justUnder * 1_000_000L, 1_000_000L)
+            .Should()
+            .BeFalse();
+    }
+
+    [Theory]
+    [InlineData(0L, 1_000_000L)]
+    [InlineData(1_000_000L, 0L)]
+    [InlineData(-1L, 1_000_000L)]
+    [InlineData(1_000_000L, -1L)]
+    public void IsUnitMismatch_MissingCount_DoesNotFire(long countA, long countB)
+    {
+        // A missing (zero/negative) count is absence of evidence, not evidence of a mismatch.
+        ShareBasisPlausibility.IsUnitMismatch(countA, countB).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

AKTX (Akari Therapeutics) showed a **$998B** market cap against a true **~$27M**. The key-stats sync rescales Yahoo's market cap onto the EDGAR cover-page share count, but Akari is a former foreign private issuer that now files 10-K/10-Q while its US listing is still an ADS: the cover page counts **91.6B ordinary shares** while Yahoo prices the **ADS (1 ADS = 80,000 ordinary)**. The form-based 20-F/40-F guard can't see domestic-form filers, so the rescale inflated the cap by the full ADS ratio — and the stored pair stayed self-consistent (cap ÷ shares = close), invisible to the derived-price scan.

No ingested SEC API exposes the registered security's title (companyfacts serves numeric facts only; the submissions feed has no security section), so the unit mismatch is detected from the figures themselves.

## Code changes

- **`ShareBasisPlausibility` (new, FinancialFacts.BusinessLogic)** — the shared definition both writers of `CommonStock.SharesOutStanding` use: `IsUnitMismatch` (two counts ≥300× apart cannot be the same unit; legit corporate-action lags stay ≤ ~250×, observed mismatches start at 458×) and `ImpliesPlausibleSharePrice` (a stored cap/shares pair whose implied price is a real quote sits on the listed-security basis).
- **`YahooPriceImportService.SyncKeyStatistics`** — drops the EDGAR base when it unit-mismatches Yahoo's own share base, keeping Yahoo's self-consistent listed-security figures verbatim exactly like the FPI path (also stops garbage cover-page counts — ABTC 458×, CNDA 768× — from poisoning the rescale). When the EDGAR base is valid it is now written to `SharesOutStanding` together with the rescaled cap, so the stored pair always moves as one, and a stale facts-importer refusal (large legitimate issuance) is corrected here where Yahoo's agreeing base proves the count plausible. The share base the guard vets and the base the rescale divides by share a single definition (`YahooShareBase`).
- **`FinancialFactsImportService.UpdateSharesOutstanding`** — refuses to overwrite a stored count that credibly sits on the listed-security basis with a cover-page count in a different unit (which would re-break the pair every facts cycle); nominal 1/100/1000-share placeholders and garbage-large counts fail the plausibility test and are still repaired.
- **Tests** — unit tests pin both predicates (thresholds, directions, missing-figure behavior, the GOOGL/COPR non-firing shapes); integration tests pin the AKTX shape, the garbage-count shape, the paired shares+cap write, and the facts-importer guard incl. the placeholder-repair and ordinary-refresh paths.

Invariants preserved (existing tests + new pins): #3575 reverse-split correction, #2503 multi-class rescale, the 20-F/40-F FPI path, and the never-overwrite-with-0 contract.