### PR TITLE
feat(yahoo): land settled daily closes promptly with a fast price lane

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Configuration/YahooPriceScraperOptions.cs
+++ b/src/Equibles.Yahoo.HostedService/Configuration/YahooPriceScraperOptions.cs
@@ -2,4 +2,14 @@ using Equibles.Worker;
 
 namespace Equibles.Yahoo.HostedService.Configuration;
 
-public class YahooPriceScraperOptions : ScraperOptions { }
+public class YahooPriceScraperOptions : ScraperOptions
+{
+    /// <summary>
+    /// Minimum hours between enrichment sweeps (key statistics + company profile — 2 extra Yahoo
+    /// calls per stock, the bulk of a cycle's traffic). Price cycles run every
+    /// <see cref="ScraperOptions.SleepIntervalHours"/>; only cycles where this interval has
+    /// elapsed since the last enrichment sweep carry the enrichment calls, so the sleep interval
+    /// can be short (fresh daily closes) without multiplying the per-stock enrichment traffic.
+    /// </summary>
+    public int EnrichmentIntervalHours { get; set; } = 24;
+}

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -49,21 +49,33 @@ public class YahooPriceImportService
         _workerOptions = workerOptions.Value;
     }
 
-    public async Task Import(CancellationToken cancellationToken)
+    public Task Import(CancellationToken cancellationToken) =>
+        Import(includeEnrichment: true, cancellationToken);
+
+    /// <summary>
+    /// One price-sync cycle over the tracked universe. With <paramref name="includeEnrichment"/>
+    /// false only the incremental chart fetch runs per stock (1 Yahoo call, and none at all for a
+    /// stock that is already current — see the settled-trading-day gate in ImportTicker), so the
+    /// worker can run frequent cheap price cycles and reserve the key-statistics + company-profile
+    /// calls (2 extra Yahoo calls per stock, the bulk of a cycle's traffic) for a slower cadence.
+    /// </summary>
+    public async Task Import(bool includeEnrichment, CancellationToken cancellationToken)
     {
         var tickerMap = await _tickerMapService.Build(
             _workerOptions.TickersToSync,
             cancellationToken
         );
-        _logger.LogInformation("Starting Yahoo price sync for {Count} stocks", tickerMap.Count);
-
-        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        _logger.LogInformation(
+            "Starting Yahoo price sync for {Count} stocks (enrichment: {Enrichment})",
+            tickerMap.Count,
+            includeEnrichment ? "on" : "off"
+        );
 
         // Before the forward-only incremental append: reconcile any stock whose stored history is
         // on a pre-split basis. GetSyncStartDate only appends, so a split that landed after the
         // last sync leaves the old rows on the wrong basis (a discontinuity in the series). Re-pull
         // those stocks' full, fully-adjusted history and overwrite the stored rows (#2879).
-        await ReconcilePendingSplits(today, cancellationToken);
+        await ReconcilePendingSplits(DateOnly.FromDateTime(DateTime.UtcNow), cancellationToken);
 
         var totalInserted = 0;
 
@@ -78,12 +90,21 @@ public class YahooPriceImportService
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Resolved per ticker, not once per cycle: a multi-hour crawl straddles the UTC
+            // midnight rollover, and a cycle-start snapshot would keep excluding the just-settled
+            // bar for every stock processed after midnight — a cycle starting 23:50 UTC used to
+            // ship a whole day late for the entire universe.
+            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
             try
             {
                 var inserted = await ImportTicker(ticker, commonStockId, today, cancellationToken);
                 totalInserted += inserted;
-                await SyncKeyStatistics(ticker, commonStockId, cancellationToken);
-                await SyncCompanyProfile(ticker, commonStockId, cancellationToken);
+                if (includeEnrichment)
+                {
+                    await SyncKeyStatistics(ticker, commonStockId, cancellationToken);
+                    await SyncCompanyProfile(ticker, commonStockId, cancellationToken);
+                }
             }
             catch (HttpRequestException ex)
             {
@@ -397,9 +418,26 @@ public class YahooPriceImportService
     // wrong twice over — the "Close" is really an intraday snapshot, and the importer is insert-only
     // (a date already present is never updated, see PersistPrices), so that partial bar freezes and
     // the real close never overwrites it. Only store bars strictly before the current UTC date; the
-    // day's settled bar is appended on the next cycle once the date has rolled over (always after a
-    // US market close), so the daily series holds settled closes only.
+    // day's settled bar is appended by the first pass over the stock after the date has rolled over
+    // (always after a US market close), so the daily series holds settled closes only.
     private static bool IsSettledDailyBar(DateOnly barDate, DateOnly today) => barDate < today;
+
+    // A chart fetch can only yield new rows when at least one NYSE trading day lies in
+    // [startDate, today) — the dates that are both unsynced and already settled. Gating the fetch
+    // on that keeps frequent price cycles cheap: a stock that is already current costs zero Yahoo
+    // calls until the next settled session exists, and weekend/holiday cycles are no-ops for the
+    // whole universe instead of ~8k fruitless chart calls each. An empty window (startDate >=
+    // today) is covered by the same rule. Full-day non-NYSE closures aren't modeled, so at worst a
+    // stock is fetched and yields nothing — never skipped when a settled bar could exist.
+    private static bool HasSettledTradingDay(DateOnly startDate, DateOnly today)
+    {
+        for (var date = startDate; date < today; date = date.AddDays(1))
+        {
+            if (UsMarketCalendar.IsTradingDay(date))
+                return true;
+        }
+        return false;
+    }
 
     private async Task<int> ImportTicker(
         string ticker,
@@ -409,7 +447,7 @@ public class YahooPriceImportService
     )
     {
         var startDate = await GetSyncStartDate(commonStockId, cancellationToken);
-        if (startDate >= today)
+        if (!HasSettledTradingDay(startDate, today))
             return 0;
 
         // One chart fetch yields the price bars plus any split and dividend

--- a/src/Equibles.Yahoo.HostedService/YahooPriceScraperWorker.cs
+++ b/src/Equibles.Yahoo.HostedService/YahooPriceScraperWorker.cs
@@ -13,6 +13,15 @@ namespace Equibles.Yahoo.HostedService;
 public class YahooPriceScraperWorker : BaseScraperWorker
 {
     private readonly WorkerOptions _workerOptions;
+    private readonly TimeSpan _enrichmentInterval;
+
+    // UTC stamp of the last cycle that carried the enrichment calls. In-memory on purpose, which
+    // means every process start RE-RUNS enrichment on its first cycle (default stamp = due). That
+    // errs on the side of extra traffic, never staleness — and is bounded: the pre-split behavior
+    // carried enrichment on every single cycle, so even one restart per cycle merely matches the
+    // old traffic, while seeding the stamp at startup instead would let frequent deploys starve
+    // enrichment indefinitely. Persisting the stamp buys nothing worth a schema change.
+    private DateTime _lastEnrichmentAt;
 
     protected override string WorkerName => "Yahoo price scraper";
     protected override TimeSpan SleepInterval { get; }
@@ -28,8 +37,17 @@ public class YahooPriceScraperWorker : BaseScraperWorker
         : base(logger, scopeFactory, errorReporter)
     {
         SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+        _enrichmentInterval = TimeSpan.FromHours(options.Value.EnrichmentIntervalHours);
         _workerOptions = workerOptions.Value;
     }
+
+    // Pure so the cadence rule is pinnable in tests: enrichment rides along only when the
+    // configured interval has elapsed since the last enrichment-carrying cycle (or none ran yet).
+    private static bool IsEnrichmentDue(
+        DateTime lastEnrichmentAt,
+        DateTime now,
+        TimeSpan enrichmentInterval
+    ) => lastEnrichmentAt == default || now - lastEnrichmentAt >= enrichmentInterval;
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
@@ -48,7 +66,17 @@ public class YahooPriceScraperWorker : BaseScraperWorker
             return;
         }
 
+        var includeEnrichment = IsEnrichmentDue(
+            _lastEnrichmentAt,
+            DateTime.UtcNow,
+            _enrichmentInterval
+        );
         var importService = scope.ServiceProvider.GetRequiredService<YahooPriceImportService>();
-        await importService.Import(stoppingToken);
+        await importService.Import(includeEnrichment, stoppingToken);
+
+        // Stamp only after the sweep ran to completion — an interrupted enrichment cycle (deploy,
+        // crash) leaves the stamp unset so the next cycle retries it.
+        if (includeEnrichment)
+            _lastEnrichmentAt = DateTime.UtcNow;
     }
 }

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSettledTradingDayGateTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSettledTradingDayGateTests.cs
@@ -1,0 +1,95 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Pins <c>YahooPriceImportService.HasSettledTradingDay</c>, the gate that lets a price cycle
+/// skip the chart fetch when no new settled bar can exist for a stock: only when at least one
+/// NYSE trading day lies in [startDate, today) can Yahoo have a new row to return. The gate is
+/// what makes frequent price cycles affordable — a current stock costs zero Yahoo calls until the
+/// next session settles, and weekend/holiday cycles are no-ops for the whole universe. The
+/// dangerous regression is a gate that returns false when a settled bar COULD exist (prices stop
+/// updating silently), so the admitting cases are pinned as tightly as the skipping ones.
+/// </summary>
+public class YahooPriceImportServiceSettledTradingDayGateTests
+{
+    private static readonly MethodInfo HasSettledTradingDayMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "HasSettledTradingDay",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static bool HasSettledTradingDay(DateOnly startDate, DateOnly today) =>
+        (bool)HasSettledTradingDayMethod.Invoke(null, [startDate, today]);
+
+    [Fact]
+    public void HasSettledTradingDay_StockAlreadyCurrent_Skips()
+    {
+        // startDate == today: the window is empty — nothing unsynced is settled yet. This is the
+        // steady state of every fast cycle after the day's bar landed; it must cost no fetch.
+        var tuesday = new DateOnly(2026, 7, 14);
+        HasSettledTradingDay(tuesday, tuesday).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasSettledTradingDay_StartDateAfterToday_Skips()
+    {
+        // Defensive: a start date past today (clock skew, MaxValue sentinel) yields an empty
+        // window, not an infinite loop or a fetch.
+        var tuesday = new DateOnly(2026, 7, 14);
+        HasSettledTradingDay(tuesday.AddDays(1), tuesday).Should().BeFalse();
+        HasSettledTradingDay(DateOnly.MaxValue, tuesday).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasSettledTradingDay_WeekdaySettled_Fetches()
+    {
+        // Monday's bar settled, Tuesday cycle: [Mon, Tue) holds one trading day — must fetch.
+        var monday = new DateOnly(2026, 7, 13);
+        var tuesday = new DateOnly(2026, 7, 14);
+        HasSettledTradingDay(monday, tuesday).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSettledTradingDay_WeekendWindow_Skips()
+    {
+        // Friday's bar stored, so startDate is Saturday. Cycles on Saturday, Sunday, and Monday
+        // itself see only weekend dates in the window (Monday's own session is still live) —
+        // every one of them must skip.
+        var saturday = new DateOnly(2026, 7, 11);
+        HasSettledTradingDay(saturday, new DateOnly(2026, 7, 12)).Should().BeFalse(); // Sunday
+        HasSettledTradingDay(saturday, new DateOnly(2026, 7, 13)).Should().BeFalse(); // Monday
+    }
+
+    [Fact]
+    public void HasSettledTradingDay_MondaySettled_TuesdayFetches()
+    {
+        // Same weekend window one day later: [Sat, Tue) now contains Monday's settled session, so
+        // the skip must end exactly here — a gate that keeps skipping stops price updates cold.
+        var saturday = new DateOnly(2026, 7, 11);
+        HasSettledTradingDay(saturday, new DateOnly(2026, 7, 14)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSettledTradingDay_HolidayWeekendWindow_Skips()
+    {
+        // Independence Day 2026 falls on a Saturday, observed Friday July 3 — a three-day
+        // non-trading stretch. With Thursday July 2 stored, cycles up to and including Monday
+        // July 6 see only the holiday + weekend in the window and must skip.
+        var friday = new DateOnly(2026, 7, 3); // observed holiday
+        HasSettledTradingDay(friday, new DateOnly(2026, 7, 6)).Should().BeFalse();
+        // Tuesday's cycle sees Monday July 6 settled — fetch resumes.
+        HasSettledTradingDay(friday, new DateOnly(2026, 7, 7)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSettledTradingDay_NeverSyncedStock_Fetches()
+    {
+        // A stock with no stored prices starts at the 2020 floor — years of settled sessions in
+        // the window, must always fetch.
+        HasSettledTradingDay(new DateOnly(2020, 1, 1), new DateOnly(2026, 7, 14))
+            .Should()
+            .BeTrue();
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceScraperWorkerEnrichmentCadenceTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceScraperWorkerEnrichmentCadenceTests.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Pins <c>YahooPriceScraperWorker.IsEnrichmentDue</c>, the rule that decides which price cycles
+/// carry the key-statistics + company-profile calls (2 extra Yahoo calls per stock — the bulk of
+/// a cycle's traffic). Price cycles run frequently for fresh closes; enrichment must ride along
+/// only once per configured interval. Both failure directions matter: enriching every fast cycle
+/// multiplies Yahoo traffic ~12x (rate-limit bans), while never enriching lets market cap and
+/// shares outstanding go permanently stale.
+/// </summary>
+public class YahooPriceScraperWorkerEnrichmentCadenceTests
+{
+    private static readonly MethodInfo IsEnrichmentDueMethod =
+        typeof(YahooPriceScraperWorker).GetMethod(
+            "IsEnrichmentDue",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static bool IsEnrichmentDue(
+        DateTime lastEnrichmentAt,
+        DateTime now,
+        TimeSpan enrichmentInterval
+    ) => (bool)IsEnrichmentDueMethod.Invoke(null, [lastEnrichmentAt, now, enrichmentInterval]);
+
+    private static readonly DateTime Now = new(2026, 7, 15, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
+
+    [Fact]
+    public void IsEnrichmentDue_NeverEnriched_IsDue()
+    {
+        // A fresh worker (default stamp) must enrich on its first cycle — a restart may only
+        // delay enrichment, never skip it.
+        IsEnrichmentDue(default, Now, Interval).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEnrichmentDue_IntervalNotElapsed_IsNotDue()
+    {
+        // A fast price cycle inside the interval must stay prices-only, or every 2h cycle carries
+        // the full ~17k enrichment calls and Yahoo rate-limits the lane.
+        IsEnrichmentDue(Now.AddHours(-2), Now, Interval).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEnrichmentDue_IntervalElapsed_IsDue()
+    {
+        // At or past the interval the cycle must enrich again, or key stats go stale forever.
+        IsEnrichmentDue(Now.AddHours(-24), Now, Interval).Should().BeTrue();
+        IsEnrichmentDue(Now.AddHours(-30), Now, Interval).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Daily closes were landing up to two days late. Three compounding causes in the price scraper:

1. `today` was resolved once at cycle start, so a multi-hour crawl that straddled the UTC midnight rollover excluded the just-settled bar for the entire universe (a cycle starting 23:50 UTC shipped a whole day late).
2. Every cycle carried 3 Yahoo calls per stock (chart + key statistics + company profile ≈ 25k requests for ~8.4k stocks), making a cycle take ~14h — far too heavy to run often.
3. The host default of `SleepIntervalHours = 24` stacked on top, for an effective cadence of ~1.5 days.

This PR makes frequent, cheap price cycles possible so settled closes are visible within hours of UTC midnight.

## Code changes

- **`YahooPriceImportService`**
  - `today` is now resolved per ticker inside the crawl loop, fixing the midnight-straddle staleness.
  - New `HasSettledTradingDay(startDate, today)` gate: the chart fetch runs only when at least one NYSE trading day (via the existing `UsMarketCalendar`) lies in `[startDate, today)`. A stock that is already current costs zero Yahoo calls until the next session settles, and weekend/holiday cycles are no-ops for the whole universe. The gate can only err toward fetching (never skips a fetchable settled bar), and split/dividend capture is unaffected because ex-dates are always trading days.
  - New `Import(bool includeEnrichment, ...)` overload; the parameterless-behavior `Import(CancellationToken)` overload is preserved (enrichment on) for existing callers.
- **`YahooPriceScraperWorker`**
  - Carries key-statistics + company-profile enrichment (2 of the 3 per-stock calls) only on cycles where the new `YahooPriceScraper:EnrichmentIntervalHours` (default 24) has elapsed since the last enrichment-carrying cycle; stamped only after a completed sweep so an interrupted cycle retries.
- **`YahooPriceScraperOptions`** — new `EnrichmentIntervalHours` option.
- **Tests** — two new unit suites pin the trading-day gate (weekend, observed-holiday, never-synced, boundary cases) and the enrichment cadence rule.

## Testing

- Full unit suite: 3,486 passed.
- Yahoo integration suite (Testcontainers): 98 passed.