### PR TITLE
fix(congress): normalize AssetName at the trade-build choke point — it is part of the upsert key

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -189,7 +189,7 @@ public class CongressionalTradeSyncService
             .ToDictionaryAsync(m => m.Name, ct);
     }
 
-    private List<CongressionalTrade> BuildTrades(
+    internal List<CongressionalTrade> BuildTrades(
         List<DisclosureTransaction> matched,
         Dictionary<string, CongressMember> members,
         Dictionary<string, CommonStock> stocks
@@ -233,7 +233,12 @@ public class CongressionalTradeSyncService
                     FilingDate = tx.FilingDate,
                     TransactionType = tx.TransactionType,
                     OwnerType = tx.OwnerType,
-                    AssetName = tx.AssetName ?? "",
+                    // The stored name is part of the trade upsert key (see PersistTrades), so it
+                    // must be normalized here no matter which scraper emitted the transaction —
+                    // an unnormalized variant would re-insert the same trade as a new row. Every
+                    // source already cleans at emission; doing it here too makes this the single
+                    // choke point, mirroring NormalizeMemberName above (GH-3374).
+                    AssetName = DisclosureParsingHelper.CleanAssetName(tx.AssetName) ?? "",
                     AmountFrom = tx.AmountFrom,
                     AmountTo = tx.AmountTo,
                 }
@@ -249,6 +254,8 @@ public class CongressionalTradeSyncService
         CancellationToken ct
     )
     {
+        // AssetName participates in this key, so dedup only works while stored names equal the
+        // current CleanAssetName output — see the invariant note on CleanAssetName.
         await dbContext
             .Set<CongressionalTrade>()
             .UpsertRange(trades)

--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -314,6 +314,12 @@ public static partial class DisclosureParsingHelper
     // "gfedcb"; the text extractor glues those tokens onto the asset name ("Weyerhaeuser Company
     // (WY) gfedcb"). Case-sensitive on purpose — the artifact is always lowercase, and a real
     // uppercase word must never be eaten. Collapses the whitespace the removal leaves behind.
+    //
+    // INVARIANT: the output is stored as CongressionalTrade.AssetName, which is part of the
+    // trade upsert unique key. Any change to what this method emits makes re-scraped trades
+    // miss their stored rows and re-insert as duplicates (the original rollout of this cleanup
+    // duplicated 8,104 production trades that way). A semantic change here MUST ship with a
+    // data repair that re-normalizes and dedupes already-stored rows.
     public static string CleanAssetName(string assetName)
     {
         if (string.IsNullOrEmpty(assetName))

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
@@ -1,0 +1,97 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Congress;
+
+// The stored AssetName is part of the congressional-trade upsert unique key, so BuildTrades
+// must be the normalization choke point: a transaction whose emitter forgot to clean the name
+// (or a stored variant produced by an older normalization) must never reach the upsert with a
+// dirty name — a mismatch there re-inserts the same trade as a duplicate row. The #4111
+// CleanAssetName rollout duplicated 8,104 production trades exactly this way, because the
+// scrapers started emitting cleaned names that no longer matched the stored dirty ones.
+public class CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests
+{
+    [Theory]
+    [InlineData(
+        "Space Exploration Technologies Corp.  - Class A Common Stock (SPCX)",
+        "Space Exploration Technologies Corp. - Class A Common Stock (SPCX)"
+    )]
+    [InlineData("Weyerhaeuser Company (WY) gfedcb", "Weyerhaeuser Company (WY)")]
+    [InlineData("Apple Inc. (AAPL)", "Apple Inc. (AAPL)")]
+    public void BuildTrades_NormalizesAssetNameForTheUpsertKey(string raw, string expected)
+    {
+        var sut = CreateService();
+        var member = new CongressMember { Name = "Jane Doe" };
+        var stock = new CommonStock();
+        var transaction = new DisclosureTransaction
+        {
+            MemberName = "Jane Doe",
+            Ticker = "WY",
+            AssetName = raw,
+            TransactionDate = new DateOnly(2026, 6, 18),
+            FilingDate = new DateOnly(2026, 7, 2),
+            TransactionType = CongressTransactionType.Purchase,
+            AmountFrom = 1001,
+            AmountTo = 15000,
+        };
+
+        var trades = sut.BuildTrades(
+            [transaction],
+            new Dictionary<string, CongressMember> { ["Jane Doe"] = member },
+            new Dictionary<string, CommonStock> { ["WY"] = stock }
+        );
+
+        trades.Should().ContainSingle().Which.AssetName.Should().Be(expected);
+    }
+
+    [Fact]
+    public void BuildTrades_NullAssetName_StoresEmptyString()
+    {
+        var sut = CreateService();
+        var member = new CongressMember { Name = "Jane Doe" };
+        var transaction = new DisclosureTransaction
+        {
+            MemberName = "Jane Doe",
+            Ticker = "WY",
+            AssetName = null,
+            TransactionDate = new DateOnly(2026, 6, 18),
+            FilingDate = new DateOnly(2026, 7, 2),
+            TransactionType = CongressTransactionType.Purchase,
+        };
+
+        var trades = sut.BuildTrades(
+            [transaction],
+            new Dictionary<string, CongressMember> { ["Jane Doe"] = member },
+            new Dictionary<string, CommonStock> { ["WY"] = new CommonStock() }
+        );
+
+        trades.Should().ContainSingle().Which.AssetName.Should().Be("");
+    }
+
+    private static CongressionalTradeSyncService CreateService()
+    {
+        var scope = Substitute.For<IServiceScope>();
+        scope.ServiceProvider.Returns(Substitute.For<IServiceProvider>());
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+
+        return new CongressionalTradeSyncService(
+            scopeFactory,
+            Options.Create(new WorkerOptions()),
+            Substitute.For<ILogger<CongressionalTradeSyncService>>(),
+            errorReporter
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The #4111 CleanAssetName rollout changed the asset names the scrapers emit, while already-stored rows kept the dirty variants (double spaces, `gfedc`/`gfedcb` checkbox artifacts). Because `AssetName` participates in the congressional-trade upsert unique key, the very next re-scrape missed every stored dirty-named row and re-inserted the same trades as new rows — 8,104 duplicated production trades (repaired in place on the production database: redundant twins deleted, remaining 916 dirty names normalized).

This PR prevents the same failure class going forward:

- `BuildTrades` now applies `CleanAssetName` itself, making it the single normalization choke point before the upsert — no emitter path (current or future) can reach the key with an unnormalized name. Mirrors the `NormalizeMemberName` pattern from GH-3374.
- The invariant is documented at both ends: `CleanAssetName` (whose output is the stored key value — any semantic change must ship with a data repair that re-normalizes and dedupes stored rows) and the `PersistTrades` upsert key.

## Code changes

- `src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs` — `BuildTrades` cleans `AssetName` at entity construction (and is now `internal` for the test); invariant note on the upsert `On(...)` key.
- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — invariant warning on `CleanAssetName`.
- `tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs` — pins that `BuildTrades` normalizes dirty names (whitespace variant, checkbox artifact), passes clean names through, and stores `""` for null.

All 3,312 unit tests pass locally.