### PR TITLE
feat(sec): tombstone deterministic filing-ingest failures with retry backoff

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260710004324_AddFailedFilingIngest.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260710004324_AddFailedFilingIngest.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710004324_AddFailedFilingIngest")]
+    partial class AddFailedFilingIngest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260710004324_AddFailedFilingIngest.cs
+++ b/src/Equibles.Migrations/Migrations/20260710004324_AddFailedFilingIngest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFailedFilingIngest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FailedFilingIngest",
+                columns: table => new
+                {
+                    AccessionNumber = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    Cik = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    FormType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    FilingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    AttemptCount = table.Column<int>(type: "integer", nullable: false),
+                    LastAttemptAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    NextRetryAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastError = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FailedFilingIngest", x => x.AccessionNumber);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FailedFilingIngest_NextRetryAt",
+                table: "FailedFilingIngest",
+                column: "NextRetryAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FailedFilingIngest");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/FailedFilingIngest.cs
+++ b/src/Equibles.Sec.Data/Models/FailedFilingIngest.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// A filing whose ingest failed deterministically (normalization threw), so
+/// nothing was persisted. Without this row the scraper re-downloaded the
+/// multi-MB submission on every enumeration forever — the audited "poison
+/// cohort" (2,466 filings burning ~25k EDGAR calls/day under the legacy
+/// sweep). The row schedules retries on an exponential backoff instead of
+/// abandoning the filing: it keeps retrying forever (capped at the max
+/// interval), so a later parser fix still ingests it and no filing is ever
+/// permanently lost. Deleted when the filing finally ingests.
+/// </summary>
+[Index(nameof(NextRetryAt))]
+public class FailedFilingIngest
+{
+    /// <summary>Accession number with dashes — globally unique in EDGAR.</summary>
+    [Key]
+    [MaxLength(30)]
+    public string AccessionNumber { get; set; }
+
+    [Required]
+    [MaxLength(20)]
+    public string Cik { get; set; }
+
+    [MaxLength(50)]
+    public string FormType { get; set; }
+
+    public DateOnly FilingDate { get; set; }
+
+    public int AttemptCount { get; set; }
+
+    public DateTime LastAttemptAt { get; set; }
+
+    /// <summary>Precomputed so the scraper's skip filter is one indexed range check.</summary>
+    public DateTime NextRetryAt { get; set; }
+
+    [MaxLength(2000)]
+    public string LastError { get; set; }
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -41,6 +41,7 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<BackfillState>();
         builder.Entity<CompanyFilingSyncState>();
         builder.Entity<FailToDeliver>();
+        builder.Entity<FailedFilingIngest>();
         builder.Entity<FormAdvAdviser>();
         builder.Entity<FormDFiling>();
         builder.Entity<FormDRelatedPerson>();

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -517,6 +517,12 @@ public class DocumentScraper : IDocumentScraper
                 filings,
                 persistenceService
             );
+
+            // Drop filings tombstoned by a previous deterministic ingest failure
+            // whose retry backoff hasn't elapsed — otherwise each enumeration
+            // re-downloads the multi-MB submission just to fail identically.
+            newFilings = await FilterTombstonedFilings(newFilings);
+
             result.DocumentsSkipped += filings.Count - newFilings.Count;
 
             foreach (var filing in newFilings)
@@ -712,6 +718,7 @@ public class DocumentScraper : IDocumentScraper
 
             await CreateDocument(company, filing, documentType);
             result.DocumentsAdded++;
+            await ClearFilingIngestTombstone(filing.AccessionNumber);
 
             _logger.LogInformation(
                 "Added document for {Ticker} - {DocumentType} - {FilingDate}",
@@ -782,6 +789,7 @@ public class DocumentScraper : IDocumentScraper
             {
                 await CreateDocument(filing.Company, filing.Filing, filing.DocumentType);
                 result.DocumentsAdded++;
+                await ClearFilingIngestTombstone(filing.Filing.AccessionNumber);
 
                 _logger.LogInformation(
                     "Deferred document succeeded for {Ticker} - {DocumentType} - {FilingDate}",
@@ -801,7 +809,150 @@ public class DocumentScraper : IDocumentScraper
                     ex.Message
                 );
                 result.DocumentsSkipped++;
+
+                // Transient HTTP failures retry on the next enumeration as
+                // before; anything else is the deterministic poison shape —
+                // tombstone it so retries follow the backoff schedule instead
+                // of re-downloading the submission every cycle.
+                if (ex is not HttpRequestException)
+                    await RecordFilingIngestFailure(filing.Company, filing.Filing, ex);
             }
+        }
+    }
+
+    // Retry backoff for tombstoned filings: 1d, 2d, 4d, ... capped at 30d.
+    // Retries never stop — a later normalizer fix still ingests the filing —
+    // but the cap bounds a permanently poisonous filing to ~one download a month.
+    internal static DateTime ComputeNextRetryAt(int attemptCount, DateTime lastAttemptAt)
+    {
+        const int maxBackoffDays = 30;
+        var backoffDays = Math.Min(Math.Pow(2, Math.Max(attemptCount, 1) - 1), maxBackoffDays);
+        return lastAttemptAt.AddDays(backoffDays);
+    }
+
+    // Drops filings whose failure tombstone says the retry backoff hasn't
+    // elapsed. One batched lookup per (company, type); best-effort — a DB
+    // hiccup falls back to processing everything, which is the old behavior.
+    private async Task<List<FilingData>> FilterTombstonedFilings(List<FilingData> filings)
+    {
+        if (filings.Count == 0)
+            return filings;
+
+        try
+        {
+            await using var scope = _serviceScopeFactory.CreateAsyncScope();
+            var tombstoneRepository =
+                scope.ServiceProvider.GetRequiredService<FailedFilingIngestRepository>();
+
+            var accessions = filings
+                .Select(f => f.AccessionNumber)
+                .Where(a => !string.IsNullOrEmpty(a))
+                .ToList();
+
+            var now = DateTime.UtcNow;
+            var notDue = await tombstoneRepository
+                .GetByAccessionNumbers(accessions)
+                .Where(t => t.NextRetryAt > now)
+                .Select(t => t.AccessionNumber)
+                .ToListAsync();
+
+            if (notDue.Count == 0)
+                return filings;
+
+            var notDueSet = notDue.ToHashSet();
+            return filings.Where(f => !notDueSet.Contains(f.AccessionNumber)).ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Tombstone prefilter failed; processing all filings");
+            return filings;
+        }
+    }
+
+    /// <summary>
+    /// Records a deterministic ingest failure so future enumerations skip the
+    /// filing until its backoff elapses. Best-effort: a failed write only means
+    /// the filing is re-attempted next cycle, exactly as before tombstones.
+    /// </summary>
+    private async Task RecordFilingIngestFailure(
+        CommonStock company,
+        FilingData filing,
+        Exception failure
+    )
+    {
+        if (string.IsNullOrEmpty(filing.AccessionNumber))
+            return;
+
+        try
+        {
+            await using var scope = _serviceScopeFactory.CreateAsyncScope();
+            var tombstoneRepository =
+                scope.ServiceProvider.GetRequiredService<FailedFilingIngestRepository>();
+
+            var tombstone = await tombstoneRepository
+                .GetByAccessionNumber(filing.AccessionNumber)
+                .FirstOrDefaultAsync();
+
+            if (tombstone == null)
+            {
+                tombstone = new FailedFilingIngest
+                {
+                    AccessionNumber = filing.AccessionNumber,
+                    Cik = string.IsNullOrEmpty(filing.Cik) ? company.Cik : filing.Cik,
+                    FormType = filing.Form,
+                    FilingDate = filing.FilingDate,
+                };
+                tombstoneRepository.Add(tombstone);
+            }
+
+            var now = DateTime.UtcNow;
+            tombstone.AttemptCount++;
+            tombstone.LastAttemptAt = now;
+            tombstone.NextRetryAt = ComputeNextRetryAt(tombstone.AttemptCount, now);
+            tombstone.LastError =
+                failure.Message?.Length > 2000 ? failure.Message[..2000] : failure.Message;
+
+            await tombstoneRepository.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not tombstone failed filing {AccessionNumber}",
+                filing.AccessionNumber
+            );
+        }
+    }
+
+    // Removes a filing's failure tombstone once it finally ingests, keeping the
+    // table meaningful as "currently failing". Best-effort; usually a PK miss.
+    private async Task ClearFilingIngestTombstone(string accessionNumber)
+    {
+        if (string.IsNullOrEmpty(accessionNumber))
+            return;
+
+        try
+        {
+            await using var scope = _serviceScopeFactory.CreateAsyncScope();
+            var tombstoneRepository =
+                scope.ServiceProvider.GetRequiredService<FailedFilingIngestRepository>();
+
+            var tombstone = await tombstoneRepository
+                .GetByAccessionNumber(accessionNumber)
+                .FirstOrDefaultAsync();
+            if (tombstone == null)
+                return;
+
+            tombstoneRepository.Delete(tombstone);
+            await tombstoneRepository.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not clear filing tombstone {AccessionNumber}",
+                accessionNumber
+            );
         }
     }
 

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -716,7 +716,12 @@ public class DocumentScraper : IDocumentScraper
                 return;
             }
 
-            await CreateDocument(company, filing, documentType);
+            if (!await CreateDocument(company, filing, documentType))
+            {
+                result.DocumentsSkipped++;
+                return;
+            }
+
             result.DocumentsAdded++;
             await ClearFilingIngestTombstone(filing.AccessionNumber);
 
@@ -787,7 +792,12 @@ public class DocumentScraper : IDocumentScraper
 
             try
             {
-                await CreateDocument(filing.Company, filing.Filing, filing.DocumentType);
+                if (!await CreateDocument(filing.Company, filing.Filing, filing.DocumentType))
+                {
+                    result.DocumentsSkipped++;
+                    continue;
+                }
+
                 result.DocumentsAdded++;
                 await ClearFilingIngestTombstone(filing.Filing.AccessionNumber);
 
@@ -810,11 +820,12 @@ public class DocumentScraper : IDocumentScraper
                 );
                 result.DocumentsSkipped++;
 
-                // Transient HTTP failures retry on the next enumeration as
-                // before; anything else is the deterministic poison shape —
-                // tombstone it so retries follow the backoff schedule instead
-                // of re-downloading the submission every cycle.
-                if (ex is not HttpRequestException)
+                // Tombstone ONLY the deterministic poison shape — the same
+                // InvalidOperationException that deferred the filing. Anything
+                // else (HTTP faults, timeouts as TaskCanceledException, deploy
+                // -window DB errors) is transient: an infra blip must not put a
+                // whole batch of ingestable filings on a multi-day backoff.
+                if (ex is InvalidOperationException)
                     await RecordFilingIngestFailure(filing.Company, filing.Filing, ex);
             }
         }
@@ -956,13 +967,16 @@ public class DocumentScraper : IDocumentScraper
         }
     }
 
-    private async Task CreateDocument(
+    // Returns true when the document is persisted (or already was); false on
+    // the silent skip paths (no extractable content), so callers neither count
+    // an add nor clear a failure tombstone for a filing that stored nothing.
+    private async Task<bool> CreateDocument(
         CommonStock companyOutContext,
         FilingData filing,
         DocumentType documentType
     )
     {
-        await _retryPipeline.ExecuteAsync(
+        return await _retryPipeline.ExecuteAsync(
             async (cancellationToken) =>
             {
                 await using var scope = _serviceScopeFactory.CreateAsyncScope();
@@ -996,7 +1010,7 @@ public class DocumentScraper : IDocumentScraper
                         filing.AccessionNumber
                     )
                 )
-                    return;
+                    return true;
 
                 var content = await secEdgarClient.GetDocumentContent(filing);
 
@@ -1051,7 +1065,7 @@ public class DocumentScraper : IDocumentScraper
                         cancellationToken
                     );
                     if (markdownDocument == null)
-                        return;
+                        return false;
                 }
 
                 await persistenceService.Save(
@@ -1075,6 +1089,7 @@ public class DocumentScraper : IDocumentScraper
                     documentType,
                     filing.FilingDate
                 );
+                return true;
             }
         );
     }

--- a/src/Equibles.Sec.Repositories/FailedFilingIngestRepository.cs
+++ b/src/Equibles.Sec.Repositories/FailedFilingIngestRepository.cs
@@ -1,0 +1,17 @@
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Repositories;
+
+public class FailedFilingIngestRepository : BaseRepository<FailedFilingIngest>
+{
+    public FailedFilingIngestRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<FailedFilingIngest> GetByAccessionNumber(string accessionNumber) =>
+        GetAll().Where(f => f.AccessionNumber == accessionNumber);
+
+    public IQueryable<FailedFilingIngest> GetByAccessionNumbers(
+        IEnumerable<string> accessionNumbers
+    ) => GetAll().Where(f => accessionNumbers.Contains(f.AccessionNumber));
+}

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperComputeNextRetryAtTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperComputeNextRetryAtTests.cs
@@ -1,0 +1,34 @@
+using Equibles.Sec.HostedService;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the tombstone backoff schedule: doubling from one day, capped at 30 —
+/// retries never stop, so a permanently poisonous filing costs at most one
+/// download a month while a later parser fix still eventually ingests it.
+/// </summary>
+public class DocumentScraperComputeNextRetryAtTests
+{
+    private static readonly DateTime Now = new(2026, 7, 10, 0, 0, 0, DateTimeKind.Utc);
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 4)]
+    [InlineData(5, 16)]
+    [InlineData(6, 30)]
+    [InlineData(50, 30)]
+    public void BackoffDoublesAndCapsAtThirtyDays(int attemptCount, int expectedDays)
+    {
+        DocumentScraper
+            .ComputeNextRetryAt(attemptCount, Now)
+            .Should()
+            .Be(Now.AddDays(expectedDays));
+    }
+
+    [Fact]
+    public void ZeroAttempts_TreatedAsFirst()
+    {
+        DocumentScraper.ComputeNextRetryAt(0, Now).Should().Be(Now.AddDays(1));
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperFilingTombstoneTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperFilingTombstoneTests.cs
@@ -208,6 +208,43 @@ public class DocumentScraperFilingTombstoneTests
         (await ctx.Set<FailedFilingIngest>().SingleAsync()).AttemptCount.Should().Be(1);
     }
 
+    public static TheoryData<Exception> TransientFailures =>
+        new()
+        {
+            new HttpRequestException("edgar down"),
+            // HttpClient timeouts surface as TaskCanceledException.
+            new TaskCanceledException("timed out"),
+        };
+
+    [Theory]
+    [MemberData(nameof(TransientFailures))]
+    public async Task TransientRetryFailure_IsNeverTombstoned(Exception transient)
+    {
+        await using var ctx = await SeedCompany(CreateContext());
+        // Deterministic failure defers the filing, then the end-of-cycle retry
+        // hits a transient fault — the filing must retry next enumeration
+        // instead of being put on a multi-day backoff by an infra blip.
+        var persistence = Substitute.For<IDocumentPersistenceService>();
+        persistence
+            .Exists(
+                Arg.Any<CommonStock>(),
+                Arg.Any<DocumentType>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<string>()
+            )
+            .Returns<bool>(
+                _ => throw new InvalidOperationException("normalizer unavailable"),
+                _ => throw transient
+            );
+        var scraper = BuildScraper(ctx, EdgarWithOneFiling(), persistence);
+
+        var result = await scraper.ScrapeDocuments();
+
+        result.DocumentsSkipped.Should().Be(1);
+        (await ctx.Set<FailedFilingIngest>().CountAsync()).Should().Be(0);
+    }
+
     [Fact]
     public async Task DueRetryThatSucceeds_ClearsTombstone()
     {

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperFilingTombstoneTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperFilingTombstoneTests.cs
@@ -1,0 +1,260 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Media.Data;
+using Equibles.Sec.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the poison-filing tombstone lifecycle: a filing whose ingest fails
+/// deterministically gets a backoff tombstone after the end-of-cycle retry,
+/// the next enumeration skips it WITHOUT re-attempting (the 25k-calls/day
+/// poison-cohort mechanism), a due retry goes through again, and a successful
+/// ingest clears the row. Retries never stop — no filing is permanently lost.
+/// </summary>
+public class DocumentScraperFilingTombstoneTests
+{
+    private const string Accession = "0000320193-25-000001";
+
+    private sealed class TombstoneOnlyModuleConfiguration : IModuleConfiguration
+    {
+        public void ConfigureEntities(ModelBuilder builder)
+        {
+            builder.Entity<FailedFilingIngest>();
+        }
+    }
+
+    private static EquiblesFinancialDbContext CreateContext() =>
+        new(
+            new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .EnableServiceProviderCaching(false)
+                .Options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new DocumentOnlyModuleConfiguration(),
+                new MediaModuleConfiguration(),
+                new TombstoneOnlyModuleConfiguration(),
+            }
+        );
+
+    private static async Task<EquiblesFinancialDbContext> SeedCompany(
+        EquiblesFinancialDbContext ctx
+    )
+    {
+        ctx.Database.EnsureCreated();
+        ctx.Set<CommonStock>()
+            .Add(
+                new CommonStock
+                {
+                    Id = Guid.NewGuid(),
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+        await ctx.SaveChangesAsync();
+        return ctx;
+    }
+
+    private static ISecEdgarClient EdgarWithOneFiling()
+    {
+        var secEdgar = Substitute.For<ISecEdgarClient>();
+        secEdgar
+            .GetCompanyFilings(
+                Arg.Any<string>(),
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>()
+            )
+            .Returns(
+                new List<FilingData>
+                {
+                    new()
+                    {
+                        Cik = "0000320193",
+                        AccessionNumber = Accession,
+                        FilingDate = new DateOnly(2025, 1, 15),
+                        ReportDate = new DateOnly(2024, 12, 31),
+                        Form = "10-K",
+                    },
+                }
+            );
+        return secEdgar;
+    }
+
+    private static DocumentScraper BuildScraper(
+        EquiblesFinancialDbContext ctx,
+        ISecEdgarClient secEdgar,
+        IDocumentPersistenceService persistence,
+        bool withWorkingConversion = false
+    )
+    {
+        var normalizer = Substitute.For<ISecDocumentHtmlNormalizer>();
+        var converter = Substitute.For<ISecDocumentHtmlToMarkdownConverter>();
+        if (withWorkingConversion)
+        {
+            normalizer.Normalize(Arg.Any<string>()).Returns("<main>10-K</main>");
+            converter.Convert(Arg.Any<string>()).Returns("# 10-K");
+        }
+
+        var services = new ServiceCollection();
+        services.AddSingleton(ctx);
+        services.AddScoped<CommonStockRepository>();
+        services.AddScoped<DocumentRepository>();
+        services.AddScoped<FailedFilingIngestRepository>();
+        services.AddSingleton(Substitute.For<IBus>());
+        services.AddScoped<CommonStockManager>();
+        services.AddSingleton(secEdgar);
+        services.AddSingleton(persistence);
+        services.AddSingleton(normalizer);
+        services.AddSingleton(converter);
+        services.AddSingleton(Substitute.For<IPdfTextExtractor>());
+        // Resolved per scope inside CreateDocument; default options keep XBRL
+        // capture disabled and the 10-K form never resolves the 8-K stitcher.
+        services.AddLogging();
+        services.AddSingleton<IOptions<XbrlCaptureOptions>>(
+            Options.Create(new XbrlCaptureOptions())
+        );
+        services.AddScoped<XbrlEnvelopeCaptureService>();
+        services.AddSingleton<IOptions<AsFiledHtmlCaptureOptions>>(
+            Options.Create(new AsFiledHtmlCaptureOptions())
+        );
+        services.AddScoped<AsFiledHtmlCaptureService>();
+        var scopeFactory = services
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+
+        return new DocumentScraper(
+            scopeFactory,
+            Substitute.For<ICompanySyncService>(),
+            Substitute.For<IFilingDiscoveryService>(),
+            new List<IFilingProcessor>(),
+            Options.Create(
+                new DocumentScraperOptions
+                {
+                    UseEventDrivenDiscovery = false,
+                    DocumentTypesToSync = [DocumentType.TenK],
+                }
+            ),
+            Options.Create(new WorkerOptions()),
+            Substitute.For<ILogger<DocumentScraper>>(),
+            new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>())
+        );
+    }
+
+    private static IDocumentPersistenceService AlwaysFailingPersistence()
+    {
+        var persistence = Substitute.For<IDocumentPersistenceService>();
+        persistence
+            .Exists(
+                Arg.Any<CommonStock>(),
+                Arg.Any<DocumentType>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<string>()
+            )
+            .Returns<bool>(_ => throw new InvalidOperationException("normalizer unavailable"));
+        return persistence;
+    }
+
+    [Fact]
+    public async Task DeterministicFailure_CreatesTombstone_AndNextCycleSkipsWithoutRetry()
+    {
+        await using var ctx = await SeedCompany(CreateContext());
+        var persistence = AlwaysFailingPersistence();
+        var scraper = BuildScraper(ctx, EdgarWithOneFiling(), persistence);
+
+        await scraper.ScrapeDocuments();
+
+        var tombstone = await ctx.Set<FailedFilingIngest>().SingleAsync();
+        tombstone.AccessionNumber.Should().Be(Accession);
+        tombstone.AttemptCount.Should().Be(1);
+        tombstone.NextRetryAt.Should().BeAfter(DateTime.UtcNow);
+        tombstone.LastError.Should().Contain("normalizer unavailable");
+
+        static int ExistsCalls(IDocumentPersistenceService p) =>
+            p.ReceivedCalls().Count(c => c.GetMethodInfo().Name == "Exists");
+        var existsCallsAfterFirstCycle = ExistsCalls(persistence);
+
+        var secondCycle = await scraper.ScrapeDocuments();
+
+        // The tombstone prefilter dropped the filing before any ingest attempt:
+        // no new Exists probe (and hence no re-download), no deferral, attempt
+        // count unchanged. The batched GetKnownFilingKeys dedup lookup still
+        // runs — it precedes the tombstone filter and is DB-only.
+        ExistsCalls(persistence).Should().Be(existsCallsAfterFirstCycle);
+        secondCycle.DocumentsSkipped.Should().Be(1);
+        secondCycle.DeferredFilings.Should().BeEmpty();
+        (await ctx.Set<FailedFilingIngest>().SingleAsync()).AttemptCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DueRetryThatSucceeds_ClearsTombstone()
+    {
+        await using var ctx = await SeedCompany(CreateContext());
+        // Pre-existing tombstone whose backoff has elapsed → the filing is due.
+        ctx.Set<FailedFilingIngest>()
+            .Add(
+                new FailedFilingIngest
+                {
+                    AccessionNumber = Accession,
+                    Cik = "0000320193",
+                    FormType = "10-K",
+                    FilingDate = new DateOnly(2025, 1, 15),
+                    AttemptCount = 3,
+                    LastAttemptAt = DateTime.UtcNow.AddDays(-5),
+                    NextRetryAt = DateTime.UtcNow.AddDays(-1),
+                    LastError = "normalizer unavailable",
+                }
+            );
+        await ctx.SaveChangesAsync();
+
+        // This time ingest succeeds: not yet persisted, content and conversion work.
+        var persistence = Substitute.For<IDocumentPersistenceService>();
+        persistence
+            .Exists(
+                Arg.Any<CommonStock>(),
+                Arg.Any<DocumentType>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<string>()
+            )
+            .Returns(false);
+        persistence
+            .GetKnownFilingKeys(
+                Arg.Any<CommonStock>(),
+                Arg.Any<DocumentType>(),
+                Arg.Any<IReadOnlyCollection<string>>()
+            )
+            .Returns(([], new HashSet<(DateOnly FilingDate, DateOnly ReportDate)>()));
+        var secEdgar = EdgarWithOneFiling();
+        secEdgar.GetDocumentContent(Arg.Any<FilingData>()).Returns("<html>10-K</html>");
+
+        var scraper = BuildScraper(ctx, secEdgar, persistence, withWorkingConversion: true);
+
+        var result = await scraper.ScrapeDocuments();
+
+        result.DocumentsAdded.Should().Be(1);
+        (await ctx.Set<FailedFilingIngest>().CountAsync()).Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

The 2026-07-08 EDGAR traffic audit found 2,466 filings whose normalization deterministically throws being re-downloaded (multi-MB full submissions) on every enumeration — nothing was persisted on failure, so every cycle repeated the identical doomed ingest (~25k calls/day under the legacy sweep; still one wasted download per filing per day after #4133's event-driven discovery).

New `FailedFilingIngest` row (keyed by accession) records each deterministic failure at the end-of-cycle deferred retry: attempt count, last error, and a precomputed `NextRetryAt` on an exponential backoff (1d doubling to a 30d cap). **Retries never stop** — a later normalizer fix still ingests the filing, so no filing is ever permanently lost — but a permanently poisonous filing costs at most one download a month. The table doubles as an operator-readable list of currently-failing filings.

Guarantees:
- Only the exact deterministic poison shape (`InvalidOperationException`, the same condition that defers the filing) is tombstoned — transient faults (HTTP errors, timeouts-as-`TaskCanceledException`, deploy-window DB errors) never are, so an infra blip can't put a batch of ingestable filings on a multi-day backoff.
- A batched prefilter drops not-due filings after the existing dedup prefilter, before any network work.
- Successful ingest deletes the row; `CreateDocument` now reports whether it actually persisted, so the silent no-content skip neither clears a tombstone nor (fixing a pre-existing miscount) counts as an added document.
- Every tombstone path is best-effort try/catch: any failure degrades to exactly the old behavior.

## Code changes

- `Equibles.Sec.Data` / `Equibles.Sec.Repositories` / `Equibles.Migrations`: `FailedFilingIngest` entity (PK accession, index on `NextRetryAt`) + repository + `AddFailedFilingIngest` migration.
- `Equibles.Sec.HostedService/DocumentScraper`: tombstone prefilter after `FilterAlreadyIngested`, failure recording in `RetryDeferredFilings`, clear-on-persist, `CreateDocument` → `Task<bool>`, internal `ComputeNextRetryAt`.
- Tests: tombstone lifecycle (create → skip-without-re-download → due-retry-success clears), transient-failure exclusion theory (HTTP fault + timeout), backoff schedule. Full suite: 3,415 green.