### PR TITLE
fix(sec): import companyfacts values served without a fiscal-period qualifier

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -283,24 +283,35 @@ public class FinancialFactsImportService
         CommonStock stock
     )
     {
-        if (!TryMapFiscalPeriod(value.Fp, out var fiscalPeriod))
-            return null;
         if (string.IsNullOrWhiteSpace(value.Accn))
             return null;
 
         var isInstant = value.Start == null;
         var periodStart = value.Start ?? value.End;
+        // SEC serves foreign private issuers' 6-K interim values with fp = null, so an
+        // unmappable fp must not drop the value outright — dropping them left every
+        // FPI's interim facts missing platform-wide. The date-derived identity below is
+        // the primary source anyway; the SEC-supplied fp is only its fallback.
+        var hasMappedFp = TryMapFiscalPeriod(value.Fp, out var fiscalPeriod);
         // Derive (FiscalYear, FiscalPeriod) from the period the fact actually
         // measures — the filing's fy/fp identifies the filing, not each
         // comparable-year value inside it (#982). Resolver returns null when
         // FYE info is missing or the duration shape is unrecognised; the
-        // original SEC-supplied identity is the fallback.
+        // original SEC-supplied identity is the fallback. Interim-instant
+        // classification is opted into only on the fp-less path, so fp-carrying
+        // values keep the exact identities they have always had.
         var resolved = FiscalPeriodResolver.Resolve(
             periodStart,
             value.End,
             stock.FiscalYearEndMonth,
-            stock.FiscalYearEndDay
+            stock.FiscalYearEndDay,
+            classifyInterimInstants: !hasMappedFp
         );
+        // With neither a mappable fp nor a date-derived identity the period cannot be
+        // placed — defaulting would route the fact into the annual bucket (the
+        // zero-valued enum member) and corrupt the dashboards, so it is dropped.
+        if (!hasMappedFp && resolved == null)
+            return null;
         return new ParsedFact
         {
             Taxonomy = taxonomy,

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
@@ -40,12 +40,22 @@ internal static class FiscalPeriodResolver
     /// <c>null</c> when the FYE is unknown or the period duration doesn't
     /// match any recognised shape — callers fall back to the filing-supplied
     /// identity in that case.
+    /// <para>
+    /// <paramref name="classifyInterimInstants"/> opts an instant that is NOT at the
+    /// fiscal-year end into quarter classification (which fiscal quarter contains the
+    /// date). Off by default: callers with an SEC-supplied fp rely on the null
+    /// fallback there, and re-labelling their instants would rewrite fiscal
+    /// identities corpus-wide. Only fp-less values (6-K interim balance sheets,
+    /// which SEC serves with <c>fp = null</c>) opt in — for them the date is the
+    /// only identity available.
+    /// </para>
     /// </summary>
     public static (int Year, SecFiscalPeriod Period)? Resolve(
         DateOnly periodStart,
         DateOnly periodEnd,
         int? fyeMonth,
-        int? fyeDay
+        int? fyeDay,
+        bool classifyInterimInstants = false
     )
     {
         if (fyeMonth is null || fyeDay is null)
@@ -78,16 +88,20 @@ internal static class FiscalPeriodResolver
         if (isAnnual || isInstant)
         {
             var closest = ClosestTo(candidates, periodEnd);
-            if (Math.Abs(closest.DayNumber - periodEnd.DayNumber) > FyeMatchWindowDays)
+            if (Math.Abs(closest.DayNumber - periodEnd.DayNumber) <= FyeMatchWindowDays)
+                return (closest.Year, SecFiscalPeriod.FullYear);
+            // An opted-in interim instant falls through to the quarter classification
+            // below; everything else keeps the null fallback (see the summary).
+            if (!isInstant || !classifyInterimInstants)
                 return null;
-            return (closest.Year, SecFiscalPeriod.FullYear);
         }
 
         var isQuarter = IsWithinDays(durationDays, QuarterMinDays, QuarterMaxDays);
         var isHalfYear = IsWithinDays(durationDays, HalfYearMinDays, HalfYearMaxDays);
         var isNineMonths = IsWithinDays(durationDays, NineMonthMinDays, NineMonthMaxDays);
 
-        if (!isQuarter && !isHalfYear && !isNineMonths)
+        var interimInstant = isInstant && classifyInterimInstants;
+        if (!interimInstant && !isQuarter && !isHalfYear && !isNineMonths)
             return null;
 
         // The fiscal year containing periodEnd is the one whose FYE is on or

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactUnmappableFpTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactUnmappableFpTests.cs
@@ -6,62 +6,33 @@ using Equibles.Sec.FinancialFacts.HostedService.Services;
 
 namespace Equibles.UnitTests.Sec;
 
+// Pins TryBuildParsedFact's handling of an unmappable fp token. SEC serves
+// foreign private issuers' 6-K interim values with fp = null (and pre-publish
+// filings occasionally carry placeholder tokens like "CQ1"), so an unmappable
+// fp must NOT drop the value outright — that left every FPI's interim facts
+// missing platform-wide. The date-derived identity (FiscalPeriodResolver) is
+// the primary source; the value is kept whenever the dates classify.
+//
+// The corruption the old reject guarded against is still guarded: when the
+// dates DON'T classify either (unknown FYE, unrecognised span), the value is
+// dropped rather than defaulting FiscalPeriod to the zero-valued enum member
+// (FullYear), which would route every unplaceable fact into the annual bucket.
 public class FinancialFactsImportServiceTryBuildParsedFactUnmappableFpTests
 {
-    // Sibling to FinancialFactsImportServiceTryBuildParsedFactWhitespaceAccnTests
-    // (whitespace-Accn rejection). This pin covers the structurally distinct
-    // FIRST early-return arm of TryBuildParsedFact:
-    //   if (!TryMapFiscalPeriod(value.Fp, out var fiscalPeriod)) return null;
-    //
-    // TryMapFiscalPeriod is itself exhaustively pinned per-arm (FY, Q1, Q2,
-    // Q3, Q4, Unknown — PRs #2272-#2275). This sibling pin defends the
-    // CALLER's reject-on-unmappable behavior: when TryMapFiscalPeriod
-    // returns false, TryBuildParsedFact must return null so the fact is
-    // dropped from the import set rather than fabricated with a default
-    // SecFiscalPeriod value.
-    //
-    // SEC's Company Facts API occasionally serves placeholder/future fp
-    // values: pre-publish "CQ1" (calendar Q1, distinct from fiscal Q1)
-    // values in pre-release filings, or future schema variants. The
-    // default(SecFiscalPeriod) for `fiscalPeriod` is FullYear (the
-    // zero-valued enum member). Without the reject — i.e. if a refactor
-    // dropped the early-return — every unmappable fp would silently
-    // default to FullYear and corrupt the dashboards by routing every
-    // unrecognized-period fact into the annual bucket.
-    //
-    // The risk this pin uniquely catches and that the whitespace-Accn
-    // sibling cannot:
-    //   • DROP-the-fp-early-return — `if (!TryMapFiscalPeriod(...)) ;`
-    //     (drop the return null body) — would compile, pass the
-    //     whitespace-Accn sibling (its Fp is "FY", valid), and silently
-    //     create a ParsedFact with FiscalPeriod=FullYear for every
-    //     unmappable wire input. CollapseToNaturalKey would then merge
-    //     it with the actual FullYear fact for the same period and
-    //     keep whichever has the later FiledDate — corrupting the
-    //     restated-value tracking.
-    //   • Wrong-arm-order regression — checking Accn before Fp would
-    //     change the production order of rejection but not the result
-    //     for this test (both are reject paths). Benign.
-    //   • SWAP-to-throw — `return null` → `throw new
-    //     ArgumentException(...)` — would compile, pass the whitespace
-    //     sibling (its Fp is "FY", success arm fires before the throw
-    //     could trigger), and crash on every legacy-format fp value.
-    //
-    // Pin: build a CompanyFactValue with Fp="FOOBAR" (a fully unrecognised
-    // wire token that exercises only the unmappable-Fp branch). Assert
-    // the helper returns null. Reflection-invoke since private static.
-    //
-    // After this PR, the two reject paths of TryBuildParsedFact (unmappable
-    // Fp + whitespace Accn) are individually defended.
-    [Fact]
-    public void TryBuildParsedFact_UnmappableFpToken_ReturnsNull()
+    private static object Invoke(CompanyFactValue value, CommonStock stock)
     {
         var method = typeof(FinancialFactsImportService).GetMethod(
             "TryBuildParsedFact",
             BindingFlags.NonPublic | BindingFlags.Static
         );
+        return method!.Invoke(
+            null,
+            [FactTaxonomy.UsGaap, "Revenues", "Revenues", null, "USD", value, stock]
+        );
+    }
 
-        var value = new CompanyFactValue
+    private static CompanyFactValue UnmappableFpInstant() =>
+        new()
         {
             Fp = "FOOBAR",
             Accn = "0000320193-24-000001",
@@ -70,6 +41,11 @@ public class FinancialFactsImportServiceTryBuildParsedFactUnmappableFpTests
             Fy = 2024,
             Filed = new DateOnly(2025, 1, 15),
         };
+
+    [Fact]
+    public void TryBuildParsedFact_UnmappableFpWithResolvableDates_KeepsDateDerivedIdentity()
+    {
+        // Instant at Dec 31 against a Sep-30 FYE: first quarter of FY2025.
         var stock = new CommonStock
         {
             Ticker = "AAPL",
@@ -77,10 +53,22 @@ public class FinancialFactsImportServiceTryBuildParsedFactUnmappableFpTests
             FiscalYearEndDay = 30,
         };
 
-        var result = method!.Invoke(
-            null,
-            [FactTaxonomy.UsGaap, "Revenues", "Revenues", null, "USD", value, stock]
-        );
+        var result = Invoke(UnmappableFpInstant(), stock);
+
+        result.Should().NotBeNull("the date-derived identity places the period without an fp");
+        var type = result.GetType();
+        type.GetProperty("FiscalYear")!.GetValue(result).Should().Be(2025);
+        type.GetProperty("FiscalPeriod")!.GetValue(result).Should().Be(SecFiscalPeriod.Q1);
+    }
+
+    [Fact]
+    public void TryBuildParsedFact_UnmappableFpAndUnknownFye_ReturnsNull()
+    {
+        // No fiscal-year end on the stock → the resolver cannot place the period
+        // either; defaulting would corrupt the annual bucket, so the value drops.
+        var stock = new CommonStock { Ticker = "AAPL" };
+
+        var result = Invoke(UnmappableFpInstant(), stock);
 
         result.Should().BeNull();
     }

--- a/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverInterimInstantOptInTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverInterimInstantOptInTests.cs
@@ -1,0 +1,73 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the opt-in interim-instant classification: an fp-less companyfacts value
+/// (SEC serves 6-K interim balance sheets with <c>fp = null</c>) has only its date
+/// as identity, so <c>classifyInterimInstants: true</c> resolves a mid-year
+/// instant to the fiscal quarter containing it. The flag must not disturb the
+/// two existing contracts: an at-FYE instant still resolves to FullYear, and
+/// default callers (no flag) still get null for a mid-year instant so the
+/// SEC-supplied identity keeps winning for fp-carrying values (#982).
+/// </summary>
+public class FiscalPeriodResolverInterimInstantOptInTests
+{
+    [Theory]
+    [InlineData(3, 31, SecFiscalPeriod.Q1)]
+    [InlineData(6, 30, SecFiscalPeriod.Q2)]
+    [InlineData(9, 30, SecFiscalPeriod.Q3)]
+    public void Resolve_OptedInInterimInstant_ClassifiesByContainingQuarter(
+        int month,
+        int day,
+        SecFiscalPeriod expected
+    )
+    {
+        var instant = new DateOnly(2024, month, day);
+
+        var result = FiscalPeriodResolver.Resolve(
+            instant,
+            instant,
+            12,
+            31,
+            classifyInterimInstants: true
+        );
+
+        result.Should().Be((2024, expected));
+    }
+
+    [Fact]
+    public void Resolve_OptedInInstantAtFye_StillResolvesFullYear()
+    {
+        var instant = new DateOnly(2024, 12, 31);
+
+        var result = FiscalPeriodResolver.Resolve(
+            instant,
+            instant,
+            12,
+            31,
+            classifyInterimInstants: true
+        );
+
+        result.Should().Be((2024, SecFiscalPeriod.FullYear));
+    }
+
+    [Fact]
+    public void Resolve_OptedInUnrecognisedDuration_StillReturnsNull()
+    {
+        // The opt-in covers instants only — a 130-day span is neither a quarter
+        // nor a half-year whatever the caller asked for.
+        var end = new DateOnly(2024, 6, 30);
+
+        var result = FiscalPeriodResolver.Resolve(
+            end.AddDays(-130),
+            end,
+            12,
+            31,
+            classifyInterimInstants: true
+        );
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
SEC's companyfacts API serves foreign private issuers' 6-K interim values with **`fp: null`** (verified live: SBLK CIK 1386716, `IncreaseDecreaseInDueToRelatedPartiesCurrent` @ 2023-06-30 → `{val: 474000, fp: null, form: "6-K"}`). `FinancialFactsImportService.TryBuildParsedFact` rejected any value whose `fp` did not map to FY/Q1–Q4, so **every FPI's interim facts were wholesale dropped** — missing from screening, statements, and every downstream surface. This also produced the largest residual family in the downstream financials-reconciliation audit (6-K is the top form among its missing-fact findings).

## Code changes
- `TryBuildParsedFact`: an unmappable `fp` no longer drops the value — the date-derived identity (`FiscalPeriodResolver.Resolve`, already the primary source per #982) places it. Only when **both** the `fp` is unmappable **and** the resolver returns null is the value dropped, preserving the original guard's purpose (never default an unplaceable period into the annual bucket, the zero-valued enum member).
- `FiscalPeriodResolver`: new opt-in `classifyInterimInstants` parameter — a mid-year instant (6-K balance-sheet date) classifies to the fiscal quarter containing it. **Off by default**, so fp-carrying callers keep byte-identical behavior (their instants still fall back to the SEC-supplied identity; nothing re-labels).
- Tests: rewrote `...TryBuildParsedFactUnmappableFpTests` for the new contract (kept with date-derived identity; dropped when the FYE is unknown) and added `FiscalPeriodResolverInterimInstantOptInTests` (Q1/Q2/Q3 classification, at-FYE still FullYear, non-instant spans unaffected).

## Verification
Full unit suite green (3,318). Existing pins for the at-FYE instant, far-instant-null (default path), and every mapped-fp arm unchanged and passing.