### PR TITLE
fix(congress): OwnerType and amount bracket join the trade upsert key — distinct same-day trades were collapsing

### DIFF
--- a/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
+++ b/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
@@ -8,7 +8,17 @@ public class CongressModuleConfiguration : Equibles.Data.IFinancialModule
     public void ConfigureEntities(ModelBuilder builder)
     {
         builder.Entity<CongressMember>();
-        builder.Entity<CongressionalTrade>();
+        // Default value has no data annotation, so it must be Fluent: OwnerType is a required
+        // member of the trade upsert unique key, and the '' default lets the migration backfill
+        // pre-existing NULL rows when the column tightens to NOT NULL. ValueGeneratedNever is
+        // load-bearing: HasDefaultValue alone marks the column ValueGenerated.OnAdd, and the
+        // FlexLabs upsert rejects generated columns in its match key (the scraper writes the
+        // value on every insert, so nothing is ever DB-generated here).
+        builder
+            .Entity<CongressionalTrade>()
+            .Property(t => t.OwnerType)
+            .HasDefaultValue("")
+            .ValueGeneratedNever();
         builder.Entity<CongressionalAnnualDisclosure>();
         builder.Entity<CongressionalDisclosureLine>();
     }

--- a/src/Equibles.Congress.Data/Models/CongressionalTrade.cs
+++ b/src/Equibles.Congress.Data/Models/CongressionalTrade.cs
@@ -7,12 +7,21 @@ namespace Equibles.Congress.Data.Models;
 
 [Index(nameof(CommonStockId), nameof(TransactionDate))]
 [Index(nameof(CongressMemberId), nameof(TransactionDate))]
+// The trade identity / upsert key (see CongressionalTradeSyncService.PersistTrades). OwnerType
+// and the amount bracket are part of a trade's identity: a member can file two same-day
+// purchases of the same stock that differ only in bracket or in who holds them (self vs.
+// spouse vs. dependent child), and without those columns the second one is silently dropped.
+// FilingDate is deliberately EXCLUDED — the disclosure feeds re-date the same filing between
+// scrapes, so keying on it would re-insert existing trades as duplicates.
 [Index(
     nameof(CommonStockId),
     nameof(CongressMemberId),
     nameof(TransactionDate),
     nameof(TransactionType),
     nameof(AssetName),
+    nameof(OwnerType),
+    nameof(AmountFrom),
+    nameof(AmountTo),
     IsUnique = true
 )]
 [Index(nameof(FilingDate))]
@@ -33,6 +42,10 @@ public class CongressionalTrade
 
     public CongressTransactionType TransactionType { get; set; }
 
+    // Not-null with a '' default (see CongressModuleConfiguration): OwnerType is part of the
+    // unique key above, and Postgres treats NULLs as distinct in unique indexes — a nullable
+    // column here would silently disable dedup for every trade without an owner annotation.
+    [Required]
     [MaxLength(64)]
     public string OwnerType { get; set; }
 

--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -232,7 +232,9 @@ public class CongressionalTradeSyncService
                     TransactionDate = tx.TransactionDate,
                     FilingDate = tx.FilingDate,
                     TransactionType = tx.TransactionType,
-                    OwnerType = tx.OwnerType,
+                    // '' rather than null: OwnerType is part of the upsert key, and Postgres
+                    // treats NULLs as distinct in unique indexes, which would disable dedup.
+                    OwnerType = tx.OwnerType ?? "",
                     // The stored name is part of the trade upsert key (see PersistTrades), so it
                     // must be normalized here no matter which scraper emitted the transaction —
                     // an unnormalized variant would re-insert the same trade as a new row. Every
@@ -254,8 +256,10 @@ public class CongressionalTradeSyncService
         CancellationToken ct
     )
     {
-        // AssetName participates in this key, so dedup only works while stored names equal the
-        // current CleanAssetName output — see the invariant note on CleanAssetName.
+        // Must match the unique index on CongressionalTrade exactly (see the identity note on
+        // the entity) or ON CONFLICT has no arbiter and the upsert throws. AssetName
+        // participates, so dedup only works while stored names equal the current
+        // CleanAssetName output — see the invariant note on CleanAssetName.
         await dbContext
             .Set<CongressionalTrade>()
             .UpsertRange(trades)
@@ -266,6 +270,9 @@ public class CongressionalTradeSyncService
                 t.TransactionDate,
                 t.TransactionType,
                 t.AssetName,
+                t.OwnerType,
+                t.AmountFrom,
+                t.AmountTo,
             })
             .NoUpdate()
             .RunAsync(ct);

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -91,7 +91,7 @@ public class CongressTools
                         var position = t.CongressMember.Position.NameForHumans();
                         var type = t.TransactionType.NameForHumans();
                         var amount = FormatAmountRange(t);
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {t.OwnerType ?? "—"} |";
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {(string.IsNullOrEmpty(t.OwnerType) ? "—" : t.OwnerType)} |";
                     }
                 );
             },
@@ -151,7 +151,7 @@ public class CongressTools
                     {
                         var type = t.TransactionType.NameForHumans();
                         var amount = FormatAmountRange(t);
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {t.OwnerType ?? "—"} |";
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {(string.IsNullOrEmpty(t.OwnerType) ? "—" : t.OwnerType)} |";
                     }
                 );
             },

--- a/src/Equibles.Migrations/Migrations/20260708010525_WidenCongressionalTradeUpsertKey.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260708010525_WidenCongressionalTradeUpsertKey.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708010525_WidenCongressionalTradeUpsertKey")]
+    partial class WidenCongressionalTradeUpsertKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260708010525_WidenCongressionalTradeUpsertKey.cs
+++ b/src/Equibles.Migrations/Migrations/20260708010525_WidenCongressionalTradeUpsertKey.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenCongressionalTradeUpsertKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CongressionalTrade_CommonStockId_CongressMemberId_Transacti~",
+                table: "CongressionalTrade");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OwnerType",
+                table: "CongressionalTrade",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CongressionalTrade_CommonStockId_CongressMemberId_Transacti~",
+                table: "CongressionalTrade",
+                columns: new[] { "CommonStockId", "CongressMemberId", "TransactionDate", "TransactionType", "AssetName", "OwnerType", "AmountFrom", "AmountTo" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CongressionalTrade_CommonStockId_CongressMemberId_Transacti~",
+                table: "CongressionalTrade");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OwnerType",
+                table: "CongressionalTrade",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldDefaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CongressionalTrade_CommonStockId_CongressMemberId_Transacti~",
+                table: "CongressionalTrade",
+                columns: new[] { "CommonStockId", "CongressMemberId", "TransactionDate", "TransactionType", "AssetName" },
+                unique: true);
+        }
+    }
+}

--- a/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
@@ -28,7 +28,7 @@
                             <td class="max-w-xs truncate">@(t.CongressMember?.Name ?? "Unknown")</td>
                             <td class="hidden md:table-cell text-sm text-base-content/60">@position</td>
                             <td><span class="badge @badgeClass badge-sm">@typeLabel</span></td>
-                            <td class="hidden md:table-cell text-sm text-base-content/60">@(t.OwnerType ?? "—")</td>
+                            <td class="hidden md:table-cell text-sm text-base-content/60">@(string.IsNullOrEmpty(t.OwnerType) ? "—" : t.OwnerType)</td>
                             <td class="text-right font-mono">@FormatAmount(t.AmountFrom, t.AmountTo)</td>
                             <td class="hidden lg:table-cell text-sm text-base-content/60">@t.FilingDate.ToString("yyyy-MM-dd")</td>
                         </tr>

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
@@ -56,7 +56,13 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
         );
     }
 
-    private static DisclosureTransaction Txn(string member, string ticker) =>
+    private static DisclosureTransaction Txn(
+        string member,
+        string ticker,
+        string ownerType = "self",
+        long amountFrom = 1_001,
+        long amountTo = 15_000
+    ) =>
         new()
         {
             MemberName = member,
@@ -66,9 +72,9 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
             TransactionDate = new DateOnly(2024, 6, 1),
             FilingDate = new DateOnly(2024, 6, 15),
             TransactionType = CongressTransactionType.Purchase,
-            OwnerType = "self",
-            AmountFrom = 1_001,
-            AmountTo = 15_000,
+            OwnerType = ownerType,
+            AmountFrom = amountFrom,
+            AmountTo = amountTo,
         };
 
     [Fact]
@@ -92,6 +98,38 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
         var trades = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
         trades.Should().ContainSingle();
         trades[0].CongressMemberId.Should().Be(member.Id);
+    }
+
+    // A member can file several same-day purchases of the same stock that differ only in the
+    // amount bracket or in who holds them (self vs. a dependent child). OwnerType and the
+    // amount bounds are part of the upsert unique key precisely so those are distinct trades;
+    // before they were added, the second one silently collapsed into the first (NoUpdate).
+    // Re-processing the same batch must still insert nothing new.
+    [Fact]
+    public async Task ProcessTransactions_DistinctSameDayTrades_AllPersistAndReprocessAddsNothing()
+    {
+        DbContext.Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc." });
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var transactions = new List<DisclosureTransaction>
+        {
+            Txn("Jane Doe", "AAPL"),
+            Txn("Jane Doe", "AAPL", amountFrom: 15_001, amountTo: 50_000),
+            Txn("Jane Doe", "AAPL", ownerType: "DC"),
+        };
+        var sut = BuildSut();
+
+        await (Task)ProcessTransactionsMethod.Invoke(sut, [transactions, CancellationToken.None]);
+        await (Task)ProcessTransactionsMethod.Invoke(sut, [transactions, CancellationToken.None]);
+
+        await using var verify = Fixture.CreateDbContext();
+        var trades = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
+        trades.Should().HaveCount(3);
+        trades
+            .Select(t => (t.OwnerType, t.AmountFrom))
+            .Should()
+            .BeEquivalentTo([("self", 1_001L), ("self", 15_001L), ("DC", 1_001L)]);
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Web/DataCountServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/DataCountServiceTests.cs
@@ -317,6 +317,7 @@ public class DataCountServiceTests : IDisposable
                     TransactionType = CongressTransactionType.Purchase,
                     AssetName = "Apple Inc. Common Stock",
                     AmountFrom = 1001,
+                    OwnerType = "self",
                     AmountTo = 15000,
                 },
                 new CongressionalTrade
@@ -328,6 +329,7 @@ public class DataCountServiceTests : IDisposable
                     TransactionType = CongressTransactionType.Sale,
                     AssetName = "Apple Inc. Options",
                     AmountFrom = 15001,
+                    OwnerType = "self",
                     AmountTo = 50000,
                 }
             );

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceEventTabsMinSyncDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceEventTabsMinSyncDateTests.cs
@@ -205,6 +205,7 @@ public class StockTabServiceEventTabsMinSyncDateTests : IDisposable
             FilingDate = date.AddDays(10),
             TransactionType = CongressTransactionType.Purchase,
             AssetName = "Apple Inc. Common Stock",
+            OwnerType = "self",
             AmountFrom = 1_001,
             AmountTo = 15_000,
         };

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs
@@ -627,6 +627,7 @@ public class StockTabServiceTests : IDisposable
                     TransactionType = CongressTransactionType.Purchase,
                     AssetName = "Apple Inc. Common Stock",
                     AmountFrom = 1_001,
+                    OwnerType = "self",
                     AmountTo = 15_000,
                 },
                 new CongressionalTrade
@@ -638,6 +639,7 @@ public class StockTabServiceTests : IDisposable
                     TransactionType = CongressTransactionType.Sale,
                     AssetName = "Apple Inc. Options",
                     AmountFrom = 15_001,
+                    OwnerType = "self",
                     AmountTo = 50_000,
                 }
             );
@@ -680,6 +682,7 @@ public class StockTabServiceTests : IDisposable
                     TransactionType = CongressTransactionType.Purchase,
                     AssetName = "Apple Inc.",
                     AmountFrom = 1_001,
+                    OwnerType = "self",
                     AmountTo = 15_000,
                 }
             );

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
@@ -76,6 +76,33 @@ public class CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests
         trades.Should().ContainSingle().Which.AssetName.Should().Be("");
     }
 
+    // OwnerType joined the upsert unique key, and Postgres treats NULLs as distinct in unique
+    // indexes — a null slipping through here would disable dedup for that trade entirely.
+    [Fact]
+    public void BuildTrades_NullOwnerType_StoresEmptyString()
+    {
+        var sut = CreateService();
+        var member = new CongressMember { Name = "Jane Doe" };
+        var transaction = new DisclosureTransaction
+        {
+            MemberName = "Jane Doe",
+            Ticker = "WY",
+            AssetName = "Weyerhaeuser Company (WY)",
+            OwnerType = null,
+            TransactionDate = new DateOnly(2026, 6, 18),
+            FilingDate = new DateOnly(2026, 7, 2),
+            TransactionType = CongressTransactionType.Purchase,
+        };
+
+        var trades = sut.BuildTrades(
+            [transaction],
+            new Dictionary<string, CongressMember> { ["Jane Doe"] = member },
+            new Dictionary<string, CommonStock> { ["WY"] = new CommonStock() }
+        );
+
+        trades.Should().ContainSingle().Which.OwnerType.Should().Be("");
+    }
+
     private static CongressionalTradeSyncService CreateService()
     {
         var scope = Substitute.For<IServiceScope>();


### PR DESCRIPTION
## Summary

The congressional-trade upsert key was `(stock, member, transaction date, type, asset name)` — amounts and owner type were not part of a trade's identity. A member's second same-day purchase of the same stock (a different amount bracket, or held by a spouse/dependent child instead of self) matched the first row and was silently dropped by `NoUpdate`.

The unique index and the upsert `On()` now include `OwnerType`, `AmountFrom` and `AmountTo`. `FilingDate` stays out deliberately: the disclosure feeds re-date the same filing between scrapes (observed in production), so keying on it would re-insert existing trades as duplicates.

Two load-bearing details:

- **`OwnerType` tightens to NOT NULL with a `''` default** — Postgres treats NULLs as distinct in unique indexes, so a nullable key column would disable dedup for every trade without an owner annotation (45% of production rows are NULL today). The migration backfills them: `UPDATE … SET "OwnerType" = '' WHERE "OwnerType" IS NULL` before `SET NOT NULL` (verified in the generated SQL). `BuildTrades` coalesces null to `''` at the choke point.
- **`ValueGeneratedNever()` on the default** — `HasDefaultValue` alone marks the column `ValueGenerated.OnAdd`, and the FlexLabs upsert rejects generated columns in its match key, which would have broken every scrape cycle. The integration suite caught this.

## Code changes

- `Equibles.Congress.Data/Models/CongressionalTrade.cs` — widened unique index + identity rationale; `[Required]` OwnerType.
- `Equibles.Congress.Data/CongressModuleConfiguration.cs` — `HasDefaultValue("").ValueGeneratedNever()` for OwnerType.
- `Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs` — `OwnerType ?? ""` in BuildTrades; upsert `On()` matches the new index.
- `Equibles.Migrations` — `WidenCongressionalTradeUpsertKey` (drop/recreate unique index, NULL backfill, NOT NULL + default).
- `Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml`, `Equibles.Congress.Mcp/Tools/CongressTools.cs` — treat `''` owner type as absent (render em dash) now that NULLs become `''`.
- Tests — unit: BuildTrades coalesces null OwnerType; integration: three same-day trades differing only in bracket/owner all persist and re-processing adds nothing; seed fixtures updated for the NOT NULL column.

Unit 3,313 and integration 2,024 all green locally.