### PR TITLE
feat(common-stocks): add KnownSicCodes catalog with the REIT SIC code

### DIFF
--- a/src/Equibles.CommonStocks.Data/Helpers/KnownSicCodes.cs
+++ b/src/Equibles.CommonStocks.Data/Helpers/KnownSicCodes.cs
@@ -1,0 +1,11 @@
+namespace Equibles.CommonStocks.Data.Helpers;
+
+// SEC EDGAR SIC codes with product meaning. CommonStock.Sic carries the 4-digit code
+// from EDGAR's submissions metadata — the authoritative classification signal.
+// Company-type detection must compare against these codes exactly; never infer a
+// company's type from its name, ticker, or third-party industry labels.
+public static class KnownSicCodes
+{
+    // Real Estate Investment Trusts.
+    public const string Reit = "6798";
+}


### PR DESCRIPTION
## Summary
Adds a small authoritative catalog of SEC EDGAR SIC codes with product meaning, starting with the REIT code (6798). Downstream features (REIT-targeted extraction sweeps, REIT-only valuation multiples like P/FFO) need one shared definition of "is a REIT" instead of scattering the literal.

## Code changes
- `src/Equibles.CommonStocks.Data/Helpers/KnownSicCodes.cs` — new static class with `Reit = "6798"` and a doc note pinning the rule: company-type detection compares against EDGAR SIC codes exactly, never name/ticker/industry-label inference.