### PR TITLE
feat(finra): liquidity filters and liquidity context on the short-squeeze board

### DIFF
--- a/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeScore.cs
+++ b/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeScore.cs
@@ -14,6 +14,17 @@ public class ShortSqueezeScore
 
     public DateOnly SettlementDate { get; set; }
 
+    /// <summary>Market capitalization in USD from the common-stock record; null when unknown.</summary>
+    public double? MarketCapitalization { get; set; }
+
+    /// <summary>
+    /// Approximate average daily dollar volume in USD: the FINRA-reported average daily
+    /// share volume (restated onto today's split basis) times the market-cap-implied
+    /// share price. Null when either input is unknown. An estimate for liquidity
+    /// gating, not a measured turnover figure.
+    /// </summary>
+    public double? AverageDailyDollarVolume { get; set; }
+
     /// <summary>Current short position as a fraction of shares outstanding (0–1 scale).</summary>
     public decimal ShortInterestPercentOfShares { get; set; }
 

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -124,6 +124,7 @@ public class ShortSqueezeScoreManager
                 s.Id,
                 s.Ticker,
                 s.SharesOutStanding,
+                s.MarketCapitalization,
             })
             .ToDictionaryAsync(s => s.Id, cancellationToken);
 
@@ -167,11 +168,14 @@ public class ShortSqueezeScoreManager
                     / (decimal)shortInterest.AverageDailyVolume.Value;
             }
 
+            var stockSplits = splitsByStock.TryGetValue(stock.Id, out var splitList)
+                ? splitList
+                : [];
             var shortInterestPercentOfShares = ShortInterestPercentOfShares(
                 shortInterest.CurrentShortPosition,
                 stock.SharesOutStanding,
                 settlementDate,
-                splitsByStock.TryGetValue(stock.Id, out var stockSplits) ? stockSplits : []
+                stockSplits
             );
             if (shortInterestPercentOfShares > MaxCredibleShortInterestRatio)
             {
@@ -180,12 +184,31 @@ public class ShortSqueezeScoreManager
                 continue;
             }
 
+            // Liquidity context for consumers that gate the board (market cap and an
+            // approximate daily dollar turnover). The ADV is a share count as-of the
+            // settlement date, so restate it onto today's basis before multiplying by
+            // the market-cap-implied CURRENT share price.
+            double? marketCap = stock.MarketCapitalization > 0 ? stock.MarketCapitalization : null;
+            double? averageDailyDollarVolume = null;
+            if (marketCap != null && shortInterest.AverageDailyVolume > 0)
+            {
+                var advOnTodaysBasis = SplitAdjustment.AdjustShareCount(
+                    shortInterest.AverageDailyVolume.Value,
+                    settlementDate,
+                    stockSplits
+                );
+                averageDailyDollarVolume =
+                    advOnTodaysBasis * (marketCap.Value / stock.SharesOutStanding);
+            }
+
             scores.Add(
                 new ShortSqueezeScore
                 {
                     CommonStockId = stock.Id,
                     Ticker = stock.Ticker,
                     SettlementDate = settlementDate,
+                    MarketCapitalization = marketCap,
+                    AverageDailyDollarVolume = averageDailyDollarVolume,
                     ShortInterestPercentOfShares = shortInterestPercentOfShares,
                     DaysToCover = daysToCover,
                     // TryGetValue, not GetValueOrDefault: a stock with no volume data

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -323,9 +323,17 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortSqueezeScores")]
     [Description(
-        "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built from short interest as a percent of shares outstanding, days to cover, and the recent change in the short share of total volume, each as a percentile across every stock reporting short interest at the latest FINRA settlement date. Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
+        "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built from short interest as a percent of shares outstanding, days to cover, and the recent change in the short share of total volume, each as a percentile across every stock reporting short interest at the latest FINRA settlement date. Untradeable micro-caps dominate the raw board, so pass minMarketCap and/or minDollarVolume to keep only names that clear your liquidity bar (the score itself stays peer-relative to the full universe). Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
     )]
     public Task<string> GetShortSqueezeScores(
+        [Description(
+            "Minimum market capitalization in US dollars (e.g. 300000000 = $300M; default 0 = no floor). Stocks with an unknown market cap are excluded when set."
+        )]
+            double minMarketCap = 0,
+        [Description(
+            "Minimum average daily dollar volume in US dollars, approximated as the FINRA average daily share volume times the market-cap-implied share price (e.g. 5000000 = $5M/day; default 0 = no floor). Stocks with unknown volume or market cap are excluded when set."
+        )]
+            double minDollarVolume = 0,
         [Description("Maximum number of stocks to return (default: 25, highest score first)")]
             int maxResults = 25
     )
@@ -338,6 +346,20 @@ public class ShortDataTools
                     return "No short-squeeze scores available — no short interest data on file.";
 
                 var settlementDate = scores[0].SettlementDate;
+
+                // Liquidity gates are a view over the scored universe, applied after the
+                // peer-relative percentiles so a stock's score never depends on the
+                // caller's filter. Null (unknown) liquidity fails an active gate.
+                var filtered = scores;
+                if (minMarketCap > 0)
+                    filtered = filtered.Where(s => s.MarketCapitalization >= minMarketCap).ToList();
+                if (minDollarVolume > 0)
+                    filtered = filtered
+                        .Where(s => s.AverageDailyDollarVolume >= minDollarVolume)
+                        .ToList();
+                if (filtered.Count == 0)
+                    return $"No scored stocks clear the requested liquidity floor (of {scores.Count} scored at settlement {settlementDate:yyyy-MM-dd}). Lower minMarketCap/minDollarVolume.";
+
                 var take = Math.Clamp(maxResults, 1, 200);
                 var sb = new System.Text.StringBuilder();
                 sb.AppendLine(
@@ -345,17 +367,17 @@ public class ShortDataTools
                 );
                 sb.AppendLine();
                 sb.AppendLine(
-                    "Score = equal-weight mean of the available factor percentiles (0-100, peer-relative)."
+                    "Score = equal-weight mean of the available factor percentiles (0-100, peer-relative). Avg $ Volume is approximate (FINRA share volume × market-cap-implied price)."
                 );
                 sb.AppendLine();
                 sb.AppendLine(
-                    "| # | Ticker | Score | Short % of Shares | Days to Cover | Short-Volume Trend |"
+                    "| # | Ticker | Score | Short % of Shares | Days to Cover | Short-Volume Trend | Market Cap | Avg $ Volume |"
                 );
                 sb.AppendLine(
-                    "|---|--------|-------|-------------------|---------------|--------------------|"
+                    "|---|--------|-------|-------------------|---------------|--------------------|------------|--------------|"
                 );
                 sb.AppendNumberedRows(
-                    scores.Take(take).ToList(),
+                    filtered.Take(take).ToList(),
                     (rank, score) =>
                     {
                         var trend =
@@ -368,17 +390,18 @@ public class ShortDataTools
                                     );
                         return $"| {rank} | {score.Ticker} | {score.Score.ToString("0", CultureInfo.InvariantCulture)} | "
                             + $"{score.ShortInterestPercentOfShares.ToString("P1", CultureInfo.InvariantCulture)} | "
-                            + $"{score.DaysToCover?.ToString("0.0", CultureInfo.InvariantCulture) ?? "-"} | {trend} |";
+                            + $"{score.DaysToCover?.ToString("0.0", CultureInfo.InvariantCulture) ?? "-"} | {trend} | "
+                            + $"{McpFormat.CompactUsd(score.MarketCapitalization)} | {McpFormat.CompactUsd(score.AverageDailyDollarVolume)} |";
                     }
                 );
 
-                if (scores.Count > take)
-                    sb.AppendLine($"\n({scores.Count - take} more scored stocks not shown.)");
+                if (filtered.Count > take)
+                    sb.AppendLine($"\n({filtered.Count - take} more scored stocks not shown.)");
 
                 return sb.ToString();
             },
             "GetShortSqueezeScores",
-            $"maxResults: {maxResults}"
+            $"minMarketCap: {minMarketCap}, minDollarVolume: {minDollarVolume}, maxResults: {maxResults}"
         );
     }
 }

--- a/src/Equibles.Mcp/Helpers/McpFormat.cs
+++ b/src/Equibles.Mcp/Helpers/McpFormat.cs
@@ -23,4 +23,26 @@ public static class McpFormat
     // invariant culture so MCP markdown does not fork the separators by host locale.
     public static string Invariant<T>(T value, string format)
         where T : IFormattable => value.ToString(format, CultureInfo.InvariantCulture);
+
+    // Compact USD for wide-magnitude dollar figures (market caps, dollar volumes):
+    // $1.23T / $45.6B / $789M / $12.3K, em-dash when null. Invariant culture so MCP
+    // markdown does not fork the decimal separator by host locale.
+    public static string CompactUsd(double? value)
+    {
+        if (value == null)
+        {
+            return Dash;
+        }
+
+        var abs = Math.Abs(value.Value);
+        var (scaled, suffix) = abs switch
+        {
+            >= 1e12 => (value.Value / 1e12, "T"),
+            >= 1e9 => (value.Value / 1e9, "B"),
+            >= 1e6 => (value.Value / 1e6, "M"),
+            >= 1e3 => (value.Value / 1e3, "K"),
+            _ => (value.Value, ""),
+        };
+        return "$" + scaled.ToString("0.##", CultureInfo.InvariantCulture) + suffix;
+    }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -92,4 +92,108 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
 
         result.Should().Contain("No short-squeeze scores available");
     }
+
+    // The raw board is dominated by untradeable micro-caps; the liquidity gates must
+    // drop them from the view (nulls fail an active gate) while leaving the scored
+    // universe — and therefore every score — untouched.
+    [Fact]
+    public async Task GetShortSqueezeScores_MinMarketCap_DropsMicroCapsAndUnknowns()
+    {
+        var settlement = new DateOnly(2026, 4, 15);
+        var large = new CommonStock
+        {
+            Ticker = "BIG",
+            Name = "Big Corp",
+            Cik = "0000000201",
+            SharesOutStanding = 100_000_000,
+            MarketCapitalization = 5_000_000_000,
+        };
+        var micro = new CommonStock
+        {
+            Ticker = "TINY",
+            Name = "Tiny Bio",
+            Cik = "0000000202",
+            SharesOutStanding = 1_000_000,
+            MarketCapitalization = 50_000_000,
+        };
+        var unknown = new CommonStock
+        {
+            Ticker = "NOCAP",
+            Name = "No Cap Corp",
+            Cik = "0000000203",
+            SharesOutStanding = 1_000_000,
+        };
+        DbContext.Set<CommonStock>().AddRange(large, micro, unknown);
+        DbContext
+            .Set<ShortInterest>()
+            .AddRange(
+                new ShortInterest
+                {
+                    CommonStockId = large.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 10_000_000,
+                    AverageDailyVolume = 2_000_000,
+                    DaysToCover = 5m,
+                },
+                new ShortInterest
+                {
+                    CommonStockId = micro.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 400_000,
+                    DaysToCover = 20m,
+                },
+                new ShortInterest
+                {
+                    CommonStockId = unknown.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 300_000,
+                    DaysToCover = 15m,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var unfiltered = await Sut().GetShortSqueezeScores();
+        var filtered = await Sut().GetShortSqueezeScores(minMarketCap: 300_000_000);
+
+        unfiltered.Should().Contain("TINY").And.Contain("NOCAP").And.Contain("BIG");
+        filtered.Should().Contain("BIG");
+        filtered.Should().NotContain("TINY", "a $50M cap fails the $300M floor");
+        filtered.Should().NotContain("NOCAP", "an unknown market cap fails an active gate");
+
+        // Liquidity context renders: $5B cap and ~$100M/day (2M shares × $50 implied).
+        filtered.Should().Contain("$5B");
+        filtered.Should().Contain("$100M");
+    }
+
+    [Fact]
+    public async Task GetShortSqueezeScores_MinDollarVolume_NothingClears_ExplainsInsteadOfEmptyTable()
+    {
+        var settlement = new DateOnly(2026, 4, 15);
+        var stock = new CommonStock
+        {
+            Ticker = "THIN",
+            Name = "Thinly Traded Corp",
+            Cik = "0000000204",
+            SharesOutStanding = 1_000_000,
+            MarketCapitalization = 10_000_000,
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStockId = stock.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 100_000,
+                    AverageDailyVolume = 10_000,
+                    DaysToCover = 10m,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortSqueezeScores(minDollarVolume: 5_000_000);
+
+        result.Should().Contain("No scored stocks clear the requested liquidity floor");
+    }
 }

--- a/tests/Equibles.UnitTests/Mcp/McpFormatCompactUsdTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpFormatCompactUsdTests.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpFormatCompactUsdTests
+{
+    [Theory]
+    [InlineData(1_230_000_000_000d, "$1.23T")]
+    [InlineData(5_000_000_000d, "$5B")]
+    [InlineData(456_000_000d, "$456M")]
+    [InlineData(12_300d, "$12.3K")]
+    [InlineData(999d, "$999")]
+    [InlineData(0d, "$0")]
+    public void CompactUsd_ScalesToTheLargestFittingSuffix(double value, string expected)
+    {
+        McpFormat.CompactUsd(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void CompactUsd_Null_RendersDash()
+    {
+        McpFormat.CompactUsd(null).Should().Be("—");
+    }
+
+    [Fact]
+    public void CompactUsd_IsCultureInvariant()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            McpFormat
+                .CompactUsd(1_230_000_000d)
+                .Should()
+                .Be("$1.23B", "the decimal separator must not fork by host locale");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Customer feedback: the squeeze board's top list is almost entirely micro-cap biotech that fails any real liquidity gate, so it isn't tradeable as-is.

- `ShortSqueezeScore` rows now carry **market cap** and an **approximate average daily dollar volume** (FINRA average daily share volume, restated onto today's split basis, times the market-cap-implied share price — documented as an estimate).
- `GetShortSqueezeScores` accepts **minMarketCap** and **minDollarVolume** floors. They are applied **after** percentile scoring, so a caller's filter is a view over the scored universe and never changes anyone's peer-relative score. Unknown liquidity fails an active gate. Both new columns render in the table.
- New `McpFormat.CompactUsd` ($1.23T/$45.6B/$789M) for wide-magnitude dollar columns, invariant-culture.

## Code changes

- `Equibles.Finra.BusinessLogic`: score model + manager enrichment (market cap, split-coherent dollar-volume estimate).
- `Equibles.Finra.Mcp`: tool params, post-score filtering, liquidity columns, nothing-clears message.
- `Equibles.Mcp`: `McpFormat.CompactUsd`.
- Tests: filter drops micro-caps and unknown-cap names while the unfiltered board keeps them; nothing-clears message; CompactUsd scaling/null/culture-invariance.