### PR TITLE
feat(mcp): add shared McpOutput helpers for MCP tool responses

### DIFF
--- a/src/Equibles.Mcp/Helpers/McpOutput.cs
+++ b/src/Equibles.Mcp/Helpers/McpOutput.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+
+namespace Equibles.Mcp.Helpers;
+
+public static class McpOutput
+{
+    // Appended after a truncated result set so the model knows more rows exist and which
+    // argument raises the cap. Returns the empty string when nothing was cut off, so callers
+    // can append it unconditionally.
+    public static string TruncationNote(int shown, int total, string argumentName = "maxResults") =>
+        shown >= total
+            ? string.Empty
+            : $"_Showing first {shown} of {total} results - raise {argumentName} to see more._";
+
+    // Strict ISO yyyy-MM-dd parse in invariant culture. Rejects any other format so a typo or
+    // locale-shaped date can't silently parse into a different day and shift the requested range.
+    public static bool TryParseDate(string input, out DateTime date) =>
+        DateTime.TryParseExact(
+            input?.Trim(),
+            "yyyy-MM-dd",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out date
+        );
+
+    // Consistent one-line rejection for an argument value outside the accepted set, so every
+    // tool phrases the correction the same way for the model.
+    public static string InvalidArgument(string argumentName, string value, string accepted) =>
+        $"Unknown {argumentName} '{value}'. Accepted: {accepted}.";
+}


### PR DESCRIPTION
## Summary
Adds one small dependency-free static helper class, `McpOutput`, to `Equibles.Mcp/Helpers` (next to `McpLimit`/`McpFormat`) so every `*.Mcp` module can emit consistent tool output during the MCP audit-fix campaign.

## Code changes
- New `src/Equibles.Mcp/Helpers/McpOutput.cs`:
  - `TruncationNote(int shown, int total, string argumentName = "maxResults")` — markdown note appended after a truncated result set; empty string when nothing was cut off so callers can append unconditionally.
  - `TryParseDate(string input, out DateTime date)` — strict ISO `yyyy-MM-dd` parse in invariant culture (mirrors the existing `TryParseBound` pattern in `FinancialFactsTools`), no silent locale fallback.
  - `InvalidArgument(string argumentName, string value, string accepted)` — consistent one-line rejection: `Unknown {argumentName} '{value}'. Accepted: {accepted}.`