### PR TITLE
fix(errors): skip cancellations when recording scraper errors

### DIFF
--- a/src/Equibles.Errors.BusinessLogic/ErrorReporter.cs
+++ b/src/Equibles.Errors.BusinessLogic/ErrorReporter.cs
@@ -19,6 +19,30 @@ public class ErrorReporter
         _logger = logger;
     }
 
+    /// <summary>
+    /// Records an exception, skipping cancellations. A cancelled operation is not a
+    /// fault worth surfacing on the Errors page: a graceful shutdown or deploy winds
+    /// in-flight work down, and an inner command/HTTP timeout aborts a single item the
+    /// caller retries next cycle. Recording "The operation was canceled" only buries
+    /// real errors, so — like <c>GlobalExceptionHandler</c> does for aborted requests —
+    /// an <see cref="OperationCanceledException"/> (including <see cref="TaskCanceledException"/>,
+    /// which derives from it) is dropped by type here instead of at each catch site.
+    /// </summary>
+    public Task Report(
+        ErrorSource source,
+        string context,
+        Exception exception,
+        string requestSummary = null
+    )
+    {
+        if (exception is OperationCanceledException)
+        {
+            return Task.CompletedTask;
+        }
+
+        return Report(source, context, exception.Message, exception.StackTrace, requestSummary);
+    }
+
     public async Task Report(
         ErrorSource source,
         string context,

--- a/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsCaptureWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsCaptureWorker.cs
@@ -115,8 +115,7 @@ public class ReportedStatementsCaptureWorker : BaseScraperWorker
                 await ErrorReporter.Report(
                     ErrorSource,
                     "ReportedStatementsCapture.Capture",
-                    ex.Message,
-                    ex.StackTrace,
+                    ex,
                     $"documentId: {document.Id}, accession: {document.AccessionNumber}"
                 );
             }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -131,8 +131,7 @@ public class FinancialFactsImportService
             await _errorReporter.Report(
                 ErrorSource.FinancialFactsScraper,
                 "FinancialFactsImport.Import",
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"ticker: {stock.Ticker}, cik: {stock.Cik}"
             );
         }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/XbrlFactsExtractionWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/XbrlFactsExtractionWorker.cs
@@ -109,8 +109,7 @@ public class XbrlFactsExtractionWorker : BaseScraperWorker
                     await ErrorReporter.Report(
                         ErrorSource,
                         "XbrlFactsExtraction.Extract",
-                        ex.Message,
-                        ex.StackTrace,
+                        ex,
                         $"documentId: {document.Id}, accession: {document.AccessionNumber}"
                     );
                 }

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -211,8 +211,7 @@ public class YahooPriceImportService
                 await _errorReporter.Report(
                     ErrorSource.YahooPriceScraper,
                     $"ReconcilePendingSplits({ticker})",
-                    ex.Message,
-                    ex.StackTrace
+                    ex
                 );
             }
         }

--- a/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs
+++ b/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs
@@ -90,6 +90,75 @@ public class ErrorReporterTests
     }
 
     [Fact]
+    public async Task Report_Exception_Cancellation_IsSkippedEntirely()
+    {
+        // A cancelled operation (graceful shutdown/deploy, or an inner command/HTTP
+        // timeout that aborts one item) is not a fault worth an Errors row — recording
+        // "The operation was canceled" only buries real errors. The typed overload drops
+        // it by type before touching the scope factory or the activity feed. Pin that:
+        // no scope is created (so ErrorManager is never asked to persist) and nothing is
+        // published. TaskCanceledException derives from OperationCanceledException, so the
+        // most common shape (a timed-out awaited task) is covered by the same check.
+        var bus = Substitute.For<IBus>();
+        var scope = Substitute.For<IServiceScope>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBus)).Returns(bus);
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var sut = new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+
+        await sut.Report(
+            ErrorSource.YahooPriceScraper,
+            context: "ReconcilePendingSplits(JILL)",
+            exception: new TaskCanceledException("The operation was canceled.")
+        );
+
+        scopeFactory.DidNotReceive().CreateScope();
+        bus.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IBus.Publish))
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public async Task Report_Exception_NonCancellation_RecordsAndPublishes()
+    {
+        // A genuine fault still flows through: the typed overload forwards the exception's
+        // message and stack trace to the string-based Report, which publishes the same
+        // activity-feed signal the happy-path test pins above. This guards against the skip
+        // check being widened to swallow every exception.
+        var bus = Substitute.For<IBus>();
+        var scope = Substitute.For<IServiceScope>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBus)).Returns(bus);
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var sut = new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+
+        await sut.Report(
+            ErrorSource.FinancialFactsScraper,
+            context: "FinancialFactsImport.Import",
+            exception: new InvalidOperationException("XBRL envelope too large")
+        );
+
+        var captured = bus.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IBus.Publish))
+            .Select(c => (ScraperActivity)c.GetArguments()[0]!)
+            .ToList();
+
+        captured.Should().HaveCount(1);
+        captured[0].Severity.Should().Be(ScraperActivitySeverity.Error);
+        captured[0]
+            .Message.Should()
+            .Contain("FinancialFactsImport.Import")
+            .And.Contain("XBRL envelope too large");
+    }
+
+    [Fact]
     public async Task Report_ScopeFactoryThrows_DoesNotPropagate()
     {
         // ErrorReporter.Report is called from inside `catch` blocks across every scraper


### PR DESCRIPTION
## Summary

Cancelled operations were landing on the Errors page as `The operation was canceled` / `Query was cancelled` rows that bury real errors. A cancellation is not a fault worth surfacing: a graceful shutdown or deploy winds in-flight work down, and an inner command/HTTP timeout aborts a single item the worker retries next cycle.

The existing shutdown guards (`catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)`) only cover cancellations tied to the worker's own token — an inner timeout carrying a different token slips through the per-item `catch (Exception)` and gets recorded.

## Code changes

- **`ErrorReporter`** — new `Report(ErrorSource, string context, Exception exception, string requestSummary = null)` overload that drops `OperationCanceledException` (including `TaskCanceledException`) by type before touching the scope factory or the activity feed, then delegates to the existing string overload for genuine faults. Same rule `GlobalExceptionHandler` already applies to aborted HTTP requests.
- **Routed the per-item catch-and-continue reporters through it**: `XbrlFactsExtractionWorker`, `ReportedStatementsCaptureWorker`, `FinancialFactsImportService`, `YahooPriceImportService` (split reconcile) now pass `ex` instead of `ex.Message, ex.StackTrace`.
- **Tests** — two new `ErrorReporterTests`: a cancellation is skipped entirely (no scope created, nothing published), and a genuine fault still records and publishes.