### PR TITLE
fix(errors): capture the inner-exception chain when recording faults

### DIFF
--- a/src/Equibles.Errors.BusinessLogic/ErrorReporter.cs
+++ b/src/Equibles.Errors.BusinessLogic/ErrorReporter.cs
@@ -1,4 +1,5 @@
 using Equibles.Core.AutoWiring;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Messaging.Contracts.Activity;
 using MassTransit;
@@ -40,7 +41,17 @@ public class ErrorReporter
             return Task.CompletedTask;
         }
 
-        return Report(source, context, exception.Message, exception.StackTrace, requestSummary);
+        // Message: flattened inner-exception chain so the Errors list shows the real cause, not a
+        // wrapper's "See the inner exception for details". StackTrace: ToString(), which carries the
+        // full inner chain (type, message and each inner stack) — StackTrace alone is the outer
+        // frames only. This mirrors what GlobalExceptionHandler already records for HTTP requests.
+        return Report(
+            source,
+            context,
+            exception.ToSummaryMessage(),
+            exception.ToString(),
+            requestSummary
+        );
     }
 
     public async Task Report(

--- a/src/Equibles.Errors.BusinessLogic/Extensions/ExceptionSummaryExtensions.cs
+++ b/src/Equibles.Errors.BusinessLogic/Extensions/ExceptionSummaryExtensions.cs
@@ -1,0 +1,33 @@
+namespace Equibles.Errors.BusinessLogic.Extensions;
+
+public static class ExceptionSummaryExtensions
+{
+    // The Errors dashboard lists rows by their Message, so a wrapper exception whose own
+    // message is "An error occurred while saving the entity changes. See the inner exception
+    // for details." (EF's DbUpdateException) or "One or more errors occurred." (AggregateException)
+    // is undiagnosable at a glance — the real cause lives in an inner exception. Flatten the
+    // InnerException chain into one line so the actual fault (e.g. the Postgres constraint
+    // violation) shows in the list without expanding the full stack. The untruncated cause + all
+    // inner stacks still go to the StackTrace column via Exception.ToString().
+    public static string ToSummaryMessage(this Exception exception)
+    {
+        if (exception == null)
+            return null;
+
+        var messages = new List<string>();
+        for (
+            var current = exception;
+            current != null && messages.Count < 5;
+            current = current.InnerException
+        )
+        {
+            var message = current.Message?.Trim();
+            // Skip blanks and consecutive duplicates: a rethrow chain often repeats the same
+            // message, which would just pad the line without adding signal.
+            if (!string.IsNullOrEmpty(message) && !messages.Contains(message))
+                messages.Add(message);
+        }
+
+        return messages.Count == 0 ? exception.Message : string.Join(" -> ", messages);
+    }
+}

--- a/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs
+++ b/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs
@@ -159,6 +159,38 @@ public class ErrorReporterTests
     }
 
     [Fact]
+    public async Task Report_Exception_WrappedInnerCause_SurfacesTheInnerMessage()
+    {
+        // A DbUpdateException's own message is "...See the inner exception for details." — useless
+        // on the Errors list. The typed overload flattens the inner chain into the recorded message
+        // (which the activity feed echoes), so the real cause is visible without expanding the stack.
+        var bus = Substitute.For<IBus>();
+        var scope = Substitute.For<IServiceScope>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBus)).Returns(bus);
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var sut = new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+
+        var wrapped = new InvalidOperationException(
+            "An error occurred while saving the entity changes. See the inner exception for details.",
+            new Exception(
+                "23505: duplicate key value violates unique constraint \"IX_IrEvent_Url\""
+            )
+        );
+
+        await sut.Report(ErrorSource.Other, context: "IrEventFlow.Plan(FASLF)", exception: wrapped);
+
+        var captured = bus.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IBus.Publish))
+            .Select(c => (ScraperActivity)c.GetArguments()[0]!)
+            .Single();
+        captured.Message.Should().Contain("duplicate key value violates unique constraint");
+    }
+
+    [Fact]
     public async Task Report_ScopeFactoryThrows_DoesNotPropagate()
     {
         // ErrorReporter.Report is called from inside `catch` blocks across every scraper

--- a/tests/Equibles.UnitTests/Errors/ExceptionSummaryExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Errors/ExceptionSummaryExtensionsTests.cs
@@ -1,0 +1,47 @@
+using Equibles.Errors.BusinessLogic.Extensions;
+
+namespace Equibles.UnitTests.Errors;
+
+public class ExceptionSummaryExtensionsTests
+{
+    [Fact]
+    public void ToSummaryMessage_NoInner_ReturnsOwnMessage()
+    {
+        var ex = new InvalidOperationException("plain failure");
+
+        ex.ToSummaryMessage().Should().Be("plain failure");
+    }
+
+    [Fact]
+    public void ToSummaryMessage_WrappedCause_JoinsOuterAndInner()
+    {
+        // The whole point: a wrapper whose message defers to "the inner exception" must surface
+        // that inner cause on one line.
+        var ex = new InvalidOperationException(
+            "See the inner exception for details.",
+            new Exception("23505: duplicate key")
+        );
+
+        var summary = ex.ToSummaryMessage();
+
+        summary.Should().Be("See the inner exception for details. -> 23505: duplicate key");
+    }
+
+    [Fact]
+    public void ToSummaryMessage_RepeatedMessagesInChain_Deduplicated()
+    {
+        // A rethrow chain often repeats the same message; padding the line with duplicates adds no
+        // signal, so consecutive/repeated identical messages collapse to one.
+        var ex = new Exception("boom", new Exception("boom", new Exception("root cause")));
+
+        ex.ToSummaryMessage().Should().Be("boom -> root cause");
+    }
+
+    [Fact]
+    public void ToSummaryMessage_Null_ReturnsNull()
+    {
+        Exception ex = null;
+
+        ex.ToSummaryMessage().Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

The `Exception`-typed `ErrorReporter.Report` overload (added for the cancellation-skip fix) recorded `exception.Message` + `exception.StackTrace` — the **outer** exception only. A wrapper such as EF's `DbUpdateException` ("An error occurred while saving the entity changes. See the inner exception for details.") or an `AggregateException` ("One or more errors occurred.") then landed on the Errors page with no trace of the real cause — the Postgres constraint violation, the null, the timeout. `GlobalExceptionHandler` already avoided this by recording `exception.ToString()`; the scraper path did not.

## Code changes

- **`ExceptionSummaryExtensions.ToSummaryMessage()`** (new) — flattens the `InnerException` chain into one deduplicated line so the Errors list shows the actual fault at a glance.
- **`ErrorReporter` typed overload** — now records `ToSummaryMessage()` as the Message and `exception.ToString()` as the StackTrace (full inner chain, matching `GlobalExceptionHandler`). All the scraper sites routed through this overload gain inner-cause capture.
- **Tests** — helper unit tests (no-inner, wrapped cause, deduped chain, null) and an `ErrorReporter` test asserting a wrapped DbUpdateException-shaped fault surfaces the inner message.