### PR TITLE
fix(congress): strict MCP arguments, truncation notes, and PTR page-break parser repairs

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -374,11 +374,13 @@ public static partial class DisclosureParsingHelper
         {
             var from = ParseAmount(matches[0]);
             var to = ParseAmount(matches[1]);
-            // A range whose upper bound parsed BELOW its lower bound is corrupt source text (an
-            // unrecoverable mid-number break). The honest representation is the module's own
-            // open-ended convention — "at least $from", i.e. (from, from) — never the corrupt
+            // A range whose upper bound parsed BELOW its lower bound is corrupt source text
+            // (an unrecoverable mid-number break, or header residue like the "$200?" cap-gains
+            // threshold). When the lower bound is a standard disclosure-bracket floor its
+            // ceiling is unambiguous — re-derive it; otherwise fall back to the module's own
+            // open-ended convention, "at least $from" = (from, from) — never the corrupt
             // pair, which downstream reads as a real (and impossible) bracket.
-            return to < from ? (from, from) : (from, to);
+            return to < from ? (from, BracketCeilingFor(from)) : (from, to);
         }
 
         if (matches.Count == 1)
@@ -386,15 +388,42 @@ public static partial class DisclosureParsingHelper
             var val = ParseAmount(matches[0]);
             // A single amount is an open-ended lower bound when phrased as
             // "Over $X" or the House top bracket "$X +" (>= $X) — both map to
-            // (val, val). Otherwise it is an upper bound, e.g. "Under $X".
+            // (val, val).
             var isOpenTopBracket =
                 amount.Contains("Over", StringComparison.OrdinalIgnoreCase)
                 || amount.TrimEnd().EndsWith('+');
-            return isOpenTopBracket ? (val, val) : (0, val);
+            if (isOpenTopBracket)
+                return (val, val);
+            // A trailing '-' marks a lower bound whose upper bound was lost to a line/page
+            // break ("$50,001 -"): re-derive the bracket ceiling instead of misreading the
+            // value as an upper bound. Otherwise a single amount is an upper bound ("Under $X").
+            if (amount.TrimEnd().EndsWith('-'))
+                return (val, BracketCeilingFor(val));
+            return (0, val);
         }
 
         return (0, 0);
     }
+
+    // The standard congressional disclosure brackets (shared by House PTRs and Senate
+    // filings): a lower bound that is a bracket floor uniquely identifies its ceiling. Values
+    // that are not a floor (exact amounts, open-ended top brackets like "Over $50,000,000")
+    // stay on the (from, from) open-ended convention.
+    private static readonly Dictionary<long, long> DisclosureBracketCeilings = new()
+    {
+        [1_001] = 15_000,
+        [15_001] = 50_000,
+        [50_001] = 100_000,
+        [100_001] = 250_000,
+        [250_001] = 500_000,
+        [500_001] = 1_000_000,
+        [1_000_001] = 5_000_000,
+        [5_000_001] = 25_000_000,
+        [25_000_001] = 50_000_000,
+    };
+
+    private static long BracketCeilingFor(long from) =>
+        DisclosureBracketCeilings.TryGetValue(from, out var ceiling) ? ceiling : from;
 
     private static long ParseAmount(Match match)
     {

--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -272,11 +272,27 @@ public partial class HouseDisclosureClient
     // first token of the asset text — member-owned holdings leave it blank,
     // which the original owner-code-anchored parser silently dropped.
     internal static List<DisclosureTransaction> ParseTransactionLines(
-        IReadOnlyList<string> lines,
+        IReadOnlyList<string> rawLines,
         string memberName,
         DateOnly filingDate
     )
     {
+        // Scrub the reprinted column-header block from every line first. The word clustering
+        // can merge the page-break header into a row's own visual line (or into a wrapped
+        // continuation), where the line-level IsTableHeaderFragment guard never sees it —
+        // production stored 707 asset names carrying the verbatim "ID Owner Asset Transaction
+        // Date Notification Amount Cap. Type Date Gains >" block, and its "$200?" threshold
+        // corrupted amount ranges into impossible brackets. Lines the scrub empties entirely
+        // are dropped, so a row's wrapped remainder on the next page keeps flowing into it
+        // instead of being cut off at the header.
+        var lines = new List<string>(rawLines.Count);
+        foreach (var rawLine in rawLines)
+        {
+            var line = StripReprintedHeader(rawLine);
+            if (!string.IsNullOrWhiteSpace(line))
+                lines.Add(line);
+        }
+
         var transactions = new List<DisclosureTransaction>();
 
         for (var i = 0; i < lines.Count; i++)
@@ -378,6 +394,14 @@ public partial class HouseDisclosureClient
             return null;
 
         assetText = assetText.Trim();
+
+        // Newer House PTR layouts print a numeric filing ID at the start of each row; when
+        // the clustering glues it onto the row text it lands in front of the owner code,
+        // defeating the ^-anchored owner regex and polluting the stored asset name
+        // ("2000080040 JT Williams-Sonoma ..."). A real asset name never starts with a bare
+        // 7+ digit token followed by whitespace.
+        assetText = LeadingFilingIdRegex().Replace(assetText, "");
+
         string owner = null;
         var ownerMatch = OwnerCodeRegex().Match(assetText);
         if (ownerMatch.Success)
@@ -463,6 +487,23 @@ public partial class HouseDisclosureClient
     // (Dependent Child). Member-owned holdings leave the column blank.
     [GeneratedRegex(@"^(SP|JT|DC)\b", RegexOptions.IgnoreCase)]
     private static partial Regex OwnerCodeRegex();
+
+    private static string StripReprintedHeader(string line) =>
+        ReprintedHeaderBlockRegex().Replace(line, " ").Trim();
+
+    // The reprinted page-break column-header block as the word clustering renders it —
+    // observed verbatim in every polluted production row. Optional leading "ID" (older
+    // layouts have no ID column) and optional trailing "$200?" (the cap-gains threshold can
+    // cluster onto a separate line) cover the variants.
+    [GeneratedRegex(
+        @"\s*(?:ID\s+)?Owner Asset Transaction Date Notification Amount Cap\. Type Date Gains >(?:\s*\$200\?)?\s*"
+    )]
+    private static partial Regex ReprintedHeaderBlockRegex();
+
+    // A row-leading numeric filing ID glued onto the row text ("2000080040 JT ..."), see
+    // BuildTransaction. Bounded to 7+ digits so a real leading number ("3M Company") survives.
+    [GeneratedRegex(@"^\d{7,}\s+")]
+    private static partial Regex LeadingFilingIdRegex();
 
     // The transaction-type marker (P, S, S (partial), S (full)) immediately
     // followed by its transaction date — the anchor identifying the line that

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -42,17 +42,18 @@ public class CongressTools
 
     [McpServerTool(Name = "GetCongressionalTrades")]
     [Description(
-        "Get congressional stock trades for a specific ticker. Shows which members of Congress bought or sold shares, transaction dates, and estimated amounts. Use SearchCongressMembers to find specific members."
+        "Get congressional stock trades for a specific ticker (newest first, last year by default). Shows which members of Congress bought or sold shares, with transaction and filing dates; amounts are the disclosed ranges, not exact values. Use GetMemberTrades for one member's trades across all tickers."
     )]
     public Task<string> GetCongressionalTrades(
         [Description("Stock ticker symbol (e.g., AAPL, MSFT, NVDA)")] string ticker,
-        [Description("Filter by transaction type: Purchase or Sale (defaults to all)")]
+        [Description(
+            "Filter by transaction type: Purchase or Sale; the synonyms Buy/Sell are accepted (defaults to all)"
+        )]
             string transactionType = null,
         [Description("Start date in YYYY-MM-DD format (defaults to 1 year ago)")]
             string startDate = null,
-        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
-            string endDate = null,
-        [Description("Maximum number of trades to return (default: 50, newest first)")]
+        [Description("End date in YYYY-MM-DD format (defaults to today)")] string endDate = null,
+        [Description("Maximum number of trades to return (default: 50, max: 500, newest first)")]
             int maxResults = 50
     )
     {
@@ -63,16 +64,20 @@ public class CongressTools
                 if (stockError != null)
                     return stockError;
 
-                var (start, end) = McpToolExecutor.ParseDateRange(
-                    startDate,
-                    endDate,
-                    McpToolExecutor.UtcYearsAgo(1)
-                );
+                var (start, end, rangeError) = ParseTradeDateRange(startDate, endDate);
+                if (rangeError != null)
+                    return rangeError;
+
+                var (typeFilter, typeError) = ParseTransactionTypeArgument(transactionType);
+                if (typeError != null)
+                    return typeError;
 
                 var query = _tradeRepository.GetByStock(stock, start, end);
-                query = ApplyTransactionTypeFilter(query, transactionType);
+                if (typeFilter != null)
+                    query = query.Where(t => t.TransactionType == typeFilter);
 
                 maxResults = McpLimit.Clamp(maxResults);
+                var totalCount = await query.CountAsync();
 
                 var trades = await query
                     .Include(t => t.CongressMember)
@@ -80,20 +85,21 @@ public class CongressTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     trades,
-                    $"No congressional trades found for {stock.Ticker} in the specified date range.",
-                    $"Congressional trades for {stock.Ticker} ({stock.Name}):",
-                    "| Date | Member | Position | Type | Amount Range | Owner |",
-                    "|------|--------|----------|------|-------------|-------|",
+                    $"No congressional trades found for {stock.Ticker} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
+                    $"Congressional trades for {stock.Ticker} ({stock.Name}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
+                    "| Date | Filed | Member | Position | Type | Amount Range | Owner |",
+                    "|------|-------|--------|----------|------|-------------|-------|",
                     t =>
                     {
                         var position = t.CongressMember.Position.NameForHumans();
                         var type = t.TransactionType.NameForHumans();
                         var amount = FormatAmountRange(t);
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {(string.IsNullOrEmpty(t.OwnerType) ? "—" : t.OwnerType)} |";
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {FormatOwner(t.OwnerType)} |";
                     }
                 );
+                return AppendTruncationNote(table, trades.Count, totalCount);
             },
             "GetCongressionalTrades",
             $"ticker: {ticker}"
@@ -102,58 +108,68 @@ public class CongressTools
 
     [McpServerTool(Name = "GetMemberTrades")]
     [Description(
-        "Get trading activity for a specific congress member. Shows all their stock trades with tickers, transaction types, and amounts. Use SearchCongressMembers to find member names."
+        "Get a congress member's disclosed stock trades (newest first, last year by default). Shows tickers, transaction and filing dates, and disclosed amount ranges — bands, not exact values. Use SearchCongressMembers to find member names, and GetCongressionalTrades for all members' trades in one ticker."
     )]
     public Task<string> GetMemberTrades(
-        [Description("Congress member name (e.g., 'Nancy Pelosi', 'Dan Crenshaw')")]
+        [Description(
+            "Congress member name, case-insensitive (e.g., 'Nancy Pelosi', 'Dan Crenshaw'); use SearchCongressMembers to find the exact name"
+        )]
             string memberName,
-        [Description("Filter by transaction type: Purchase or Sale (defaults to all)")]
+        [Description(
+            "Filter by transaction type: Purchase or Sale; the synonyms Buy/Sell are accepted (defaults to all)"
+        )]
             string transactionType = null,
         [Description("Start date in YYYY-MM-DD format (defaults to 1 year ago)")]
             string startDate = null,
-        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
-            string endDate = null,
-        [Description("Maximum number of trades to return (default: 50, newest first)")]
+        [Description("End date in YYYY-MM-DD format (defaults to today)")] string endDate = null,
+        [Description("Maximum number of trades to return (default: 50, max: 500, newest first)")]
             int maxResults = 50
     )
     {
         return _runner.Execute(
             async () =>
             {
-                var member = await _memberRepository.GetByName(memberName.Trim());
+                var member = await ResolveMember(memberName.Trim());
                 if (member == null)
                     return $"Member '{memberName}' not found. Use SearchCongressMembers to find the exact name.";
 
-                var (start, end) = McpToolExecutor.ParseDateRange(
-                    startDate,
-                    endDate,
-                    McpToolExecutor.UtcYearsAgo(1)
-                );
+                var (start, end, rangeError) = ParseTradeDateRange(startDate, endDate);
+                if (rangeError != null)
+                    return rangeError;
+
+                var (typeFilter, typeError) = ParseTransactionTypeArgument(transactionType);
+                if (typeError != null)
+                    return typeError;
 
                 var query = _tradeRepository
                     .GetByMember(member)
                     .Where(t => t.TransactionDate >= start && t.TransactionDate <= end);
-                query = ApplyTransactionTypeFilter(query, transactionType);
+                if (typeFilter != null)
+                    query = query.Where(t => t.TransactionType == typeFilter);
+
+                maxResults = McpLimit.Clamp(maxResults);
+                var totalCount = await query.CountAsync();
 
                 var trades = await query
                     .Include(t => t.CommonStock)
                     .OrderByDescending(t => t.TransactionDate)
-                    .Take(McpLimit.Clamp(maxResults))
+                    .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     trades,
-                    $"No trades found for {member.Name} ({member.Position.NameForHumans()}) in the specified date range.",
-                    $"Trades by {member.Name} ({member.Position.NameForHumans()}):",
-                    "| Date | Ticker | Type | Amount Range | Asset | Owner |",
-                    "|------|--------|------|-------------|-------|-------|",
+                    $"No trades found for {member.Name} ({member.Position.NameForHumans()}) between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
+                    $"Trades by {member.Name} ({member.Position.NameForHumans()}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
+                    "| Date | Filed | Ticker | Type | Amount Range | Asset | Owner |",
+                    "|------|-------|--------|------|-------------|-------|-------|",
                     t =>
                     {
                         var type = t.TransactionType.NameForHumans();
                         var amount = FormatAmountRange(t);
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {(string.IsNullOrEmpty(t.OwnerType) ? "—" : t.OwnerType)} |";
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {FormatOwner(t.OwnerType)} |";
                     }
                 );
+                return AppendTruncationNote(table, trades.Count, totalCount);
             },
             "GetMemberTrades",
             $"memberName: {memberName}"
@@ -162,24 +178,28 @@ public class CongressTools
 
     [McpServerTool(Name = "GetMemberNetWorth")]
     [Description(
-        "Get a congress member's net worth history from their annual financial disclosures. Disclosed values are ranges, so every year is a band (minimum-maximum), never a point estimate. Only electronically filed reports are read: a missing year means no electronic filing, not zero net worth."
+        "Get a congress member's net worth history from their annual financial disclosures. Disclosed values are ranges, so every year is a band (minimum-maximum), never a point estimate. Only electronically filed reports are read: a missing year means no electronic filing, not zero net worth. Use SearchCongressMembers to find member names."
     )]
     public Task<string> GetMemberNetWorth(
-        [Description("Congress member name (e.g., 'Nancy Pelosi', 'Marsha Blackburn')")]
+        [Description(
+            "Congress member name, case-insensitive (e.g., 'Nancy Pelosi', 'Marsha Blackburn'); use SearchCongressMembers to find the exact name"
+        )]
             string memberName,
-        [Description("Maximum number of years to return (default: 20, newest first)")]
+        [Description("Maximum number of years to return (default: 20, max: 500, newest first)")]
             int maxResults = 20
     )
     {
         return _runner.Execute(
             async () =>
             {
-                var member = await _memberRepository.GetByName(memberName.Trim());
+                var member = await ResolveMember(memberName.Trim());
                 if (member == null)
                     return $"Member '{memberName}' not found. Use SearchCongressMembers to find the exact name.";
 
-                var disclosures = await _disclosureRepository
-                    .GetByMember(member)
+                var query = _disclosureRepository.GetByMember(member);
+                var totalCount = await query.CountAsync();
+
+                var disclosures = await query
                     .OrderByDescending(d => d.Year)
                     .Take(McpLimit.Clamp(maxResults))
                     .Select(d => new
@@ -197,15 +217,16 @@ public class CongressTools
                     })
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     disclosures,
                     $"No electronically filed annual disclosure found for {member.Name} ({member.Position.NameForHumans()}). Paper filings are not read, so this does not mean zero net worth.",
-                    $"Net worth of {member.Name} ({member.Position.NameForHumans()}), as disclosed in annual financial reports (band = sum of disclosed asset minimums minus liability maximums, through asset maximums minus liability minimums):",
-                    "| Year | Filed | Net Worth Minimum | Net Worth Maximum | Assets | Liabilities |",
-                    "|------|-------|-------------------|-------------------|--------|-------------|",
+                    $"Net worth of {member.Name} ({member.Position.NameForHumans()}), as disclosed in annual financial reports (band = sum of disclosed asset minimums minus liability maximums, through asset maximums minus liability minimums; Asset Lines / Liability Lines are counts of disclosed line items, not dollar amounts):",
+                    "| Year | Filed | Net Worth Minimum | Net Worth Maximum | Asset Lines | Liability Lines |",
+                    "|------|-------|-------------------|-------------------|-------------|-----------------|",
                     d =>
                         $"| {d.Year} | {d.FiledDate:yyyy-MM-dd} | {FormatSignedAmount(d.NetWorthMinimum)} | {FormatSignedAmount(d.NetWorthMaximum)} | {d.AssetCount} | {d.LiabilityCount} |"
                 );
+                return AppendTruncationNote(table, disclosures.Count, totalCount);
             },
             "GetMemberNetWorth",
             $"memberName: {memberName}"
@@ -218,26 +239,35 @@ public class CongressTools
 
     [McpServerTool(Name = "SearchCongressMembers")]
     [Description(
-        "Search for members of Congress by name. Returns matching members with their position (Senator/Representative). Use this to discover member names before calling GetMemberTrades."
+        "Search for members of Congress by name. Returns matching members with their position (Senator/Representative). Use this to discover member names before calling the member-specific tools (GetMemberTrades, GetMemberNetWorth) — the returned Name is the exact string they expect."
     )]
     public Task<string> SearchCongressMembers(
         [Description("Search query — partial or full name (e.g., 'Pelosi', 'Cruz', 'Dan')")]
             string query,
-        [Description("Maximum number of results to return (default: 20)")] int maxResults = 20
+        [Description("Filter by position: Senator or Representative (defaults to both)")]
+            string position = null,
+        [Description("Maximum number of results to return (default: 20, max: 500)")]
+            int maxResults = 20
     )
     {
         return _runner.Execute(
             async () =>
             {
+                var (positionFilter, positionError) = ParsePositionArgument(position);
+                if (positionError != null)
+                    return positionError;
+
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var members = await _memberRepository
-                    .Search(query.Trim())
-                    .OrderBy(m => m.Name)
-                    .Take(maxResults)
-                    .ToListAsync();
+                var memberQuery = _memberRepository.Search(query.Trim());
+                if (positionFilter != null)
+                    memberQuery = memberQuery.Where(m => m.Position == positionFilter);
 
-                return MarkdownTable.Render(
+                var totalCount = await memberQuery.CountAsync();
+
+                var members = await memberQuery.OrderBy(m => m.Name).Take(maxResults).ToListAsync();
+
+                var table = MarkdownTable.Render(
                     members,
                     $"No congress members found matching '{query}'.",
                     $"Congress members matching '{query}':",
@@ -245,10 +275,25 @@ public class CongressTools
                     "|------|----------|",
                     m => $"| {m.Name} | {m.Position.NameForHumans()} |"
                 );
+                return AppendTruncationNote(table, members.Count, totalCount);
             },
             "SearchCongressMembers",
             $"query: {query}"
         );
+    }
+
+    // Exact lookup is case-insensitive (see CongressMemberRepository.GetByName); when it
+    // misses, fall back to a contains-match only when it is unambiguous — 'pelosi' resolves,
+    // while a query matching several members still asks the caller to disambiguate via
+    // SearchCongressMembers.
+    private async Task<CongressMember> ResolveMember(string memberName)
+    {
+        var member = await _memberRepository.GetByName(memberName);
+        if (member != null)
+            return member;
+
+        var matches = await _memberRepository.Search(memberName).Take(2).ToListAsync();
+        return matches.Count == 1 ? matches[0] : null;
     }
 
     // Format with InvariantCulture so the MCP markdown does not fork the separators by host
@@ -256,18 +301,122 @@ public class CongressTools
     private static string FormatAmountRange(CongressionalTrade t) =>
         $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
 
-    private static IQueryable<CongressionalTrade> ApplyTransactionTypeFilter(
-        IQueryable<CongressionalTrade> query,
+    // House PTRs disclose raw owner codes (SP/JT/DC) while Senate rows arrive spelled out;
+    // render one vocabulary — the Senate labels — so a table never mixes "SP" and "Spouse".
+    // The stored value is untouched: OwnerType is part of the trade upsert key.
+    private static string FormatOwner(string ownerType) =>
+        string.IsNullOrEmpty(ownerType)
+            ? "—"
+            : ownerType.ToUpperInvariant() switch
+            {
+                "SP" => "Spouse",
+                "JT" => "Joint",
+                "DC" => "Child",
+                _ => ownerType,
+            };
+
+    // TruncationNote is empty when nothing was cut off; the blank line keeps the note out of
+    // the markdown table block.
+    private static string AppendTruncationNote(string table, int shown, int total)
+    {
+        var note = McpOutput.TruncationNote(shown, total);
+        return note.Length == 0 ? table : $"{table}\n{note}";
+    }
+
+    // Strict date arguments: a malformed date must correct the caller, never silently fall
+    // back to the default window — the caller could not tell which range was actually applied.
+    private static (DateOnly Date, string Error) ParseDateArgument(
+        string value,
+        string argumentName,
+        DateOnly fallback
+    )
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return (fallback, null);
+        if (McpOutput.TryParseDate(value, out var parsed))
+            return (DateOnly.FromDateTime(parsed), null);
+        return (default, McpOutput.InvalidArgument(argumentName, value, "yyyy-MM-dd"));
+    }
+
+    private static (DateOnly Start, DateOnly End, string Error) ParseTradeDateRange(
+        string startDate,
+        string endDate
+    )
+    {
+        var (start, startError) = ParseDateArgument(
+            startDate,
+            "startDate",
+            McpToolExecutor.UtcYearsAgo(1)
+        );
+        if (startError != null)
+            return (default, default, startError);
+
+        var (end, endError) = ParseDateArgument(
+            endDate,
+            "endDate",
+            DateOnly.FromDateTime(DateTime.UtcNow)
+        );
+        if (endError != null)
+            return (default, default, endError);
+
+        if (start > end)
+            return (
+                default,
+                default,
+                $"Invalid date range: startDate {start:yyyy-MM-dd} is after endDate {end:yyyy-MM-dd}."
+            );
+
+        return (start, end, null);
+    }
+
+    // Purchase/Sale plus the synonyms an LLM naturally reaches for. Deliberately NOT
+    // Enum.TryParse: that accepts numeric strings ("2"), producing an undefined enum value
+    // that silently filters every row out.
+    private static readonly Dictionary<string, CongressTransactionType> TransactionTypeAliases =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Purchase"] = CongressTransactionType.Purchase,
+            ["Buy"] = CongressTransactionType.Purchase,
+            ["Sale"] = CongressTransactionType.Sale,
+            ["Sell"] = CongressTransactionType.Sale,
+        };
+
+    // An unrecognised transaction type must error, never silently return unfiltered results:
+    // a caller asking for "Buys" would confidently misread the mixed rows as purchases.
+    private static (CongressTransactionType? Type, string Error) ParseTransactionTypeArgument(
         string transactionType
     )
     {
-        if (
-            string.IsNullOrEmpty(transactionType)
-            || !Enum.TryParse<CongressTransactionType>(transactionType, true, out var parsedType)
-        )
-        {
-            return query;
-        }
-        return query.Where(t => t.TransactionType == parsedType);
+        if (string.IsNullOrWhiteSpace(transactionType))
+            return (null, null);
+        if (TransactionTypeAliases.TryGetValue(transactionType.Trim(), out var parsed))
+            return (parsed, null);
+        return (
+            null,
+            McpOutput.InvalidArgument(
+                "transactionType",
+                transactionType,
+                "Purchase or Sale (synonyms: Buy, Sell)"
+            )
+        );
+    }
+
+    private static readonly Dictionary<string, CongressPosition> PositionAliases = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        ["Senator"] = CongressPosition.Senator,
+        ["Senate"] = CongressPosition.Senator,
+        ["Representative"] = CongressPosition.Representative,
+        ["House"] = CongressPosition.Representative,
+    };
+
+    private static (CongressPosition? Position, string Error) ParsePositionArgument(string position)
+    {
+        if (string.IsNullOrWhiteSpace(position))
+            return (null, null);
+        if (PositionAliases.TryGetValue(position.Trim(), out var parsed))
+            return (parsed, null);
+        return (null, McpOutput.InvalidArgument("position", position, "Senator or Representative"));
     }
 }

--- a/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
@@ -11,7 +11,10 @@ public class CongressMemberRepository : BaseRepository<CongressMember>
 
     public async Task<CongressMember> GetByName(string name)
     {
-        return await GetAll().FirstOrDefaultAsync(m => m.Name == name);
+        // Case-insensitive exact match (same pattern as CommonStockRepository.GetByName):
+        // the name arrives as caller-typed input, and == is case-sensitive in PostgreSQL,
+        // so 'nancy pelosi' would miss 'Nancy Pelosi'.
+        return await GetAll().FirstOrDefaultAsync(m => m.Name.ToLower() == name.ToLower());
     }
 
     public IQueryable<CongressMember> Search(string search)

--- a/tests/Equibles.IntegrationTests/Congress/CongressRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressRepositoryTests.cs
@@ -70,15 +70,18 @@ public class CongressMemberRepositoryTests : IDisposable
     }
 
     [Fact]
-    public async Task GetByName_CaseSensitive_ReturnsNullForWrongCase()
+    public async Task GetByName_WrongCase_StillReturnsMember()
     {
+        // Case-insensitive on purpose: the name arrives as caller-typed input (MCP tools),
+        // and a case mismatch is purely cosmetic — 'nancy pelosi' must find 'Nancy Pelosi'.
         var member = CreateMember("Nancy Pelosi");
         _dbContext.Set<CongressMember>().Add(member);
         await _dbContext.SaveChangesAsync();
 
         var result = await _repository.GetByName("nancy pelosi");
 
-        result.Should().BeNull();
+        result.Should().NotBeNull();
+        result.Id.Should().Be(member.Id);
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberTradesUnknownTransactionTypeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberTradesUnknownTransactionTypeTests.cs
@@ -9,31 +9,20 @@ using Xunit;
 namespace Equibles.IntegrationTests.Mcp;
 
 /// <summary>
-/// Adversarial cover for <c>GetMemberTrades</c>'s transaction-type filter (the shared
-/// <c>ApplyTransactionTypeFilter</c> helper). The parameter is documented as "Purchase or Sale
-/// (defaults to all)", so an unrecognised value is invalid input that must degrade gracefully —
-/// the filter is ignored and every trade is returned, never an internal error or an empty result.
-/// Existing tests only cover exact and lowercase valid types, leaving the unparseable-input
-/// fall-through branch unexercised.
+/// Adversarial cover for <c>GetMemberTrades</c>'s transaction-type filter. An unrecognised
+/// value must produce an explicit one-line error naming the accepted values — the previous
+/// graceful degradation (ignore the filter, return every trade) made an LLM passing "banana"
+/// (or any unmapped word) confidently misreport a mixed list as filtered. The natural
+/// synonyms Buy/Sell must keep working as Purchase/Sale.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class CongressToolsGetMemberTradesUnknownTransactionTypeTests : ParadeDbMcpTestBase
 {
-    private CongressTools Sut() =>
-        new(
-            new CongressionalTradeRepository(DbContext),
-            new CongressMemberRepository(DbContext),
-            new CongressionalAnnualDisclosureRepository(DbContext),
-            new CommonStockRepository(DbContext),
-            ErrorManager,
-            NullLogger<CongressTools>()
-        );
-
     public CongressToolsGetMemberTradesUnknownTransactionTypeTests(ParadeDbFixture fixture)
         : base(fixture) { }
 
     [Fact]
-    public async Task GetMemberTrades_UnknownTransactionType_IgnoresFilterAndReturnsAllTrades()
+    public async Task GetMemberTrades_UnknownTransactionType_ErrorsListingAcceptedValues()
     {
         var member = new CongressMember
         {
@@ -48,7 +37,8 @@ public class CongressToolsGetMemberTradesUnknownTransactionTypeTests : ParadeDbM
         };
         DbContext.Add(member);
         DbContext.Add(stock);
-        // One Purchase and one Sale on distinct dates, so an applied-vs-ignored filter is visible.
+        // One Purchase and one Sale on distinct dates, so a silently-ignored filter (both
+        // dates rendered) is distinguishable from the expected explicit error.
         DbContext.Add(
             MakeTrade(member, stock, new DateOnly(2026, 3, 1), CongressTransactionType.Purchase)
         );
@@ -75,10 +65,60 @@ public class CongressToolsGetMemberTradesUnknownTransactionTypeTests : ParadeDbM
             endDate: "2026-12-31"
         );
 
-        // An unparseable type is ignored, so both trades surface — no internal error, no empty set.
-        output.Should().NotContain("An error occurred while executing");
+        // Strict: the unknown value corrects the caller instead of silently returning
+        // unfiltered trades — no trade rows, no internal error.
+        output
+            .Should()
+            .Be(
+                "Unknown transactionType 'banana'. Accepted: Purchase or Sale (synonyms: Buy, Sell)."
+            );
+    }
+
+    [Fact]
+    public async Task GetMemberTrades_BuySynonym_FiltersToPurchases()
+    {
+        var member = new CongressMember
+        {
+            Name = "Nancy Pelosi",
+            Position = CongressPosition.Representative,
+        };
+        var stock = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corporation",
+            Cik = "0001045810",
+        };
+        DbContext.Add(member);
+        DbContext.Add(stock);
+        DbContext.Add(
+            MakeTrade(member, stock, new DateOnly(2026, 3, 1), CongressTransactionType.Purchase)
+        );
+        DbContext.Add(
+            MakeTrade(member, stock, new DateOnly(2026, 3, 2), CongressTransactionType.Sale)
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new CongressTools(
+            new CongressionalTradeRepository(verify),
+            new CongressMemberRepository(verify),
+            new CongressionalAnnualDisclosureRepository(verify),
+            new CommonStockRepository(verify),
+            ErrorManager,
+            NullLogger<CongressTools>()
+        );
+
+        var output = await sut.GetMemberTrades(
+            "Nancy Pelosi",
+            transactionType: "Buy",
+            startDate: "2026-01-01",
+            endDate: "2026-12-31"
+        );
+
+        // "Buy" maps to Purchase — only the purchase row surfaces.
         output.Should().Contain("2026-03-01");
-        output.Should().Contain("2026-03-02");
+        output.Should().NotContain("2026-03-02");
     }
 
     private static CongressionalTrade MakeTrade(

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
@@ -45,7 +45,8 @@ public class CongressToolsTests : ParadeDbMcpTestBase
         CongressTransactionType type = CongressTransactionType.Purchase,
         long amountFrom = 1_000,
         long amountTo = 15_000,
-        string assetName = "Common Stock"
+        string assetName = "Common Stock",
+        string ownerType = "Self"
     ) =>
         new()
         {
@@ -56,7 +57,7 @@ public class CongressToolsTests : ParadeDbMcpTestBase
             TransactionDate = transactionDate,
             FilingDate = transactionDate.AddDays(30),
             TransactionType = type,
-            OwnerType = "Self",
+            OwnerType = ownerType,
             AssetName = assetName,
             AmountFrom = amountFrom,
             AmountTo = amountTo,
@@ -297,5 +298,239 @@ public class CongressToolsTests : ParadeDbMcpTestBase
         var result = await Sut().SearchCongressMembers("pelosi");
 
         result.Should().Contain("Nancy Pelosi");
+    }
+
+    [Fact]
+    public async Task SearchCongressMembers_MoreMatchesThanMaxResults_AppendsTruncationNote()
+    {
+        DbContext
+            .Set<CongressMember>()
+            .AddRange(
+                new CongressMember
+                {
+                    Name = "Dan Crenshaw",
+                    Position = CongressPosition.Representative,
+                },
+                new CongressMember
+                {
+                    Name = "Daniel Goldman",
+                    Position = CongressPosition.Representative,
+                },
+                new CongressMember
+                {
+                    Name = "Daniel Meuser",
+                    Position = CongressPosition.Representative,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().SearchCongressMembers("Dan", maxResults: 2);
+
+        // Alphabetical order means later-alphabet members are cut; the caller must be told.
+        result.Should().Contain("Showing first 2 of 3 results - raise maxResults to see more.");
+        result.Should().NotContain("Daniel Meuser");
+    }
+
+    [Fact]
+    public async Task SearchCongressMembers_PositionFilter_ReturnsOnlyThatChamber()
+    {
+        DbContext
+            .Set<CongressMember>()
+            .AddRange(
+                new CongressMember { Name = "Rick Scott", Position = CongressPosition.Senator },
+                new CongressMember
+                {
+                    Name = "Austin Scott",
+                    Position = CongressPosition.Representative,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().SearchCongressMembers("Scott", position: "Senator");
+
+        result.Should().Contain("Rick Scott");
+        result.Should().NotContain("Austin Scott");
+    }
+
+    [Fact]
+    public async Task SearchCongressMembers_UnknownPosition_ErrorsListingAcceptedValues()
+    {
+        var result = await Sut().SearchCongressMembers("Scott", position: "Governor");
+
+        result.Should().Be("Unknown position 'Governor'. Accepted: Senator or Representative.");
+    }
+
+    // ── strict arguments and result framing ──────────────────────────────
+
+    [Fact]
+    public async Task GetCongressionalTrades_MalformedStartDate_ErrorsWithAcceptedFormat()
+    {
+        DbContext.Set<CommonStock>().Add(NvdaStock());
+        await DbContext.SaveChangesAsync();
+
+        // US-style dates must correct the caller, never silently fall back to the default
+        // 1-year window (the caller could not tell which range was applied).
+        var result = await Sut().GetCongressionalTrades("NVDA", startDate: "06/01/2026");
+
+        result.Should().Be("Unknown startDate '06/01/2026'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetMemberTrades_InvertedDateRange_ErrorsExplicitly()
+    {
+        DbContext.Set<CongressMember>().Add(PelosiMember());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetMemberTrades("Nancy Pelosi", startDate: "2026-01-01", endDate: "2025-01-01");
+
+        result.Should().Be("Invalid date range: startDate 2026-01-01 is after endDate 2025-01-01.");
+    }
+
+    [Fact]
+    public async Task GetCongressionalTrades_TitleEchoesEffectiveDateWindow()
+    {
+        var stock = NvdaStock();
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<CongressMember>().Add(pelosi);
+        DbContext.Set<CongressionalTrade>().Add(TradeFor(pelosi, stock, new DateOnly(2026, 3, 15)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetCongressionalTrades("NVDA", startDate: "2026-01-01", endDate: "2026-04-30");
+
+        // The applied window must be visible: a default-window result is otherwise
+        // indistinguishable from an all-time history.
+        result
+            .Should()
+            .Contain(
+                "Congressional trades for NVDA (NVIDIA Corporation), 2026-01-01 to 2026-04-30:"
+            );
+    }
+
+    [Fact]
+    public async Task GetCongressionalTrades_MoreTradesThanMaxResults_AppendsTruncationNote()
+    {
+        var stock = NvdaStock();
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<CongressMember>().Add(pelosi);
+        DbContext
+            .Set<CongressionalTrade>()
+            .AddRange(
+                TradeFor(pelosi, stock, new DateOnly(2026, 3, 10), assetName: "First"),
+                TradeFor(pelosi, stock, new DateOnly(2026, 3, 11), assetName: "Second"),
+                TradeFor(pelosi, stock, new DateOnly(2026, 3, 12), assetName: "Third")
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetCongressionalTrades(
+                "NVDA",
+                startDate: "2026-01-01",
+                endDate: "2026-04-30",
+                maxResults: 2
+            );
+
+        result.Should().Contain("Showing first 2 of 3 results - raise maxResults to see more.");
+    }
+
+    [Fact]
+    public async Task GetCongressionalTrades_HouseOwnerCode_RenderedAsSenateLabel()
+    {
+        var stock = NvdaStock();
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<CongressMember>().Add(pelosi);
+        DbContext
+            .Set<CongressionalTrade>()
+            .Add(TradeFor(pelosi, stock, new DateOnly(2026, 3, 15), ownerType: "SP"));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetCongressionalTrades("NVDA", startDate: "2026-01-01", endDate: "2026-04-30");
+
+        // One vocabulary: the raw House code renders as the Senate label.
+        result.Should().Contain("| Spouse |");
+        result.Should().NotContain("| SP |");
+    }
+
+    [Fact]
+    public async Task GetMemberTrades_RendersFilingDateColumn()
+    {
+        var stock = NvdaStock();
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<CongressMember>().Add(pelosi);
+        // Filed 30 days after the trade: STOCK Act disclosures lag, so the date the market
+        // learned of the trade must be visible next to the transaction date.
+        DbContext
+            .Set<CongressionalTrade>()
+            .Add(TradeFor(pelosi, stock, new DateOnly(2026, 3, 15)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetMemberTrades("Nancy Pelosi", startDate: "2026-01-01", endDate: "2026-04-30");
+
+        result.Should().Contain("| Date | Filed |");
+        result.Should().Contain("| 2026-03-15 | 2026-04-14 |");
+    }
+
+    // ── member resolution ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetMemberTrades_MemberNameWrongCase_StillResolves()
+    {
+        var stock = NvdaStock();
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<CongressMember>().Add(pelosi);
+        DbContext.Set<CongressionalTrade>().Add(TradeFor(pelosi, stock, new DateOnly(2026, 3, 15)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetMemberTrades("nancy pelosi", startDate: "2026-01-01", endDate: "2026-04-30");
+
+        result.Should().Contain("Trades by Nancy Pelosi (Representative)");
+    }
+
+    [Fact]
+    public async Task GetMemberTrades_UniquePartialName_ResolvesUnambiguously()
+    {
+        var stock = NvdaStock();
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<CongressMember>().AddRange(pelosi, CrenshawMember());
+        DbContext.Set<CongressionalTrade>().Add(TradeFor(pelosi, stock, new DateOnly(2026, 3, 15)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetMemberTrades("Pelosi", startDate: "2026-01-01", endDate: "2026-04-30");
+
+        result.Should().Contain("Trades by Nancy Pelosi (Representative)");
+    }
+
+    [Fact]
+    public async Task GetMemberTrades_AmbiguousPartialName_StaysNotFound()
+    {
+        DbContext
+            .Set<CongressMember>()
+            .AddRange(
+                new CongressMember { Name = "Rick Scott", Position = CongressPosition.Senator },
+                new CongressMember
+                {
+                    Name = "Austin Scott",
+                    Position = CongressPosition.Representative,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        // Two members match: guessing either would silently answer about the wrong person.
+        var result = await Sut().GetMemberTrades("Scott");
+
+        result
+            .Should()
+            .Be("Member 'Scott' not found. Use SearchCongressMembers to find the exact name.");
     }
 }

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperBrokenAmountTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperBrokenAmountTests.cs
@@ -35,14 +35,38 @@ public class DisclosureParsingHelperBrokenAmountTests
     }
 
     [Fact]
-    public void ParseAmountRange_CorruptInvertedBracket_FallsBackToOpenEndedLowerBound()
+    public void ParseAmountRange_CorruptInvertedBracketOnBracketFloor_RederivesCeiling()
     {
-        // An upper bound that parsed below the lower bound is unrecoverable source corruption —
-        // "at least $from" is the honest read, never the impossible pair.
+        // An upper bound that parsed below the lower bound is source corruption (a mid-number
+        // break, or page-break header residue like the "$200?" cap-gains threshold). $50,001
+        // is a standard disclosure-bracket floor, so its ceiling is unambiguous — production
+        // held 49 rows stored as the impossible ($50,001, $50,001)-style band this way.
         var (from, to) = DisclosureParsingHelper.ParseAmountRange("$50,001 - $200junk000");
 
         Assert.Equal(50001, from);
-        Assert.Equal(50001, to);
+        Assert.Equal(100000, to);
+    }
+
+    [Fact]
+    public void ParseAmountRange_CorruptInvertedBracketOffBracketFloor_FallsBackToOpenEndedLowerBound()
+    {
+        // A lower bound that is NOT a standard bracket floor has no derivable ceiling —
+        // "at least $from" stays the honest read, never the impossible pair.
+        var (from, to) = DisclosureParsingHelper.ParseAmountRange("$1,234 - $200junk000");
+
+        Assert.Equal(1234, from);
+        Assert.Equal(1234, to);
+    }
+
+    [Fact]
+    public void ParseAmountRange_LoneLowerBoundWithTrailingDash_RederivesCeiling()
+    {
+        // "$50,001 -" is a range whose upper bound was lost to a line/page break: the value
+        // is a LOWER bound, and reading it as "up to $50,001" inverts the disclosure.
+        var (from, to) = DisclosureParsingHelper.ParseAmountRange("$50,001 -");
+
+        Assert.Equal(50001, from);
+        Assert.Equal(100000, to);
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientReprintedHeaderScrubTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientReprintedHeaderScrubTests.cs
@@ -1,0 +1,118 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// A page break reprints the PTR column-header block, and the word clustering can land it
+/// anywhere: merged into a row's own visual line, or as a standalone line splitting a row
+/// from its wrapped remainder. The line-level header guard (#3378) only covers the standalone
+/// case — and even there it CUT OFF the wrapped remainder instead of flowing past the header.
+/// Production stored 707 asset names carrying the verbatim header block and 49 impossible
+/// amount brackets (e.g. $50,001–$50,001) from the header's "$200?" cap-gains threshold
+/// bleeding into the amount text. The parser must scrub the block wherever it lands and keep
+/// the row's wrapped remainder.
+/// </summary>
+public class HouseDisclosureClientReprintedHeaderScrubTests
+{
+    private const string HeaderBlock =
+        "ID Owner Asset Transaction Date Notification Amount Cap. Type Date Gains >";
+
+    private static readonly DateOnly FilingDate = new(2026, 2, 1);
+
+    private static List<DisclosureTransaction> Parse(params string[] lines) =>
+        HouseDisclosureClient.ParseTransactionLines(lines, "Nancy Pelosi", FilingDate);
+
+    [Fact]
+    public void ParseTransactionLines_HeaderBlockMergedIntoAnchorLine_IsScrubbedFromAssetName()
+    {
+        // The production shape behind the 707 polluted rows: the reprinted header words sit
+        // inside the row's own reconstructed line, splitting the wrapped asset name.
+        var result = Parse(
+            $"SP Tempus AI, Inc. - Class A Common {HeaderBlock} Stock (TEM) P 01/16/2026 01/16/2026 $50,001 - $100,000",
+            "F      S     : New"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.AssetName.Should().Be("Tempus AI, Inc. - Class A Common Stock (TEM)");
+        tx.Ticker.Should().Be("TEM");
+        tx.OwnerType.Should().Be("SP");
+        tx.AmountFrom.Should().Be(50_001);
+        tx.AmountTo.Should().Be(100_000);
+    }
+
+    [Fact]
+    public void ParseTransactionLines_StandaloneHeaderLine_WrappedRemainderStillFlowsIntoRow()
+    {
+        // Page break mid-row: the header reprint separates the row from its wrapped remainder
+        // (rest of the asset name + the upper amount bound). The old guard stopped at the
+        // header, truncating the asset name and misreading "$50,001 -" as "up to $50,001".
+        var result = Parse(
+            "SP Tempus AI, Inc. - Class A Common P 01/16/2026 01/16/2026 $50,001 -",
+            HeaderBlock,
+            "Stock (TEM) $100,000",
+            "F      S     : New"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.AssetName.Should().Be("Tempus AI, Inc. - Class A Common Stock (TEM)");
+        tx.Ticker.Should().Be("TEM");
+        tx.AmountFrom.Should().Be(50_001);
+        tx.AmountTo.Should().Be(100_000);
+    }
+
+    [Fact]
+    public void ParseTransactionLines_HeaderLineWithCapGainsThreshold_ThresholdNeverBleedsIntoAmount()
+    {
+        // The header's "$200?" cap-gains threshold is a dollar token: unscrubbed, it becomes
+        // the range's "upper bound" and the corrupt pair collapses to an impossible bracket.
+        var result = Parse(
+            "JT Acme Corporation - Common P 02/10/2026 02/11/2026 $15,001 -",
+            $"{HeaderBlock} $200?",
+            "Stock (ACME) $50,000",
+            "F      S     : New"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.AssetName.Should().Be("Acme Corporation - Common Stock (ACME)");
+        tx.AmountFrom.Should().Be(15_001);
+        tx.AmountTo.Should().Be(50_000);
+    }
+
+    [Fact]
+    public void ParseTransactionLines_RowLeadingFilingId_IsStrippedAndOwnerCodeStillDetected()
+    {
+        // Newer PTR layouts print a numeric filing ID at the start of each row; glued onto
+        // the row text it defeated the ^-anchored owner regex and was stored as part of the
+        // asset name ("2000080040 JT Williams-Sonoma ..." — 386 production rows).
+        var result = Parse(
+            "2000080040 JT Williams-Sonoma, Inc. Common Stock (WSM) P 05/27/2021 05/28/2021 $15,001 - $50,000",
+            "F      S     : New"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.AssetName.Should().Be("Williams-Sonoma, Inc. Common Stock (WSM)");
+        tx.Ticker.Should().Be("WSM");
+        tx.OwnerType.Should().Be("JT");
+        tx.AmountFrom.Should().Be(15_001);
+        tx.AmountTo.Should().Be(50_000);
+    }
+
+    [Fact]
+    public void ParseTransactionLines_HeaderBetweenTwoCompleteRows_NeitherRowIsPolluted()
+    {
+        // A page break BETWEEN rows: the header must not attach to either neighbour.
+        var result = Parse(
+            "SP Apple Inc. - Common Stock (AAPL) P 03/03/2026 03/05/2026 $1,001 - $15,000",
+            HeaderBlock,
+            "Microsoft Corporation (MSFT) S 03/04/2026 03/06/2026 $1,001 - $15,000",
+            "F      S     : New"
+        );
+
+        result.Should().HaveCount(2);
+        result[0].AssetName.Should().Be("Apple Inc. - Common Stock (AAPL)");
+        result[1].AssetName.Should().Be("Microsoft Corporation (MSFT)");
+        result[1].TransactionType.Should().Be(CongressTransactionType.Sale);
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/CongressToolsApplyTransactionTypeFilterCaseInsensitiveTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/CongressToolsApplyTransactionTypeFilterCaseInsensitiveTests.cs
@@ -4,63 +4,77 @@ using Equibles.Congress.Mcp.Tools;
 
 namespace Equibles.UnitTests.Mcp;
 
+/// <summary>
+/// Pins <c>ParseTransactionTypeArgument</c>, the strict transaction-type parser shared by
+/// GetCongressionalTrades and GetMemberTrades. The contract: case-insensitive Purchase/Sale
+/// plus the Buy/Sell synonyms an LLM naturally reaches for; anything else — including numeric
+/// enum strings, which <c>Enum.TryParse</c> would happily accept as undefined values — must
+/// produce an explicit error naming the accepted values, never a silently unfiltered result
+/// (the previous behavior returned ALL trades for "Buy", which callers misread as purchases).
+/// </summary>
 public class CongressToolsApplyTransactionTypeFilterCaseInsensitiveTests
 {
-    // ApplyTransactionTypeFilter is unpinned. Its body:
-    //     Enum.TryParse<CongressTransactionType>(transactionType, true, out var parsedType)
-    // — the `true` argument enables CASE-INSENSITIVE parsing. The
-    // GetMemberTrades MCP tool routes its `transactionType` parameter
-    // through this helper, and LLM clients produce user-natural casings
-    // ("purchase", "Sale", "SALE") far more often than the canonical
-    // "Purchase"/"Sale" form.
-    //
-    // The risks this pin uniquely catches:
-    //
-    //   • Drop-the-true regression — `Enum.TryParse<CongressTransactionType>
-    //     (transactionType, out var parsedType)` (someone "simplifies"
-    //     the overload set) would compile, default to case-SENSITIVE
-    //     parsing, and silently REJECT every lowercase user input —
-    //     falling through to "return query unchanged" and rendering
-    //     UNFILTERED results when the user asked for "purchase only".
-    //     The MCP response would include sales too, confusing the LLM's
-    //     downstream analysis.
-    //
-    //   • Drop-the-filter regression — `return query;` instead of
-    //     `return query.Where(...)` (the happy-path filter arm) —
-    //     would return all rows for every recognised type. Caught
-    //     by this pin's "filter applied" count assertion.
-    //
-    //   • Wrong-enum-value regression — parsing succeeds but matches
-    //     the wrong variant (e.g. "purchase" → Sale). Caught by
-    //     this pin's distinct-value assertion (the surviving trade
-    //     must be the Purchase one).
-    //
-    // Adversarial input: lowercase "purchase" against a two-trade
-    // IQueryable (one Purchase, one Sale). Working code: returns 1
-    // trade (the Purchase). Drop-the-true: returns 2 trades (filter
-    // skipped because parse failed). Wrong-enum: returns 1 trade
-    // but it's the Sale.
-    [Fact]
-    public void ApplyTransactionTypeFilter_LowercasePurchase_FiltersToPurchaseTradesViaCaseInsensitiveParse()
+    private static (CongressTransactionType? Type, string Error) Parse(string transactionType)
     {
         var method = typeof(CongressTools).GetMethod(
-            "ApplyTransactionTypeFilter",
+            "ParseTransactionTypeArgument",
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
-        var purchaseId = Guid.NewGuid();
-        var saleId = Guid.NewGuid();
-        var trades = new List<CongressionalTrade>
-        {
-            new() { Id = purchaseId, TransactionType = CongressTransactionType.Purchase },
-            new() { Id = saleId, TransactionType = CongressTransactionType.Sale },
-        }.AsQueryable();
+        return ((CongressTransactionType? Type, string Error))
+            method!.Invoke(null, [transactionType])!;
+    }
 
-        var filtered = (IQueryable<CongressionalTrade>)method!.Invoke(null, [trades, "purchase"]);
+    [Theory]
+    [InlineData("Purchase", CongressTransactionType.Purchase)]
+    [InlineData("purchase", CongressTransactionType.Purchase)]
+    [InlineData("PURCHASE", CongressTransactionType.Purchase)]
+    [InlineData("Buy", CongressTransactionType.Purchase)]
+    [InlineData("buy", CongressTransactionType.Purchase)]
+    [InlineData("Sale", CongressTransactionType.Sale)]
+    [InlineData("sale", CongressTransactionType.Sale)]
+    [InlineData("Sell", CongressTransactionType.Sale)]
+    [InlineData("SELL", CongressTransactionType.Sale)]
+    [InlineData(" Sale ", CongressTransactionType.Sale)]
+    public void ParseTransactionTypeArgument_KnownValueAnyCase_ParsesWithoutError(
+        string input,
+        CongressTransactionType expected
+    )
+    {
+        var (type, error) = Parse(input);
 
-        var results = filtered.ToList();
-        results.Should().ContainSingle();
-        results[0].TransactionType.Should().Be(CongressTransactionType.Purchase);
-        results[0].Id.Should().Be(purchaseId);
+        error.Should().BeNull();
+        type.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseTransactionTypeArgument_Blank_MeansNoFilter(string input)
+    {
+        var (type, error) = Parse(input);
+
+        error.Should().BeNull();
+        type.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("banana")]
+    [InlineData("Exchange")]
+    // Enum.TryParse would accept a numeric string as an undefined enum value that filters
+    // every row out; the strict parser must reject it like any other unknown value.
+    [InlineData("2")]
+    [InlineData("0")]
+    public void ParseTransactionTypeArgument_UnknownValue_ErrorsListingAcceptedValues(string input)
+    {
+        var (type, error) = Parse(input);
+
+        type.Should().BeNull();
+        error
+            .Should()
+            .Be(
+                $"Unknown transactionType '{input}'. Accepted: Purchase or Sale (synonyms: Buy, Sell)."
+            );
     }
 }


### PR DESCRIPTION
## Summary

Fixes all congress-package findings from the MCP tools audit (GetCongressionalTrades, GetMemberTrades, GetMemberNetWorth, SearchCongressMembers + the House PTR parser feeding them).

## Code changes

**MCP tools (`Equibles.Congress.Mcp/Tools/CongressTools.cs`)**
- Unknown `transactionType` now errors listing the accepted values (Purchase/Sale + Buy/Sell synonyms) instead of silently returning unfiltered trades; numeric enum strings are rejected.
- Strict `yyyy-MM-dd` date arguments via the shared `McpOutput` helpers — malformed dates and inverted ranges error instead of silently falling back.
- Titles echo the applied date window; all list tools count before `Take` and append the shared truncation note.
- Trade tables gain a **Filed** column and render one owner vocabulary (House SP/JT/DC codes decode to the Senate Spouse/Joint/Child labels at render time only — stored values, part of the upsert key, are untouched).
- `GetMemberNetWorth` headers renamed to **Asset Lines / Liability Lines** (they are line counts, not amounts).
- `SearchCongressMembers` gains an optional `position` filter; descriptions cross-reference both member-scoped tools.
- Member lookup is case-insensitive (`CongressMemberRepository.GetByName`, same pattern as `CommonStockRepository`) with an unambiguous-contains fallback.

**House PTR parser (`Equibles.Congress.HostedService`)**
- Scrubs the reprinted page-break column-header block from every extracted line — production stored 707 asset names carrying the verbatim `ID Owner Asset Transaction ... Gains >` block that the line-level guard (#3715) can't see when the header merges into a row's own line; lines the scrub empties are dropped so a row's wrapped remainder keeps flowing instead of being cut off at the header.
- Strips the row-leading numeric filing ID newer PTR layouts print (386 polluted rows; it also defeated the owner-code regex).
- `ParseAmountRange`: a corrupt inverted range bottoming on a standard disclosure-bracket floor re-derives its unambiguous ceiling (49 impossible $X–$X production brackets); a lone lower bound with a trailing dash is no longer misread as an upper bound.

## Tests
- New `HouseDisclosureClientReprintedHeaderScrubTests` (5 tests; 4 fail without the fix).
- Updated the pinned unknown-transactionType, corrupt-bracket, and case-sensitivity tests to the new contracts; added strict-date/truncation/owner-label/member-resolution integration tests.
- `Equibles.UnitTests` (Congress scope: 295) and `Equibles.IntegrationTests` (Congress scope: 88) green; `Equibles.Web` + `Equibles.Worker.Host` build clean.