### PR TITLE
feat(finra): add an earnings-proximity catalyst to the squeeze score via an optional calendar seam

### DIFF
--- a/src/Equibles.Finra.BusinessLogic/IEarningsProximitySource.cs
+++ b/src/Equibles.Finra.BusinessLogic/IEarningsProximitySource.cs
@@ -1,0 +1,25 @@
+namespace Equibles.Finra.BusinessLogic;
+
+/// <summary>
+/// Optional data source for the squeeze score's earnings-proximity catalyst:
+/// which stocks currently sit inside the window around a scheduled earnings
+/// event where squeezes cluster (from
+/// <see cref="ShortSqueezeScoreManager.EarningsProximityLeadWeekdays"/> weekdays
+/// before the event to <see cref="ShortSqueezeScoreManager.EarningsProximityTrailWeekdays"/>
+/// weekdays after it). The open-source build ships no implementation — earnings
+/// calendars are not part of the public dataset — so the catalyst simply never
+/// fires; a host that knows earnings dates registers an implementation and every
+/// squeeze surface picks the boost up through the manager.
+/// </summary>
+public interface IEarningsProximitySource
+{
+    /// <summary>
+    /// Of <paramref name="stockIds"/>, the stocks currently inside the earnings
+    /// window. A stock the source knows nothing about is simply absent — absence
+    /// of calendar data means no catalyst, never an error.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetStocksNearEarnings(
+        IReadOnlyCollection<Guid> stockIds,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeScore.cs
+++ b/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeScore.cs
@@ -78,6 +78,14 @@ public class ShortSqueezeScore
     /// </summary>
     public bool HasVolumeSurgeCatalyst { get; set; }
 
+    /// <summary>
+    /// True when a scheduled earnings event sits inside the squeeze window (a few
+    /// weekdays either side of the announcement — where squeezes cluster). Requires
+    /// a registered <see cref="IEarningsProximitySource"/>; without calendar data
+    /// the flag is simply false.
+    /// </summary>
+    public bool HasEarningsProximityCatalyst { get; set; }
+
     public double ShortInterestPercentile { get; set; }
 
     public double? DaysToCoverPercentile { get; set; }

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -37,8 +37,11 @@ namespace Equibles.Finra.BusinessLogic;
 ///
 /// <para>Catalyst boosts (additive rank points, capped at <see cref="MaxCatalystBoost"/>,
 /// composite clamped to 100): a statistically extreme positive weekly return
-/// (+<see cref="PriceSpikeCatalystBoost"/>) and abnormal dollar turnover with the price
-/// moving against the shorts (+<see cref="VolumeSurgeCatalystBoost"/>).</para>
+/// (+<see cref="PriceSpikeCatalystBoost"/>), abnormal dollar turnover with the price
+/// moving against the shorts (+<see cref="VolumeSurgeCatalystBoost"/>), and a scheduled
+/// earnings event inside the squeeze window
+/// (+<see cref="EarningsProximityCatalystBoost"/>, via any registered
+/// <see cref="IEarningsProximitySource"/>).</para>
 ///
 /// <para>Factors a stock has no data for drop out and their weight is redistributed over
 /// the rest. The universe is every stock reporting short interest at the latest
@@ -83,6 +86,20 @@ public class ShortSqueezeScoreManager
     /// <summary>Rank points added for abnormal dollar turnover on a positive move.</summary>
     public const double VolumeSurgeCatalystBoost = 10;
 
+    /// <summary>
+    /// Rank points added when a scheduled earnings event is close — squeezes cluster
+    /// around earnings announcements, so a crowded short base near one is at elevated
+    /// risk. Fires only when a registered <see cref="IEarningsProximitySource"/>
+    /// knows the stock's earnings date; no calendar data simply means no boost.
+    /// </summary>
+    public const double EarningsProximityCatalystBoost = 10;
+
+    /// <summary>The earnings window opens this many weekdays before the event.</summary>
+    public const int EarningsProximityLeadWeekdays = 5;
+
+    /// <summary>The earnings window closes this many weekdays after the event.</summary>
+    public const int EarningsProximityTrailWeekdays = 3;
+
     /// <summary>Ceiling on the total catalyst boost, mirroring the published models.</summary>
     public const double MaxCatalystBoost = 20;
 
@@ -121,6 +138,7 @@ public class ShortSqueezeScoreManager
     private readonly StockSplitRepository _stockSplitRepository;
     private readonly FailToDeliverRepository _failToDeliverRepository;
     private readonly DailyStockPriceRepository _dailyStockPriceRepository;
+    private readonly IEnumerable<IEarningsProximitySource> _earningsProximitySources;
 
     public ShortSqueezeScoreManager(
         ShortInterestRepository shortInterestRepository,
@@ -128,7 +146,8 @@ public class ShortSqueezeScoreManager
         CommonStockRepository commonStockRepository,
         StockSplitRepository stockSplitRepository,
         FailToDeliverRepository failToDeliverRepository,
-        DailyStockPriceRepository dailyStockPriceRepository
+        DailyStockPriceRepository dailyStockPriceRepository,
+        IEnumerable<IEarningsProximitySource> earningsProximitySources
     )
     {
         _shortInterestRepository = shortInterestRepository;
@@ -137,6 +156,7 @@ public class ShortSqueezeScoreManager
         _stockSplitRepository = stockSplitRepository;
         _failToDeliverRepository = failToDeliverRepository;
         _dailyStockPriceRepository = dailyStockPriceRepository;
+        _earningsProximitySources = earningsProximitySources;
     }
 
     public async Task<List<ShortSqueezeScore>> Compute(
@@ -219,6 +239,7 @@ public class ShortSqueezeScoreManager
         var scoredStockIds = stocks.Keys.ToList();
         var failsToDeliver = await LoadFailsToDeliver(scoredStockIds, cancellationToken);
         var priceFactors = await LoadPriceFactors(scoredStockIds, cancellationToken);
+        var nearEarnings = await LoadStocksNearEarnings(scoredStockIds, cancellationToken);
 
         var scores = new List<ShortSqueezeScore>();
         foreach (var shortInterest in shortInterests)
@@ -312,6 +333,7 @@ public class ShortSqueezeScoreManager
                     PriceAboveVwap = factors.PriceAboveVwap,
                     HasPriceSpikeCatalyst = factors.HasPriceSpikeCatalyst,
                     HasVolumeSurgeCatalyst = factors.HasVolumeSurgeCatalyst,
+                    HasEarningsProximityCatalyst = nearEarnings.Contains(stock.Id),
                 }
             );
         }
@@ -418,6 +440,25 @@ public class ShortSqueezeScoreManager
         }
 
         return quantities;
+    }
+
+    /// <summary>
+    /// Unions the stocks every registered <see cref="IEarningsProximitySource"/>
+    /// reports as inside the earnings window. With no sources registered (the
+    /// open-source default) the set is empty and the catalyst never fires.
+    /// </summary>
+    private async Task<HashSet<Guid>> LoadStocksNearEarnings(
+        List<Guid> stockIds,
+        CancellationToken cancellationToken
+    )
+    {
+        var nearEarnings = new HashSet<Guid>();
+        foreach (var source in _earningsProximitySources)
+        {
+            nearEarnings.UnionWith(await source.GetStocksNearEarnings(stockIds, cancellationToken));
+        }
+
+        return nearEarnings;
     }
 
     /// <summary>
@@ -644,6 +685,11 @@ public class ShortSqueezeScoreManager
             if (score.HasVolumeSurgeCatalyst)
             {
                 boost += VolumeSurgeCatalystBoost;
+            }
+
+            if (score.HasEarningsProximityCatalyst)
+            {
+                boost += EarningsProximityCatalystBoost;
             }
 
             score.CatalystBoost = Math.Min(boost, MaxCatalystBoost);

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -327,13 +327,14 @@ public class ShortDataTools
 
     private static string FormatCatalysts(ShortSqueezeScore score)
     {
-        if (score.HasPriceSpikeCatalyst && score.HasVolumeSurgeCatalyst)
-            return "PriceSpike+VolumeSurge";
+        var active = new List<string>(3);
         if (score.HasPriceSpikeCatalyst)
-            return "PriceSpike";
+            active.Add("PriceSpike");
         if (score.HasVolumeSurgeCatalyst)
-            return "VolumeSurge";
-        return "-";
+            active.Add("VolumeSurge");
+        if (score.HasEarningsProximityCatalyst)
+            active.Add("EarningsSoon");
+        return active.Count == 0 ? "-" : string.Join("+", active);
     }
 
     // Thin forwarder so existing reflection-based normalization tests still find the method.
@@ -342,7 +343,7 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortSqueezeScores")]
     [Description(
-        "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built as the weighted mean of six factor percentiles across every stock reporting short interest at the latest FINRA settlement date (short interest % of shares 30%, days to cover 20%, price vs trailing VWAP — how far shorts are underwater — 15%, short-volume trend 15%, change in short interest 10%, fails-to-deliver pressure 10%), plus catalyst boosts (+10 for a statistically extreme weekly price spike, +10 for abnormal dollar volume on a positive move, capped at +20, clamped to 100). Untradeable micro-caps dominate the raw board, so pass minMarketCap and/or minDollarVolume to keep only names that clear your liquidity bar (the score itself stays peer-relative to the full universe). Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
+        "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built as the weighted mean of six factor percentiles across every stock reporting short interest at the latest FINRA settlement date (short interest % of shares 30%, days to cover 20%, price vs trailing VWAP — how far shorts are underwater — 15%, short-volume trend 15%, change in short interest 10%, fails-to-deliver pressure 10%), plus catalyst boosts (+10 for a statistically extreme weekly price spike, +10 for abnormal dollar volume on a positive move, +10 when a scheduled earnings event is within a few weekdays — squeezes cluster around earnings — capped at +20, clamped to 100). Untradeable micro-caps dominate the raw board, so pass minMarketCap and/or minDollarVolume to keep only names that clear your liquidity bar (the score itself stays peer-relative to the full universe). Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
     )]
     public Task<string> GetShortSqueezeScores(
         [Description(

--- a/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
@@ -24,9 +24,12 @@ public class ShortSqueezeScoreManagerTests : IDisposable
 
     private readonly EquiblesFinancialDbContext _dbContext;
     private readonly ShortSqueezeScoreManager _manager;
+    private readonly StubEarningsProximitySource _earningsSource = new();
+    private readonly List<IEarningsProximitySource> _earningsProximitySources;
 
     public ShortSqueezeScoreManagerTests()
     {
+        _earningsProximitySources = [_earningsSource];
         _dbContext = TestDbContextFactory.Create(
             new FinraModuleConfiguration(),
             new CommonStocksModuleConfiguration(),
@@ -39,7 +42,8 @@ public class ShortSqueezeScoreManagerTests : IDisposable
             new CommonStockRepository(_dbContext),
             new StockSplitRepository(_dbContext),
             new FailToDeliverRepository(_dbContext),
-            new DailyStockPriceRepository(_dbContext)
+            new DailyStockPriceRepository(_dbContext),
+            _earningsProximitySources
         );
     }
 
@@ -396,6 +400,42 @@ public class ShortSqueezeScoreManagerTests : IDisposable
         scores.Single().HasPriceSpikeCatalyst.Should().BeFalse();
         scores.Single().HasVolumeSurgeCatalyst.Should().BeFalse();
         scores.Single().CatalystBoost.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Compute_StockInsideTheEarningsWindow_GetsTheEarningsCatalystBoost()
+    {
+        // A source flags REPORT as near earnings; PEER is not flagged. The boost is
+        // additive on top of the weighted base and must mark the flag for consumers.
+        var reporting = SeedStock("REPORT", sharesOutstanding: 1_000_000);
+        var peer = SeedStock("PEER", sharesOutstanding: 1_000_000);
+        SeedShortInterest(reporting, shortPosition: 100_000, daysToCover: 2m);
+        SeedShortInterest(peer, shortPosition: 200_000, daysToCover: 4m);
+        _earningsSource.NearEarnings.Add(reporting.Id);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        var flagged = scores.Single(s => s.Ticker == "REPORT");
+        var unflagged = scores.Single(s => s.Ticker == "PEER");
+        flagged.HasEarningsProximityCatalyst.Should().BeTrue();
+        flagged.CatalystBoost.Should().Be(ShortSqueezeScoreManager.EarningsProximityCatalystBoost);
+        flagged.Score.Should().Be(flagged.BaseScore + 10);
+        unflagged.HasEarningsProximityCatalyst.Should().BeFalse();
+        unflagged.CatalystBoost.Should().Be(0);
+    }
+
+    // Test double for the optional earnings-calendar seam: reports exactly the ids
+    // the test whitelists, intersected with the requested universe like a real
+    // implementation would.
+    private class StubEarningsProximitySource : IEarningsProximitySource
+    {
+        public HashSet<Guid> NearEarnings { get; } = [];
+
+        public Task<IReadOnlySet<Guid>> GetStocksNearEarnings(
+            IReadOnlyCollection<Guid> stockIds,
+            CancellationToken cancellationToken
+        ) => Task.FromResult<IReadOnlySet<Guid>>(NearEarnings.Where(stockIds.Contains).ToHashSet());
     }
 
     // The full Sec module registers pgvector-typed embedding entities the in-memory

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
@@ -27,7 +27,8 @@ public class ShortDataToolsGetLargestShortVolumeCultureInvarianceTests : ParadeD
                 new CommonStockRepository(DbContext),
                 new StockSplitRepository(DbContext),
                 new FailToDeliverRepository(DbContext),
-                new DailyStockPriceRepository(DbContext)
+                new DailyStockPriceRepository(DbContext),
+                []
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
@@ -28,7 +28,8 @@ public class ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests
                 new CommonStockRepository(DbContext),
                 new StockSplitRepository(DbContext),
                 new FailToDeliverRepository(DbContext),
-                new DailyStockPriceRepository(DbContext)
+                new DailyStockPriceRepository(DbContext),
+                []
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
@@ -27,7 +27,8 @@ public class ShortDataToolsGetShortInterestCultureInvarianceTests : ParadeDbMcpT
                 new CommonStockRepository(DbContext),
                 new StockSplitRepository(DbContext),
                 new FailToDeliverRepository(DbContext),
-                new DailyStockPriceRepository(DbContext)
+                new DailyStockPriceRepository(DbContext),
+                []
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
@@ -27,7 +27,8 @@ public class ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests : Para
                 new CommonStockRepository(DbContext),
                 new StockSplitRepository(DbContext),
                 new FailToDeliverRepository(DbContext),
-                new DailyStockPriceRepository(DbContext)
+                new DailyStockPriceRepository(DbContext),
+                []
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
@@ -36,7 +36,8 @@ public class ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTes
                 new CommonStockRepository(DbContext),
                 new StockSplitRepository(DbContext),
                 new FailToDeliverRepository(DbContext),
-                new DailyStockPriceRepository(DbContext)
+                new DailyStockPriceRepository(DbContext),
+                []
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -27,7 +27,8 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
                 new CommonStockRepository(DbContext),
                 new StockSplitRepository(DbContext),
                 new FailToDeliverRepository(DbContext),
-                new DailyStockPriceRepository(DbContext)
+                new DailyStockPriceRepository(DbContext),
+                []
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
@@ -27,7 +27,8 @@ public class ShortDataToolsGetShortVolumeCultureInvarianceTests : ParadeDbMcpTes
                 new CommonStockRepository(DbContext),
                 new StockSplitRepository(DbContext),
                 new FailToDeliverRepository(DbContext),
-                new DailyStockPriceRepository(DbContext)
+                new DailyStockPriceRepository(DbContext),
+                []
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -26,7 +26,8 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
                 new CommonStockRepository(DbContext),
                 new StockSplitRepository(DbContext),
                 new FailToDeliverRepository(DbContext),
-                new DailyStockPriceRepository(DbContext)
+                new DailyStockPriceRepository(DbContext),
+                []
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
@@ -38,7 +38,8 @@ public class ShortDataToolsZeroChangeTests : ParadeDbMcpTestBase
                 new CommonStockRepository(DbContext),
                 new StockSplitRepository(DbContext),
                 new FailToDeliverRepository(DbContext),
-                new DailyStockPriceRepository(DbContext)
+                new DailyStockPriceRepository(DbContext),
+                []
             ),
             new StockSplitRepository(DbContext),
             ErrorManager,

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerCatalystBoostTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerCatalystBoostTests.cs
@@ -43,6 +43,36 @@ public class ShortSqueezeScoreManagerCatalystBoostTests
     }
 
     [Fact]
+    public void ApplyPercentiles_EarningsProximityAlone_AddsItsBoost()
+    {
+        var reporting = Score(0.5m);
+        reporting.HasEarningsProximityCatalyst = true;
+
+        InvokeApplyPercentiles([Score(0.1m), Score(0.9m), reporting]);
+
+        reporting
+            .CatalystBoost.Should()
+            .Be(ShortSqueezeScoreManager.EarningsProximityCatalystBoost);
+        reporting.Score.Should().Be(50 + ShortSqueezeScoreManager.EarningsProximityCatalystBoost);
+    }
+
+    [Fact]
+    public void ApplyPercentiles_AllThreeCatalysts_StillCappedAtTheMaximum()
+    {
+        // 3 × 10 rank points of raw boost must not exceed the +20 ceiling the
+        // published models cap event overlays at.
+        var everything = Score(0.5m);
+        everything.HasPriceSpikeCatalyst = true;
+        everything.HasVolumeSurgeCatalyst = true;
+        everything.HasEarningsProximityCatalyst = true;
+
+        InvokeApplyPercentiles([Score(0.1m), Score(0.9m), everything]);
+
+        everything.CatalystBoost.Should().Be(ShortSqueezeScoreManager.MaxCatalystBoost);
+        everything.Score.Should().Be(50 + ShortSqueezeScoreManager.MaxCatalystBoost);
+    }
+
+    [Fact]
     public void ApplyPercentiles_BoostOnTopOfTheUniverse_ClampsTheCompositeAt100()
     {
         // The top-percentile stock already sits at 100; catalysts must not push the


### PR DESCRIPTION
## Summary

Squeezes cluster around earnings announcements — the published models (IHS Markit's US Short Squeeze Model) boost the composite inside a window around the event (5 weekdays before through 3 after). The open-source dataset has no earnings calendar, so this adds an optional seam rather than a data dependency: hosts that know earnings dates register a source, and every squeeze surface picks the boost up through the manager; with no source registered the catalyst never fires and behavior is unchanged.

## Code changes

- `IEarningsProximitySource` (new) — answers which of the scored stocks are currently inside the earnings window (window constants documented on the manager).
- `ShortSqueezeScoreManager` — takes `IEnumerable<IEarningsProximitySource>`, unions the sources, and adds `EarningsProximityCatalystBoost` (+10) for flagged stocks; the total catalyst boost stays capped at +20, composite clamped to 100.
- `ShortSqueezeScore.HasEarningsProximityCatalyst` — new flag for consumers.
- `ShortDataTools` — Catalysts column renders `EarningsSoon`; tool description documents the third boost.
- Tests: unit — earnings boost alone, three-catalyst cap; integration — stub source flags a stock → flag + boost + score; existing constructions updated for the new optional dependency.

## Testing

- Unit: squeeze suites 25/25 green (full suite builds clean).
- Integration: manager + ShortDataTools 49/49 green (ParadeDB).