### PR TITLE
fix(mcp): honest transaction labels, split-adjusted ownership ranking, and insider search affiliation

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Equibles.InsiderTrading.Mcp.csproj
+++ b/src/Equibles.InsiderTrading.Mcp/Equibles.InsiderTrading.Mcp.csproj
@@ -9,5 +9,6 @@
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -1,11 +1,14 @@
 using System.ComponentModel;
 using System.Globalization;
+using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Core.Extensions;
 using Equibles.CorporateActions.Data;
 using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -48,13 +51,59 @@ public class InsiderTradingTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
+    // User-facing labels accepted by the transactionType argument. Buy/Sell alias the
+    // Purchase/Sale codes because those are the labels the table renders; Holding is
+    // deliberately absent — position snapshots are excluded from transaction lists
+    // (see ExcludeHoldings).
+    private static readonly Dictionary<string, TransactionCode> TransactionTypeAliases = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        ["Buy"] = TransactionCode.Purchase,
+        ["Purchase"] = TransactionCode.Purchase,
+        ["Sell"] = TransactionCode.Sale,
+        ["Sale"] = TransactionCode.Sale,
+        ["Award"] = TransactionCode.Award,
+        ["Conversion"] = TransactionCode.Conversion,
+        ["Exercise"] = TransactionCode.Exercise,
+        ["TaxPayment"] = TransactionCode.TaxPayment,
+        ["Tax Payment"] = TransactionCode.TaxPayment,
+        ["Expiration"] = TransactionCode.Expiration,
+        ["Gift"] = TransactionCode.Gift,
+        ["Inheritance"] = TransactionCode.Inheritance,
+        ["Discretionary"] = TransactionCode.Discretionary,
+        ["Other"] = TransactionCode.Other,
+    };
+
+    private const string AcceptedTransactionTypes =
+        "Buy, Sell, Award, Conversion, Exercise, TaxPayment, Expiration, Gift, Inheritance, Discretionary, Other";
+
     [McpServerTool(Name = "GetInsiderTransactions")]
     [Description(
-        "Get recent insider trading transactions (purchases, sales, awards) for a stock from SEC Form 3 and Form 4 filings. Shows insider name, role, transaction type, shares, price, and post-transaction ownership. Use this to understand insider buying/selling activity."
+        "Get recent insider trading transactions for a stock from SEC Form 3/4/5 filings, newest first. The Type column carries the SEC transaction code meaning: 'Buy'/'Sell' are open-market purchases/sales only, while Award, Conversion, Exercise, Tax Payment, Expiration, Gift, Inheritance, Discretionary and Other are compensation or derivative mechanics — not conviction trades. The 10b5-1 column marks trades made under a pre-arranged Rule 10b5-1 plan ('-' = filing predates the 2023 checkbox). Per-row Shares/Price/Value are as filed; Owned After is the post-transaction balance restated onto today's split basis, tracked per security kind and ownership form. Supports optional date-range, transaction-type and insider-name filters to reach history beyond the newest rows. Use this to understand insider buying/selling activity."
     )]
     public Task<string> GetInsiderTransactions(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
-        [Description("Maximum number of transactions to return (default: 50)")] int maxResults = 50
+        [Description(
+            "Maximum number of transactions to return (default: 50, max: 500; values outside 1-500 are clamped)"
+        )]
+            int maxResults = 50,
+        [Description(
+            "Only include transactions on or after this date, format yyyy-MM-dd (optional)"
+        )]
+            string fromDate = null,
+        [Description(
+            "Only include transactions on or before this date, format yyyy-MM-dd (optional)"
+        )]
+            string toDate = null,
+        [Description(
+            "Only include one transaction type: Buy, Sell, Award, Conversion, Exercise, TaxPayment, Expiration, Gift, Inheritance, Discretionary or Other (optional)"
+        )]
+            string transactionType = null,
+        [Description(
+            "Only include transactions by insiders whose SEC-filed name contains every word of this value, case-insensitive (e.g. 'Huang') (optional)"
+        )]
+            string insiderName = null
     )
     {
         return _runner.Execute(
@@ -66,12 +115,71 @@ public class InsiderTradingTools
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var transactions = await _transactionRepository
+                var query = _transactionRepository
                     .GetByStockWithOwner(stock)
                     .ExcludeHoldings()
+                    // Degenerate rows (zero shares AND zero resulting balance — e.g. a Form 3
+                    // filed by an insider owning nothing) carry no information and would burn
+                    // maxResults slots.
+                    .Where(t => t.Shares != 0 || t.SharesOwnedAfter != 0);
+
+                var filtered = false;
+                if (!string.IsNullOrWhiteSpace(fromDate))
+                {
+                    if (!McpOutput.TryParseDate(fromDate, out var from))
+                        return McpOutput.InvalidArgument("fromDate", fromDate, "yyyy-MM-dd");
+                    var fromDay = DateOnly.FromDateTime(from);
+                    query = query.Where(t => t.TransactionDate >= fromDay);
+                    filtered = true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(toDate))
+                {
+                    if (!McpOutput.TryParseDate(toDate, out var to))
+                        return McpOutput.InvalidArgument("toDate", toDate, "yyyy-MM-dd");
+                    var toDay = DateOnly.FromDateTime(to);
+                    query = query.Where(t => t.TransactionDate <= toDay);
+                    filtered = true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(transactionType))
+                {
+                    if (!TransactionTypeAliases.TryGetValue(transactionType.Trim(), out var code))
+                        return McpOutput.InvalidArgument(
+                            "transactionType",
+                            transactionType,
+                            AcceptedTransactionTypes
+                        );
+                    query = query.Where(t => t.TransactionCode == code);
+                    filtered = true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(insiderName))
+                {
+                    // Same token-AND contains contract as SearchInsiders, against the
+                    // SEC-filed legal name.
+                    foreach (
+                        var token in insiderName.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                    )
+                    {
+                        var pattern = LikePattern.Contains(token);
+                        query = query.Where(t =>
+                            EF.Functions.ILike(t.InsiderOwner.Name, pattern, LikePattern.EscapeChar)
+                        );
+                    }
+                    filtered = true;
+                }
+
+                var total = await query.CountAsync();
+                var transactions = await query
                     .OrderByDescending(t => t.TransactionDate)
                     .Take(maxResults)
                     .ToListAsync();
+
+                if (transactions.Count == 0)
+                    return filtered
+                        ? $"No insider transactions found for {stock.Ticker} matching the given filters."
+                        : $"No insider transactions found for {stock.Ticker}.";
 
                 // Each row is an as-filed record: the per-row Shares, Price, and Value stay
                 // exactly as reported so Shares × Price = Value holds within the row (the total
@@ -81,22 +189,33 @@ public class InsiderTradingTools
                 // so it alone is restated onto today's split basis.
                 var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
 
-                return MarkdownTable.Render(
+                var sb = new StringBuilder();
+                sb.AppendLine($"Recent insider transactions for {stock.Name} ({stock.Ticker}):");
+                sb.AppendLine($"Showing {transactions.Count} most recent transactions");
+                sb.AppendLine(
+                    "_Shares/Price/Value are as filed; Owned After is the post-transaction balance restated onto today's split basis. Balances are tracked per security kind and ownership form (see Security/Ownership), not as one running total per insider. 10b5-1 '-' means the filing predates the 2023 checkbox._"
+                );
+                sb.AppendLine();
+                sb.AppendLine(
+                    "| Date | Insider | Role | Type | Shares | Price | Value | Owned After | Security | Ownership | 10b5-1 |"
+                );
+                sb.AppendLine(
+                    "|------|---------|------|------|--------|-------|-------|-------------|----------|-----------|--------|"
+                );
+                sb.AppendRows(
                     transactions,
-                    $"No insider transactions found for {ticker}.",
-                    $"Recent insider transactions for {stock.Name} ({ticker}):",
-                    $"Showing {transactions.Count} most recent transactions",
-                    "| Date | Insider | Role | Type | Shares | Price | Value | Owned After |",
-                    "|------|---------|------|------|--------|-------|-------|-------------|",
                     t =>
                     {
                         var role = GetRole(t.InsiderOwner);
+                        // Reserve the Buy/Sell trade labels strictly for open-market
+                        // purchases/sales; every other SEC code renders its own meaning so
+                        // comp mechanics (conversions, tax withholding, expirations) are
+                        // never mistaken for conviction trades.
                         var type = t.TransactionCode switch
                         {
-                            TransactionCode.Award => "Award",
-                            TransactionCode.Gift => "Gift",
-                            TransactionCode.Exercise => "Exercise",
-                            _ => t.AcquiredDisposed == AcquiredDisposed.Acquired ? "Buy" : "Sell",
+                            TransactionCode.Purchase => "Buy",
+                            TransactionCode.Sale => "Sell",
+                            _ => t.TransactionCode.NameForHumans(),
                         };
 
                         var value = t.Shares * t.PricePerShare;
@@ -105,21 +224,40 @@ public class InsiderTradingTools
                             t.TransactionDate,
                             splits
                         );
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(ownedAfter)} |";
+                        var plan = t.IsRule10b5One switch
+                        {
+                            true => "Yes",
+                            false => "No",
+                            null => "-",
+                        };
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(ownedAfter)} | {t.SecurityKind.NameForHumans()} | {t.OwnershipNature.NameForHumans()} | {plan} |";
                     }
                 );
+
+                var truncation = McpOutput.TruncationNote(transactions.Count, total);
+                if (truncation.Length > 0)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine(truncation);
+                }
+
+                return sb.ToString();
             },
             "GetInsiderTransactions",
-            $"ticker: {ticker}"
+            $"ticker: {ticker}, fromDate: {fromDate}, toDate: {toDate}, transactionType: {transactionType}, insiderName: {insiderName}"
         );
     }
 
     [McpServerTool(Name = "GetInsiderOwnership")]
     [Description(
-        "Get a summary of current insider ownership for a stock. Shows each insider, their role, total shares held, and their most recent transaction. Use this to understand the insider ownership structure of a company."
+        "Get a summary of insider ownership for a stock, ranked by shares held. Each row is as-of that insider's most recent SEC Form 3/4/5 filing (former insiders may linger with stale dates or zero shares), and share counts are restated onto today's split basis, so they can differ from the raw figures in older filings. Returns at most maxResults insiders (default 30). Use this to understand the insider ownership structure of a company; use GetInsiderTransactions for the underlying trades."
     )]
     public Task<string> GetInsiderOwnership(
-        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker
+        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description(
+            "Maximum number of insiders to return (default: 30, max: 500; values outside 1-500 are clamped)"
+        )]
+            int maxResults = 30
     )
     {
         return _runner.Execute(
@@ -129,8 +267,14 @@ public class InsiderTradingTools
                 if (stockError != null)
                     return stockError;
 
+                maxResults = McpLimit.Clamp(maxResults);
+
                 var byStock = _transactionRepository.GetByStock(stock);
 
+                // One row per insider (their latest filing). Materialize them ALL before
+                // ranking: each row sits on its own split basis, and cutting on the raw
+                // counts would under-rank insiders whose last filing predates a large split
+                // (pre-split counts are smaller until restated).
                 var latestTransactions = await _transactionRepository
                     .GetByStockWithOwner(stock)
                     .Where(t =>
@@ -142,13 +286,11 @@ public class InsiderTradingTools
                             .Select(t2 => t2.Id)
                             .First()
                     )
-                    .OrderByDescending(t => t.SharesOwnedAfter)
-                    .Take(30)
                     .ToListAsync();
 
-                // Each insider's most recent position is reported as-of its own transaction
-                // date, so different rows sit on different split bases; restate them all onto
-                // today's basis and re-rank by the adjusted holding so the ordering is correct.
+                // Restate every position onto today's basis, then rank and cut on the
+                // adjusted holding so the ordering — and the top-N cut itself — compares
+                // like with like.
                 var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
                 var ranked = latestTransactions
                     .OrderByDescending(t =>
@@ -158,19 +300,27 @@ public class InsiderTradingTools
                             splits
                         )
                     )
+                    .Take(maxResults)
                     .ToList();
 
-                return MarkdownTable.Render(
+                if (ranked.Count == 0)
+                    return $"No insider ownership data found for {stock.Ticker}.";
+
+                var sb = new StringBuilder();
+                sb.AppendLine($"Insider ownership summary for {stock.Name} ({stock.Ticker}):");
+                sb.AppendLine($"Showing {ranked.Count} insiders with most recent data");
+                sb.AppendLine(
+                    "_Each row is as-of that insider's most recent filing; Shares Owned is restated onto today's split basis. Former insiders may linger with stale dates or zero shares._"
+                );
+                sb.AppendLine();
+                sb.AppendLine("| Insider | Role | Shares Owned | Last Transaction | Last Date |");
+                sb.AppendLine("|---------|------|-------------|-----------------|-----------|");
+                sb.AppendRows(
                     ranked,
-                    $"No insider ownership data found for {ticker}.",
-                    $"Insider ownership summary for {stock.Name} ({ticker}):",
-                    $"Showing {ranked.Count} insiders with most recent data",
-                    "| Insider | Role | Shares Owned | Last Transaction | Last Date |",
-                    "|---------|------|-------------|-----------------|-----------|",
                     t =>
                     {
                         var role = GetRole(t.InsiderOwner);
-                        var lastType = t.TransactionCode.ToString();
+                        var lastType = t.TransactionCode.NameForHumans();
                         var sharesOwned = McpFormat.WholeNumber(
                             SplitAdjustment.AdjustShareCount(
                                 t.SharesOwnedAfter,
@@ -181,6 +331,15 @@ public class InsiderTradingTools
                         return $"| {t.InsiderOwner.Name} | {role} | {sharesOwned} | {lastType} | {t.TransactionDate:yyyy-MM-dd} |";
                     }
                 );
+
+                var truncation = McpOutput.TruncationNote(ranked.Count, latestTransactions.Count);
+                if (truncation.Length > 0)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine(truncation);
+                }
+
+                return sb.ToString();
             },
             "GetInsiderOwnership",
             $"ticker: {ticker}"
@@ -193,7 +352,10 @@ public class InsiderTradingTools
     )]
     public Task<string> GetProposedSales(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
-        [Description("Maximum number of notices to return (default: 50)")] int maxResults = 50
+        [Description(
+            "Maximum number of notices to return (default: 50, max: 500; values outside 1-500 are clamped)"
+        )]
+            int maxResults = 50
     )
     {
         return _runner.Execute(
@@ -215,8 +377,8 @@ public class InsiderTradingTools
                 // count is never compared across a split here.
                 return MarkdownTable.Render(
                     filings,
-                    $"No Form 144 proposed sales found for {ticker}.",
-                    $"Recent proposed sales (Form 144) for {stock.Name} ({ticker}):",
+                    $"No Form 144 proposed sales found for {stock.Ticker}.",
+                    $"Recent proposed sales (Form 144) for {stock.Name} ({stock.Ticker}):",
                     $"Showing {filings.Count} most recent notices",
                     "| Filed | Seller | Relationship | Shares | Market Value | Approx. Sale Date | Broker |",
                     "|-------|--------|--------------|--------|--------------|-------------------|--------|",
@@ -236,11 +398,14 @@ public class InsiderTradingTools
 
     [McpServerTool(Name = "SearchInsiders")]
     [Description(
-        "Search for corporate insiders (directors, officers, 10% owners) by name. Returns matching insiders with their CIK and role information."
+        "Search for corporate insiders (directors, officers, 10% owners) by name. Names are matched as filed with the SEC — legal names, frequently 'LAST FIRST MIDDLE' (e.g. Jensen Huang is filed as 'HUANG JEN HSUN') — and every word of the query must appear in the name, so retry with the surname alone when a full name misses. Returns matching insiders with their CIK, role, the company of their most recent filing, and location, ordered by most recent filing activity. Pivot to the sibling ticker-keyed tools with the returned company ticker (e.g. GetInsiderTransactions with its insiderName filter) to see a person's trades."
     )]
     public Task<string> SearchInsiders(
         [Description("Search query for insider name")] string query,
-        [Description("Maximum number of results (default: 10)")] int maxResults = 10
+        [Description(
+            "Maximum number of results (default: 10, max: 500; values outside 1-500 are clamped)"
+        )]
+            int maxResults = 10
     )
     {
         return _runner.Execute(
@@ -248,26 +413,79 @@ public class InsiderTradingTools
             {
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var insiders = await _ownerRepository.Search(query).Take(maxResults).ToListAsync();
+                var matches = _ownerRepository.Search(query);
+                var total = await matches.CountAsync();
 
-                return MarkdownTable.Render(
+                // Deterministic order: most recently active filers first (the insider the
+                // caller wants is far more likely among them than in an arbitrary
+                // Postgres-chosen subset of, say, 557 Smiths), then name/CIK as stable
+                // tie-breakers. The coalesce keeps never-filed owners last — Postgres
+                // sorts NULLs first on a DESC order.
+                var insiders = await matches
+                    .OrderByDescending(o =>
+                        o.Transactions.Max(t => (DateOnly?)t.TransactionDate) ?? DateOnly.MinValue
+                    )
+                    .ThenBy(o => o.Name)
+                    .ThenBy(o => o.OwnerCik)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                if (insiders.Count == 0)
+                    return $"No insiders found matching '{query}'. Names are matched as filed with the SEC (legal names, often 'LAST FIRST MIDDLE') and every word of the query must appear in the name - retry with the surname alone.";
+
+                // The issuer of each owner's most recent transaction — the affiliation that
+                // disambiguates common surnames and gives the caller the ticker the sibling
+                // tools are keyed on.
+                var ownerIds = insiders.Select(i => i.Id).ToList();
+                var byOwners = _transactionRepository.GetByOwnerIds(ownerIds);
+                var latestByOwner = (
+                    await byOwners
+                        .Where(t =>
+                            t.Id
+                            == byOwners
+                                .Where(t2 => t2.InsiderOwnerId == t.InsiderOwnerId)
+                                .OrderByDescending(t2 => t2.TransactionDate)
+                                .ThenByDescending(t2 => t2.FilingDate)
+                                .Select(t2 => t2.Id)
+                                .First()
+                        )
+                        .Include(t => t.CommonStock)
+                        .ToListAsync()
+                ).ToDictionary(t => t.InsiderOwnerId);
+
+                var sb = new StringBuilder();
+                sb.AppendLine($"Insiders matching '{query}':");
+                sb.AppendLine();
+                sb.AppendLine("| Name | CIK | Role | Company (latest filing) | Location |");
+                sb.AppendLine("|------|-----|------|-------------------------|----------|");
+                sb.AppendRows(
                     insiders,
-                    $"No insiders found matching '{query}'.",
-                    $"Insiders matching '{query}':",
-                    "| Name | CIK | Role | Location |",
-                    "|------|-----|------|----------|",
                     insider =>
                     {
                         var role = GetRole(insider);
+                        var company =
+                            latestByOwner.TryGetValue(insider.Id, out var transaction)
+                            && transaction.CommonStock != null
+                                ? $"{transaction.CommonStock.Name} ({transaction.CommonStock.Ticker})"
+                                : "-";
                         var location = string.Join(
                             ", ",
                             new[] { insider.City, insider.StateOrCountry }.Where(s =>
                                 !string.IsNullOrEmpty(s)
                             )
                         );
-                        return $"| {insider.Name} | {insider.OwnerCik} | {role} | {location} |";
+                        return $"| {insider.Name} | {insider.OwnerCik} | {role} | {company} | {location} |";
                     }
                 );
+
+                var truncation = McpOutput.TruncationNote(insiders.Count, total);
+                if (truncation.Length > 0)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine(truncation);
+                }
+
+                return sb.ToString();
             },
             "SearchInsiders",
             $"query: {query}"

--- a/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
@@ -35,6 +35,11 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
         return GetAll().Where(t => t.InsiderOwnerId == owner.Id);
     }
 
+    public IQueryable<InsiderTransaction> GetByOwnerIds(IEnumerable<Guid> ownerIds)
+    {
+        return GetAll().Where(t => ownerIds.Contains(t.InsiderOwnerId));
+    }
+
     public IQueryable<InsiderTransaction> GetHistoryByStock(CommonStock stock)
     {
         return GetAll().Where(t => t.CommonStockId == stock.Id);

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -381,7 +381,9 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
 
         result
             .Should()
-            .Contain("| Date | Insider | Role | Type | Shares | Price | Value | Owned After |");
+            .Contain(
+                "| Date | Insider | Role | Type | Shares | Price | Value | Owned After | Security | Ownership | 10b5-1 |"
+            );
     }
 
     // ══════════════════════════════════════════════════════════════════
@@ -506,6 +508,44 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task GetInsiderTransactions_InsiderNameFilter_LimitsToMatchingInsiders()
+    {
+        // The insiderName filter is the pivot SearchInsiders points at: it matches the
+        // SEC-filed name with the same case-insensitive token-AND contract (ILike, so
+        // Postgres-only). Rows by other insiders must not leak through.
+        var stock = CreateStock("NVDA", "NVIDIA Corp");
+        var huang = CreateOwner(cik: "0000111001", name: "HUANG JEN HSUN");
+        var kress = CreateOwner(cik: "0000111002", name: "Kress Colette");
+        await SeedStock(stock);
+        await SeedOwner(huang);
+        await SeedOwner(kress);
+        await SeedTransaction(CreateTransaction(stock, huang, accessionNumber: "0001-24-110001"));
+        await SeedTransaction(CreateTransaction(stock, kress, accessionNumber: "0001-24-110002"));
+
+        var result = await Sut().GetInsiderTransactions("NVDA", insiderName: "huang");
+
+        result.Should().Contain("HUANG JEN HSUN");
+        result.Should().NotContain("Kress Colette");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_InsiderNameFilter_NoMatch_SaysFiltersMatchedNothing()
+    {
+        // A filtered empty result must not read like "this stock has no insider data".
+        var stock = CreateStock("NVDA", "NVIDIA Corp");
+        var owner = CreateOwner(cik: "0000111003", name: "Kress Colette");
+        await SeedStock(stock);
+        await SeedOwner(owner);
+        await SeedTransaction(CreateTransaction(stock, owner, accessionNumber: "0001-24-110003"));
+
+        var result = await Sut().GetInsiderTransactions("NVDA", insiderName: "Nonexistent");
+
+        result
+            .Should()
+            .Contain("No insider transactions found for NVDA matching the given filters.");
+    }
+
+    [Fact]
     public async Task SearchInsiders_NoRoleFlags_ShowsInsiderFallback()
     {
         // Some SEC filings create an InsiderOwner with all role flags false and
@@ -528,5 +568,124 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
 
         result.Should().Contain("Unclassified Person");
         result.Should().Contain("Insider");
+    }
+
+    [Fact]
+    public async Task SearchInsiders_ShowsCompanyOfMostRecentFiling()
+    {
+        // The company column is the disambiguator for common surnames and carries the
+        // ticker the sibling (ticker-keyed) tools need. It comes from the owner's most
+        // recent transaction issuer.
+        var older = CreateStock("INTC", "Intel Corp");
+        var newer = CreateStock("NVDA", "NVIDIA Corp");
+        var owner = CreateOwner(cik: "0000222001", name: "HUANG JEN HSUN");
+        await SeedStock(older);
+        await SeedStock(newer);
+        await SeedOwner(owner);
+        await SeedTransaction(
+            CreateTransaction(
+                older,
+                owner,
+                transactionDate: new DateOnly(2020, 1, 10),
+                accessionNumber: "0001-24-220001"
+            )
+        );
+        await SeedTransaction(
+            CreateTransaction(
+                newer,
+                owner,
+                transactionDate: new DateOnly(2024, 6, 20),
+                accessionNumber: "0001-24-220002"
+            )
+        );
+
+        var result = await Sut().SearchInsiders("Huang");
+
+        result.Should().Contain("| Name | CIK | Role | Company (latest filing) | Location |");
+        result.Should().Contain("NVIDIA Corp (NVDA)");
+        result.Should().NotContain("Intel Corp (INTC)");
+    }
+
+    [Fact]
+    public async Task SearchInsiders_OwnerWithoutTransactions_ShowsDashForCompany()
+    {
+        await SeedOwner(CreateOwner(cik: "0000222002", name: "Dormant Person"));
+
+        var result = await Sut().SearchInsiders("Dormant");
+
+        result.Should().Contain("Dormant Person");
+        result.Should().Contain("| - |");
+    }
+
+    [Fact]
+    public async Task SearchInsiders_OrdersByMostRecentFilingActivity()
+    {
+        // Without an ORDER BY, Postgres returns an arbitrary subset/order for common
+        // surnames. The contract is: most recently active filers first, never-filed
+        // owners last (the DESC NULLS FIRST trap), name as tie-breaker.
+        var stock = CreateStock("AAPL", "Apple Inc.");
+        var stale = CreateOwner(cik: "0000333001", name: "Smith Stale");
+        var active = CreateOwner(cik: "0000333002", name: "Smith Active");
+        var neverFiled = CreateOwner(cik: "0000333003", name: "Smith Neverfiled");
+        await SeedStock(stock);
+        await SeedOwner(stale);
+        await SeedOwner(active);
+        await SeedOwner(neverFiled);
+        await SeedTransaction(
+            CreateTransaction(
+                stock,
+                stale,
+                transactionDate: new DateOnly(2020, 1, 10),
+                accessionNumber: "0001-24-330001"
+            )
+        );
+        await SeedTransaction(
+            CreateTransaction(
+                stock,
+                active,
+                transactionDate: new DateOnly(2024, 6, 20),
+                accessionNumber: "0001-24-330002"
+            )
+        );
+
+        var result = await Sut().SearchInsiders("Smith");
+
+        var activeAt = result.IndexOf("Smith Active", StringComparison.Ordinal);
+        var staleAt = result.IndexOf("Smith Stale", StringComparison.Ordinal);
+        var neverAt = result.IndexOf("Smith Neverfiled", StringComparison.Ordinal);
+        activeAt.Should().BePositive();
+        activeAt.Should().BeLessThan(staleAt);
+        staleAt.Should().BeLessThan(neverAt);
+    }
+
+    [Fact]
+    public async Task SearchInsiders_Truncated_AppendsTruncationNote()
+    {
+        DbContext
+            .Set<InsiderOwner>()
+            .AddRange(
+                CreateOwner(cik: "0000444001", name: "Trunc One"),
+                CreateOwner(cik: "0000444002", name: "Trunc Two"),
+                CreateOwner(cik: "0000444003", name: "Trunc Three")
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().SearchInsiders("Trunc", maxResults: 2);
+
+        result.Should().Contain("Showing first 2 of 3 results - raise maxResults to see more.");
+    }
+
+    [Fact]
+    public async Task SearchInsiders_NaturalNameMiss_ExplainsFiledNameMatching()
+    {
+        // 'Jensen Huang' finds nothing because the SEC-filed legal name is
+        // 'HUANG JEN HSUN' and every query token must appear in the name. The
+        // empty state must teach the retry (surname alone), not read as "no data".
+        await SeedOwner(CreateOwner(cik: "0000555001", name: "HUANG JEN HSUN"));
+
+        var result = await Sut().SearchInsiders("Jensen Huang");
+
+        result.Should().Contain("No insiders found matching 'Jensen Huang'");
+        result.Should().Contain("retry with the surname alone");
     }
 }

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipRankingTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipRankingTests.cs
@@ -1,0 +1,280 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Mcp.Tools;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Media.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Mcp;
+
+/// <summary>
+/// Pins the GetInsiderOwnership ranking contract from the MCP audit: the top-N cut must
+/// compare split-ADJUSTED holdings, not raw per-filing counts. Each insider's latest row
+/// sits on its own split basis — a pre-split count is smaller until restated — so cutting
+/// on the raw counts silently dropped genuinely top holders whose last Form 4 predated a
+/// large split while smaller post-split holders survived. Also pins the maxResults
+/// argument + truncation note that replaced the hidden hard-coded 30-row cap, and the
+/// canonical-ticker echo in the header.
+/// </summary>
+public class InsiderTradingToolsOwnershipRankingTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+                new InsiderTradingModuleConfiguration(),
+                new ErrorsModuleConfiguration(),
+                // InsiderFiling navigates to Media's File (Content), so the model pulls the File
+                // entity in and needs Media's configuration (the StorageProvider conversion) or
+                // model finalization fails.
+                new MediaModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static InsiderTradingTools Sut(EquiblesFinancialDbContext db) =>
+        new(
+            new InsiderTransactionRepository(db),
+            new InsiderOwnerRepository(db),
+            new Form144FilingRepository(db),
+            new CommonStockRepository(db),
+            new StockSplitRepository(db),
+            new ErrorManager(new ErrorRepository(db)),
+            Substitute.For<ILogger<InsiderTradingTools>>()
+        );
+
+    private static InsiderTransaction NewTransaction(
+        CommonStock stock,
+        InsiderOwner owner,
+        DateOnly transactionDate,
+        long sharesOwnedAfter,
+        string accessionNumber,
+        TransactionCode code = TransactionCode.Sale
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            CommonStock = stock,
+            InsiderOwnerId = owner.Id,
+            InsiderOwner = owner,
+            TransactionDate = transactionDate,
+            FilingDate = transactionDate.AddDays(2),
+            TransactionCode = code,
+            Shares = 100,
+            PricePerShare = 50m,
+            AcquiredDisposed = AcquiredDisposed.Disposed,
+            SharesOwnedAfter = sharesOwnedAfter,
+            OwnershipNature = OwnershipNature.Direct,
+            SecurityTitle = "Common Stock",
+            AccessionNumber = accessionNumber,
+        };
+
+    [Fact]
+    public async Task GetInsiderOwnership_TopNCut_RanksOnSplitAdjustedCounts()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "0001045810",
+        };
+        var preSplitHolder = new InsiderOwner
+        {
+            OwnerCik = "0000000001",
+            Name = "Pre Split Holder",
+            IsDirector = true,
+        };
+        var postSplitHolder = new InsiderOwner
+        {
+            OwnerCik = "0000000002",
+            Name = "Post Split Holder",
+            IsDirector = true,
+        };
+        db.AddRange(stock, preSplitHolder, postSplitHolder);
+
+        // 40:1 split AFTER the pre-split holder's last filing: raw 86,080 restates to
+        // 3,443,200 — a larger holding than the post-split holder's 1,000,000.
+        db.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                EffectiveDate = new DateOnly(2024, 6, 10),
+                Numerator = 40,
+                Denominator = 1,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        db.Add(
+            NewTransaction(
+                stock,
+                preSplitHolder,
+                new DateOnly(2020, 3, 31),
+                sharesOwnedAfter: 86_080,
+                accessionNumber: "acc-pre-1"
+            )
+        );
+        db.Add(
+            NewTransaction(
+                stock,
+                postSplitHolder,
+                new DateOnly(2024, 7, 1),
+                sharesOwnedAfter: 1_000_000,
+                accessionNumber: "acc-post-1"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        // With a 1-row cut, only the genuinely larger (adjusted) holder may survive.
+        // Cutting on the RAW counts would instead keep the post-split holder
+        // (1,000,000 > 86,080) and drop the true top holder from the table entirely.
+        var output = await Sut(db).GetInsiderOwnership("NVDA", maxResults: 1);
+
+        output.Should().Contain("Pre Split Holder");
+        output.Should().Contain("3,443,200");
+        output.Should().NotContain("Post Split Holder");
+    }
+
+    [Fact]
+    public async Task GetInsiderOwnership_Truncated_AppendsTruncationNote()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var first = new InsiderOwner
+        {
+            OwnerCik = "0000000011",
+            Name = "First Holder",
+            IsDirector = true,
+        };
+        var second = new InsiderOwner
+        {
+            OwnerCik = "0000000012",
+            Name = "Second Holder",
+            IsDirector = true,
+        };
+        db.AddRange(stock, first, second);
+        db.Add(
+            NewTransaction(
+                stock,
+                first,
+                new DateOnly(2024, 6, 1),
+                sharesOwnedAfter: 9_000,
+                accessionNumber: "acc-t-1"
+            )
+        );
+        db.Add(
+            NewTransaction(
+                stock,
+                second,
+                new DateOnly(2024, 6, 1),
+                sharesOwnedAfter: 1_000,
+                accessionNumber: "acc-t-2"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("AAPL", maxResults: 1);
+
+        output.Should().Contain("First Holder");
+        output.Should().NotContain("Second Holder");
+        output.Should().Contain("Showing first 1 of 2 results - raise maxResults to see more.");
+    }
+
+    [Fact]
+    public async Task GetInsiderOwnership_LowercaseTicker_EchoesCanonicalTicker()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            OwnerCik = "0000000021",
+            Name = "Case Test",
+            IsDirector = true,
+        };
+        db.AddRange(stock, owner);
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                new DateOnly(2024, 6, 1),
+                sharesOwnedAfter: 5_000,
+                accessionNumber: "acc-c-1"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("aapl");
+
+        output.Should().Contain("Insider ownership summary for Apple Inc. (AAPL):");
+        output.Should().NotContain("(aapl)");
+    }
+
+    [Fact]
+    public async Task GetInsiderOwnership_LastTransaction_RendersDisplayName()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            OwnerCik = "0000000031",
+            Name = "Withheld Shares",
+            IsDirector = true,
+        };
+        db.AddRange(stock, owner);
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                new DateOnly(2024, 6, 1),
+                sharesOwnedAfter: 5_000,
+                accessionNumber: "acc-d-1",
+                code: TransactionCode.TaxPayment
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("AAPL");
+
+        output.Should().Contain("| Tax Payment |");
+        output.Should().NotContain("TaxPayment");
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsTransactionRenderingAndFilterTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsTransactionRenderingAndFilterTests.cs
@@ -1,0 +1,434 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Mcp.Tools;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Media.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Mcp;
+
+/// <summary>
+/// Pins the GetInsiderTransactions rendering and filter contract introduced by the MCP
+/// audit: the Buy/Sell labels are reserved for the open-market Purchase/Sale codes and
+/// every other SEC code renders its own meaning (a Conversion or Tax Payment reported
+/// as "Buy"/"Sell" told the model an open-market trade happened that never did); the
+/// Rule 10b5-1 plan flag is surfaced; degenerate zero-share/zero-balance rows are
+/// dropped; and the date-range/transactionType arguments reject unparseable values
+/// instead of silently ignoring them.
+/// </summary>
+public class InsiderTradingToolsTransactionRenderingAndFilterTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+                new InsiderTradingModuleConfiguration(),
+                new ErrorsModuleConfiguration(),
+                // InsiderFiling navigates to Media's File (Content), so the model pulls the File
+                // entity in and needs Media's configuration (the StorageProvider conversion) or
+                // model finalization fails.
+                new MediaModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static InsiderTradingTools Sut(EquiblesFinancialDbContext db) =>
+        new(
+            new InsiderTransactionRepository(db),
+            new InsiderOwnerRepository(db),
+            new Form144FilingRepository(db),
+            new CommonStockRepository(db),
+            new StockSplitRepository(db),
+            new ErrorManager(new ErrorRepository(db)),
+            Substitute.For<ILogger<InsiderTradingTools>>()
+        );
+
+    private static CommonStock NewStock() =>
+        new()
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+
+    private static InsiderOwner NewOwner(string name = "John Doe", string cik = "0001234567") =>
+        new()
+        {
+            OwnerCik = cik,
+            Name = name,
+            IsDirector = true,
+        };
+
+    private static InsiderTransaction NewTransaction(
+        CommonStock stock,
+        InsiderOwner owner,
+        TransactionCode code,
+        AcquiredDisposed acquiredDisposed,
+        string accessionNumber,
+        DateOnly? transactionDate = null,
+        long shares = 1000,
+        decimal pricePerShare = 100m,
+        long sharesOwnedAfter = 5000,
+        bool? isRule10b5One = null
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            CommonStock = stock,
+            InsiderOwnerId = owner.Id,
+            InsiderOwner = owner,
+            TransactionDate = transactionDate ?? new DateOnly(2024, 6, 1),
+            FilingDate = (transactionDate ?? new DateOnly(2024, 6, 1)).AddDays(2),
+            TransactionCode = code,
+            Shares = shares,
+            PricePerShare = pricePerShare,
+            AcquiredDisposed = acquiredDisposed,
+            SharesOwnedAfter = sharesOwnedAfter,
+            OwnershipNature = OwnershipNature.Direct,
+            SecurityTitle = "Common Stock",
+            AccessionNumber = accessionNumber,
+            IsRule10b5One = isRule10b5One,
+        };
+
+    [Fact]
+    public async Task GetInsiderTransactions_ConversionRow_RendersConversionNotBuy()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        var owner = NewOwner();
+        db.AddRange(stock, owner);
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Conversion,
+                AcquiredDisposed.Acquired,
+                "acc-1"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("AAPL");
+
+        output.Should().Contain("| Conversion |");
+        output.Should().NotContain("| Buy |");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_TaxPaymentRow_RendersTaxPaymentNotSell()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        var owner = NewOwner();
+        db.AddRange(stock, owner);
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.TaxPayment,
+                AcquiredDisposed.Disposed,
+                "acc-1"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("AAPL");
+
+        output.Should().Contain("| Tax Payment |");
+        output.Should().NotContain("| Sell |");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_Rule10b5OneFlag_RendersYesNoAndDash()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        var owner = NewOwner();
+        db.AddRange(stock, owner);
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Sale,
+                AcquiredDisposed.Disposed,
+                "acc-1",
+                transactionDate: new DateOnly(2024, 6, 3),
+                isRule10b5One: true
+            )
+        );
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Sale,
+                AcquiredDisposed.Disposed,
+                "acc-2",
+                transactionDate: new DateOnly(2024, 6, 2),
+                isRule10b5One: false
+            )
+        );
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Sale,
+                AcquiredDisposed.Disposed,
+                "acc-3",
+                transactionDate: new DateOnly(2024, 6, 1),
+                isRule10b5One: null
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("AAPL");
+
+        output.Should().Contain("| 10b5-1 |");
+        output.Should().Contain("| Yes |");
+        output.Should().Contain("| No |");
+        output.Should().Contain("| - |");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_ZeroShareZeroBalanceRow_IsDropped()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        var real = NewOwner(name: "Real Trader", cik: "0000000001");
+        var ghost = NewOwner(name: "Ghost Filer", cik: "0000000002");
+        db.AddRange(stock, real, ghost);
+        db.Add(
+            NewTransaction(
+                stock,
+                real,
+                TransactionCode.Purchase,
+                AcquiredDisposed.Acquired,
+                "acc-1"
+            )
+        );
+        // A parser artifact / no-securities Form 3: zero shares, zero price, zero balance.
+        db.Add(
+            NewTransaction(
+                stock,
+                ghost,
+                TransactionCode.Other,
+                AcquiredDisposed.Acquired,
+                "acc-2",
+                shares: 0,
+                pricePerShare: 0m,
+                sharesOwnedAfter: 0
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("AAPL");
+
+        output.Should().Contain("Real Trader");
+        output.Should().NotContain("Ghost Filer");
+        output.Should().Contain("Showing 1 most recent transactions");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_InvalidFromDate_ReturnsStrictError()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("AAPL", fromDate: "June 2024");
+
+        output.Should().Be("Unknown fromDate 'June 2024'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_InvalidTransactionType_ListsAcceptedValues()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("AAPL", transactionType: "Bought");
+
+        output
+            .Should()
+            .Be(
+                "Unknown transactionType 'Bought'. Accepted: Buy, Sell, Award, Conversion, Exercise, TaxPayment, Expiration, Gift, Inheritance, Discretionary, Other."
+            );
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_DateRange_LimitsToWindow()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        var owner = NewOwner();
+        db.AddRange(stock, owner);
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Purchase,
+                AcquiredDisposed.Acquired,
+                "acc-1",
+                transactionDate: new DateOnly(2024, 1, 15)
+            )
+        );
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Purchase,
+                AcquiredDisposed.Acquired,
+                "acc-2",
+                transactionDate: new DateOnly(2024, 3, 15)
+            )
+        );
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Purchase,
+                AcquiredDisposed.Acquired,
+                "acc-3",
+                transactionDate: new DateOnly(2024, 6, 15)
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db)
+            .GetInsiderTransactions("AAPL", fromDate: "2024-02-01", toDate: "2024-05-01");
+
+        output.Should().Contain("2024-03-15");
+        output.Should().NotContain("2024-01-15");
+        output.Should().NotContain("2024-06-15");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_TransactionTypeBuy_FiltersToOpenMarketPurchases()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        var owner = NewOwner();
+        db.AddRange(stock, owner);
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Purchase,
+                AcquiredDisposed.Acquired,
+                "acc-1"
+            )
+        );
+        db.Add(
+            NewTransaction(stock, owner, TransactionCode.Sale, AcquiredDisposed.Disposed, "acc-2")
+        );
+        db.Add(
+            NewTransaction(stock, owner, TransactionCode.Award, AcquiredDisposed.Acquired, "acc-3")
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("AAPL", transactionType: "Buy");
+
+        output.Should().Contain("| Buy |");
+        output.Should().NotContain("| Sell |");
+        output.Should().NotContain("| Award |");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_Truncated_AppendsTruncationNote()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        var owner = NewOwner();
+        db.AddRange(stock, owner);
+        for (var i = 0; i < 3; i++)
+        {
+            db.Add(
+                NewTransaction(
+                    stock,
+                    owner,
+                    TransactionCode.Purchase,
+                    AcquiredDisposed.Acquired,
+                    $"acc-{i}",
+                    transactionDate: new DateOnly(2024, 1 + i, 1)
+                )
+            );
+        }
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("AAPL", maxResults: 2);
+
+        output.Should().Contain("Showing first 2 of 3 results - raise maxResults to see more.");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_NotTruncated_HasNoTruncationNote()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        var owner = NewOwner();
+        db.AddRange(stock, owner);
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Purchase,
+                AcquiredDisposed.Acquired,
+                "acc-1"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("AAPL");
+
+        output.Should().NotContain("raise maxResults to see more");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_LowercaseTicker_EchoesCanonicalTicker()
+    {
+        await using var db = NewDb();
+        var stock = NewStock();
+        var owner = NewOwner();
+        db.AddRange(stock, owner);
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                TransactionCode.Purchase,
+                AcquiredDisposed.Acquired,
+                "acc-1"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("aapl");
+
+        output.Should().Contain("Apple Inc. (AAPL)");
+        output.Should().NotContain("(aapl)");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes all audit findings for the insider-trading MCP tools (GetInsiderTransactions, GetInsiderOwnership, SearchInsiders).

**GetInsiderTransactions**
- Non-market SEC transaction codes were collapsed into misleading `Buy`/`Sell` labels via the `AcquiredDisposed` fallback — an RSU conversion (code M) plus tax withholding (code F) read as an open-market buy/sell pair. `Buy`/`Sell` are now reserved strictly for Purchase/Sale; every other code renders its display name (Conversion, Tax Payment, Expiration, Discretionary, Other, ...).
- New `10b5-1`, `Security` (derivative vs non-derivative) and `Ownership` (direct vs indirect) columns plus a preamble note explaining that Owned After is split-adjusted while Shares/Price/Value are as filed and that balances are per bucket — the "self-contradictory running balance" from the audit.
- New optional `fromDate`/`toDate` (strict `yyyy-MM-dd`), `transactionType` (Buy/Sell + all SEC code names) and `insiderName` (token-AND, case-insensitive) filters, so history beyond the newest 500 rows is reachable. Unparseable values return a one-line error listing the accepted values — no silent fallbacks.
- Degenerate zero-share/zero-balance rows are dropped; truncation now appends `Showing first N of M results — raise maxResults ...`.

**GetInsiderOwnership**
- The top-30 cut ran on RAW per-filing share counts and only re-ranked the survivors after split adjustment, so a top holder whose last Form 4 predated a big split could be dropped entirely. The per-insider latest rows are now materialized, restated onto today's basis, and the ranking + cut both use adjusted counts.
- The hidden hard-coded 30-row cap is replaced by a `maxResults` argument (default 30, clamped 1-500) with a truncation note.

**SearchInsiders**
- New `Company (latest filing)` column (name + ticker of the owner's most recent transaction issuer) — the disambiguator for common surnames and the pivot to the ticker-keyed sibling tools (which now accept `insiderName`), closing the "CIK is a dead end" finding.
- Deterministic ordering: most recent filing activity first (coalesced so never-filed owners sort last despite Postgres `DESC NULLS FIRST`), then name/CIK; truncated results carry a note instead of posing as the full set.
- The matching contract (SEC-filed legal names, often `LAST FIRST MIDDLE`, token-AND) is documented in the description and taught in the empty state ("retry with the surname alone").

All three tools echo the canonical resolved ticker instead of the caller's casing, and every `maxResults` description documents the 1-500 clamp.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — all tool changes above; descriptions updated to the new contracts.
- `src/Equibles.InsiderTrading.Mcp/Equibles.InsiderTrading.Mcp.csproj` — reference `Equibles.Core` for `NameForHumans()` (same as Cboe/Sec MCP modules).
- `src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs` — new `GetByOwnerIds` for the batched latest-transaction-per-owner lookup.
- `tests/Equibles.UnitTests/Mcp/InsiderTradingToolsTransactionRenderingAndFilterTests.cs` — new: code labels, 10b5-1 rendering, zero-row drop, strict date/type errors, date-range + type filters, truncation, canonical ticker echo.
- `tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipRankingTests.cs` — new: split-adjusted top-N cut (fails on a raw-count cut), maxResults + truncation note, canonical ticker, display-name rendering.
- `tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs` — Postgres-only additions (ILike, ordering translation): insiderName filter, filtered empty state, company column, activity ordering with never-filed-last, truncation note, natural-name empty-state guidance; header pin updated.

MCP tool names and existing parameter names/semantics unchanged (additive only).