### PR TITLE
fix(mcp): financial-facts tool audit fixes (GetFinancialFact, CompareFinancialFact, GetFinancialStatement, GetRevenueBreakdown)

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -274,6 +274,21 @@ public static class FinancialConceptAliases
                 "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalentsPeriodIncreaseDecreaseExcludingExchangeRateEffect"
             ),
         ],
+
+        // ── Risk disclosures ────────────────────────────────────────────────
+        // Concentration-risk percentage (ASC 275/280): the share of revenue or
+        // receivables attributable to a filer's largest customer(s), as a
+        // fraction (0.31 = 31%). Filers usually tag it per customer/benchmark
+        // (dimensioned), so the consolidated-only fact tools surface it only
+        // where an entity-level figure is tagged; both taxonomy spellings are
+        // listed because issuers file the element under us-gaap and srt.
+        ["customer-concentration"] =
+        [
+            G("ConcentrationRiskPercentage1"),
+            G("ConcentrationRiskPercentage"),
+            new(FactTaxonomy.Srt, "ConcentrationRiskPercentage1"),
+            new(FactTaxonomy.Srt, "ConcentrationRiskPercentage"),
+        ],
     };
 
     // Spelt-out synonyms normalise onto a canonical key so callers can use
@@ -310,6 +325,8 @@ public static class FinancialConceptAliases
         ["pp&e"] = "property-plant-and-equipment",
         ["aoci"] = "accumulated-oci",
         ["apic"] = "additional-paid-in-capital",
+        ["concentration-risk"] = "customer-concentration",
+        ["customer-concentration-risk"] = "customer-concentration",
     };
 
     public static IReadOnlyCollection<string> SupportedAliases => Map.Keys;

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -52,7 +52,9 @@ public class FinancialFactsTools
         "Get a single financial concept (e.g. revenue, net income, diluted EPS, total "
             + "assets, operating cash flow) over time for a company, sourced from SEC "
             + "Company Facts (structured XBRL). Returns a time series, one row per fiscal "
-            + "period, using the latest restated value unless asOriginallyReported is set."
+            + "period, using the latest restated value unless asOriginallyReported is set. "
+            + "Fiscal years/quarters follow the company's own fiscal calendar. For a full "
+            + "statement use GetFinancialStatement; to compare peers use CompareFinancialFact."
     )]
     public Task<string> GetFinancialFact(
         [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -70,7 +72,13 @@ public class FinancialFactsTools
             "When true, show the value as originally filed (earliest filing) instead of "
                 + "the latest restatement. Default false."
         )]
-            bool asOriginallyReported = false
+            bool asOriginallyReported = false,
+        [Description(
+            "Optional fiscal-period filter: 'FY' (annual only) or 'Q1'..'Q4'. Note that "
+                + "discrete Q4 rows exist only where the filer reported a discrete fourth "
+                + "quarter (most large filers stopped after ~2021)."
+        )]
+            string fiscalPeriod = null
     )
     {
         return _runner.Execute(
@@ -102,6 +110,18 @@ public class FinancialFactsTools
                 if (!TryParseBound(toDate, out var toBound))
                     return $"Unknown date '{toDate}'. Use YYYY-MM-DD.";
 
+                SecFiscalPeriod? periodFilter = null;
+                if (!string.IsNullOrWhiteSpace(fiscalPeriod))
+                {
+                    if (!FactArgs.TryParsePeriod(fiscalPeriod, out var parsedPeriod))
+                        return McpOutput.InvalidArgument(
+                            "fiscalPeriod",
+                            fiscalPeriod,
+                            "'FY' or 'Q1'..'Q4'"
+                        );
+                    periodFilter = parsedPeriod;
+                }
+
                 // conceptId → alias priority (0 = the alias's primary tag). Used
                 // to break ties deterministically when one period carries facts
                 // under several of the alias's tags (the ASC 606 transition).
@@ -120,13 +140,16 @@ public class FinancialFactsTools
                 // ReportedQuarterPromotion; a full-year total can never qualify).
                 var allFacts = ReportedQuarterPromotion.WithPromotedFourthQuarters(facts);
 
-                // Form / period-end filtering in memory: a single concept's
-                // history is small, and DocumentType is a value-converted type
-                // so equality is kept off the SQL side for provider safety.
+                // Form / period-end / fiscal-period filtering in memory: a
+                // single concept's history is small, and DocumentType is a
+                // value-converted type so equality is kept off the SQL side
+                // for provider safety. The fiscal-period filter runs after
+                // promotion so a Q4 request sees the promoted rows.
                 var filtered = allFacts.Where(f =>
                     (formFilter == null || f.Form == formFilter)
                     && (fromBound == null || f.PeriodEnd >= fromBound.Value)
                     && (toBound == null || f.PeriodEnd <= toBound.Value)
+                    && (periodFilter == null || f.FiscalPeriod == periodFilter.Value)
                 );
 
                 // One row per fiscal period. The alias may span several tags and
@@ -134,31 +157,62 @@ public class FinancialFactsTools
                 // (the ASC 606 transition year tags both Revenues and the new
                 // concept). Pick deterministically: the alias's primary tag
                 // wins, then the latest filing — or the earliest, when the
-                // caller wants the figure as originally reported.
-                var perPeriod = filtered
-                    .GroupBy(f => (f.FiscalYear, f.FiscalPeriod))
-                    .Select(g => PickBestFact(g, conceptPriority, asOriginallyReported))
+                // caller wants the figure as originally reported. The picked
+                // rows are then deduped by actual reporting span, because a
+                // date window can degenerate a fiscal group to a comparative
+                // re-report of an earlier period (see DedupeByReportingSpan).
+                var perPeriod = DedupeByReportingSpan(
+                        filtered
+                            .GroupBy(f => (f.FiscalYear, f.FiscalPeriod))
+                            .Select(g => PickBestFact(g, conceptPriority, asOriginallyReported))
+                    )
                     .OrderByDescending(f => f.PeriodEnd)
-                    .Take(Math.Clamp(maxResults, 1, MaxResultsCap))
                     .ToList();
 
-                if (perPeriod.Count == 0)
+                var shown = perPeriod.Take(Math.Clamp(maxResults, 1, MaxResultsCap)).ToList();
+
+                if (shown.Count == 0)
                     return $"No '{concept}' data found for {stock.Ticker} with the given filters.";
 
-                return RenderFactHistoryTable(concept, stock, asOriginallyReported, perPeriod);
+                return RenderFactHistoryTable(
+                    concept,
+                    stock,
+                    asOriginallyReported,
+                    shown,
+                    perPeriod.Count
+                );
             },
             "GetFinancialFact",
             $"ticker: {FactMarkdown.Clean(ticker)}, concept: {FactMarkdown.Clean(concept)}, "
-                + $"form: {FactMarkdown.Clean(form)}"
+                + $"form: {FactMarkdown.Clean(form)}, "
+                + $"fiscalPeriod: {FactMarkdown.Clean(fiscalPeriod)}"
         );
     }
+
+    // A fromDate/toDate window can exclude a fiscal year's own period end while
+    // keeping a comparative re-report of an EARLIER period — a filing re-reports
+    // prior periods under its own fiscal identity, so that group degenerates to
+    // the comparative alone and its pick duplicates a period end another group
+    // already covers, under the wrong fiscal-year label (NVDA's FY2026 10-K
+    // re-reporting FY2025 EPS surfaced as a second "FY 2026" row when toDate
+    // excluded 2026-01-25). One row per actual reporting span: the smallest
+    // fiscal-year stamp is the period's own identity, because comparative
+    // re-filings always re-stamp the same span under the filing's LATER year
+    // (same rule as ReportedQuarterPromotion's anchor).
+    internal static List<FinancialFact> DedupeByReportingSpan(IEnumerable<FinancialFact> picked) =>
+        picked
+            .GroupBy(f => (f.PeriodStart, f.PeriodEnd, f.PeriodType))
+            .Select(g => g.OrderBy(f => f.FiscalYear).ThenBy(f => f.FiscalPeriod).First())
+            .ToList();
 
     [McpServerTool(Name = "CompareFinancialFact")]
     [Description(
         "Compare one financial concept across several companies for the same fiscal "
             + "period — peer comparison. Returns one row per ticker with the "
             + "latest-restated value; tickers with no data for the period are listed "
-            + "separately."
+            + "separately. Fiscal year/period follow each company's OWN fiscal calendar "
+            + "(e.g. NVDA's fiscal 2025 ended January 2025), so peer rows can cover very "
+            + "different calendar months — check the Period End column."
     )]
     public Task<string> CompareFinancialFact(
         [Description("Comma-separated tickers, e.g. 'AAPL,MSFT,GOOGL' (max 25)")] string tickers,
@@ -275,7 +329,8 @@ public class FinancialFactsTools
         string concept,
         CommonStock stock,
         bool asOriginallyReported,
-        List<FinancialFact> perPeriod
+        List<FinancialFact> perPeriod,
+        int totalPeriods
     )
     {
         var basis = asOriginallyReported ? "as originally reported" : "latest restated";
@@ -296,6 +351,14 @@ public class FinancialFactsTools
                 + $"{FactMarkdown.Cell(f.AccessionNumber)} |"
         );
 
+        // Rows are newest first, so "first N" reads correctly; a no-op empty
+        // line when nothing was cut off.
+        if (perPeriod.Count < totalPeriods)
+        {
+            result.AppendLine();
+            result.AppendLine(McpOutput.TruncationNote(perPeriod.Count, totalPeriods));
+        }
+
         return result.ToString();
     }
 
@@ -310,6 +373,10 @@ public class FinancialFactsTools
     {
         var rows = new List<(string Ticker, string Name, FinancialFact Fact)>();
         var skipped = new List<string>();
+        // A company's primary and secondary tickers (GOOGL/GOOG) resolve to the
+        // same stock; a second request string for a stock already in the table
+        // would duplicate its row, so it is reported instead of re-added.
+        var rowTickerByStockId = new Dictionary<Guid, string>();
         foreach (var ticker in requested)
         {
             if (!stockByTicker.TryGetValue(ticker, out var stock))
@@ -317,15 +384,30 @@ public class FinancialFactsTools
                 skipped.Add($"{FactMarkdown.Cell(ticker)} (not found)");
                 continue;
             }
+            if (rowTickerByStockId.TryGetValue(stock.Id, out var firstTicker))
+            {
+                skipped.Add($"{FactMarkdown.Cell(ticker)} (same company as {firstTicker})");
+                continue;
+            }
+            rowTickerByStockId.Add(stock.Id, ticker);
             if (!bestByStock.TryGetValue(stock.Id, out var best))
             {
                 skipped.Add($"{FactMarkdown.Cell(ticker)} (no data)");
                 continue;
             }
-            rows.Add((stock.Ticker, stock.Name, best));
+            // The row stays traceable to the caller's input: a secondary-ticker
+            // request shows that ticker, with the primary in parentheses.
+            var label = ticker == stock.Ticker ? stock.Ticker : $"{ticker} ({stock.Ticker})";
+            rows.Add((label, stock.Name, best));
         }
         return (rows, skipped);
     }
+
+    // Peer period ends further apart than one calendar quarter mean the rows
+    // cover materially different calendar months (NVDA's fiscal Q2 2025 ended
+    // July 2024; AMD's ended June 2025) — flag it so the comparison is never
+    // read as same-calendar-period.
+    private const int MaxAlignedPeriodEndSpreadDays = 92;
 
     private static string RenderComparisonTable(
         string concept,
@@ -337,8 +419,8 @@ public class FinancialFactsTools
     {
         var result = MarkdownTable.Start(
             $"{concept} — {fiscalYear} {period.NameForHumans()} peer comparison:",
-            "| Ticker | Company | Value | Unit | Form | Filed |",
-            "|--------|---------|------:|------|------|-------|"
+            "| Ticker | Company | Value | Unit | Period End | Form | Filed |",
+            "|--------|---------|------:|------|-----------|------|-------|"
         );
         result.AppendRows(
             rows,
@@ -346,6 +428,7 @@ public class FinancialFactsTools
                 $"| {FactMarkdown.Cell(r.Ticker)} | {FactMarkdown.Cell(r.Name)} | "
                 + $"{FactMarkdown.Value(r.Fact.Value, r.Fact.Unit)} | "
                 + $"{FactMarkdown.Cell(r.Fact.Unit)} | "
+                + $"{r.Fact.PeriodEnd:yyyy-MM-dd} | "
                 + $"{FactMarkdown.Cell(r.Fact.Form?.DisplayName)} | "
                 + $"{r.Fact.FiledDate:yyyy-MM-dd} |"
         );
@@ -355,6 +438,18 @@ public class FinancialFactsTools
                 $"\n_No company reported '{concept}' for {fiscalYear} "
                     + $"{period.NameForHumans()}._"
             );
+
+        if (rows.Count > 1)
+        {
+            var earliest = rows.Min(r => r.Fact.PeriodEnd);
+            var latest = rows.Max(r => r.Fact.PeriodEnd);
+            if (latest.DayNumber - earliest.DayNumber > MaxAlignedPeriodEndSpreadDays)
+                result.AppendLine(
+                    $"\n_Note: fiscal calendars differ across these companies — period ends "
+                        + $"span {earliest:yyyy-MM-dd} to {latest:yyyy-MM-dd}. Each row covers "
+                        + "that company's own fiscal period, not the same calendar months._"
+                );
+        }
 
         if (skipped.Count > 0)
             result.AppendLine($"\n_Skipped: {string.Join(", ", skipped)}._");

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -47,19 +47,26 @@ public class FinancialStatementTools
             + "given fiscal year and period, sourced from SEC Company Facts (structured XBRL). "
             + "Returns the standard line items (e.g. revenue, net income, total assets, "
             + "operating cash flow) with the latest-restated value for the period. "
-            + "Company-specific dimensional facts (e.g. product-segment revenue) are not included."
+            + "Company-specific dimensional facts (e.g. product-segment revenue) are not "
+            + "included — use GetRevenueBreakdown for segment/geographic revenue, and "
+            + "GetFinancialFact or CompareFinancialFact for one line item across periods "
+            + "or across companies."
     )]
     public Task<string> GetFinancialStatement(
         [Description("Stock ticker symbol (e.g., AAPL, MSFT, GME)")] string ticker,
         [Description(
             "Statement: 'income' (income statement), 'balance' (balance sheet), or "
-                + "'cashflow' (cash-flow statement). Defaults to income."
+                + "'cashflow' (cash-flow statement); the aliases 'is'/'p&l', 'bs' and 'cf' "
+                + "also work. Defaults to income."
         )]
             string statement = "income",
         [Description("Fiscal year, e.g. 2023. Defaults to the latest reported year.")]
             int? year = null,
         [Description(
-            "Fiscal period: 'FY' (annual) or 'Q1'..'Q4'. Defaults to the latest reported period."
+            "Fiscal period: 'FY' (annual) or 'Q1'..'Q4'. Defaults to the latest reported "
+                + "period. Most filers report no discrete Q4 income/cash-flow facts in XBRL "
+                + "(the fourth quarter is embedded in the full-year figure) — use 'FY' for "
+                + "annual figures."
         )]
             string period = null
     )
@@ -88,14 +95,6 @@ public class FinancialStatementTools
                     requestedPeriod = parsedPeriod;
                 }
 
-                var (selectedYear, selectedPeriod, periodError) = await ResolveStatementPeriod(
-                    stock,
-                    year,
-                    requestedPeriod
-                );
-                if (periodError != null)
-                    return periodError;
-
                 var statementLines = FinancialStatementConcepts.For(statementType);
                 var (taxonomies, tags) = StatementLineFacts.CollectConceptPairs(statementLines);
 
@@ -110,6 +109,20 @@ public class FinancialStatementTools
                     .ToListAsync();
                 var conceptIdByKey = concepts.ToDictionary(c => (c.Taxonomy, c.Tag), c => c.Id);
                 var conceptIds = concepts.Select(c => c.Id).ToHashSet();
+
+                // Period availability is scoped to the requested statement's
+                // concepts: a (year, Q4) that only exists via balance-sheet
+                // instants must not validate an income-statement request and
+                // then render an empty table.
+                var (selectedYear, selectedPeriod, periodError) = await ResolveStatementPeriod(
+                    stock,
+                    statementType,
+                    year,
+                    requestedPeriod,
+                    conceptIds
+                );
+                if (periodError != null)
+                    return periodError;
 
                 var facts = await _financialFactRepository
                     .GetConsolidatedByStock(stock)
@@ -168,12 +181,18 @@ public class FinancialStatementTools
         );
 
         var rendered = 0;
+        var omitted = 0;
+        DateOnly? earliestFiled = null;
+        DateOnly? latestFiled = null;
         foreach (var line in statementLines)
         {
             var fact = StatementLineFacts.PickFact(line, conceptIdByKey, latestByConcept);
             if (fact == null)
             {
-                result.AppendLine($"| {FactMarkdown.Cell(line.Label)} | — | | | | |");
+                // The template carries industry-specific lines (bank/insurer/
+                // REIT top lines) most filers never report — dash-only rows
+                // are noise, so unreported lines are omitted and counted.
+                omitted++;
                 continue;
             }
 
@@ -186,10 +205,30 @@ public class FinancialStatementTools
                     + $"{fact.FiledDate:yyyy-MM-dd} |"
             );
             rendered++;
+            if (earliestFiled == null || fact.FiledDate < earliestFiled)
+                earliestFiled = fact.FiledDate;
+            if (latestFiled == null || fact.FiledDate > latestFiled)
+                latestFiled = fact.FiledDate;
         }
 
         if (rendered == 0)
-            result.AppendLine($"\n_No line items of this statement were reported for the period._");
+            return $"No {statementType.NameForHumans().ToLowerInvariant()} line items were "
+                + $"reported by {stock.Ticker} for FY{selectedYear} "
+                + $"{selectedPeriod.NameForHumans()}.";
+
+        if (omitted > 0)
+            result.AppendLine(
+                "\n_Line items the filer did not report for this period are omitted._"
+            );
+
+        // Each line independently takes its latest restatement, so one
+        // statement can mix filing vintages — flag it so a partially restated
+        // total that disagrees with non-restated components is explainable.
+        if (earliestFiled != latestFiled)
+            result.AppendLine(
+                $"\n_Values reflect the latest restatement per line; source filings span "
+                    + $"{earliestFiled:yyyy-MM-dd} to {latestFiled:yyyy-MM-dd} — see the Filed column._"
+            );
 
         return result.ToString();
     }
@@ -198,20 +237,37 @@ public class FinancialStatementTools
         int FiscalYear,
         SecFiscalPeriod FiscalPeriod,
         string Error
-    )> ResolveStatementPeriod(CommonStock stock, int? year, SecFiscalPeriod? requestedPeriod)
+    )> ResolveStatementPeriod(
+        CommonStock stock,
+        FinancialStatementType statementType,
+        int? year,
+        SecFiscalPeriod? requestedPeriod,
+        IReadOnlySet<Guid> statementConceptIds
+    )
     {
+        var statementName = statementType.NameForHumans().ToLowerInvariant();
         var availablePeriods = await _financialFactRepository
             .GetConsolidatedByStock(stock)
+            .Where(f => statementConceptIds.Contains(f.FinancialConceptId))
             .Select(f => new { f.FiscalYear, f.FiscalPeriod })
             .Distinct()
             .ToListAsync();
 
         if (availablePeriods.Count == 0)
+        {
+            // Distinguish "nothing ingested at all" from "nothing for THIS
+            // statement" so the caller isn't told a covered company is absent.
+            var hasAnyFacts = await _financialFactRepository
+                .GetConsolidatedByStock(stock)
+                .AnyAsync();
             return (
                 default,
                 default,
-                $"No structured financial facts have been ingested for {stock.Ticker}."
+                hasAnyFacts
+                    ? $"No {statementName} line items have been ingested for {stock.Ticker}."
+                    : $"No structured financial facts have been ingested for {stock.Ticker}."
             );
+        }
 
         var ordered = availablePeriods
             .OrderByDescending(p => p.FiscalYear)
@@ -232,12 +288,23 @@ public class FinancialStatementTools
             var wanted =
                 $"{(year?.ToString() ?? "the latest year")} "
                 + $"{(requestedPeriod?.NameForHumans() ?? "period")}";
-            return (
-                default,
-                default,
-                $"{stock.Ticker} has no data for {wanted}. Latest available: "
-                    + $"FY{latest.FiscalYear} {latest.FiscalPeriod.NameForHumans()}."
-            );
+            var message =
+                $"{stock.Ticker} has no {statementName} data for {wanted}. Latest available: "
+                + $"FY{latest.FiscalYear} {latest.FiscalPeriod.NameForHumans()}.";
+            // The Q4-under-FY trap: SEC Company Facts embeds the fourth
+            // quarter's flow facts in the full-year duration, so a Q4
+            // income/cash-flow request usually has nothing to find — that is
+            // an XBRL filing convention, not a gap in the company's reporting.
+            if (
+                requestedPeriod == SecFiscalPeriod.Q4
+                && statementType != FinancialStatementType.BalanceSheet
+            )
+                message +=
+                    " Most filers report no discrete fourth-quarter flow facts in XBRL — "
+                    + "the fourth quarter is embedded in the full-year figure. Use period "
+                    + "'FY' for annual figures, or GetFinancialFact for a single concept "
+                    + "(it surfaces reported discrete Q4 rows where they exist).";
+            return (default, default, message);
         }
 
         return (selected.FiscalYear, selected.FiscalPeriod, null);

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -80,7 +80,11 @@ public class RevenueBreakdownTools
         "Get a company's revenue disaggregated by business segment, geography and "
             + "product/service, from the dimensional XBRL facts the issuer tags in its own "
             + "filings. Annual fiscal years only, latest restated values, one table per axis "
-            + "the company reports; values are as-reported and never estimated."
+            + "the company reports; values are as-reported and never estimated. Rows within "
+            + "one table can OVERLAP when the issuer tags several granularities on the same "
+            + "axis (a parent segment alongside its components), so never sum rows to derive "
+            + "total revenue — use the consolidated total row each table carries. For "
+            + "consolidated figures use GetFinancialStatement or GetFinancialFact."
     )]
     public Task<string> GetRevenueBreakdown(
         [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -103,10 +107,25 @@ public class RevenueBreakdownTools
 
                 var taxonomies = conceptRefs.Select(r => r.Taxonomy).Distinct().ToList();
                 var tags = conceptRefs.Select(r => r.Tag).ToList();
-                var conceptIds = await _financialConceptRepository
+                // conceptId → position of its tag in the alias's ordered list;
+                // the alias's primary tag wins when picking the consolidated
+                // total to display (same rule as GetFinancialFact's pick).
+                var priorityByPair = new Dictionary<(FactTaxonomy, string), int>();
+                for (var i = 0; i < conceptRefs.Count; i++)
+                    priorityByPair.TryAdd((conceptRefs[i].Taxonomy, conceptRefs[i].Tag), i);
+                var conceptRows = await _financialConceptRepository
                     .GetMatching(taxonomies, tags)
-                    .Select(c => c.Id)
+                    .Select(c => new
+                    {
+                        c.Id,
+                        c.Taxonomy,
+                        c.Tag,
+                    })
                     .ToListAsync();
+                var priorityById = conceptRows
+                    .Where(c => priorityByPair.ContainsKey((c.Taxonomy, c.Tag)))
+                    .ToDictionary(c => c.Id, c => priorityByPair[(c.Taxonomy, c.Tag)]);
+                var conceptIds = priorityById.Keys.ToList();
                 if (conceptIds.Count == 0)
                     return $"No revenue data has been ingested for {stock.Ticker}.";
 
@@ -180,15 +199,50 @@ public class RevenueBreakdownTools
                                     .ToList()
                     );
 
+                // One display figure per (period, unit) for the tables' total
+                // row: the alias's primary tag wins, then the latest filing —
+                // mirroring GetFinancialFact's deterministic pick.
+                var displayTotals = consolidated
+                    .GroupBy(f => (f.PeriodEnd, f.Unit))
+                    .ToDictionary(
+                        g => g.Key,
+                        g =>
+                            g.OrderBy(f => priorityById[f.FinancialConceptId])
+                                .ThenByDescending(f => f.FiledDate)
+                                .First()
+                                .Value
+                    );
+
                 var years = Math.Clamp(maxYears, 1, MaxYearsCap);
                 var result = new StringBuilder();
                 result.AppendLine(
                     $"Revenue breakdown for {stock.Ticker} ({FactMarkdown.Cell(stock.Name)}) — "
                         + "annual fiscal years, latest restated values:"
                 );
-                AppendAxis(result, "By segment", rows, SegmentAxes, years, totals);
-                AppendAxis(result, "By geography", rows, GeographyAxes, years, totals);
-                AppendAxis(result, "By product & service", rows, ProductAxes, years, totals);
+                result.AppendLine(
+                    "_Components are shown exactly as the issuer tags them: a renamed member "
+                        + "appears as a new row, so '—' gaps can reflect renames or "
+                        + "reclassifications rather than zero revenue._"
+                );
+                AppendAxis(result, "By segment", rows, SegmentAxes, years, totals, displayTotals);
+                AppendAxis(
+                    result,
+                    "By geography",
+                    rows,
+                    GeographyAxes,
+                    years,
+                    totals,
+                    displayTotals
+                );
+                AppendAxis(
+                    result,
+                    "By product & service",
+                    rows,
+                    ProductAxes,
+                    years,
+                    totals,
+                    displayTotals
+                );
                 return result.ToString();
             },
             "GetRevenueBreakdown",
@@ -196,13 +250,20 @@ public class RevenueBreakdownTools
         );
     }
 
+    // How far above the consolidated total a period's member sum must land before the
+    // axis is flagged as carrying overlapping granularities. Looser than
+    // ReconciliationTolerance so per-member rounding can never trip it; a genuine
+    // parent-plus-components overlap overshoots by the whole parent.
+    private const decimal OverlapNoteTolerance = 0.02m;
+
     private static void AppendAxis(
         StringBuilder result,
         string title,
         List<DimensionalRevenueRow> rows,
         string[] axes,
         int maxYears,
-        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals,
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), decimal> displayTotals
     )
     {
         var (unit, periodEnds, members) = BuildAxisSeries(rows, axes, maxYears, totals);
@@ -225,6 +286,57 @@ public class RevenueBreakdownTools
                 $"| {FactMarkdown.Cell(member.Label)} | " + string.Join(" | ", cells) + " |"
             );
         }
+
+        // The consolidated figure the members must be read against — lets a
+        // consumer compute revenue shares and spot overlapping rows without a
+        // second tool call. Costs nothing: the totals are already loaded.
+        var totalCells = periodEnds
+            .Select(p =>
+                displayTotals.TryGetValue((p, unit), out var total)
+                    ? FactMarkdown.Value(total, unit)
+                    : "—"
+            )
+            .ToList();
+        if (totalCells.Any(c => c != "—"))
+            result.AppendLine(
+                "| **Total revenue (consolidated)** | " + string.Join(" | ", totalCells) + " |"
+            );
+
+        // An issuer can tag a parent level alongside its components on the same
+        // axis (AAPL's Product/Service next to iPhone/Mac/iPad; NVDA's Data
+        // Center next to Compute/Networking). Those rows survive the disjoint-
+        // scheme collapse because the schemes share or nest members, so the
+        // column sums to well over consolidated revenue — say so rather than
+        // let a consumer double-count.
+        var overlaps = false;
+        for (var i = 0; i < periodEnds.Count && !overlaps; i++)
+        {
+            if (!displayTotals.TryGetValue((periodEnds[i], unit), out var total) || total == 0m)
+                continue;
+            var memberSum = members.Sum(m => m.Values[i] ?? 0m);
+            overlaps = memberSum - total > Math.Abs(total) * OverlapNoteTolerance;
+        }
+        if (overlaps)
+            result.AppendLine(
+                "\n_Rows on this axis overlap: the issuer tags more than one granularity "
+                    + "(a parent component alongside its parts), so rows must NOT be summed — "
+                    + "reconcile against the consolidated total row._"
+            );
+
+        // Older fiscal years beyond maxYears exist — say so instead of letting
+        // the series read as the full history.
+        var availableYears = rows.Where(r => axes.Contains(r.Axis) && r.Unit == unit)
+            .Select(r => r.PeriodEnd)
+            .Distinct()
+            .Count();
+        if (availableYears > periodEnds.Count)
+            result.AppendLine(
+                periodEnds.Count >= MaxYearsCap
+                    ? $"\n_Showing the latest {periodEnds.Count} of {availableYears} fiscal "
+                        + "years (the tool's maximum)._"
+                    : $"\n_Showing the latest {periodEnds.Count} of {availableYears} fiscal "
+                        + $"years — raise maxYears (max {MaxYearsCap}) to see more._"
+            );
     }
 
     // Resolve the surviving (member, period) facts for one axis, one row per cell — all in a
@@ -551,7 +663,14 @@ public class RevenueBreakdownTools
 
         if (local.EndsWith("Member", StringComparison.Ordinal) && local.Length > "Member".Length)
             local = local[..^"Member".Length];
-        return Regex.Replace(local, "(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", " ");
+        // The (?<!^[A-Z]) guard keeps a lone leading capital attached to the word
+        // that follows: Apple's IPhoneMember reads "IPhone", never "I Phone".
+        // Boundaries deeper in the name still split ("USSegment" → "US Segment").
+        return Regex.Replace(
+            local,
+            "(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?<!^[A-Z])(?=[A-Z][a-z])",
+            " "
+        );
     }
 
     internal sealed record DimensionalRevenueRow(

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsComparativeWindowLeakTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsComparativeWindowLeakTests.cs
@@ -1,0 +1,246 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Repositories;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// A filing re-reports comparative prior periods under its OWN fiscal
+/// identity. A toDate window that excludes the reporting year's own period end
+/// degenerates that (year, FY) group to the comparative alone, so per-group
+/// picking emitted the SAME period end twice — once with the wrong FY label
+/// and, in as-originally-reported mode, with a LATER filing's value. Live
+/// repro: NVDA eps-diluted, form=10-K, toDate=2025-12-31 returned period end
+/// 2025-01-26 as both "FY 2025" and "FY 2026".
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FinancialFactsToolsComparativeWindowLeakTests : ParadeDbMcpTestBase
+{
+    public FinancialFactsToolsComparativeWindowLeakTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private FinancialFactsTools Sut() =>
+        new(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<FinancialFactsTools>()
+        );
+
+    private static CommonStock Nvidia() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp",
+            Cik = "0001045810",
+        };
+
+    private void AddAnnualFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        int fiscalYearStamp,
+        DateOnly periodStart,
+        DateOnly periodEnd,
+        decimal value,
+        DateOnly filed,
+        string accession
+    )
+    {
+        DbContext
+            .Set<FinancialFact>()
+            .Add(
+                new FinancialFact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = concept.Id,
+                    Unit = "USD/shares",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = periodStart,
+                    PeriodEnd = periodEnd,
+                    Value = value,
+                    FiscalYear = fiscalYearStamp,
+                    FiscalPeriod = SecFiscalPeriod.FullYear,
+                    Form = DocumentType.TenK,
+                    FiledDate = filed,
+                    AccessionNumber = accession,
+                }
+            );
+    }
+
+    private async Task<CommonStock> SeedNvdaEps()
+    {
+        var stock = Nvidia();
+        DbContext.Set<CommonStock>().Add(stock);
+        var eps = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "EarningsPerShareDiluted",
+            Label = "EarningsPerShareDiluted",
+        };
+        DbContext.Set<FinancialConcept>().Add(eps);
+        // FY2025 as filed by NVDA's own FY2025 10-K.
+        AddAnnualFact(
+            stock,
+            eps,
+            2025,
+            new DateOnly(2024, 1, 29),
+            new DateOnly(2025, 1, 26),
+            2.94m,
+            new DateOnly(2025, 2, 26),
+            "nvda-fy2025"
+        );
+        // The FY2026 10-K: its own year...
+        AddAnnualFact(
+            stock,
+            eps,
+            2026,
+            new DateOnly(2025, 1, 27),
+            new DateOnly(2026, 1, 25),
+            4.61m,
+            new DateOnly(2026, 2, 25),
+            "nvda-fy2026"
+        );
+        // ...plus the FY2025 comparative, re-stamped under the filing's own
+        // fiscal identity (2026) — the leak's raw material.
+        AddAnnualFact(
+            stock,
+            eps,
+            2026,
+            new DateOnly(2024, 1, 29),
+            new DateOnly(2025, 1, 26),
+            2.94m,
+            new DateOnly(2026, 2, 25),
+            "nvda-fy2026"
+        );
+        await DbContext.SaveChangesAsync();
+        return stock;
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_ToDateExcludesOwnPeriodEnd_ComparativeDoesNotLeakAsExtraRow()
+    {
+        await SeedNvdaEps();
+
+        var result = await Sut()
+            .GetFinancialFact(
+                "NVDA",
+                "eps-diluted",
+                form: "10-K",
+                toDate: "2025-12-31",
+                asOriginallyReported: true
+            );
+
+        // Exactly one row for period end 2025-01-26, labeled with ITS year.
+        var occurrences = result.Split("| 2025-01-26 |").Length - 1;
+        occurrences.Should().Be(1, "one reporting span is one row");
+        result.Should().Contain("| 2025-01-26 | 2025 |");
+        result
+            .Should()
+            .NotContain(
+                "| 2025-01-26 | 2026 |",
+                "the comparative's re-stamp is not a period of its own"
+            );
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_NoWindow_BothYearsSurfaceOnce()
+    {
+        await SeedNvdaEps();
+
+        var result = await Sut().GetFinancialFact("NVDA", "eps-diluted");
+
+        result.Should().Contain("| 2026-01-25 | 2026 |");
+        result.Should().Contain("| 2025-01-26 | 2025 |");
+        (result.Split("| 2025-01-26 |").Length - 1).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_FiscalPeriodFilter_ReturnsOnlyMatchingPeriods()
+    {
+        var stock = Nvidia();
+        DbContext.Set<CommonStock>().Add(stock);
+        var revenue = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenues",
+        };
+        DbContext.Set<FinancialConcept>().Add(revenue);
+        DbContext
+            .Set<FinancialFact>()
+            .AddRange(
+                new FinancialFact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = revenue.Id,
+                    Unit = "USD",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(2025, 1, 27),
+                    PeriodEnd = new DateOnly(2025, 4, 27),
+                    Value = 44_000_000_000m,
+                    FiscalYear = 2026,
+                    FiscalPeriod = SecFiscalPeriod.Q1,
+                    Form = DocumentType.TenQ,
+                    FiledDate = new DateOnly(2025, 5, 28),
+                    AccessionNumber = "nvda-q1",
+                },
+                new FinancialFact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = revenue.Id,
+                    Unit = "USD",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(2024, 1, 29),
+                    PeriodEnd = new DateOnly(2025, 1, 26),
+                    Value = 130_000_000_000m,
+                    FiscalYear = 2025,
+                    FiscalPeriod = SecFiscalPeriod.FullYear,
+                    Form = DocumentType.TenK,
+                    FiledDate = new DateOnly(2025, 2, 26),
+                    AccessionNumber = "nvda-fy",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("NVDA", "revenue", fiscalPeriod: "FY");
+
+        result.Should().Contain("$130,000,000,000");
+        result.Should().NotContain("$44,000,000,000", "Q1 rows are filtered out");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_UnknownFiscalPeriod_ReturnsGuidance()
+    {
+        var stock = Nvidia();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("NVDA", "revenue", fiscalPeriod: "H1");
+
+        result.Should().Contain("Unknown fiscalPeriod 'H1'");
+        result.Should().Contain("'FY' or 'Q1'..'Q4'");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_MorePeriodsThanMaxResults_AppendsTruncationNote()
+    {
+        await SeedNvdaEps();
+
+        var result = await Sut().GetFinancialFact("NVDA", "eps-diluted", maxResults: 1);
+
+        result.Should().Contain("Showing first 1 of 2 results");
+        result.Should().Contain("maxResults");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsQ4AndScopingTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsQ4AndScopingTests.cs
@@ -1,0 +1,215 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Repositories;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// The Q4-under-FY trap: SEC Company Facts embeds fourth-quarter flow facts in
+/// the full-year duration, so income/cash-flow period='Q4' used to validate
+/// off balance-sheet instants stamped (year, Q4) and then render a table of 30
+/// dashes with "no line items were reported" — reading as if the company
+/// reported nothing in Q4. Period availability must be scoped to the requested
+/// statement's concepts, and a failed Q4 flow request must explain the filing
+/// convention instead.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FinancialStatementToolsQ4AndScopingTests : ParadeDbMcpTestBase
+{
+    public FinancialStatementToolsQ4AndScopingTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private FinancialStatementTools Sut() =>
+        new(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<FinancialStatementTools>()
+        );
+
+    private CommonStock AddApple()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        return stock;
+    }
+
+    private FinancialConcept AddConcept(string tag)
+    {
+        var c = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = tag,
+            Label = tag,
+        };
+        DbContext.Set<FinancialConcept>().Add(c);
+        return c;
+    }
+
+    private void AddFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        int fy,
+        SecFiscalPeriod period,
+        FactPeriodType periodType,
+        DateOnly periodStart,
+        DateOnly periodEnd,
+        decimal value,
+        DateOnly filed,
+        string accession
+    )
+    {
+        DbContext
+            .Set<FinancialFact>()
+            .Add(
+                new FinancialFact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = concept.Id,
+                    Unit = "USD",
+                    PeriodType = periodType,
+                    PeriodStart = periodStart,
+                    PeriodEnd = periodEnd,
+                    Value = value,
+                    FiscalYear = fy,
+                    FiscalPeriod = period,
+                    Form = DocumentType.TenK,
+                    FiledDate = filed,
+                    AccessionNumber = accession,
+                }
+            );
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_Q4IncomeWithOnlyBalanceInstantsUnderQ4_ExplainsTheFilingConventionInsteadOfEmptyTable()
+    {
+        var stock = AddApple();
+        var revenue = AddConcept("Revenues");
+        var assets = AddConcept("Assets");
+        // The annual income figure — Q4 flows live inside this duration.
+        AddFact(
+            stock,
+            revenue,
+            2023,
+            SecFiscalPeriod.FullYear,
+            FactPeriodType.Duration,
+            new DateOnly(2022, 9, 25),
+            new DateOnly(2023, 9, 30),
+            383_000_000_000m,
+            new DateOnly(2023, 11, 3),
+            "aapl-fy23"
+        );
+        // A balance-sheet instant stamped (2023, Q4) — the row that used to
+        // validate an income-statement Q4 request.
+        AddFact(
+            stock,
+            assets,
+            2023,
+            SecFiscalPeriod.Q4,
+            FactPeriodType.Instant,
+            new DateOnly(2023, 9, 30),
+            new DateOnly(2023, 9, 30),
+            352_583_000_000m,
+            new DateOnly(2023, 11, 3),
+            "aapl-fy23"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetFinancialStatement("AAPL", statement: "income", year: 2023, period: "Q4");
+
+        result.Should().Contain("has no income statement data for 2023 Q4");
+        result.Should().Contain("embedded in the full-year figure");
+        result.Should().Contain("Use period 'FY'");
+        result.Should().NotContain("| Revenue |", "no table is rendered for an unavailable period");
+        result
+            .Should()
+            .NotContain(
+                "No line items of this statement were reported",
+                "the misleading empty-table footnote is gone"
+            );
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_StatementWithNoIngestedLines_SaysSoInsteadOfClaimingNothingIngested()
+    {
+        var stock = AddApple();
+        var assets = AddConcept("Assets");
+        AddFact(
+            stock,
+            assets,
+            2023,
+            SecFiscalPeriod.FullYear,
+            FactPeriodType.Instant,
+            new DateOnly(2023, 9, 30),
+            new DateOnly(2023, 9, 30),
+            352_583_000_000m,
+            new DateOnly(2023, 11, 3),
+            "aapl-fy23"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialStatement("AAPL", statement: "cashflow");
+
+        result.Should().Contain("No cash flow line items have been ingested for AAPL");
+        result
+            .Should()
+            .NotContain(
+                "No structured financial facts have been ingested",
+                "balance-sheet facts ARE ingested — only this statement is empty"
+            );
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_MixedFilingVintages_FlagsTheRestatementSpan()
+    {
+        var stock = AddApple();
+        var revenue = AddConcept("Revenues");
+        var netIncome = AddConcept("NetIncomeLoss");
+        AddFact(
+            stock,
+            revenue,
+            2023,
+            SecFiscalPeriod.FullYear,
+            FactPeriodType.Duration,
+            new DateOnly(2022, 9, 25),
+            new DateOnly(2023, 9, 30),
+            383_000_000_000m,
+            new DateOnly(2023, 11, 3),
+            "aapl-fy23"
+        );
+        // Net income restated by a later filing — the statement now mixes
+        // filing vintages and must say so.
+        AddFact(
+            stock,
+            netIncome,
+            2023,
+            SecFiscalPeriod.FullYear,
+            FactPeriodType.Duration,
+            new DateOnly(2022, 9, 25),
+            new DateOnly(2023, 9, 30),
+            97_000_000_000m,
+            new DateOnly(2025, 10, 31),
+            "aapl-fy25-restate"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialStatement("AAPL", statement: "income", year: 2023);
+
+        result.Should().Contain("source filings span 2023-11-03 to 2025-10-31");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
@@ -121,9 +121,12 @@ public class FinancialStatementToolsTests : ParadeDbMcpTestBase
         result.Should().Contain("Income Statement for AAPL (Apple Inc.) — FY2023 FY:");
         result.Should().Contain("| Revenue | $400,000,000,000 | USD |");
         result.Should().NotContain("$383,000,000,000", "the latest-filed restatement wins");
-        // A curated concept the company never reported still renders as a
-        // placeholder row so the statement keeps its shape.
-        result.Should().Contain("| Net Income | — |");
+        // Curated concepts the company never reported are omitted (dash-only
+        // template rows are token noise), with one note flagging the omission.
+        result.Should().NotContain("| Net Income |");
+        result
+            .Should()
+            .Contain("_Line items the filer did not report for this period are omitted._");
     }
 
     private async Task SeedRevenue(
@@ -186,7 +189,7 @@ public class FinancialStatementToolsTests : ParadeDbMcpTestBase
         var result = await Sut()
             .GetFinancialStatement("AAPL", statement: "income", year: 2023, period: "Q2");
 
-        result.Should().Contain("has no data for 2023 Q2");
+        result.Should().Contain("has no income statement data for 2023 Q2");
         result.Should().Contain("Latest available: FY2023 FY");
         result
             .Should()

--- a/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsTotalRowAndOverlapTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsTotalRowAndOverlapTests.cs
@@ -1,0 +1,207 @@
+using System.Security.Cryptography;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Repositories;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Issuers tag overlapping granularity levels on one axis — Apple's
+/// Product/Service parents alongside iPhone/Mac/iPad/Wearables, NVDA's Data
+/// Center alongside Compute + Networking. The disjoint-scheme collapse can
+/// never fire on those shapes (the schemes share or nest members), so the
+/// table's rows sum to ~2x revenue. Each axis table must therefore carry the
+/// consolidated total row (shares become computable, double-counting becomes
+/// visible) and an explicit overlap caution when the rows overshoot it.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class RevenueBreakdownToolsTotalRowAndOverlapTests : ParadeDbMcpTestBase
+{
+    private const string ProductAxis = "srt:ProductOrServiceAxis";
+
+    public RevenueBreakdownToolsTotalRowAndOverlapTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private RevenueBreakdownTools Sut() =>
+        new(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<RevenueBreakdownTools>()
+        );
+
+    private CommonStock AddStock(string ticker)
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = $"{ticker} Inc.",
+            Cik = "0000320193",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        return stock;
+    }
+
+    private FinancialConcept AddConcept(string tag)
+    {
+        var c = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = tag,
+            Label = tag,
+        };
+        DbContext.Set<FinancialConcept>().Add(c);
+        return c;
+    }
+
+    private void AddFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        int fy,
+        decimal value,
+        params (string Axis, string Member)[] dimensions
+    )
+    {
+        var fact = new FinancialFact
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Unit = "USD",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = new DateOnly(fy, 1, 1),
+            PeriodEnd = new DateOnly(fy, 12, 31),
+            Value = value,
+            FiscalYear = fy,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenK,
+            FiledDate = new DateOnly(fy + 1, 2, 1),
+            AccessionNumber = $"acc-{Guid.NewGuid():N}"[..20],
+            DimensionsKey = DimensionsKeyOf(dimensions),
+        };
+        foreach (var (axis, member) in dimensions)
+            fact.Dimensions.Add(
+                new FinancialFactDimension
+                {
+                    FinancialFactId = fact.Id,
+                    Axis = axis,
+                    Member = member,
+                }
+            );
+        DbContext.Set<FinancialFact>().Add(fact);
+    }
+
+    private static string DimensionsKeyOf((string Axis, string Member)[] dimensions)
+    {
+        if (dimensions.Length == 0)
+            return "";
+        var canonical = string.Join(
+            "|",
+            dimensions
+                .OrderBy(d => d.Axis)
+                .ThenBy(d => d.Member)
+                .Select(d => $"{d.Axis}={d.Member}")
+        );
+        return Convert
+            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)))
+            .ToLowerInvariant();
+    }
+
+    [Fact]
+    public async Task GetRevenueBreakdown_NestedParentAlongsideComponents_TotalRowAndOverlapCaution()
+    {
+        var stock = AddStock("AAPL");
+        var revenue = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
+        // Consolidated total: 416.
+        AddFact(stock, revenue, 2024, 416_000_000_000m);
+        // Parent scheme: Product + Service = 416.
+        AddFact(stock, revenue, 2024, 307_000_000_000m, (ProductAxis, "us-gaap:ProductMember"));
+        AddFact(stock, revenue, 2024, 109_000_000_000m, (ProductAxis, "us-gaap:ServiceMember"));
+        // Product's components — they nest under (and share Service with) the
+        // parent scheme, so no disjoint full-total partition exists.
+        AddFact(stock, revenue, 2024, 200_000_000_000m, (ProductAxis, "aapl:IPhoneMember"));
+        AddFact(stock, revenue, 2024, 40_000_000_000m, (ProductAxis, "aapl:MacMember"));
+        AddFact(stock, revenue, 2024, 30_000_000_000m, (ProductAxis, "aapl:IPadMember"));
+        AddFact(
+            stock,
+            revenue,
+            2024,
+            37_000_000_000m,
+            (ProductAxis, "aapl:WearablesHomeandAccessoriesMember")
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("AAPL");
+
+        result.Should().Contain("Total revenue (consolidated)");
+        result.Should().Contain("$416,000,000,000");
+        result.Should().Contain("Rows on this axis overlap");
+        result.Should().Contain("must NOT be summed");
+        result
+            .Should()
+            .Contain("shown exactly as the issuer tags them", "the rename caveat is stated");
+        result.Should().Contain("IPhone").And.NotContain("I Phone");
+    }
+
+    [Fact]
+    public async Task GetRevenueBreakdown_SingleCleanScheme_TotalRowButNoOverlapCaution()
+    {
+        var stock = AddStock("CLEAN");
+        var revenue = AddConcept("Revenues");
+        AddFact(stock, revenue, 2024, 100_000_000_000m);
+        AddFact(
+            stock,
+            revenue,
+            2024,
+            60_000_000_000m,
+            ("us-gaap:StatementBusinessSegmentsAxis", "clean:CloudMember")
+        );
+        AddFact(
+            stock,
+            revenue,
+            2024,
+            40_000_000_000m,
+            ("us-gaap:StatementBusinessSegmentsAxis", "clean:HardwareMember")
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("CLEAN");
+
+        result.Should().Contain("Total revenue (consolidated)");
+        result.Should().Contain("$100,000,000,000");
+        result.Should().NotContain("Rows on this axis overlap");
+    }
+
+    [Fact]
+    public async Task GetRevenueBreakdown_MoreYearsThanMaxYears_AppendsTruncationNote()
+    {
+        var stock = AddStock("YEARS");
+        var revenue = AddConcept("Revenues");
+        foreach (var fy in new[] { 2022, 2023, 2024 })
+        {
+            AddFact(stock, revenue, fy, 100m);
+            AddFact(
+                stock,
+                revenue,
+                fy,
+                100m,
+                ("us-gaap:StatementBusinessSegmentsAxis", "years:OnlyMember")
+            );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("YEARS", maxYears: 2);
+
+        result.Should().Contain("Showing the latest 2 of 3 fiscal years");
+        result.Should().Contain("raise maxYears");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesCustomerConcentrationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesCustomerConcentrationTests.cs
@@ -1,0 +1,52 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Filers that tag their customer-concentration disclosure carry it under the
+/// ConcentrationRiskPercentage elements (us-gaap and srt spellings). The
+/// 'customer-concentration' alias makes that tagged data reachable through
+/// the FinancialFacts tools; without it the tags were ingested but had no
+/// caller-facing name.
+/// </summary>
+public class FinancialConceptAliasesCustomerConcentrationTests
+{
+    [Fact]
+    public void TryResolve_CustomerConcentration_MapsConcentrationRiskPercentageTags()
+    {
+        var resolved = FinancialConceptAliases.TryResolve(
+            "customer-concentration",
+            out var concepts
+        );
+
+        resolved.Should().BeTrue();
+        concepts
+            .Select(c => (c.Taxonomy, c.Tag))
+            .Should()
+            .ContainInOrder(
+                (FactTaxonomy.UsGaap, "ConcentrationRiskPercentage1"),
+                (FactTaxonomy.UsGaap, "ConcentrationRiskPercentage"),
+                (FactTaxonomy.Srt, "ConcentrationRiskPercentage1"),
+                (FactTaxonomy.Srt, "ConcentrationRiskPercentage")
+            );
+    }
+
+    [Theory]
+    [InlineData("concentration-risk")]
+    [InlineData("customer-concentration-risk")]
+    [InlineData("Customer Concentration")]
+    public void TryResolve_Synonyms_ResolveToCustomerConcentration(string alias)
+    {
+        var resolved = FinancialConceptAliases.TryResolve(alias, out var concepts);
+
+        resolved.Should().BeTrue();
+        concepts.Should().Contain(c => c.Tag == "ConcentrationRiskPercentage1");
+    }
+
+    [Fact]
+    public void SupportedAliases_ListCustomerConcentration()
+    {
+        FinancialConceptAliases.SupportedAliases.Should().Contain("customer-concentration");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsBuildComparisonRowsDuplicateStockTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsBuildComparisonRowsDuplicateStockTests.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// A company's primary and secondary tickers (GOOGL/GOOG) resolve to the same
+/// CommonStock, and BuildComparisonRows historically added one row per
+/// requested string — 'GOOGL,GOOG' produced two identical GOOGL rows, and a
+/// secondary-only request came back labeled with a ticker the caller never
+/// asked for. One row per company; repeats are reported in the skip list; a
+/// secondary-ticker row stays traceable to the caller's input.
+/// </summary>
+public class FinancialFactsToolsBuildComparisonRowsDuplicateStockTests
+{
+    private static readonly Guid AlphabetId = Guid.NewGuid();
+
+    private static CommonStock Alphabet() =>
+        new()
+        {
+            Id = AlphabetId,
+            Ticker = "GOOGL",
+            Name = "Alphabet Inc.",
+            SecondaryTickers = ["GOOG"],
+        };
+
+    private static FinancialFact Fact() =>
+        new()
+        {
+            CommonStockId = AlphabetId,
+            Value = 307_394_000_000m,
+            Unit = "USD",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = new DateOnly(2023, 1, 1),
+            PeriodEnd = new DateOnly(2023, 12, 31),
+            FiscalYear = 2023,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenK,
+            FiledDate = new DateOnly(2024, 1, 30),
+            AccessionNumber = "acc-goog",
+        };
+
+    private static (
+        List<(string Ticker, string Name, FinancialFact Fact)> Rows,
+        List<string> Skipped
+    ) Invoke(List<string> requested, Dictionary<string, CommonStock> stockByTicker)
+    {
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "BuildComparisonRows",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var bestByStock = new Dictionary<Guid, FinancialFact> { [AlphabetId] = Fact() };
+        return ((List<(string Ticker, string Name, FinancialFact Fact)>, List<string>))
+            method.Invoke(null, [requested, stockByTicker, bestByStock]);
+    }
+
+    [Fact]
+    public void BuildComparisonRows_PrimaryAndSecondaryTickerOfSameStock_OneRowPlusDuplicateNotice()
+    {
+        var stock = Alphabet();
+        var stockByTicker = new Dictionary<string, CommonStock>
+        {
+            ["GOOGL"] = stock,
+            ["GOOG"] = stock,
+        };
+
+        var (rows, skipped) = Invoke(["GOOGL", "GOOG"], stockByTicker);
+
+        rows.Should().HaveCount(1, "one company gets one comparison row");
+        rows[0].Ticker.Should().Be("GOOGL");
+        skipped.Should().ContainSingle(s => s.Contains("GOOG (same company as GOOGL)"));
+    }
+
+    [Fact]
+    public void BuildComparisonRows_SecondaryTickerOnly_RowTraceableToRequestedTicker()
+    {
+        var stock = Alphabet();
+        var stockByTicker = new Dictionary<string, CommonStock> { ["GOOG"] = stock };
+
+        var (rows, skipped) = Invoke(["GOOG"], stockByTicker);
+
+        rows.Should().HaveCount(1);
+        rows[0].Ticker.Should().Be("GOOG (GOOGL)", "the caller asked for GOOG");
+        skipped.Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsDedupeByReportingSpanTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsDedupeByReportingSpanTests.cs
@@ -1,0 +1,103 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// A filing re-reports comparative prior periods under its OWN fiscal
+/// identity, so a fromDate/toDate window that excludes a fiscal year's own
+/// period end degenerates that (year, FY) group to the comparative alone —
+/// and per-group picking then emits the SAME reporting span twice, once with
+/// the wrong fiscal-year label. Live repro: NVDA eps-diluted, form=10-K,
+/// toDate=2025-12-31 returned period end 2025-01-26 as both "FY 2025" and
+/// "FY 2026" ($2.94 each). DedupeByReportingSpan keeps one row per actual
+/// (PeriodStart, PeriodEnd, PeriodType) span, preferring the SMALLEST
+/// fiscal-year stamp — the original filing's identity, since comparative
+/// re-filings always re-stamp under the filing's later year.
+/// </summary>
+public class FinancialFactsToolsDedupeByReportingSpanTests
+{
+    private static FinancialFact AnnualFact(
+        int fiscalYearStamp,
+        DateOnly periodStart,
+        DateOnly periodEnd,
+        DateOnly filed
+    ) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            FinancialConceptId = Guid.NewGuid(),
+            Value = 2.94m,
+            Unit = "USD/shares",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            FiscalYear = fiscalYearStamp,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenK,
+            FiledDate = filed,
+            AccessionNumber = $"acc-{fiscalYearStamp}",
+        };
+
+    [Fact]
+    public void DedupeByReportingSpan_ComparativeReStampedUnderLaterYear_KeepsOriginalFiscalYearOnly()
+    {
+        // The picked row from the (2025, FY) group — NVDA's own FY2025 filing.
+        var original = AnnualFact(
+            2025,
+            new DateOnly(2024, 1, 29),
+            new DateOnly(2025, 1, 26),
+            new DateOnly(2025, 2, 26)
+        );
+        // The picked row from the degenerate (2026, FY) group — the FY2026
+        // 10-K's comparative re-report of the SAME span, re-stamped 2026.
+        var comparative = AnnualFact(
+            2026,
+            new DateOnly(2024, 1, 29),
+            new DateOnly(2025, 1, 26),
+            new DateOnly(2026, 2, 25)
+        );
+        // An untouched earlier year must pass through unchanged.
+        var earlier = AnnualFact(
+            2024,
+            new DateOnly(2023, 1, 30),
+            new DateOnly(2024, 1, 28),
+            new DateOnly(2024, 2, 21)
+        );
+
+        var result = FinancialFactsTools.DedupeByReportingSpan([comparative, original, earlier]);
+
+        result.Should().HaveCount(2, "the two picks covering one span collapse to one row");
+        result
+            .Single(f => f.PeriodEnd == new DateOnly(2025, 1, 26))
+            .FiscalYear.Should()
+            .Be(2025, "the smallest stamp is the period's own fiscal identity");
+        result.Should().Contain(f => f.FiscalYear == 2024);
+    }
+
+    [Fact]
+    public void DedupeByReportingSpan_DistinctSpansSharingAPeriodEnd_BothSurvive()
+    {
+        // A promoted discrete Q4 and the annual figure end the same day but
+        // cover different spans — both are real rows and must both survive.
+        var annual = AnnualFact(
+            2020,
+            new DateOnly(2019, 1, 28),
+            new DateOnly(2020, 1, 26),
+            new DateOnly(2020, 2, 20)
+        );
+        var promotedQ4 = AnnualFact(
+            2020,
+            new DateOnly(2019, 10, 28),
+            new DateOnly(2020, 1, 26),
+            new DateOnly(2020, 2, 20)
+        );
+        promotedQ4.FiscalPeriod = SecFiscalPeriod.Q4;
+
+        var result = FinancialFactsTools.DedupeByReportingSpan([annual, promotedQ4]);
+
+        result.Should().HaveCount(2);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderComparisonTablePeriodEndTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderComparisonTablePeriodEndTests.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// XBRL fiscal years are filer-relative: a "fiscal 2025 Q2" comparison mixed
+/// NVDA's quarter ended 2024-07-28 with AMD/INTC quarters ended mid-2025 —
+/// ~11 months apart — with nothing but the Filed column hinting at it. The
+/// comparison table must carry each row's Period End, and flag the fiscal-
+/// calendar misalignment when peer period ends spread wider than a quarter.
+/// </summary>
+public class FinancialFactsToolsRenderComparisonTablePeriodEndTests
+{
+    private static FinancialFact QuarterFact(DateOnly periodEnd, decimal value) =>
+        new()
+        {
+            Value = value,
+            Unit = "USD/shares",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = periodEnd.AddDays(-91),
+            PeriodEnd = periodEnd,
+            FiscalYear = 2025,
+            FiscalPeriod = SecFiscalPeriod.Q2,
+            Form = DocumentType.TenQ,
+            FiledDate = periodEnd.AddDays(30),
+            AccessionNumber = "acc",
+        };
+
+    private static string Render(params (string Ticker, DateOnly PeriodEnd)[] rows)
+    {
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "RenderComparisonTable",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var tableRows = rows.Select(r =>
+                (r.Ticker, $"{r.Ticker} Inc.", QuarterFact(r.PeriodEnd, 1m))
+            )
+            .ToList();
+        return (string)
+            method.Invoke(
+                null,
+                ["eps-diluted", 2025, SecFiscalPeriod.Q2, tableRows, new List<string>()]
+            );
+    }
+
+    [Fact]
+    public void RenderComparisonTable_Always_CarriesPeriodEndColumn()
+    {
+        var result = Render(("NVDA", new DateOnly(2024, 7, 28)));
+
+        result.Should().Contain("| Period End |");
+        result.Should().Contain("| 2024-07-28 |");
+    }
+
+    [Fact]
+    public void RenderComparisonTable_PeriodEndsSpreadBeyondAQuarter_FlagsFiscalCalendarMismatch()
+    {
+        var result = Render(
+            ("NVDA", new DateOnly(2024, 7, 28)),
+            ("AMD", new DateOnly(2025, 6, 28))
+        );
+
+        result.Should().Contain("fiscal calendars differ");
+        result.Should().Contain("2024-07-28 to 2025-06-28");
+    }
+
+    [Fact]
+    public void RenderComparisonTable_AlignedPeriodEnds_NoMismatchNote()
+    {
+        var result = Render(
+            ("AAPL", new DateOnly(2023, 9, 30)),
+            ("MSFT", new DateOnly(2023, 6, 30))
+        );
+
+        result.Should().NotContain("fiscal calendars differ");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableLatestRestatedLabelTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableLatestRestatedLabelTests.cs
@@ -57,7 +57,7 @@ public class FinancialFactsToolsRenderFactHistoryTableLatestRestatedLabelTests
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
         var perPeriod = new List<FinancialFact>();
 
-        var result = (string)method.Invoke(null, ["Revenues", stock, false, perPeriod]);
+        var result = (string)method.Invoke(null, ["Revenues", stock, false, perPeriod, 0]);
 
         result.Should().Contain("latest restated");
         result.Should().NotContain("as originally reported");

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableOriginallyReportedLabelTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableOriginallyReportedLabelTests.cs
@@ -41,7 +41,7 @@ public class FinancialFactsToolsRenderFactHistoryTableOriginallyReportedLabelTes
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
         var perPeriod = new List<FinancialFact>();
 
-        var result = (string)method.Invoke(null, ["Revenues", stock, true, perPeriod]);
+        var result = (string)method.Invoke(null, ["Revenues", stock, true, perPeriod, 0]);
 
         result.Should().Contain("as originally reported");
         result.Should().NotContain("latest restated");

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableTruncationNoteTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableTruncationNoteTests.cs
@@ -1,0 +1,61 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// GetFinancialFact caps the table at maxResults but historically gave no
+/// signal that more periods exist — an LLM consumer could not distinguish
+/// "history starts here" from "truncated at the limit". The renderer must
+/// append the shared truncation note when (and only when) rows were cut off.
+/// </summary>
+public class FinancialFactsToolsRenderFactHistoryTableTruncationNoteTests
+{
+    private static string Render(int shown, int total)
+    {
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "RenderFactHistoryTable",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var stock = new CommonStock { Ticker = "NVDA", Name = "NVIDIA Corp" };
+        var perPeriod = Enumerable
+            .Range(0, shown)
+            .Select(i => new FinancialFact
+            {
+                Value = 1_000m + i,
+                Unit = "USD",
+                PeriodType = FactPeriodType.Duration,
+                PeriodStart = new DateOnly(2020 + i, 1, 1),
+                PeriodEnd = new DateOnly(2020 + i, 12, 31),
+                FiscalYear = 2020 + i,
+                FiscalPeriod = SecFiscalPeriod.FullYear,
+                Form = DocumentType.TenK,
+                FiledDate = new DateOnly(2021 + i, 2, 1),
+                AccessionNumber = $"acc-{i}",
+            })
+            .ToList();
+
+        return (string)method.Invoke(null, ["revenue", stock, false, perPeriod, total]);
+    }
+
+    [Fact]
+    public void RenderFactHistoryTable_MorePeriodsThanShown_AppendsTruncationNote()
+    {
+        var result = Render(shown: 2, total: 5);
+
+        result.Should().Contain("Showing first 2 of 5 results");
+        result.Should().Contain("maxResults");
+    }
+
+    [Fact]
+    public void RenderFactHistoryTable_NothingCutOff_NoTruncationNote()
+    {
+        var result = Render(shown: 2, total: 2);
+
+        result.Should().NotContain("Showing first");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizeLeadingCapitalTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizeLeadingCapitalTests.cs
@@ -1,0 +1,33 @@
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// The PascalCase-splitting regex used to break a lone leading capital off the
+/// word that follows, mangling Apple's flagship member labels: IPhoneMember →
+/// "I Phone", IPadMember → "I Pad". A lone leading capital stays attached to
+/// its word; boundaries deeper in the name must still split.
+/// </summary>
+public class RevenueBreakdownToolsHumanizeLeadingCapitalTests
+{
+    [Theory]
+    [InlineData("aapl:IPhoneMember", "IPhone")]
+    [InlineData("aapl:IPadMember", "IPad")]
+    [InlineData("aapl:MacMember", "Mac")]
+    public void Humanize_LoneLeadingCapital_StaysAttachedToItsWord(string qname, string expected)
+    {
+        RevenueBreakdownTools.Humanize(qname).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Humanize_AcronymPrefixDeeperInName_StillSplits()
+    {
+        RevenueBreakdownTools.Humanize("x:USSegmentMember").Should().Be("US Segment");
+    }
+
+    [Fact]
+    public void Humanize_PlainPascalCase_StillSplits()
+    {
+        RevenueBreakdownTools.Humanize("nvda:DataCenterMember").Should().Be("Data Center");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes every audit finding for the four FinancialFacts MCP tools (live-call audit against prod):

**GetFinancialFact**
- HIGH: a fromDate/toDate window that excludes a fiscal year's own period end let a later filing's comparative re-report surface as a duplicate row under the wrong FY label (NVDA eps-diluted, toDate=2025-12-31 → period end 2025-01-26 as both FY2025 and FY2026, violating one-row-per-period and as-originally-reported semantics). Picked rows are now deduped by actual reporting span, keeping the smallest fiscal-year stamp (the period's own identity — comparatives always re-stamp under the filing's later year).
- Truncation is signposted ("Showing first N of M results - raise maxResults…").
- New optional `fiscalPeriod` filter ('FY'/'Q1'..'Q4', additive) with a strict unknown-value error; description notes discrete Q4 rows exist only where reported.

**CompareFinancialFact**
- Period End column + a fiscal-calendar note when peer period ends spread wider than one quarter (fiscal years are filer-relative; the audit's NVDA/AMD/INTC "Q2 2025" rows were ~11 calendar months apart with no signal).
- Requesting a company's primary and secondary ticker (GOOGL,GOOG) no longer yields duplicate rows — repeats are reported as "same company as X", and a secondary-ticker row renders as "GOOG (GOOGL)" so it stays traceable to the request.
- Description documents the filer-relative fiscal calendar.

**GetFinancialStatement**
- HIGH: period='Q4' for income/cashflow returned a 30-row all-dash table with "no line items were reported" (the Q4-under-FY trap: the period validated off balance-sheet instants). Period availability is now scoped to the requested statement's concept set, and a failed Q4 flow request explains the XBRL filing convention and points to 'FY' / GetFinancialFact.
- Unreported template lines are omitted (one note) instead of ~7-10 permanently empty industry-specific dash rows per call; rendered==0 returns a message, never an empty table.
- A statement mixing filing vintages flags the restatement span ("source filings span A to B").
- Statement/period descriptions document accepted aliases ('bs', 'cf', 'p&l', …), the Q4 caveat, and sibling tools.

**GetRevenueBreakdown**
- Each axis table now carries a "Total revenue (consolidated)" row (from the already-loaded totals; alias-primary tag then latest filing) and an explicit do-not-sum caution when rows overshoot it — the AAPL Product/Service-next-to-iPhone/Mac/iPad and NVDA DataCenter-next-to-Compute/Networking shapes can never be collapsed disjointly, so rows sum to ~2x revenue.
- Humanize keeps a lone leading capital attached (IPhoneMember → "IPhone", not "I Phone"); deeper acronym boundaries still split ("USSegment" → "US Segment").
- Output states members are shown exactly as tagged (rename gaps ≠ zero revenue); years cut off by maxYears are signposted; description carries the overlap caveat + sibling pointers.

**FinancialConceptAliases**
- New `customer-concentration` alias (synonyms `concentration-risk`, `customer-concentration-risk`) mapping ConcentrationRiskPercentage1/ConcentrationRiskPercentage under us-gaap and srt, so tagged concentration facts become reachable.

## Code changes
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — span dedupe (`DedupeByReportingSpan`), truncation note, `fiscalPeriod` arg, comparison Period End column + spread note + same-company dedupe, descriptions.
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs` — statement-scoped `ResolveStatementPeriod`, Q4 explanation, omitted-lines + vintage notes, descriptions.
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs` — display totals, total row, overlap caution, year truncation note, Humanize leading-capital fix, as-tagged note, description.
- `src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs` — customer-concentration alias + synonyms.
- Tests: 7 new unit classes + 3 new integration classes; 2 reflection-based render tests and 2 integration assertions updated for the new shapes. The comparative-leak integration test was verified to fail without the dedupe.

MCP tool names and existing parameter semantics are unchanged (additive only).