### PR TITLE
fix(cboe): make GetLatestPerType compose-safe (translatable latest-per-type)

### DIFF
--- a/src/Equibles.Cboe.Repositories/CboePutCallRatioRepository.cs
+++ b/src/Equibles.Cboe.Repositories/CboePutCallRatioRepository.cs
@@ -30,8 +30,11 @@ public class CboePutCallRatioRepository : BaseRepository<CboePutCallRatio>
 
     public IQueryable<CboePutCallRatio> GetLatestPerType()
     {
+        // The latest row for each ratio type. Expressed as a correlated max-date filter rather than
+        // GroupBy(...).Select(g => g.OrderByDescending(...).First()), which EF Core cannot translate — it
+        // throws KeyNotFoundException "EmptyProjectionMember" at runtime. (RatioType, Date) is unique, so
+        // matching the max date per type yields exactly one row per type.
         return GetAll()
-            .GroupBy(r => r.RatioType)
-            .Select(g => g.OrderByDescending(r => r.Date).First());
+            .Where(r => r.Date == GetAll().Where(x => x.RatioType == r.RatioType).Max(x => x.Date));
     }
 }

--- a/tests/Equibles.IntegrationTests/Cboe/CboePutCallRatioRepositoryGetLatestTests.cs
+++ b/tests/Equibles.IntegrationTests/Cboe/CboePutCallRatioRepositoryGetLatestTests.cs
@@ -7,12 +7,11 @@ using Xunit;
 namespace Equibles.IntegrationTests.Cboe;
 
 /// <summary>
-/// Pins <see cref="CboePutCallRatioRepository.GetLatestPerType"/> — the
-/// query behind the CBOE put/call dashboard tile. Uses
-/// <c>GroupBy(RatioType).Select(g =&gt; g.OrderByDescending(Date).First())</c>;
-/// EF Core's GroupBy-with-non-aggregated-Select translates differently per
-/// provider, so this only round-trips correctly against the real Postgres
-/// fixture.
+/// Pins <see cref="CboePutCallRatioRepository.GetLatestPerType"/> — the query behind the CBOE
+/// put/call dashboard tile and the rating card's market backdrop. It returns the newest row per
+/// ratio type via a correlated max-date filter (a plain GroupBy(...).Select(g =&gt; g.First()) is not
+/// server-translatable and throws at runtime). Query translation is provider-specific, so these
+/// only round-trip correctly against the real Postgres fixture.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class CboePutCallRatioRepositoryGetLatestTests : ParadeDbMcpTestBase
@@ -61,5 +60,53 @@ public class CboePutCallRatioRepositoryGetLatestTests : ParadeDbMcpTestBase
         latest[CboePutCallRatioType.Total].Date.Should().Be(new DateOnly(2024, 12, 24));
         latest[CboePutCallRatioType.Total].PutCallRatio.Should().Be(0.92m);
         latest[CboePutCallRatioType.Equity].Date.Should().Be(new DateOnly(2024, 12, 20));
+    }
+
+    [Fact]
+    public async Task GetLatestPerType_FilteredToOneTypeThenFirst_TranslatesAndReturnsNewest()
+    {
+        // Regression: callers compose a further Where(type).FirstOrDefault() on top of
+        // GetLatestPerType() (e.g. to read just the Equity ratio). The old
+        // GroupBy(...).Select(g => g.First()) shape threw EF Core's KeyNotFoundException
+        // "EmptyProjectionMember" at runtime when composed this way, 500-ing the caller. The
+        // query must stay server-translatable and return the newest row for the filtered type.
+        DbContext.Add(
+            new CboePutCallRatio
+            {
+                RatioType = CboePutCallRatioType.Equity,
+                Date = new DateOnly(2024, 12, 19),
+                PutCallRatio = 0.70m,
+            }
+        );
+        DbContext.Add(
+            new CboePutCallRatio
+            {
+                RatioType = CboePutCallRatioType.Equity,
+                Date = new DateOnly(2024, 12, 20),
+                PutCallRatio = 0.65m,
+            }
+        );
+        DbContext.Add(
+            new CboePutCallRatio
+            {
+                RatioType = CboePutCallRatioType.Total,
+                Date = new DateOnly(2024, 12, 24),
+                PutCallRatio = 0.92m,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new CboePutCallRatioRepository(verify);
+
+        var equity = await sut.GetLatestPerType()
+            .Where(r => r.RatioType == CboePutCallRatioType.Equity)
+            .AsNoTracking()
+            .FirstOrDefaultAsync();
+
+        equity.Should().NotBeNull();
+        equity.Date.Should().Be(new DateOnly(2024, 12, 20));
+        equity.PutCallRatio.Should().Be(0.65m);
     }
 }


### PR DESCRIPTION
## Summary

`CboePutCallRatioRepository.GetLatestPerType()` used `GroupBy(r => r.RatioType).Select(g => g.OrderByDescending(r => r.Date).First())`. That query translates on its own, but composing a further `Where(r => r.RatioType == …).FirstOrDefault()` on top of it — which callers do to read a single ratio type — makes EF Core throw `KeyNotFoundException: 'EmptyProjectionMember'` at runtime (it 500'd every stock summary page downstream via the rating card's market backdrop).

## Code changes

- `src/Equibles.Cboe.Repositories/CboePutCallRatioRepository.cs` — rewrite `GetLatestPerType()` as a correlated max-date filter (`Where(r => r.Date == GetAll().Where(x => x.RatioType == r.RatioType).Max(x => x.Date))`). `(RatioType, Date)` is unique, so it returns exactly one row per type and stays translatable when composed.
- `tests/Equibles.IntegrationTests/Cboe/CboePutCallRatioRepositoryGetLatestTests.cs` — add a regression test that composes `Where(type).FirstOrDefault()` on top of `GetLatestPerType()` and asserts it translates + returns the newest row (fails on the old shape). Both tests pass against the real Postgres fixture.