### PR TITLE
fix(holdings): resolve retired CUSIPs and follow issuer CUSIP changes

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -4,6 +4,7 @@ using Equibles.Core.AutoWiring;
 using Equibles.Core.Exceptions;
 using Equibles.Messaging.Contracts.CommonStocks;
 using MassTransit;
+using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.CommonStocks.BusinessLogic;
 
@@ -25,13 +26,25 @@ public class CommonStockManager
     /// backfill quarterly 13F data sets that were processed while this stock
     /// was still unresolvable. A no-op change publishes nothing.
     /// <para>
+    /// Replacing a non-null CUSIP (an issuer-level CUSIP change) also records the
+    /// retired value as a <see cref="CommonStockCusipAlias"/>. Filings keep
+    /// referencing the old CUSIP — laggard 13F filers for a quarter or two, and
+    /// historical data sets forever — so import-time resolution must keep mapping
+    /// it to this stock. Without the alias, the backfill triggered by the change
+    /// would silently drop old-CUSIP lines wherever a restatement amendment
+    /// deletes and re-inserts a quarter.
+    /// </para>
+    /// <para>
     /// This is a financial-domain event, so it publishes via the root
     /// <see cref="IBus"/> rather than the scoped <c>IPublishEndpoint</c>. A host
     /// that enables a bus outbox on a different context (e.g. the commercial
     /// customer database) would otherwise capture this publish into that context
     /// and never deliver it, since this flow only saves the financial context.
-    /// Delivery is at-least-once; the consumer is idempotent, so a publish lost to
-    /// a crash is recovered on the next resolve.
+    /// The consumer is idempotent; a publish lost after the save committed is
+    /// not retried here (the next resolve sees the stored value and no-ops), but
+    /// the consumer's ledger clear is global, so any later
+    /// <see cref="StockCusipChanged"/> from any stock re-imports the missed
+    /// data sets and heals the gap.
     /// </para>
     /// </summary>
     public async Task SetCusip(CommonStock commonStock, string cusip)
@@ -44,6 +57,25 @@ public class CommonStockManager
         }
 
         var previousCusip = commonStock.Cusip;
+
+        // The alias table enforces one CUSIP → one stock, ever (global unique
+        // index): a retired CUSIP already recorded — even for another stock —
+        // is left with its first owner rather than reassigned. The existence
+        // check is case-insensitive so a case-variant CUSIP can't slip past
+        // the index as a duplicate row.
+        var normalizedPrevious = previousCusip?.ToUpperInvariant();
+        if (
+            previousCusip != null
+            && !await _commonStockRepository
+                .GetCusipAliases()
+                .AnyAsync(a => a.Cusip.ToUpper() == normalizedPrevious)
+        )
+        {
+            _commonStockRepository.AddCusipAlias(
+                new CommonStockCusipAlias { CommonStockId = commonStock.Id, Cusip = previousCusip }
+            );
+        }
+
         commonStock.Cusip = cusip;
 
         await _commonStockRepository.SaveChanges();

--- a/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
+++ b/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
@@ -9,6 +9,7 @@ public class CommonStocksModuleConfiguration : Equibles.Data.IFinancialModule
     public void ConfigureEntities(ModelBuilder builder)
     {
         builder.Entity<CommonStock>();
+        builder.Entity<CommonStockCusipAlias>();
         builder.Entity<Industry>();
         builder.Entity<Sector>();
     }

--- a/src/Equibles.CommonStocks.Data/Models/CommonStockCusipAlias.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStockCusipAlias.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// A CUSIP that previously identified the stock's listed share class. Corporate
+/// actions (share-class conversions, reincorporations, name changes) assign the
+/// security a new CUSIP; filings keep referencing the retired one — laggard 13F
+/// filers for a quarter or two, and every historical data set forever — so
+/// import-time CUSIP resolution maps the union of the current CUSIP and these
+/// aliases to the stock. Rows are recorded by
+/// <c>CommonStockManager.SetCusip</c> whenever a non-null CUSIP changes.
+/// </summary>
+[Index(nameof(Cusip), IsUnique = true)]
+[Index(nameof(CommonStockId))]
+public class CommonStockCusipAlias
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+
+    public virtual CommonStock CommonStock { get; set; }
+
+    [Required]
+    [MaxLength(9)]
+    public string Cusip { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -128,4 +128,20 @@ public class CommonStockRepository : BaseRepository<CommonStock>
             .Where(cs => cs.SecondaryTickers.Count > 0)
             .SelectMany(cs => cs.SecondaryTickers);
     }
+
+    /// <summary>
+    /// Retired CUSIPs recorded when a stock's CUSIP changed. They belong to the
+    /// CommonStock aggregate (no independent lifecycle), so access lives here
+    /// rather than in a dedicated repository.
+    /// </summary>
+    public IQueryable<CommonStockCusipAlias> GetCusipAliases()
+    {
+        return DbContext.Set<CommonStockCusipAlias>().AsQueryable();
+    }
+
+    public CommonStockCusipAlias AddCusipAlias(CommonStockCusipAlias alias)
+    {
+        DbContext.Set<CommonStockCusipAlias>().Add(alias);
+        return alias;
+    }
 }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -368,15 +368,35 @@ public class HoldingsImportService
             .Select(cs => new { cs.Id, cs.Cusip })
             .ToListAsync(cancellationToken);
 
+        // Retired CUSIPs must keep resolving: after an issuer-level CUSIP change,
+        // laggard filers reference the old CUSIP for a quarter or two and every
+        // historical data set does forever. Map the union of current CUSIPs and
+        // aliases, with the current CUSIP winning a collision — otherwise a
+        // re-import (the backfill a CUSIP change itself triggers) would drop
+        // old-CUSIP lines wherever a restatement amendment rebuilds a quarter.
+        var stockIdsQuery = query.Select(cs => cs.Id);
+        var cusipAliases = await stockRepo
+            .GetCusipAliases()
+            .Where(a =>
+                uniqueCusipsList.Contains(a.Cusip) && stockIdsQuery.Contains(a.CommonStockId)
+            )
+            .Select(a => new { a.CommonStockId, a.Cusip })
+            .ToListAsync(cancellationToken);
+
         var cusipMapping = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
+        foreach (var alias in cusipAliases)
+        {
+            cusipMapping[alias.Cusip] = alias.CommonStockId;
+        }
         foreach (var stock in stocksWithCusip)
         {
             cusipMapping[stock.Cusip] = stock.Id;
         }
 
         _logger.LogInformation(
-            "Mapped {Count} CUSIPs to tracked stocks (out of {Total} in data set)",
+            "Mapped {Count} CUSIPs to tracked stocks ({AliasCount} retired aliases, out of {Total} in data set)",
             cusipMapping.Count,
+            cusipAliases.Count,
             uniqueCusips.Count
         );
 

--- a/src/Equibles.Migrations/Migrations/20260708202302_AddCommonStockCusipAlias.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260708202302_AddCommonStockCusipAlias.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708202302_AddCommonStockCusipAlias")]
+    partial class AddCommonStockCusipAlias
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260708202302_AddCommonStockCusipAlias.cs
+++ b/src/Equibles.Migrations/Migrations/20260708202302_AddCommonStockCusipAlias.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommonStockCusipAlias : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CommonStockCusipAlias",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Cusip = table.Column<string>(type: "character varying(9)", maxLength: 9, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CommonStockCusipAlias", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CommonStockCusipAlias_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStockCusipAlias_CommonStockId",
+                table: "CommonStockCusipAlias",
+                column: "CommonStockId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStockCusipAlias_Cusip",
+                table: "CommonStockCusipAlias",
+                column: "Cusip",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CommonStockCusipAlias");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -128,12 +128,18 @@ public class FtdImportService
 
         if (cusipsSeeded > 0)
         {
-            _logger.LogInformation("Seeded {Count} new CUSIPs from FTD data", cusipsSeeded);
+            _logger.LogInformation("Seeded or updated {Count} CUSIPs from FTD data", cusipsSeeded);
         }
     }
 
     /// <summary>
-    /// Seeds CUSIP values on CommonStock records by matching FTD ticker→CUSIP pairs.
+    /// Seeds and updates CUSIP values on CommonStock records by matching FTD
+    /// ticker→CUSIP pairs. Beyond filling stocks that have no CUSIP yet, this is
+    /// the pipeline's only detector for issuer-level CUSIP changes (share-class
+    /// conversions, reincorporations): the CNS feed keys rows by trading symbol,
+    /// so when a symbol's CUSIP moves, the stored stock must follow — otherwise
+    /// every new 13F line for the stock references a CUSIP nothing maps and the
+    /// stock's holders silently collapse to the laggards still filing the old one.
     /// </summary>
     private async Task<int> SeedCusips(
         List<FtdRecord> records,
@@ -142,14 +148,25 @@ public class FtdImportService
     )
     {
         var strippedAliases = BuildStrippedTickerAliases(tickerMap);
-        var tickerToCusip = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // Latest settlement date wins: during a CUSIP transition a single FTD
+        // file can carry both the retiring and the replacement CUSIP for one
+        // symbol, and the most recent trading day reflects the current security.
+        var tickerToCusip = new Dictionary<string, (string Cusip, DateOnly SettlementDate)>(
+            StringComparer.OrdinalIgnoreCase
+        );
         foreach (var record in records)
         {
             if (string.IsNullOrEmpty(record.Cusip) || string.IsNullOrEmpty(record.Symbol))
                 continue;
             if (!TryResolveSymbol(record.Symbol, tickerMap, strippedAliases, out var ticker))
                 continue;
-            tickerToCusip.TryAdd(ticker, record.Cusip);
+            if (
+                !tickerToCusip.TryGetValue(ticker, out var current)
+                || record.SettlementDate > current.SettlementDate
+            )
+            {
+                tickerToCusip[ticker] = (record.Cusip, record.SettlementDate);
+            }
         }
 
         if (tickerToCusip.Count == 0)
@@ -160,22 +177,50 @@ public class FtdImportService
         var stockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
 
         var tickers = tickerToCusip.Keys.ToList();
-        var stocks = await stockRepo
-            .GetByTickers(tickers)
-            .Where(s => s.Cusip == null)
+        var stocks = await stockRepo.GetByTickers(tickers).ToListAsync(cancellationToken);
+
+        // Guard against ticker recycling: if a delisted issuer's symbol is
+        // reassigned to a different company before CompanySync retires the
+        // stale stock, the FTD feed maps the freed symbol to the NEW issuer's
+        // CUSIP. Adopting a CUSIP that is currently another tracked stock's
+        // identity would leave two stocks sharing one CUSIP (the CommonStock
+        // Cusip index is non-unique) and misroute that CUSIP's 13F lines, so
+        // such rows are skipped — CompanySync owns ticker reassignment.
+        var resolvedCusips = tickerToCusip.Values.Select(v => v.Cusip).Distinct().ToList();
+        var cusipOwners = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
+        var owners = await stockRepo
+            .GetAll()
+            .Where(s => s.Cusip != null && resolvedCusips.Contains(s.Cusip))
+            .Select(s => new { s.Id, s.Cusip })
             .ToListAsync(cancellationToken);
+        foreach (var owner in owners)
+        {
+            cusipOwners[owner.Cusip] = owner.Id;
+        }
 
         var seeded = 0;
         foreach (var stock in stocks)
         {
-            if (tickerToCusip.TryGetValue(stock.Ticker, out var cusip))
+            if (!tickerToCusip.TryGetValue(stock.Ticker, out var resolved))
+                continue;
+            if (string.Equals(stock.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (cusipOwners.TryGetValue(resolved.Cusip, out var ownerId) && ownerId != stock.Id)
             {
-                // Route through the manager so a StockCusipChanged event is
-                // published (outbox) — lets Holdings backfill any 13F data
-                // sets processed before this stock had a CUSIP.
-                await stockManager.SetCusip(stock, cusip);
-                seeded++;
+                _logger.LogWarning(
+                    "FTD maps {Ticker} to CUSIP {Cusip}, but that CUSIP already identifies another tracked stock — skipping (possible ticker reuse)",
+                    stock.Ticker,
+                    resolved.Cusip
+                );
+                continue;
             }
+
+            // Route through the manager so a StockCusipChanged event is
+            // published (outbox) — lets Holdings backfill any 13F data
+            // sets processed before this stock had a CUSIP (or while it
+            // still carried the retired one, kept as an alias).
+            await stockManager.SetCusip(stock, resolved.Cusip);
+            seeded++;
         }
 
         return seeded;

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCusipAliasTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCusipAliasTests.cs
@@ -1,0 +1,255 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// After an issuer-level CUSIP change, filings referencing the retired CUSIP
+/// must keep resolving to the stock: laggard 13F filers use it for a quarter or
+/// two, and every historical data set uses it forever — including the full
+/// re-import that a CUSIP change itself triggers (StockCusipChangedConsumer
+/// clears the processed-data-set ledger). BBUC made the failure visible: its
+/// Class A conversion retired 11259V106 for 113006100, and until aliases
+/// existed, whichever CUSIP was NOT stored on the stock silently dropped at
+/// BuildCusipMapping. Pin both resolution rules: (1) a retired CUSIP maps via
+/// its <see cref="CommonStockCusipAlias"/> row, (2) a stock's CURRENT CUSIP
+/// wins over another stock's alias claiming the same CUSIP.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServiceCusipAliasTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public HoldingsImportServiceCusipAliasTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.ResetAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private HoldingsImportService CreateImporter(IStockPriceProvider priceProvider)
+    {
+        return new HoldingsImportService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            priceProvider,
+            Substitute.For<MassTransit.IBus>()
+        );
+    }
+
+    private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)
+    {
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, body) in entries)
+            {
+                var entry = writer.CreateEntry(name);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(body);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    private static IStockPriceProvider PriceProviderReturning(
+        Dictionary<(Guid, DateOnly), decimal> prices
+    )
+    {
+        var provider = Substitute.For<IStockPriceProvider>();
+        provider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(prices));
+        return provider;
+    }
+
+    [Fact]
+    public async Task ImportDataSet_FilingReferencesRetiredCusip_ResolvesViaAliasToStock()
+    {
+        // BBUC post-change shape: the stock carries the NEW CUSIP; a laggard
+        // filer (or any historical data set) still reports the OLD one.
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BBUC",
+            Name = "Brookfield Business Corp",
+            Cik = "1654795",
+            Cusip = "113006100",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockCusipAlias>()
+                .Add(new CommonStockCusipAlias { CommonStockId = stock.Id, Cusip = "11259V106" });
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2026, 3, 31);
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-001\t2026-05-08\t2026-03-31\t0001142031\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-001\tN\tPrivate Management Group\tIrvine\tCA\t028-04556\t105909\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+            + "ACC-001\t11259V106\t921231\tSH\t\tSOLE\t921231\t0\t0\tCL A EXC SUB VTG\t\n";
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+
+        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 32m };
+        var sut = CreateImporter(PriceProviderReturning(prices));
+
+        var result = await sut.ImportDataSet(
+            archive,
+            new DateOnly(2026, 1, 1),
+            CancellationToken.None
+        );
+
+        result.IsComplete.Should().BeTrue();
+
+        using var verify = FreshContext();
+        var holding = await verify.Set<InstitutionalHolding>().SingleAsync();
+        holding.CommonStockId.Should().Be(stock.Id);
+        holding.Cusip.Should().Be("11259V106");
+        holding.Shares.Should().Be(921231);
+    }
+
+    [Fact]
+    public async Task ImportDataSet_AliasCollidesWithAnotherStocksCurrentCusip_CurrentCusipWins()
+    {
+        // Precedence pin: if a CUSIP is simultaneously stock A's CURRENT value
+        // and stock B's retired alias (a shape only bad data can produce), the
+        // current assignment is authoritative.
+        var stockA = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAA",
+            Name = "Current Owner Corp",
+            Cik = "0000000001",
+            Cusip = "999999999",
+        };
+        var stockB = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BBB",
+            Name = "Stale Alias Corp",
+            Cik = "0000000002",
+            Cusip = "888888888",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().AddRange(stockA, stockB);
+            seed.Set<CommonStockCusipAlias>()
+                .Add(new CommonStockCusipAlias { CommonStockId = stockB.Id, Cusip = "999999999" });
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2026, 3, 31);
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-002\t2026-05-08\t2026-03-31\t0001067983\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-002\tN\tBerkshire Hathaway\tOmaha\tNE\t028-12345\t12345\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+            + "ACC-002\t999999999\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t\n";
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+
+        var prices = new Dictionary<(Guid, DateOnly), decimal>
+        {
+            [(stockA.Id, reportDate)] = 100m,
+            [(stockB.Id, reportDate)] = 100m,
+        };
+        var sut = CreateImporter(PriceProviderReturning(prices));
+
+        var result = await sut.ImportDataSet(
+            archive,
+            new DateOnly(2026, 1, 1),
+            CancellationToken.None
+        );
+
+        result.IsComplete.Should().BeTrue();
+
+        using var verify = FreshContext();
+        var holding = await verify.Set<InstitutionalHolding>().SingleAsync();
+        holding.CommonStockId.Should().Be(stockA.Id);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
@@ -1,0 +1,329 @@
+using System.Collections;
+using System.Reflection;
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging.Contracts.CommonStocks;
+using Equibles.Sec.HostedService.Services;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// SeedCusips historically only filled stocks whose CUSIP was still null, so an
+/// issuer-level CUSIP change (BBUC's Class A conversion retired 11259V106 for
+/// 113006100 in Q1 2026) was never picked up: every new 13F line referenced a
+/// CUSIP nothing mapped, and the stock's holder count silently collapsed to the
+/// laggard filers still using the old CUSIP. Pin the change-detection contract:
+/// (1) a changed FTD CUSIP updates the stored stock, (2) the retired CUSIP is
+/// recorded as a <see cref="CommonStockCusipAlias"/> so old filings keep
+/// resolving, (3) StockCusipChanged is published so Holdings backfills, and
+/// (4) the per-symbol CUSIP is resolved by LATEST SETTLEMENT DATE — a
+/// transition file carries both CUSIPs, and neither first-row-wins nor
+/// last-row-wins picks the right one.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public FtdImportServiceSeedCusipsUpdatesChangedCusipTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    [Fact]
+    public async Task SeedCusips_SymbolCusipChanged_UpdatesStockRecordsAliasAndPublishesEvent()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BBUC",
+            Name = "Brookfield Business Corp",
+            Cik = "1654795",
+            Cusip = "11259V106",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var publishEndpoint = Substitute.For<IBus>();
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(CommonStockManager))
+                    .Returns(
+                        new CommonStockManager(new CommonStockRepository(ctx), publishEndpoint)
+                    );
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+
+        var sut = new FtdImportService(
+            scopeFactory,
+            Substitute.For<ISecEdgarClient>(),
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions())
+        );
+
+        // Transition file: the retiring CUSIP trades on the early settlement
+        // days and the replacement on the latest. Order the rows so the
+        // newest-dated row sits in the middle — first-row-wins and
+        // last-row-wins would both resolve the OLD CUSIP; only
+        // latest-settlement-date-wins resolves the NEW one.
+        var recordType = typeof(FtdImportService).Assembly.GetType(
+            "Equibles.Sec.HostedService.Models.FtdRecord"
+        )!;
+        var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(recordType))!;
+
+        void AddRecord(string cusip, DateOnly settlementDate)
+        {
+            var record = Activator.CreateInstance(recordType)!;
+            recordType.GetProperty("Cusip")!.SetValue(record, cusip);
+            recordType.GetProperty("Symbol")!.SetValue(record, "BBUC");
+            recordType.GetProperty("SettlementDate")!.SetValue(record, settlementDate);
+            list.Add(record);
+        }
+
+        AddRecord("11259V106", new DateOnly(2026, 3, 10));
+        AddRecord("113006100", new DateOnly(2026, 3, 27));
+        AddRecord("11259V106", new DateOnly(2026, 3, 5));
+
+        var tickerMap = new Dictionary<string, Guid> { ["BBUC"] = stock.Id };
+
+        var seedCusips = typeof(FtdImportService).GetMethod(
+            "SeedCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var seeded = await (Task<int>)
+            seedCusips.Invoke(sut, [list, tickerMap, CancellationToken.None])!;
+
+        seeded.Should().Be(1);
+
+        await publishEndpoint
+            .Received(1)
+            .Publish(
+                Arg.Is<StockCusipChanged>(e =>
+                    e.CommonStockId == stock.Id
+                    && e.Ticker == "BBUC"
+                    && e.Cusip == "113006100"
+                    && e.PreviousCusip == "11259V106"
+                ),
+                Arg.Any<CancellationToken>()
+            );
+
+        using var verify = FreshContext();
+        var persisted = await verify.Set<CommonStock>().FirstAsync(s => s.Id == stock.Id);
+        persisted.Cusip.Should().Be("113006100");
+
+        var alias = await verify.Set<CommonStockCusipAlias>().SingleAsync();
+        alias.Cusip.Should().Be("11259V106");
+        alias.CommonStockId.Should().Be(stock.Id);
+    }
+
+    [Fact]
+    public async Task SeedCusips_ResolvedCusipBelongsToAnotherStock_SkipsWithoutUpdating()
+    {
+        // Ticker-recycling shape: a delisted issuer's stale stock still holds
+        // the freed symbol, and the FTD feed now maps that symbol to a CUSIP
+        // that already identifies a different tracked stock. Adopting it would
+        // leave two stocks sharing one CUSIP, so the row must be skipped.
+        var staleStock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "TICK",
+            Name = "Delisted Corp",
+            Cik = "0000000001",
+            Cusip = "111111111",
+        };
+        var currentOwner = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "NEWCO",
+            Name = "New Owner Corp",
+            Cik = "0000000002",
+            Cusip = "222222222",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().AddRange(staleStock, currentOwner);
+            await seed.SaveChangesAsync();
+        }
+
+        var publishEndpoint = Substitute.For<IBus>();
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(CommonStockManager))
+                    .Returns(
+                        new CommonStockManager(new CommonStockRepository(ctx), publishEndpoint)
+                    );
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+
+        var sut = new FtdImportService(
+            scopeFactory,
+            Substitute.For<ISecEdgarClient>(),
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions())
+        );
+
+        var recordType = typeof(FtdImportService).Assembly.GetType(
+            "Equibles.Sec.HostedService.Models.FtdRecord"
+        )!;
+        var record = Activator.CreateInstance(recordType)!;
+        recordType.GetProperty("Cusip")!.SetValue(record, "222222222");
+        recordType.GetProperty("Symbol")!.SetValue(record, "TICK");
+        recordType.GetProperty("SettlementDate")!.SetValue(record, new DateOnly(2026, 6, 12));
+        var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(recordType))!;
+        list.Add(record);
+
+        var tickerMap = new Dictionary<string, Guid>
+        {
+            ["TICK"] = staleStock.Id,
+            ["NEWCO"] = currentOwner.Id,
+        };
+
+        var seedCusips = typeof(FtdImportService).GetMethod(
+            "SeedCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var seeded = await (Task<int>)
+            seedCusips.Invoke(sut, [list, tickerMap, CancellationToken.None])!;
+
+        seeded.Should().Be(0);
+        await publishEndpoint
+            .DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+
+        using var verify = FreshContext();
+        var persistedStale = await verify.Set<CommonStock>().FirstAsync(s => s.Id == staleStock.Id);
+        persistedStale.Cusip.Should().Be("111111111");
+    }
+
+    [Fact]
+    public async Task SeedCusips_CusipUnchanged_UpdatesNothingAndPublishesNothing()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BBUC",
+            Name = "Brookfield Business Corp",
+            Cik = "1654795",
+            Cusip = "113006100",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var publishEndpoint = Substitute.For<IBus>();
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(CommonStockManager))
+                    .Returns(
+                        new CommonStockManager(new CommonStockRepository(ctx), publishEndpoint)
+                    );
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+
+        var sut = new FtdImportService(
+            scopeFactory,
+            Substitute.For<ISecEdgarClient>(),
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions())
+        );
+
+        var recordType = typeof(FtdImportService).Assembly.GetType(
+            "Equibles.Sec.HostedService.Models.FtdRecord"
+        )!;
+        var record = Activator.CreateInstance(recordType)!;
+        recordType.GetProperty("Cusip")!.SetValue(record, "113006100");
+        recordType.GetProperty("Symbol")!.SetValue(record, "BBUC");
+        recordType.GetProperty("SettlementDate")!.SetValue(record, new DateOnly(2026, 6, 12));
+        var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(recordType))!;
+        list.Add(record);
+
+        var tickerMap = new Dictionary<string, Guid> { ["BBUC"] = stock.Id };
+
+        var seedCusips = typeof(FtdImportService).GetMethod(
+            "SeedCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var seeded = await (Task<int>)
+            seedCusips.Invoke(sut, [list, tickerMap, CancellationToken.None])!;
+
+        seeded.Should().Be(0);
+        await publishEndpoint
+            .DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+
+        using var verify = FreshContext();
+        (await verify.Set<CommonStockCusipAlias>().AnyAsync()).Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipRecordsAliasTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipRecordsAliasTests.cs
@@ -1,0 +1,90 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+// SetCusip's alias contract: replacing a non-null CUSIP records the retired
+// value as a CommonStockCusipAlias so import-time resolution keeps mapping it
+// to the stock (laggard 13F filers and historical data sets reference the old
+// CUSIP long after the change). First-time seeding (null → value) retires
+// nothing, so it must record nothing; and a CUSIP already present in the alias
+// table must not be added twice (the unique index would abort the save).
+public class CommonStockManagerSetCusipRecordsAliasTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[] { new CommonStocksModuleConfiguration() }
+        );
+    }
+
+    private static async Task<(
+        CommonStockManager Sut,
+        EquiblesFinancialDbContext Db,
+        CommonStock Stock
+    )> Arrange(string initialCusip)
+    {
+        var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "BBUC",
+            Name = "Brookfield Business Corp",
+            Cik = "1654795",
+            Cusip = initialCusip,
+        };
+        db.Set<CommonStock>().Add(stock);
+        await db.SaveChangesAsync();
+
+        var sut = new CommonStockManager(new CommonStockRepository(db), Substitute.For<IBus>());
+        return (sut, db, stock);
+    }
+
+    [Fact]
+    public async Task SetCusip_ReplacingExistingCusip_RecordsRetiredCusipAsAlias()
+    {
+        var (sut, db, stock) = await Arrange("11259V106");
+
+        await sut.SetCusip(stock, "113006100");
+
+        stock.Cusip.Should().Be("113006100");
+        var alias = await db.Set<CommonStockCusipAlias>().SingleAsync();
+        alias.Cusip.Should().Be("11259V106");
+        alias.CommonStockId.Should().Be(stock.Id);
+    }
+
+    [Fact]
+    public async Task SetCusip_FirstTimeSeedingFromNull_RecordsNoAlias()
+    {
+        var (sut, db, stock) = await Arrange(null);
+
+        await sut.SetCusip(stock, "113006100");
+
+        stock.Cusip.Should().Be("113006100");
+        (await db.Set<CommonStockCusipAlias>().AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SetCusip_RetiredCusipAlreadyAliased_DoesNotDuplicateAliasRow()
+    {
+        var (sut, db, stock) = await Arrange("11259V106");
+        db.Set<CommonStockCusipAlias>()
+            .Add(new CommonStockCusipAlias { CommonStockId = stock.Id, Cusip = "11259V106" });
+        await db.SaveChangesAsync();
+
+        await sut.SetCusip(stock, "113006100");
+
+        stock.Cusip.Should().Be("113006100");
+        var aliases = await db.Set<CommonStockCusipAlias>().ToListAsync();
+        aliases.Should().ContainSingle().Which.Cusip.Should().Be("11259V106");
+    }
+}


### PR DESCRIPTION
## Summary

An issuer-level CUSIP change (share-class conversion, reincorporation) silently collapsed a stock's institutional holders. `FtdImportService.SeedCusips` only seeded CUSIPs onto stocks that had none — it never updated a changed one — so after a change every new 13F line referenced a CUSIP nothing mapped, and `BuildCusipMapping` dropped it. Brookfield Business Corp (BBUC) made it visible: 11259V106 was retired for 113006100 in Q1 2026 (verified in BlackRock's and Geode's raw 13Fs and in the CNS fails feed, which lists the symbol as "BROOKFIELD BUSINESS CORP NEW"), and the quarter's holder count fell from 134 to the 6 laggards still filing the old CUSIP.

## Code changes

- **`CommonStockCusipAlias` (new entity + migration)** — retired CUSIPs, unique index on `Cusip`, FK cascade to `CommonStock`. Recorded by `CommonStockManager.SetCusip` whenever a non-null CUSIP is replaced, so old-CUSIP filings keep resolving — critically including the full re-import that the change itself triggers (`StockCusipChangedConsumer` clears the processed-data-set ledger), where restatement amendments delete holder+quarter rows and re-insert only lines that map.
- **`CommonStockRepository`** — `GetCusipAliases()` / `AddCusipAlias()`, aggregate-scoped (no new repository class, no manager ctor change — avoids touching ~36 existing construction sites).
- **`FtdImportService.SeedCusips`** — resolves each symbol's CUSIP by latest settlement date (a transition file carries both the retiring and the replacement CUSIP) and updates changed CUSIPs. Guarded against ticker recycling: a CUSIP that currently identifies another tracked stock is never adopted (logged and skipped).
- **`HoldingsImportService.BuildCusipMapping`** — maps the union of current CUSIPs and aliases, current CUSIP winning collisions; also fixes 13D/G issuer scoping through aliases.
- **Tests** — 3 unit (alias recording contract), 5 integration (change detection incl. latest-settlement-date pin, unchanged no-op, recycling guard, alias-resolved import, current-beats-alias precedence). Full unit suite (3375) and targeted integration set (73) pass locally.

Note for the commercial repo: the pin bump must ship with the paired commercial migration in the same unit of work.