### PR TITLE
feat(sec): event-driven EDGAR filing discovery replacing per-CIK submissions polling

### DIFF
--- a/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
@@ -83,6 +83,19 @@ public interface ISecEdgarClient
     );
 
     /// <summary>
+    /// Fetches one page of EDGAR's "Latest Filings" ATOM feed — the real-time
+    /// stream of accepted submissions across all filers. The feed is a rolling
+    /// window of the most recent entries only, so callers that must not miss a
+    /// filing have to reconcile against the daily index; this is the
+    /// low-latency discovery layer, never the source of truth.
+    /// </summary>
+    Task<List<EdgarRecentFilingEntry>> GetRecentFilings(
+        int start = 0,
+        int count = 100,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Returns the most recent <c>reportDate</c> for a given form type from the
     /// SEC submissions feed's <c>filings.recent</c> section. Uses the cached
     /// submissions payload when available (zero extra SEC requests after

--- a/src/Equibles.Integrations.Sec/Extensions/DocumentTypeExtensions.cs
+++ b/src/Equibles.Integrations.Sec/Extensions/DocumentTypeExtensions.cs
@@ -4,7 +4,7 @@ using Equibles.Integrations.Sec.Models;
 
 namespace Equibles.Integrations.Sec.Extensions;
 
-internal static class DocumentTypeExtensions
+public static class DocumentTypeExtensions
 {
     public static string GetFormName(this DocumentTypeFilter documentType)
     {

--- a/src/Equibles.Integrations.Sec/Models/EdgarRecentFilingEntry.cs
+++ b/src/Equibles.Integrations.Sec/Models/EdgarRecentFilingEntry.cs
@@ -1,0 +1,26 @@
+namespace Equibles.Integrations.Sec.Models;
+
+/// <summary>
+/// One entry of SEC EDGAR's "Latest Filings" ATOM feed
+/// (<c>/cgi-bin/browse-edgar?action=getcurrent&amp;output=atom</c>) — the
+/// real-time dissemination stream. A single submission produces one entry per
+/// associated entity (filer, subject company, reporting person), each carrying
+/// that entity's own CIK, so ownership forms surface both the person and the
+/// issuer. The feed is a rolling window of the most recent entries only; a
+/// burst larger than the window scrolls older entries out unseen, so it can
+/// never be the sole discovery source.
+/// </summary>
+public class EdgarRecentFilingEntry
+{
+    /// <summary>Zero-padded 10-digit CIK of the entity this entry is about.</summary>
+    public string Cik { get; set; }
+
+    public string FormType { get; set; }
+
+    /// <summary>Accession number with dashes, e.g. <c>0001995137-26-000012</c>.</summary>
+    public string AccessionNumber { get; set; }
+
+    public string CompanyName { get; set; }
+
+    public DateTimeOffset? Updated { get; set; }
+}

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -518,6 +518,94 @@ public class SecEdgarClient : ISecEdgarClient
         return await response.Content.ReadAsStreamAsync();
     }
 
+    public async Task<List<EdgarRecentFilingEntry>> GetRecentFilings(
+        int start = 0,
+        int count = 100,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var url =
+            $"{FilesBaseUrl}/cgi-bin/browse-edgar?action=getcurrent&type=&company=&dateb=&owner=include&start={start}&count={count}&output=atom";
+        var content = await FetchStringAsync(url);
+        return ParseRecentFilingsAtom(content);
+    }
+
+    /// <summary>
+    /// Parses the "Latest Filings" ATOM payload. Entry shape:
+    /// title "144 - Company Name (0001995137) (Reporting)", form type in the
+    /// category term, accession in the id tag
+    /// ("urn:tag:sec.gov,2008:accession-number=0001995137-26-000012").
+    /// Entries missing a parseable CIK, form or accession are skipped rather
+    /// than failing the page — the daily-index layer backstops anything lost.
+    /// </summary>
+    internal static List<EdgarRecentFilingEntry> ParseRecentFilingsAtom(string xml)
+    {
+        var entries = new List<EdgarRecentFilingEntry>();
+        if (string.IsNullOrWhiteSpace(xml))
+            return entries;
+
+        System.Xml.Linq.XNamespace atom = "http://www.w3.org/2005/Atom";
+        var feed = System.Xml.Linq.XDocument.Parse(xml);
+
+        foreach (var entry in feed.Descendants(atom + "entry"))
+        {
+            var title = entry.Element(atom + "title")?.Value ?? string.Empty;
+            var formType = entry
+                .Elements(atom + "category")
+                .FirstOrDefault()
+                ?.Attribute("term")
+                ?.Value;
+            var id = entry.Element(atom + "id")?.Value ?? string.Empty;
+
+            var accessionMarkerIndex = id.LastIndexOf('=');
+            var accession =
+                accessionMarkerIndex >= 0 && accessionMarkerIndex < id.Length - 1
+                    ? id[(accessionMarkerIndex + 1)..].Trim()
+                    : null;
+
+            var cikMatch = RecentFilingCikPattern.Match(title);
+            if (
+                string.IsNullOrEmpty(formType)
+                || string.IsNullOrEmpty(accession)
+                || !cikMatch.Success
+            )
+                continue;
+
+            // "144 - Camerana Niccolo (0001995137) (Reporting)" → name sits between
+            // the first " - " and the CIK parenthesis.
+            var nameStart = title.IndexOf(" - ", StringComparison.Ordinal);
+            var companyName = nameStart >= 0 ? title[(nameStart + 3)..cikMatch.Index].Trim() : null;
+
+            DateTimeOffset? updated = DateTimeOffset.TryParse(
+                entry.Element(atom + "updated")?.Value,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None,
+                out var parsedUpdated
+            )
+                ? parsedUpdated
+                : null;
+
+            entries.Add(
+                new EdgarRecentFilingEntry
+                {
+                    Cik = cikMatch.Groups[1].Value,
+                    FormType = formType,
+                    AccessionNumber = accession,
+                    CompanyName = companyName,
+                    Updated = updated,
+                }
+            );
+        }
+
+        return entries;
+    }
+
+    // Matches the CIK parenthesis in a feed entry title, e.g. "(0001995137)".
+    private static readonly System.Text.RegularExpressions.Regex RecentFilingCikPattern = new(
+        @"\((\d{5,10})\)",
+        System.Text.RegularExpressions.RegexOptions.Compiled
+    );
+
     // 13F-HR and 13F-HR/A both start with this; the default form set for the
     // back-compatible GetDailyIndex.
     private static readonly string[] ThirteenFFormPrefixes = ["13F-HR"];

--- a/src/Equibles.Migrations/Migrations/20260709143544_AddCompanyFilingSyncState.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260709143544_AddCompanyFilingSyncState.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709143544_AddCompanyFilingSyncState")]
+    partial class AddCompanyFilingSyncState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260709143544_AddCompanyFilingSyncState.cs
+++ b/src/Equibles.Migrations/Migrations/20260709143544_AddCompanyFilingSyncState.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompanyFilingSyncState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CompanyFilingSyncState",
+                columns: table => new
+                {
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LastSyncedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompanyFilingSyncState", x => x.CommonStockId);
+                    table.ForeignKey(
+                        name: "FK_CompanyFilingSyncState_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompanyFilingSyncState_LastSyncedAt",
+                table: "CompanyFilingSyncState",
+                column: "LastSyncedAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CompanyFilingSyncState");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/CompanyFilingSyncState.cs
+++ b/src/Equibles.Sec.Data/Models/CompanyFilingSyncState.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// Per-company filing-enumeration watermark for event-driven EDGAR discovery:
+/// when the document scraper last listed this company's submissions. No row
+/// means the company was never fully synced (fresh onboarding) and gets a full
+/// historical backfill; a stale row schedules the periodic reconciliation
+/// re-sweep that backstops the real-time discovery feeds. Rows cascade with
+/// the stock, so a replaced company re-onboards from scratch.
+/// </summary>
+[Index(nameof(LastSyncedAt))]
+public class CompanyFilingSyncState
+{
+    [Key]
+    public Guid CommonStockId { get; set; }
+
+    [ForeignKey(nameof(CommonStockId))]
+    public virtual CommonStock CommonStock { get; set; }
+
+    public DateTime LastSyncedAt { get; set; }
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -39,6 +39,7 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         });
 
         builder.Entity<BackfillState>();
+        builder.Entity<CompanyFilingSyncState>();
         builder.Entity<FailToDeliver>();
         builder.Entity<FormAdvAdviser>();
         builder.Entity<FormDFiling>();

--- a/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
@@ -29,4 +29,36 @@ public class DocumentScraperOptions
         DocumentType.NportPa,
         DocumentType.Def14A,
     ];
+
+    // Event-driven discovery replaces the legacy sweep that re-fetched every
+    // company's submissions JSON every cycle (>95% of those polls found nothing;
+    // they consumed a third of the shared EDGAR request budget). Kill switch:
+    // false restores the legacy full sweep with no code change.
+    public bool UseEventDrivenDiscovery { get; set; } = true;
+
+    // Minimum seconds between "Latest Filings" ATOM feed polls. The feed holds
+    // ~100 entries per page and peak dissemination bursts run tens of filings a
+    // minute, so the poll interval bounds the realtime layer's blind window.
+    public int RecentFeedPollSeconds { get; set; } = 60;
+
+    // Max ATOM pages (100 entries each) walked per poll when every entry is
+    // still unseen (first poll after a boot, or a heavy burst).
+    public int RecentFeedMaxPages { get; set; } = 5;
+
+    // A company whose last full filing enumeration is older than this gets a
+    // reconciliation re-sweep — the correctness backstop that converges on the
+    // authoritative submissions JSON no matter what the realtime layers missed.
+    public int ReconciliationHours { get; set; } = 24;
+
+    // Cap on reconciliation re-sweeps per cycle so a cold start (no stamps yet)
+    // drains as a rolling backfill instead of one monster cycle.
+    public int MaxReconciliationsPerCycle { get; set; } = 400;
+
+    // Max daily-index days processed per cycle when catching up after downtime.
+    public int DailyIndexMaxDaysPerCycle { get; set; } = 7;
+
+    // Minimum minutes between SEC company-directory syncs in event-driven mode.
+    // The legacy sweep synced once per multi-hour cycle; event-driven cycles run
+    // every few seconds, so an unthrottled sync would hammer company_tickers.
+    public int CompanySyncIntervalMinutes { get; set; } = 60;
 }

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -26,6 +26,7 @@ public class DocumentScraper : IDocumentScraper
 {
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly ICompanySyncService _companySyncService;
+    private readonly IFilingDiscoveryService _filingDiscoveryService;
     private readonly IEnumerable<IFilingProcessor> _filingProcessors;
     private readonly DocumentScraperOptions _options;
     private readonly WorkerOptions _workerOptions;
@@ -44,9 +45,15 @@ public class DocumentScraper : IDocumentScraper
         (DocumentTypeFilter.FortyF, "40-F"),
     ];
 
+    // When the company directory was last synced from SEC. Static because the
+    // scraper is resolved per cycle and event-driven cycles run every few
+    // seconds — an unthrottled sync would re-fetch company_tickers each time.
+    private static DateTime _lastCompanySyncAtUtc;
+
     public DocumentScraper(
         IServiceScopeFactory serviceScopeFactory,
         ICompanySyncService companySyncService,
+        IFilingDiscoveryService filingDiscoveryService,
         IEnumerable<IFilingProcessor> filingProcessors,
         IOptions<DocumentScraperOptions> options,
         IOptions<WorkerOptions> workerOptions,
@@ -56,6 +63,7 @@ public class DocumentScraper : IDocumentScraper
     {
         _serviceScopeFactory = serviceScopeFactory;
         _companySyncService = companySyncService;
+        _filingDiscoveryService = filingDiscoveryService;
         _filingProcessors = filingProcessors;
         _options = options.Value;
         _workerOptions = workerOptions.Value;
@@ -73,20 +81,32 @@ public class DocumentScraper : IDocumentScraper
         {
             _logger.LogInformation("Starting document scraping process...");
 
-            await _companySyncService.SyncCompaniesFromSecApi();
+            if (ShouldSyncCompanies())
+            {
+                await _companySyncService.SyncCompaniesFromSecApi();
+                _lastCompanySyncAtUtc = DateTime.UtcNow;
+            }
 
             var companiesUntracked = await GetAllCompaniesWithNoTracking();
+
+            var targets = _options.UseEventDrivenDiscovery
+                ? await SelectEventDrivenTargets(companiesUntracked, cancellationToken)
+                : companiesUntracked;
+
             _logger.LogInformation(
                 "Found {CompanyCount} companies to process for documents",
-                companiesUntracked.Count
+                targets.Count
             );
 
-            foreach (var companyUntracked in companiesUntracked)
+            foreach (var companyUntracked in targets)
             {
                 if (cancellationToken.IsCancellationRequested)
                     break;
 
                 await ProcessCompanyDocumentsWithScope(companyUntracked, result);
+
+                if (_options.UseEventDrivenDiscovery)
+                    await StampFilingSyncState(companyUntracked);
 
                 result.CompaniesProcessed++;
             }
@@ -113,6 +133,148 @@ public class DocumentScraper : IDocumentScraper
         }
 
         return result;
+    }
+
+    // Test seam: the throttle stamp is static (it must outlive the per-cycle
+    // scraper), so suites reset it to stay order-independent.
+    internal static void ResetCompanySyncThrottleForTests() => _lastCompanySyncAtUtc = default;
+
+    // Legacy mode syncs every cycle (one multi-hour full sweep per cycle keeps
+    // that cheap); event-driven mode throttles to the configured interval.
+    private bool ShouldSyncCompanies() =>
+        !_options.UseEventDrivenDiscovery
+        || DateTime.UtcNow - _lastCompanySyncAtUtc
+            >= TimeSpan.FromMinutes(_options.CompanySyncIntervalMinutes);
+
+    /// <summary>
+    /// The cycle's work list under event-driven discovery: companies flagged by
+    /// the real-time feeds, plus the reconciliation batch — never-synced
+    /// companies (fresh onboarding, full historical backfill) and companies
+    /// whose last enumeration went stale. Discovery targets come first so a
+    /// fresh filing is never queued behind a long reconciliation batch.
+    /// </summary>
+    private async Task<List<CommonStock>> SelectEventDrivenTargets(
+        List<CommonStock> companies,
+        CancellationToken cancellationToken
+    )
+    {
+        var discovered = await _filingDiscoveryService.DiscoverCompaniesWithNewFilings(
+            companies,
+            cancellationToken
+        );
+
+        var reconciliation = await SelectReconciliationBatch(
+            companies,
+            discovered,
+            cancellationToken
+        );
+
+        if (discovered.Count > 0 || reconciliation.Count > 0)
+        {
+            _logger.LogInformation(
+                "Event-driven discovery: {Discovered} companies with new filings, {Reconciliation} due for reconciliation",
+                discovered.Count,
+                reconciliation.Count
+            );
+        }
+
+        return [.. discovered, .. reconciliation];
+    }
+
+    private async Task<List<CommonStock>> SelectReconciliationBatch(
+        List<CommonStock> companies,
+        List<CommonStock> alreadySelected,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var syncStateRepository =
+            scope.ServiceProvider.GetRequiredService<CompanyFilingSyncStateRepository>();
+
+        var lastSyncedByCompany = await syncStateRepository
+            .GetAll()
+            .AsNoTracking()
+            .ToDictionaryAsync(s => s.CommonStockId, s => s.LastSyncedAt, cancellationToken);
+
+        return SelectDueCompanies(
+            companies,
+            lastSyncedByCompany,
+            alreadySelected.Select(c => c.Id).ToHashSet(),
+            DateTime.UtcNow.AddHours(-_options.ReconciliationHours),
+            _options.MaxReconciliationsPerCycle
+        );
+    }
+
+    /// <summary>
+    /// Companies due for a reconciliation sweep: never synced (no stamp) or
+    /// stamped before the cutoff. Never-synced first, then stalest first, so a
+    /// cold start drains as an ordered rolling backfill under the cap.
+    /// </summary>
+    internal static List<CommonStock> SelectDueCompanies(
+        List<CommonStock> companies,
+        Dictionary<Guid, DateTime> lastSyncedByCompany,
+        HashSet<Guid> excludedIds,
+        DateTime cutoff,
+        int maxCompanies
+    ) =>
+        companies
+            .Where(c => !excludedIds.Contains(c.Id))
+            .Where(c =>
+                !lastSyncedByCompany.TryGetValue(c.Id, out var lastSynced) || lastSynced < cutoff
+            )
+            .OrderBy(c =>
+                lastSyncedByCompany.TryGetValue(c.Id, out var lastSynced)
+                    ? lastSynced
+                    : DateTime.MinValue
+            )
+            .Take(maxCompanies)
+            .ToList();
+
+    /// <summary>
+    /// Records that this company's filings were fully enumerated now. Stamped
+    /// even after a partial failure — the company is retried by the next
+    /// reconciliation window (or the next discovery event) rather than every
+    /// cycle, which bounds how much budget a persistently failing company burns.
+    /// </summary>
+    private async Task StampFilingSyncState(CommonStock company)
+    {
+        try
+        {
+            await using var scope = _serviceScopeFactory.CreateAsyncScope();
+            var syncStateRepository =
+                scope.ServiceProvider.GetRequiredService<CompanyFilingSyncStateRepository>();
+
+            var state = await syncStateRepository
+                .GetByCommonStockId(company.Id)
+                .FirstOrDefaultAsync();
+
+            if (state == null)
+            {
+                syncStateRepository.Add(
+                    new CompanyFilingSyncState
+                    {
+                        CommonStockId = company.Id,
+                        LastSyncedAt = DateTime.UtcNow,
+                    }
+                );
+            }
+            else
+            {
+                state.LastSyncedAt = DateTime.UtcNow;
+            }
+
+            await syncStateRepository.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            // A missed stamp only means the company re-enters the next
+            // reconciliation batch (or vanished mid-cycle via company sync).
+            _logger.LogWarning(
+                ex,
+                "Could not stamp filing sync state for {Ticker}",
+                company.Ticker
+            );
+        }
     }
 
     private async Task<List<CommonStock>> GetAllCompaniesWithNoTracking()

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<DocumentImageService>();
         services.AddScoped<FilingItemsBackfillService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();
+        services.AddScoped<IFilingDiscoveryService, FilingDiscoveryService>();
         // Primary IWebsiteSource (consumed by the CommonStocks website discovery
         // worker): the website disclosure mandated in the stocks' own stored filings.
         services.AddScoped<IWebsiteSource, FilingsWebsiteSource>();

--- a/src/Equibles.Sec.HostedService/Services/FilingDiscoveryService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FilingDiscoveryService.cs
@@ -1,0 +1,332 @@
+using System.Collections.Concurrent;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Extensions;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Extensions;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Sec.HostedService.Services;
+
+public class FilingDiscoveryService : IFilingDiscoveryService
+{
+    internal const string DailyIndexStateName = "SecFilingDiscovery.DailyIndex";
+
+    // Cross-cycle memos — the service is resolved per scrape cycle, so state
+    // that must survive between cycles is static (same pattern as
+    // CompanySyncService's blank-website memo). The worker is single-threaded;
+    // the concurrent dictionary is for safety, not contention.
+    private static DateTime _lastFeedPollAtUtc;
+    private static readonly ConcurrentDictionary<string, DateTime> SeenFeedEntries = new();
+    private static readonly TimeSpan SeenFeedEntryRetention = TimeSpan.FromHours(12);
+
+    private const int FeedPageSize = 100;
+
+    private static readonly TimeZoneInfo EasternTimeZone = ResolveEasternTimeZone();
+
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly BackfillStateRepository _backfillStateRepository;
+    private readonly DocumentScraperOptions _options;
+    private readonly ILogger<FilingDiscoveryService> _logger;
+
+    public FilingDiscoveryService(
+        ISecEdgarClient secEdgarClient,
+        BackfillStateRepository backfillStateRepository,
+        IOptions<DocumentScraperOptions> options,
+        ILogger<FilingDiscoveryService> logger
+    )
+    {
+        _secEdgarClient = secEdgarClient;
+        _backfillStateRepository = backfillStateRepository;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<List<CommonStock>> DiscoverCompaniesWithNewFilings(
+        IReadOnlyList<CommonStock> trackedCompanies,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var cikToCompany = BuildCikMap(trackedCompanies);
+        var syncedForms = BuildSyncedFormSet();
+        var dirty = new Dictionary<Guid, CommonStock>();
+
+        await CollectFromRecentFeed(cikToCompany, syncedForms, dirty, cancellationToken);
+        await CollectFromDailyIndex(cikToCompany, syncedForms, dirty, cancellationToken);
+
+        return [.. dirty.Values];
+    }
+
+    /// <summary>
+    /// Polls the "Latest Filings" ATOM feed when the poll interval has elapsed
+    /// and marks tracked filers dirty. Pages until it overlaps entries already
+    /// seen by a previous poll (or the page cap), so a burst bigger than one
+    /// page is still swept. A failed poll is only logged: the daily index and
+    /// the reconciliation sweep guarantee eventual pickup.
+    /// </summary>
+    private async Task CollectFromRecentFeed(
+        Dictionary<long, CommonStock> cikToCompany,
+        HashSet<string> syncedForms,
+        Dictionary<Guid, CommonStock> dirty,
+        CancellationToken cancellationToken
+    )
+    {
+        var utcNow = DateTime.UtcNow;
+        if (utcNow - _lastFeedPollAtUtc < TimeSpan.FromSeconds(_options.RecentFeedPollSeconds))
+            return;
+        _lastFeedPollAtUtc = utcNow;
+
+        PruneSeenFeedEntries(utcNow);
+
+        for (var page = 0; page < _options.RecentFeedMaxPages; page++)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            List<EdgarRecentFilingEntry> entries;
+            try
+            {
+                entries = await _secEdgarClient.GetRecentFilings(
+                    page * FeedPageSize,
+                    FeedPageSize,
+                    cancellationToken
+                );
+            }
+            catch (Exception ex) when (ex is HttpRequestException or System.Xml.XmlException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Latest-filings feed poll failed on page {Page}; the daily index and reconciliation sweep will backstop",
+                    page
+                );
+                return;
+            }
+
+            var sawKnownEntry = false;
+            foreach (var entry in entries)
+            {
+                // The same accession appears once per associated entity (filer,
+                // subject, reporting owner), each with its own CIK — key on both
+                // so a page boundary can't hide the tracked side of a filing.
+                var seenKey = $"{entry.AccessionNumber}|{entry.Cik}";
+                if (!SeenFeedEntries.TryAdd(seenKey, utcNow))
+                {
+                    sawKnownEntry = true;
+                    continue;
+                }
+
+                if (!syncedForms.Contains(entry.FormType))
+                    continue;
+
+                if (TryResolveCompany(cikToCompany, entry.Cik, out var company))
+                    dirty[company.Id] = company;
+            }
+
+            // Overlap with the previous poll (or a short page) means the window
+            // between polls is fully covered — stop paging.
+            if (sawKnownEntry || entries.Count < FeedPageSize)
+                return;
+        }
+
+        _logger.LogWarning(
+            "Latest-filings feed poll exhausted {Pages} pages without overlapping the previous poll — a burst may have scrolled entries out; the daily index will catch them",
+            _options.RecentFeedMaxPages
+        );
+    }
+
+    /// <summary>
+    /// Walks the immutable per-day master indexes from the persisted watermark
+    /// through the latest final day, marking tracked filers dirty. The
+    /// watermark only advances past a day whose index was fetched and parsed,
+    /// so throttles and outages hold it back and the gap is re-swept next
+    /// cycle — never silently skipped. Cold start pins the watermark to the
+    /// latest final day instead of replaying history: the reconciliation sweep
+    /// owns historical coverage.
+    /// </summary>
+    private async Task CollectFromDailyIndex(
+        Dictionary<long, CommonStock> cikToCompany,
+        HashSet<string> syncedForms,
+        Dictionary<Guid, CommonStock> dirty,
+        CancellationToken cancellationToken
+    )
+    {
+        var latestFinalDay = LatestFinalIndexDay(DateTime.UtcNow);
+        var state = await _backfillStateRepository.GetByName(DailyIndexStateName);
+
+        if (state?.Floor == null)
+        {
+            if (state == null)
+            {
+                state = new BackfillState { Name = DailyIndexStateName };
+                _backfillStateRepository.Add(state);
+            }
+            state.Floor = ToUtcDate(latestFinalDay);
+            await _backfillStateRepository.SaveChanges();
+            _logger.LogInformation(
+                "Daily-index discovery watermark initialized at {Day:yyyy-MM-dd}",
+                latestFinalDay
+            );
+            return;
+        }
+
+        var floor = DateOnly.FromDateTime(state.Floor.Value);
+        var formPrefixes = syncedForms.ToList();
+        var processedDays = 0;
+
+        for (
+            var day = floor.AddDays(1);
+            day <= latestFinalDay && processedDays < _options.DailyIndexMaxDaysPerCycle;
+            day = day.AddDays(1)
+        )
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            List<EdgarDailyIndexEntry> entries;
+            try
+            {
+                entries = await _secEdgarClient.GetDailyIndexForForms(
+                    day,
+                    formPrefixes,
+                    cancellationToken
+                );
+            }
+            catch (HttpRequestException ex)
+            {
+                // NEVER advance past a day that failed to fetch — that would
+                // silently drop its filings until the reconciliation sweep.
+                _logger.LogWarning(
+                    ex,
+                    "Daily index fetch failed for {Day:yyyy-MM-dd}; holding discovery watermark at {Floor:yyyy-MM-dd}",
+                    day,
+                    floor
+                );
+                break;
+            }
+
+            foreach (var entry in entries)
+            {
+                // The client filter is prefix-based (so "4" also returns 424B2
+                // rows); re-check with an exact match before dirtying a company.
+                if (!syncedForms.Contains(entry.FormType))
+                    continue;
+
+                if (TryResolveCompany(cikToCompany, entry.Cik, out var company))
+                    dirty[company.Id] = company;
+            }
+
+            state.Floor = ToUtcDate(day);
+            floor = day;
+            processedDays++;
+        }
+
+        if (processedDays > 0)
+        {
+            await _backfillStateRepository.SaveChanges();
+            _logger.LogInformation(
+                "Daily-index discovery advanced watermark to {Floor:yyyy-MM-dd} ({Days} day(s) processed, {Dirty} companies flagged so far)",
+                floor,
+                processedDays,
+                dirty.Count
+            );
+        }
+    }
+
+    /// <summary>
+    /// The most recent day whose master index is final. The index for day D
+    /// keeps growing until EDGAR's evening batch completes, so D only becomes
+    /// eligible from 06:00 Eastern on D+1 — processing it earlier would advance
+    /// the watermark past filings that hadn't been written to the index yet.
+    /// </summary>
+    internal static DateOnly LatestFinalIndexDay(DateTime utcNow)
+    {
+        var easternNow = TimeZoneInfo.ConvertTimeFromUtc(utcNow, EasternTimeZone);
+        var previousDay = DateOnly.FromDateTime(easternNow).AddDays(-1);
+        return easternNow.Hour >= 6 ? previousDay : previousDay.AddDays(-1);
+    }
+
+    /// <summary>
+    /// Maps every tracked CIK — primary and subsidiary — to its company,
+    /// keyed numerically because EDGAR surfaces CIKs both zero-padded
+    /// ("0000320193") and bare ("320193").
+    /// </summary>
+    internal static Dictionary<long, CommonStock> BuildCikMap(
+        IReadOnlyList<CommonStock> trackedCompanies
+    )
+    {
+        var map = new Dictionary<long, CommonStock>();
+        foreach (var company in trackedCompanies)
+        {
+            if (long.TryParse(company.Cik, out var primaryCik))
+                map.TryAdd(primaryCik, company);
+
+            foreach (var secondaryCik in company.SecondaryCiks ?? [])
+            {
+                if (long.TryParse(secondaryCik, out var cik))
+                    map.TryAdd(cik, company);
+            }
+        }
+
+        return map;
+    }
+
+    private HashSet<string> BuildSyncedFormSet()
+    {
+        var forms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var documentType in _options.DocumentTypesToSync)
+        {
+            var filter = documentType.ToSecEdgarFilter();
+            if (filter != null)
+                forms.Add(filter.Value.GetFormName());
+        }
+
+        return forms;
+    }
+
+    private static bool TryResolveCompany(
+        Dictionary<long, CommonStock> cikToCompany,
+        string cik,
+        out CommonStock company
+    )
+    {
+        company = null;
+        return long.TryParse(cik, out var numericCik)
+            && cikToCompany.TryGetValue(numericCik, out company);
+    }
+
+    // BackfillState.Floor is a timestamptz; Npgsql rejects non-UTC kinds.
+    private static DateTime ToUtcDate(DateOnly day) =>
+        day.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+    private static void PruneSeenFeedEntries(DateTime utcNow)
+    {
+        foreach (var entry in SeenFeedEntries)
+        {
+            if (utcNow - entry.Value > SeenFeedEntryRetention)
+                SeenFeedEntries.TryRemove(entry.Key, out _);
+        }
+    }
+
+    private static TimeZoneInfo ResolveEasternTimeZone()
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+        }
+    }
+
+    // Test seam: the memos are static (they must outlive the per-cycle service),
+    // so suites reset them to stay order-independent.
+    internal static void ResetCrossCycleStateForTests()
+    {
+        _lastFeedPollAtUtc = default;
+        SeenFeedEntries.Clear();
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/FilingDiscoveryService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FilingDiscoveryService.cs
@@ -95,7 +95,11 @@ public class FilingDiscoveryService : IFilingDiscoveryService
                     cancellationToken
                 );
             }
-            catch (Exception ex) when (ex is HttpRequestException or System.Xml.XmlException)
+            // Best-effort layer: any fetch/parse failure (HTTP error, timeout —
+            // which surfaces as TaskCanceledException, not HttpRequestException —
+            // transport IO, malformed XML) must not abort the cycle and discard
+            // the dirty set; only a genuine shutdown propagates.
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
             {
                 _logger.LogWarning(
                     ex,
@@ -194,10 +198,13 @@ public class FilingDiscoveryService : IFilingDiscoveryService
                     cancellationToken
                 );
             }
-            catch (HttpRequestException ex)
+            // NEVER advance past a day that failed to fetch — that would
+            // silently drop its filings until the reconciliation sweep. Broad
+            // by design (timeouts surface as TaskCanceledException, transport
+            // failures as IOException) with a guard so a genuine shutdown still
+            // propagates; the watermark held below makes the failure safe.
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
             {
-                // NEVER advance past a day that failed to fetch — that would
-                // silently drop its filings until the reconciliation sweep.
                 _logger.LogWarning(
                     ex,
                     "Daily index fetch failed for {Day:yyyy-MM-dd}; holding discovery watermark at {Floor:yyyy-MM-dd}",

--- a/src/Equibles.Sec.HostedService/Services/IFilingDiscoveryService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IFilingDiscoveryService.cs
@@ -1,0 +1,20 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.Sec.HostedService.Services;
+
+public interface IFilingDiscoveryService
+{
+    /// <summary>
+    /// Returns the tracked companies that likely have new filings since the
+    /// last cycle, discovered from EDGAR's centralized feeds: the real-time
+    /// "Latest Filings" ATOM stream (minutes of latency, lossy under bursts)
+    /// plus the immutable per-day master index (complete, hours of latency,
+    /// watermarked so downtime is caught up without loss). Both layers are
+    /// best-effort — the periodic per-company reconciliation sweep is the
+    /// correctness backstop for anything they miss.
+    /// </summary>
+    Task<List<CommonStock>> DiscoverCompaniesWithNewFilings(
+        IReadOnlyList<CommonStock> trackedCompanies,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Equibles.Sec.Repositories/CompanyFilingSyncStateRepository.cs
+++ b/src/Equibles.Sec.Repositories/CompanyFilingSyncStateRepository.cs
@@ -1,0 +1,13 @@
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Repositories;
+
+public class CompanyFilingSyncStateRepository : BaseRepository<CompanyFilingSyncState>
+{
+    public CompanyFilingSyncStateRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<CompanyFilingSyncState> GetByCommonStockId(Guid commonStockId) =>
+        GetAll().Where(s => s.CommonStockId == commonStockId);
+}

--- a/tests/Equibles.IntegrationTests/Sec/DocumentScraperCompanySyncFailureTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentScraperCompanySyncFailureTests.cs
@@ -39,8 +39,9 @@ public class DocumentScraperCompanySyncFailureTests
         var sut = new DocumentScraper(
             Substitute.For<IServiceScopeFactory>(),
             companySync,
+            Substitute.For<IFilingDiscoveryService>(),
             Enumerable.Empty<IFilingProcessor>(),
-            Options.Create(new DocumentScraperOptions()),
+            Options.Create(new DocumentScraperOptions { UseEventDrivenDiscovery = false }),
             Options.Create(new WorkerOptions()),
             Substitute.For<ILogger<DocumentScraper>>(),
             errorReporter

--- a/tests/Equibles.UnitTests/Integrations/SecEdgarClientParseRecentFilingsAtomTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/SecEdgarClientParseRecentFilingsAtomTests.cs
@@ -1,0 +1,91 @@
+using Equibles.Integrations.Sec;
+
+namespace Equibles.UnitTests.Integrations;
+
+/// <summary>
+/// Pins the "Latest Filings" ATOM parsing: entry shape lifted from a live feed
+/// capture. Malformed entries must be skipped (never fail the page) because a
+/// dropped page would blind the realtime discovery layer for a full poll.
+/// </summary>
+public class SecEdgarClientParseRecentFilingsAtomTests
+{
+    private const string FeedXml = """
+        <?xml version="1.0" encoding="ISO-8859-1" ?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Latest Filings - Thu, 09 Jul 2026 10:16:48 EDT</title>
+        <entry>
+        <title>144 - Camerana Niccolo (0001995137) (Reporting)</title>
+        <link rel="alternate" type="text/html" href="https://www.sec.gov/Archives/edgar/data/1995137/000199513726000012/0001995137-26-000012-index.htm"/>
+        <updated>2026-07-09T10:16:01-04:00</updated>
+        <category scheme="https://www.sec.gov/" label="form type" term="144"/>
+        <id>urn:tag:sec.gov,2008:accession-number=0001995137-26-000012</id>
+        </entry>
+        <entry>
+        <title>144 - Scorpio Tankers Inc. (0001483934) (Subject)</title>
+        <link rel="alternate" type="text/html" href="https://www.sec.gov/Archives/edgar/data/1483934/000199513726000012/0001995137-26-000012-index.htm"/>
+        <updated>2026-07-09T10:16:01-04:00</updated>
+        <category scheme="https://www.sec.gov/" label="form type" term="144"/>
+        <id>urn:tag:sec.gov,2008:accession-number=0001995137-26-000012</id>
+        </entry>
+        <entry>
+        <title>424B2 - HSBC USA INC /MD/ (0000083246) (Filer)</title>
+        <updated>2026-07-09T10:15:37-04:00</updated>
+        <category scheme="https://www.sec.gov/" label="form type" term="424B2"/>
+        <id>urn:tag:sec.gov,2008:accession-number=0001104659-26-082152</id>
+        </entry>
+        <entry>
+        <title>no cik in this title</title>
+        <updated>2026-07-09T10:15:00-04:00</updated>
+        <category scheme="https://www.sec.gov/" label="form type" term="8-K"/>
+        <id>urn:tag:sec.gov,2008:accession-number=0001104659-26-082153</id>
+        </entry>
+        </feed>
+        """;
+
+    [Fact]
+    public void ParseRecentFilingsAtom_ParsesWellFormedEntries()
+    {
+        var entries = SecEdgarClient.ParseRecentFilingsAtom(FeedXml);
+
+        entries.Should().HaveCount(3);
+
+        var first = entries[0];
+        first.Cik.Should().Be("0001995137");
+        first.FormType.Should().Be("144");
+        first.AccessionNumber.Should().Be("0001995137-26-000012");
+        first.CompanyName.Should().Be("Camerana Niccolo");
+        first
+            .Updated.Should()
+            .Be(new DateTimeOffset(2026, 7, 9, 10, 16, 1, TimeSpan.FromHours(-4)));
+    }
+
+    [Fact]
+    public void ParseRecentFilingsAtom_SameAccessionKeepsOneEntryPerEntity()
+    {
+        var entries = SecEdgarClient.ParseRecentFilingsAtom(FeedXml);
+
+        var sameAccession = entries
+            .Where(e => e.AccessionNumber == "0001995137-26-000012")
+            .ToList();
+
+        // A Form 144 lists both the reporting person and the subject company —
+        // the subject side is what maps the filing to a tracked issuer.
+        sameAccession.Should().HaveCount(2);
+        sameAccession.Select(e => e.Cik).Should().Contain(["0001995137", "0001483934"]);
+    }
+
+    [Fact]
+    public void ParseRecentFilingsAtom_EntryWithoutParseableCik_IsSkipped()
+    {
+        var entries = SecEdgarClient.ParseRecentFilingsAtom(FeedXml);
+
+        entries.Should().NotContain(e => e.AccessionNumber == "0001104659-26-082153");
+    }
+
+    [Fact]
+    public void ParseRecentFilingsAtom_EmptyPayload_ReturnsEmpty()
+    {
+        SecEdgarClient.ParseRecentFilingsAtom("").Should().BeEmpty();
+        SecEdgarClient.ParseRecentFilingsAtom(null).Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperBuildRetryPipelineFinalAttemptErrorLogTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperBuildRetryPipelineFinalAttemptErrorLogTests.cs
@@ -32,6 +32,7 @@ public class DocumentScraperBuildRetryPipelineFinalAttemptErrorLogTests
         var scraper = new DocumentScraper(
             Substitute.For<IServiceScopeFactory>(),
             Substitute.For<ICompanySyncService>(),
+            Substitute.For<IFilingDiscoveryService>(),
             new List<IFilingProcessor>(),
             Options.Create(new DocumentScraperOptions()),
             Options.Create(new WorkerOptions()),

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperDeferredRetryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperDeferredRetryTests.cs
@@ -121,9 +121,14 @@ public class DocumentScraperDeferredRetryTests
         var scraper = new DocumentScraper(
             scopeFactory,
             Substitute.For<ICompanySyncService>(),
+            Substitute.For<IFilingDiscoveryService>(),
             new List<IFilingProcessor>(),
             Options.Create(
-                new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] }
+                new DocumentScraperOptions
+                {
+                    UseEventDrivenDiscovery = false,
+                    DocumentTypesToSync = [DocumentType.TenK],
+                }
             ),
             Options.Create(new WorkerOptions()),
             Substitute.For<ILogger<DocumentScraper>>(),

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperProcessCompanyScopeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperProcessCompanyScopeTests.cs
@@ -78,6 +78,7 @@ public class DocumentScraperProcessCompanyScopeTests
         return new DocumentScraper(
             scopeFactory,
             Substitute.For<ICompanySyncService>(),
+            Substitute.For<IFilingDiscoveryService>(),
             new List<IFilingProcessor>(),
             Options.Create(options),
             Options.Create(new WorkerOptions()),
@@ -121,7 +122,11 @@ public class DocumentScraperProcessCompanyScopeTests
         // == null branch logs a warning and continues, no error recorded.
         var scraper = BuildScraper(
             db,
-            new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.Other] }
+            new DocumentScraperOptions
+            {
+                UseEventDrivenDiscovery = false,
+                DocumentTypesToSync = [DocumentType.Other],
+            }
         );
         var result = new ScrapingResult();
 
@@ -138,7 +143,14 @@ public class DocumentScraperProcessCompanyScopeTests
         // Null DocumentTypesToSync makes the foreach throw; the per-company
         // catch must convert that into a recorded error (company is loaded, so
         // the catch's company.Ticker access is safe) rather than propagating.
-        var scraper = BuildScraper(db, new DocumentScraperOptions { DocumentTypesToSync = null });
+        var scraper = BuildScraper(
+            db,
+            new DocumentScraperOptions
+            {
+                UseEventDrivenDiscovery = false,
+                DocumentTypesToSync = null,
+            }
+        );
         var result = new ScrapingResult();
 
         await InvokeProcess(scraper, company, result);

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperProcessDocTypeCatchTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperProcessDocTypeCatchTests.cs
@@ -42,6 +42,7 @@ public class DocumentScraperProcessDocTypeCatchTests
         var scraper = new DocumentScraper(
             Substitute.For<IServiceScopeFactory>(),
             Substitute.For<ICompanySyncService>(),
+            Substitute.For<IFilingDiscoveryService>(),
             new List<IFilingProcessor>(),
             Options.Create(new DocumentScraperOptions()),
             Options.Create(new WorkerOptions()),

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperProcessFilingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperProcessFilingTests.cs
@@ -56,6 +56,7 @@ public class DocumentScraperProcessFilingTests
         return new DocumentScraper(
             scopeFactory,
             Substitute.For<ICompanySyncService>(),
+            Substitute.For<IFilingDiscoveryService>(),
             processor == null ? new List<IFilingProcessor>() : [processor],
             Options.Create(new DocumentScraperOptions()),
             Options.Create(new WorkerOptions()),

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperSelectDueCompaniesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperSelectDueCompaniesTests.cs
@@ -1,0 +1,95 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.HostedService;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the reconciliation batch selection: never-synced companies (fresh
+/// onboarding) always lead, stalest stamps follow, fresh stamps and companies
+/// already picked by realtime discovery are excluded, and the per-cycle cap
+/// turns a cold start into a rolling backfill instead of one monster cycle.
+/// </summary>
+public class DocumentScraperSelectDueCompaniesTests
+{
+    private static readonly DateTime Now = new(2026, 7, 9, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Cutoff = Now.AddHours(-24);
+
+    private static CommonStock Company(string ticker) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Cik = "1",
+        };
+
+    [Fact]
+    public void NeverSyncedCompaniesComeFirst()
+    {
+        var neverSynced = Company("NEW");
+        var stale = Company("OLD");
+
+        var due = DocumentScraper.SelectDueCompanies(
+            [stale, neverSynced],
+            new Dictionary<Guid, DateTime> { [stale.Id] = Cutoff.AddHours(-1) },
+            [],
+            Cutoff,
+            10
+        );
+
+        due.Should().HaveCount(2);
+        due[0].Should().BeSameAs(neverSynced);
+        due[1].Should().BeSameAs(stale);
+    }
+
+    [Fact]
+    public void FreshlySyncedCompaniesAreNotDue()
+    {
+        var fresh = Company("FRESH");
+
+        var due = DocumentScraper.SelectDueCompanies(
+            [fresh],
+            new Dictionary<Guid, DateTime> { [fresh.Id] = Now.AddHours(-1) },
+            [],
+            Cutoff,
+            10
+        );
+
+        due.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StalestCompaniesAreOrderedFirstAndCapApplies()
+    {
+        var stale1 = Company("S1");
+        var stale2 = Company("S2");
+        var stale3 = Company("S3");
+        var stamps = new Dictionary<Guid, DateTime>
+        {
+            [stale1.Id] = Cutoff.AddHours(-3),
+            [stale2.Id] = Cutoff.AddHours(-9),
+            [stale3.Id] = Cutoff.AddHours(-6),
+        };
+
+        var due = DocumentScraper.SelectDueCompanies(
+            [stale1, stale2, stale3],
+            stamps,
+            [],
+            Cutoff,
+            2
+        );
+
+        due.Should().HaveCount(2);
+        due[0].Should().BeSameAs(stale2);
+        due[1].Should().BeSameAs(stale3);
+    }
+
+    [Fact]
+    public void CompaniesAlreadySelectedByDiscoveryAreExcluded()
+    {
+        var dirty = Company("DIRTY");
+
+        var due = DocumentScraper.SelectDueCompanies([dirty], [], [dirty.Id], Cutoff, 10);
+
+        due.Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -134,7 +134,11 @@ public class DocumentScraperTests
             )
             .Returns(false);
 
-        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var options = new DocumentScraperOptions
+        {
+            UseEventDrivenDiscovery = false,
+            DocumentTypesToSync = [DocumentType.TenK],
+        };
         var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
 
         result.CompaniesProcessed.Should().Be(1);
@@ -204,7 +208,11 @@ public class DocumentScraperTests
                 )
             );
 
-        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var options = new DocumentScraperOptions
+        {
+            UseEventDrivenDiscovery = false,
+            DocumentTypesToSync = [DocumentType.TenK],
+        };
         var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
 
         result.DocumentsFound.Should().Be(1);
@@ -262,7 +270,11 @@ public class DocumentScraperTests
                 },
             ]);
 
-        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.FormFour] };
+        var options = new DocumentScraperOptions
+        {
+            UseEventDrivenDiscovery = false,
+            DocumentTypesToSync = [DocumentType.FormFour],
+        };
         var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
 
         result.DocumentsFound.Should().Be(1);
@@ -337,7 +349,11 @@ public class DocumentScraperTests
             )
             .Returns(false);
 
-        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var options = new DocumentScraperOptions
+        {
+            UseEventDrivenDiscovery = false,
+            DocumentTypesToSync = [DocumentType.TenK],
+        };
         var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
 
         result.CompaniesProcessed.Should().Be(2);
@@ -410,7 +426,11 @@ public class DocumentScraperTests
             .SecEdgarClient.GetCompanyFilings("0000123456", DocumentTypeFilter.TenK, null)
             .Returns([BuildFiling("0000123456", "0000123456-25-000009", "NOT-A-FORM")]);
 
-        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var options = new DocumentScraperOptions
+        {
+            UseEventDrivenDiscovery = false,
+            DocumentTypesToSync = [DocumentType.TenK],
+        };
         var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
 
         result.DocumentsFound.Should().Be(1);
@@ -457,7 +477,11 @@ public class DocumentScraperTests
             )
             .Returns<bool>(_ => throw new Exception("persistence down"));
 
-        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var options = new DocumentScraperOptions
+        {
+            UseEventDrivenDiscovery = false,
+            DocumentTypesToSync = [DocumentType.TenK],
+        };
         var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
 
         result.DocumentsFound.Should().Be(1);
@@ -484,7 +508,11 @@ public class DocumentScraperTests
             .SecEdgarClient.GetCompanyFilings("0000123456", DocumentTypeFilter.TenK, null)
             .Returns<List<FilingData>>(_ => throw new HttpRequestException("SEC EDGAR 503"));
 
-        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var options = new DocumentScraperOptions
+        {
+            UseEventDrivenDiscovery = false,
+            DocumentTypesToSync = [DocumentType.TenK],
+        };
         var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
 
         result.CompaniesProcessed.Should().Be(1);
@@ -517,7 +545,11 @@ public class DocumentScraperTests
             )
             .Returns<bool>(_ => throw new HttpRequestException("persistence HTTP fault"));
 
-        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var options = new DocumentScraperOptions
+        {
+            UseEventDrivenDiscovery = false,
+            DocumentTypesToSync = [DocumentType.TenK],
+        };
         var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
 
         result.DocumentsFound.Should().Be(1);
@@ -773,8 +805,16 @@ public class DocumentScraperTests
             return new DocumentScraper(
                 ScopeFactory,
                 CompanySync,
+                Substitute.For<IFilingDiscoveryService>(),
                 FilingProcessors,
-                Options.Create(options ?? new DocumentScraperOptions { DocumentTypesToSync = [] }),
+                Options.Create(
+                    options
+                        ?? new DocumentScraperOptions
+                        {
+                            UseEventDrivenDiscovery = false,
+                            DocumentTypesToSync = [],
+                        }
+                ),
                 Options.Create(workerOptions ?? new WorkerOptions()),
                 Substitute.For<ILogger<DocumentScraper>>(),
                 errorReporter

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperUpdateCompanyMetadataErrorIsolationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperUpdateCompanyMetadataErrorIsolationTests.cs
@@ -84,8 +84,15 @@ public class DocumentScraperUpdateCompanyMetadataErrorIsolationTests
         var scraper = new DocumentScraper(
             scopeFactory,
             Substitute.For<ICompanySyncService>(),
+            Substitute.For<IFilingDiscoveryService>(),
             [],
-            Options.Create(new DocumentScraperOptions { DocumentTypesToSync = [] }),
+            Options.Create(
+                new DocumentScraperOptions
+                {
+                    UseEventDrivenDiscovery = false,
+                    DocumentTypesToSync = [],
+                }
+            ),
             Options.Create(new WorkerOptions()),
             Substitute.For<ILogger<DocumentScraper>>(),
             errorReporter

--- a/tests/Equibles.UnitTests/Sec/FilingDiscoveryServiceDiscoveryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FilingDiscoveryServiceDiscoveryTests.cs
@@ -1,0 +1,283 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the event-driven discovery contract: the realtime feed only dirties
+/// tracked filers of synced forms and never re-dirties an already-seen entry;
+/// the daily-index watermark initializes without replaying history, advances
+/// only past cleanly fetched days, holds on a fetch failure (the #1264
+/// lesson — a skipped day is silently lost filings), and re-checks the
+/// client's prefix-matched rows with an exact form comparison so "4" cannot
+/// dirty a 424B2 filer.
+/// </summary>
+public class FilingDiscoveryServiceDiscoveryTests
+{
+    private static readonly DateOnly LatestFinalDay = FilingDiscoveryService.LatestFinalIndexDay(
+        DateTime.UtcNow
+    );
+
+    private sealed class BackfillStateOnlyModuleConfiguration : IModuleConfiguration
+    {
+        public void ConfigureEntities(ModelBuilder builder)
+        {
+            builder.Entity<BackfillState>();
+        }
+    }
+
+    private static EquiblesFinancialDbContext CreateContext() =>
+        new(
+            new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .EnableServiceProviderCaching(false)
+                .Options,
+            new IModuleConfiguration[] { new BackfillStateOnlyModuleConfiguration() }
+        );
+
+    private static FilingDiscoveryService CreateService(
+        ISecEdgarClient secEdgarClient,
+        EquiblesFinancialDbContext context,
+        DocumentScraperOptions options = null
+    ) =>
+        new(
+            secEdgarClient,
+            new BackfillStateRepository(context),
+            Options.Create(options ?? new DocumentScraperOptions()),
+            Substitute.For<ILogger<FilingDiscoveryService>>()
+        );
+
+    private static CommonStock Tracked(string ticker, string cik) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Cik = cik,
+        };
+
+    private static ISecEdgarClient ClientWithFeed(params EdgarRecentFilingEntry[] entries)
+    {
+        var client = Substitute.For<ISecEdgarClient>();
+        client
+            .GetRecentFilings(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([.. entries]);
+        client
+            .GetDailyIndexForForms(
+                Arg.Any<DateOnly>(),
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+        return client;
+    }
+
+    public FilingDiscoveryServiceDiscoveryTests()
+    {
+        FilingDiscoveryService.ResetCrossCycleStateForTests();
+    }
+
+    [Fact]
+    public async Task Feed_TrackedFilerOfSyncedForm_IsDirtied()
+    {
+        await using var context = CreateContext();
+        var apple = Tracked("AAPL", "320193");
+        var client = ClientWithFeed(
+            new EdgarRecentFilingEntry
+            {
+                Cik = "0000320193",
+                FormType = "8-K",
+                AccessionNumber = "0000320193-26-000001",
+            }
+        );
+
+        var dirty = await CreateService(client, context).DiscoverCompaniesWithNewFilings([apple]);
+
+        dirty.Should().ContainSingle().Which.Should().BeSameAs(apple);
+    }
+
+    [Fact]
+    public async Task Feed_UntrackedCikOrUnsyncedForm_IsIgnored()
+    {
+        await using var context = CreateContext();
+        var apple = Tracked("AAPL", "320193");
+        var client = ClientWithFeed(
+            new EdgarRecentFilingEntry
+            {
+                Cik = "0000999999",
+                FormType = "8-K",
+                AccessionNumber = "0000999999-26-000001",
+            },
+            new EdgarRecentFilingEntry
+            {
+                Cik = "0000320193",
+                FormType = "424B2",
+                AccessionNumber = "0000320193-26-000002",
+            }
+        );
+
+        var dirty = await CreateService(client, context).DiscoverCompaniesWithNewFilings([apple]);
+
+        dirty.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Feed_AlreadySeenEntry_IsNotReDirtied()
+    {
+        await using var context = CreateContext();
+        var apple = Tracked("AAPL", "320193");
+        var client = ClientWithFeed(
+            new EdgarRecentFilingEntry
+            {
+                Cik = "0000320193",
+                FormType = "8-K",
+                AccessionNumber = "0000320193-26-000001",
+            }
+        );
+        // Poll throttle off so both cycles poll the feed.
+        var options = new DocumentScraperOptions { RecentFeedPollSeconds = 0 };
+
+        var service = CreateService(client, context, options);
+        var firstCycle = await service.DiscoverCompaniesWithNewFilings([apple]);
+        var secondCycle = await service.DiscoverCompaniesWithNewFilings([apple]);
+
+        firstCycle.Should().ContainSingle();
+        secondCycle.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Feed_PollFailure_IsSwallowed()
+    {
+        await using var context = CreateContext();
+        var client = Substitute.For<ISecEdgarClient>();
+        client
+            .GetRecentFilings(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException());
+        client
+            .GetDailyIndexForForms(
+                Arg.Any<DateOnly>(),
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+
+        var dirty = await CreateService(client, context)
+            .DiscoverCompaniesWithNewFilings([Tracked("AAPL", "320193")]);
+
+        dirty.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DailyIndex_ColdStart_InitializesWatermarkWithoutReplayingHistory()
+    {
+        await using var context = CreateContext();
+        var client = ClientWithFeed();
+
+        await CreateService(client, context)
+            .DiscoverCompaniesWithNewFilings([Tracked("AAPL", "320193")]);
+
+        var state = await context.Set<BackfillState>().SingleAsync();
+        state.Name.Should().Be(FilingDiscoveryService.DailyIndexStateName);
+        state.Floor.Should().Be(LatestFinalDay.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+        await client
+            .DidNotReceive()
+            .GetDailyIndexForForms(
+                Arg.Any<DateOnly>(),
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task DailyIndex_PendingDays_DirtyTrackedFilersAndAdvanceWatermark()
+    {
+        await using var context = CreateContext();
+        var apple = Tracked("AAPL", "320193");
+        var pendingDay = LatestFinalDay;
+        context
+            .Set<BackfillState>()
+            .Add(
+                new BackfillState
+                {
+                    Name = FilingDiscoveryService.DailyIndexStateName,
+                    Floor = pendingDay.AddDays(-1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+                }
+            );
+        await context.SaveChangesAsync();
+
+        var client = ClientWithFeed();
+        client
+            .GetDailyIndexForForms(
+                pendingDay,
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns([
+                new EdgarDailyIndexEntry
+                {
+                    Cik = "320193",
+                    FormType = "8-K",
+                    AccessionNumber = "0000320193-26-000009",
+                    DateFiled = pendingDay,
+                },
+                // Prefix over-match from the client ("4" also returns 424B2
+                // rows) must be re-filtered exactly.
+                new EdgarDailyIndexEntry
+                {
+                    Cik = "320193",
+                    FormType = "424B2",
+                    AccessionNumber = "0000320193-26-000010",
+                    DateFiled = pendingDay,
+                },
+            ]);
+
+        var dirty = await CreateService(client, context).DiscoverCompaniesWithNewFilings([apple]);
+
+        dirty.Should().ContainSingle().Which.Should().BeSameAs(apple);
+        var state = await context.Set<BackfillState>().SingleAsync();
+        state.Floor.Should().Be(pendingDay.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task DailyIndex_FetchFailure_HoldsWatermark()
+    {
+        await using var context = CreateContext();
+        var floorDay = LatestFinalDay.AddDays(-1);
+        context
+            .Set<BackfillState>()
+            .Add(
+                new BackfillState
+                {
+                    Name = FilingDiscoveryService.DailyIndexStateName,
+                    Floor = floorDay.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+                }
+            );
+        await context.SaveChangesAsync();
+
+        var client = ClientWithFeed();
+        client
+            .GetDailyIndexForForms(
+                Arg.Any<DateOnly>(),
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new HttpRequestException());
+
+        var dirty = await CreateService(client, context)
+            .DiscoverCompaniesWithNewFilings([Tracked("AAPL", "320193")]);
+
+        dirty.Should().BeEmpty();
+        var state = await context.Set<BackfillState>().SingleAsync();
+        state.Floor.Should().Be(floorDay.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FilingDiscoveryServiceStaticsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FilingDiscoveryServiceStaticsTests.cs
@@ -1,0 +1,84 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the pure discovery helpers: the daily-index finality boundary (a day's
+/// master index keeps growing until EDGAR's evening batch, so advancing the
+/// watermark too early silently drops filings) and the numeric CIK map (EDGAR
+/// surfaces the same CIK zero-padded in the ATOM feed and bare in master.idx).
+/// </summary>
+public class FilingDiscoveryServiceStaticsTests
+{
+    // July dates: Eastern is EDT (UTC-4).
+
+    [Fact]
+    public void LatestFinalIndexDay_AfterSixAmEastern_IsPreviousDay()
+    {
+        // 11:00 UTC = 07:00 EDT on Jul 9 → Jul 8 is final.
+        var result = FilingDiscoveryService.LatestFinalIndexDay(
+            new DateTime(2026, 7, 9, 11, 0, 0, DateTimeKind.Utc)
+        );
+
+        result.Should().Be(new DateOnly(2026, 7, 8));
+    }
+
+    [Fact]
+    public void LatestFinalIndexDay_BeforeSixAmEastern_HoldsAnExtraDay()
+    {
+        // 09:00 UTC = 05:00 EDT on Jul 9 → Jul 8's index may still be growing.
+        var result = FilingDiscoveryService.LatestFinalIndexDay(
+            new DateTime(2026, 7, 9, 9, 0, 0, DateTimeKind.Utc)
+        );
+
+        result.Should().Be(new DateOnly(2026, 7, 7));
+    }
+
+    [Fact]
+    public void LatestFinalIndexDay_LateUtcEvening_IsStillSameEasternDay()
+    {
+        // 02:00 UTC Jul 10 = 22:00 EDT Jul 9 → Jul 8 is the latest final day.
+        var result = FilingDiscoveryService.LatestFinalIndexDay(
+            new DateTime(2026, 7, 10, 2, 0, 0, DateTimeKind.Utc)
+        );
+
+        result.Should().Be(new DateOnly(2026, 7, 8));
+    }
+
+    [Fact]
+    public void BuildCikMap_MatchesPaddedAndBareCiks()
+    {
+        var company = new CommonStock { Ticker = "AAPL", Cik = "320193" };
+
+        var map = FilingDiscoveryService.BuildCikMap([company]);
+
+        map.Should().ContainKey(320193L).WhoseValue.Should().BeSameAs(company);
+        // Padded feed CIK parses to the same key.
+        long.Parse("0000320193").Should().Be(320193L);
+    }
+
+    [Fact]
+    public void BuildCikMap_IncludesSecondaryCiks()
+    {
+        var company = new CommonStock
+        {
+            Ticker = "ATAI",
+            Cik = "1840904",
+            SecondaryCiks = ["0002012345"],
+        };
+
+        var map = FilingDiscoveryService.BuildCikMap([company]);
+
+        map.Should().ContainKey(1840904L);
+        map.Should().ContainKey(2012345L).WhoseValue.Should().BeSameAs(company);
+    }
+
+    [Fact]
+    public void BuildCikMap_IgnoresUnparseableCiks()
+    {
+        var company = new CommonStock { Ticker = "BAD", Cik = "not-a-cik" };
+
+        FilingDiscoveryService.BuildCikMap([company]).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

The document scraper re-fetched every tracked company's submissions JSON every cycle — ~135k EDGAR calls/day with >95% of polls finding nothing, a third of the shared 5 req/s budget. Discovery is now event-driven and layered so a filing can be delayed but never permanently missed:

1. **Realtime** — EDGAR's `getcurrent` "Latest Filings" ATOM feed (minutes of latency). Paged until it overlaps the previous poll; a burst larger than the page budget or a failed poll is only logged, because the layers below own correctness.
2. **Daily index** — the immutable per-day `master.idx` behind a persisted `BackfillState` watermark. The watermark only advances past a day whose index was fetched and parsed cleanly (throttles/timeouts hold it), and a day only becomes eligible from 06:00 ET on D+1 so a still-growing index is never treated as final.
3. **Reconciliation** — every company's filings are re-enumerated at least once per `ReconciliationHours` (default 24h) via the new `CompanyFilingSyncState` stamp. Never-synced companies lead the batch, so newly onboarded stocks get the same full historical backfill as before, immediately.

`DocumentScraperOptions.UseEventDrivenDiscovery=false` is a config kill switch restoring the legacy sweep unchanged.

Expected effect: ~135k calls/day drop to ~15k (feed polls + daily indexes + one reconciliation pass), freeing ~30% of the EDGAR budget, while new-filing latency improves from up to ~1.5h to minutes.

## Code changes

- `Equibles.Integrations.Sec`: new `GetRecentFilings` (ATOM feed fetch + parser, entries keyed per associated entity so ownership forms surface the issuer CIK), new `EdgarRecentFilingEntry` model, `GetFormName` extension made public.
- `Equibles.Sec.Data` / `Equibles.Sec.Repositories` / `Equibles.Migrations`: new `CompanyFilingSyncState` entity (PK/FK to CommonStock, cascade) + repository + `AddCompanyFilingSyncState` migration.
- `Equibles.Sec.HostedService`: new `FilingDiscoveryService` (feed layer with cross-cycle seen-entry memo, daily-index watermark layer with exact form re-filtering over the client's prefix match); `DocumentScraper` orchestrates discovery + reconciliation targets in event mode and stamps sync state per company; company-directory sync throttled in event mode; new options with safe defaults.
- Tests: 21 new tests (ATOM parser, finality boundary, CIK map, reconciliation selection, feed/watermark semantics incl. hold-on-failure); the 8 existing `DocumentScraper` suites pin `UseEventDrivenDiscovery=false` to keep verifying the legacy path they were written for.