### PR TITLE
fix(sec): resolve retired CUSIP aliases in NPORT fund-holdings lookup

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -105,7 +105,7 @@ public class NportTools
                     return $"No CUSIP is on record for {ticker}, so its fund ownership cannot be resolved from Form NPORT-P reports.";
 
                 var currentPositions = _nportRepository
-                    .GetHoldingsByCusip(stock.Cusip)
+                    .GetHoldingsByStockCusip(stock)
                     .Join(
                         _nportRepository.GetLatestPerSeries(DateOnly.MinValue),
                         h => h.NportFilingId,

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -47,6 +47,24 @@ public class NportFilingRepository : BaseRepository<NportFiling>
     }
 
     /// <summary>
+    /// The reported holding rows carrying the stock's current CUSIP or any of its retired-CUSIP
+    /// aliases (<see cref="CommonStockCusipAlias"/>), across all NPORT filings. After an issuer-level
+    /// CUSIP change a fund keeps reporting the position under the old CUSIP — a laggard filer for a
+    /// quarter or two, and every historical report forever — so the reverse lookup must match the
+    /// alias too, mirroring the 13F import-time alias union, or the fund reads as having exited.
+    /// </summary>
+    public IQueryable<NportHolding> GetHoldingsByStockCusip(CommonStock stock)
+    {
+        var cusips = DbContext
+            .Set<CommonStockCusipAlias>()
+            .Where(a => a.CommonStockId == stock.Id)
+            .Select(a => a.Cusip);
+        return DbContext
+            .Set<NportHolding>()
+            .Where(h => h.Cusip == stock.Cusip || cusips.Contains(h.Cusip));
+    }
+
+    /// <summary>
     /// Filings of a sweep-discovered series, identified by registrant CIK and series id (an id-less
     /// registrant collapses to its single fund). Lets the sweep tell whether it has stored this
     /// series before, so a later report holding none of our tracked stocks is still recorded as the

--- a/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
@@ -93,6 +93,32 @@ public class NportFundsHoldingStockToolTests : IDisposable
         result.Should().Contain("No fund reports a position in AAPL");
     }
 
+    [Fact]
+    public async Task GetFundsHoldingStock_PositionReportedUnderRetiredCusipAlias_IsResolved()
+    {
+        // The stock's issuer-level CUSIP changed: the current CUSIP is on the stock, the retired one
+        // is recorded as a CommonStockCusipAlias. A fund still reports the position under the OLD CUSIP
+        // (a laggard filer, and every historical report forever), so the reverse lookup must resolve it
+        // through the alias — mirroring the 13F import-time alias union — instead of showing the fund
+        // as having exited.
+        var stock = SeedStock("BBUC", cusip: "113006100");
+        _dbContext
+            .Set<CommonStockCusipAlias>()
+            .Add(new CommonStockCusipAlias { CommonStockId = stock.Id, Cusip = "11259V106" });
+        _dbContext.SaveChanges();
+
+        var fund = SeedStock("VOO", cusip: null, cik: "0000036405");
+        var filing = MakeFiling(fund.Id, "acc-current", new DateOnly(2025, 1, 31));
+        filing.Holdings.Add(MakeHolding("11259V106", 5_000_000m));
+        _dbContext.Set<NportFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundsHoldingStock("BBUC");
+
+        result.Should().Contain("VANGUARD INDEX FUNDS");
+        result.Should().Contain("1 current fund positions");
+    }
+
     private CommonStock SeedStock(string ticker, string cusip, string cik = null)
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

The reverse fund-holdings lookup (`GetFundsHoldingStock`) matched only a stock's current CUSIP. After an issuer-level CUSIP change, every fund position reported under the retired CUSIP — laggard filers for a quarter or two, and all historical NPORT-P reports forever — dropped out, so the funds read as having exited the position.

This mirrors the existing 13F import-time fix (`CommonStockCusipAlias`): resolve the union of the stock's current CUSIP and its recorded aliases.

## Code changes

- **`NportFilingRepository.GetHoldingsByStockCusip(CommonStock)`** — new query returning holding rows whose CUSIP is the stock's current CUSIP or any of its `CommonStockCusipAlias` rows (a correlated subquery; the current-CUSIP arm preserves the previous exact-match behavior for stocks with no alias).
- **`NportTools.GetFundsHoldingStock`** — uses the alias-aware lookup instead of `GetHoldingsByCusip(stock.Cusip)`.
- **Test** — `GetFundsHoldingStock_PositionReportedUnderRetiredCusipAlias_IsResolved`: a fund reporting a position under the stock's retired CUSIP now resolves through the alias. Fails on the old single-CUSIP match, passes with the fix; the existing four tests are unchanged and still green.

Consumed downstream by the commercial fund-holdings surfaces (portal "held by funds", REST `/v1` fund owners, agent tool), which adopt this method in EquiblesCommercial.
