### PR TITLE
fix(yahoo): store the cap's own share base when there is no EDGAR count

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -603,11 +603,11 @@ public class YahooPriceImportService
         );
 
         // A foreign private issuer (20-F/40-F filer) reports its cover-page count in ordinary
-        // shares, a different unit from the US-listed ADR Yahoo prices. Yahoo already returns a
-        // correct, self-consistent ADR market cap + ADR share count for the ticker, so reconciling
-        // it onto the EDGAR ordinary base would inflate market cap by the ADR ratio (e.g. Latam
-        // Airlines $16.7B -> $33T at ~2000x). Drop the EDGAR count for these issuers so Yahoo's ADR
-        // figures stand verbatim; the reconciliation stays in force for domestic 10-K/10-Q filers.
+        // shares, a different unit from the US-listed ADR Yahoo prices. Yahoo returns the correct
+        // market cap and the share base it was built on for the ticker, so reconciling it onto
+        // the EDGAR ordinary base would inflate market cap by the ADR ratio (e.g. Latam Airlines
+        // $16.7B -> $33T at ~2000x). Drop the EDGAR count for these issuers so Yahoo's figures
+        // stand verbatim; the reconciliation stays in force for domestic 10-K/10-Q filers.
         if (
             edgarShares != null
             && await sharesProvider.IsForeignPrivateIssuer(stock, cancellationToken)
@@ -628,23 +628,27 @@ public class YahooPriceImportService
         // threshold is deliberately far above any corporate-action lag (see
         // MaxPlausibleSameUnitRatio), so a lagging reverse split — where EDGAR is right and the
         // rescale must proceed (#3575) — cannot trip it.
+        var yahooShareBase = YahooShareBase(stats);
         if (
             edgarShares is > 0
-            && ShareBasisPlausibility.IsUnitMismatch(edgarShares.Value, YahooShareBase(stats))
+            && ShareBasisPlausibility.IsUnitMismatch(edgarShares.Value, yahooShareBase)
         )
             edgarShares = null;
 
         // Per-field conservative writes: only update on actual change, and never
         // overwrite a known value with 0 (treated as Yahoo "unknown" by the rest of
         // the codebase).
+        //
+        // Without an EDGAR base the stored pair comes entirely from Yahoo, and the share count
+        // must be the base Yahoo built its market cap on (impliedSharesOutstanding when provided
+        // — see YahooShareBase), NOT the quoted-listing sharesOutstanding. For a foreign ADR or
+        // OTC ordinary Yahoo's market cap is the full-company figure while sharesOutstanding
+        // counts only the US listing, so storing that count leaves the derived price
+        // (cap ÷ shares) off by the ADR ratio / listing mix (CYATY 21x, SNHIY 12.8x, JHPCY 26x).
         var changed = false;
-        if (
-            edgarShares == null
-            && stats.SharesOutstanding != 0
-            && stock.SharesOutStanding != stats.SharesOutstanding
-        )
+        if (edgarShares == null && yahooShareBase != 0 && stock.SharesOutStanding != yahooShareBase)
         {
-            stock.SharesOutStanding = stats.SharesOutstanding;
+            stock.SharesOutStanding = yahooShareBase;
             changed = true;
         }
         // When the EDGAR count is the authoritative base (not dropped above), store it here too —

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -872,6 +872,74 @@ public class YahooPriceImportServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Import_ForeignAdrWithFullCompanyCap_StoresYahooImpliedShareBase()
+    {
+        // A foreign ADR where Yahoo's market cap is the FULL-COMPANY figure (built on
+        // impliedSharesOutstanding) while sharesOutstanding counts only the US listing.
+        // Storing the listing count against the full-company cap leaves the derived price
+        // (cap ÷ shares) off by the ADR ratio / listing mix — CYATY read 21x the close. The
+        // share count stored must be the base the cap was built on, so the pair stays
+        // self-consistent.
+        var stock = CreateStock("CYATY", "Cyient Limited");
+        await SeedStocks(stock);
+
+        _sharesProvider.GetCurrentSharesOutstanding(stock).Returns(1_400_000_000L);
+        _sharesProvider.IsForeignPrivateIssuer(stock).Returns(true);
+
+        _yahooClient
+            .GetChart("CYATY", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new YahooChartData());
+        _yahooClient
+            .GetKeyStatistics("CYATY")
+            .Returns(
+                new KeyStatistics
+                {
+                    SharesOutstanding = 33_100_000,
+                    ImpliedSharesOutstanding = 700_000_000,
+                    MarketCapitalization = 16_380_000_000d,
+                }
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "CYATY");
+        updated.MarketCapitalization.Should().Be(16_380_000_000d);
+        updated.SharesOutStanding.Should().Be(700_000_000);
+    }
+
+    [Fact]
+    public async Task Import_NoEdgarFactWithFullCompanyCap_StoresYahooImpliedShareBase()
+    {
+        // Same listing-mix inconsistency for an OTC ordinary with no EDGAR fact at all (the
+        // provider returns null rather than the FPI guard dropping it): the stored share count
+        // must still be the base Yahoo built its cap on, not the single-listing count.
+        var stock = CreateStock("PCCYF", "PICC Property and Casualty Co.");
+        await SeedStocks(stock);
+
+        _sharesProvider.GetCurrentSharesOutstanding(stock).Returns((long?)null);
+
+        _yahooClient
+            .GetChart("PCCYF", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new YahooChartData());
+        _yahooClient
+            .GetKeyStatistics("PCCYF")
+            .Returns(
+                new KeyStatistics
+                {
+                    SharesOutstanding = 1_900_000_000,
+                    ImpliedSharesOutstanding = 22_200_000_000,
+                    MarketCapitalization = 298_100_000_000d,
+                }
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "PCCYF");
+        updated.MarketCapitalization.Should().Be(298_100_000_000d);
+        updated.SharesOutStanding.Should().Be(22_200_000_000);
+    }
+
+    [Fact]
     public async Task Import_GarbageSmallEdgarCount_KeepsYahooPairInsteadOfRescaling()
     {
         // ABTC's shape: the EDGAR-side count is orders of magnitude below any real basis (a


### PR DESCRIPTION
## Summary

When the key-stats sync has no EDGAR share base (foreign private issuers, unit-mismatch drops, or no EDGAR fact at all), it stored Yahoo's quoted-listing `sharesOutstanding` while keeping Yahoo's market cap verbatim. For foreign ADRs and OTC ordinaries the cap is the **full-company** figure (built on `impliedSharesOutstanding`) while `sharesOutstanding` counts only the US listing, so the stored pair disagreed by the ADR ratio / listing mix and the derived price (cap ÷ shares) read up to 83× the latest close — CYATY 21×, SNHIY 12.8×, JHPCY 25.7×, PBNNF 83× in the production scan (42 residual rows over $10B cap on 2026-07-13).

Fix: store the share base the cap was actually built on — `impliedSharesOutstanding` when Yahoo provides it, else the quoted count (unchanged behavior) — so the stored pair is always self-consistent. This is the same `YahooShareBase` definition the unit-mismatch guard already vets against, now hoisted to a single local shared by both.

Residual family 1 of daniel3303/EquiblesCommercial#5599.

## Code changes

- `src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — the no-EDGAR-base share write now stores `YahooShareBase(stats)` instead of `stats.SharesOutstanding`; the share base is computed once and shared with the unit-mismatch guard; comments updated (the FPI note no longer claims Yahoo's quoted pair is always self-consistent).
- `tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs` — two new tests: an FPI ADR whose cap is full-company (stores the implied base), and an OTC ordinary with no EDGAR fact at all (same). Existing tests pin the fallback when implied is absent.

## Testing

- `Equibles.IntegrationTests` YahooPriceImportServiceTests: 32/32 pass (2 new).
- `Equibles.UnitTests` ReconcileMarketCap + ShareBasisPlausibility: 27/27 pass.
- csharpier (pinned) run on both files.