### PR TITLE
feat(finra): rebuild the short-squeeze score as a weighted six-factor composite with catalyst boosts

### DIFF
--- a/src/Equibles.Finra.BusinessLogic/Equibles.Finra.BusinessLogic.csproj
+++ b/src/Equibles.Finra.BusinessLogic/Equibles.Finra.BusinessLogic.csproj
@@ -7,5 +7,7 @@
     <ProjectReference Include="..\Equibles.Finra.Repositories\Equibles.Finra.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Sec.Repositories\Equibles.Sec.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeDailyBar.cs
+++ b/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeDailyBar.cs
@@ -1,0 +1,15 @@
+namespace Equibles.Finra.BusinessLogic.Models;
+
+/// <summary>
+/// One daily price bar of the minimal shape the squeeze price factors need.
+/// <see cref="AdjustedClose"/> is the split- and dividend-adjusted close (a
+/// comparable series across time); <see cref="Close"/> and <see cref="Volume"/>
+/// are the raw as-traded figures for the day, whose product is that day's
+/// dollar turnover on a self-consistent basis regardless of later splits.
+/// </summary>
+public readonly record struct ShortSqueezeDailyBar(
+    DateOnly Date,
+    decimal AdjustedClose,
+    decimal Close,
+    long Volume
+);

--- a/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezePriceFactors.cs
+++ b/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezePriceFactors.cs
@@ -1,0 +1,30 @@
+namespace Equibles.Finra.BusinessLogic.Models;
+
+/// <summary>
+/// The price-derived pieces of a stock's squeeze score, computed by
+/// <see cref="ShortSqueezePriceFactorCalculator"/> from its recent daily bars.
+/// </summary>
+public class ShortSqueezePriceFactors
+{
+    /// <summary>
+    /// How far the latest adjusted close sits above (positive) or below (negative)
+    /// the trailing volume-weighted average price, as a fraction of that average.
+    /// A proxy for the aggregate paper loss of open short positions — the deeper
+    /// the price trades above the level where recent volume changed hands, the
+    /// more of the short base is underwater. Null when the price history is too
+    /// short to average meaningfully.
+    /// </summary>
+    public decimal? PriceAboveVwap { get; set; }
+
+    /// <summary>
+    /// True when the recent-window return is positive and statistically extreme
+    /// versus the stock's own daily volatility — the price-spike catalyst.
+    /// </summary>
+    public bool HasPriceSpikeCatalyst { get; set; }
+
+    /// <summary>
+    /// True when recent dollar turnover runs a multiple of the stock's baseline
+    /// turnover while the recent return is positive — the abnormal-volume catalyst.
+    /// </summary>
+    public bool HasVolumeSurgeCatalyst { get; set; }
+}

--- a/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeScore.cs
+++ b/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeScore.cs
@@ -2,9 +2,12 @@ namespace Equibles.Finra.BusinessLogic.Models;
 
 /// <summary>
 /// One stock's composite short-squeeze score for a FINRA settlement date: the raw
-/// factor values and each factor's 0–100 percentile across the scored universe, with
-/// <see cref="Score"/> the equal-weight mean of the available factor percentiles.
-/// Factors a stock lacks data for are null and simply drop out of its mean.
+/// factor values, each factor's 0–100 percentile across the scored universe, the
+/// catalyst flags, and the resulting <see cref="Score"/>. The composite is the
+/// weight-averaged mean of the available factor percentiles (see
+/// <see cref="ShortSqueezeScoreManager"/> for the weights) plus the catalyst boost,
+/// clamped to 100. Factors a stock lacks data for are null and drop out of the
+/// weighted mean, their weight redistributed over the factors that remain.
 /// </summary>
 public class ShortSqueezeScore
 {
@@ -37,12 +40,71 @@ public class ShortSqueezeScore
     /// </summary>
     public decimal? ShortVolumeShareTrend { get; set; }
 
+    /// <summary>
+    /// Change in the short position versus the previous FINRA report, as a fraction
+    /// of the previous position (0.15 = shorts grew 15%), with both positions
+    /// restated onto today's split basis. Positive = the short crowd is building.
+    /// Null when the previous position is unknown or zero.
+    /// </summary>
+    public decimal? ShortInterestChangePercent { get; set; }
+
+    /// <summary>
+    /// The worst single-day fails-to-deliver quantity over the trailing window
+    /// (restated onto today's split basis) as a fraction of shares outstanding.
+    /// Persistent or spiking fails signal delivery pressure in the lending market —
+    /// the closest public analog to hard-to-borrow conditions. Zero means the SEC
+    /// feed reported no fails for the stock; null means the feed itself had no data.
+    /// </summary>
+    public decimal? FailsToDeliverPercentOfShares { get; set; }
+
+    /// <summary>
+    /// The latest close versus the trailing volume-weighted average price, as a
+    /// fraction of that average (0.25 = price sits 25% above where recent volume
+    /// traded). A proxy for how far open shorts are underwater — the capital-
+    /// constraint condition squeezes ignite from. Null without enough price history.
+    /// </summary>
+    public decimal? PriceAboveVwap { get; set; }
+
+    /// <summary>
+    /// True when the last trading week's return is positive and statistically
+    /// extreme versus the stock's own daily volatility — a squeeze may already be
+    /// igniting.
+    /// </summary>
+    public bool HasPriceSpikeCatalyst { get; set; }
+
+    /// <summary>
+    /// True when the last trading week's dollar turnover runs a multiple of the
+    /// stock's baseline while the price moves against the shorts.
+    /// </summary>
+    public bool HasVolumeSurgeCatalyst { get; set; }
+
     public double ShortInterestPercentile { get; set; }
 
     public double? DaysToCoverPercentile { get; set; }
 
     public double? ShortVolumeTrendPercentile { get; set; }
 
-    /// <summary>Composite 0–100 score: the mean of the available factor percentiles.</summary>
+    public double? ShortInterestChangePercentile { get; set; }
+
+    public double? FailsToDeliverPercentile { get; set; }
+
+    public double? PriceAboveVwapPercentile { get; set; }
+
+    /// <summary>
+    /// The weighted mean of the available factor percentiles, before the catalyst
+    /// boost — the structural "how crowded and stressed is the short side" reading.
+    /// </summary>
+    public double BaseScore { get; set; }
+
+    /// <summary>
+    /// Rank points added for active catalysts (see the manager's boost constants),
+    /// capped at <see cref="ShortSqueezeScoreManager.MaxCatalystBoost"/>.
+    /// </summary>
+    public double CatalystBoost { get; set; }
+
+    /// <summary>
+    /// Composite 0–100 score: <see cref="BaseScore"/> plus <see cref="CatalystBoost"/>,
+    /// clamped to 100.
+    /// </summary>
     public double Score { get; set; }
 }

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezePriceFactorCalculator.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezePriceFactorCalculator.cs
@@ -1,0 +1,190 @@
+using Equibles.Finra.BusinessLogic.Models;
+
+namespace Equibles.Finra.BusinessLogic;
+
+/// <summary>
+/// Computes the price-derived squeeze factors from a stock's recent daily bars:
+/// the shorts-underwater proxy (price versus trailing VWAP) and the two catalyst
+/// flags (price spike, volume surge). Pure math over an already-loaded series so
+/// the thresholds are unit-testable without a database.
+/// </summary>
+public static class ShortSqueezePriceFactorCalculator
+{
+    /// <summary>Bars in the recent window the catalysts measure (one trading week).</summary>
+    public const int RecentWindowBars = 5;
+
+    /// <summary>Bars in the baseline window the recent window is compared against.</summary>
+    public const int BaselineWindowBars = 60;
+
+    /// <summary>
+    /// Minimum baseline bars required before the catalysts are evaluated — with
+    /// fewer, the volatility and turnover baselines are too noisy to flag against.
+    /// </summary>
+    public const int MinBaselineBars = 30;
+
+    /// <summary>Minimum bars required for the trailing VWAP to be meaningful.</summary>
+    public const int MinVwapBars = 20;
+
+    /// <summary>
+    /// A series whose last bar is older than this many calendar days before the
+    /// universe's latest price date is stale (halted or delisted) — price factors
+    /// computed from it would describe the past, so none are produced.
+    /// </summary>
+    public const int MaxStaleCalendarDays = 10;
+
+    /// <summary>
+    /// The price-spike threshold: the recent-window return must be at least this
+    /// many standard deviations of the same-length baseline return distribution
+    /// (daily sigma scaled by the square root of the window length).
+    /// </summary>
+    public const double PriceSpikeSigmaMultiple = 2;
+
+    /// <summary>
+    /// The volume-surge threshold: recent average dollar turnover must be at
+    /// least this multiple of the baseline average.
+    /// </summary>
+    public const double VolumeSurgeMultiple = 2;
+
+    /// <summary>
+    /// Computes the factors from <paramref name="bars"/> (ordered by date
+    /// ascending, most recent last). <paramref name="universeLatestDate"/> is the
+    /// most recent price date across the whole scored universe, used to reject
+    /// stale series. Returns an empty result (null proxy, no catalysts) rather
+    /// than null so callers never branch.
+    /// </summary>
+    public static ShortSqueezePriceFactors Compute(
+        IReadOnlyList<ShortSqueezeDailyBar> bars,
+        DateOnly universeLatestDate
+    )
+    {
+        var factors = new ShortSqueezePriceFactors();
+        if (bars.Count == 0)
+        {
+            return factors;
+        }
+
+        var last = bars[^1];
+        if (last.Date < universeLatestDate.AddDays(-MaxStaleCalendarDays))
+        {
+            return factors;
+        }
+
+        factors.PriceAboveVwap = PriceAboveVwap(bars, last);
+
+        // Catalysts compare the last RecentWindowBars against the up-to
+        // BaselineWindowBars immediately before them.
+        var baselineCount = Math.Min(bars.Count - RecentWindowBars, BaselineWindowBars);
+        if (baselineCount < MinBaselineBars)
+        {
+            return factors;
+        }
+
+        var recentStart = bars.Count - RecentWindowBars;
+        var baselineStart = recentStart - baselineCount;
+
+        var entryClose = bars[recentStart - 1].AdjustedClose;
+        if (entryClose <= 0)
+        {
+            return factors;
+        }
+
+        var recentReturn = (double)(last.AdjustedClose / entryClose - 1);
+        if (recentReturn <= 0)
+        {
+            // Both catalysts require price moving AGAINST the shorts; a volume or
+            // volatility burst on the way down is covering, not a squeeze trigger.
+            return factors;
+        }
+
+        var dailySigma = BaselineDailyReturnSigma(bars, baselineStart, recentStart);
+        factors.HasPriceSpikeCatalyst =
+            dailySigma > 0
+            && recentReturn >= PriceSpikeSigmaMultiple * dailySigma * Math.Sqrt(RecentWindowBars);
+
+        var baselineTurnover = AverageDollarTurnover(bars, baselineStart, recentStart);
+        var recentTurnover = AverageDollarTurnover(bars, recentStart, bars.Count);
+        factors.HasVolumeSurgeCatalyst =
+            baselineTurnover > 0 && recentTurnover >= VolumeSurgeMultiple * baselineTurnover;
+
+        return factors;
+    }
+
+    /// <summary>
+    /// The latest close versus the volume-weighted average adjusted close over the
+    /// trailing window (up to baseline + recent bars). Falls back to the simple
+    /// mean when the window traded no volume at all.
+    /// </summary>
+    private static decimal? PriceAboveVwap(
+        IReadOnlyList<ShortSqueezeDailyBar> bars,
+        ShortSqueezeDailyBar last
+    )
+    {
+        var windowStart = Math.Max(0, bars.Count - (BaselineWindowBars + RecentWindowBars));
+        var windowCount = bars.Count - windowStart;
+        if (windowCount < MinVwapBars)
+        {
+            return null;
+        }
+
+        decimal priceVolumeSum = 0;
+        decimal volumeSum = 0;
+        decimal closeSum = 0;
+        for (var i = windowStart; i < bars.Count; i++)
+        {
+            priceVolumeSum += bars[i].AdjustedClose * bars[i].Volume;
+            volumeSum += bars[i].Volume;
+            closeSum += bars[i].AdjustedClose;
+        }
+
+        var vwap = volumeSum > 0 ? priceVolumeSum / volumeSum : closeSum / windowCount;
+        return vwap > 0 ? last.AdjustedClose / vwap - 1 : null;
+    }
+
+    /// <summary>
+    /// Sample standard deviation of the day-over-day returns inside the baseline
+    /// window. Zero when any close in the window is non-positive (a corrupt bar
+    /// makes the distribution meaningless, which disables the spike catalyst).
+    /// </summary>
+    private static double BaselineDailyReturnSigma(
+        IReadOnlyList<ShortSqueezeDailyBar> bars,
+        int baselineStart,
+        int recentStart
+    )
+    {
+        var returns = new List<double>(recentStart - baselineStart);
+        for (var i = baselineStart + 1; i < recentStart; i++)
+        {
+            var previous = bars[i - 1].AdjustedClose;
+            if (previous <= 0 || bars[i].AdjustedClose <= 0)
+            {
+                return 0;
+            }
+
+            returns.Add((double)(bars[i].AdjustedClose / previous - 1));
+        }
+
+        if (returns.Count < 2)
+        {
+            return 0;
+        }
+
+        var mean = returns.Average();
+        var sumOfSquares = returns.Sum(r => (r - mean) * (r - mean));
+        return Math.Sqrt(sumOfSquares / (returns.Count - 1));
+    }
+
+    private static double AverageDollarTurnover(
+        IReadOnlyList<ShortSqueezeDailyBar> bars,
+        int start,
+        int end
+    )
+    {
+        double sum = 0;
+        for (var i = start; i < end; i++)
+        {
+            sum += (double)bars[i].Close * bars[i].Volume;
+        }
+
+        return sum / (end - start);
+    }
+}

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -6,31 +6,85 @@ using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.BusinessLogic.Models;
 using Equibles.Finra.Repositories;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Finra.BusinessLogic;
 
 /// <summary>
 /// Computes a composite 0–100 short-squeeze score per stock from data already stored —
-/// no scraper and no per-ticker heuristics. Three factors, each normalized to a
-/// percentile across the scored universe so the score is peer-relative:
+/// no scraper and no per-ticker heuristics. The construction follows the structure of
+/// the published squeeze models (IHS Markit's US Short Squeeze Model most directly):
+/// a set of crowdedness / capital-constraint factors, each normalized to a percentile
+/// across the scored universe and combined as a weighted mean, plus additive catalyst
+/// boosts for event conditions that ignite squeezes.
+///
+/// <para>Crowdedness factors (weight — higher percentile = more squeeze-prone):</para>
 /// <list type="bullet">
-/// <item>short interest as a fraction of shares outstanding,</item>
-/// <item>days-to-cover (FINRA-reported, or short position ÷ average daily volume),</item>
+/// <item>short interest as a fraction of shares outstanding (30%),</item>
+/// <item>days-to-cover — FINRA-reported, or short position ÷ average daily volume (20%),</item>
+/// <item>price versus trailing VWAP — how far open shorts are underwater, the public-data
+/// analog of transaction-level out-of-the-money share measures (15%),</item>
 /// <item>the change in the short share of total volume between the last two weeks and
-/// the two before them (rising = pressure building).</item>
+/// the two before them — rising = pressure building (15%),</item>
+/// <item>the change in the short position versus the previous FINRA report — the crowd
+/// is still building (10%),</item>
+/// <item>fails-to-deliver pressure — the worst trailing single-day FTD quantity as a
+/// fraction of shares outstanding, the closest public proxy for hard-to-borrow
+/// conditions (10%).</item>
 /// </list>
-/// The composite is the equal-weight mean of the factor percentiles a stock has data
-/// for — weights are deliberate and documented rather than tuned. The universe is every
-/// stock reporting short interest at the latest settlement date with a known
-/// shares-outstanding count and a physically credible short-interest ratio (see
-/// <see cref="MaxCredibleShortInterestRatio"/>).
+///
+/// <para>Catalyst boosts (additive rank points, capped at <see cref="MaxCatalystBoost"/>,
+/// composite clamped to 100): a statistically extreme positive weekly return
+/// (+<see cref="PriceSpikeCatalystBoost"/>) and abnormal dollar turnover with the price
+/// moving against the shorts (+<see cref="VolumeSurgeCatalystBoost"/>).</para>
+///
+/// <para>Factors a stock has no data for drop out and their weight is redistributed over
+/// the rest. The universe is every stock reporting short interest at the latest
+/// settlement date with a known shares-outstanding count and a physically credible
+/// short-interest ratio (see <see cref="MaxCredibleShortInterestRatio"/>).</para>
 /// </summary>
 [Service]
 public class ShortSqueezeScoreManager
 {
     /// <summary>Each trend window pools two calendar weeks of daily short-volume rows.</summary>
     public const int TrendWindowDays = 14;
+
+    /// <summary>
+    /// Trailing calendar window over which fails-to-deliver pressure is measured,
+    /// ending at the SEC feed's latest settlement date (the feed publishes with a
+    /// multi-week lag, so "latest available" is the honest anchor).
+    /// </summary>
+    public const int FailsToDeliverWindowDays = 30;
+
+    /// <summary>
+    /// Calendar days of daily bars loaded per stock for the price factors — enough
+    /// for the 60-trading-day baseline plus the recent week plus market holidays.
+    /// </summary>
+    public const int PriceHistoryCalendarDays = 100;
+
+    /// <summary>
+    /// Factor weights, deliberate and documented rather than fitted: the two classic
+    /// crowdedness measures carry half the composite, the underwater proxy and the
+    /// short-volume trend (the "pressure is mounting" readings) 15% each, and the two
+    /// noisier corroborating signals 10% each.
+    /// </summary>
+    public const double ShortInterestWeight = 0.30;
+    public const double DaysToCoverWeight = 0.20;
+    public const double PriceAboveVwapWeight = 0.15;
+    public const double ShortVolumeTrendWeight = 0.15;
+    public const double ShortInterestChangeWeight = 0.10;
+    public const double FailsToDeliverWeight = 0.10;
+
+    /// <summary>Rank points added when the weekly return is a statistical outlier.</summary>
+    public const double PriceSpikeCatalystBoost = 10;
+
+    /// <summary>Rank points added for abnormal dollar turnover on a positive move.</summary>
+    public const double VolumeSurgeCatalystBoost = 10;
+
+    /// <summary>Ceiling on the total catalyst boost, mirroring the published models.</summary>
+    public const double MaxCatalystBoost = 20;
 
     /// <summary>
     /// The listed-security kinds that can never be squeeze candidates: FINRA
@@ -65,18 +119,24 @@ public class ShortSqueezeScoreManager
     private readonly DailyShortVolumeRepository _dailyShortVolumeRepository;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly StockSplitRepository _stockSplitRepository;
+    private readonly FailToDeliverRepository _failToDeliverRepository;
+    private readonly DailyStockPriceRepository _dailyStockPriceRepository;
 
     public ShortSqueezeScoreManager(
         ShortInterestRepository shortInterestRepository,
         DailyShortVolumeRepository dailyShortVolumeRepository,
         CommonStockRepository commonStockRepository,
-        StockSplitRepository stockSplitRepository
+        StockSplitRepository stockSplitRepository,
+        FailToDeliverRepository failToDeliverRepository,
+        DailyStockPriceRepository dailyStockPriceRepository
     )
     {
         _shortInterestRepository = shortInterestRepository;
         _dailyShortVolumeRepository = dailyShortVolumeRepository;
         _commonStockRepository = commonStockRepository;
         _stockSplitRepository = stockSplitRepository;
+        _failToDeliverRepository = failToDeliverRepository;
+        _dailyStockPriceRepository = dailyStockPriceRepository;
     }
 
     public async Task<List<ShortSqueezeScore>> Compute(
@@ -104,6 +164,7 @@ public class ShortSqueezeScoreManager
             {
                 s.CommonStockId,
                 s.CurrentShortPosition,
+                s.PreviousShortPosition,
                 s.AverageDailyVolume,
                 DaysToCover = s.DaysToCover >= decimal.MinValue && s.DaysToCover <= decimal.MaxValue
                     ? s.DaysToCover
@@ -143,6 +204,21 @@ public class ShortSqueezeScoreManager
         )
             .GroupBy(s => s.CommonStockId)
             .ToDictionary(g => g.Key, g => (IReadOnlyList<StockSplit>)g.ToList());
+
+        // The previous settlement date anchors the split basis of PreviousShortPosition.
+        // FINRA publishes the whole market on one bi-monthly cycle, so the second-newest
+        // distinct date is every stock's previous report. (A few hundred dates, cheap.)
+        var settlementDates = await _shortInterestRepository
+            .GetAllSettlementDates()
+            .ToListAsync(cancellationToken);
+        var previousSettlementDate = settlementDates
+            .Where(d => d < settlementDate)
+            .OrderByDescending(d => d)
+            .FirstOrDefault();
+
+        var scoredStockIds = stocks.Keys.ToList();
+        var failsToDeliver = await LoadFailsToDeliver(scoredStockIds, cancellationToken);
+        var priceFactors = await LoadPriceFactors(scoredStockIds, cancellationToken);
 
         var scores = new List<ShortSqueezeScore>();
         foreach (var shortInterest in shortInterests)
@@ -201,6 +277,10 @@ public class ShortSqueezeScoreManager
                     advOnTodaysBasis * (marketCap.Value / stock.SharesOutStanding);
             }
 
+            var factors = priceFactors.TryGetValue(stock.Id, out var stockFactors)
+                ? stockFactors
+                : new ShortSqueezePriceFactors();
+
             scores.Add(
                 new ShortSqueezeScore
                 {
@@ -216,6 +296,22 @@ public class ShortSqueezeScoreManager
                     ShortVolumeShareTrend = trends.TryGetValue(stock.Id, out var trend)
                         ? trend
                         : null,
+                    ShortInterestChangePercent = ShortInterestChangePercent(
+                        shortInterest.CurrentShortPosition,
+                        settlementDate,
+                        shortInterest.PreviousShortPosition,
+                        previousSettlementDate,
+                        stockSplits
+                    ),
+                    FailsToDeliverPercentOfShares = FailsToDeliverPercentOfShares(
+                        stock.Id,
+                        stock.SharesOutStanding,
+                        failsToDeliver,
+                        stockSplits
+                    ),
+                    PriceAboveVwap = factors.PriceAboveVwap,
+                    HasPriceSpikeCatalyst = factors.HasPriceSpikeCatalyst,
+                    HasVolumeSurgeCatalyst = factors.HasVolumeSurgeCatalyst,
                 }
             );
         }
@@ -273,6 +369,105 @@ public class ShortSqueezeScoreManager
     }
 
     /// <summary>
+    /// Loads each scored stock's daily fails-to-deliver quantities over the trailing
+    /// window ending at the SEC feed's latest settlement date, each paired with its
+    /// date so it can be split-restated per observation. Returns null when the feed
+    /// holds no data at all — then the factor is unknowable and must drop out for
+    /// everyone, which is different from a covered stock reporting no fails (a true
+    /// zero).
+    /// </summary>
+    private async Task<Dictionary<Guid, List<(DateOnly Date, long Quantity)>>> LoadFailsToDeliver(
+        List<Guid> stockIds,
+        CancellationToken cancellationToken
+    )
+    {
+        var latestDate = await _failToDeliverRepository
+            .GetLatestDate()
+            .FirstOrDefaultAsync(cancellationToken);
+        if (latestDate == default)
+        {
+            return null;
+        }
+
+        var windowStart = latestDate.AddDays(-FailsToDeliverWindowDays);
+        var rows = await _failToDeliverRepository
+            .GetAll()
+            .Where(f =>
+                f.SettlementDate > windowStart
+                && f.SettlementDate <= latestDate
+                && stockIds.Contains(f.CommonStockId)
+            )
+            .Select(f => new
+            {
+                f.CommonStockId,
+                f.SettlementDate,
+                f.Quantity,
+            })
+            .ToListAsync(cancellationToken);
+
+        var quantities = new Dictionary<Guid, List<(DateOnly Date, long Quantity)>>();
+        foreach (var row in rows)
+        {
+            if (!quantities.TryGetValue(row.CommonStockId, out var list))
+            {
+                list = [];
+                quantities[row.CommonStockId] = list;
+            }
+
+            list.Add((row.SettlementDate, row.Quantity));
+        }
+
+        return quantities;
+    }
+
+    /// <summary>
+    /// Loads the trailing daily bars for the scored universe in one query and computes
+    /// each stock's price factors. The universe's latest price date anchors the
+    /// staleness check inside the calculator, so a halted or delisted series produces
+    /// no price factors instead of factors about the past.
+    /// </summary>
+    private async Task<Dictionary<Guid, ShortSqueezePriceFactors>> LoadPriceFactors(
+        List<Guid> stockIds,
+        CancellationToken cancellationToken
+    )
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var cutoff = today.AddDays(-PriceHistoryCalendarDays);
+        var bars = await _dailyStockPriceRepository
+            .GetByStocks(stockIds, cutoff, today)
+            .Select(p => new
+            {
+                p.CommonStockId,
+                p.Date,
+                p.AdjustedClose,
+                p.Close,
+                p.Volume,
+            })
+            .ToListAsync(cancellationToken);
+
+        var result = new Dictionary<Guid, ShortSqueezePriceFactors>();
+        if (bars.Count == 0)
+        {
+            return result;
+        }
+
+        var universeLatestDate = bars.Max(b => b.Date);
+        foreach (var group in bars.GroupBy(b => b.CommonStockId))
+        {
+            var series = group
+                .OrderBy(b => b.Date)
+                .Select(b => new ShortSqueezeDailyBar(b.Date, b.AdjustedClose, b.Close, b.Volume))
+                .ToList();
+            result[group.Key] = ShortSqueezePriceFactorCalculator.Compute(
+                series,
+                universeLatestDate
+            );
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Short interest as a fraction of shares outstanding, with the short position
     /// restated onto today's split basis first. The short position is a share COUNT
     /// as-of <paramref name="settlementDate"/>; the shares-outstanding denominator is
@@ -291,6 +486,78 @@ public class ShortSqueezeScoreManager
         return currentShortPosition * factor / sharesOutstanding;
     }
 
+    /// <summary>
+    /// Change in the short position versus the previous FINRA report as a fraction of
+    /// the previous position, with BOTH positions restated onto today's split basis —
+    /// a split between the two reports would otherwise masquerade as a position change
+    /// of the split factor. Null when the previous position or its date is unknown.
+    /// </summary>
+    private static decimal? ShortInterestChangePercent(
+        long currentPosition,
+        DateOnly settlementDate,
+        long previousPosition,
+        DateOnly previousSettlementDate,
+        IReadOnlyList<StockSplit> splits
+    )
+    {
+        if (previousPosition <= 0 || previousSettlementDate == default)
+        {
+            return null;
+        }
+
+        var currentOnTodaysBasis = SplitAdjustment.AdjustShareCount(
+            currentPosition,
+            settlementDate,
+            splits
+        );
+        var previousOnTodaysBasis = SplitAdjustment.AdjustShareCount(
+            previousPosition,
+            previousSettlementDate,
+            splits
+        );
+        if (previousOnTodaysBasis <= 0)
+        {
+            return null;
+        }
+
+        return (currentOnTodaysBasis - previousOnTodaysBasis) / (decimal)previousOnTodaysBasis;
+    }
+
+    /// <summary>
+    /// The stock's worst trailing single-day fails-to-deliver quantity — each daily
+    /// observation restated onto today's split basis as-of its own settlement date —
+    /// as a fraction of shares outstanding. A stock the live feed reports no fails
+    /// for scores a true zero; when the feed has no data at all
+    /// (<paramref name="failsToDeliver"/> is null) the factor is null and drops out
+    /// of the composite.
+    /// </summary>
+    private static decimal? FailsToDeliverPercentOfShares(
+        Guid stockId,
+        long sharesOutstanding,
+        Dictionary<Guid, List<(DateOnly Date, long Quantity)>> failsToDeliver,
+        IReadOnlyList<StockSplit> splits
+    )
+    {
+        if (failsToDeliver == null)
+        {
+            return null;
+        }
+
+        if (!failsToDeliver.TryGetValue(stockId, out var quantities))
+        {
+            return 0m;
+        }
+
+        var worst = 0L;
+        foreach (var (date, quantity) in quantities)
+        {
+            var onTodaysBasis = SplitAdjustment.AdjustShareCount(quantity, date, splits);
+            worst = Math.Max(worst, onTodaysBasis);
+        }
+
+        return (decimal)worst / sharesOutstanding;
+    }
+
     private static void ApplyPercentiles(List<ShortSqueezeScore> scores)
     {
         var shortInterestPercentiles = Percentiles(
@@ -306,40 +573,86 @@ public class ShortSqueezeScoreManager
                 .Where(s => s.ShortVolumeShareTrend != null)
                 .Select(s => (s.CommonStockId, s.ShortVolumeShareTrend.Value))
         );
+        var changePercentiles = Percentiles(
+            scores
+                .Where(s => s.ShortInterestChangePercent != null)
+                .Select(s => (s.CommonStockId, s.ShortInterestChangePercent.Value))
+        );
+        var failsToDeliverPercentiles = Percentiles(
+            scores
+                .Where(s => s.FailsToDeliverPercentOfShares != null)
+                .Select(s => (s.CommonStockId, s.FailsToDeliverPercentOfShares.Value))
+        );
+        var priceAboveVwapPercentiles = Percentiles(
+            scores
+                .Where(s => s.PriceAboveVwap != null)
+                .Select(s => (s.CommonStockId, s.PriceAboveVwap.Value))
+        );
 
         foreach (var score in scores)
         {
             score.ShortInterestPercentile = shortInterestPercentiles[score.CommonStockId];
-            score.DaysToCoverPercentile = daysToCoverPercentiles.TryGetValue(
-                score.CommonStockId,
-                out var daysToCover
-            )
-                ? daysToCover
-                : null;
-            score.ShortVolumeTrendPercentile = trendPercentiles.TryGetValue(
-                score.CommonStockId,
-                out var trend
-            )
-                ? trend
-                : null;
+            score.DaysToCoverPercentile = Lookup(daysToCoverPercentiles, score.CommonStockId);
+            score.ShortVolumeTrendPercentile = Lookup(trendPercentiles, score.CommonStockId);
+            score.ShortInterestChangePercentile = Lookup(changePercentiles, score.CommonStockId);
+            score.FailsToDeliverPercentile = Lookup(failsToDeliverPercentiles, score.CommonStockId);
+            score.PriceAboveVwapPercentile = Lookup(priceAboveVwapPercentiles, score.CommonStockId);
 
-            double total = score.ShortInterestPercentile;
-            var factors = 1;
+            // Weighted mean over the factors this stock has data for: a missing
+            // factor's weight is redistributed by dividing by the sum of the
+            // weights actually present.
+            var total = ShortInterestWeight * score.ShortInterestPercentile;
+            var weight = ShortInterestWeight;
             if (score.DaysToCoverPercentile != null)
             {
-                total += score.DaysToCoverPercentile.Value;
-                factors++;
+                total += DaysToCoverWeight * score.DaysToCoverPercentile.Value;
+                weight += DaysToCoverWeight;
             }
 
             if (score.ShortVolumeTrendPercentile != null)
             {
-                total += score.ShortVolumeTrendPercentile.Value;
-                factors++;
+                total += ShortVolumeTrendWeight * score.ShortVolumeTrendPercentile.Value;
+                weight += ShortVolumeTrendWeight;
             }
 
-            score.Score = Math.Round(total / factors, 2);
+            if (score.ShortInterestChangePercentile != null)
+            {
+                total += ShortInterestChangeWeight * score.ShortInterestChangePercentile.Value;
+                weight += ShortInterestChangeWeight;
+            }
+
+            if (score.FailsToDeliverPercentile != null)
+            {
+                total += FailsToDeliverWeight * score.FailsToDeliverPercentile.Value;
+                weight += FailsToDeliverWeight;
+            }
+
+            if (score.PriceAboveVwapPercentile != null)
+            {
+                total += PriceAboveVwapWeight * score.PriceAboveVwapPercentile.Value;
+                weight += PriceAboveVwapWeight;
+            }
+
+            score.BaseScore = Math.Round(total / weight, 2);
+
+            var boost = 0d;
+            if (score.HasPriceSpikeCatalyst)
+            {
+                boost += PriceSpikeCatalystBoost;
+            }
+
+            if (score.HasVolumeSurgeCatalyst)
+            {
+                boost += VolumeSurgeCatalystBoost;
+            }
+
+            score.CatalystBoost = Math.Min(boost, MaxCatalystBoost);
+            score.Score = Math.Round(Math.Min(100, score.BaseScore + score.CatalystBoost), 2);
         }
     }
+
+    private static double? Lookup(Dictionary<Guid, double> percentiles, Guid stockId) =>
+        percentiles.TryGetValue(stockId, out var value) ? value : null;
 
     /// <summary>
     /// Average-rank percentiles on a 0–100 scale: ties share the mean of the ranks

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -10,6 +10,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.BusinessLogic.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Repositories;
 using Equibles.Mcp;
@@ -317,13 +318,31 @@ public class ShortDataTools
     private static string FormatSignedChange(long change) =>
         change >= 0 ? $"+{McpFormat.WholeNumber(change)}" : McpFormat.WholeNumber(change);
 
+    // Fractions rendered as explicit-sign percentages ("+3.1%"), dash when unknown.
+    private static string FormatSignedPercent(decimal? fraction) =>
+        fraction == null
+            ? "-"
+            : (fraction > 0 ? "+" : "")
+                + fraction.Value.ToString("P1", CultureInfo.InvariantCulture);
+
+    private static string FormatCatalysts(ShortSqueezeScore score)
+    {
+        if (score.HasPriceSpikeCatalyst && score.HasVolumeSurgeCatalyst)
+            return "PriceSpike+VolumeSurge";
+        if (score.HasPriceSpikeCatalyst)
+            return "PriceSpike";
+        if (score.HasVolumeSurgeCatalyst)
+            return "VolumeSurge";
+        return "-";
+    }
+
     // Thin forwarder so existing reflection-based normalization tests still find the method.
     private Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker) =>
         _commonStockRepository.ResolveByTicker(ticker);
 
     [McpServerTool(Name = "GetShortSqueezeScores")]
     [Description(
-        "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built from short interest as a percent of shares outstanding, days to cover, and the recent change in the short share of total volume, each as a percentile across every stock reporting short interest at the latest FINRA settlement date. Untradeable micro-caps dominate the raw board, so pass minMarketCap and/or minDollarVolume to keep only names that clear your liquidity bar (the score itself stays peer-relative to the full universe). Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
+        "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built as the weighted mean of six factor percentiles across every stock reporting short interest at the latest FINRA settlement date (short interest % of shares 30%, days to cover 20%, price vs trailing VWAP — how far shorts are underwater — 15%, short-volume trend 15%, change in short interest 10%, fails-to-deliver pressure 10%), plus catalyst boosts (+10 for a statistically extreme weekly price spike, +10 for abnormal dollar volume on a positive move, capped at +20, clamped to 100). Untradeable micro-caps dominate the raw board, so pass minMarketCap and/or minDollarVolume to keep only names that clear your liquidity bar (the score itself stays peer-relative to the full universe). Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
     )]
     public Task<string> GetShortSqueezeScores(
         [Description(
@@ -367,30 +386,26 @@ public class ShortDataTools
                 );
                 sb.AppendLine();
                 sb.AppendLine(
-                    "Score = equal-weight mean of the available factor percentiles (0-100, peer-relative). Avg $ Volume is approximate (FINRA share volume × market-cap-implied price)."
+                    "Score = weighted mean of the available factor percentiles (0-100, peer-relative) plus catalyst boosts (price spike / volume surge, capped at +20). Avg $ Volume is approximate (FINRA share volume × market-cap-implied price)."
                 );
                 sb.AppendLine();
                 sb.AppendLine(
-                    "| # | Ticker | Score | Short % of Shares | Days to Cover | Short-Volume Trend | Market Cap | Avg $ Volume |"
+                    "| # | Ticker | Score | Short % of Shares | Days to Cover | Short-Volume Trend | Δ Short Interest | Worst FTD % | Price vs VWAP | Catalysts | Market Cap | Avg $ Volume |"
                 );
                 sb.AppendLine(
-                    "|---|--------|-------|-------------------|---------------|--------------------|------------|--------------|"
+                    "|---|--------|-------|-------------------|---------------|--------------------|------------------|-------------|---------------|-----------|------------|--------------|"
                 );
                 sb.AppendNumberedRows(
                     filtered.Take(take).ToList(),
                     (rank, score) =>
                     {
-                        var trend =
-                            score.ShortVolumeShareTrend == null
-                                ? "-"
-                                : (score.ShortVolumeShareTrend > 0 ? "+" : "")
-                                    + score.ShortVolumeShareTrend.Value.ToString(
-                                        "P1",
-                                        CultureInfo.InvariantCulture
-                                    );
                         return $"| {rank} | {score.Ticker} | {score.Score.ToString("0", CultureInfo.InvariantCulture)} | "
                             + $"{score.ShortInterestPercentOfShares.ToString("P1", CultureInfo.InvariantCulture)} | "
-                            + $"{score.DaysToCover?.ToString("0.0", CultureInfo.InvariantCulture) ?? "-"} | {trend} | "
+                            + $"{score.DaysToCover?.ToString("0.0", CultureInfo.InvariantCulture) ?? "-"} | "
+                            + $"{FormatSignedPercent(score.ShortVolumeShareTrend)} | "
+                            + $"{FormatSignedPercent(score.ShortInterestChangePercent)} | "
+                            + $"{McpFormat.OrDash(score.FailsToDeliverPercentOfShares, "P2")} | "
+                            + $"{FormatSignedPercent(score.PriceAboveVwap)} | {FormatCatalysts(score)} | "
                             + $"{McpFormat.CompactUsd(score.MarketCapitalization)} | {McpFormat.CompactUsd(score.AverageDailyDollarVolume)} |";
                     }
                 );

--- a/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
@@ -8,6 +8,11 @@ using Equibles.Finra.Data;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
 using FluentAssertions;
 using Xunit;
 
@@ -24,13 +29,17 @@ public class ShortSqueezeScoreManagerTests : IDisposable
     {
         _dbContext = TestDbContextFactory.Create(
             new FinraModuleConfiguration(),
-            new CommonStocksModuleConfiguration()
+            new CommonStocksModuleConfiguration(),
+            new FailToDeliverOnlyModule(),
+            new YahooModuleConfiguration()
         );
         _manager = new ShortSqueezeScoreManager(
             new ShortInterestRepository(_dbContext),
             new DailyShortVolumeRepository(_dbContext),
             new CommonStockRepository(_dbContext),
-            new StockSplitRepository(_dbContext)
+            new StockSplitRepository(_dbContext),
+            new FailToDeliverRepository(_dbContext),
+            new DailyStockPriceRepository(_dbContext)
         );
     }
 
@@ -222,6 +231,181 @@ public class ShortSqueezeScoreManagerTests : IDisposable
         scores.Select(s => s.Ticker).Should().BeEquivalentTo(["EQTY", "MLP"]);
     }
 
+    [Fact]
+    public async Task Compute_NoFailsToDeliverFeed_FactorIsNullForEveryone()
+    {
+        // An empty FTD table means the feed is absent, not that no stock ever fails
+        // to deliver — the factor must be unknowable (null) rather than a flattering
+        // universe-wide zero.
+        var stock = SeedStock("NOFTD", sharesOutstanding: 1_000_000);
+        SeedShortInterest(stock, shortPosition: 100_000, daysToCover: 2m);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Single().FailsToDeliverPercentOfShares.Should().BeNull();
+        scores.Single().FailsToDeliverPercentile.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Compute_FailsToDeliverSpike_ScoresWorstDayAndZeroFillsCoveredPeers()
+    {
+        // FAILS has a 50k worst day on a 1M share count (5%); CLEAN appears nowhere
+        // in a live feed, which is a true zero — delivery is fine — not a missing
+        // factor. The zero must be scored, keeping CLEAN below FAILS on the factor.
+        var fails = SeedStock("FAILS", sharesOutstanding: 1_000_000);
+        var clean = SeedStock("CLEAN", sharesOutstanding: 1_000_000);
+        SeedShortInterest(fails, shortPosition: 100_000, daysToCover: 2m);
+        SeedShortInterest(clean, shortPosition: 100_000, daysToCover: 2m);
+        _dbContext
+            .Set<FailToDeliver>()
+            .AddRange(
+                new FailToDeliver
+                {
+                    CommonStockId = fails.Id,
+                    SettlementDate = SettlementDate.AddDays(-3),
+                    Quantity = 50_000,
+                    Price = 10m,
+                },
+                new FailToDeliver
+                {
+                    CommonStockId = fails.Id,
+                    SettlementDate = SettlementDate.AddDays(-10),
+                    Quantity = 20_000,
+                    Price = 10m,
+                }
+            );
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        var spiking = scores.Single(s => s.Ticker == "FAILS");
+        var covered = scores.Single(s => s.Ticker == "CLEAN");
+        spiking.FailsToDeliverPercentOfShares.Should().Be(0.05m, "the WORST day counts");
+        covered.FailsToDeliverPercentOfShares.Should().Be(0m);
+        spiking.FailsToDeliverPercentile.Should().Be(100);
+        covered.FailsToDeliverPercentile.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Compute_PreviousReportOnFile_YieldsShortInterestChange()
+    {
+        // BUILD grew its short position 50% versus the previous report; SHRINK cut
+        // it in half. The change factor must carry the signed fraction for both.
+        var build = SeedStock("BUILD", sharesOutstanding: 1_000_000);
+        var shrink = SeedStock("SHRINK", sharesOutstanding: 1_000_000);
+        SeedShortInterest(
+            build,
+            shortPosition: 150_000,
+            daysToCover: 2m,
+            previousPosition: 100_000
+        );
+        SeedShortInterest(
+            shrink,
+            shortPosition: 100_000,
+            daysToCover: 2m,
+            previousPosition: 200_000
+        );
+        // The previous settlement date must exist in the table for the change's
+        // split basis to be anchored — seed the previous cycle's rows.
+        _dbContext
+            .Set<ShortInterest>()
+            .AddRange(
+                new ShortInterest
+                {
+                    CommonStockId = build.Id,
+                    SettlementDate = SettlementDate.AddDays(-14),
+                    CurrentShortPosition = 100_000,
+                },
+                new ShortInterest
+                {
+                    CommonStockId = shrink.Id,
+                    SettlementDate = SettlementDate.AddDays(-14),
+                    CurrentShortPosition = 200_000,
+                }
+            );
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Single(s => s.Ticker == "BUILD").ShortInterestChangePercent.Should().Be(0.5m);
+        scores.Single(s => s.Ticker == "SHRINK").ShortInterestChangePercent.Should().Be(-0.5m);
+    }
+
+    [Fact]
+    public async Task Compute_NoPreviousPosition_ChangeFactorDropsOut()
+    {
+        var fresh = SeedStock("FRESH", sharesOutstanding: 1_000_000);
+        SeedShortInterest(fresh, shortPosition: 100_000, daysToCover: 2m);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Single().ShortInterestChangePercent.Should().BeNull();
+        scores.Single().ShortInterestChangePercentile.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Compute_RecentPriceHistory_ProducesPriceFactors()
+    {
+        // Price factors anchor on the CURRENT price tape (squeeze pressure now),
+        // not the settlement date — so the seeded series must be recent relative
+        // to the wall clock the manager loads against.
+        var stock = SeedStock("PRICED", sharesOutstanding: 1_000_000);
+        SeedShortInterest(stock, shortPosition: 100_000, daysToCover: 2m);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        for (var i = 0; i < 65; i++)
+        {
+            var close = i == 64 ? 130m : 100m;
+            _dbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = today.AddDays(i - 64),
+                        Open = close,
+                        High = close,
+                        Low = close,
+                        Close = close,
+                        AdjustedClose = close,
+                        Volume = 1_000,
+                    }
+                );
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Single().PriceAboveVwap.Should().NotBeNull();
+        scores.Single().PriceAboveVwap.Should().BeGreaterThan(0.25m);
+    }
+
+    [Fact]
+    public async Task Compute_NoPriceHistory_PriceFactorsDropOut()
+    {
+        var stock = SeedStock("NOPX", sharesOutstanding: 1_000_000);
+        SeedShortInterest(stock, shortPosition: 100_000, daysToCover: 2m);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Single().PriceAboveVwap.Should().BeNull();
+        scores.Single().PriceAboveVwapPercentile.Should().BeNull();
+        scores.Single().HasPriceSpikeCatalyst.Should().BeFalse();
+        scores.Single().HasVolumeSurgeCatalyst.Should().BeFalse();
+        scores.Single().CatalystBoost.Should().Be(0);
+    }
+
+    // The full Sec module registers pgvector-typed embedding entities the in-memory
+    // provider cannot model; the squeeze manager only needs the FailToDeliver table.
+    private class FailToDeliverOnlyModule : Equibles.Data.IFinancialModule
+    {
+        public void ConfigureEntities(Microsoft.EntityFrameworkCore.ModelBuilder builder) =>
+            builder.Entity<FailToDeliver>();
+    }
+
     private CommonStock SeedStock(
         string ticker,
         long sharesOutstanding,
@@ -240,7 +424,12 @@ public class ShortSqueezeScoreManagerTests : IDisposable
         return stock;
     }
 
-    private void SeedShortInterest(CommonStock stock, long shortPosition, decimal daysToCover)
+    private void SeedShortInterest(
+        CommonStock stock,
+        long shortPosition,
+        decimal daysToCover,
+        long previousPosition = 0
+    )
     {
         _dbContext
             .Set<ShortInterest>()
@@ -250,6 +439,7 @@ public class ShortSqueezeScoreManagerTests : IDisposable
                     CommonStockId = stock.Id,
                     SettlementDate = SettlementDate,
                     CurrentShortPosition = shortPosition,
+                    PreviousShortPosition = previousPosition,
                     DaysToCover = daysToCover,
                 }
             );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
@@ -7,6 +7,8 @@ using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -23,7 +25,9 @@ public class ShortDataToolsGetLargestShortVolumeCultureInvarianceTests : ParadeD
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
                 new CommonStockRepository(DbContext),
-                new StockSplitRepository(DbContext)
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext)
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
@@ -7,6 +7,8 @@ using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -24,7 +26,9 @@ public class ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
                 new CommonStockRepository(DbContext),
-                new StockSplitRepository(DbContext)
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext)
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
@@ -7,6 +7,8 @@ using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -23,7 +25,9 @@ public class ShortDataToolsGetShortInterestCultureInvarianceTests : ParadeDbMcpT
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
                 new CommonStockRepository(DbContext),
-                new StockSplitRepository(DbContext)
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext)
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
@@ -7,6 +7,8 @@ using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -23,7 +25,9 @@ public class ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests : Para
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
                 new CommonStockRepository(DbContext),
-                new StockSplitRepository(DbContext)
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext)
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
@@ -7,6 +7,8 @@ using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -32,7 +34,9 @@ public class ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTes
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
                 new CommonStockRepository(DbContext),
-                new StockSplitRepository(DbContext)
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext)
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -6,6 +6,8 @@ using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using FluentAssertions;
 using Xunit;
 
@@ -23,7 +25,9 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
                 new CommonStockRepository(DbContext),
-                new StockSplitRepository(DbContext)
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext)
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
@@ -7,6 +7,8 @@ using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -23,7 +25,9 @@ public class ShortDataToolsGetShortVolumeCultureInvarianceTests : ParadeDbMcpTes
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
                 new CommonStockRepository(DbContext),
-                new StockSplitRepository(DbContext)
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext)
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -6,6 +6,8 @@ using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -22,7 +24,9 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
                 new CommonStockRepository(DbContext),
-                new StockSplitRepository(DbContext)
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext)
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
@@ -6,6 +6,8 @@ using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -34,7 +36,9 @@ public class ShortDataToolsZeroChangeTests : ParadeDbMcpTestBase
                 new ShortInterestRepository(DbContext),
                 new DailyShortVolumeRepository(DbContext),
                 new CommonStockRepository(DbContext),
-                new StockSplitRepository(DbContext)
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext)
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezePriceFactorCalculatorCatalystTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezePriceFactorCalculatorCatalystTests.cs
@@ -1,0 +1,111 @@
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.BusinessLogic.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Pins the catalyst detection (ShortSqueezePriceFactorCalculator): the price
+/// spike fires when the recent-window return is positive and a
+/// <see cref="ShortSqueezePriceFactorCalculator.PriceSpikeSigmaMultiple"/>-sigma
+/// outlier versus the stock's own baseline volatility; the volume surge fires when
+/// recent dollar turnover runs
+/// <see cref="ShortSqueezePriceFactorCalculator.VolumeSurgeMultiple"/>× the
+/// baseline while the price moves against the shorts. Neither fires on a negative
+/// move (that is covering, not a squeeze trigger) or on a baseline too short to
+/// flag against.
+/// </summary>
+public class ShortSqueezePriceFactorCalculatorCatalystTests
+{
+    [Fact]
+    public void Compute_ExtremePositiveWeek_FlagsThePriceSpike()
+    {
+        // Quiet ±0.5% baseline (daily sigma ≈ 0.5%, so the 5-bar threshold is ≈2.2%)
+        // then a +30% final week on unchanged volume: a clear spike, but 1.3× dollar
+        // turnover stays under the 2× surge bar.
+        var bars = QuietBaselineThenFinalWeek(finalWeekClose: 130m, finalWeekVolume: 1_000);
+
+        var factors = ShortSqueezePriceFactorCalculator.Compute(bars, bars[^1].Date);
+
+        factors.HasPriceSpikeCatalyst.Should().BeTrue();
+        factors.HasVolumeSurgeCatalyst.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Compute_TurnoverBurstOnAModestRise_FlagsTheVolumeSurgeOnly()
+    {
+        // A +1% week is inside the ±0.5%-sigma threshold (≈2.2%), but 4× the volume
+        // at an unchanged price level is a clear dollar-turnover surge.
+        var bars = QuietBaselineThenFinalWeek(finalWeekClose: 101m, finalWeekVolume: 4_000);
+
+        var factors = ShortSqueezePriceFactorCalculator.Compute(bars, bars[^1].Date);
+
+        factors.HasPriceSpikeCatalyst.Should().BeFalse();
+        factors.HasVolumeSurgeCatalyst.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Compute_CrashOnHugeVolume_FlagsNothing()
+    {
+        // Price collapsing on heavy volume is shorts WINNING (or covering) — the
+        // catalysts require the move to run against them.
+        var bars = QuietBaselineThenFinalWeek(finalWeekClose: 60m, finalWeekVolume: 10_000);
+
+        var factors = ShortSqueezePriceFactorCalculator.Compute(bars, bars[^1].Date);
+
+        factors.HasPriceSpikeCatalyst.Should().BeFalse();
+        factors.HasVolumeSurgeCatalyst.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Compute_BaselineTooShort_CatalystsStayOff()
+    {
+        // 25 baseline bars + the recent week is under the 30-bar minimum baseline:
+        // the VWAP proxy still computes (≥ 20 bars) but no catalyst may fire on a
+        // volatility estimate that thin.
+        var bars = QuietBaselineThenFinalWeek(
+            finalWeekClose: 130m,
+            finalWeekVolume: 10_000,
+            baselineBars: 25
+        );
+
+        var factors = ShortSqueezePriceFactorCalculator.Compute(bars, bars[^1].Date);
+
+        factors.PriceAboveVwap.Should().NotBeNull();
+        factors.HasPriceSpikeCatalyst.Should().BeFalse();
+        factors.HasVolumeSurgeCatalyst.Should().BeFalse();
+    }
+
+    // A ±0.5% zig-zag around 100 on constant volume for the baseline, then five
+    // final bars stepping linearly to `finalWeekClose` on `finalWeekVolume`.
+    private static List<ShortSqueezeDailyBar> QuietBaselineThenFinalWeek(
+        decimal finalWeekClose,
+        long finalWeekVolume,
+        int baselineBars = 61
+    )
+    {
+        var end = new DateOnly(2026, 7, 1);
+        var total = baselineBars + 5;
+        var bars = new List<ShortSqueezeDailyBar>(total);
+        for (var i = 0; i < baselineBars; i++)
+        {
+            var close = i % 2 == 0 ? 100m : 100.5m;
+            bars.Add(new ShortSqueezeDailyBar(end.AddDays(i - total + 1), close, close, 1_000));
+        }
+
+        var start = bars[^1].AdjustedClose;
+        for (var i = 0; i < 5; i++)
+        {
+            var close = start + (finalWeekClose - start) * (i + 1) / 5;
+            bars.Add(
+                new ShortSqueezeDailyBar(
+                    end.AddDays(baselineBars + i - total + 1),
+                    close,
+                    close,
+                    finalWeekVolume
+                )
+            );
+        }
+
+        return bars;
+    }
+}

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezePriceFactorCalculatorVwapTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezePriceFactorCalculatorVwapTests.cs
@@ -1,0 +1,116 @@
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.BusinessLogic.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Pins the shorts-underwater proxy (ShortSqueezePriceFactorCalculator): price
+/// versus the trailing volume-weighted average — zero on a flat series, positive
+/// when the last close trades above where the volume changed hands, null when the
+/// series is too short (fewer than <see cref="ShortSqueezePriceFactorCalculator.MinVwapBars"/>
+/// bars) or stale (last bar more than
+/// <see cref="ShortSqueezePriceFactorCalculator.MaxStaleCalendarDays"/> days behind
+/// the universe's latest price date).
+/// </summary>
+public class ShortSqueezePriceFactorCalculatorVwapTests
+{
+    [Fact]
+    public void Compute_FlatSeries_PriceSitsOnTheVwap()
+    {
+        var bars = Series(count: 65, close: _ => 100m, volume: _ => 1_000);
+
+        var factors = ShortSqueezePriceFactorCalculator.Compute(bars, bars[^1].Date);
+
+        factors.PriceAboveVwap.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Compute_LastCloseAboveTheVolumeWeightedAverage_ProxyIsPositive()
+    {
+        // Flat at 100 for the whole window except a final bar at 130 — the VWAP sits
+        // barely above 100, so the proxy must be close to +30%.
+        var bars = Series(count: 65, close: i => i == 64 ? 130m : 100m, volume: _ => 1_000);
+
+        var factors = ShortSqueezePriceFactorCalculator.Compute(bars, bars[^1].Date);
+
+        factors.PriceAboveVwap.Should().BeGreaterThan(0.25m);
+    }
+
+    [Fact]
+    public void Compute_HighVolumeDaysDominateTheAverage_ProxyIsVolumeWeighted()
+    {
+        // Half the window at 100 on heavy volume, half at 200 on negligible volume:
+        // a simple mean sits near 150, but the VOLUME-weighted average stays near
+        // 100 — so a last close of 200 must read as ~+100%, not ~+33%.
+        var bars = Series(
+            count: 64,
+            close: i => i < 32 ? 100m : 200m,
+            volume: i => i < 32 ? 1_000_000 : 1
+        );
+
+        var factors = ShortSqueezePriceFactorCalculator.Compute(bars, bars[^1].Date);
+
+        factors.PriceAboveVwap.Should().BeGreaterThan(0.9m);
+    }
+
+    [Fact]
+    public void Compute_TooFewBars_ProxyIsNull()
+    {
+        var bars = Series(
+            count: ShortSqueezePriceFactorCalculator.MinVwapBars - 1,
+            close: _ => 100m,
+            volume: _ => 1_000
+        );
+
+        var factors = ShortSqueezePriceFactorCalculator.Compute(bars, bars[^1].Date);
+
+        factors.PriceAboveVwap.Should().BeNull();
+    }
+
+    [Fact]
+    public void Compute_StaleSeries_ProducesNoFactorsAtAll()
+    {
+        // A series that stopped trading (halt / delisting) would otherwise score on
+        // frozen history; a last bar older than the staleness bound must disable
+        // every price factor.
+        var bars = Series(count: 65, close: i => i == 64 ? 130m : 100m, volume: _ => 1_000);
+        var universeLatestDate = bars[^1]
+            .Date.AddDays(ShortSqueezePriceFactorCalculator.MaxStaleCalendarDays + 1);
+
+        var factors = ShortSqueezePriceFactorCalculator.Compute(bars, universeLatestDate);
+
+        factors.PriceAboveVwap.Should().BeNull();
+        factors.HasPriceSpikeCatalyst.Should().BeFalse();
+        factors.HasVolumeSurgeCatalyst.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Compute_EmptySeries_ProducesNoFactors()
+    {
+        var factors = ShortSqueezePriceFactorCalculator.Compute([], new DateOnly(2026, 7, 1));
+
+        factors.PriceAboveVwap.Should().BeNull();
+        factors.HasPriceSpikeCatalyst.Should().BeFalse();
+        factors.HasVolumeSurgeCatalyst.Should().BeFalse();
+    }
+
+    // Consecutive daily bars ending 2026-07-01; adjusted and raw close are equal so
+    // the tests read naturally.
+    private static List<ShortSqueezeDailyBar> Series(
+        int count,
+        Func<int, decimal> close,
+        Func<int, long> volume
+    )
+    {
+        var end = new DateOnly(2026, 7, 1);
+        return Enumerable
+            .Range(0, count)
+            .Select(i => new ShortSqueezeDailyBar(
+                end.AddDays(i - count + 1),
+                close(i),
+                close(i),
+                volume(i)
+            ))
+            .ToList();
+    }
+}

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerCatalystBoostTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerCatalystBoostTests.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.BusinessLogic.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Pins the catalyst overlay (ShortSqueezeScoreManager.ApplyPercentiles): each
+/// active catalyst adds its boost on top of the weighted base, the total boost is
+/// capped at <see cref="ShortSqueezeScoreManager.MaxCatalystBoost"/>, and the
+/// composite never exceeds 100 — the additive-event structure of the published
+/// squeeze models.
+/// </summary>
+public class ShortSqueezeScoreManagerCatalystBoostTests
+{
+    [Fact]
+    public void ApplyPercentiles_SingleCatalyst_AddsItsBoostToTheBase()
+    {
+        var quiet = Score(0.1m);
+        var spiking = Score(0.5m);
+        spiking.HasPriceSpikeCatalyst = true;
+
+        InvokeApplyPercentiles([quiet, Score(0.9m), spiking]);
+
+        spiking.BaseScore.Should().Be(50);
+        spiking.CatalystBoost.Should().Be(ShortSqueezeScoreManager.PriceSpikeCatalystBoost);
+        spiking.Score.Should().Be(50 + ShortSqueezeScoreManager.PriceSpikeCatalystBoost);
+        quiet.CatalystBoost.Should().Be(0);
+        quiet.Score.Should().Be(quiet.BaseScore);
+    }
+
+    [Fact]
+    public void ApplyPercentiles_BothCatalysts_BoostIsCappedAtTheMaximum()
+    {
+        var both = Score(0.5m);
+        both.HasPriceSpikeCatalyst = true;
+        both.HasVolumeSurgeCatalyst = true;
+
+        InvokeApplyPercentiles([Score(0.1m), Score(0.9m), both]);
+
+        both.CatalystBoost.Should().Be(ShortSqueezeScoreManager.MaxCatalystBoost);
+        both.Score.Should().Be(50 + ShortSqueezeScoreManager.MaxCatalystBoost);
+    }
+
+    [Fact]
+    public void ApplyPercentiles_BoostOnTopOfTheUniverse_ClampsTheCompositeAt100()
+    {
+        // The top-percentile stock already sits at 100; catalysts must not push the
+        // composite past the scale's ceiling.
+        var top = Score(0.9m);
+        top.HasPriceSpikeCatalyst = true;
+        top.HasVolumeSurgeCatalyst = true;
+
+        InvokeApplyPercentiles([Score(0.1m), top]);
+
+        top.BaseScore.Should().Be(100);
+        top.CatalystBoost.Should().Be(ShortSqueezeScoreManager.MaxCatalystBoost);
+        top.Score.Should().Be(100);
+    }
+
+    private static ShortSqueezeScore Score(decimal shortInterestPercentOfShares) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            ShortInterestPercentOfShares = shortInterestPercentOfShares,
+        };
+
+    private static void InvokeApplyPercentiles(List<ShortSqueezeScore> scores)
+    {
+        var method = typeof(ShortSqueezeScoreManager).GetMethod(
+            "ApplyPercentiles",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.Should().NotBeNull();
+        method!.Invoke(null, [scores]);
+    }
+}

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerWeightedCompositeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerWeightedCompositeTests.cs
@@ -1,0 +1,124 @@
+using System.Reflection;
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.BusinessLogic.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Pins the weighted composite (ShortSqueezeScoreManager.ApplyPercentiles): the
+/// base score is the WEIGHTED mean of the available factor percentiles — short
+/// interest 30%, days-to-cover 20%, price-above-VWAP 15%, short-volume trend 15%,
+/// short-interest change 10%, fails-to-deliver 10% — with a missing factor's
+/// weight redistributed over the factors present, never defaulted to a percentile.
+/// </summary>
+public class ShortSqueezeScoreManagerWeightedCompositeTests
+{
+    [Fact]
+    public void ApplyPercentiles_AllFactorsPresent_ScoreIsWeightedMeanOfPercentiles()
+    {
+        // Three stocks with strictly ordered values on every factor, so each stock's
+        // factor percentiles are 0 / 50 / 100 exactly. LOW leads only on short
+        // interest (its other five percentiles are 0) and HIGH trails only on short
+        // interest — pinning the 30% / 70% split between short interest and the rest.
+        var leadsOnShortInterestOnly = FullyPopulatedScore(rank: 2);
+        var middle = FullyPopulatedScore(rank: 1);
+        var leadsOnEverythingElse = FullyPopulatedScore(rank: 0);
+        // Flip the short-interest ordering so the "leads on everything else" stock
+        // has the LOWEST short interest.
+        leadsOnShortInterestOnly.ShortInterestPercentOfShares = 0.9m;
+        middle.ShortInterestPercentOfShares = 0.5m;
+        leadsOnEverythingElse.ShortInterestPercentOfShares = 0.1m;
+
+        var scores = new List<ShortSqueezeScore>
+        {
+            leadsOnShortInterestOnly,
+            middle,
+            leadsOnEverythingElse,
+        };
+
+        InvokeApplyPercentiles(scores);
+
+        // Weighted means: 0.30×100 = 30 · all-50 = 50 · 0.70×100 = 70.
+        leadsOnShortInterestOnly.BaseScore.Should().Be(30);
+        middle.BaseScore.Should().Be(50);
+        leadsOnEverythingElse.BaseScore.Should().Be(70);
+        // No catalysts flagged, so the composite equals the base.
+        leadsOnShortInterestOnly.Score.Should().Be(30);
+        leadsOnEverythingElse.Score.Should().Be(70);
+    }
+
+    [Fact]
+    public void ApplyPercentiles_OnlyShortInterestAndDaysToCover_WeightsRenormalizeToTheirRatio()
+    {
+        // Two stocks with opposite orderings on the only two factors present: the
+        // 30/20 weights must renormalize to 60/40 of the two-factor composite.
+        var highShortInterest = new ShortSqueezeScore
+        {
+            CommonStockId = Guid.NewGuid(),
+            ShortInterestPercentOfShares = 0.9m,
+            DaysToCover = 1m,
+        };
+        var highDaysToCover = new ShortSqueezeScore
+        {
+            CommonStockId = Guid.NewGuid(),
+            ShortInterestPercentOfShares = 0.1m,
+            DaysToCover = 9m,
+        };
+
+        InvokeApplyPercentiles([highShortInterest, highDaysToCover]);
+
+        // (0.30×100 + 0.20×0) / 0.50 = 60 and (0.30×0 + 0.20×100) / 0.50 = 40.
+        highShortInterest.BaseScore.Should().Be(60);
+        highDaysToCover.BaseScore.Should().Be(40);
+    }
+
+    [Fact]
+    public void ApplyPercentiles_MissingFactors_StayNullAndDropOut()
+    {
+        // A stock with NOTHING but short interest must score on it alone (weight
+        // renormalizes to 100%), and every absent factor keeps a null percentile.
+        var bare = new ShortSqueezeScore
+        {
+            CommonStockId = Guid.NewGuid(),
+            ShortInterestPercentOfShares = 0.9m,
+        };
+        var full = FullyPopulatedScore(rank: 0);
+        full.ShortInterestPercentOfShares = 0.1m;
+
+        InvokeApplyPercentiles([bare, full]);
+
+        bare.DaysToCoverPercentile.Should().BeNull();
+        bare.ShortVolumeTrendPercentile.Should().BeNull();
+        bare.ShortInterestChangePercentile.Should().BeNull();
+        bare.FailsToDeliverPercentile.Should().BeNull();
+        bare.PriceAboveVwapPercentile.Should().BeNull();
+        bare.BaseScore.Should().Be(bare.ShortInterestPercentile);
+    }
+
+    // A score with every factor populated, ordered by `rank` (0 = highest value on
+    // every factor, so rank 0 tops every percentile set it shares with lower ranks).
+    private static ShortSqueezeScore FullyPopulatedScore(int rank)
+    {
+        var level = 3 - rank; // rank 0 → 3 (highest), rank 2 → 1 (lowest)
+        return new ShortSqueezeScore
+        {
+            CommonStockId = Guid.NewGuid(),
+            ShortInterestPercentOfShares = level * 0.1m,
+            DaysToCover = level,
+            ShortVolumeShareTrend = level * 0.05m,
+            ShortInterestChangePercent = level * 0.2m,
+            FailsToDeliverPercentOfShares = level * 0.01m,
+            PriceAboveVwap = level * 0.1m,
+        };
+    }
+
+    private static void InvokeApplyPercentiles(List<ShortSqueezeScore> scores)
+    {
+        var method = typeof(ShortSqueezeScoreManager).GetMethod(
+            "ApplyPercentiles",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.Should().NotBeNull();
+        method!.Invoke(null, [scores]);
+    }
+}


### PR DESCRIPTION
## Summary

The short-squeeze score was an equal-weight mean of three factor percentiles (short interest % of shares, days to cover, short-volume trend) — too coarse to reliably separate genuinely squeezable names from merely heavily-shorted ones. This rebuilds it following the structure of the strongest published methodology (IHS Markit's US Short Squeeze Model): a weighted composite of crowdedness / capital-constraint factor percentiles plus additive catalyst boosts for the event conditions squeezes ignite from.

**Factors (percentile-ranked across the scored universe, weighted mean, missing factors drop out with weight redistributed):**

| Factor | Weight | Rationale |
|---|---|---|
| Short interest % of shares outstanding | 30% | classic crowdedness |
| Days to cover | 20% | size of the exit doorway |
| Price vs trailing 60d VWAP | 15% | how far open shorts are underwater — public-data analog of Markit's out-of-the-money share measures |
| Short-volume ratio trend | 15% | pressure building |
| Δ short interest vs previous report | 10% | crowd still building (both legs split-restated) |
| Fails-to-deliver pressure | 10% | worst trailing single-day FTD % of shares — closest public proxy for hard-to-borrow |

**Catalyst overlay** (additive rank points, capped at +20, composite clamped to 100, mirroring Markit's event structure): +10 when the last week's return is a 2σ outlier vs the stock's own daily volatility; +10 when weekly dollar turnover runs 2× baseline while the price moves against the shorts. Neither fires on a negative move (that's covering, not a squeeze) or on a stale/thin price series.

The score stays 0–100 and peer-relative, so downstream consumers (screener thresholds, rating bands, MCP/REST payloads) keep their semantics.

## Code changes

- `ShortSqueezeScoreManager` — six-factor weighted composite + catalyst boosts; loads FTDs (30d window anchored at the feed's latest date, per-observation split restatement, true-zero vs feed-absent distinction) and ~100 calendar days of daily bars in one query each; previous-report change split-restates both legs using the previous cycle's settlement date.
- `ShortSqueezePriceFactorCalculator` (new, pure) — VWAP underwater proxy, price-spike and volume-surge catalysts, staleness/min-bars guards; unit-testable without a database.
- `ShortSqueezeScore` — new raw factor values, percentiles, catalyst flags, `BaseScore`/`CatalystBoost`.
- `ShortDataTools.GetShortSqueezeScores` — description + table extended with the new factors and catalyst flags.
- Tests: new unit suites pinning the weights, renormalization, boost cap/clamp, and all calculator thresholds; integration tests extended for FTD zero-vs-null, Δ short interest, and price-factor wiring; existing manager/tool tests updated for the new constructor.

## Testing

- `Equibles.UnitTests`: full suite green (3,469).
- `Equibles.IntegrationTests`: ShortSqueezeScoreManager (14) + ShortDataTools (34, real ParadeDB) green.