### PR TITLE
fix(congress): rejoin thousands groups broken by PDF line breaks; never store an inverted amount bracket

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -362,10 +362,24 @@ public static partial class DisclosureParsingHelper
         if (string.IsNullOrWhiteSpace(amount))
             return (0, 0);
 
+        // PDF text extraction can break one number across lines ("$200,\n000"), and the digit
+        // regex stops at the whitespace — production stored a "$50,001 - $200,000" bracket as
+        // (50001, 200). Rejoin digit groups a comma+whitespace split before matching; only the
+        // exact thousands-group shape is touched, so genuinely separate numbers never merge.
+        amount = BrokenThousandsRegex().Replace(amount, ",");
+
         var matches = AmountRegex().Matches(amount);
 
         if (matches.Count >= 2)
-            return (ParseAmount(matches[0]), ParseAmount(matches[1]));
+        {
+            var from = ParseAmount(matches[0]);
+            var to = ParseAmount(matches[1]);
+            // A range whose upper bound parsed BELOW its lower bound is corrupt source text (an
+            // unrecoverable mid-number break). The honest representation is the module's own
+            // open-ended convention — "at least $from", i.e. (from, from) — never the corrupt
+            // pair, which downstream reads as a real (and impossible) bracket.
+            return to < from ? (from, from) : (from, to);
+        }
 
         if (matches.Count == 1)
         {
@@ -415,6 +429,11 @@ public static partial class DisclosureParsingHelper
     // Matches dollar amounts: $1,001 — requires $ prefix to avoid false positives
     [GeneratedRegex(@"\$([\d,]+)")]
     public static partial Regex AmountRegex();
+
+    // A thousands group broken by extracted-PDF whitespace: a digit, its comma, whitespace (incl.
+    // newlines), then exactly three digits ("200,\n000" / "200, 000"). Replaced with the bare comma.
+    [GeneratedRegex(@"(?<=\d),\s+(?=\d{3}(?!\d))")]
+    public static partial Regex BrokenThousandsRegex();
 
     // Matches href attribute in anchor tags
     [GeneratedRegex(@"href=[""']([^""']+)[""']")]

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperBrokenAmountTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperBrokenAmountTests.cs
@@ -14,7 +14,10 @@ public class DisclosureParsingHelperBrokenAmountTests
     [InlineData("$50,001 - $200, 000", 50001, 200000)]
     [InlineData("$1,000,\n001 - $5,000,000", 1000001, 5000000)]
     public void ParseAmountRange_ThousandsGroupBrokenByWhitespace_RejoinsTheNumber(
-        string text, long expectedFrom, long expectedTo)
+        string text,
+        long expectedFrom,
+        long expectedTo
+    )
     {
         var (from, to) = DisclosureParsingHelper.ParseAmountRange(text);
 

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperBrokenAmountTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperBrokenAmountTests.cs
@@ -1,0 +1,55 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+// Contract: ParseAmountRange survives extracted-PDF text that breaks a number's thousands group
+// across whitespace/newlines ("$200,\n000"), and never stores a corrupt inverted bracket —
+// production held 56 rows like (50001, 200) from a "$50,001 - $200,000" disclosure, which
+// downstream surfaced as an impossible range. An unrecoverable upper bound falls back to the
+// module's own open-ended convention: (from, from) = "at least $from".
+public class DisclosureParsingHelperBrokenAmountTests
+{
+    [Theory]
+    [InlineData("$50,001 - $200,\n000", 50001, 200000)]
+    [InlineData("$50,001 - $200, 000", 50001, 200000)]
+    [InlineData("$1,000,\n001 - $5,000,000", 1000001, 5000000)]
+    public void ParseAmountRange_ThousandsGroupBrokenByWhitespace_RejoinsTheNumber(
+        string text, long expectedFrom, long expectedTo)
+    {
+        var (from, to) = DisclosureParsingHelper.ParseAmountRange(text);
+
+        Assert.Equal(expectedFrom, from);
+        Assert.Equal(expectedTo, to);
+    }
+
+    [Fact]
+    public void ParseAmountRange_IntactRange_IsUnchanged()
+    {
+        var (from, to) = DisclosureParsingHelper.ParseAmountRange("$50,001 - $200,000");
+
+        Assert.Equal(50001, from);
+        Assert.Equal(200000, to);
+    }
+
+    [Fact]
+    public void ParseAmountRange_CorruptInvertedBracket_FallsBackToOpenEndedLowerBound()
+    {
+        // An upper bound that parsed below the lower bound is unrecoverable source corruption —
+        // "at least $from" is the honest read, never the impossible pair.
+        var (from, to) = DisclosureParsingHelper.ParseAmountRange("$50,001 - $200junk000");
+
+        Assert.Equal(50001, from);
+        Assert.Equal(50001, to);
+    }
+
+    [Fact]
+    public void ParseAmountRange_TwoSeparateNumbers_NeverMerge()
+    {
+        // The rejoin only touches the exact comma+whitespace+three-digits shape; a genuine pair
+        // of amounts separated by whitespace stays two numbers.
+        var (from, to) = DisclosureParsingHelper.ParseAmountRange("$1,001 - $15,000");
+
+        Assert.Equal(1001, from);
+        Assert.Equal(15000, to);
+    }
+}


### PR DESCRIPTION
## Summary

Extracted disclosure text can break a number's thousands group across lines (`$200,<newline>000`), and `AmountRegex` stops at the whitespace — a `$50,001 – $200,000` bracket was stored as `(50001, 200)`, an impossible range that downstream consumers (the commercial platform's congressional-trades surfaces) present verbatim. 56 such rows exist in production.

## Code changes

- `DisclosureParsingHelper.ParseAmountRange`: pre-matching rejoin of the exact `digit-comma + whitespace + three-digits` break shape (`BrokenThousandsRegex`), so genuinely separate amounts can never merge; a residual range whose upper bound still parses below its lower falls back to the module's own open-ended convention `(from, from)` — 'at least $from' — instead of storing the corrupt pair.
- Tests: broken-across-lines/spaces shapes, an intact range, the corrupt-inverted fallback, and a no-merge guard for genuine pairs.