### PR TITLE
feat(sec): search pool controls — exclude tickers, multiple document types, per-company cap

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
@@ -44,40 +44,53 @@ public class HybridChunkSearcher
         _logger = logger;
     }
 
+    // How much deeper the BM25 pool goes when a per-company cap is active: the cap
+    // discards a dominant filer's surplus hits, so the pool must hold enough distinct
+    // companies to refill the requested result count.
+    private const int PerCompanyOverFetchFactor = 5;
+
     public async Task<List<Chunk>> Search(
         string query,
         int maxResults,
         string ticker = null,
+        IReadOnlyCollection<string> excludeTickers = null,
         Guid? documentId = null,
-        DocumentType documentType = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
+        int maxResultsPerCompany = 0,
         DateOnly? startDate = null,
         DateOnly? endDate = null,
         CancellationToken cancellationToken = default
     )
     {
         // When the semantic arm is live, BM25 returns a deeper pool so RRF has more to reorder;
-        // otherwise it returns exactly what the caller asked for.
+        // otherwise it returns exactly what the caller asked for. A per-company cap also deepens
+        // the pool: capping discards surplus hits, and the pool must still fill maxResults.
         var semanticActive =
             _options.Enabled
             && _options.VectorSource != VectorSource.Off
             && _embeddingClient.IsEnabled;
-        var bm25Limit = semanticActive
-            ? Math.Max(maxResults, _options.CandidatePoolSize)
-            : maxResults;
+        var bm25Limit = maxResults;
+        if (semanticActive)
+            bm25Limit = Math.Max(bm25Limit, _options.CandidatePoolSize);
+        if (maxResultsPerCompany > 0)
+            bm25Limit = Math.Max(bm25Limit, maxResults * PerCompanyOverFetchFactor);
 
         var bm25 = await _chunkRepository.HybridSearch(
             query,
             bm25Limit,
             ticker,
+            excludeTickers,
             documentId,
-            documentType,
+            documentTypes,
             startDate,
             endDate,
             cancellationToken
         );
 
         if (!semanticActive || bm25.Count == 0)
-            return bm25.Take(maxResults).ToList();
+            return ApplyPoolControls(bm25, excludeTickers, documentTypes, maxResultsPerCompany)
+                .Take(maxResults)
+                .ToList();
 
         // Bound the whole semantic arm: the global search aggregator abandons a slow provider but
         // doesn't cancel it, and the embedding server is shared with the backfill — so cap the
@@ -85,26 +98,76 @@ public class HybridChunkSearcher
         using var semanticCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         semanticCts.CancelAfter(TimeSpan.FromSeconds(_options.SemanticTimeoutSeconds));
 
+        // The corpus-wide vector arm scopes by a single document type; with several
+        // requested it runs unscoped and the type filter is enforced post-fusion below.
         var vectorIds = await RankSemantically(
             query,
             bm25,
             ticker,
             documentId,
-            documentType,
+            documentTypes is { Count: 1 } ? documentTypes.First() : null,
             startDate,
             endDate,
             semanticCts.Token
         );
         if (vectorIds.Count == 0)
-            return bm25.Take(maxResults).ToList();
+            return ApplyPoolControls(bm25, excludeTickers, documentTypes, maxResultsPerCompany)
+                .Take(maxResults)
+                .ToList();
 
         var bm25Ids = bm25.Select(chunk => chunk.Id).ToList();
-        var fusedIds = RrfFusion
-            .Fuse([bm25Ids, vectorIds], _options.RrfK)
+        // Fuse the full pool (not just maxResults): the pool controls below discard
+        // hits, so the fused list must stay deep enough to refill the result count.
+        var fusedIds = RrfFusion.Fuse([bm25Ids, vectorIds], _options.RrfK).ToList();
+
+        var fused = await MaterializeInOrder(fusedIds, bm25, cancellationToken);
+        return ApplyPoolControls(fused, excludeTickers, documentTypes, maxResultsPerCompany)
             .Take(maxResults)
             .ToList();
+    }
 
-        return await MaterializeInOrder(fusedIds, bm25, cancellationToken);
+    // The pool controls, re-applied AFTER fusion: the BM25 arm already resolves
+    // exclusions and type filters inside the index, but the corpus vector arm knows
+    // neither, so a fused list can reintroduce an excluded ticker or an unrequested
+    // type. The per-company cap keeps each filer's best-ranked chunks in relevance
+    // order — one chatty filer must not fill the whole result set. Chunks without a
+    // ticker pass the cap untouched (they cannot flood by company).
+    //
+    // SINGLE-ENUMERATION ONLY: the cap closes over a mutable per-ticker counter, so a
+    // second enumeration of the same returned value would see spent counters and drop
+    // everything. Every caller consumes it exactly once via .Take(...).ToList().
+    private static IEnumerable<Chunk> ApplyPoolControls(
+        IEnumerable<Chunk> chunks,
+        IReadOnlyCollection<string> excludeTickers,
+        IReadOnlyCollection<DocumentType> documentTypes,
+        int maxResultsPerCompany
+    )
+    {
+        if (excludeTickers is { Count: > 0 })
+        {
+            var excluded = new HashSet<string>(excludeTickers, StringComparer.OrdinalIgnoreCase);
+            chunks = chunks.Where(chunk =>
+                chunk.Ticker == null || !excluded.Contains(chunk.Ticker)
+            );
+        }
+
+        if (documentTypes is { Count: > 1 })
+            chunks = chunks.Where(chunk => documentTypes.Contains(chunk.DocumentType));
+
+        if (maxResultsPerCompany <= 0)
+            return chunks;
+
+        var perTicker = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        return chunks.Where(chunk =>
+        {
+            if (chunk.Ticker == null)
+                return true;
+            var count = perTicker.GetValueOrDefault(chunk.Ticker);
+            if (count >= maxResultsPerCompany)
+                return false;
+            perTicker[chunk.Ticker] = count + 1;
+            return true;
+        });
     }
 
     // Produces a semantic ranking of chunk ids, swallowing any embedding-server failure into an

--- a/src/Equibles.Sec.BusinessLogic/Search/IRagManager.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/IRagManager.cs
@@ -8,15 +8,17 @@ public interface IRagManager
     public Task<List<Chunk>> SearchRelevantChunks(
         string query,
         int maxResults = 5,
-        DocumentType documentType = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
         DateOnly? startDate = null,
-        DateOnly? endDate = null
+        DateOnly? endDate = null,
+        IReadOnlyCollection<string> excludeTickers = null,
+        int maxResultsPerCompany = 0
     );
     public Task<List<Chunk>> SearchRelevantChunksByCompany(
         string query,
         string ticker,
         int maxResults = 5,
-        DocumentType documentType = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
         DateOnly? startDate = null,
         DateOnly? endDate = null
     );

--- a/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
@@ -31,15 +31,19 @@ public class RagManager : IRagManager
     public async Task<List<Chunk>> SearchRelevantChunks(
         string query,
         int maxResults = 5,
-        DocumentType documentType = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
         DateOnly? startDate = null,
-        DateOnly? endDate = null
+        DateOnly? endDate = null,
+        IReadOnlyCollection<string> excludeTickers = null,
+        int maxResultsPerCompany = 0
     )
     {
         var chunks = await _hybridChunkSearcher.Search(
             query,
             maxResults,
-            documentType: documentType,
+            excludeTickers: excludeTickers,
+            documentTypes: documentTypes,
+            maxResultsPerCompany: maxResultsPerCompany,
             startDate: startDate,
             endDate: endDate
         );
@@ -52,7 +56,7 @@ public class RagManager : IRagManager
         string query,
         string ticker,
         int maxResults = 5,
-        DocumentType documentType = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
         DateOnly? startDate = null,
         DateOnly? endDate = null
     )
@@ -62,7 +66,7 @@ public class RagManager : IRagManager
             query,
             maxResults,
             ticker,
-            documentType: documentType,
+            documentTypes: documentTypes,
             startDate: startDate,
             endDate: endDate
         );
@@ -97,7 +101,7 @@ public class RagManager : IRagManager
         int maxResults = 5
     )
     {
-        return await SearchRelevantChunks(query, maxResults, documentType);
+        return await SearchRelevantChunks(query, maxResults, [documentType]);
     }
 
     public Task<string> BuildContext(List<Chunk> chunks)

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -19,6 +19,9 @@ public class RagSearchTools
     private const string DocumentTypeDescription =
         "Document type filter. Allowed values: 'TenK', 'TenQ', 'EightK', 'TenKa', 'TenQa', 'EightKa', 'TwentyF', 'SixK', 'FortyF'";
 
+    private const string DocumentTypesDescription =
+        "Document type filter — one value or a comma-separated list (e.g. 'TenK,TenQ'). Allowed values: 'TenK', 'TenQ', 'EightK', 'TenKa', 'TenQa', 'EightKa', 'TwentyF', 'SixK', 'FortyF'";
+
     private readonly IRagManager _ragManager;
     private readonly ISecDocumentService _secDocumentService;
     private readonly McpToolRunner _runner;
@@ -37,27 +40,36 @@ public class RagSearchTools
 
     [McpServerTool(Name = "SearchDocuments")]
     [Description(
-        "Search the Equibles SEC filing database across all companies and document types using hybrid keyword and semantic search. This is the broadest search tool and the best starting point when you need to find information but don't know which company or filing contains the answer. Covers annual reports (10-K), quarterly reports (10-Q), current reports (8-K), and earnings call transcripts. Results can be filtered by filing date range using startDate/endDate. Returns matching excerpts with company name, ticker, document type, and filing date. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. Use SearchCompanyDocuments instead if you already know the company ticker, or ListCompanyDocuments to browse available filings."
+        "Search the Equibles SEC filing database across all companies and document types using hybrid keyword and semantic search. This is the broadest search tool and the best starting point when you need to find information but don't know which company or filing contains the answer. Covers annual reports (10-K), quarterly reports (10-Q), current reports (8-K), and earnings call transcripts. Results can be filtered by filing date range using startDate/endDate. Returns matching excerpts with company name, ticker, document type, and filing date. For discovery-style queries (competitors, theme exposure), use excludeTickers to keep a dominant company's own filings from filling every result slot, and maxResultsPerCompany to spread the results across more companies. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. Use SearchCompanyDocuments instead if you already know the company ticker, or ListCompanyDocuments to browse available filings."
     )]
     public Task<string> SearchDocuments(
         [Description("Natural language search query")] string query,
         [Description("Maximum number of results to return (default: 5)")] int maxResults = 5,
-        [Description(DocumentTypeDescription)] string documentType = null,
+        [Description(DocumentTypesDescription)] string documentType = null,
         [Description("Optional start date filter in YYYY-MM-DD format")] DateTime? startDate = null,
-        [Description("Optional end date filter in YYYY-MM-DD format")] DateTime? endDate = null
+        [Description("Optional end date filter in YYYY-MM-DD format")] DateTime? endDate = null,
+        [Description(
+            "Tickers whose filings are excluded from the results — one value or a comma-separated list (e.g. 'AAPL,MSFT'). Use when a company's own filings would dominate the results for a query about its market."
+        )]
+            string excludeTickers = null,
+        [Description(
+            "Maximum results from any single company (default: 0 = unlimited). Set a small value (e.g. 2) to spread results across more companies for discovery-style queries."
+        )]
+            int maxResultsPerCompany = 0
     )
     {
         return _runner.Execute(
             async () =>
             {
                 maxResults = McpLimit.Clamp(maxResults);
-                var parsedType = ParseDocumentType(documentType);
                 var chunks = await _ragManager.SearchRelevantChunks(
                     query,
                     maxResults,
-                    parsedType,
+                    ParseDocumentTypes(documentType),
                     ToDateOnly(startDate),
-                    ToDateOnly(endDate)
+                    ToDateOnly(endDate),
+                    ParseTickers(excludeTickers),
+                    Math.Max(maxResultsPerCompany, 0)
                 );
                 return await _ragManager.BuildContext(chunks);
             },
@@ -74,7 +86,7 @@ public class RagSearchTools
         [Description("Natural language search query")] string query,
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
         [Description("Maximum number of results to return (default: 5)")] int maxResults = 5,
-        [Description(DocumentTypeDescription)] string documentType = null,
+        [Description(DocumentTypesDescription)] string documentType = null,
         [Description("Optional start date filter in YYYY-MM-DD format")] DateTime? startDate = null,
         [Description("Optional end date filter in YYYY-MM-DD format")] DateTime? endDate = null
     )
@@ -83,12 +95,11 @@ public class RagSearchTools
             async () =>
             {
                 maxResults = McpLimit.Clamp(maxResults);
-                var parsedType = ParseDocumentType(documentType);
                 var chunks = await _ragManager.SearchRelevantChunksByCompany(
                     query,
                     ticker,
                     maxResults,
-                    parsedType,
+                    ParseDocumentTypes(documentType),
                     ToDateOnly(startDate),
                     ToDateOnly(endDate)
                 );
@@ -190,6 +201,37 @@ public class RagSearchTools
             return null;
 
         return DocumentType.FromDisplayName(documentType) ?? DocumentType.FromValue(documentType);
+    }
+
+    // The comma-separated variant for the search tools. Unrecognized entries are
+    // skipped rather than erroring, matching the single-type parameter's established
+    // lenient behavior (an unknown value has always meant "no type filter"); null when
+    // nothing usable remains.
+    private static IReadOnlyCollection<DocumentType> ParseDocumentTypes(string documentTypes)
+    {
+        if (string.IsNullOrWhiteSpace(documentTypes))
+            return null;
+
+        var parsed = documentTypes
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(ParseDocumentType)
+            .Where(type => type != null)
+            .Distinct()
+            .ToList();
+        return parsed.Count > 0 ? parsed : null;
+    }
+
+    // Comma-separated tickers for the exclusion filter; null when nothing usable.
+    private static IReadOnlyCollection<string> ParseTickers(string tickers)
+    {
+        if (string.IsNullOrWhiteSpace(tickers))
+            return null;
+
+        var parsed = tickers
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return parsed.Count > 0 ? parsed : null;
     }
 
     private static DateOnly? ToDateOnly(DateTime? value) =>

--- a/src/Equibles.Sec.Repositories/ChunkRepository.cs
+++ b/src/Equibles.Sec.Repositories/ChunkRepository.cs
@@ -22,8 +22,9 @@ public class ChunkRepository : BaseRepository<Chunk>
         string searchText,
         int maxResults,
         string ticker = null,
+        IReadOnlyCollection<string> excludeTickers = null,
         Guid? documentId = null,
-        DocumentType documentType = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
         DateOnly? startDate = null,
         DateOnly? endDate = null,
         CancellationToken cancellationToken = default
@@ -49,15 +50,50 @@ public class ChunkRepository : BaseRepository<Chunk>
         if (documentId.HasValue)
             clauses.Add(ParadeDbJsonQuery.Term(nameof(Chunk.DocumentId), documentId.Value));
 
-        if (documentType != null)
+        // One type is a plain required term; several nest as a boolean of shoulds (a
+        // boolean with only should clauses requires at least one to match), so "10-K or
+        // 10-Q" still resolves inside the index.
+        if (documentTypes is { Count: 1 })
             clauses.Add(
                 ParadeDbJsonQuery.Term(
                     nameof(Chunk.DocumentType),
-                    documentType.Value.ToLowerInvariant()
+                    documentTypes.First().Value.ToLowerInvariant()
+                )
+            );
+        else if (documentTypes is { Count: > 1 })
+            clauses.Add(
+                ParadeDbJsonQuery.Boolean(b =>
+                    b.Should(
+                        documentTypes
+                            .Select(t =>
+                                ParadeDbJsonQuery.Term(
+                                    nameof(Chunk.DocumentType),
+                                    t.Value.ToLowerInvariant()
+                                )
+                            )
+                            .ToArray()
+                    )
                 )
             );
 
-        var searchQuery = ParadeDbJsonQuery.Boolean(b => b.Must(clauses.ToArray())).ToJson();
+        var searchQuery = ParadeDbJsonQuery
+            .Boolean(b =>
+            {
+                b.Must(clauses.ToArray());
+                // Exclusion must live INSIDE the index too: dropping a dominant filer's
+                // hits after scoring would silently shrink the result set instead of
+                // refilling it with the next-best matches (a subject company can own
+                // 90% of the top hits for its own flagship keyword).
+                if (excludeTickers is { Count: > 0 })
+                    b.MustNot(
+                        excludeTickers
+                            .Select(t =>
+                                ParadeDbJsonQuery.Term(nameof(Chunk.Ticker), t.ToLowerInvariant())
+                            )
+                            .ToArray()
+                    );
+            })
+            .ToJson();
 
         var query = DbContext.Set<Chunk>().Where(c => EF.Functions.JsonSearch(c.Id, searchQuery));
 

--- a/tests/Equibles.IntegrationTests/Sec/ChunkRepositoryHybridSearchPoolControlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/ChunkRepositoryHybridSearchPoolControlTests.cs
@@ -1,0 +1,256 @@
+using System.Data.Common;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit.Abstractions;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins the pool controls on <see cref="ChunkRepository.HybridSearch"/>: excluded
+/// tickers and the multi-document-type filter must resolve INSIDE the BM25 boolean
+/// query (a Tantivy <c>must_not</c> / nested <c>should</c> within the <c>@@@</c>
+/// predicate), never as SQL heap-filter predicates. Post-filtering scored hits would
+/// both re-introduce the #2157 heap-filter blowup and silently shrink the result set
+/// instead of refilling it with the next-best matches — the exact failure that let a
+/// thesis subject's own filings occupy 36 of the 40 discovery hits for its flagship
+/// keyword.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class ChunkRepositoryHybridSearchPoolControlTests : ParadeDbMcpTestBase
+{
+    private readonly ITestOutputHelper _output;
+
+    public ChunkRepositoryHybridSearchPoolControlTests(
+        ParadeDbFixture fixture,
+        ITestOutputHelper output
+    )
+        : base(fixture)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task HybridSearch_ExcludeTickers_RefillsWithOtherCompanies()
+    {
+        // Apple dominates the match set; excluding it must surface the other filers
+        // rather than returning a shrunken, Apple-shaped hole.
+        var apple = SeedStock("AAPL", "Apple Inc.", "0000320193");
+        var microsoft = SeedStock("MSFT", "Microsoft Corp.", "0000789019");
+        var alphabet = SeedStock("GOOG", "Alphabet Inc.", "0001652044");
+        var appleFiling = SeedDocument(apple, DocumentType.TenK);
+        for (var index = 0; index < 5; index++)
+            SeedChunk(
+                appleFiling,
+                $"Services revenue grew substantially in segment {index}.",
+                "AAPL",
+                index
+            );
+        SeedChunk(
+            SeedDocument(microsoft, DocumentType.TenK),
+            "Services revenue rose across the cloud unit.",
+            "MSFT"
+        );
+        SeedChunk(
+            SeedDocument(alphabet, DocumentType.TenK),
+            "Services revenue expanded in the ads unit.",
+            "GOOG"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var sut = new ChunkRepository(DbContext);
+
+        var results = await sut.HybridSearch(
+            "services revenue",
+            maxResults: 10,
+            excludeTickers: ["AAPL"]
+        );
+
+        results.Should().NotBeEmpty();
+        results.Should().AllSatisfy(c => c.Ticker.Should().NotBe("AAPL"));
+        results.Select(c => c.Ticker).Should().Contain(["MSFT", "GOOG"]);
+    }
+
+    [Fact]
+    public async Task HybridSearch_MultipleDocumentTypes_ReturnsOnlyThoseTypes()
+    {
+        var apple = SeedStock("AAPL", "Apple Inc.", "0000320193");
+        SeedChunk(
+            SeedDocument(apple, DocumentType.TenK),
+            "Services revenue grew in the annual report.",
+            "AAPL"
+        );
+        SeedChunk(
+            SeedDocument(apple, DocumentType.TenQ),
+            "Services revenue grew in the quarter.",
+            "AAPL",
+            index: 1
+        );
+        SeedChunk(
+            SeedDocument(apple, DocumentType.EightK),
+            "Services revenue grew per the current report.",
+            "AAPL",
+            index: 2
+        );
+        await DbContext.SaveChangesAsync();
+
+        var sut = new ChunkRepository(DbContext);
+
+        var results = await sut.HybridSearch(
+            "services revenue",
+            maxResults: 10,
+            documentTypes: [DocumentType.TenK, DocumentType.TenQ]
+        );
+
+        results.Should().NotBeEmpty();
+        results
+            .Select(c => c.DocumentType)
+            .Distinct()
+            .Should()
+            .BeEquivalentTo([DocumentType.TenK, DocumentType.TenQ]);
+    }
+
+    [Fact]
+    public async Task HybridSearch_PoolControls_RideInsideTheBm25Query_NotSqlHeapFilters()
+    {
+        var apple = SeedStock("AAPL", "Apple Inc.", "0000320193");
+        SeedChunk(
+            SeedDocument(apple, DocumentType.TenK),
+            "Services revenue grew substantially this quarter.",
+            "AAPL"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var interceptor = new CapturingCommandInterceptor();
+        await using var instrumentedContext = Fixture.CreateDbContext(builder =>
+            builder.AddInterceptors(interceptor)
+        );
+        var sut = new ChunkRepository(instrumentedContext);
+
+        await sut.HybridSearch(
+            "services revenue",
+            maxResults: 10,
+            excludeTickers: ["MSFT", "GOOG"],
+            documentTypes: [DocumentType.TenK, DocumentType.TenQ]
+        );
+
+        var sql = interceptor.GetChunkSelectCommandText();
+        _output.WriteLine(sql);
+
+        sql.Should().NotBeNull();
+        sql.Should().Contain("@@@", "the filters must ride inside the BM25 search operator");
+        sql.Should().Contain("jsonb", "the boolean query is passed as a ::jsonb predicate");
+        // The projection legitimately selects the columns; only PREDICATE forms would
+        // re-introduce the #2157 heap filter.
+        sql.Should()
+            .NotContainAny(
+                ["\"Ticker\" <>", "\"Ticker\" NOT IN", "\"Ticker\" ="],
+                "the exclusion must live inside the BM25 query, not a SQL heap-filter predicate"
+            );
+        sql.Should()
+            .NotContainAny(
+                ["\"DocumentType\" =", "\"DocumentType\" IN"],
+                "the type filter must live inside the BM25 query, not a SQL heap-filter predicate"
+            );
+    }
+
+    private CommonStock SeedStock(string ticker, string name, string cik)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = name,
+            Cik = cik,
+        };
+        DbContext.Add(stock);
+        return stock;
+    }
+
+    private Document SeedDocument(CommonStock stock, DocumentType documentType)
+    {
+        var fileContent = new FileContent { Bytes = "placeholder"u8.ToArray() };
+        var file = new File
+        {
+            Name = "filing",
+            Extension = "txt",
+            ContentType = "text/plain",
+            Size = fileContent.Bytes.Length,
+            FileContent = fileContent,
+        };
+        fileContent.FileId = file.Id;
+        DbContext.Add(file);
+
+        var document = new Document
+        {
+            CommonStock = stock,
+            CommonStockId = stock.Id,
+            Content = file,
+            ContentId = file.Id,
+            DocumentType = documentType,
+            ReportingDate = new DateOnly(2026, 1, 15),
+            ReportingForDate = new DateOnly(2025, 12, 31),
+            LineCount = 1,
+        };
+        DbContext.Add(document);
+        return document;
+    }
+
+    private void SeedChunk(Document document, string content, string ticker, int index = 0)
+    {
+        DbContext.Add(
+            new Chunk
+            {
+                Document = document,
+                DocumentId = document.Id,
+                Index = index,
+                StartPosition = 0,
+                EndPosition = content.Length,
+                StartLineNumber = 1,
+                Content = content,
+                DocumentType = document.DocumentType,
+                Ticker = ticker,
+                ReportingDate = DateTime.SpecifyKind(
+                    document.ReportingDate.ToDateTime(TimeOnly.MinValue),
+                    DateTimeKind.Utc
+                ),
+            }
+        );
+    }
+
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        private readonly List<string> _commands = new();
+
+        public string GetChunkSelectCommandText() =>
+            _commands.LastOrDefault(c =>
+                c.StartsWith("SELECT", StringComparison.Ordinal)
+                && c.Contains("\"Chunk\"", StringComparison.Ordinal)
+            );
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result
+        )
+        {
+            _commands.Add(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _commands.Add(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/HybridChunkSearcherPerCompanyCapTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/HybridChunkSearcherPerCompanyCapTests.cs
@@ -1,0 +1,133 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins <see cref="Equibles.Sec.BusinessLogic.Search.HybridChunkSearcher"/>'s
+/// per-company cap over the real BM25 ranking: one chatty filer must not fill the
+/// whole result set. The searcher over-fetches the BM25 pool and keeps each company's
+/// best-ranked chunks up to the cap, so the freed slots refill with the next-best
+/// companies instead of shrinking the result.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HybridChunkSearcherPerCompanyCapTests : ParadeDbMcpTestBase
+{
+    public HybridChunkSearcherPerCompanyCapTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Search_PerCompanyCap_SpreadsResultsAcrossCompanies()
+    {
+        // Apple matches six times over — without the cap it fills all four slots.
+        var apple = SeedStock("AAPL", "Apple Inc.", "0000320193");
+        var appleFiling = SeedDocument(apple);
+        for (var index = 0; index < 6; index++)
+            SeedChunk(
+                appleFiling,
+                $"Services revenue grew substantially in segment {index}.",
+                "AAPL",
+                index
+            );
+        var microsoft = SeedStock("MSFT", "Microsoft Corp.", "0000789019");
+        SeedChunk(SeedDocument(microsoft), "Services revenue rose across the cloud unit.", "MSFT");
+        await DbContext.SaveChangesAsync();
+
+        var sut = HybridChunkSearcherFactory.Bm25Only(DbContext);
+
+        var results = await sut.Search("services revenue", maxResults: 4, maxResultsPerCompany: 2);
+
+        results.Should().NotBeEmpty();
+        results.Count(c => c.Ticker == "AAPL").Should().BeLessThanOrEqualTo(2);
+        results.Select(c => c.Ticker).Should().Contain("MSFT");
+    }
+
+    [Fact]
+    public async Task Search_NoCap_KeepsThePlainRelevanceOrdering()
+    {
+        var apple = SeedStock("AAPL", "Apple Inc.", "0000320193");
+        var appleFiling = SeedDocument(apple);
+        for (var index = 0; index < 3; index++)
+            SeedChunk(
+                appleFiling,
+                $"Services revenue grew substantially in segment {index}.",
+                "AAPL",
+                index
+            );
+        await DbContext.SaveChangesAsync();
+
+        var sut = HybridChunkSearcherFactory.Bm25Only(DbContext);
+
+        var results = await sut.Search("services revenue", maxResults: 3);
+
+        results.Should().HaveCount(3);
+        results.Should().AllSatisfy(c => c.Ticker.Should().Be("AAPL"));
+    }
+
+    private CommonStock SeedStock(string ticker, string name, string cik)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = name,
+            Cik = cik,
+        };
+        DbContext.Add(stock);
+        return stock;
+    }
+
+    private Document SeedDocument(CommonStock stock)
+    {
+        var fileContent = new FileContent { Bytes = "placeholder"u8.ToArray() };
+        var file = new File
+        {
+            Name = "filing",
+            Extension = "txt",
+            ContentType = "text/plain",
+            Size = fileContent.Bytes.Length,
+            FileContent = fileContent,
+        };
+        fileContent.FileId = file.Id;
+        DbContext.Add(file);
+
+        var document = new Document
+        {
+            CommonStock = stock,
+            CommonStockId = stock.Id,
+            Content = file,
+            ContentId = file.Id,
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2026, 1, 15),
+            ReportingForDate = new DateOnly(2025, 12, 31),
+            LineCount = 1,
+        };
+        DbContext.Add(document);
+        return document;
+    }
+
+    private void SeedChunk(Document document, string content, string ticker, int index = 0)
+    {
+        DbContext.Add(
+            new Chunk
+            {
+                Document = document,
+                DocumentId = document.Id,
+                Index = index,
+                StartPosition = 0,
+                EndPosition = content.Length,
+                StartLineNumber = 1,
+                Content = content,
+                DocumentType = document.DocumentType,
+                Ticker = ticker,
+                ReportingDate = DateTime.SpecifyKind(
+                    document.ReportingDate.ToDateTime(TimeOnly.MinValue),
+                    DateTimeKind.Utc
+                ),
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The corpus search's raw BM25 top-N degenerates to a handful of chatty filers for discovery-style queries: a company researching its own market gets pools dominated by its own filings (a prod peer-discovery run saw the subject take 36 of 40 hits for its flagship keyword), and sector keywords surface one industry's boilerplate en masse. This adds three pool controls, threaded from the ParadeDB query through the searcher, RagManager, and the SearchDocuments/SearchCompanyDocuments MCP tools:

- **excludeTickers** — rendered as in-index `must_not` terms inside the BM25 boolean, so freed slots refill with the next-best matches (client-side filtering can't do this). Same #2157 rule as the existing filters: everything resolves inside the index, never as a SQL heap filter.
- **documentTypes (one or many)** — a single type stays a required term; several nest as a boolean of shoulds. The MCP tools' `documentType` parameter now accepts a comma-separated list (single-value calls behave identically).
- **maxResultsPerCompany** — the searcher over-fetches the BM25 pool, fuses the full pool, and keeps each company's best-ranked chunks up to the cap in relevance order; exclusion/type/cap are re-applied post-fusion because the corpus vector arm can't see them.

## Code changes

- `Equibles.Sec.Repositories/ChunkRepository.cs` — HybridSearch signature (`excludeTickers`, `documentTypes`), boolean query composition.
- `Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs` — Search signature, over-fetch sizing, `ApplyPoolControls` (single-enumeration, documented).
- `Equibles.Sec.BusinessLogic/Search/{IRagManager,RagManager}.cs` — passthroughs.
- `Equibles.Sec.Mcp/Tools/RagSearchTools.cs` — SearchDocuments gains `excludeTickers` + `maxResultsPerCompany`, CSV `documentType` on both search tools; lenient CSV parsers.
- New integration tests (real ParadeDB): in-index query shape for exclusion + multi-type, and the per-company cap spreading results. 10/10 pass locally; unit suite 3471/3471.