### PR TITLE
fix(financial-facts): close the null-size XBRL OOM gap

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -141,9 +141,30 @@ public class XbrlFactExtractionService
             return 0;
         }
 
-        var envelope = Encoding.UTF8.GetString(
-            GzipCompressor.Decompress(await _fileManager.GetContent(document.XbrlContent))
+        var content = GzipCompressor.Decompress(
+            await _fileManager.GetContent(document.XbrlContent)
         );
+
+        // XbrlUncompressedSize is nullable and populated at capture time, so a row that never
+        // recorded it (legacy/backfilled captures) slips past the pre-decompress check above.
+        // Re-check the actual decompressed length — the authoritative value that size approximates —
+        // before the parse materialises the envelope string (2x) and the DOM (many x) that OOM the
+        // worker on a nine-figure envelope. A skipped document completes its sweep normally, exactly
+        // as the size pre-check does.
+        if (content.LongLength > MaxParseableEnvelopeBytes)
+        {
+            _logger.LogWarning(
+                "Skipping dimensional-fact extraction for document {DocumentId} ({Accession}): "
+                    + "decompressed envelope is {Size} bytes, above the {Limit}-byte parse ceiling.",
+                document.Id,
+                document.AccessionNumber,
+                content.LongLength,
+                MaxParseableEnvelopeBytes
+            );
+            return 0;
+        }
+
+        var envelope = Encoding.UTF8.GetString(content);
 
         // Standalone (pre-inline) instances predate the 2019 cover-page
         // taxonomy, so only inline envelopes can carry 12(b) listings.

--- a/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceOversizedEnvelopeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceOversizedEnvelopeTests.cs
@@ -24,12 +24,19 @@ public class XbrlFactExtractionServiceOversizedEnvelopeTests
     /// </summary>
     private sealed class RecordingFileManager : IFileManager
     {
+        private readonly byte[] _uncompressedContent;
+
+        public RecordingFileManager(byte[] uncompressedContent = null)
+        {
+            _uncompressedContent = uncompressedContent ?? "<html></html>"u8.ToArray();
+        }
+
         public bool ContentLoaded { get; private set; }
 
         public Task<byte[]> GetContent(File file)
         {
             ContentLoaded = true;
-            return Task.FromResult(GzipCompressor.Compress("<html></html>"u8.ToArray()));
+            return Task.FromResult(GzipCompressor.Compress(_uncompressedContent));
         }
 
         public Task<File> SaveFile(byte[] content, string fileName, bool protect = false) =>
@@ -48,9 +55,11 @@ public class XbrlFactExtractionServiceOversizedEnvelopeTests
         public void DeleteFile(File file) => throw new NotSupportedException();
     }
 
-    private static (XbrlFactExtractionService Service, RecordingFileManager Files) BuildService()
+    private static (XbrlFactExtractionService Service, RecordingFileManager Files) BuildService(
+        byte[] uncompressedContent = null
+    )
     {
-        var files = new RecordingFileManager();
+        var files = new RecordingFileManager(uncompressedContent);
         var service = new XbrlFactExtractionService(
             scopeFactory: null,
             new InlineXbrlParser(),
@@ -102,5 +111,21 @@ public class XbrlFactExtractionServiceOversizedEnvelopeTests
         await service.Extract(document, CancellationToken.None);
 
         files.ContentLoaded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Extract_UnknownSizeButDecompressedContentAboveCeiling_SkipsBeforeParsing()
+    {
+        // A row with no recorded size slips past the pre-decompress guard, so the actual
+        // decompressed length is the safety net: an unknown-size envelope that turns out to be
+        // nine-figure must still be refused (returning 0, terminal) rather than OOM the parse.
+        // The bytes compress to almost nothing, so the fixture stays cheap.
+        var oversized = new byte[XbrlFactExtractionService.MaxParseableEnvelopeBytes + 1];
+        var (service, _) = BuildService(oversized);
+        var document = CapturedDocument(uncompressedSize: null);
+
+        var persisted = await service.Extract(document, CancellationToken.None);
+
+        persisted.Should().Be(0);
     }
 }


### PR DESCRIPTION
## Summary

The XBRL parse-size ceiling (#4116) that stops a nine-figure envelope from OOM-ing the worker gates on `Document.XbrlUncompressedSize` — which is `long?`. A captured row that never recorded a size (legacy/backfilled captures) evaluates `null > ceiling` as false, slips past the guard, and can still OOM the parse. There are none in production today, but it's the one hole left in the guard.

## Code changes

- **`XbrlFactExtractionService.Extract`** — after decompressing the content, re-check its actual byte length (`content.LongLength`) against `MaxParseableEnvelopeBytes` before materialising the envelope string (2x) and DOM (many x). An oversized envelope is skipped the same terminal way the size pre-check skips it. The cheap pre-check still short-circuits known-huge rows before any content is loaded.
- **Test** — a new oversized-envelope case: unknown recorded size but a decompressed payload above the ceiling is refused (returns 0) instead of parsed.

## Context

The two `OutOfMemoryException` rows on backoffice `/errors` were the same 190 MB 6-K, both **before** #4116 deployed (14:17, 2026-07-07); it is now correctly skipped and stamped at the current version. This PR hardens the remaining null-size path so the class can't return through it.