### PR TITLE
feat(sec): tombstone the insider processor's deterministic skips

### DIFF
--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -831,16 +831,6 @@ public class DocumentScraper : IDocumentScraper
         }
     }
 
-    // Retry backoff for tombstoned filings: 1d, 2d, 4d, ... capped at 30d.
-    // Retries never stop — a later normalizer fix still ingests the filing —
-    // but the cap bounds a permanently poisonous filing to ~one download a month.
-    internal static DateTime ComputeNextRetryAt(int attemptCount, DateTime lastAttemptAt)
-    {
-        const int maxBackoffDays = 30;
-        var backoffDays = Math.Min(Math.Pow(2, Math.Max(attemptCount, 1) - 1), maxBackoffDays);
-        return lastAttemptAt.AddDays(backoffDays);
-    }
-
     // Drops filings whose failure tombstone says the retry backoff hasn't
     // elapsed. One batched lookup per (company, type); best-effort — a DB
     // hiccup falls back to processing everything, which is the old behavior.
@@ -891,39 +881,16 @@ public class DocumentScraper : IDocumentScraper
         Exception failure
     )
     {
-        if (string.IsNullOrEmpty(filing.AccessionNumber))
-            return;
-
         try
         {
             await using var scope = _serviceScopeFactory.CreateAsyncScope();
-            var tombstoneRepository =
-                scope.ServiceProvider.GetRequiredService<FailedFilingIngestRepository>();
-
-            var tombstone = await tombstoneRepository
-                .GetByAccessionNumber(filing.AccessionNumber)
-                .FirstOrDefaultAsync();
-
-            if (tombstone == null)
-            {
-                tombstone = new FailedFilingIngest
-                {
-                    AccessionNumber = filing.AccessionNumber,
-                    Cik = string.IsNullOrEmpty(filing.Cik) ? company.Cik : filing.Cik,
-                    FormType = filing.Form,
-                    FilingDate = filing.FilingDate,
-                };
-                tombstoneRepository.Add(tombstone);
-            }
-
-            var now = DateTime.UtcNow;
-            tombstone.AttemptCount++;
-            tombstone.LastAttemptAt = now;
-            tombstone.NextRetryAt = ComputeNextRetryAt(tombstone.AttemptCount, now);
-            tombstone.LastError =
-                failure.Message?.Length > 2000 ? failure.Message[..2000] : failure.Message;
-
-            await tombstoneRepository.SaveChanges();
+            await FilingIngestTombstones.Record(
+                scope.ServiceProvider.GetRequiredService<FailedFilingIngestRepository>(),
+                company.Cik,
+                filing,
+                failure.Message,
+                _logger
+            );
         }
         catch (Exception ex)
         {
@@ -939,23 +906,14 @@ public class DocumentScraper : IDocumentScraper
     // table meaningful as "currently failing". Best-effort; usually a PK miss.
     private async Task ClearFilingIngestTombstone(string accessionNumber)
     {
-        if (string.IsNullOrEmpty(accessionNumber))
-            return;
-
         try
         {
             await using var scope = _serviceScopeFactory.CreateAsyncScope();
-            var tombstoneRepository =
-                scope.ServiceProvider.GetRequiredService<FailedFilingIngestRepository>();
-
-            var tombstone = await tombstoneRepository
-                .GetByAccessionNumber(accessionNumber)
-                .FirstOrDefaultAsync();
-            if (tombstone == null)
-                return;
-
-            tombstoneRepository.Delete(tombstone);
-            await tombstoneRepository.SaveChanges();
+            await FilingIngestTombstones.Clear(
+                scope.ServiceProvider.GetRequiredService<FailedFilingIngestRepository>(),
+                accessionNumber,
+                _logger
+            );
         }
         catch (Exception ex)
         {

--- a/src/Equibles.Sec.HostedService/Services/FilingIngestTombstones.cs
+++ b/src/Equibles.Sec.HostedService/Services/FilingIngestTombstones.cs
@@ -1,0 +1,118 @@
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Shared write path for filing-ingest tombstones, used by the document
+/// scraper's deferred-failure path and by filing processors whose deliberate
+/// deterministic skips (stale superseded amendments, pre-XML-era ownership
+/// documents, malformed XML) previously persisted nothing — so every
+/// enumeration re-downloaded the submission just to re-skip it. Only verdicts
+/// that hold regardless of which company's feed surfaced the filing may be
+/// recorded here: the tombstone is keyed by accession and consulted globally,
+/// so a company-relative skip (issuer mismatch) must never be tombstoned or it
+/// would suppress the real issuer's ingest. Retries never stop (backoff caps
+/// at 30 days), so no filing is ever permanently lost.
+/// </summary>
+internal static class FilingIngestTombstones
+{
+    // Retry backoff: 1d, 2d, 4d, ... capped at 30d. A permanently poisonous
+    // filing costs at most one download a month while a later parser fix still
+    // eventually ingests it.
+    internal static DateTime ComputeNextRetryAt(int attemptCount, DateTime lastAttemptAt)
+    {
+        const int maxBackoffDays = 30;
+        var backoffDays = Math.Min(Math.Pow(2, Math.Max(attemptCount, 1) - 1), maxBackoffDays);
+        return lastAttemptAt.AddDays(backoffDays);
+    }
+
+    /// <summary>
+    /// Upserts the filing's tombstone: attempt count, last reason, and the next
+    /// retry per the backoff. Best-effort — a failed write only means the
+    /// filing is re-attempted on the next enumeration, exactly as before
+    /// tombstones existed.
+    /// </summary>
+    internal static async Task Record(
+        FailedFilingIngestRepository repository,
+        string cik,
+        FilingData filing,
+        string reason,
+        ILogger logger
+    )
+    {
+        if (string.IsNullOrEmpty(filing.AccessionNumber))
+            return;
+
+        try
+        {
+            var tombstone = await repository
+                .GetByAccessionNumber(filing.AccessionNumber)
+                .FirstOrDefaultAsync();
+
+            if (tombstone == null)
+            {
+                tombstone = new FailedFilingIngest
+                {
+                    AccessionNumber = filing.AccessionNumber,
+                    Cik = string.IsNullOrEmpty(filing.Cik) ? cik : filing.Cik,
+                    FormType = filing.Form,
+                    FilingDate = filing.FilingDate,
+                };
+                repository.Add(tombstone);
+            }
+
+            var now = DateTime.UtcNow;
+            tombstone.AttemptCount++;
+            tombstone.LastAttemptAt = now;
+            tombstone.NextRetryAt = ComputeNextRetryAt(tombstone.AttemptCount, now);
+            tombstone.LastError = reason?.Length > 2000 ? reason[..2000] : reason;
+
+            await repository.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Could not tombstone failed filing {AccessionNumber}",
+                filing.AccessionNumber
+            );
+        }
+    }
+
+    /// <summary>
+    /// Removes a filing's tombstone once it finally ingests, keeping the table
+    /// meaningful as "currently failing". Best-effort; usually a PK miss.
+    /// </summary>
+    internal static async Task Clear(
+        FailedFilingIngestRepository repository,
+        string accessionNumber,
+        ILogger logger
+    )
+    {
+        if (string.IsNullOrEmpty(accessionNumber))
+            return;
+
+        try
+        {
+            var tombstone = await repository
+                .GetByAccessionNumber(accessionNumber)
+                .FirstOrDefaultAsync();
+            if (tombstone == null)
+                return;
+
+            repository.Delete(tombstone);
+            await repository.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Could not clear filing tombstone {AccessionNumber}",
+                accessionNumber
+            );
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -12,6 +12,7 @@ using Equibles.Integrations.Sec.Models;
 using Equibles.Media.BusinessLogic;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -136,9 +137,31 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
         }
 
-        var root = await TryParseOwnershipRoot(xmlContent, filing, companyTicker);
+        var tombstoneRepository =
+            scope.ServiceProvider.GetRequiredService<FailedFilingIngestRepository>();
+
+        var (root, deterministicSkipReason) = await TryParseOwnershipRoot(
+            xmlContent,
+            filing,
+            companyTicker
+        );
         if (root == null)
+        {
+            // Only content-based verdicts (identical for every feed that
+            // surfaces this accession) are tombstoned; a possibly-transient
+            // parse failure retries next enumeration as before.
+            if (deterministicSkipReason != null)
+            {
+                await FilingIngestTombstones.Record(
+                    tombstoneRepository,
+                    companyOutContext.Cik,
+                    filing,
+                    deterministicSkipReason,
+                    _logger
+                );
+            }
             return false;
+        }
 
         // A Form 4 appears in the EDGAR submissions feed of every CIK it references —
         // the issuer and each reporting owner. When a tracked public company (e.g.
@@ -152,7 +175,18 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         var owner = await TryResolveOwner(root, ownerRepository, filing, companyTicker);
         if (owner == null)
+        {
+            // Content-based verdict: the ownership XML itself lacks a usable
+            // reporting-owner identity, regardless of which feed surfaced it.
+            await FilingIngestTombstones.Record(
+                tombstoneRepository,
+                companyOutContext.Cik,
+                filing,
+                "ownership XML missing reporting-owner identity",
+                _logger
+            );
             return false;
+        }
 
         var isAmendment = filing.Form.Contains("/A", StringComparison.OrdinalIgnoreCase);
 
@@ -200,6 +234,18 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                     filing.AccessionNumber,
                     companyTicker
                 );
+                // Nothing is persisted for a stale amendment, so without a
+                // tombstone every enumeration re-downloads it just to re-skip.
+                // The verdict is the issuer's own data (a mismatched issuer
+                // never reaches this branch), and the monthly retry
+                // re-evaluates it if the newer amendment's rows ever go away.
+                await FilingIngestTombstones.Record(
+                    tombstoneRepository,
+                    companyOutContext.Cik,
+                    filing,
+                    "superseded by a newer ingested amendment of the same original",
+                    _logger
+                );
                 return false;
             }
 
@@ -246,6 +292,11 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 originalFilingDate,
                 supersededAccession
             );
+            await FilingIngestTombstones.Clear(
+                tombstoneRepository,
+                filing.AccessionNumber,
+                _logger
+            );
             return true;
         }
 
@@ -267,6 +318,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         }
 
         await transactionRepository.SaveChanges();
+        await FilingIngestTombstones.Clear(tombstoneRepository, filing.AccessionNumber, _logger);
 
         _logger.LogInformation(
             "Imported {Count} insider transactions for {Ticker} from {Form} - {AccessionNumber}",
@@ -479,7 +531,11 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         );
     }
 
-    private async Task<XElement> TryParseOwnershipRoot(
+    // Returns the parsed ownership root, or (null, reason) when the content is
+    // deterministically unparseable — the reason marks it safe to tombstone
+    // (the verdict is identical for every feed that surfaces the accession).
+    // A possibly-transient failure returns (null, null): retry next enumeration.
+    private async Task<(XElement Root, string DeterministicSkipReason)> TryParseOwnershipRoot(
         string xmlContent,
         FilingData filing,
         string companyTicker
@@ -498,7 +554,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 companyTicker,
                 filing.AccessionNumber
             );
-            return null;
+            return (null, "legacy non-XML ownership filing (pre-2003, unsupported by design)");
         }
 
         XDocument doc;
@@ -518,7 +574,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 companyTicker,
                 filing.AccessionNumber
             );
-            return null;
+            return (null, $"malformed ownership XML: {ex.Message}");
         }
         catch (Exception ex)
         {
@@ -535,7 +591,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 ex.StackTrace,
                 $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
             );
-            return null;
+            return (null, null);
         }
 
         var root = doc.Root;
@@ -546,10 +602,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 companyTicker,
                 filing.AccessionNumber
             );
-            return null;
+            return (null, null);
         }
 
-        return root;
+        return (root, null);
     }
 
     // True when the filing's issuer is the company being processed (matched by primary

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
@@ -11,6 +11,7 @@ using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.BusinessLogic;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.Logging;
@@ -109,6 +110,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
             (typeof(InsiderOwnerRepository), ownerRepo),
             (typeof(InsiderTransactionRepository), txRepo),
             (typeof(InsiderFilingRepository), filingRepo),
+            (typeof(FailedFilingIngestRepository), new FailedFilingIngestRepository(dbContext)),
             (typeof(IFileManager), Substitute.For<IFileManager>()),
             (typeof(ErrorManager), errorManager),
             (typeof(DailyStockPriceRepository), dailyStockPriceRepo),

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
@@ -13,6 +13,7 @@ using Equibles.Media.BusinessLogic;
 using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.Logging;
@@ -50,6 +51,7 @@ public class InsiderTradingFilingProcessorMalformedOwnershipXmlTests
             (typeof(InsiderOwnerRepository), new InsiderOwnerRepository(dbContext)),
             (typeof(InsiderTransactionRepository), new InsiderTransactionRepository(dbContext)),
             (typeof(InsiderFilingRepository), new InsiderFilingRepository(dbContext)),
+            (typeof(FailedFilingIngestRepository), new FailedFilingIngestRepository(dbContext)),
             (typeof(IFileManager), Substitute.For<IFileManager>()),
             (typeof(ErrorManager), new ErrorManager(new ErrorRepository(dbContext))),
             (typeof(DailyStockPriceRepository), new DailyStockPriceRepository(dbContext)),

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -14,6 +14,7 @@ using Equibles.Media.BusinessLogic;
 using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -396,6 +397,7 @@ public class InsiderTradingFilingProcessorTests
             (typeof(InsiderOwnerRepository), ownerRepo),
             (typeof(InsiderTransactionRepository), txRepo),
             (typeof(InsiderFilingRepository), filingRepo),
+            (typeof(FailedFilingIngestRepository), new FailedFilingIngestRepository(dbContext)),
             (typeof(IFileManager), fileManager),
             (typeof(ErrorManager), errorManager),
             (typeof(DailyStockPriceRepository), dailyStockPriceRepo),

--- a/tests/Equibles.UnitTests/Sec/FilingIngestTombstonesComputeNextRetryAtTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FilingIngestTombstonesComputeNextRetryAtTests.cs
@@ -1,4 +1,4 @@
-using Equibles.Sec.HostedService;
+using Equibles.Sec.HostedService.Services;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -7,7 +7,7 @@ namespace Equibles.UnitTests.Sec;
 /// retries never stop, so a permanently poisonous filing costs at most one
 /// download a month while a later parser fix still eventually ingests it.
 /// </summary>
-public class DocumentScraperComputeNextRetryAtTests
+public class FilingIngestTombstonesComputeNextRetryAtTests
 {
     private static readonly DateTime Now = new(2026, 7, 10, 0, 0, 0, DateTimeKind.Utc);
 
@@ -20,7 +20,7 @@ public class DocumentScraperComputeNextRetryAtTests
     [InlineData(50, 30)]
     public void BackoffDoublesAndCapsAtThirtyDays(int attemptCount, int expectedDays)
     {
-        DocumentScraper
+        FilingIngestTombstones
             .ComputeNextRetryAt(attemptCount, Now)
             .Should()
             .Be(Now.AddDays(expectedDays));
@@ -29,6 +29,6 @@ public class DocumentScraperComputeNextRetryAtTests
     [Fact]
     public void ZeroAttempts_TreatedAsFirst()
     {
-        DocumentScraper.ComputeNextRetryAt(0, Now).Should().Be(Now.AddDays(1));
+        FilingIngestTombstones.ComputeNextRetryAt(0, Now).Should().Be(Now.AddDays(1));
     }
 }

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
@@ -1,0 +1,257 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins which insider-processor skip outcomes tombstone the filing and which
+/// never may. Deterministic content verdicts (legacy non-XML, malformed XML,
+/// stale superseded amendment) previously persisted nothing, so every
+/// enumeration re-downloaded the multi-MB submission just to re-skip it — the
+/// processor-path poison shape. Company-relative or transient outcomes
+/// (issuer mismatch, empty content) must NEVER tombstone: the tombstone is
+/// keyed by accession and consulted globally, so recording a mismatch would
+/// suppress the real issuer's ingest of the same filing.
+/// </summary>
+public class InsiderTradingFilingProcessorSkipTombstoneTests
+{
+    private const string Accession = "0001185185-23-001302";
+    private const string IssuerCik = "1236275";
+    private const string OwnerCik = "0009999999";
+
+    private sealed class SecTombstoneModuleConfiguration : IModuleConfiguration
+    {
+        public void ConfigureEntities(ModelBuilder builder)
+        {
+            builder.Entity<FailedFilingIngest>();
+            builder.Entity<InsiderOwner>();
+            builder.Entity<InsiderTransaction>();
+            builder.Entity<InsiderFiling>();
+        }
+    }
+
+    private static EquiblesFinancialDbContext CreateContext() =>
+        new(
+            new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .EnableServiceProviderCaching(false)
+                .Options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new MediaModuleConfiguration(),
+                new SecTombstoneModuleConfiguration(),
+            }
+        );
+
+    private static InsiderTradingFilingProcessor BuildProcessor(
+        EquiblesFinancialDbContext ctx,
+        string documentContent
+    )
+    {
+        var secEdgar = Substitute.For<ISecEdgarClient>();
+        secEdgar.GetDocumentContent(Arg.Any<FilingData>()).Returns(documentContent);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(ctx);
+        services.AddSingleton(secEdgar);
+        services.AddSingleton(Substitute.For<IFileManager>());
+        services.AddScoped<InsiderOwnerRepository>();
+        services.AddScoped<InsiderTransactionRepository>();
+        services.AddScoped<InsiderFilingRepository>();
+        services.AddScoped<FailedFilingIngestRepository>();
+        services.AddScoped<DailyStockPriceRepository>();
+        services.AddScoped<InsiderTransactionPriceValidator>();
+        var scopeFactory = services
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+
+        return new InsiderTradingFilingProcessor(
+            scopeFactory,
+            Substitute.For<ILogger<InsiderTradingFilingProcessor>>(),
+            new Equibles.Errors.BusinessLogic.ErrorReporter(
+                scopeFactory,
+                Substitute.For<ILogger<Equibles.Errors.BusinessLogic.ErrorReporter>>()
+            )
+        );
+    }
+
+    private static CommonStock Issuer() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "QXO",
+            Cik = IssuerCik,
+        };
+
+    private static FilingData Filing(string form = "4") =>
+        new()
+        {
+            Cik = IssuerCik,
+            AccessionNumber = Accession,
+            FilingDate = new DateOnly(2023, 6, 1),
+            ReportDate = new DateOnly(2023, 5, 30),
+            Form = form,
+        };
+
+    private static string OwnershipXml(
+        string issuerCik = IssuerCik,
+        string documentType = "4",
+        string dateOfOriginalSubmission = null,
+        bool includeOwner = true
+    )
+    {
+        var original =
+            dateOfOriginalSubmission == null
+                ? ""
+                : $"<dateOfOriginalSubmission>{dateOfOriginalSubmission}</dateOfOriginalSubmission>";
+        var owner = includeOwner
+            ? $"""
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>{OwnerCik}</rptOwnerCik>
+                        <rptOwnerName>Doe John</rptOwnerName>
+                    </reportingOwnerId>
+                </reportingOwner>
+                """
+            : "<reportingOwner></reportingOwner>";
+        return $"""
+            <ownershipDocument>
+                <schemaVersion>X0306</schemaVersion>
+                <documentType>{documentType}</documentType>
+                {original}
+                <periodOfReport>2023-05-30</periodOfReport>
+                <issuer>
+                    <issuerCik>{issuerCik}</issuerCik>
+                    <issuerName>QXO, Inc.</issuerName>
+                    <issuerTradingSymbol>QXO</issuerTradingSymbol>
+                </issuer>
+                {owner}
+            </ownershipDocument>
+            """;
+    }
+
+    [Fact]
+    public async Task LegacyNonXmlFiling_IsTombstoned()
+    {
+        await using var ctx = CreateContext();
+        var processor = BuildProcessor(ctx, "PEM plain-text paper filing, no XML here");
+
+        var processed = await processor.Process(Filing(), Issuer());
+
+        processed.Should().BeFalse();
+        var tombstone = await ctx.Set<FailedFilingIngest>().SingleAsync();
+        tombstone.AccessionNumber.Should().Be(Accession);
+        tombstone.LastError.Should().Contain("legacy non-XML");
+    }
+
+    [Fact]
+    public async Task MalformedOwnershipXml_IsTombstoned()
+    {
+        await using var ctx = CreateContext();
+        var processor = BuildProcessor(ctx, "<ownershipDocument><unclosed></ownershipDocument");
+
+        var processed = await processor.Process(Filing(), Issuer());
+
+        processed.Should().BeFalse();
+        var tombstone = await ctx.Set<FailedFilingIngest>().SingleAsync();
+        tombstone.LastError.Should().Contain("malformed ownership XML");
+    }
+
+    [Fact]
+    public async Task StaleAmendment_NewerAmendmentAlreadyIngested_IsTombstoned()
+    {
+        await using var ctx = CreateContext();
+        var issuer = Issuer();
+        var owner = new InsiderOwner { OwnerCik = OwnerCik, Name = "Doe John" };
+        ctx.Set<InsiderOwner>().Add(owner);
+        await ctx.SaveChangesAsync();
+        // A NEWER amendment of the same original is already ingested.
+        ctx.Set<InsiderTransaction>()
+            .Add(
+                new InsiderTransaction
+                {
+                    InsiderOwnerId = owner.Id,
+                    CommonStockId = issuer.Id,
+                    FilingDate = new DateOnly(2023, 7, 1),
+                    TransactionDate = new DateOnly(2023, 5, 30),
+                    TransactionCode = TransactionCode.Other,
+                    AccessionNumber = "0001185185-23-009999",
+                    SecurityTitle = "Common Stock",
+                    TransactionOrder = 1,
+                    IsAmendment = true,
+                    OriginalFilingDate = new DateOnly(2023, 5, 25),
+                    IsPriceValid = true,
+                    Notes = [],
+                    ParserVersion = InsiderTransaction.CurrentParserVersion,
+                }
+            );
+        await ctx.SaveChangesAsync();
+
+        var processor = BuildProcessor(
+            ctx,
+            OwnershipXml(documentType: "4/A", dateOfOriginalSubmission: "2023-05-25")
+        );
+
+        var processed = await processor.Process(Filing(form: "4/A"), issuer);
+
+        processed.Should().BeFalse();
+        var tombstone = await ctx.Set<FailedFilingIngest>().SingleAsync();
+        tombstone.LastError.Should().Contain("newer ingested amendment");
+    }
+
+    [Fact]
+    public async Task IssuerMismatch_IsNeverTombstoned()
+    {
+        await using var ctx = CreateContext();
+        // The filing surfaced via a reporting-owner feed: its issuer is another
+        // company. Tombstoning it would suppress the real issuer's ingest.
+        var processor = BuildProcessor(ctx, OwnershipXml(issuerCik: "7777777"));
+
+        var processed = await processor.Process(Filing(), Issuer());
+
+        processed.Should().BeFalse();
+        (await ctx.Set<FailedFilingIngest>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task EmptyContent_IsNeverTombstoned()
+    {
+        await using var ctx = CreateContext();
+        var processor = BuildProcessor(ctx, "");
+
+        var processed = await processor.Process(Filing(), Issuer());
+
+        processed.Should().BeFalse();
+        (await ctx.Set<FailedFilingIngest>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MissingReportingOwnerIdentity_IsTombstoned()
+    {
+        await using var ctx = CreateContext();
+        var processor = BuildProcessor(ctx, OwnershipXml(includeOwner: false));
+
+        var processed = await processor.Process(Filing(), Issuer());
+
+        processed.Should().BeFalse();
+        var tombstone = await ctx.Set<FailedFilingIngest>().SingleAsync();
+        tombstone.LastError.Should().Contain("reporting-owner identity");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
@@ -243,6 +243,39 @@ public class InsiderTradingFilingProcessorSkipTombstoneTests
     }
 
     [Fact]
+    public async Task SuccessfulIngest_ClearsExistingTombstone()
+    {
+        await using var ctx = CreateContext();
+        // A previously-failing filing (e.g. tombstoned before a parser fix)
+        // whose backoff elapsed: the retry succeeds and must delete the row so
+        // the table stays meaningful as "currently failing".
+        ctx.Set<FailedFilingIngest>()
+            .Add(
+                new FailedFilingIngest
+                {
+                    AccessionNumber = Accession,
+                    Cik = IssuerCik,
+                    FormType = "4",
+                    FilingDate = new DateOnly(2023, 6, 1),
+                    AttemptCount = 2,
+                    LastAttemptAt = DateTime.UtcNow.AddDays(-3),
+                    NextRetryAt = DateTime.UtcNow.AddDays(-1),
+                    LastError = "malformed ownership XML",
+                }
+            );
+        await ctx.SaveChangesAsync();
+
+        // Valid ownership XML with no transaction tables → the 0-transaction
+        // sentinel path, which is a successful ingest (returns true).
+        var processor = BuildProcessor(ctx, OwnershipXml());
+
+        var processed = await processor.Process(Filing(), Issuer());
+
+        processed.Should().BeTrue();
+        (await ctx.Set<FailedFilingIngest>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
     public async Task MissingReportingOwnerIdentity_IsTombstoned()
     {
         await using var ctx = CreateContext();

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorTryParseOwnershipRootLegacyTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorTryParseOwnershipRootLegacyTests.cs
@@ -76,9 +76,14 @@ public class InsiderTradingFilingProcessorTryParseOwnershipRootLegacyTests
             Cik = "0000320193",
         };
 
-        var task = (Task<XElement>)method.Invoke(processor, [legacyEnvelope, filing, "AAPL"]);
-        var result = await task;
+        var task =
+            (Task<(XElement Root, string DeterministicSkipReason)>)
+                method.Invoke(processor, [legacyEnvelope, filing, "AAPL"]);
+        var (root, deterministicSkipReason) = await task;
 
-        result.Should().BeNull();
+        root.Should().BeNull();
+        // The legacy shape is a deterministic content verdict, so it also
+        // carries the tombstone reason that stops the per-cycle re-download.
+        deterministicSkipReason.Should().Contain("legacy non-XML");
     }
 }


### PR DESCRIPTION
## Summary

A production probe after #4136 exposed a second poison shape: the insider processor's deliberate skips persist nothing, so every enumeration re-downloads the multi-MB submission just to re-skip it — a stale superseded amendment, a pre-2003 PEM/SGML ownership filing (historically numerous), malformed ownership XML, or XML missing the reporting-owner identity. Actively-filing companies re-enumerate on every dirty event, so their stale amendments were still fetched a dozen times a day (verified live: QXO's two poison filings, 24 downloads each in 48h, zero rows).

Those four **content-based** verdicts now record through the shared `FilingIngestTombstones` helper (extracted from `DocumentScraper`), and a successful ingest clears the row. The safety invariant is explicit and tested from both sides: the tombstone is accession-keyed and consulted globally, so **company-relative or possibly-transient outcomes are never tombstoned** — issuer mismatch (the same Form 4 must stay fetchable for the real issuer's feed), empty content, generic parse exceptions. The stale-amendment verdict is safe because `IssuerMatchesCompany` precedes it and the newer-amendment query is scoped to the issuer's own rows. Backoff and no-permanent-loss semantics unchanged: retries continue forever, capped at monthly.

## Code changes

- `Equibles.Sec.HostedService/Services/FilingIngestTombstones.cs`: shared Record/Clear/backoff (moved from `DocumentScraper`, which now delegates).
- `InsiderTradingFilingProcessor`: `TryParseOwnershipRoot` returns `(root, deterministicSkipReason)`; Record at the four safe skip sites; Clear on the sentinel and main import success paths.
- Tests: 7 new unit tests (each tombstoned verdict, both never-tombstone contracts, clear-on-success), legacy-parse pin updated to the tuple shape, integration harnesses register the repo. Suites: 3,422 unit + 75 processor integration tests green.

Follow-up: #4137 tracks auditing the remaining processors (Form 144, Form D, N-CEN, N-PORT) for the same pattern.