### PR TITLE
fix(sec-mcp): surface reported discrete Q4 filed under fp=FY in fact tools

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FiscalPeriodSpanDays.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FiscalPeriodSpanDays.cs
@@ -1,0 +1,16 @@
+namespace Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+/// <summary>
+/// Reporting-period span guards used to tell a discrete fiscal quarter from a
+/// full year or a year-to-date span, sized for 52/53-week and 4-4-5 calendars
+/// with headroom: a discrete quarter runs 13 weeks (14 in a 53-week year's long
+/// quarter), a fiscal year at least 52 weeks. A duration between
+/// <see cref="MaxDiscreteQuarterDays"/> and <see cref="MinAnnualSpanDays"/> is a
+/// year-to-date span — never a quarter, never a year.
+/// </summary>
+internal static class FiscalPeriodSpanDays
+{
+    internal const int MinDiscreteQuarterDays = 80;
+    internal const int MaxDiscreteQuarterDays = 100;
+    internal const int MinAnnualSpanDays = 350;
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/ReportedQuarterPromotion.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/ReportedQuarterPromotion.cs
@@ -1,0 +1,122 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+/// <summary>
+/// SEC Company Facts files a filer's REPORTED discrete fourth quarter under
+/// fp=FY — the same fiscal identity as the annual figure. Tools that group facts
+/// by (FiscalYear, FiscalPeriod) span-gate that row out of the annual group
+/// (correctly: the year must show the annual figure) but never see it as a
+/// quarter, so Q4 rows were absent for every filer whose Company Facts carry Q4
+/// frames (NVDA through FY2020). Promotion re-homes those rows onto the Q4
+/// identity so the company's own reported figure surfaces.
+///
+/// A full-year total can never be promoted: only durations spanning a discrete
+/// quarter qualify, and only when a genuine annual-span fact ends the same day —
+/// that anchor also supplies the fiscal year, because comparative re-filings
+/// re-stamp the same period under the filing's later year (the original filing
+/// carries the smallest stamp). A fiscal-year-change transition stub (a ~90-day
+/// "year" with no annual-span fact ending that day) has no anchor and keeps its
+/// annual identity.
+/// </summary>
+internal static class ReportedQuarterPromotion
+{
+    /// <summary>
+    /// A full history load: returns the input plus one Q4-stamped copy of every
+    /// reported discrete fourth quarter filed under fp=FY, its fiscal year taken
+    /// from the smallest stamp among the annual-span facts ending the same day.
+    /// Originals are kept (the annual group's span gate already ignores them);
+    /// the input is never mutated.
+    /// </summary>
+    internal static List<FinancialFact> WithPromotedFourthQuarters(List<FinancialFact> facts)
+    {
+        var fiscalYearByYearEnd = facts
+            .Where(f =>
+                f.FiscalPeriod == SecFiscalPeriod.FullYear
+                && f.PeriodType == FactPeriodType.Duration
+                && Span(f) >= FiscalPeriodSpanDays.MinAnnualSpanDays
+            )
+            .GroupBy(f => f.PeriodEnd)
+            .ToDictionary(g => g.Key, g => g.Min(f => f.FiscalYear));
+        if (fiscalYearByYearEnd.Count == 0)
+            return facts;
+
+        var promoted = facts
+            .Where(IsQuarterSpanFullYearDuration)
+            .Where(f => fiscalYearByYearEnd.ContainsKey(f.PeriodEnd))
+            .Select(f => Promote(f, fiscalYearByYearEnd[f.PeriodEnd]))
+            .ToList();
+        if (promoted.Count == 0)
+            return facts;
+
+        return [.. facts, .. promoted];
+    }
+
+    /// <summary>
+    /// A year-scoped load (one fiscal-year stamp per company): promotes only the
+    /// quarter-span fp=FY rows ending exactly where the slice's own year does —
+    /// the LATEST annual-span period end per company. Comparative re-filings in
+    /// the slice end earlier and must not pose as the requested year's fourth
+    /// quarter (their value belongs to the prior year).
+    /// </summary>
+    internal static IEnumerable<FinancialFact> PromotedFourthQuartersForYearSlice(
+        IEnumerable<FinancialFact> companyFacts
+    )
+    {
+        var fullYearDurations = companyFacts
+            .Where(f =>
+                f.FiscalPeriod == SecFiscalPeriod.FullYear
+                && f.PeriodType == FactPeriodType.Duration
+            )
+            .ToList();
+        var annualEnds = fullYearDurations
+            .Where(f => Span(f) >= FiscalPeriodSpanDays.MinAnnualSpanDays)
+            .Select(f => f.PeriodEnd)
+            .ToList();
+        if (annualEnds.Count == 0)
+            return [];
+
+        var ownYearEnd = annualEnds.Max();
+        return fullYearDurations
+            .Where(IsQuarterSpanFullYearDuration)
+            .Where(f => f.PeriodEnd == ownYearEnd)
+            .Select(f => Promote(f, f.FiscalYear));
+    }
+
+    private static bool IsQuarterSpanFullYearDuration(FinancialFact fact)
+    {
+        if (
+            fact.FiscalPeriod != SecFiscalPeriod.FullYear
+            || fact.PeriodType != FactPeriodType.Duration
+        )
+            return false;
+        var span = Span(fact);
+        return span >= FiscalPeriodSpanDays.MinDiscreteQuarterDays
+            && span <= FiscalPeriodSpanDays.MaxDiscreteQuarterDays;
+    }
+
+    // A copy, never a mutation — the source rows may be EF-tracked entities.
+    private static FinancialFact Promote(FinancialFact fact, int fiscalYear) =>
+        new()
+        {
+            CommonStockId = fact.CommonStockId,
+            FinancialConceptId = fact.FinancialConceptId,
+            DocumentId = fact.DocumentId,
+            Unit = fact.Unit,
+            PeriodType = fact.PeriodType,
+            PeriodStart = fact.PeriodStart,
+            PeriodEnd = fact.PeriodEnd,
+            Value = fact.Value,
+            FiscalYear = fiscalYear,
+            FiscalPeriod = SecFiscalPeriod.Q4,
+            Form = fact.Form,
+            FiledDate = fact.FiledDate,
+            AccessionNumber = fact.AccessionNumber,
+            Frame = fact.Frame,
+            DimensionsKey = fact.DimensionsKey,
+        };
+
+    private static int Span(FinancialFact fact) =>
+        fact.PeriodEnd.DayNumber - fact.PeriodStart.DayNumber;
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -28,15 +28,6 @@ public class FinancialFactsTools
     private const int MaxResultsCap = 200;
     private const int MaxTickers = 25;
 
-    // A 10-Q tags each flow line twice under the same fiscal (year, period): the
-    // discrete three-month quarter and the fiscal year-to-date (6 months at Q2,
-    // 9 at Q3). A quarterly query must surface the discrete quarter, so prefer a
-    // duration spanning at most one quarter; the annual period symmetrically
-    // prefers a full-year span. The longest a discrete quarter runs (14-week
-    // 4-4-5 quarter, with headroom) and the shortest a fiscal year runs (52 weeks).
-    private const int MaxDiscreteQuarterDays = 100;
-    private const int MinAnnualSpanDays = 350;
-
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
@@ -123,10 +114,16 @@ public class FinancialFactsTools
                     .Where(f => conceptPriority.Keys.Contains(f.FinancialConceptId))
                     .ToListAsync();
 
+                // Reported discrete fourth quarters hide under fp=FY — the same
+                // fiscal identity as the annual figure — so grouping by stamp
+                // alone never surfaces them as Q4 rows. Promote them first (see
+                // ReportedQuarterPromotion; a full-year total can never qualify).
+                var allFacts = ReportedQuarterPromotion.WithPromotedFourthQuarters(facts);
+
                 // Form / period-end filtering in memory: a single concept's
                 // history is small, and DocumentType is a value-converted type
                 // so equality is kept off the SQL side for provider safety.
-                var filtered = facts.Where(f =>
+                var filtered = allFacts.Where(f =>
                     (formFilter == null || f.Form == formFilter)
                     && (fromBound == null || f.PeriodEnd >= fromBound.Value)
                     && (toBound == null || f.PeriodEnd <= toBound.Value)
@@ -221,14 +218,40 @@ public class FinancialFactsTools
                 }
 
                 var stockIds = stocks.Select(s => s.Id).ToList();
+                // A Q4 request must also load the year's fp=FY rows: filers whose
+                // Company Facts carry Q4 frames report the discrete fourth quarter
+                // under the FullYear stamp (see ReportedQuarterPromotion).
+                var includeFullYearForQ4 = period == SecFiscalPeriod.Q4;
                 var facts = await _financialFactRepository
                     .GetConsolidatedByStocks(stockIds)
                     .Where(f =>
                         f.FiscalYear == fiscalYear
-                        && f.FiscalPeriod == period
+                        && (
+                            f.FiscalPeriod == period
+                            || (includeFullYearForQ4 && f.FiscalPeriod == SecFiscalPeriod.FullYear)
+                        )
                         && conceptPriority.Keys.Contains(f.FinancialConceptId)
                     )
                     .ToListAsync();
+
+                if (includeFullYearForQ4)
+                {
+                    // Promote per company: only a quarter-span row ending exactly
+                    // where the company's own year does is that year's fourth
+                    // quarter — comparative re-filings in the slice end earlier
+                    // and belong to the prior year. The remaining fp=FY rows
+                    // (the annual totals) are dropped, never compared as Q4.
+                    facts = facts
+                        .Where(f => f.FiscalPeriod == SecFiscalPeriod.Q4)
+                        .Concat(
+                            facts
+                                .GroupBy(f => f.CommonStockId)
+                                .SelectMany(
+                                    ReportedQuarterPromotion.PromotedFourthQuartersForYearSlice
+                                )
+                        )
+                        .ToList();
+                }
 
                 // Same deterministic pick as GetFinancialFact: the alias's
                 // primary tag wins, then the latest filing, then accession as a
@@ -363,8 +386,8 @@ public class FinancialFactsTools
                     return true;
                 var spanDays = f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber;
                 return fiscalPeriod == SecFiscalPeriod.FullYear
-                    ? spanDays >= MinAnnualSpanDays
-                    : spanDays <= MaxDiscreteQuarterDays;
+                    ? spanDays >= FiscalPeriodSpanDays.MinAnnualSpanDays
+                    : spanDays <= FiscalPeriodSpanDays.MaxDiscreteQuarterDays;
             })
             .ToList();
         if (preferredSpan.Count > 0)

--- a/tests/Equibles.UnitTests/Sec/ReportedQuarterPromotionHistoryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ReportedQuarterPromotionHistoryTests.cs
@@ -1,0 +1,117 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class ReportedQuarterPromotionHistoryTests
+{
+    // SEC Company Facts files a filer's reported discrete fourth quarter under
+    // fp=FY (NVDA through FY2020): the ~90-day duration shares the annual figure's
+    // fiscal identity, so stamp-based grouping never surfaces it as a Q4 row. The
+    // history promotion must add a Q4-stamped copy — keyed to the year of the
+    // annual-span fact ending the same day — while the annual total itself, being
+    // a ~365-day span, must never qualify.
+    [Fact]
+    public void WithPromotedFourthQuarters_ReportedQ4UnderFullYearStamp_AddsQ4Copy()
+    {
+        var facts = new List<FinancialFact>
+        {
+            MakeFullYearFlow(2018, 2_911m, new DateOnly(2017, 10, 30), new DateOnly(2018, 1, 28)),
+            MakeFullYearFlow(2018, 9_714m, new DateOnly(2017, 1, 30), new DateOnly(2018, 1, 28)),
+        };
+
+        var result = ReportedQuarterPromotion.WithPromotedFourthQuarters(facts);
+
+        result.Should().HaveCount(3, "one Q4 copy joins the two original rows");
+        var promoted = result.Single(f => f.FiscalPeriod == SecFiscalPeriod.Q4);
+        promoted.Value.Should().Be(2_911m, "the promoted value is the quarter's, never the year's");
+        promoted.FiscalYear.Should().Be(2018);
+        promoted.Form.Should().Be(DocumentType.TenK, "the copy keeps the source filing's form");
+        facts.Should().HaveCount(2, "the input list is never mutated");
+    }
+
+    // Comparative re-filings re-stamp the same discrete quarter under the filing's
+    // later fiscal year. The promoted copy must take its year from the annual
+    // anchor's smallest stamp — the original filing — so the row lands under the
+    // year the quarter belongs to.
+    [Fact]
+    public void WithPromotedFourthQuarters_ComparativeReStampedVintage_UsesTheAnchorYear()
+    {
+        var facts = new List<FinancialFact>
+        {
+            // The FY2019 10-K re-reports FY2018's Q4 and annual under stamp 2019.
+            MakeFullYearFlow(2019, 2_911m, new DateOnly(2017, 10, 30), new DateOnly(2018, 1, 28)),
+            MakeFullYearFlow(2019, 9_714m, new DateOnly(2017, 1, 30), new DateOnly(2018, 1, 28)),
+            // The original FY2018 10-K.
+            MakeFullYearFlow(2018, 9_714m, new DateOnly(2017, 1, 30), new DateOnly(2018, 1, 28)),
+        };
+
+        var result = ReportedQuarterPromotion.WithPromotedFourthQuarters(facts);
+
+        var promoted = result.Single(f => f.FiscalPeriod == SecFiscalPeriod.Q4);
+        promoted
+            .FiscalYear.Should()
+            .Be(2018, "the smallest annual stamp is the original filing's own year");
+    }
+
+    // A fiscal-year-change transition "year" spans roughly a quarter with no
+    // annual-span fact ending the same day. Without an anchor there is nothing to
+    // promote — the stub keeps its annual identity rather than posing as Q4.
+    [Fact]
+    public void WithPromotedFourthQuarters_TransitionStubWithoutAnnualAnchor_PromotesNothing()
+    {
+        var facts = new List<FinancialFact>
+        {
+            MakeFullYearFlow(2024, 90m, new DateOnly(2024, 10, 1), new DateOnly(2024, 12, 31)),
+        };
+
+        var result = ReportedQuarterPromotion.WithPromotedFourthQuarters(facts);
+
+        result.Should().BeSameAs(facts, "with nothing to promote the input is returned as-is");
+    }
+
+    // Annual-span rows alone can never produce a Q4: a full-year total must never
+    // masquerade as a quarter.
+    [Fact]
+    public void WithPromotedFourthQuarters_AnnualSpansOnly_PromotesNothing()
+    {
+        var facts = new List<FinancialFact>
+        {
+            MakeFullYearFlow(2023, 380m, new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31)),
+            MakeFullYearFlow(2024, 400m, new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31)),
+        };
+
+        var result = ReportedQuarterPromotion.WithPromotedFourthQuarters(facts);
+
+        result
+            .Should()
+            .OnlyContain(
+                f => f.FiscalPeriod == SecFiscalPeriod.FullYear,
+                "no Q4 row may appear without a reported quarter-span duration"
+            );
+    }
+
+    private static FinancialFact MakeFullYearFlow(
+        int fiscalYear,
+        decimal value,
+        DateOnly periodStart,
+        DateOnly periodEnd
+    ) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            FinancialConceptId = Guid.NewGuid(),
+            Unit = "USD",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            Value = value,
+            FiscalYear = fiscalYear,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenK,
+            FiledDate = periodEnd.AddDays(30),
+            AccessionNumber = "0000000000-24-000001",
+        };
+}

--- a/tests/Equibles.UnitTests/Sec/ReportedQuarterPromotionYearSliceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ReportedQuarterPromotionYearSliceTests.cs
@@ -1,0 +1,125 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class ReportedQuarterPromotionYearSliceTests
+{
+    // CompareFinancialFact loads one fiscal-year stamp per company, and that slice
+    // carries comparative re-filings: the year's own annual and Q4 PLUS the prior
+    // year's annual and Q4 re-stamped under the requested year. Only the
+    // quarter-span row ending exactly where the slice's own year does (the latest
+    // annual-span period end) is the requested year's fourth quarter — promoting
+    // the comparative would report the PRIOR year's quarter under this year's label.
+    [Fact]
+    public void PromotedFourthQuartersForYearSlice_SliceWithComparatives_PromotesOnlyTheOwnYearEnd()
+    {
+        var stockId = Guid.NewGuid();
+        var slice = new List<FinancialFact>
+        {
+            // Own year (ends 2019-01-27).
+            MakeFullYearFlow(
+                stockId,
+                11_716m,
+                new DateOnly(2018, 1, 29),
+                new DateOnly(2019, 1, 27)
+            ),
+            MakeFullYearFlow(
+                stockId,
+                2_205m,
+                new DateOnly(2018, 10, 29),
+                new DateOnly(2019, 1, 27)
+            ),
+            // Prior year re-reported as comparatives under the same stamp.
+            MakeFullYearFlow(stockId, 9_714m, new DateOnly(2017, 1, 30), new DateOnly(2018, 1, 28)),
+            MakeFullYearFlow(
+                stockId,
+                2_911m,
+                new DateOnly(2017, 10, 30),
+                new DateOnly(2018, 1, 28)
+            ),
+        };
+
+        var promoted = ReportedQuarterPromotion.PromotedFourthQuartersForYearSlice(slice).ToList();
+
+        var quarter = promoted.Should().ContainSingle("only the own-year Q4 qualifies").Subject;
+        quarter.Value.Should().Be(2_205m);
+        quarter.PeriodEnd.Should().Be(new DateOnly(2019, 1, 27));
+        quarter.FiscalPeriod.Should().Be(SecFiscalPeriod.Q4);
+    }
+
+    // A slice whose own year reports no discrete fourth quarter (post-FY2020
+    // filers) must promote nothing — the comparative quarter that IS present
+    // belongs to the prior year and must not pose as this year's Q4.
+    [Fact]
+    public void PromotedFourthQuartersForYearSlice_OnlyComparativeQuarterPresent_PromotesNothing()
+    {
+        var stockId = Guid.NewGuid();
+        var slice = new List<FinancialFact>
+        {
+            // Own year (ends 2021-01-31) — annual only, no discrete Q4.
+            MakeFullYearFlow(
+                stockId,
+                16_675m,
+                new DateOnly(2020, 1, 27),
+                new DateOnly(2021, 1, 31)
+            ),
+            // Prior year's Q4 re-reported as a comparative under the same stamp.
+            MakeFullYearFlow(
+                stockId,
+                3_105m,
+                new DateOnly(2019, 10, 28),
+                new DateOnly(2020, 1, 26)
+            ),
+        };
+
+        var promoted = ReportedQuarterPromotion.PromotedFourthQuartersForYearSlice(slice).ToList();
+
+        promoted.Should().BeEmpty("the comparative quarter belongs to the prior fiscal year");
+    }
+
+    // The annual total itself — the only other fp=FY row ending at the own year
+    // end — spans a full year and must never be promoted to Q4.
+    [Fact]
+    public void PromotedFourthQuartersForYearSlice_AnnualSpanAtOwnYearEnd_IsNeverPromoted()
+    {
+        var stockId = Guid.NewGuid();
+        var slice = new List<FinancialFact>
+        {
+            MakeFullYearFlow(
+                stockId,
+                10_918m,
+                new DateOnly(2019, 1, 28),
+                new DateOnly(2020, 1, 26)
+            ),
+        };
+
+        var promoted = ReportedQuarterPromotion.PromotedFourthQuartersForYearSlice(slice).ToList();
+
+        promoted.Should().BeEmpty("a full-year total may never masquerade as a quarter");
+    }
+
+    private static FinancialFact MakeFullYearFlow(
+        Guid stockId,
+        decimal value,
+        DateOnly periodStart,
+        DateOnly periodEnd
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            FinancialConceptId = Guid.NewGuid(),
+            Unit = "USD",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            Value = value,
+            FiscalYear = 2019,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenK,
+            FiledDate = periodEnd.AddDays(30),
+            AccessionNumber = "0000000000-24-000001",
+        };
+}


### PR DESCRIPTION
## Summary

- `GetFinancialFact` and `CompareFinancialFact` returned no Q4 rows for filers whose SEC Company Facts carry a reported discrete fourth quarter (most filers through ~FY2020): SEC files that quarter under `fp=FY`, so grouping by the `(FiscalYear, FiscalPeriod)` stamp span-gated it out of the annual group and it never surfaced as a quarter.
- New `ReportedQuarterPromotion` helper re-homes quarter-span (80–100 day) `FullYear`-stamped durations onto the Q4 identity. A full-year total can never be promoted: only quarter-span durations qualify, and only anchored to a genuine annual-span fact — history loads key the fiscal year to the anchor's smallest stamp (comparative re-filings re-stamp under later years); the year-scoped comparison load promotes only rows ending exactly at the company's own year end, so a comparative can never pose as the requested year's quarter.
- Span constants move to a shared `FiscalPeriodSpanDays` helper used by both the promotion and `PickBestFact`.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Helpers/ReportedQuarterPromotion.cs` — new promotion helper (history + year-slice variants, copies rather than mutates).
- `src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FiscalPeriodSpanDays.cs` — shared span constants (adds the 80-day quarter floor).
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — `GetFinancialFact` promotes before filtering/grouping; `CompareFinancialFact` widens a Q4 request to load the year's `fp=FY` rows and promotes per company.
- `tests/Equibles.UnitTests/Sec/ReportedQuarterPromotion*.cs` — 7 tests: promotion, anchor-year selection, transition-stub and annual-total exclusion, comparative-slice hazards.