### PR TITLE
fix(worker): swallow scope-creation failures in best-effort activity publish

### DIFF
--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -44,12 +44,12 @@ public abstract class BaseScraperWorker : BackgroundService
         CancellationToken cancellationToken
     )
     {
-        var bus = TryGetBus();
-        if (bus is null)
-            return;
-
         try
         {
+            var bus = TryGetBus();
+            if (bus is null)
+                return;
+
             await bus.Publish(
                 new ScraperActivity(
                     Source: WorkerName,
@@ -68,7 +68,9 @@ public abstract class BaseScraperWorker : BackgroundService
         catch (Exception ex)
         {
             // The activity feed is best-effort. A failure here must never
-            // crash the scraper; log at Debug so it shows under verbose
+            // crash the scraper — this also covers the ObjectDisposedException
+            // CreateScope() throws when the host is tearing down the root
+            // provider during shutdown. Log at Debug so it shows under verbose
             // logging but doesn't pollute normal runs.
             Logger.LogDebug(ex, "Failed to publish ScraperActivity for {Worker}", WorkerName);
         }

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerDisposedProviderTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerDisposedProviderTests.cs
@@ -1,0 +1,88 @@
+#nullable enable
+
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Worker;
+
+public class BaseScraperWorkerDisposedProviderTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ScopeCreationThrowsObjectDisposed_WorkerCompletesWithoutFault()
+    {
+        // Repro for the shutdown noise seen in production: during host teardown
+        // the root IServiceProvider is disposed, so PublishActivity's
+        // CreateScope() throws ObjectDisposedException. That exception is not an
+        // OperationCanceledException, so it escaped ExecuteAsync and made the
+        // host log "BackgroundService failed" + a StopHost fatal for every
+        // worker still in its cancellation path. The activity feed is
+        // best-effort — scope-creation failures must be swallowed like any
+        // other publish failure.
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns<IServiceScope>(_ =>
+                throw new ObjectDisposedException(nameof(IServiceProvider))
+            );
+
+        var reporter = new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+        using var worker = new DisposedProviderTestWorker(
+            Substitute.For<ILogger>(),
+            scopeFactory,
+            reporter
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        // The "cycle started" publish already hits the throwing factory;
+        // reaching DoWork proves the failure was swallowed instead of escaping.
+        await WaitUntil(() => worker.DoWorkCalls >= 1);
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.DoWorkCalls.Should().BeGreaterThanOrEqualTo(1);
+        // Cancellation lands in DoWork, so the worker exits through its
+        // OperationCanceledException handler — whose "cancelled" publish also
+        // hits the throwing factory — and must still complete without fault.
+        worker.ExecuteTask.Should().NotBeNull();
+        worker.ExecuteTask!.IsCompletedSuccessfully.Should().BeTrue();
+    }
+
+    private static async Task WaitUntil(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+                return;
+            await Task.Delay(10);
+        }
+    }
+
+    private sealed class DisposedProviderTestWorker : BaseScraperWorker
+    {
+        protected override string WorkerName => "TestWorker";
+        protected override TimeSpan SleepInterval => TimeSpan.FromSeconds(30);
+        protected override ErrorSource ErrorSource => ErrorSource.Other;
+
+        public int DoWorkCalls;
+
+        public DisposedProviderTestWorker(
+            ILogger logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter
+        )
+            : base(logger, scopeFactory, errorReporter) { }
+
+        protected override async Task DoWork(CancellationToken stoppingToken)
+        {
+            Interlocked.Increment(ref DoWorkCalls);
+            // Block until shutdown so cancellation surfaces inside DoWork and
+            // the worker exits through its cancelled path (the production
+            // stack: cancelled → PublishActivity → CreateScope).
+            await Task.Delay(Timeout.Infinite, stoppingToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

On every worker-host shutdown, each scraper worker still in its cancellation path logged `[ERR] BackgroundService failed` + `[FTL] The HostOptions.BackgroundServiceExceptionBehavior is configured to StopHost...`. The cause: `BaseScraperWorker.PublishActivity` called `TryGetBus()` — which does `ScopeFactory.CreateScope()` — outside its try/catch. During host teardown the root `IServiceProvider` is disposed, `CreateScope()` throws `ObjectDisposedException`, and since that is not an `OperationCanceledException` the host's cancellation carve-out does not apply: the exception escapes `ExecuteAsync` and the host logs a spurious fatal for every worker.

The activity feed is best-effort by design ("a failure here must never crash the scraper"), so scope-creation failures must be swallowed like any other publish failure.

Closes #4131

## Code changes

- **`src/Equibles.Worker/BaseScraperWorker.cs`**: moved the `TryGetBus()` call and its null check inside the existing try block in `PublishActivity`, so `ObjectDisposedException` (and anything else thrown by scope creation / bus resolution) lands in the existing best-effort catch-all that logs at Debug. The `catch (OperationCanceledException)` clause stays first; the catch-all comment now mentions the `CreateScope()` teardown case.
- **`tests/Equibles.UnitTests/Worker/BaseScraperWorkerDisposedProviderTests.cs`**: regression test — a minimal `BaseScraperWorker` subclass with an `IServiceScopeFactory` stub whose `CreateScope()` throws `ObjectDisposedException`; the worker runs a cycle, is stopped through its cancellation path (the production stack), and `ExecuteTask` must complete without fault. Fails on `main`, passes with the fix.
