### PR TITLE
fix(mcp): fund directory + Form D/144 tool audit fixes (GetFundHoldings, SearchFunds, GetFundProfile, GetFundOperations, GetExemptOfferings, GetProposedSales)

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -348,14 +348,22 @@ public class InsiderTradingTools
 
     [McpServerTool(Name = "GetProposedSales")]
     [Description(
-        "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the approximate sale date, and the broker. Use this to anticipate upcoming insider selling before it shows up as an executed Form 4."
+        "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the proposed sale as a share of shares outstanding, the approximate sale date, and the broker. Results are the most recent notices first and a note flags when more exist than were returned; use fromDate/toDate to scope a period (heavy 10b5-1 filers can flood the recency window with small daily notices). Use this to anticipate upcoming insider selling before it shows up as an executed Form 4."
     )]
     public Task<string> GetProposedSales(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
         [Description(
             "Maximum number of notices to return (default: 50, max: 500; values outside 1-500 are clamped)"
         )]
-            int maxResults = 50
+            int maxResults = 50,
+        [Description(
+            "Optional earliest filing date to include, ISO format yyyy-MM-dd (e.g., 2025-01-01)"
+        )]
+            string fromDate = null,
+        [Description(
+            "Optional latest filing date to include, ISO format yyyy-MM-dd (e.g., 2025-12-31)"
+        )]
+            string toDate = null
     )
     {
         return _runner.Execute(
@@ -365,8 +373,29 @@ public class InsiderTradingTools
                 if (stockError != null)
                     return stockError;
 
-                var filings = await _form144Repository
-                    .GetByStock(stock)
+                var query = _form144Repository.GetByStock(stock);
+
+                if (!string.IsNullOrWhiteSpace(fromDate))
+                {
+                    if (!McpOutput.TryParseDate(fromDate, out var from))
+                        return McpOutput.InvalidArgument("fromDate", fromDate, "yyyy-MM-dd");
+                    var fromDay = DateOnly.FromDateTime(from);
+                    query = query.Where(f => f.FilingDate >= fromDay);
+                }
+
+                if (!string.IsNullOrWhiteSpace(toDate))
+                {
+                    if (!McpOutput.TryParseDate(toDate, out var to))
+                        return McpOutput.InvalidArgument("toDate", toDate, "yyyy-MM-dd");
+                    var toDay = DateOnly.FromDateTime(to);
+                    query = query.Where(f => f.FilingDate <= toDay);
+                }
+
+                var totalCount = await query.CountAsync();
+                if (totalCount == 0)
+                    return $"No Form 144 proposed sales found for {stock.Ticker}.";
+
+                var filings = await query
                     .OrderByDescending(f => f.FilingDate)
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
@@ -374,26 +403,48 @@ public class InsiderTradingTools
                 // Each Form 144 is an as-filed notice: the proposed Shares pair with the
                 // notice's own Aggregate Market Value, so both stay exactly as reported. The
                 // list is ordered by filing date, not by an adjusted quantity, so a filed share
-                // count is never compared across a split here.
-                return MarkdownTable.Render(
-                    filings,
-                    $"No Form 144 proposed sales found for {stock.Ticker}.",
+                // count is never compared across a split here. % Outstanding likewise divides
+                // two figures reported on the same notice, so it is split-consistent per row.
+                var result = MarkdownTable.Start(
                     $"Recent proposed sales (Form 144) for {stock.Name} ({stock.Ticker}):",
-                    $"Showing {filings.Count} most recent notices",
-                    "| Filed | Seller | Relationship | Shares | Market Value | Approx. Sale Date | Broker |",
-                    "|-------|--------|--------------|--------|--------------|-------------------|--------|",
+                    $"Showing {filings.Count} of {totalCount} most recent notices",
+                    "| Filed | Seller | Relationship | Shares | Market Value | % Outstanding | Approx. Sale Date | Broker |",
+                    "|-------|--------|--------------|--------|--------------|---------------|-------------------|--------|"
+                );
+
+                result.AppendRows(
+                    filings,
                     f =>
                     {
                         var approxSaleDate =
                             f.ApproxSaleDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
                             ?? "-";
-                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {approxSaleDate} | {f.BrokerName} |";
+                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {FormatPercentOfOutstanding(f.SharesToBeSold, f.SharesOutstanding)} | {approxSaleDate} | {f.BrokerName} |";
                     }
                 );
+
+                var note = McpOutput.TruncationNote(filings.Count, totalCount);
+                if (note.Length > 0)
+                {
+                    result.AppendLine();
+                    result.AppendLine(note);
+                }
+
+                return result.ToString();
             },
             "GetProposedSales",
             $"ticker: {ticker}"
         );
+    }
+
+    // The standard Form 144 materiality signal: the proposed sale as a share of the notice's own
+    // reported shares outstanding. "-" when the filing reported no share count.
+    private static string FormatPercentOfOutstanding(long sharesToBeSold, long sharesOutstanding)
+    {
+        if (sharesOutstanding <= 0)
+            return "-";
+        var percent = sharesToBeSold / (decimal)sharesOutstanding * 100m;
+        return McpFormat.Invariant(percent, "0.####") + "%";
     }
 
     [McpServerTool(Name = "SearchInsiders")]

--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -34,11 +35,22 @@ public class FormDTools
 
     [McpServerTool(Name = "GetExemptOfferings")]
     [Description(
-        "Get recent exempt securities offerings (private placements) for a company from SEC Form D notices. Each Form D reports a Regulation D offering, showing the issuer, the total offering amount and amount sold so far (either a dollar figure or \"Indefinite\"), the minimum investment, the number of investors, the claimed exemptions, and whether the notice is an amendment. Use this to track how a company is raising private capital alongside its public filings."
+        "Get recent exempt securities offerings (private placements) for a company from SEC Form D notices. Each Form D reports a Regulation D offering, showing the issuer, the date of first sale, the total offering amount (a dollar figure or \"Indefinite\"), the amounts sold and remaining, the minimum investment, the number of investors, the claimed exemptions, whether the notice is an amendment (D/A), and its SEC accession number. Ongoing offerings are re-noticed through D/A amendments that RESTATE the same offering — group rows by first-sale date and offering amount and use only the latest notice of each chain, or capital raised will be counted several times over. Use this to track how a company is raising private capital alongside its public filings."
     )]
     public Task<string> GetExemptOfferings(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
-        [Description("Maximum number of notices to return (default: 50)")] int maxResults = 50
+        [Description(
+            "Maximum number of notices to return (default: 50, max: 500; values outside 1-500 are clamped)"
+        )]
+            int maxResults = 50,
+        [Description(
+            "Optional earliest filing date to include, ISO format yyyy-MM-dd (e.g., 2024-01-01)"
+        )]
+            string fromDate = null,
+        [Description(
+            "Optional latest filing date to include, ISO format yyyy-MM-dd (e.g., 2024-12-31)"
+        )]
+            string toDate = null
     )
     {
         return _runner.Execute(
@@ -48,21 +60,56 @@ public class FormDTools
                 if (stockError != null)
                     return stockError;
 
-                var filings = await _formDRepository
-                    .GetByStock(stock)
+                var query = _formDRepository.GetByStock(stock);
+
+                if (!string.IsNullOrWhiteSpace(fromDate))
+                {
+                    if (!McpOutput.TryParseDate(fromDate, out var from))
+                        return McpOutput.InvalidArgument("fromDate", fromDate, "yyyy-MM-dd");
+                    var fromDay = DateOnly.FromDateTime(from);
+                    query = query.Where(f => f.FilingDate >= fromDay);
+                }
+
+                if (!string.IsNullOrWhiteSpace(toDate))
+                {
+                    if (!McpOutput.TryParseDate(toDate, out var to))
+                        return McpOutput.InvalidArgument("toDate", toDate, "yyyy-MM-dd");
+                    var toDay = DateOnly.FromDateTime(to);
+                    query = query.Where(f => f.FilingDate <= toDay);
+                }
+
+                var totalCount = await query.CountAsync();
+                if (totalCount == 0)
+                    return $"No Form D exempt offerings found for {ticker}.";
+
+                var filings = await query
                     .OrderByDescending(f => f.FilingDate)
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
-                return MarkdownTable.Render(
-                    filings,
-                    $"No Form D exempt offerings found for {ticker}.",
+                var result = MarkdownTable.Start(
                     $"Recent exempt offerings (Form D) for {stock.Name} ({ticker}) — showing {filings.Count} most recent notices:",
-                    "| Filed | Amendment | Industry | Offering Amount | Sold | Min. Investment | Investors | Exemptions |",
-                    "|-------|-----------|----------|-----------------|------|-----------------|-----------|------------|",
-                    f =>
-                        $"| {f.FilingDate:yyyy-MM-dd} | {(f.IsAmendment ? "Yes" : "No")} | {f.IndustryGroup ?? "-"} | {FormatAmount(f.TotalOfferingAmount, f.IsOfferingAmountIndefinite)} | ${McpFormat.WholeNumber(f.TotalAmountSold)} | ${McpFormat.WholeNumber(f.MinimumInvestmentAccepted)} | {McpFormat.WholeNumber(f.TotalNumberAlreadyInvested)} | {f.FederalExemptions ?? "-"} |"
+                    "| Filed | Amendment | First Sale | Industry | Offering Amount | Sold | Remaining | Min. Investment | Investors | Exemptions | Accession |",
+                    "|-------|-----------|------------|----------|-----------------|------|-----------|-----------------|-----------|------------|-----------|"
                 );
+
+                result.AppendRows(
+                    filings,
+                    f =>
+                        $"| {f.FilingDate:yyyy-MM-dd} | {(f.IsAmendment ? "Yes" : "No")} | {(f.DateOfFirstSale.HasValue ? f.DateOfFirstSale.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) : "-")} | {f.IndustryGroup ?? "-"} | {FormatAmount(f.TotalOfferingAmount, f.IsOfferingAmountIndefinite)} | ${McpFormat.WholeNumber(f.TotalAmountSold)} | {FormatAmount(f.TotalRemaining, f.IsRemainingIndefinite)} | ${McpFormat.WholeNumber(f.MinimumInvestmentAccepted)} | {McpFormat.WholeNumber(f.TotalNumberAlreadyInvested)} | {f.FederalExemptions ?? "-"} | {f.AccessionNumber ?? "-"} |"
+                );
+
+                if (filings.Any(f => f.IsAmendment))
+                {
+                    result.AppendLine();
+                    result.AppendLine(
+                        "_D/A amendments restate a prior notice for the same offering — group rows by first-sale date and offering amount; the latest notice of a chain supersedes the earlier ones, so do not sum Sold across a chain._"
+                    );
+                }
+
+                TruncationNotes.Append(result, filings.Count, totalCount);
+
+                return result.ToString();
             },
             "GetExemptOfferings",
             $"ticker: {ticker}"

--- a/src/Equibles.Sec.Mcp/Tools/FundCodes.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FundCodes.cs
@@ -1,0 +1,75 @@
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.Sec.Mcp.Tools;
+
+/// <summary>
+/// Render-time glosses for the raw SEC enumeration codes the fund tools would otherwise leak
+/// verbatim ("NS", "EC", "S-6"). Each gloss keeps the original code visible and appends a short
+/// human label, so an LLM consumer needs no out-of-band legend while a consumer keying on the raw
+/// code still finds it. Unknown codes pass through unchanged — the glosses annotate, never gate.
+/// </summary>
+internal static class FundCodes
+{
+    /// <summary>NPORT-P holding unit codes (Item C.7): what <c>Balance</c> is denominated in.</summary>
+    internal static string Unit(string code) =>
+        code switch
+        {
+            null or "" => "-",
+            "NS" => "NS (shares)",
+            "PA" => "PA (principal amount)",
+            "NC" => "NC (contracts)",
+            _ => code,
+        };
+
+    /// <summary>NPORT-P asset-category codes (Item C.4.a).</summary>
+    internal static string AssetCategory(string code) =>
+        code switch
+        {
+            null or "" => "-",
+            "EC" => "EC (equity-common)",
+            "EP" => "EP (equity-preferred)",
+            "DBT" => "DBT (debt)",
+            "STIV" => "STIV (short-term investment vehicle)",
+            "RA" => "RA (repurchase agreement)",
+            "LON" => "LON (loan)",
+            "SN" => "SN (structured note)",
+            "RE" => "RE (real estate)",
+            "COMM" => "COMM (commodity)",
+            "DE" => "DE (derivative-equity)",
+            "DCO" => "DCO (derivative-commodity)",
+            "DCR" => "DCR (derivative-credit)",
+            "DFE" => "DFE (derivative-foreign exchange)",
+            "DIR" => "DIR (derivative-interest rate)",
+            "DO" => "DO (derivative-other)",
+            "ABS-MBS" => "ABS-MBS (mortgage-backed security)",
+            "ABS-APCP" => "ABS-APCP (asset-backed commercial paper)",
+            "ABS-CBDO" => "ABS-CBDO (collateralized bond/debt obligation)",
+            "ABS-O" => "ABS-O (other asset-backed security)",
+            _ => code,
+        };
+
+    /// <summary>
+    /// N-CEN registrant classification: the registration form the investment company is organised
+    /// under. These double as the <c>FundSeries.FundType</c> values.
+    /// </summary>
+    internal static string RegistrationType(string code) =>
+        code switch
+        {
+            null or "" => "-",
+            "N-1A" => "N-1A (open-end fund)",
+            "N-2" => "N-2 (closed-end fund)",
+            "N-3" => "N-3 (variable annuity, managed separate account)",
+            "N-4" => "N-4 (variable annuity, unit investment trust)",
+            "N-5" => "N-5 (small business investment company)",
+            "N-6" => "N-6 (variable life separate account)",
+            "S-1" or "S-6" => code + " (unit investment trust)",
+            _ => code,
+        };
+
+    /// <summary>
+    /// A holding balance without the noise ".00" share counts carry: whole quantities (the NS/NC
+    /// cases) render with no decimals, fractional ones keep two.
+    /// </summary>
+    internal static string Balance(decimal balance) =>
+        McpFormat.Invariant(balance, balance == decimal.Truncate(balance) ? "N0" : "N2");
+}

--- a/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
@@ -37,15 +37,15 @@ public class FundDirectoryTools
 
     [McpServerTool(Name = "SearchFunds")]
     [Description(
-        "Search the directory of registered investment companies (mutual funds and ETFs) that file SEC Form NPORT-P, by fund name, ticker or registrant. Returns each matching fund series with its profile id (use it with GetFundProfile), ticker (when the fund is itself listed), net assets, number of reported holdings and latest report date, largest funds first. Covers the large multi-series trusts (iShares, Vanguard, Fidelity) that have no ticker of their own."
+        "Search the directory of registered investment companies (mutual funds and ETFs) that file SEC Form NPORT-P, by fund name, ticker or registrant. Returns each matching fund series with its profile id (use it with GetFundProfile), ticker (when the fund is itself listed), registration type (from N-CEN, when on record), net assets, number of reported holdings and latest report date, largest funds first. Covers the large multi-series trusts (iShares, Vanguard, Fidelity) that have no ticker of their own. Only a fund's own series-level ticker matches (e.g. IWM, SPY); share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) are not indexed — search those by fund name instead (e.g. 'Vanguard 500')."
     )]
     public Task<string> SearchFunds(
         [Description(
-            "Fund name, ticker or registrant to search for (e.g., 'Russell 2000', 'iShares', 'VOO')"
+            "Fund name, ticker or registrant to search for (e.g., 'Russell 2000', 'iShares', 'IWM'). Share-class tickers of multi-class mutual funds (e.g. VOO) do not match — use the fund's name."
         )]
             string query,
         [Description(
-            "Maximum number of funds to return, largest by net assets first (default: 20)"
+            "Maximum number of funds to return, largest by net assets first (default: 20, max: 500)"
         )]
             int maxResults = 20
     )
@@ -57,22 +57,25 @@ public class FundDirectoryTools
                     return "Provide a fund name, ticker or registrant to search for.";
 
                 var term = query.Trim().ToLower();
-                var matches = await _fundSeriesRepository
+                var allMatches = _fundSeriesRepository
                     .GetAll()
                     .Where(f =>
                         (f.SeriesName != null && f.SeriesName.ToLower().Contains(term))
                         || (f.RegistrantName != null && f.RegistrantName.ToLower().Contains(term))
                         || (f.Ticker != null && f.Ticker.ToLower().Contains(term))
-                    )
+                    );
+
+                var totalCount = await allMatches.CountAsync();
+                if (totalCount == 0)
+                    return $"No registered funds match '{query}'. Share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) are not searchable — try the fund's name instead.";
+
+                var matches = await allMatches
                     .OrderByDescending(f => f.NetAssets)
-                    .Take(Math.Max(1, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
-                if (matches.Count == 0)
-                    return $"No registered funds match '{query}'.";
-
                 var result = MarkdownTable.Start(
-                    $"Registered funds matching '{query}', largest by net assets first ({matches.Count}):",
+                    $"Registered funds matching '{query}', largest by net assets first (showing {matches.Count} of {totalCount}):",
                     "| Fund | Profile id | Ticker | Type | Net Assets (USD) | Holdings | Latest Report |",
                     "|------|-----------|--------|------|------------------|----------|---------------|"
                 );
@@ -80,8 +83,10 @@ public class FundDirectoryTools
                 result.AppendRows(
                     matches,
                     f =>
-                        $"| {f.SeriesName ?? f.RegistrantName ?? "-"} | {f.Slug} | {f.Ticker ?? "-"} | {f.FundType ?? "-"} | ${FormatAmount(f.NetAssets)} | {f.PositionCount} | {f.LatestReportPeriodDate:yyyy-MM-dd} |"
+                        $"| {f.SeriesName ?? f.RegistrantName ?? "-"} | {f.Slug} | {f.Ticker ?? "-"} | {FundCodes.RegistrationType(f.FundType)} | ${FormatAmount(f.NetAssets)} | {f.PositionCount} | {f.LatestReportPeriodDate:yyyy-MM-dd} |"
                 );
+
+                TruncationNotes.Append(result, matches.Count, totalCount);
 
                 return result.ToString();
             },
@@ -92,14 +97,14 @@ public class FundDirectoryTools
 
     [McpServerTool(Name = "GetFundProfile")]
     [Description(
-        "Get a registered fund's profile and largest holdings from its most recent SEC Form NPORT-P report. Accepts a fund profile id from SearchFunds or a fund's own ticker. Returns the fund's registrant and series, reporting period, net and total assets, then its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value, share of net assets and asset category. For the large multi-series trusts only positions in tracked stocks are stored, so the holdings shown are the fund's tracked-stock positions; the net-asset totals are the fund's real totals."
+        "Get a registered fund's profile and largest holdings from its most recent SEC Form NPORT-P report. Accepts a fund profile id from SearchFunds or a fund's own ticker. Returns the fund's registrant and series, reporting period, net and total assets, then its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value, share of net assets and asset category. Prefer this after SearchFunds: the profile id reaches the many fund series that have no ticker of their own; GetFundHoldings is the equivalent view, and GetFundsHoldingStock answers the inverse question (which funds own a stock). For the large multi-series trusts only positions in tracked stocks are stored, so the holdings shown are the fund's tracked-stock positions; the net-asset totals are the fund's real totals."
     )]
     public Task<string> GetFundProfile(
         [Description(
-            "Fund profile id from SearchFunds (e.g., 'ishares-russell-2000-etf-s000002277') or a fund ticker (e.g., 'VOO')"
+            "Fund profile id from SearchFunds (e.g., 'ishares-russell-2000-etf-s000004344') or a fund's own ticker (e.g., 'IWM'). Share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) do not resolve — find the fund by name via SearchFunds."
         )]
             string fund,
-        [Description("Maximum number of holdings to return, largest first (default: 20)")]
+        [Description("Maximum number of holdings to return, largest first (default: 20, max: 500)")]
             int maxResults = 20
     )
     {
@@ -120,7 +125,7 @@ public class FundDirectoryTools
                     .FirstOrDefaultAsync();
 
                 if (series == null)
-                    return $"No registered fund found for '{fund}'. Use SearchFunds to find a fund's profile id.";
+                    return $"No registered fund found for '{fund}'. Use SearchFunds to find a fund's profile id — share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) do not resolve, so search by fund name.";
 
                 var latest = await _nportRepository
                     .GetSeriesReportsByPeriod(
@@ -138,7 +143,7 @@ public class FundDirectoryTools
 
                 var holdings = latest
                     .Holdings.OrderByDescending(h => h.ValueUsd)
-                    .Take(Math.Max(1, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToList();
 
                 var header =
@@ -158,8 +163,10 @@ public class FundDirectoryTools
                 result.AppendRows(
                     holdings,
                     h =>
-                        $"| {h.Name ?? "-"} | {h.Cusip ?? "-"} | {FormatAmount(h.Balance)} | {h.Units ?? "-"} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {h.AssetCategory ?? "-"} | {h.InvestmentCountry ?? "-"} |"
+                        $"| {h.Name ?? "-"} | {h.Cusip ?? "-"} | {FundCodes.Balance(h.Balance)} | {FundCodes.Unit(h.Units)} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {FundCodes.AssetCategory(h.AssetCategory)} | {h.InvestmentCountry ?? "-"} |"
                 );
+
+                TruncationNotes.Append(result, holdings.Count, latest.Holdings.Count);
 
                 return result.ToString();
             },

--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -35,11 +35,11 @@ public class NCenTools
 
     [McpServerTool(Name = "GetFundOperations")]
     [Description(
-        "Get operational data for a registered investment company (mutual fund, ETF or closed-end fund) from its SEC Form N-CEN annual reports. Each N-CEN shows the registrant's classification (e.g. N-1A open-end, N-2 closed-end), Investment Company Act file number, reporting period, and whether it was the fund's first or last filing, followed by the fund's named service providers — investment advisers, sub-advisers, custodians, transfer agents, administrators, auditors and underwriters. Use this to see who runs and services a fund. Only registered funds file N-CEN; operating companies will return no data."
+        "Get operational data for a registered investment company from its SEC Form N-CEN annual reports. Resolves exchange-listed tickers only — ETFs, closed-end funds and unit investment trusts; an unlisted mutual-fund share-class ticker (e.g. VFIAX) will not resolve, so find that fund via SearchFunds/GetFundProfile instead. Each N-CEN shows the registrant's classification (e.g. N-1A open-end, N-2 closed-end, S-6 unit investment trust), Investment Company Act file number, reporting period, and whether it was the fund's first or last filing, followed by the service providers named on the most recent report only — investment advisers, sub-advisers, custodians, transfer agents, administrators, auditors and underwriters. Use this to see who runs and services a fund. Only registered funds file N-CEN; operating companies will return no data."
     )]
     public Task<string> GetFundOperations(
         [Description("Fund or ETF ticker symbol (e.g., MXF, SPY)")] string ticker,
-        [Description("Maximum number of annual reports to return (default: 10)")]
+        [Description("Maximum number of annual reports to return (default: 10, max: 500)")]
             int maxResults = 10
     )
     {
@@ -69,7 +69,7 @@ public class NCenTools
                 result.AppendRows(
                     filings,
                     f =>
-                        $"| {f.FilingDate:yyyy-MM-dd} | {f.ReportEndingPeriod:yyyy-MM-dd} | {f.InvestmentCompanyType ?? "-"} | {f.InvestmentCompanyFileNumber ?? "-"} | {(f.IsAmendment ? "Yes" : "No")} | {(f.IsFirstFiling ? "Yes" : "No")} | {(f.IsLastFiling ? "Yes" : "No")} |"
+                        $"| {f.FilingDate:yyyy-MM-dd} | {f.ReportEndingPeriod:yyyy-MM-dd} | {FundCodes.RegistrationType(f.InvestmentCompanyType)} | {f.InvestmentCompanyFileNumber ?? "-"} | {(f.IsAmendment ? "Yes" : "No")} | {(f.IsFirstFiling ? "Yes" : "No")} | {(f.IsLastFiling ? "Yes" : "No")} |"
                 );
 
                 AppendServiceProviders(result, filings[0]);
@@ -83,8 +83,17 @@ public class NCenTools
 
     private static void AppendServiceProviders(System.Text.StringBuilder result, NCenFiling latest)
     {
+        // Providers are always sourced from the newest report only; say so explicitly when it
+        // names none, or a consumer reads the missing section as "no providers on record" even
+        // though an older report in the same response may list them.
         if (latest.ServiceProviders.Count == 0)
+        {
+            result.AppendLine();
+            result.AppendLine(
+                $"The latest report (filed {latest.FilingDate:yyyy-MM-dd}) names no service providers."
+            );
             return;
+        }
 
         result.AppendLine();
         result.AppendLine(

--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -18,53 +18,50 @@ public class NportTools
 {
     private readonly NportFilingRepository _nportRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly FundSeriesRepository _fundSeriesRepository;
     private readonly McpToolRunner _runner;
 
     public NportTools(
         NportFilingRepository nportRepository,
         CommonStockRepository commonStockRepository,
+        FundSeriesRepository fundSeriesRepository,
         ErrorManager errorManager,
         ILogger<NportTools> logger
     )
     {
         _nportRepository = nportRepository;
         _commonStockRepository = commonStockRepository;
+        _fundSeriesRepository = fundSeriesRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetFundHoldings")]
     [Description(
-        "Get the portfolio holdings of a registered investment company (mutual fund or ETF) from its most recent SEC Form NPORT-P monthly report. Returns the fund's series, reporting period and net assets, followed by its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value and share of net assets, with the asset category (e.g. EC equity-common, DBT debt, DE derivative). Use this to see what a fund or ETF owns. Only registered funds file NPORT-P; operating companies will return no data."
+        "Get the portfolio holdings of a registered investment company (mutual fund or ETF) from its most recent SEC Form NPORT-P monthly report. Accepts the fund's own ticker or a fund profile id from SearchFunds, so it also reaches the many fund series that have no ticker of their own. Returns the fund's series, reporting period and net assets, followed by its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value and share of net assets, with the asset category. Use SearchFunds to discover funds, GetFundProfile for the same view with the fund's registrant and total assets, and GetFundsHoldingStock for the inverse question (which funds own a stock). Only registered funds file NPORT-P; operating companies will return no data. Share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) do not resolve — find those funds by name via SearchFunds."
     )]
     public Task<string> GetFundHoldings(
-        [Description("Fund or ETF ticker symbol (e.g., SPY, VOO)")] string ticker,
-        [Description("Maximum number of holdings to return, largest first (default: 20)")]
+        [Description(
+            "Fund or ETF ticker symbol (e.g., SPY, IWM) or a fund profile id from SearchFunds (e.g., 'vanguard-500-index-fund-s000002839')"
+        )]
+            string ticker,
+        [Description("Maximum number of holdings to return, largest first (default: 20, max: 500)")]
             int maxResults = 20
     )
     {
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
-                if (stockError != null)
-                    return stockError;
-
-                var filing = await _nportRepository
-                    .GetByStock(stock)
-                    .Include(f => f.Holdings)
-                    .OrderByDescending(f => f.FilingDate)
-                    .FirstOrDefaultAsync();
-
-                if (filing == null)
-                    return $"No Form NPORT-P portfolio reports found for {ticker}.";
+                var (filing, fundName, error) = await ResolveLatestFiling(ticker);
+                if (error != null)
+                    return error;
 
                 var holdings = filing
                     .Holdings.OrderByDescending(h => h.ValueUsd)
-                    .Take(maxResults)
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToList();
 
                 var result = MarkdownTable.Start(
-                    $"Portfolio holdings for {filing.SeriesName ?? stock.Name} ({ticker}) — "
+                    $"Portfolio holdings for {fundName} ({ticker}) — "
                         + $"reported {filing.ReportPeriodDate:yyyy-MM-dd}, net assets ${FormatAmount(filing.NetAssets)}, "
                         + $"{filing.Holdings.Count} total holdings, showing the largest {holdings.Count}:",
                     "| Holding | CUSIP | Balance | Units | Value (USD) | % Net Assets | Category | Country |",
@@ -74,14 +71,81 @@ public class NportTools
                 result.AppendRows(
                     holdings,
                     h =>
-                        $"| {h.Name ?? "-"} | {h.Cusip ?? "-"} | {FormatAmount(h.Balance)} | {h.Units ?? "-"} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {h.AssetCategory ?? "-"} | {h.InvestmentCountry ?? "-"} |"
+                        $"| {h.Name ?? "-"} | {h.Cusip ?? "-"} | {FundCodes.Balance(h.Balance)} | {FundCodes.Unit(h.Units)} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {FundCodes.AssetCategory(h.AssetCategory)} | {h.InvestmentCountry ?? "-"} |"
                 );
+
+                TruncationNotes.Append(result, holdings.Count, filing.Holdings.Count);
 
                 return result.ToString();
             },
             "GetFundHoldings",
             $"ticker: {ticker}"
         );
+    }
+
+    /// <summary>
+    /// Resolves the identifier to the fund's most recent NPORT-P report: first as a tracked
+    /// stock's ticker, then — funds and share classes absent from the stock table — through the
+    /// fund directory by profile id (slug) or series-level ticker, the same lookup
+    /// <c>GetFundProfile</c> uses. The latest report is the one with the greatest report period
+    /// (filing date as tiebreaker), so a late-filed amendment of an older period never shadows
+    /// the newest period.
+    /// </summary>
+    private async Task<(NportFiling Filing, string FundName, string Error)> ResolveLatestFiling(
+        string identifier
+    )
+    {
+        if (string.IsNullOrWhiteSpace(identifier))
+            return (null, null, "Provide a fund ticker or a profile id from SearchFunds.");
+
+        var (stock, _) = await _commonStockRepository.ResolveByTicker(identifier);
+        if (stock != null)
+        {
+            var filing = await _nportRepository
+                .GetByStock(stock)
+                .Include(f => f.Holdings)
+                .OrderByDescending(f => f.ReportPeriodDate)
+                .ThenByDescending(f => f.FilingDate)
+                .FirstOrDefaultAsync();
+
+            return filing == null
+                ? (null, null, $"No Form NPORT-P portfolio reports found for {identifier}.")
+                : (filing, filing.SeriesName ?? stock.Name, null);
+        }
+
+        var key = identifier.Trim();
+        var lowerKey = key.ToLower();
+        var series = await _fundSeriesRepository
+            .GetAll()
+            .Where(f => f.Slug == key || (f.Ticker != null && f.Ticker.ToLower() == lowerKey))
+            .OrderByDescending(f => f.NetAssets)
+            .FirstOrDefaultAsync();
+
+        if (series == null)
+            return (
+                null,
+                null,
+                $"No fund or ETF found for '{identifier}'. Use SearchFunds to find the fund and pass its profile id — share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) do not resolve, so search by fund name."
+            );
+
+        var latest = await _nportRepository
+            .GetSeriesReportsByPeriod(
+                series.CommonStockId,
+                series.RegistrantCik,
+                series.SeriesId,
+                DateOnly.MinValue
+            )
+            .Include(f => f.Holdings)
+            .OrderByDescending(f => f.ReportPeriodDate)
+            .FirstOrDefaultAsync();
+
+        return latest == null
+            ? (
+                null,
+                null,
+                $"No Form NPORT-P report is on record for {series.SeriesName ?? series.RegistrantName}."
+            )
+            : (latest, series.SeriesName ?? series.RegistrantName, null);
     }
 
     [McpServerTool(Name = "GetFundsHoldingStock")]

--- a/src/Equibles.Sec.Mcp/Tools/TruncationNotes.cs
+++ b/src/Equibles.Sec.Mcp/Tools/TruncationNotes.cs
@@ -1,0 +1,22 @@
+using System.Text;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.Sec.Mcp.Tools;
+
+/// <summary>
+/// Appends <see cref="McpOutput.TruncationNote"/> under a rendered markdown table. The leading
+/// blank line is load-bearing: without it a strict CommonMark renderer absorbs the note into the
+/// table as a stray single-cell row. No-op when nothing was cut off.
+/// </summary>
+internal static class TruncationNotes
+{
+    internal static void Append(StringBuilder result, int shown, int total)
+    {
+        var note = McpOutput.TruncationNote(shown, total);
+        if (note.Length > 0)
+        {
+            result.AppendLine();
+            result.AppendLine(note);
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
@@ -28,6 +28,7 @@ public class SecTestModuleConfiguration : Equibles.Data.IModuleConfiguration
         });
 
         builder.Entity<FailToDeliver>();
+        builder.Entity<FundSeries>();
         builder.Entity<FormDFiling>();
         builder.Entity<FormDRelatedPerson>();
         builder.Entity<NCenFiling>();

--- a/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
@@ -117,7 +117,87 @@ public class Form144ProposedSalesToolTests : IDisposable
 
         var result = await _tools.GetProposedSales("AAPL", maxResults: 2);
 
-        result.Should().Contain("Showing 2 most recent notices");
+        result.Should().Contain("Showing 2 of 5 most recent notices");
+        result.Should().Contain("Showing first 2 of 5 results");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_AllNoticesShown_OmitsTruncationNote()
+    {
+        var stock = SeedStock();
+        _dbContext
+            .Set<Form144Filing>()
+            .Add(MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1000));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        result.Should().Contain("Showing 1 of 1 most recent notices");
+        result.Should().NotContain("raise maxResults");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_DateRange_FiltersByFilingDate()
+    {
+        var stock = SeedStock();
+        _dbContext
+            .Set<Form144Filing>()
+            .Add(MakeFiling(stock.Id, "early", new DateOnly(2026, 1, 10), "EARLY SELLER", 1000));
+        _dbContext
+            .Set<Form144Filing>()
+            .Add(MakeFiling(stock.Id, "late", new DateOnly(2026, 6, 10), "LATE SELLER", 2000));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales(
+            "AAPL",
+            fromDate: "2026-03-01",
+            toDate: "2026-12-31"
+        );
+
+        result.Should().Contain("LATE SELLER");
+        result.Should().NotContain("EARLY SELLER");
+        result.Should().Contain("Showing 1 of 1 most recent notices");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_MalformedDate_ReturnsAcceptedFormatError()
+    {
+        SeedStock();
+
+        var result = await _tools.GetProposedSales("AAPL", toDate: "June 2026");
+
+        result.Should().Contain("Unknown toDate 'June 2026'");
+        result.Should().Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_RendersPercentOfSharesOutstanding()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1_000_000);
+        filing.SharesOutstanding = 2_000_000_000;
+        _dbContext.Set<Form144Filing>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        // 1,000,000 / 2,000,000,000 = 0.05% — the notice's own share base, as filed.
+        result.Should().Contain("% Outstanding");
+        result.Should().Contain("| 0.05% |");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_NoSharesOutstandingOnNotice_RendersDash()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1000);
+        filing.SharesOutstanding = 0;
+        _dbContext.Set<Form144Filing>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        result.Should().Contain("| - |");
     }
 
     private static Form144Filing MakeFiling(

--- a/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
@@ -115,6 +115,86 @@ public class FormDExemptOfferingsToolTests : IDisposable
         var result = await _tools.GetExemptOfferings("AAPL", maxResults: 2);
 
         result.Should().Contain("showing 2 most recent notices");
+        result.Should().Contain("Showing first 2 of 5 results");
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_RendersOfferingIdentityColumns()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "0001213900-25-000001", new DateOnly(2025, 3, 1));
+        filing.DateOfFirstSale = new DateOnly(2024, 11, 20);
+        filing.TotalRemaining = 123_456;
+        _dbContext.Set<FormDFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetExemptOfferings("AAPL");
+
+        // The chain anchor (first-sale date), the remaining amount, and the accession number
+        // are what lets a consumer group D/A restatements of the same offering.
+        result.Should().Contain("First Sale").And.Contain("2024-11-20");
+        result.Should().Contain("Remaining").And.Contain("$123,456");
+        result.Should().Contain("Accession").And.Contain("0001213900-25-000001");
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_WithAmendment_AppendsChainGroupingNote()
+    {
+        var stock = SeedStock();
+        var amendment = MakeFiling(stock.Id, "acc-a", new DateOnly(2025, 3, 1));
+        amendment.IsAmendment = true;
+        _dbContext.Set<FormDFiling>().Add(amendment);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetExemptOfferings("AAPL");
+
+        result.Should().Contain("restate a prior notice");
+        result.Should().Contain("do not sum Sold across a chain");
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_WithoutAmendments_OmitsChainGroupingNote()
+    {
+        var stock = SeedStock();
+        _dbContext.Set<FormDFiling>().Add(MakeFiling(stock.Id, "acc", new DateOnly(2025, 3, 1)));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetExemptOfferings("AAPL");
+
+        result.Should().NotContain("restate a prior notice");
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_DateRange_FiltersByFilingDate()
+    {
+        var stock = SeedStock();
+        _dbContext
+            .Set<FormDFiling>()
+            .Add(MakeFiling(stock.Id, "early", new DateOnly(2025, 1, 10), offeringAmount: 111_000));
+        _dbContext
+            .Set<FormDFiling>()
+            .Add(MakeFiling(stock.Id, "late", new DateOnly(2025, 6, 10), offeringAmount: 250_000));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetExemptOfferings(
+            "AAPL",
+            fromDate: "2025-03-01",
+            toDate: "2025-12-31"
+        );
+
+        result.Should().Contain("250,000");
+        result.Should().NotContain("111,000");
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_MalformedDate_ReturnsAcceptedFormatError()
+    {
+        SeedStock();
+
+        var result = await _tools.GetExemptOfferings("AAPL", fromDate: "01/13/2025");
+
+        result.Should().Contain("Unknown fromDate '01/13/2025'");
+        result.Should().Contain("yyyy-MM-dd");
     }
 
     private static FormDFiling MakeFiling(

--- a/tests/Equibles.IntegrationTests/Mcp/FundDirectoryToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FundDirectoryToolsTests.cs
@@ -1,0 +1,182 @@
+using Equibles.CommonStocks.Data;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class FundDirectoryToolsTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly FundDirectoryTools _tools;
+
+    public FundDirectoryToolsTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        _tools = new FundDirectoryTools(
+            new FundSeriesRepository(_dbContext),
+            new NportFilingRepository(_dbContext),
+            errorManager: null,
+            NullLogger<FundDirectoryTools>.Instance
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task SearchFunds_MoreMatchesThanMaxResults_ReportsTotalAndTruncationNote()
+    {
+        for (var i = 0; i < 3; i++)
+            SeedSeries($"ACME FUND {i}", $"S00000{i}", netAssets: 1_000_000m * (i + 1));
+
+        var result = await _tools.SearchFunds("Acme", maxResults: 2);
+
+        result.Should().Contain("showing 2 of 3");
+        result.Should().Contain("Showing first 2 of 3 results");
+        // Largest by net assets first: fund 2 shown, fund 0 cut off.
+        result.Should().Contain("ACME FUND 2");
+        result.Should().NotContain("ACME FUND 0");
+    }
+
+    [Fact]
+    public async Task SearchFunds_AllMatchesShown_OmitsTruncationNote()
+    {
+        SeedSeries("ACME FUND", "S000001");
+
+        var result = await _tools.SearchFunds("Acme");
+
+        result.Should().Contain("showing 1 of 1");
+        result.Should().NotContain("raise maxResults");
+    }
+
+    [Fact]
+    public async Task SearchFunds_GlossesRegistrationTypeCode()
+    {
+        SeedSeries("ACME CLOSED-END FUND", "S000001", fundType: "N-2");
+
+        var result = await _tools.SearchFunds("Acme");
+
+        result.Should().Contain("N-2 (closed-end fund)");
+    }
+
+    [Fact]
+    public async Task SearchFunds_NoMatch_ExplainsShareClassTickerGap()
+    {
+        var result = await _tools.SearchFunds("VOO");
+
+        result.Should().Contain("No registered funds match 'VOO'");
+        result.Should().Contain("Share-class tickers");
+    }
+
+    [Fact]
+    public async Task GetFundProfile_GlossesUnitAndCategoryCodesAndDropsWholeShareDecimals()
+    {
+        var series = SeedSeries("ACME FUND", "S000001");
+        var filing = MakeFiling(series, "acc-1", new DateOnly(2026, 5, 15));
+        filing.Holdings.Add(MakeHolding("BIG CO", 5_000_000m));
+        _dbContext.Set<NportFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundProfile(series.Slug);
+
+        result.Should().Contain("NS (shares)");
+        result.Should().Contain("EC (equity-common)");
+        result.Should().Contain("| 5,000,000 |", "whole share balances carry no .00 noise");
+    }
+
+    [Fact]
+    public async Task GetFundProfile_MoreHoldingsThanMaxResults_AppendsTruncationNote()
+    {
+        var series = SeedSeries("ACME FUND", "S000001");
+        var filing = MakeFiling(series, "acc-1", new DateOnly(2026, 5, 15));
+        for (var i = 0; i < 5; i++)
+            filing.Holdings.Add(MakeHolding($"CO {i}", 1_000m * (i + 1)));
+        _dbContext.Set<NportFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundProfile(series.Slug, maxResults: 2);
+
+        result.Should().Contain("showing the largest 2");
+        result.Should().Contain("Showing first 2 of 5 results");
+    }
+
+    [Fact]
+    public async Task GetFundProfile_UnknownFund_PointsAtSearchFundsAndNamesTheShareClassGap()
+    {
+        var result = await _tools.GetFundProfile("VOO");
+
+        result.Should().Contain("No registered fund found for 'VOO'");
+        result.Should().Contain("SearchFunds");
+        result.Should().Contain("share-class tickers");
+    }
+
+    private FundSeries SeedSeries(
+        string name,
+        string seriesId,
+        decimal netAssets = 1_000_000m,
+        string fundType = null
+    )
+    {
+        var series = new FundSeries
+        {
+            IdentityKey = $"rc:0000999999:{seriesId}",
+            Slug = $"{name.ToLower().Replace(' ', '-').Replace("--", "-")}-{seriesId.ToLower()}",
+            RegistrantCik = "0000999999",
+            SeriesId = seriesId,
+            SeriesName = name,
+            RegistrantName = "ACME TRUST",
+            LatestReportPeriodDate = new DateOnly(2026, 3, 31),
+            LatestFilingDate = new DateOnly(2026, 5, 15),
+            NetAssets = netAssets,
+            TotalAssets = netAssets,
+            PositionCount = 1,
+            FundType = fundType,
+        };
+        _dbContext.Set<FundSeries>().Add(series);
+        _dbContext.SaveChanges();
+        return series;
+    }
+
+    private static NportFiling MakeFiling(FundSeries series, string accession, DateOnly filingDate)
+    {
+        return new NportFiling
+        {
+            CommonStockId = null,
+            RegistrantCik = series.RegistrantCik,
+            AccessionNumber = accession,
+            FilingDate = filingDate,
+            IsAmendment = false,
+            RegistrantName = series.RegistrantName,
+            SeriesName = series.SeriesName,
+            SeriesId = series.SeriesId,
+            ReportPeriodDate = new DateOnly(2026, 3, 31),
+            ReportPeriodEnd = filingDate,
+            TotalAssets = 1_200_000_000m,
+            TotalLiabilities = 50_000_000m,
+            NetAssets = 1_150_000_000m,
+        };
+    }
+
+    private static NportHolding MakeHolding(string name, decimal valueUsd)
+    {
+        return new NportHolding
+        {
+            Name = name,
+            Balance = valueUsd,
+            Units = "NS",
+            Currency = "USD",
+            ValueUsd = valueUsd,
+            PercentValue = 1.0m,
+            PayoffProfile = "Long",
+            AssetCategory = "EC",
+            IssuerCategory = "CORP",
+            InvestmentCountry = "US",
+        };
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolNewestFilingProvidersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolNewestFilingProvidersTests.cs
@@ -12,10 +12,10 @@ namespace Equibles.IntegrationTests.Mcp;
 
 /// <summary>
 /// Adversarial cover for <c>GetFundOperations</c>'s service-provider section, which the helper
-/// sources from the latest report only. When the newest filing reports no service providers, no
-/// "Service providers" section should render — and an older filing's providers must not leak in.
-/// Existing tests only seed providers on the newest filing, leaving both the empty-on-newest early
-/// return and the newest-filing selection unexercised.
+/// sources from the latest report only. When the newest filing reports no service providers, an
+/// explicit "names no service providers" note must render — and an older filing's providers must
+/// not leak in. Existing tests only seed providers on the newest filing, leaving both the
+/// empty-on-newest note and the newest-filing selection unexercised.
 /// </summary>
 public class NCenFundOperationsToolNewestFilingProvidersTests : IDisposable
 {
@@ -39,7 +39,7 @@ public class NCenFundOperationsToolNewestFilingProvidersTests : IDisposable
     public void Dispose() => _dbContext.Dispose();
 
     [Fact]
-    public async Task GetFundOperations_NewestFilingHasNoProviders_OmitsServiceProvidersSection()
+    public async Task GetFundOperations_NewestFilingHasNoProviders_EmitsNoteWithoutLeakingOlderProviders()
     {
         var stock = new CommonStock
         {
@@ -67,9 +67,12 @@ public class NCenFundOperationsToolNewestFilingProvidersTests : IDisposable
 
         var result = await _tools.GetFundOperations("MXF");
 
-        // The section reflects only the latest report, which has no providers — so it is omitted,
-        // and the older filing's provider must not leak in.
-        result.Should().NotContain("Service providers");
+        // The section reflects only the latest report, which has no providers — so an explicit
+        // note renders instead of a silently missing section, and the older filing's provider
+        // must not leak in.
+        result.Should().Contain("names no service providers");
+        result.Should().Contain("2025-01-15");
+        result.Should().NotContain("Service providers reported");
         result.Should().NotContain("OLD ADVISER FIRM");
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolTests.cs
@@ -112,6 +112,18 @@ public class NCenFundOperationsToolTests : IDisposable
         result.Should().Contain("showing 2 most recent");
     }
 
+    [Fact]
+    public async Task GetFundOperations_GlossesRegistrationTypeCode()
+    {
+        var stock = SeedStock();
+        _dbContext.Set<NCenFiling>().Add(MakeFiling(stock.Id, "acc", new DateOnly(2025, 1, 15)));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundOperations("MXF");
+
+        result.Should().Contain("N-2 (closed-end fund)");
+    }
+
     private static NCenFiling MakeFiling(Guid stockId, string accession, DateOnly filingDate)
     {
         return new NCenFiling

--- a/tests/Equibles.IntegrationTests/Mcp/NportFundHoldingsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportFundHoldingsToolTests.cs
@@ -24,6 +24,7 @@ public class NportFundHoldingsToolTests : IDisposable
         _tools = new NportTools(
             new NportFilingRepository(_dbContext),
             new CommonStockRepository(_dbContext),
+            new FundSeriesRepository(_dbContext),
             errorManager: null,
             NullLogger<NportTools>.Instance
         );
@@ -103,6 +104,131 @@ public class NportFundHoldingsToolTests : IDisposable
         var result = await _tools.GetFundHoldings("VOO", maxResults: 2);
 
         result.Should().Contain("showing the largest 2");
+        result.Should().Contain("Showing first 2 of 5 results");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_LateFiledAmendmentOfOlderPeriod_DoesNotShadowNewestPeriod()
+    {
+        var stock = SeedStock();
+
+        var current = MakeFiling(stock.Id, "current", new DateOnly(2025, 3, 15));
+        current.ReportPeriodDate = new DateOnly(2025, 2, 28);
+        current.Holdings.Add(MakeHolding("CURRENT CO", 1_000_000m));
+        _dbContext.Set<NportFiling>().Add(current);
+
+        // Amendment of an OLDER period filed AFTER the current period's report: picking by
+        // filing date alone would surface this stale-period portfolio as "most recent".
+        var amendment = MakeFiling(stock.Id, "amendment", new DateOnly(2025, 4, 1));
+        amendment.ReportPeriodDate = new DateOnly(2024, 12, 31);
+        amendment.IsAmendment = true;
+        amendment.Holdings.Add(MakeHolding("AMENDED CO", 2_000_000m));
+        _dbContext.Set<NportFiling>().Add(amendment);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundHoldings("VOO");
+
+        result.Should().Contain("CURRENT CO");
+        result.Should().Contain("2025-02-28");
+        result.Should().NotContain("AMENDED CO");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_GlossesUnitAndCategoryCodesAndDropsWholeShareDecimals()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2025, 1, 31));
+        filing.Holdings.Add(MakeHolding("BIG CO", 5_000_000m));
+        _dbContext.Set<NportFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundHoldings("VOO");
+
+        result.Should().Contain("NS (shares)");
+        result.Should().Contain("EC (equity-common)");
+        result.Should().Contain("| 5,000,000 |", "whole share balances carry no .00 noise");
+        result.Should().NotContain("| 5,000,000.00 |");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_TickerlessTrustSeries_ResolvesThroughFundDirectorySlug()
+    {
+        SeedTrustSeries();
+        _dbContext.Set<NportFiling>().Add(MakeTrustFiling("acc-1", new DateOnly(2026, 5, 15)));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundHoldings("vanguard-500-index-fund-s000002839");
+
+        result.Should().Contain("VANGUARD 500 INDEX FUND");
+        result.Should().Contain("TRACKED CO");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_SeriesLevelTicker_ResolvesThroughFundDirectory()
+    {
+        SeedTrustSeries(ticker: "VFV");
+        _dbContext.Set<NportFiling>().Add(MakeTrustFiling("acc-1", new DateOnly(2026, 5, 15)));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundHoldings("vfv");
+
+        result.Should().Contain("VANGUARD 500 INDEX FUND");
+        result.Should().Contain("TRACKED CO");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_UnknownIdentifier_PointsAtSearchFunds()
+    {
+        var result = await _tools.GetFundHoldings("VOO");
+
+        result.Should().Contain("No fund or ETF found for 'VOO'");
+        result.Should().Contain("SearchFunds");
+    }
+
+    private void SeedTrustSeries(string ticker = null)
+    {
+        _dbContext
+            .Set<FundSeries>()
+            .Add(
+                new FundSeries
+                {
+                    IdentityKey = "rc:0000102909:S000002839",
+                    Slug = "vanguard-500-index-fund-s000002839",
+                    RegistrantCik = "0000102909",
+                    SeriesId = "S000002839",
+                    SeriesName = "VANGUARD 500 INDEX FUND",
+                    RegistrantName = "VANGUARD INDEX FUNDS",
+                    Ticker = ticker,
+                    LatestReportPeriodDate = new DateOnly(2026, 3, 31),
+                    LatestFilingDate = new DateOnly(2026, 5, 15),
+                    NetAssets = 1_400_000_000_000m,
+                    TotalAssets = 1_450_000_000_000m,
+                    PositionCount = 1,
+                }
+            );
+        _dbContext.SaveChanges();
+    }
+
+    private static NportFiling MakeTrustFiling(string accession, DateOnly filingDate)
+    {
+        var filing = new NportFiling
+        {
+            CommonStockId = null,
+            RegistrantCik = "0000102909",
+            AccessionNumber = accession,
+            FilingDate = filingDate,
+            IsAmendment = false,
+            RegistrantName = "VANGUARD INDEX FUNDS",
+            SeriesName = "VANGUARD 500 INDEX FUND",
+            SeriesId = "S000002839",
+            ReportPeriodDate = new DateOnly(2026, 3, 31),
+            ReportPeriodEnd = filingDate,
+            TotalAssets = 1_450_000_000_000m,
+            TotalLiabilities = 50_000_000_000m,
+            NetAssets = 1_400_000_000_000m,
+        };
+        filing.Holdings.Add(MakeHolding("TRACKED CO", 10_000_000m));
+        return filing;
     }
 
     private static NportFiling MakeFiling(Guid stockId, string accession, DateOnly filingDate)

--- a/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
@@ -26,6 +26,7 @@ public class NportFundsHoldingStockToolTests : IDisposable
         _tools = new NportTools(
             new NportFilingRepository(_dbContext),
             new CommonStockRepository(_dbContext),
+            new FundSeriesRepository(_dbContext),
             errorManager: null,
             NullLogger<NportTools>.Instance
         );

--- a/tests/Equibles.IntegrationTests/Mcp/NportToolsGetFundsHoldingStockNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportToolsGetFundsHoldingStockNegativeMaxResultsTests.cs
@@ -20,6 +20,7 @@ public class NportToolsGetFundsHoldingStockNegativeMaxResultsTests : ParadeDbMcp
         new(
             new NportFilingRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new FundSeriesRepository(DbContext),
             ErrorManager,
             NullLogger<NportTools>()
         );


### PR DESCRIPTION
## Summary

Fixes all audit findings for the fund-directory and Form D / Form 144 MCP tools, verified against live MCP calls and prod data.

- **GetFundHoldings**: resolution fell through only the CommonStock table, so the tool's own documented example (VOO) failed with a misleading "Stock 'VOO' not found." It now falls back to the FundSeries directory (profile id or series-level ticker — the same lookup GetFundProfile uses), and the not-found error points at SearchFunds and names the share-class-ticker gap. Latest report is now picked by report period with filing date as tiebreaker, so a late-filed NPORT-P/A amendment of an older period can no longer shadow the newest portfolio.
- **SearchFunds / GetFundProfile**: both documented examples failed live ('VOO' and the stale 'ishares-russell-2000-etf-s000002277' id). Replaced with live-verified values (IWM / ishares-russell-2000-etf-s000004344 / vanguard-500-index-fund-s000002839); descriptions now state that share-class tickers of multi-class mutual funds (VOO, VFIAX) never match and to search by name. SearchFunds reports shown-of-total counts, appends a truncation note and clamps maxResults to the shared [1, 500] bound.
- **Raw SEC codes decoded at render time** (new `FundCodes` gloss helper): NPORT units (NS/PA/NC), NPORT asset categories (EC/DBT/DE/…), N-CEN registration types (N-1A/N-2/S-6/…) — the SearchFunds Type column and GetFundOperations Type column now render "N-2 (closed-end fund)" instead of bare form codes. Whole share balances drop the ".00" noise.
- **GetFundOperations**: description states only exchange-listed tickers resolve (mutual-fund share classes → SearchFunds/GetFundProfile) and that service providers come from the most recent report only; when that report names none, the output says so explicitly instead of silently omitting the section.
- **GetExemptOfferings**: D/A amendment chains were indistinguishable, so summing Sold overcounted capital raised ~3x for regular re-filers. Adds First Sale / Remaining / Accession columns and an explanatory chain-grouping note, optional fromDate/toDate filters (strict yyyy-MM-dd via `McpOutput`), a truncation note, and fixes the description (only the offering amount can be "Indefinite").
- **GetProposedSales**: shown-of-total subtitle + truncation note (a daily 10b5-1 filer floods the recency window), optional fromDate/toDate filters, documented [1, 500] clamp, and a % Outstanding column (proposed sale over the notice's own reported share base).

## Code changes

- `src/Equibles.Sec.Mcp/Tools/FundCodes.cs` (new) — render-time glosses for NPORT/N-CEN enumeration codes + whole-balance formatting.
- `src/Equibles.Sec.Mcp/Tools/TruncationNotes.cs` (new) — appends `McpOutput.TruncationNote` under a table with the load-bearing blank line.
- `src/Equibles.Sec.Mcp/Tools/NportTools.cs` — directory fallback (new `FundSeriesRepository` ctor dependency), period-ordered latest report, glosses, clamp, truncation note, description updates.
- `src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs`, `NCenTools.cs`, `FormDTools.cs`, `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — as above; tool names and existing parameter names/semantics unchanged (new parameters are optional with null defaults).
- Tests: new `FundDirectoryToolsTests`; extended NPORT/N-CEN/Form D/Form 144 suites (directory fallback, amendment-shadowing regression, glosses, date filters, strict-date errors, truncation notes, % outstanding); `SecTestModuleConfiguration` registers `FundSeries`.

Deferred (needs schema/refresh-pipeline work, no migrations in this PR): persisting class-level tickers so VOO/VFIAX resolve to their series — see PR discussion in the audit notes.