### PR TITLE
fix(sec): make the NPORT reverse-holdings queries plannable at scale

### DIFF
--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -52,16 +52,32 @@ public class NportFilingRepository : BaseRepository<NportFiling>
     /// CUSIP change a fund keeps reporting the position under the old CUSIP — a laggard filer for a
     /// quarter or two, and every historical report forever — so the reverse lookup must match the
     /// alias too, mirroring the 13F import-time alias union, or the fund reads as having exited.
+    ///
+    /// The current CUSIP is unioned into the alias subquery (read off the stock's own row) rather
+    /// than OR-ed as a separate predicate: <c>Cusip = $1 OR Cusip IN (subquery)</c> defeats the
+    /// CUSIP index and degrades to a full scan of the holdings table, while a single
+    /// <c>Cusip IN (subquery)</c> plans as an index semi-join. Stocks without a CUSIP have no
+    /// NPORT identity, so the lookup is empty for them (callers guard, and a NULL never matches
+    /// an IN) — cusip-less holding rows (bonds, foreign instruments) are never swept in.
     /// </summary>
     public IQueryable<NportHolding> GetHoldingsByStockCusip(CommonStock stock)
     {
+        // The explicit not-null filters on both legs let EF's nullability analysis emit the
+        // membership test as a plain equality semi-join instead of null-compensating it into
+        // "= OR both-null", which would defeat the CUSIP index the same way the OR did.
         var cusips = DbContext
             .Set<CommonStockCusipAlias>()
             .Where(a => a.CommonStockId == stock.Id)
-            .Select(a => a.Cusip);
+            .Select(a => a.Cusip)
+            .Union(
+                DbContext
+                    .Set<CommonStock>()
+                    .Where(s => s.Id == stock.Id && s.Cusip != null)
+                    .Select(s => s.Cusip)
+            );
         return DbContext
             .Set<NportHolding>()
-            .Where(h => h.Cusip == stock.Cusip || cusips.Contains(h.Cusip));
+            .Where(h => h.Cusip != null && cusips.Contains(h.Cusip));
     }
 
     /// <summary>
@@ -104,36 +120,106 @@ public class NportFilingRepository : BaseRepository<NportFiling>
     ///
     /// The latest report is the one with the greatest report period, breaking ties by filing date
     /// and then accession number so amendments and re-filings of the same period win.
+    ///
+    /// The supersedes check is split into three registrant-population branches (tracked-stock
+    /// filings, CIK-scoped trust filings, identity-less filings) concatenated with UNION ALL,
+    /// rather than one anti-join whose identity condition ORs the populations together: a filing
+    /// only ever competes with filings of its own population, and the OR form gives the anti-join
+    /// no hashable key, degrading it to an O(N²) nested loop over every pair of filings (observed
+    /// at ~8 s per call). Each branch leads with a plain equality on its population's key, so the
+    /// planner hash-partitions the anti-join and the whole dedup runs in milliseconds. The series
+    /// wildcard and newer-report conditions are identical in every branch.
     /// </summary>
     public IQueryable<NportFiling> GetLatestPerSeries(DateOnly floor)
     {
         var filings = GetAll().Where(f => f.ReportPeriodDate >= floor);
-        return filings.Where(f =>
-            !filings.Any(f2 =>
-                (
-                    (f.CommonStockId != null && f2.CommonStockId == f.CommonStockId)
-                    || (
-                        f.CommonStockId == null
-                        && f2.CommonStockId == null
-                        && f2.RegistrantCik == f.RegistrantCik
+
+        // Tracked funds: scoped by CommonStockId.
+        var trackedFunds = filings
+            .Where(f => f.CommonStockId != null)
+            .Where(f =>
+                !filings.Any(f2 =>
+                    f2.CommonStockId == f.CommonStockId
+                    && (
+                        f2.SeriesId == f.SeriesId
+                        || string.IsNullOrEmpty(f.SeriesId)
+                        || string.IsNullOrEmpty(f2.SeriesId)
+                    )
+                    && (
+                        f2.ReportPeriodDate > f.ReportPeriodDate
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate > f.FilingDate
+                        )
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate == f.FilingDate
+                            && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+                        )
                     )
                 )
-                && (
-                    f2.SeriesId == f.SeriesId
-                    || string.IsNullOrEmpty(f.SeriesId)
-                    || string.IsNullOrEmpty(f2.SeriesId)
-                )
-                && (
-                    f2.ReportPeriodDate > f.ReportPeriodDate
-                    || (f2.ReportPeriodDate == f.ReportPeriodDate && f2.FilingDate > f.FilingDate)
-                    || (
-                        f2.ReportPeriodDate == f.ReportPeriodDate
-                        && f2.FilingDate == f.FilingDate
-                        && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+            );
+
+        // Sweep-discovered trusts: stock-less, scoped by RegistrantCik. The redundant
+        // f.RegistrantCik != null inside the anti-join lambda lets EF's nullability analysis
+        // emit a plain (hashable) equality instead of null-compensating it into
+        // "= OR both-null" — which would give the anti-join no hash key again.
+        var trustSeries = filings
+            .Where(f => f.CommonStockId == null && f.RegistrantCik != null)
+            .Where(f =>
+                !filings.Any(f2 =>
+                    f2.CommonStockId == null
+                    && f.RegistrantCik != null
+                    && f2.RegistrantCik == f.RegistrantCik
+                    && (
+                        f2.SeriesId == f.SeriesId
+                        || string.IsNullOrEmpty(f.SeriesId)
+                        || string.IsNullOrEmpty(f2.SeriesId)
+                    )
+                    && (
+                        f2.ReportPeriodDate > f.ReportPeriodDate
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate > f.FilingDate
+                        )
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate == f.FilingDate
+                            && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+                        )
                     )
                 )
-            )
-        );
+            );
+
+        // Identity-less filings (no stock, no CIK): they all share one identity, mirroring the
+        // original OR form's null-equals-null arm. Empty in practice, kept for equivalence.
+        var identityless = filings
+            .Where(f => f.CommonStockId == null && f.RegistrantCik == null)
+            .Where(f =>
+                !filings.Any(f2 =>
+                    f2.CommonStockId == null
+                    && f2.RegistrantCik == null
+                    && (
+                        f2.SeriesId == f.SeriesId
+                        || string.IsNullOrEmpty(f.SeriesId)
+                        || string.IsNullOrEmpty(f2.SeriesId)
+                    )
+                    && (
+                        f2.ReportPeriodDate > f.ReportPeriodDate
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate > f.FilingDate
+                        )
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate == f.FilingDate
+                            && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+                        )
+                    )
+                )
+            );
+
+        return trackedFunds.Concat(trustSeries).Concat(identityless);
     }
 
     /// <summary>

--- a/tests/Equibles.UnitTests/Sec/NportFilingRepositoryQueryTranslationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/NportFilingRepositoryQueryTranslationTests.cs
@@ -1,0 +1,83 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Media.Data;
+using Equibles.Sec.Data;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the SQL shapes that keep the NPORT reverse-holdings path plannable. Both queries were
+/// observed at multiple seconds per call at production scale before being restructured
+/// (~9.5 s per stock-summary render): the CUSIP lookup OR-ed a constant with an uncorrelated
+/// subquery (which defeats the CUSIP index and degrades to a full scan of the 25M-row holdings
+/// table), and the latest-per-series dedup OR-ed its registrant-population identity legs into
+/// one anti-join condition (no hashable key → an O(N²) nested loop over every filing pair).
+/// <c>ToQueryString</c> runs the full Npgsql translation pipeline offline, so an EF upgrade or
+/// refactor that regresses either shape fails here instead of on every stock page render.
+/// </summary>
+public class NportFilingRepositoryQueryTranslationTests
+{
+    private static EquiblesFinancialDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only", o => o.UseVector())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        return new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new MediaModuleConfiguration(),
+                new SecModuleConfiguration(),
+            }
+        );
+    }
+
+    [Fact]
+    public void GetHoldingsByStockCusip_TranslatesToASingleInSemiJoin_NeverAnOr()
+    {
+        using var ctx = CreateContext();
+        var repository = new NportFilingRepository(ctx);
+
+        var sql = repository
+            .GetHoldingsByStockCusip(
+                new CommonStock { Id = Guid.NewGuid(), Cusip = "037833100" }
+            )
+            .ToQueryString();
+
+        // The current CUSIP must ride inside the alias subquery (UNION), never as a separate
+        // OR-ed predicate — "Cusip = $1 OR Cusip IN (subquery)" is unplannable via the index.
+        sql.ToUpperInvariant().Should().Contain("UNION");
+        sql.ToUpperInvariant().Should().NotContain(" OR ");
+    }
+
+    [Fact]
+    public void GetLatestPerSeries_TranslatesToPartitionedBranches_WithHashableIdentityKeys()
+    {
+        using var ctx = CreateContext();
+        var repository = new NportFilingRepository(ctx);
+
+        var sql = repository.GetLatestPerSeries(new DateOnly(2024, 1, 1)).ToQueryString();
+        var flat = System.Text.RegularExpressions.Regex.Replace(sql, @"\s+", " ");
+
+        // One branch per registrant population, concatenated — never one OR-ed identity.
+        System.Text.RegularExpressions.Regex
+            .Matches(flat, "UNION ALL")
+            .Count.Should()
+            .Be(2);
+
+        // The trust branch's anti-join must keep a bare RegistrantCik equality: EF null
+        // compensation ("= OR both-null") would strip the anti-join of its hash key and
+        // regress it to the O(N²) nested loop. The in-lambda "f.RegistrantCik != null"
+        // guard is what keeps the compensation out — pin that it worked.
+        flat.Should()
+            .NotMatchRegex(
+                "\"RegistrantCik\" = \\w+\\.\"RegistrantCik\"\\)? OR",
+                "the RegistrantCik anti-join key must stay a plain hashable equality"
+            );
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/NportFilingRepositoryQueryTranslationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/NportFilingRepositoryQueryTranslationTests.cs
@@ -44,9 +44,7 @@ public class NportFilingRepositoryQueryTranslationTests
         var repository = new NportFilingRepository(ctx);
 
         var sql = repository
-            .GetHoldingsByStockCusip(
-                new CommonStock { Id = Guid.NewGuid(), Cusip = "037833100" }
-            )
+            .GetHoldingsByStockCusip(new CommonStock { Id = Guid.NewGuid(), Cusip = "037833100" })
             .ToQueryString();
 
         // The current CUSIP must ride inside the alias subquery (UNION), never as a separate
@@ -65,10 +63,7 @@ public class NportFilingRepositoryQueryTranslationTests
         var flat = System.Text.RegularExpressions.Regex.Replace(sql, @"\s+", " ");
 
         // One branch per registrant population, concatenated — never one OR-ed identity.
-        System.Text.RegularExpressions.Regex
-            .Matches(flat, "UNION ALL")
-            .Count.Should()
-            .Be(2);
+        System.Text.RegularExpressions.Regex.Matches(flat, "UNION ALL").Count.Should().Be(2);
 
         // The trust branch's anti-join must keep a bare RegistrantCik equality: EF null
         // compensation ("= OR both-null") would strip the anti-join of its hash key and


### PR DESCRIPTION
## Summary

The two query shapes behind the "funds holding this stock" lookup were unplannable at production scale and dominated every consumer's latency (~9.5s per cold stock-summary render on the commercial portal; same cost in the MCP/REST GetFundsHoldingStock tools and the fund-series directory rebuild):

1. **`GetHoldingsByStockCusip`** — `Cusip = $1 OR Cusip IN (subquery)` defeats the CUSIP index (Postgres cannot index an OR between a constant and an uncorrelated subquery) and degrades to a full scan of the 25M-row holdings table (~5s). The current CUSIP now rides inside the alias subquery via `UNION`, and explicit not-null filters keep EF's null compensation from reintroducing the OR. Plans as an index semi-join: **0.3ms** measured on production data.

2. **`GetLatestPerSeries`** — the anti-join's identity condition OR-ed the registrant populations together, leaving no hashable key → O(N²) nested loop (10,342² = 85M join-filter evaluations, ~8s). A filing only ever competes with filings of its own population (the identity legs are mutually exclusive), so the dedup is now three partition-scoped branches concatenated with UNION ALL, each leading with a plain hashable equality: **~18ms** measured, with an identical result set (7,621 = 7,621 rows on production data).

## Code changes

- `src/Equibles.Sec.Repositories/NportFilingRepository.cs` — both query rewrites, with comments explaining why the shapes matter (incl. the redundant in-lambda not-null guard that keeps EF from null-compensating the RegistrantCik equality).
- `tests/Equibles.UnitTests/Sec/NportFilingRepositoryQueryTranslationTests.cs` — new ToQueryString translation tests pinning both shapes (no OR in the CUSIP lookup; two UNION ALLs + a bare RegistrantCik equality in the dedup), so a regression fails offline instead of on every stock page.

## Verification

- Semantics: existing `NportFilingRepositoryTests` + `NportFundHoldingsToolTests` (19 tests) pass; both rewrites produce identical row sets on production data (raw-SQL A/B).
- Plans: EXPLAIN ANALYZE on production — 0.335ms (was ~5s) and 17.8ms (was ~8s).
- Full unit suite: 3488/3488 green. Integration suite: 2060/2065 — the 5 failures are the `YahooPriceImportServiceCompanyProfile*` tests, already red on main (introduced by #4155), unrelated to this diff.