### PR TITLE
feat(sec): classify each ticker's listed security from the cover-page 12(b) table

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -39,6 +39,22 @@ public class CommonStock
     public double MarketCapitalization { get; set; }
     public long SharesOutStanding { get; set; }
 
+    /// <summary>
+    /// What kind of security this row's ticker is, classified from the issuer's SEC
+    /// cover-page 12(b) registration table (see <see cref="ListedSecurityType"/>).
+    /// <see cref="ListedSecurityType.Unknown"/> until a filing whose 12(b) table
+    /// carries the ticker has been extracted.
+    /// </summary>
+    public ListedSecurityType ListedSecurityType { get; set; }
+
+    /// <summary>
+    /// The <c>dei:Security12bTitle</c> the classification came from (e.g.
+    /// "6.875% Senior Secured Notes due 2068"), verbatim from the filing; null
+    /// while <see cref="ListedSecurityType"/> is <see cref="ListedSecurityType.Unknown"/>.
+    /// </summary>
+    [MaxLength(500)]
+    public string ListedSecurityTitle { get; set; }
+
     public List<string> SecondaryTickers
     {
         get => field ?? [];

--- a/src/Equibles.CommonStocks.Data/Models/ListedSecurityType.cs
+++ b/src/Equibles.CommonStocks.Data/Models/ListedSecurityType.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// What kind of security a stock row's ticker actually is, classified from the
+/// issuer's SEC cover-page 12(b) registration table (<c>dei:Security12bTitle</c>
+/// matched to the row's ticker via <c>dei:TradingSymbol</c>) — the authoritative
+/// statement of each listed security's title, never a ticker or name heuristic.
+/// The stock universe is keyed by tickers carrying FINRA/price data, so a row can
+/// be an issuer's exchange-traded note or preferred series rather than its common
+/// equity (e.g. a bankrupt issuer whose only listed security is a baby bond);
+/// per-share figures computed against such a row's common-share record are
+/// meaningless, and equity-only surfaces exclude the unambiguously non-equity
+/// kinds (<see cref="PreferredShares"/>, <see cref="DebtSecurities"/>,
+/// <see cref="Warrants"/>, <see cref="Rights"/>). <see cref="Units"/> stays
+/// included: MLP common units (Energy Transfer, Enterprise Products) are genuine
+/// operating equity, indistinguishable by title from fund units.
+/// </summary>
+public enum ListedSecurityType
+{
+    /// <summary>
+    /// No 12(b) registration row matches the ticker — the issuer lists nothing on
+    /// an exchange (OTC / 12(g) registrants), the cover page has not been
+    /// extracted yet, or the ticker on record differs from the filed symbol.
+    /// Treated as equity by surfaces: exclusion requires positive evidence.
+    /// </summary>
+    [Display(Name = "Unknown")]
+    Unknown = 0,
+
+    /// <summary>Common stock, ordinary shares, ADS/ADR, or REIT shares of beneficial interest.</summary>
+    [Display(Name = "Common shares")]
+    CommonShares = 1,
+
+    /// <summary>A preferred/preference series, including depositary shares representing one.</summary>
+    [Display(Name = "Preferred shares")]
+    PreferredShares = 2,
+
+    /// <summary>Exchange-traded debt — notes, debentures, or bonds (baby bonds).</summary>
+    [Display(Name = "Debt securities")]
+    DebtSecurities = 3,
+
+    [Display(Name = "Warrants")]
+    Warrants = 4,
+
+    [Display(Name = "Rights")]
+    Rights = 5,
+
+    /// <summary>
+    /// Units — SPAC units, fund/trust units, or MLP common units. Deliberately NOT
+    /// excluded from equity surfaces: MLP common units are operating equity.
+    /// </summary>
+    [Display(Name = "Units")]
+    Units = 6,
+
+    /// <summary>A 12(b) title that fits no known kind; treated as equity, like <see cref="Unknown"/>.</summary>
+    [Display(Name = "Other")]
+    Other = 7,
+}

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.CorporateActions.Data;
@@ -30,6 +31,24 @@ public class ShortSqueezeScoreManager
 {
     /// <summary>Each trend window pools two calendar weeks of daily short-volume rows.</summary>
     public const int TrendWindowDays = 14;
+
+    /// <summary>
+    /// The listed-security kinds that can never be squeeze candidates: FINRA
+    /// reports short interest on these tickers (exchange-traded notes,
+    /// preferred series, warrants, rights), but the issuer's common-share
+    /// record is the wrong denominator for them, so no honest ratio exists.
+    /// Classified from the SEC 12(b) cover-page title (see
+    /// <see cref="ListedSecurityType"/>); Unknown/Other/Units stay in — MLP
+    /// common units are genuine operating equity, and exclusion requires
+    /// positive evidence.
+    /// </summary>
+    private static readonly ListedSecurityType[] NonEquityListingTypes =
+    [
+        ListedSecurityType.PreferredShares,
+        ListedSecurityType.DebtSecurities,
+        ListedSecurityType.Warrants,
+        ListedSecurityType.Rights,
+    ];
 
     /// <summary>
     /// Highest short-interest-to-shares-outstanding ratio accepted as a real measurement. No
@@ -95,7 +114,11 @@ public class ShortSqueezeScoreManager
         var stockIds = shortInterests.Select(s => s.CommonStockId).Distinct().ToList();
         var stocks = await _commonStockRepository
             .GetAll()
-            .Where(s => stockIds.Contains(s.Id) && s.SharesOutStanding > 0)
+            .Where(s =>
+                stockIds.Contains(s.Id)
+                && s.SharesOutStanding > 0
+                && !NonEquityListingTypes.Contains(s.ListedSecurityType)
+            )
             .Select(s => new
             {
                 s.Id,

--- a/src/Equibles.Migrations/Migrations/20260708013533_AddListedSecurityClassification.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260708013533_AddListedSecurityClassification.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708013533_AddListedSecurityClassification")]
+    partial class AddListedSecurityClassification
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260708013533_AddListedSecurityClassification.cs
+++ b/src/Equibles.Migrations/Migrations/20260708013533_AddListedSecurityClassification.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddListedSecurityClassification : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ListedSecurityTitle",
+                table: "CommonStock",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ListedSecurityType",
+                table: "CommonStock",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "ListedSecurity",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TradingSymbol = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Title = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    ExchangeName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    AccessionNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    FiledDate = table.Column<DateOnly>(type: "date", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ListedSecurity", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ListedSecurity_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ListedSecurity_CommonStockId_TradingSymbol",
+                table: "ListedSecurity",
+                columns: new[] { "CommonStockId", "TradingSymbol" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ListedSecurity");
+
+            migrationBuilder.DropColumn(
+                name: "ListedSecurityTitle",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "ListedSecurityType",
+                table: "CommonStock");
+        }
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ListedSecurityClassifier.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ListedSecurityClassifier.cs
@@ -1,0 +1,117 @@
+using System.Text.RegularExpressions;
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic;
+
+/// <summary>
+/// Maps a security's SEC 12(b) registration title (<c>dei:Security12bTitle</c>)
+/// to its <see cref="ListedSecurityType"/>. The title is the issuer's own
+/// authoritative statement of what the listed security is, so this is a
+/// deterministic mapping of the designated field — not a ticker or company-name
+/// heuristic, which the data-accuracy rules forbid.
+///
+/// <para>
+/// Three ordered rules, each matching whole words only:
+/// <list type="number">
+/// <item>Rider clauses are stripped first — parenthetical segments and
+/// trailing "associated …" language ("Common Stock (and associated Preferred
+/// Share Purchase Rights)") describe a poison-pill rider attached to the
+/// security, not the security itself; classifying them would exclude genuine
+/// common stock.</item>
+/// <item>A "purchase warrants/rights/units" phrase names the security by its
+/// trailing head noun ("Common Stock Purchase Warrants" is a listed warrant),
+/// so that wrapper wins. The phrase requires the wrapper immediately after
+/// "purchase": "Warrants to purchase Common Units" does not fire it.</item>
+/// <item>Otherwise the kind whose keyword appears EARLIEST in the remaining
+/// title wins — titles lead with the security's own noun and then describe
+/// what they bundle ("Units, each consisting of one share of Class A Common
+/// Stock and one Warrant") or convert into ("Warrants to purchase Common
+/// Units").</item>
+/// </list>
+/// One deliberate asymmetry: bare "depositary shares" is not a common-equity
+/// keyword (those receipts usually wrap a preferred series, named later in the
+/// title), while "American depositary shares" is — an ADS is the US-listed
+/// form of ordinary shares. Titles matching nothing map to
+/// <see cref="ListedSecurityType.Other"/>, which surfaces treat exactly like
+/// <see cref="ListedSecurityType.Unknown"/> — exclusion always requires
+/// positive evidence.
+/// </para>
+/// </summary>
+public static class ListedSecurityClassifier
+{
+    // Whole-word, case-insensitive tests. Word boundaries stop "rights" from
+    // matching inside "brights" and "unit" inside "united"; singular/plural is
+    // handled by matching the stem with an optional 's'.
+    private static readonly (Regex Pattern, ListedSecurityType Type)[] Kinds =
+    [
+        (Pattern("warrants?"), ListedSecurityType.Warrants),
+        (Pattern("rights?"), ListedSecurityType.Rights),
+        (Pattern("units?"), ListedSecurityType.Units),
+        (Pattern("preferred|preference"), ListedSecurityType.PreferredShares),
+        (Pattern("notes?|debentures?|bonds?"), ListedSecurityType.DebtSecurities),
+        (
+            Pattern(
+                "common (stock|shares?)|ordinary shares?|american depositary (shares?|receipts?)|shares? of beneficial interest"
+            ),
+            ListedSecurityType.CommonShares
+        ),
+    ];
+
+    // Rider language: a parenthetical segment, or a clause from "associated"
+    // (optionally led by ", and" / "together with") to the end of the title.
+    // Both always describe something attached to the listed security.
+    private static readonly Regex Parenthetical = new(
+        @"\([^)]*\)",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled
+    );
+    private static readonly Regex AssociatedTail = new(
+        @"[,;]?\s+(and\s+|together\s+with\s+)?(the\s+)?associated\b.*$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled
+    );
+
+    // "… Purchase Warrants" / "… Purchase Rights" / "… Purchase Units": the
+    // wrapper immediately after "purchase" is the title's head noun.
+    private static readonly (Regex Pattern, ListedSecurityType Type)[] PurchaseWrappers =
+    [
+        (Pattern("purchase warrants?"), ListedSecurityType.Warrants),
+        (Pattern("purchase rights?"), ListedSecurityType.Rights),
+        (Pattern("purchase units?"), ListedSecurityType.Units),
+    ];
+
+    private static Regex Pattern(string body) =>
+        new(
+            $@"\b(?:{body})\b",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled
+        );
+
+    public static ListedSecurityType Classify(string securityTitle)
+    {
+        if (string.IsNullOrWhiteSpace(securityTitle))
+            return ListedSecurityType.Unknown;
+
+        var title = AssociatedTail.Replace(Parenthetical.Replace(securityTitle, " "), " ");
+        if (string.IsNullOrWhiteSpace(title))
+            return ListedSecurityType.Other;
+
+        foreach (var (pattern, type) in PurchaseWrappers)
+        {
+            if (pattern.IsMatch(title))
+                return type;
+        }
+
+        var best = ListedSecurityType.Other;
+        var bestIndex = int.MaxValue;
+        foreach (var (pattern, type) in Kinds)
+        {
+            var match = pattern.Match(title);
+            // Strict '<': on the (unobserved) chance two kinds match at the same
+            // position, the earlier entry in Kinds wins deterministically.
+            if (match.Success && match.Index < bestIndex)
+            {
+                bestIndex = match.Index;
+                best = type;
+            }
+        }
+        return best;
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/InlineXbrlParseResult.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/InlineXbrlParseResult.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+
+/// <summary>
+/// Everything one pass over an inline-XBRL envelope yields: the numeric facts
+/// and the cover-page 12(b) security listings. Combined so the multi-megabyte
+/// document is DOM-parsed once for both.
+/// </summary>
+public class InlineXbrlParseResult
+{
+    public List<ParsedXbrlFact> Facts { get; set; } = [];
+    public List<ParsedSecurityListing> CoverListings { get; set; } = [];
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedSecurityListing.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedSecurityListing.cs
@@ -1,0 +1,14 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+
+/// <summary>
+/// One row of a filing's cover-page 12(b) registration table, as parsed from the
+/// inline-XBRL envelope: the security's title with the trading symbol and
+/// exchange filed in the same XBRL context. Symbol and exchange are null when
+/// the filer omitted them from the title's context.
+/// </summary>
+public class ParsedSecurityListing
+{
+    public string Title { get; set; }
+    public string TradingSymbol { get; set; }
+    public string ExchangeName { get; set; }
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -26,16 +26,27 @@ namespace Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
 /// </para>
 ///
 /// <para>
-/// Scope: <c>ix:nonFraction</c> (numeric) only. Narrative
-/// <c>ix:nonNumeric</c>, <c>continuation</c> elements, fragmented values,
-/// and <c>typedMember</c> dimensions are out of scope for this first
-/// iteration; <c>decimals="INF"</c> resolves to <see cref="int.MaxValue"/>.
+/// Scope: <c>ix:nonFraction</c> (numeric) facts, plus exactly one narrative
+/// use of <c>ix:nonNumeric</c> — the three cover-page 12(b) registration tags
+/// (<c>dei:Security12bTitle</c> / <c>dei:TradingSymbol</c> /
+/// <c>dei:SecurityExchangeName</c>), whose short text values pair into
+/// security listings by shared context. General narrative text,
+/// <c>continuation</c> elements, fragmented values, and <c>typedMember</c>
+/// dimensions remain out of scope; <c>decimals="INF"</c> resolves to
+/// <see cref="int.MaxValue"/>.
 /// </para>
 /// </summary>
 [Service]
 public class InlineXbrlParser
 {
     private const string NonFractionLocalName = "ix:nonfraction";
+    private const string NonNumericLocalName = "ix:nonnumeric";
+
+    // The cover-page 12(b) registration tags. The only ix:nonNumeric names this
+    // parser reads — a whitelist, so narrative text blocks are never touched.
+    private const string Security12bTitleName = "dei:Security12bTitle";
+    private const string TradingSymbolName = "dei:TradingSymbol";
+    private const string SecurityExchangeName = "dei:SecurityExchangeName";
     private const string ContextLocalName = "xbrli:context";
     private const string UnitLocalName = "xbrli:unit";
     private const string PeriodLocalName = "xbrli:period";
@@ -63,14 +74,20 @@ public class InlineXbrlParser
         new HtmlParserOptions { IsAcceptingCustomElementsEverywhere = true }
     );
 
-    public List<ParsedXbrlFact> Parse(string html)
+    public List<ParsedXbrlFact> Parse(string html) => ParseEnvelope(html).Facts;
+
+    /// <summary>
+    /// One pass over the envelope yielding both the numeric facts and the
+    /// cover-page 12(b) listings — the document is DOM-parsed once for both.
+    /// </summary>
+    public InlineXbrlParseResult ParseEnvelope(string html)
     {
         if (string.IsNullOrWhiteSpace(html))
-            return [];
+            return new InlineXbrlParseResult();
 
         var document = _parser.ParseDocument(html);
         if (document?.DocumentElement == null)
-            return [];
+            return new InlineXbrlParseResult();
 
         var contexts = BuildContextMap(document);
         var units = BuildUnitMap(document);
@@ -82,7 +99,89 @@ public class InlineXbrlParser
             if (TryParseFact(element, contexts, units, namespaces, out var fact))
                 facts.Add(fact);
         }
-        return facts;
+        return new InlineXbrlParseResult
+        {
+            Facts = facts,
+            CoverListings = ExtractCoverListings(document),
+        };
+    }
+
+    /// <summary>
+    /// Pairs the cover page's 12(b) registration facts into listings. Each
+    /// registered security's title / symbol / exchange share one XBRL context
+    /// (the per-security member on a class-of-stock axis, or the dimensionless
+    /// context when only one security is registered), so grouping the three
+    /// whitelisted <c>ix:nonNumeric</c> tags by <c>contextRef</c> reassembles
+    /// the table's rows without resolving contexts at all. Only groups that
+    /// carry a title become listings; a repeated rendering of the same fact in
+    /// a context keeps the first non-empty value.
+    /// </summary>
+    private static List<ParsedSecurityListing> ExtractCoverListings(IDocument document)
+    {
+        var byContext = new Dictionary<string, ParsedSecurityListing>(StringComparer.Ordinal);
+        var contextOrder = new List<string>();
+
+        foreach (var element in FindByLocalName(document, NonNumericLocalName))
+        {
+            var name = element.GetAttribute("name");
+            if (string.IsNullOrEmpty(name))
+                continue;
+
+            var isTitle = string.Equals(
+                name,
+                Security12bTitleName,
+                StringComparison.OrdinalIgnoreCase
+            );
+            var isSymbol = string.Equals(
+                name,
+                TradingSymbolName,
+                StringComparison.OrdinalIgnoreCase
+            );
+            var isExchange = string.Equals(
+                name,
+                SecurityExchangeName,
+                StringComparison.OrdinalIgnoreCase
+            );
+            if (!isTitle && !isSymbol && !isExchange)
+                continue;
+
+            var contextRef =
+                element.GetAttribute("contextRef") ?? element.GetAttribute("contextref");
+            if (string.IsNullOrEmpty(contextRef))
+                continue;
+
+            var text = CollapseWhitespace(element.TextContent);
+            if (string.IsNullOrEmpty(text))
+                continue;
+
+            if (!byContext.TryGetValue(contextRef, out var listing))
+            {
+                listing = new ParsedSecurityListing();
+                byContext[contextRef] = listing;
+                contextOrder.Add(contextRef);
+            }
+
+            if (isTitle)
+                listing.Title ??= text;
+            else if (isSymbol)
+                listing.TradingSymbol ??= text;
+            else
+                listing.ExchangeName ??= text;
+        }
+
+        return contextOrder
+            .Select(id => byContext[id])
+            .Where(listing => listing.Title != null)
+            .ToList();
+    }
+
+    // Cover-page text values are short strings, but escaped titles can carry
+    // nested markup whose TextContent folds in newlines and runs of spaces.
+    private static string CollapseWhitespace(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        return string.Join(' ', value.Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
     }
 
     /// <summary>

--- a/src/Equibles.Sec.FinancialFacts.Data/FinancialFactsModuleConfiguration.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/FinancialFactsModuleConfiguration.cs
@@ -31,5 +31,7 @@ public class FinancialFactsModuleConfiguration : Equibles.Data.IFinancialModule
         });
 
         builder.Entity<FinancialFactsSyncStatus>();
+
+        builder.Entity<ListedSecurity>();
     }
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/ListedSecurity.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/ListedSecurity.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel.DataAnnotations;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.FinancialFacts.Data.Models;
+
+/// <summary>
+/// One row of an issuer's SEC cover-page 12(b) registration table — the
+/// authoritative pairing of a listed security's title, trading symbol and
+/// exchange (<c>dei:Security12bTitle</c> / <c>dei:TradingSymbol</c> /
+/// <c>dei:SecurityExchangeName</c>), extracted from the filing's raw XBRL
+/// envelope. One row per (issuer, symbol); a newer filing's statement replaces
+/// an older one, so each row always reflects the most recent filing that
+/// mentioned the symbol. Rows whose symbol left the newest filing (a delisted
+/// note) are kept — they remain the latest authoritative statement about that
+/// symbol. Source of the per-ticker classification materialized on
+/// <see cref="CommonStock.ListedSecurityType"/>.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(TradingSymbol), IsUnique = true)]
+public class ListedSecurity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    /// <summary>
+    /// The filed <c>dei:TradingSymbol</c>, normalized for matching (uppercase,
+    /// class separators removed — filings write "BRK.B" where ticker feeds use
+    /// "BRK-B").
+    /// </summary>
+    [Required]
+    [MaxLength(32)]
+    public string TradingSymbol { get; set; }
+
+    /// <summary>The <c>dei:Security12bTitle</c>, verbatim from the filing.</summary>
+    [Required]
+    [MaxLength(500)]
+    public string Title { get; set; }
+
+    /// <summary>The <c>dei:SecurityExchangeName</c> from the same context, when filed.</summary>
+    [MaxLength(100)]
+    public string ExchangeName { get; set; }
+
+    /// <summary>Accession of the filing this row's statement came from.</summary>
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    /// <summary>Filing date of that filing — newer statements replace older ones.</summary>
+    public DateOnly FiledDate { get; set; }
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -1,9 +1,11 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Media.BusinessLogic;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Sec.FinancialFacts.BusinessLogic.Models;
 using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
 using Equibles.Sec.FinancialFacts.Data.Enums;
@@ -58,7 +60,9 @@ public class XbrlFactExtractionService
     // coverage in InlineXbrlParser.
     // Version 3: filer-extension (company-specific) concepts persisted under
     // FactTaxonomy.Custom, consolidated contexts included.
-    public const int CurrentVersion = 3;
+    // Version 4: cover-page 12(b) security listings extracted from inline
+    // envelopes; the re-drain classifies every stock's ListedSecurityType.
+    public const int CurrentVersion = 4;
 
     private const int InsertBatchSize = 1000;
 
@@ -80,6 +84,14 @@ public class XbrlFactExtractionService
     // rather than truncated — a truncated QName would corrupt the key.
     private const int UnitMaxLength = 32;
     private const int QNameMaxLength = 256;
+
+    // Column limits for cover-page listing text (ListedSecurity.Title /
+    // ExchangeName). Unlike QNames these are display strings, so an
+    // over-length value is truncated rather than dropped — the leading text
+    // carries the security kind the classifier reads.
+    private const int ListingTitleMaxLength = 500;
+    private const int ListingExchangeMaxLength = 100;
+    private const int ListingSymbolMaxLength = 32;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly InlineXbrlParser _inlineParser;
@@ -133,10 +145,21 @@ public class XbrlFactExtractionService
             GzipCompressor.Decompress(await _fileManager.GetContent(document.XbrlContent))
         );
 
-        var parsed =
-            document.XbrlType == XbrlType.StandaloneXbrl
-                ? _standaloneParser.Parse(envelope)
-                : _inlineParser.Parse(envelope);
+        // Standalone (pre-inline) instances predate the 2019 cover-page
+        // taxonomy, so only inline envelopes can carry 12(b) listings.
+        List<ParsedXbrlFact> parsed;
+        if (document.XbrlType == XbrlType.StandaloneXbrl)
+        {
+            parsed = _standaloneParser.Parse(envelope);
+        }
+        else
+        {
+            var result = _inlineParser.ParseEnvelope(envelope);
+            parsed = result.Facts;
+            // Before the numeric early-return: a filing whose numeric facts
+            // are all API-covered still states the 12(b) table.
+            await PersistCoverListings(document, result.CoverListings, cancellationToken);
+        }
 
         var persistable = CollapseToNaturalKey(SelectPersistable(parsed));
         if (persistable.Count == 0)
@@ -438,6 +461,122 @@ public class XbrlFactExtractionService
 
         return rows.Where(r => pairs.Contains((r.Taxonomy, r.Tag)))
             .ToDictionary(r => (r.Taxonomy, r.Tag), r => r.Id);
+    }
+
+    /// <summary>
+    /// Upserts the filing's cover-page 12(b) rows into <see cref="ListedSecurity"/>
+    /// (per-symbol, newer filing wins — the historical drain visits old filings
+    /// after new ones, so an older statement never overwrites a newer row) and
+    /// re-materializes the stock's <see cref="CommonStock.ListedSecurityType"/>
+    /// from the row matching its ticker. A filing with no usable 12(b) rows
+    /// leaves both untouched: absence of the table is not evidence the
+    /// previously-stated rows stopped being true (many report types omit the
+    /// cover), and delisted symbols keep their last authoritative statement.
+    /// </summary>
+    internal async Task PersistCoverListings(
+        Document document,
+        List<ParsedSecurityListing> listings,
+        CancellationToken cancellationToken
+    )
+    {
+        // One candidate per normalized symbol; the first rendering in the
+        // filing wins when a symbol repeats.
+        var incoming = new Dictionary<string, ParsedSecurityListing>(StringComparer.Ordinal);
+        foreach (var listing in listings)
+        {
+            var symbol = NormalizeTradingSymbol(listing.TradingSymbol);
+            if (symbol == null || string.IsNullOrWhiteSpace(listing.Title))
+                continue;
+            incoming.TryAdd(symbol, listing);
+        }
+        if (incoming.Count == 0)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepository = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var listedRepository = scope.ServiceProvider.GetRequiredService<ListedSecurityRepository>();
+
+        var stock = await stockRepository
+            .GetByIds([document.CommonStockId])
+            .FirstOrDefaultAsync(cancellationToken);
+        if (stock == null)
+            return;
+
+        var existingBySymbol = await listedRepository
+            .GetByStock(stock)
+            .ToDictionaryAsync(row => row.TradingSymbol, StringComparer.Ordinal, cancellationToken);
+
+        foreach (var (symbol, listing) in incoming)
+        {
+            if (existingBySymbol.TryGetValue(symbol, out var row))
+            {
+                if (document.ReportingDate < row.FiledDate)
+                    continue;
+            }
+            else
+            {
+                row = listedRepository.Add(
+                    new ListedSecurity { CommonStockId = stock.Id, TradingSymbol = symbol }
+                );
+                existingBySymbol[symbol] = row;
+            }
+
+            row.Title = Truncate(listing.Title, ListingTitleMaxLength);
+            row.ExchangeName = Truncate(listing.ExchangeName, ListingExchangeMaxLength);
+            row.AccessionNumber = document.AccessionNumber;
+            row.FiledDate = document.ReportingDate;
+        }
+
+        // Classification is derived state: recompute from the freshest statement
+        // about the stock's own ticker, whichever filing this pass processed.
+        var tickerSymbol = NormalizeTradingSymbol(stock.Ticker);
+        if (tickerSymbol != null && existingBySymbol.TryGetValue(tickerSymbol, out var tickerRow))
+        {
+            stock.ListedSecurityType = ListedSecurityClassifier.Classify(tickerRow.Title);
+            stock.ListedSecurityTitle = tickerRow.Title;
+        }
+
+        await listedRepository.SaveChanges();
+    }
+
+    /// <summary>
+    /// A filed <c>dei:TradingSymbol</c> normalized for matching: uppercased with
+    /// class separators removed, because filings write "BRK.B" where ticker
+    /// feeds use "BRK-B". Placeholders filers type when a security has no
+    /// symbol ("N/A", "None") and over-length values resolve to null — checked
+    /// before separator stripping so the "N/A" placeholder can never collide
+    /// with a genuine ticker "NA".
+    /// </summary>
+    internal static string NormalizeTradingSymbol(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+            return null;
+
+        var trimmed = symbol.Trim();
+        if (
+            trimmed.Equals("n/a", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("none", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("not applicable", StringComparison.OrdinalIgnoreCase)
+        )
+            return null;
+
+        var normalized = trimmed
+            .ToUpperInvariant()
+            .Replace(".", string.Empty)
+            .Replace("-", string.Empty)
+            .Replace("/", string.Empty)
+            .Replace(" ", string.Empty);
+        if (normalized.Length == 0 || normalized.Length > ListingSymbolMaxLength)
+            return null;
+
+        return normalized;
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+        return value.Length <= maxLength ? value : value.Substring(0, maxLength);
     }
 
     private async Task FlushFacts(List<FinancialFact> items)

--- a/src/Equibles.Sec.FinancialFacts.Repositories/ListedSecurityRepository.cs
+++ b/src/Equibles.Sec.FinancialFacts.Repositories/ListedSecurityRepository.cs
@@ -1,0 +1,16 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Sec.FinancialFacts.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.Repositories;
+
+public class ListedSecurityRepository : BaseRepository<ListedSecurity>
+{
+    public ListedSecurityRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<ListedSecurity> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(s => s.CommonStockId == stock.Id);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
@@ -194,7 +194,39 @@ public class ShortSqueezeScoreManagerTests : IDisposable
         scores.Should().OnlyContain(s => s.ShortInterestPercentOfShares <= 2m);
     }
 
-    private CommonStock SeedStock(string ticker, long sharesOutstanding)
+    [Fact]
+    public async Task Compute_NonEquityListing_ExcludesStockFromUniverse()
+    {
+        // A ticker classified from its 12(b) cover-page title as an
+        // exchange-traded note (a baby bond) can never be a squeeze candidate —
+        // the issuer's common-share record is the wrong denominator for it.
+        // Units stay in: MLP common units are genuine operating equity.
+        var equity = SeedStock("EQTY", sharesOutstanding: 1_000_000);
+        var note = SeedStock(
+            "NOTE",
+            sharesOutstanding: 1_000_000,
+            listedSecurityType: ListedSecurityType.DebtSecurities
+        );
+        var mlp = SeedStock(
+            "MLP",
+            sharesOutstanding: 1_000_000,
+            listedSecurityType: ListedSecurityType.Units
+        );
+        SeedShortInterest(equity, shortPosition: 100_000, daysToCover: 2m);
+        SeedShortInterest(note, shortPosition: 150_000, daysToCover: 3m);
+        SeedShortInterest(mlp, shortPosition: 120_000, daysToCover: 2m);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Select(s => s.Ticker).Should().BeEquivalentTo(["EQTY", "MLP"]);
+    }
+
+    private CommonStock SeedStock(
+        string ticker,
+        long sharesOutstanding,
+        ListedSecurityType listedSecurityType = ListedSecurityType.Unknown
+    )
     {
         var stock = new CommonStock
         {
@@ -202,6 +234,7 @@ public class ShortSqueezeScoreManagerTests : IDisposable
             Name = $"{ticker} Corp.",
             Cik = ticker,
             SharesOutStanding = sharesOutstanding,
+            ListedSecurityType = listedSecurityType,
         };
         _dbContext.Set<CommonStock>().Add(stock);
         return stock;

--- a/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceCoverListingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceCoverListingsTests.cs
@@ -1,0 +1,277 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// End-to-end pin of the cover-page 12(b) extraction (#5568): a captured
+/// inline envelope's Security12bTitle / TradingSymbol / SecurityExchangeName
+/// facts land as ListedSecurity rows, and the row matching the stock's own
+/// ticker materializes its ListedSecurityType — so an issuer whose only listed
+/// security is a baby bond stops passing for common equity. Also pins the
+/// ordering guard (the historical drain visits old filings after new ones, so
+/// an older filing's statement must never overwrite a newer row) and symbol
+/// normalization end to end (filings write "BRK.B" where the ticker feed says
+/// "BRK-B").
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class XbrlFactExtractionServiceCoverListingsTests : ParadeDbMcpTestBase
+{
+    public XbrlFactExtractionServiceCoverListingsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Extract_CoverWithNoteAndCommonRows_PersistsListingsAndClassifiesTicker()
+    {
+        // The QVC shape: the stock row's ticker IS the listed baby bond.
+        var stock = SeedStock(ticker: "QVCC");
+        var document = await SeedDocument(
+            stock,
+            CoverEnvelope(
+                ("Common", "Common Stock, par value $0.01 per share", "QVCGA", "NASDAQ"),
+                ("Notes68", "6.875% Senior Secured Notes due 2068", "QVCC", "NASDAQ")
+            ),
+            accession: "0001355096-26-000010",
+            reportingDate: new DateOnly(2026, 5, 15)
+        );
+
+        await BuildSut().Extract(document, CancellationToken.None);
+
+        var rows = await DbContext
+            .Set<ListedSecurity>()
+            .Where(r => r.CommonStockId == stock.Id)
+            .OrderBy(r => r.TradingSymbol)
+            .ToListAsync(CancellationToken.None);
+
+        rows.Should().HaveCount(2);
+        rows[0].TradingSymbol.Should().Be("QVCC");
+        rows[0].Title.Should().Be("6.875% Senior Secured Notes due 2068");
+        rows[0].ExchangeName.Should().Be("NASDAQ");
+        rows[0].AccessionNumber.Should().Be("0001355096-26-000010");
+        rows[0].FiledDate.Should().Be(new DateOnly(2026, 5, 15));
+        rows[1].TradingSymbol.Should().Be("QVCGA");
+
+        var reloaded = await ReloadStock(stock);
+        reloaded.ListedSecurityType.Should().Be(ListedSecurityType.DebtSecurities);
+        reloaded.ListedSecurityTitle.Should().Be("6.875% Senior Secured Notes due 2068");
+    }
+
+    [Fact]
+    public async Task Extract_OlderFiling_NeverOverwritesNewerStatement()
+    {
+        var stock = SeedStock(ticker: "SOHO");
+        var newer = await SeedDocument(
+            stock,
+            CoverEnvelope(("C1", "Common Stock, par value $0.01", "SOHO", "NASDAQ")),
+            accession: "0001301236-26-000020",
+            reportingDate: new DateOnly(2026, 4, 15)
+        );
+        var older = await SeedDocument(
+            stock,
+            CoverEnvelope(("C1", "An obsolete earlier title", "SOHO", "NYSE")),
+            accession: "0001301236-25-000009",
+            reportingDate: new DateOnly(2025, 3, 20)
+        );
+
+        var sut = BuildSut();
+        await sut.Extract(newer, CancellationToken.None);
+        await sut.Extract(older, CancellationToken.None);
+
+        var row = (
+            await DbContext
+                .Set<ListedSecurity>()
+                .Where(r => r.CommonStockId == stock.Id)
+                .ToListAsync(CancellationToken.None)
+        )
+            .Should()
+            .ContainSingle()
+            .Subject;
+        row.Title.Should().Be("Common Stock, par value $0.01");
+        row.FiledDate.Should().Be(new DateOnly(2026, 4, 15));
+
+        var reloaded = await ReloadStock(stock);
+        reloaded.ListedSecurityType.Should().Be(ListedSecurityType.CommonShares);
+    }
+
+    [Fact]
+    public async Task Extract_FiledDotSymbol_MatchesDashTicker()
+    {
+        // The ticker feed writes class shares with a dash; the filing uses a
+        // dot. Both must normalize onto the same row or the class share never
+        // classifies.
+        var stock = SeedStock(ticker: "BRK-B");
+        var document = await SeedDocument(
+            stock,
+            CoverEnvelope(("C1", "Class B Common Stock", "BRK.B", "NYSE")),
+            accession: "0001067983-26-000005",
+            reportingDate: new DateOnly(2026, 2, 25)
+        );
+
+        await BuildSut().Extract(document, CancellationToken.None);
+
+        var reloaded = await ReloadStock(stock);
+        reloaded.ListedSecurityType.Should().Be(ListedSecurityType.CommonShares);
+        reloaded.ListedSecurityTitle.Should().Be("Class B Common Stock");
+    }
+
+    [Fact]
+    public async Task Extract_EnvelopeWithoutCoverFacts_LeavesClassificationUntouched()
+    {
+        // Many report types carry no 12(b) table; absence is not evidence.
+        var stock = SeedStock(ticker: "ACME");
+        var document = await SeedDocument(
+            stock,
+            CoverEnvelope(),
+            accession: "0000000001-26-000001",
+            reportingDate: new DateOnly(2026, 6, 1)
+        );
+
+        await BuildSut().Extract(document, CancellationToken.None);
+
+        (await DbContext.Set<ListedSecurity>().CountAsync(CancellationToken.None)).Should().Be(0);
+        var reloaded = await ReloadStock(stock);
+        reloaded.ListedSecurityType.Should().Be(ListedSecurityType.Unknown);
+        reloaded.ListedSecurityTitle.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Extract_SameDocumentTwice_KeepsOneRowPerSymbol()
+    {
+        var stock = SeedStock(ticker: "ACME");
+        var document = await SeedDocument(
+            stock,
+            CoverEnvelope(("C1", "Common Stock", "ACME", "NYSE")),
+            accession: "0000000001-26-000002",
+            reportingDate: new DateOnly(2026, 6, 1)
+        );
+
+        var sut = BuildSut();
+        await sut.Extract(document, CancellationToken.None);
+        await sut.Extract(document, CancellationToken.None);
+
+        (
+            await DbContext
+                .Set<ListedSecurity>()
+                .CountAsync(r => r.CommonStockId == stock.Id, CancellationToken.None)
+        )
+            .Should()
+            .Be(1);
+    }
+
+    private XbrlFactExtractionService BuildSut()
+    {
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(EquiblesFinancialDbContext), DbContext),
+            (typeof(FinancialConceptRepository), new FinancialConceptRepository(DbContext)),
+            (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
+            (typeof(ListedSecurityRepository), new ListedSecurityRepository(DbContext))
+        );
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
+        return new XbrlFactExtractionService(
+            scopeFactory,
+            new InlineXbrlParser(),
+            new StandaloneXbrlParser(),
+            fileManager,
+            NullLogger<XbrlFactExtractionService>()
+        );
+    }
+
+    private CommonStock SeedStock(string ticker)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Corp.",
+            Cik = ticker,
+        };
+        DbContext.Add(stock);
+        return stock;
+    }
+
+    private async Task<CommonStock> ReloadStock(CommonStock stock)
+    {
+        return await DbContext
+            .Set<CommonStock>()
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == stock.Id, CancellationToken.None);
+    }
+
+    private async Task<Document> SeedDocument(
+        CommonStock stock,
+        string envelope,
+        string accession,
+        DateOnly reportingDate
+    )
+    {
+        var compressed = GzipCompressor.Compress(System.Text.Encoding.UTF8.GetBytes(envelope));
+        var xbrlFile = new File
+        {
+            Name = "xbrl-envelope",
+            Extension = "gz",
+            ContentType = "application/gzip",
+            Size = compressed.Length,
+            FileContent = new Equibles.Media.Data.Models.FileContent { Bytes = compressed },
+        };
+        var contentFile = new File
+        {
+            Name = "primary-doc",
+            Extension = "txt",
+            ContentType = "text/plain",
+            Size = 1,
+            FileContent = new Equibles.Media.Data.Models.FileContent { Bytes = [0x20] },
+        };
+
+        var document = new Document
+        {
+            CommonStock = stock,
+            Content = contentFile,
+            DocumentType = DocumentType.TenQ,
+            ReportingDate = reportingDate,
+            ReportingForDate = reportingDate.AddMonths(-1),
+            AccessionNumber = accession,
+            XbrlStatus = XbrlCaptureStatus.Captured,
+            XbrlType = XbrlType.InlineIxbrl,
+            XbrlContent = xbrlFile,
+            XbrlUncompressedSize = envelope.Length,
+        };
+
+        DbContext.Add(document);
+        await DbContext.SaveChangesAsync(CancellationToken.None);
+        return document;
+    }
+
+    // A minimal inline envelope whose only iXBRL content is the cover's 12(b)
+    // rows — one context per registered security.
+    private static string CoverEnvelope(
+        params (string Context, string Title, string Symbol, string Exchange)[] listings
+    )
+    {
+        var body = string.Concat(
+            listings.Select(l =>
+                $"<ix:nonNumeric name=\"dei:Security12bTitle\" contextRef=\"{l.Context}\">{l.Title}</ix:nonNumeric>"
+                + $"<ix:nonNumeric name=\"dei:TradingSymbol\" contextRef=\"{l.Context}\">{l.Symbol}</ix:nonNumeric>"
+                + $"<ix:nonNumeric name=\"dei:SecurityExchangeName\" contextRef=\"{l.Context}\">{l.Exchange}</ix:nonNumeric>"
+            )
+        );
+        return "<html xmlns=\"http://www.w3.org/1999/xhtml\" "
+            + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+            + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+            + "xmlns:dei=\"http://xbrl.sec.gov/dei/2025\">"
+            + "<body>"
+            + body
+            + "</body></html>";
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserCoverListingsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserCoverListingsTests.cs
@@ -1,0 +1,159 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins ParseEnvelope's cover-page 12(b) extraction: the three whitelisted
+/// dei nonNumeric tags pair into listings by shared contextRef — the
+/// per-security context a multi-listing cover dimensions on a class axis, or
+/// the dimensionless context of a single-listing cover — with no context
+/// resolution at all, so listings survive documents whose contexts the numeric
+/// path would reject. General narrative nonNumeric text must never leak in.
+/// </summary>
+public class InlineXbrlParserCoverListingsTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:xbrldi=\"http://xbrl.org/2006/xbrldi\" "
+        + "xmlns:dei=\"http://xbrl.sec.gov/dei/2023\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2023\""
+        + "><body>";
+
+    private const string DocClose = "</body></html>";
+
+    [Fact]
+    public void ParseEnvelope_MultiListingCover_PairsTitleSymbolExchangeByContext()
+    {
+        // A bankrupt-retailer shape: common stock plus two listed baby bonds,
+        // each 12(b) row in its own per-security context.
+        var html =
+            DocOpen
+            + "<ix:nonNumeric name=\"dei:Security12bTitle\" contextRef=\"Common\">Common Stock, par value $0.01 per share</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:TradingSymbol\" contextRef=\"Common\">QVCGA</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:SecurityExchangeName\" contextRef=\"Common\">NASDAQ</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:Security12bTitle\" contextRef=\"Notes68\">6.875% Senior Secured Notes due 2068</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:TradingSymbol\" contextRef=\"Notes68\">QVCC</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:SecurityExchangeName\" contextRef=\"Notes68\">NASDAQ</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:Security12bTitle\" contextRef=\"Notes67\">6.375% Senior Secured Notes due 2067</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:TradingSymbol\" contextRef=\"Notes67\">QVCD</ix:nonNumeric>"
+            + DocClose;
+
+        var listings = new InlineXbrlParser().ParseEnvelope(html).CoverListings;
+
+        listings.Should().HaveCount(3);
+        listings[0].Title.Should().Be("Common Stock, par value $0.01 per share");
+        listings[0].TradingSymbol.Should().Be("QVCGA");
+        listings[0].ExchangeName.Should().Be("NASDAQ");
+        listings[1].Title.Should().Be("6.875% Senior Secured Notes due 2068");
+        listings[1].TradingSymbol.Should().Be("QVCC");
+        listings[2].TradingSymbol.Should().Be("QVCD");
+        listings[2].ExchangeName.Should().BeNull("this row's context filed no exchange fact");
+    }
+
+    [Fact]
+    public void ParseEnvelope_SingleListingDimensionlessCover_YieldsOneListing()
+    {
+        var html =
+            DocOpen
+            + "<ix:nonNumeric name=\"dei:Security12bTitle\" contextRef=\"C0\">Common Stock, no par value</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:TradingSymbol\" contextRef=\"C0\">ACME</ix:nonNumeric>"
+            + DocClose;
+
+        var listing = new InlineXbrlParser()
+            .ParseEnvelope(html)
+            .CoverListings.Should()
+            .ContainSingle()
+            .Subject;
+
+        listing.Title.Should().Be("Common Stock, no par value");
+        listing.TradingSymbol.Should().Be("ACME");
+    }
+
+    [Fact]
+    public void ParseEnvelope_SymbolWithoutTitleInContext_YieldsNoListing()
+    {
+        // dei:TradingSymbol also appears outside the 12(b) table (e.g. the
+        // document-information block); a context with no title is not a
+        // registration row.
+        var html =
+            DocOpen
+            + "<ix:nonNumeric name=\"dei:TradingSymbol\" contextRef=\"DocInfo\">ACME</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:EntityRegistrantName\" contextRef=\"DocInfo\">Acme Corp</ix:nonNumeric>"
+            + DocClose;
+
+        new InlineXbrlParser().ParseEnvelope(html).CoverListings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseEnvelope_EscapedTitleMarkup_CollapsesToPlainText()
+    {
+        // escape="true" titles carry nested markup; TextContent folds it in
+        // with newlines and runs of spaces that must collapse to single spaces.
+        var html =
+            DocOpen
+            + "<ix:nonNumeric name=\"dei:Security12bTitle\" contextRef=\"C1\" escape=\"true\">Depositary Shares, each representing\n      a 1/1,000th interest in a share of <span>Series A Preferred Stock</span></ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:TradingSymbol\" contextRef=\"C1\">ACME-PA</ix:nonNumeric>"
+            + DocClose;
+
+        var listing = new InlineXbrlParser()
+            .ParseEnvelope(html)
+            .CoverListings.Should()
+            .ContainSingle()
+            .Subject;
+
+        listing
+            .Title.Should()
+            .Be(
+                "Depositary Shares, each representing a 1/1,000th interest in a share of Series A Preferred Stock"
+            );
+    }
+
+    [Fact]
+    public void ParseEnvelope_RepeatedFactInSameContext_KeepsFirstNonEmptyValue()
+    {
+        var html =
+            DocOpen
+            + "<ix:nonNumeric name=\"dei:Security12bTitle\" contextRef=\"C1\">Common Stock</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:Security12bTitle\" contextRef=\"C1\">Common Stock (restated rendering)</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:TradingSymbol\" contextRef=\"C1\">ACME</ix:nonNumeric>"
+            + DocClose;
+
+        var listing = new InlineXbrlParser()
+            .ParseEnvelope(html)
+            .CoverListings.Should()
+            .ContainSingle()
+            .Subject;
+
+        listing.Title.Should().Be("Common Stock");
+    }
+
+    [Fact]
+    public void Parse_UnchangedByCoverExtraction_StillReturnsNumericFacts()
+    {
+        // The numeric contract is untouched: Parse still returns the facts a
+        // combined envelope carries, and the cover listings ride the same pass.
+        var html =
+            DocOpen
+            + "<div style=\"display:none\"><ix:header><ix:resources>"
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2026-03-31</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"usd\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + "</ix:resources></ix:header></div>"
+            + "<ix:nonNumeric name=\"dei:Security12bTitle\" contextRef=\"C1\">Common Stock</ix:nonNumeric>"
+            + "<ix:nonNumeric name=\"dei:TradingSymbol\" contextRef=\"C1\">ACME</ix:nonNumeric>"
+            + "<ix:nonFraction name=\"us-gaap:Assets\" contextRef=\"C1\" unitRef=\"usd\" decimals=\"0\">1000</ix:nonFraction>"
+            + DocClose;
+
+        var result = new InlineXbrlParser().ParseEnvelope(html);
+
+        result.Facts.Should().ContainSingle().Which.Value.Should().Be(1000m);
+        result.CoverListings.Should().ContainSingle().Which.TradingSymbol.Should().Be("ACME");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/ListedSecurityClassifierTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ListedSecurityClassifierTests.cs
@@ -1,0 +1,94 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the 12(b)-title classifier on real cover-page titles. The earliest
+/// keyword in the title decides the kind — a title leads with the security's
+/// own noun and then describes what it bundles, converts into, or carries as a
+/// rider — so a SPAC unit that mentions warrants is a unit, a warrant over MLP
+/// units is a warrant, and common stock with a poison-pill rights rider stays
+/// common. Trailing-head-noun purchase forms ("Common Stock Purchase
+/// Warrants") classify as the wrapper, while the same phrase in rider language
+/// stays with the security it rides on. Nothing here reads tickers or company
+/// names; the input is always the authoritative dei:Security12bTitle text.
+/// </summary>
+public class ListedSecurityClassifierTests
+{
+    [Theory]
+    // Plain equity shapes.
+    [InlineData("Common Stock, par value $0.01 per share", ListedSecurityType.CommonShares)]
+    [InlineData("Class A Common Stock", ListedSecurityType.CommonShares)]
+    [InlineData("Class A Ordinary Shares", ListedSecurityType.CommonShares)]
+    [InlineData("Common Shares of Beneficial Interest", ListedSecurityType.CommonShares)]
+    [InlineData("Shares of Beneficial Interest", ListedSecurityType.CommonShares)]
+    [InlineData(
+        "American Depositary Shares, each representing two Class A ordinary shares",
+        ListedSecurityType.CommonShares
+    )]
+    // The poison-pill rider: the rights are attached to the common, not listed.
+    [InlineData(
+        "Common Stock, par value $0.01 per share (and associated Preferred Share Purchase Rights)",
+        ListedSecurityType.CommonShares
+    )]
+    // Preferred, including the depositary-receipt form (bare "Depositary
+    // Shares" is deliberately not a common-equity keyword).
+    [InlineData(
+        "7.00% Series B Cumulative Redeemable Perpetual Preferred Stock",
+        ListedSecurityType.PreferredShares
+    )]
+    [InlineData(
+        "Depositary Shares, each representing a 1/1,000th interest in a share of Series A Preferred Stock",
+        ListedSecurityType.PreferredShares
+    )]
+    // Exchange-traded debt — the QVC baby-bond shape.
+    [InlineData("6.875% Senior Secured Notes due 2068", ListedSecurityType.DebtSecurities)]
+    [InlineData("8.00% Subordinated Debentures due 2032", ListedSecurityType.DebtSecurities)]
+    // Wrappers lead with their own noun whatever they embed.
+    [InlineData(
+        "Units, each consisting of one share of Class A Common Stock and one-half of one redeemable Warrant",
+        ListedSecurityType.Units
+    )]
+    [InlineData("Warrants to purchase Common Units", ListedSecurityType.Warrants)]
+    [InlineData(
+        "Redeemable warrants, each whole warrant exercisable for one share of Class A common stock",
+        ListedSecurityType.Warrants
+    )]
+    [InlineData("Subscription Rights to purchase Common Stock", ListedSecurityType.Rights)]
+    // Trailing-head-noun form: "<underlier> Purchase Warrants/Rights" IS the
+    // wrapper — the real 12(b) shape for standalone listed warrants and
+    // poison-pill rights registered in their own row.
+    [InlineData("Common Stock Purchase Warrants", ListedSecurityType.Warrants)]
+    [InlineData("Class A Common Stock Purchase Warrants", ListedSecurityType.Warrants)]
+    [InlineData("Preferred Share Purchase Rights", ListedSecurityType.Rights)]
+    // …but the same phrase inside rider language stays with the security it
+    // rides on, parenthesized or not — classifying the rider would exclude
+    // genuine common stock.
+    [InlineData(
+        "Common Stock, par value $0.01 per share, together with the associated Preferred Stock Purchase Rights",
+        ListedSecurityType.CommonShares
+    )]
+    // MLP and fund units both classify Units; surfaces deliberately keep them.
+    [InlineData("Common Units Representing Limited Partner Interests", ListedSecurityType.Units)]
+    [InlineData("Units Representing Limited Partnership Interests", ListedSecurityType.Units)]
+    // Word boundaries: "United" is not a unit, "brights" is not a right.
+    [InlineData("United Insurance Capital Stock", ListedSecurityType.Other)]
+    // Unrecognized titles are Other — treated like Unknown, never excluded.
+    [InlineData("Purchase Contracts", ListedSecurityType.Other)]
+    public void Classify_Title_MapsToKind(string title, ListedSecurityType expected)
+    {
+        ListedSecurityClassifier.Classify(title).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Classify_MissingTitle_IsUnknown(string title)
+    {
+        ListedSecurityClassifier.Classify(title).Should().Be(ListedSecurityType.Unknown);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceNormalizeTradingSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceNormalizeTradingSymbolTests.cs
@@ -1,0 +1,41 @@
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins trading-symbol normalization: filings write class tickers with dots
+/// ("BRK.B") where the platform's ticker feed uses dashes ("BRK-B"), so both
+/// must normalize to the same key or a class share never matches its own 12(b)
+/// row. Placeholder values filers type for unlisted securities must resolve to
+/// null BEFORE separator stripping — "N/A" stripped first would collide with
+/// the genuine ticker "NA".
+/// </summary>
+public class XbrlFactExtractionServiceNormalizeTradingSymbolTests
+{
+    [Theory]
+    [InlineData("BRK.B", "BRKB")]
+    [InlineData("BRK-B", "BRKB")]
+    [InlineData(" qvcc ", "QVCC")]
+    [InlineData("RDS/A", "RDSA")]
+    [InlineData("NA", "NA")]
+    public void NormalizeTradingSymbol_Value_NormalizesToMatchKey(string raw, string expected)
+    {
+        XbrlFactExtractionService.NormalizeTradingSymbol(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("N/A")]
+    [InlineData("n/a")]
+    [InlineData("None")]
+    [InlineData("Not Applicable")]
+    [InlineData("THIS-SYMBOL-IS-FAR-TOO-LONG-TO-BE-A-REAL-TICKER")]
+    public void NormalizeTradingSymbol_PlaceholderOrUnusable_ReturnsNull(string raw)
+    {
+        XbrlFactExtractionService.NormalizeTradingSymbol(raw).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

The stock universe is keyed by tickers carrying FINRA/price data, so a row can be an issuer's exchange-traded note or preferred series rather than its common equity — QVC, Inc.'s only listed security is a baby bond; Sotherly Hotels' common went private while its preferreds still trade. Per-share figures computed against such a row's common-share record are meaningless, and nothing on record said what kind of security a ticker is. Heuristics on tickers/names are forbidden; the authoritative source is the SEC cover-page 12(b) registration table, whose text facts (`dei:Security12bTitle` / `dei:TradingSymbol` / `dei:SecurityExchangeName`) the Company Facts API never carries.

## How it works

1. **Parse** — `InlineXbrlParser` gains a combined `ParseEnvelope` (one DOM pass) that additionally pairs the three whitelisted `ix:nonNumeric` cover tags into listings by shared `contextRef` — no context resolution needed, since each registered security's facts share one context. Standalone pre-inline instances predate the 2019 cover-page taxonomy, so they're out of scope by construction; general narrative `nonNumeric` text is never touched.
2. **Persist** — a new `ListedSecurity` table stores each issuer's 12(b) rows per symbol (newer filing wins — the historical drain visits old filings after new ones, so an older statement never overwrites). Rides `XbrlFactExtractionService` (version 3 → 4, so the sweep re-drains the captured corpus, newest first — purely local, no EDGAR traffic) and runs before the numeric early-return so filings whose numeric facts are all API-covered still land their table.
3. **Classify** — the row matching the stock's own ticker (symbols normalized: filings write "BRK.B" where ticker feeds use "BRK-B"; "N/A"/"None" placeholders rejected before separator-stripping so they can't collide with the genuine ticker "NA") materializes `CommonStock.ListedSecurityType` + `ListedSecurityTitle`. The classifier is deterministic on the title: the kind whose keyword appears earliest wins, because titles lead with the security's own noun and then describe what they bundle ("Units, each consisting of … one Warrant"), convert into ("Warrants to purchase Common Units"), or carry as a rider ("Common Stock (and associated Preferred Share Purchase Rights)"). Unmatched tickers stay `Unknown`.
4. **Exclude** — `ShortSqueezeScoreManager` drops `PreferredShares`/`DebtSecurities`/`Warrants`/`Rights` from the scored universe (same treatment as an unknown share count). `Units` deliberately stays: MLP common units (Energy Transfer, Enterprise Products) are genuine operating equity indistinguishable by title from fund units, and exclusion always requires positive evidence — `Unknown`/`Other` are never excluded.

## Code changes

- `ListedSecurityType` enum + two `CommonStock` columns; `ListedSecurity` entity/repository/module registration; migration.
- `InlineXbrlParser.ParseEnvelope` + `ParsedSecurityListing`/`InlineXbrlParseResult` models.
- `ListedSecurityClassifier` (earliest-keyword, whole-word).
- `XbrlFactExtractionService`: cover-listing persistence + ticker classification, `NormalizeTradingSymbol`, version 4.
- `ShortSqueezeScoreManager`: non-equity exclusion.

## Tests

- Classifier matrix over real title shapes (baby bonds, depositary-preferred, SPAC units/warrants, MLP units, poison-pill riders, word-boundary traps).
- Parser: multi-listing/single-listing covers, symbol-without-title contexts, escaped-markup collapse, repeated facts, numeric-contract regression.
- Symbol normalization (dot/dash/slash, placeholder-vs-"NA" ordering).
- Integration: end-to-end extraction to `ListedSecurity` rows + stock classification, newer-filing guard, dot-symbol↔dash-ticker match, no-cover no-op, idempotency; squeeze exclusion (note dropped, MLP kept).
- Full local gate: Release build green, all 3,353 unit tests pass, affected integration suites (14) pass.