### PR TITLE
fix(sec): stop failed full rescans from starving stranded backfill rows

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
@@ -48,7 +48,7 @@ public class DocumentProcessor : IDocumentProcessor
     )
     {
         var attempted = 0;
-        var chunked = 0;
+        var progressed = 0;
 
         foreach (var document in documents)
         {
@@ -61,8 +61,8 @@ public class DocumentProcessor : IDocumentProcessor
             attempted++;
             try
             {
-                if (await ChunkDocument(document))
-                    chunked++;
+                await ChunkDocument(document);
+                progressed++;
             }
             catch (Exception ex)
             {
@@ -70,16 +70,19 @@ public class DocumentProcessor : IDocumentProcessor
             }
         }
 
-        // Same systemic-outage guard as GenerateEmbeddings: isolated failures above keep the
-        // batch draining, but a batch where NOTHING could be chunked (blob store unreachable,
-        // every document's content missing) must fault the cycle so the worker's error ladder
-        // reports it — instead of dissolving into per-document logs while the pending count
-        // sits frozen with no surfaced error.
-        if (attempted > 0 && chunked == 0)
+        // Same systemic-outage guard as GenerateEmbeddings, with one deliberate difference:
+        // deterministic non-outcomes (blank content, content that chunks to zero) count as
+        // progress — they are logged and can never succeed, so faulting on them would wedge
+        // the worker on a single poison document at the frontier. Only thrown failures count
+        // (blob store unreachable, content missing), and only when EVERY attempted document
+        // threw: that is a systemic outage the worker must back off from and eventually
+        // report — instead of dissolving into per-document logs while the pending count sits
+        // frozen with no surfaced error. A batch cut short by cancellation is not a signal.
+        if (!cancellationToken.IsCancellationRequested && attempted > 0 && progressed == 0)
         {
             throw new InvalidOperationException(
-                $"No chunks were produced for any of {attempted} documents — their content "
-                    + "could not be loaded or chunked. Backing off this cycle."
+                $"Chunking failed for all {attempted} documents in the batch — the content "
+                    + "store is likely unavailable. Backing off this cycle."
             );
         }
     }
@@ -131,8 +134,9 @@ public class DocumentProcessor : IDocumentProcessor
         // draining) from a systemic outage. If we attempted chunks but embedded
         // none, the embedding server is down: throw so the worker's base loop
         // logs it loudly, reports it, and backs off for a cycle — instead of
-        // hot-looping on the same batch with zero progress and no error.
-        if (totalChunks > 0 && totalEmbedded == 0)
+        // hot-looping on the same batch with zero progress and no error. A batch
+        // cut short by cancellation is shutdown, not an outage signal.
+        if (!cancellationToken.IsCancellationRequested && totalChunks > 0 && totalEmbedded == 0)
         {
             throw new InvalidOperationException(
                 $"No embeddings were produced for any of {totalChunks} chunks — "
@@ -141,21 +145,18 @@ public class DocumentProcessor : IDocumentProcessor
         }
     }
 
-    // True when the document ends the call with at least one chunk (created now, or already
-    // present from an earlier pass); false when nothing could be produced — content missing,
-    // empty, or chunking to zero — so the caller can tell a draining batch from a dead one.
-    private async Task<bool> ChunkDocument(Document document)
+    private async Task ChunkDocument(Document document)
     {
         if (document == null)
         {
             _logger.LogWarning("Document is null, skipping processing");
-            return false;
+            return;
         }
 
         if (document.Chunks.Any())
         {
             _logger.LogInformation("Document {DocumentId} already chunked, skipping", document.Id);
-            return true;
+            return;
         }
 
         _logger.LogInformation(
@@ -169,7 +170,7 @@ public class DocumentProcessor : IDocumentProcessor
         if (string.IsNullOrWhiteSpace(content))
         {
             _logger.LogWarning("Document {DocumentId} has no content", document.Id);
-            return false;
+            return;
         }
 
         var chunks = await CreateChunks(document, content);
@@ -178,7 +179,6 @@ public class DocumentProcessor : IDocumentProcessor
             chunks.Count,
             document.Id
         );
-        return chunks.Count > 0;
     }
 
     private async Task<string> GetDocumentContent(Document document)

--- a/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
@@ -47,6 +47,9 @@ public class DocumentProcessor : IDocumentProcessor
         CancellationToken cancellationToken
     )
     {
+        var attempted = 0;
+        var chunked = 0;
+
         foreach (var document in documents)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -55,14 +58,29 @@ public class DocumentProcessor : IDocumentProcessor
                 break;
             }
 
+            attempted++;
             try
             {
-                await ChunkDocument(document);
+                if (await ChunkDocument(document))
+                    chunked++;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error chunking document {DocumentId}", document.Id);
             }
+        }
+
+        // Same systemic-outage guard as GenerateEmbeddings: isolated failures above keep the
+        // batch draining, but a batch where NOTHING could be chunked (blob store unreachable,
+        // every document's content missing) must fault the cycle so the worker's error ladder
+        // reports it — instead of dissolving into per-document logs while the pending count
+        // sits frozen with no surfaced error.
+        if (attempted > 0 && chunked == 0)
+        {
+            throw new InvalidOperationException(
+                $"No chunks were produced for any of {attempted} documents — their content "
+                    + "could not be loaded or chunked. Backing off this cycle."
+            );
         }
     }
 
@@ -123,18 +141,21 @@ public class DocumentProcessor : IDocumentProcessor
         }
     }
 
-    private async Task ChunkDocument(Document document)
+    // True when the document ends the call with at least one chunk (created now, or already
+    // present from an earlier pass); false when nothing could be produced — content missing,
+    // empty, or chunking to zero — so the caller can tell a draining batch from a dead one.
+    private async Task<bool> ChunkDocument(Document document)
     {
         if (document == null)
         {
             _logger.LogWarning("Document is null, skipping processing");
-            return;
+            return false;
         }
 
         if (document.Chunks.Any())
         {
             _logger.LogInformation("Document {DocumentId} already chunked, skipping", document.Id);
-            return;
+            return true;
         }
 
         _logger.LogInformation(
@@ -148,7 +169,7 @@ public class DocumentProcessor : IDocumentProcessor
         if (string.IsNullOrWhiteSpace(content))
         {
             _logger.LogWarning("Document {DocumentId} has no content", document.Id);
-            return;
+            return false;
         }
 
         var chunks = await CreateChunks(document, content);
@@ -157,6 +178,7 @@ public class DocumentProcessor : IDocumentProcessor
             chunks.Count,
             document.Id
         );
+        return chunks.Count > 0;
     }
 
     private async Task<string> GetDocumentContent(Document document)

--- a/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
+++ b/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
@@ -13,7 +13,8 @@ public class DocumentProcessorWorker : BaseScraperWorker
 
     // The embedding sidecar (vLLM) is recycled by autoheal and on every deploy, and then reloads
     // its model for a minute or two. During that window every embedding cycle faults ("no
-    // embeddings produced — server likely down"). A faulted cycle backs off ~15s (ErrorBackoff is
+    // embeddings produced — server likely down"); an all-fail chunking batch (blob store
+    // unreachable) faults the same way. A faulted cycle backs off ~15s (ErrorBackoff is
     // capped at SleepInterval), so this many consecutive faults is roughly five minutes of solid
     // outage — comfortably past a normal reload. Below it the faults are transient and stay out of
     // the Errors page; only a genuinely sustained outage records a single row. Live "is it down"

--- a/src/Equibles.Sec.HostedService/Services/BackfillCursor.cs
+++ b/src/Equibles.Sec.HostedService/Services/BackfillCursor.cs
@@ -29,6 +29,13 @@ public class BackfillCursor
     // deploy bursts neither repeat the scan per boot nor dodge it indefinitely.
     private static readonly TimeSpan FullRescanInterval = TimeSpan.FromDays(1);
 
+    // Retry spacing after a full rescan that started but failed (query timeout, interrupted
+    // process). Rows older than the bounded window are reachable ONLY by the full rescan, and
+    // its stamp is written before the scan runs — so charging a failed scan the full daily
+    // interval starves those rows for a day per failure, indefinitely under a recurring
+    // timeout. Long enough to not crash-loop a minutes-long scan, far shorter than a day.
+    private static readonly TimeSpan FailedFullRescanRetryInterval = TimeSpan.FromMinutes(30);
+
     private DateTime _lastBoundedScanUtc = DateTime.MinValue;
 
     /// <summary>The BackfillState row key this cursor hydrates from and persists to.</summary>
@@ -111,5 +118,15 @@ public class BackfillCursor
 
         LastFullRescanAt = utcNow;
         return true;
+    }
+
+    /// <summary>
+    /// Rewinds the full-rescan stamp after a scan that was admitted but failed, so the next
+    /// attempt is admitted <see cref="FailedFullRescanRetryInterval"/> from <paramref name="utcNow"/>
+    /// instead of a full rescan interval later. The floor is left untouched.
+    /// </summary>
+    public void MarkFullRescanFailed(DateTime utcNow)
+    {
+        LastFullRescanAt = utcNow - FullRescanInterval + FailedFullRescanRetryInterval;
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
@@ -73,7 +73,10 @@ public class DocumentManager
             return false;
 
         _logger.LogInformation("Chunking {Count} documents", pendingDocuments.Count);
-        await _documentProcessor.ProcessDocuments(pendingDocuments, cancellationToken);
+        await ProcessOrRewind(
+            () => _documentProcessor.ProcessDocuments(pendingDocuments, cancellationToken),
+            cursor
+        );
         cursor.Advance(pendingDocuments[^1].CreationTime);
         await PersistCursor(cursor);
         return true;
@@ -108,10 +111,33 @@ public class DocumentManager
             "Generating embeddings for {Count} chunks",
             chunksWithoutEmbeddings.Count
         );
-        await _documentProcessor.GenerateEmbeddings(chunksWithoutEmbeddings, cancellationToken);
+        await ProcessOrRewind(
+            () => _documentProcessor.GenerateEmbeddings(chunksWithoutEmbeddings, cancellationToken),
+            cursor
+        );
         cursor.Advance(chunksWithoutEmbeddings[^1].CreationTime);
         await PersistCursor(cursor);
         return true;
+    }
+
+    // An all-fail batch throws (systemic outage) and the cursor then never advances past it.
+    // If that batch came from the daily full rescan its slot was already stamped, so without
+    // a rewind the stranded rows wait a whole day per fault — the #4143 starvation, moved one
+    // step downstream from the scan to its processing. The caller can't tell which tier
+    // produced the batch, and rewinding unconditionally is safe: for floored/bounded batches
+    // it merely pulls the next full rescan earlier.
+    private async Task ProcessOrRewind(Func<Task> process, BackfillCursor cursor)
+    {
+        try
+        {
+            await process();
+        }
+        catch
+        {
+            cursor.MarkFullRescanFailed(DateTime.UtcNow);
+            await TryPersistCursor(cursor);
+            throw;
+        }
     }
 
     // Floored batch first; when the frontier drains, an hourly rescan bounded a week behind the

--- a/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
@@ -144,11 +144,43 @@ public class DocumentManager
         if (!cursor.TryStartFullRescan(utcNow))
             return [];
 
-        // Stamp before scanning: an interrupted scan then waits out the interval instead of a
+        // Stamp before scanning: an interrupted scan then waits out an interval instead of a
         // crash-loop re-running the minutes-long scan on every boot; fresh work still flows
         // through the floored and bounded tiers regardless.
         await PersistCursor(cursor);
-        return await query(null);
+        try
+        {
+            return await query(null);
+        }
+        catch
+        {
+            // A failed scan must not consume the whole daily slot: rows behind the bounded
+            // window are reachable only here, so charging every fault a full interval starves
+            // them indefinitely under a recurring query timeout. Rewind the stamp to a short
+            // retry spacing and let the fault propagate to the worker's error ladder.
+            cursor.MarkFullRescanFailed(utcNow);
+            await TryPersistCursor(cursor);
+            throw;
+        }
+    }
+
+    // Persist that must never mask an in-flight scan fault: if the store is down the original
+    // exception carries the diagnosis, and the rewound stamp still lives on the in-memory
+    // cursor for this process.
+    private async Task TryPersistCursor(BackfillCursor cursor)
+    {
+        try
+        {
+            await PersistCursor(cursor);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not persist the rewound full-rescan stamp for {Cursor}",
+                cursor.Name
+            );
+        }
     }
 
     private async Task HydrateCursor(BackfillCursor cursor)

--- a/src/Equibles.Sec.Repositories/BackfillStateRepository.cs
+++ b/src/Equibles.Sec.Repositories/BackfillStateRepository.cs
@@ -9,7 +9,7 @@ public class BackfillStateRepository : BaseRepository<BackfillState>
     public BackfillStateRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
 
-    public async Task<BackfillState> GetByName(string name)
+    public virtual async Task<BackfillState> GetByName(string name)
     {
         return await GetAll().FirstOrDefaultAsync(s => s.Name == name);
     }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
@@ -326,6 +326,67 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
             );
     }
 
+    [Fact]
+    public async Task GenerateEmbeddingBatch_ProcessorThrows_RewindsTheFullRescanStampAndDoesNotAdvance()
+    {
+        // The all-fail guard in the processor throws on a systemic outage AFTER the batch was
+        // loaded — so when that batch came from the daily full rescan, the slot was already
+        // stamped and the stranded rows would wait a whole day per fault (the #4143 starvation
+        // moved downstream from the scan to its processing). The batch failure must rewind the
+        // persisted stamp to the short failure spacing and must not advance the floor.
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+        };
+        var file = MakeFile();
+        var document = MakeDocument(
+            stock,
+            file,
+            contentId: file.Id,
+            createdAt: DateTime.UtcNow.AddMinutes(-10)
+        );
+        var pendingChunk = MakeChunk(
+            document,
+            content: "needs embedding",
+            index: 0,
+            createdAt: DateTime.UtcNow.AddMinutes(-5)
+        );
+
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<File>().Add(file);
+        DbContext.Set<Document>().Add(document);
+        DbContext.Set<Chunk>().Add(pendingChunk);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        _processor
+            .GenerateEmbeddings(Arg.Any<List<Chunk>>(), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromException(
+                    new InvalidOperationException("No embeddings were produced for any chunks")
+                )
+            );
+
+        var cursor = new BackfillCursor("chunk-embedding");
+        var act = () =>
+            NewEmbeddingManager().GenerateEmbeddingBatch(cursor, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        var state = await new BackfillStateRepository(DbContext).GetByName("chunk-embedding");
+        state.Should().NotBeNull();
+        state!.Floor.Should().BeNull("a failed batch must not advance past its rows");
+        state
+            .LastFullRescanAt.Should()
+            .BeCloseTo(
+                DateTime.UtcNow.AddDays(-1).AddMinutes(30),
+                TimeSpan.FromMinutes(2),
+                "the failed batch re-admits the full rescan after the short failure spacing, not a day"
+            );
+    }
+
     private DocumentManager NewEmbeddingManager() =>
         new(
             new DocumentRepository(DbContext),

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
@@ -16,7 +16,8 @@ public class DocumentProcessorTests
 {
     private static DocumentProcessor CreateSut(
         IEmbeddingClient embeddingClient,
-        ILogger<DocumentProcessor> logger = null
+        ILogger<DocumentProcessor> logger = null,
+        IFileManager fileManager = null
     )
     {
         return new DocumentProcessor(
@@ -25,7 +26,7 @@ public class DocumentProcessorTests
             embeddingClient,
             new ChunkingStrategy(new TokenCounter()),
             Options.Create(new EmbeddingConfig { ModelName = "test-model" }),
-            Substitute.For<IFileManager>(),
+            fileManager ?? Substitute.For<IFileManager>(),
             logger ?? Substitute.For<ILogger<DocumentProcessor>>()
         );
     }
@@ -77,13 +78,16 @@ public class DocumentProcessorTests
         // forward-progressing past data anomalies (incomplete uploads,
         // corrupted blobs, FK orphans).
         //
-        // Setup: one Document with a CommonStock populated (so the leading
-        // LogInformation in ChunkDocument doesn't NRE before reaching the
-        // throw) but Content == null. Assert that ProcessDocuments
-        // completes without throwing AND that ILogger received exactly one
-        // Error call mentioning that document's Id.
+        // Setup: one Document with Content == null plus one healthy document
+        // (so the batch makes progress and the all-fail guard stays quiet).
+        // Assert that ProcessDocuments completes without throwing AND that
+        // ILogger received exactly one Error call for the bad document.
         var logger = Substitute.For<ILogger<DocumentProcessor>>();
-        var sut = CreateSut(Substitute.For<IEmbeddingClient>(), logger);
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager
+            .GetContent(Arg.Any<Equibles.Media.Data.Models.File>())
+            .Returns(System.Text.Encoding.UTF8.GetBytes("real filing content"));
+        var sut = CreateSut(Substitute.For<IEmbeddingClient>(), logger, fileManager);
         var documentId = Guid.NewGuid();
         var documents = new List<Document>
         {
@@ -92,6 +96,13 @@ public class DocumentProcessorTests
                 Id = documentId,
                 CommonStock = new CommonStock { Name = "Test Co", Ticker = "TEST" },
                 Content = null,
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                DocumentType = DocumentType.TenK,
+                CommonStock = new CommonStock { Name = "Good Co", Ticker = "GOOD" },
+                Content = new Equibles.Media.Data.Models.File(),
             },
         };
 
@@ -106,6 +117,64 @@ public class DocumentProcessorTests
             )
             .Should()
             .ContainSingle();
+    }
+
+    [Fact]
+    public async Task ProcessDocuments_EveryDocumentFails_ThrowsSoTheWorkerCycleFaults()
+    {
+        // Sibling guard to GenerateEmbeddings' "no embeddings produced" throw: isolated
+        // failures keep the batch draining, but a batch where NOTHING could be chunked
+        // (blob store unreachable, every document's content missing) must fault the cycle
+        // so the worker's error ladder backs off and eventually reports — instead of the
+        // batch dissolving into per-document error logs while the pending count sits
+        // frozen with no surfaced error (the #4143 starvation signature).
+        var sut = CreateSut(Substitute.For<IEmbeddingClient>());
+        var documents = new List<Document>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                CommonStock = new CommonStock { Name = "Test Co", Ticker = "TEST" },
+                Content = null,
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                CommonStock = new CommonStock { Name = "Other Co", Ticker = "OTHR" },
+                Content = null,
+            },
+        };
+
+        var act = () => sut.ProcessDocuments(documents, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*No chunks*");
+    }
+
+    [Fact]
+    public async Task ProcessDocuments_OnlyWhitespaceContent_CountsAsFailureAndThrows()
+    {
+        // A document whose content loads but is blank can never gain chunks — it must count
+        // as a failure for the all-fail guard, not as quiet success, or a batch of such
+        // documents would keep the guard silent while producing nothing.
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager
+            .GetContent(Arg.Any<Equibles.Media.Data.Models.File>())
+            .Returns(System.Text.Encoding.UTF8.GetBytes("   \n\t  "));
+        var sut = CreateSut(Substitute.For<IEmbeddingClient>(), fileManager: fileManager);
+        var documents = new List<Document>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                DocumentType = DocumentType.TenK,
+                CommonStock = new CommonStock { Name = "Test Co", Ticker = "TEST" },
+                Content = new Equibles.Media.Data.Models.File(),
+            },
+        };
+
+        var act = () => sut.ProcessDocuments(documents, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*No chunks*");
     }
 
     private static (DocumentProcessor Sut, EmbeddingRepository Repo) CreateSutWithRepo(

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
@@ -147,15 +147,16 @@ public class DocumentProcessorTests
 
         var act = () => sut.ProcessDocuments(documents, CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*No chunks*");
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Chunking failed*");
     }
 
     [Fact]
-    public async Task ProcessDocuments_OnlyWhitespaceContent_CountsAsFailureAndThrows()
+    public async Task ProcessDocuments_OnlyWhitespaceContent_IsProgressNotAFault()
     {
-        // A document whose content loads but is blank can never gain chunks — it must count
-        // as a failure for the all-fail guard, not as quiet success, or a batch of such
-        // documents would keep the guard silent while producing nothing.
+        // A document whose content loads but is blank can never gain chunks — it is a
+        // deterministic non-outcome, not a transient failure. It must NOT trip the all-fail
+        // guard: a single such poison document at the frontier would otherwise wedge the
+        // worker (the batch never advances past it, Phase 2 never runs again).
         var fileManager = Substitute.For<IFileManager>();
         fileManager
             .GetContent(Arg.Any<Equibles.Media.Data.Models.File>())
@@ -174,7 +175,46 @@ public class DocumentProcessorTests
 
         var act = () => sut.ProcessDocuments(documents, CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*No chunks*");
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task ProcessDocuments_CancelledMidBatch_DoesNotTreatThePartialBatchAsAnOutage()
+    {
+        // Cancellation after a failed first document leaves attempted=1, progressed=0 —
+        // indistinguishable from a systemic outage by the counters alone. Shutdown must not
+        // surface as a fault: the guard is gated on the token.
+        using var cts = new CancellationTokenSource();
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager
+            .GetContent(Arg.Any<Equibles.Media.Data.Models.File>())
+            .Returns<byte[]>(_ =>
+            {
+                cts.Cancel();
+                throw new IOException("blob store gone");
+            });
+        var sut = CreateSut(Substitute.For<IEmbeddingClient>(), fileManager: fileManager);
+        var documents = new List<Document>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                DocumentType = DocumentType.TenK,
+                CommonStock = new CommonStock { Name = "Test Co", Ticker = "TEST" },
+                Content = new Equibles.Media.Data.Models.File(),
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                DocumentType = DocumentType.TenK,
+                CommonStock = new CommonStock { Name = "Other Co", Ticker = "OTHR" },
+                Content = new Equibles.Media.Data.Models.File(),
+            },
+        };
+
+        var act = () => sut.ProcessDocuments(documents, cts.Token);
+
+        await act.Should().NotThrowAsync();
     }
 
     private static (DocumentProcessor Sut, EmbeddingRepository Repo) CreateSutWithRepo(

--- a/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/BackfillCursorTests.cs
@@ -124,6 +124,35 @@ public class BackfillCursorTests
     }
 
     [Fact]
+    public void MarkFullRescanFailed_ReadmitsAfterTheShortRetryInterval_NotTheFullDay()
+    {
+        // A full rescan that was admitted but failed (query timeout, interrupted process)
+        // must not cost the whole daily interval: rows behind the bounded window are
+        // reachable only by the full rescan, so charging every fault a day starves them
+        // indefinitely under a recurring timeout.
+        var cursor = new BackfillCursor("test");
+        cursor.TryStartFullRescan(Now);
+
+        cursor.MarkFullRescanFailed(Now);
+
+        cursor.TryStartFullRescan(Now.AddMinutes(29)).Should().BeFalse();
+        cursor.TryStartFullRescan(Now.AddMinutes(31)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void MarkFullRescanFailed_KeepsFloor()
+    {
+        var cursor = new BackfillCursor("test");
+        var frontier = Now.AddDays(-1);
+        cursor.Advance(frontier);
+        cursor.TryStartFullRescan(Now);
+
+        cursor.MarkFullRescanFailed(Now);
+
+        cursor.Floor.Should().Be(frontier);
+    }
+
+    [Fact]
     public void TryStartBoundedRescan_NoFloor_IsRefused()
     {
         // A floorless cursor has never processed anything — there is no frontier to look

--- a/tests/Equibles.UnitTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentManagerTests.cs
@@ -84,6 +84,51 @@ public class DocumentManagerTests
         result.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task GenerateEmbeddingBatch_FullRescanQueryThrows_RewindsTheStampAndRethrows()
+    {
+        // The full-rescan stamp is persisted BEFORE the unfloored scan runs (crash-loop
+        // protection), so without the rewind a scan that faults — the minutes-long chunk
+        // anti-join exceeding the command timeout — silently consumes the whole daily slot,
+        // and rows behind the bounded window starve a day per fault, indefinitely under a
+        // recurring timeout. A failed scan must be re-admitted after the short failure
+        // interval instead, and the fault must still reach the worker's error ladder.
+        var embeddingConfig = Options.Create(
+            new EmbeddingConfig
+            {
+                Enabled = true,
+                BaseUrl = "http://localhost:8080",
+                ModelName = "test-model",
+            }
+        );
+        var chunkRepository = Substitute.For<ChunkRepository>(
+            (Equibles.Data.EquiblesFinancialDbContext)null
+        );
+        chunkRepository
+            .When(r => r.GetAll())
+            .Do(_ => throw new InvalidOperationException("query timeout"));
+        var backfillStateRepository = Substitute.For<BackfillStateRepository>(
+            (Equibles.Data.EquiblesFinancialDbContext)null
+        );
+
+        var sut = new DocumentManager(
+            null,
+            chunkRepository,
+            backfillStateRepository,
+            Substitute.For<IDocumentProcessor>(),
+            embeddingConfig,
+            Substitute.For<ILogger<DocumentManager>>()
+        );
+        var cursor = new BackfillCursor("chunk-embedding");
+
+        var act = () => sut.GenerateEmbeddingBatch(cursor, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*query timeout*");
+        cursor
+            .LastFullRescanAt.Should()
+            .BeCloseTo(DateTime.UtcNow.AddDays(-1).AddMinutes(30), TimeSpan.FromMinutes(2));
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // EmbeddingConfig — IsConfigured logic
     // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fixes #4143. Rows left behind the backfill frontier — older than the bounded rescan's 7-day lookback — are reachable only by the once-daily unfloored full rescan. That scan's stamp is persisted **before** it runs (crash-loop protection), so a scan that faulted (the minutes-long `Chunk` anti-join exceeding the 600s command timeout, observed in production) silently consumed the whole daily slot, starving those rows a day per fault, indefinitely under a recurring timeout, with no surfaced error. The same starvation existed one step downstream: a full-rescan batch whose *processing* all-failed (97 documents with missing blob files, observed 2026-07-04) also burned the daily slot silently.

Three changes:
- **Failed full rescans retry after 30 minutes, not a day.** When the unfloored query throws, `BackfillCursor.MarkFullRescanFailed` rewinds the stamp to a short retry spacing and the fault still propagates to the worker's error ladder. Crash-loop protection is preserved.
- **An all-fail chunking batch faults the cycle — and also rewinds the stamp.** Mirrors `GenerateEmbeddings`' "no embeddings produced" guard: a batch where every attempted document *threw* (blob store unreachable, content missing) throws so the worker backs off and reports past its threshold, and `DocumentManager` rewinds the rescan stamp so a full-rescan batch isn't charged the daily slot. Deterministic non-outcomes (blank content, content chunking to zero) count as **progress** — they can never succeed, and faulting on them would wedge the worker on one poison document at the frontier. Both phases skip the guard when the batch was cut short by cancellation.
- **`BackfillStateRepository.GetByName` made virtual** for test substitutability.

## Code changes

- `BackfillCursor` — `FailedFullRescanRetryInterval` (30 min) + `MarkFullRescanFailed(utcNow)`; floor untouched.
- `DocumentManager` — `LoadBatch` wraps the unfloored `query(null)` in try/catch (rewind, best-effort persist, rethrow); `ProcessOrRewind` applies the same rewind when batch processing throws in either phase.
- `DocumentProcessor` — `ProcessDocuments` counts attempted vs progressed and throws only when a non-cancelled, non-empty batch had every document throw; blank/zero-chunk outcomes are logged progress. `GenerateEmbeddings`' existing guard gains the same cancellation gate.
- `DocumentProcessorWorker` — threshold comment covers both fault sources.
- Tests: cursor rewind spacing + floor retention (unit); full-rescan query fault rewinds stamp and rethrows (unit); all-fail batch throws / mixed batch drains / blank content is progress / cancelled partial batch is not an outage (integration, substitutes); processor-throw rewinds the persisted stamp without advancing the floor (integration, ParadeDB).

## Verification

- `dotnet build Equibles.sln -c Release` — 0 errors.
- Unit suite: 3453 passed. Integration (DocumentProcessor/DocumentManager scope): 19 passed.