### PR TITLE
fix(mcp): audit fixes for the six document/search MCP tools

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
@@ -59,6 +59,7 @@ public class HybridChunkSearcher
         int maxResultsPerCompany = 0,
         DateOnly? startDate = null,
         DateOnly? endDate = null,
+        bool disjunctiveFallback = false,
         CancellationToken cancellationToken = default
     )
     {
@@ -84,8 +85,31 @@ public class HybridChunkSearcher
             documentTypes,
             startDate,
             endDate,
-            cancellationToken
+            cancellationToken: cancellationToken
         );
+
+        // Opt-in recall fallback: BM25 ANDs every query token, so a wordy natural-language
+        // query where a single token has no match ("drivers" vs the filing's "driven")
+        // excludes every on-point chunk. When the conjunctive pass can't fill the request,
+        // top up from a disjunctive (any-token) pass — conjunctive hits keep their rank and
+        // the broader hits only append after them, so precise matches never lose position.
+        if (disjunctiveFallback && bm25.Count < maxResults)
+        {
+            var disjunctive = await _chunkRepository.HybridSearch(
+                query,
+                bm25Limit,
+                ticker,
+                excludeTickers,
+                documentId,
+                documentTypes,
+                startDate,
+                endDate,
+                conjunctive: false,
+                cancellationToken: cancellationToken
+            );
+            var seen = bm25.Select(chunk => chunk.Id).ToHashSet();
+            bm25 = bm25.Concat(disjunctive.Where(chunk => !seen.Contains(chunk.Id))).ToList();
+        }
 
         if (!semanticActive || bm25.Count == 0)
             return ApplyPoolControls(bm25, excludeTickers, documentTypes, maxResultsPerCompany)

--- a/src/Equibles.Sec.BusinessLogic/Search/IRagManager.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/IRagManager.cs
@@ -30,7 +30,12 @@ public interface IRagManager
     public Task<List<Chunk>> SearchRelevantChunksByDocument(
         string query,
         Guid documentId,
-        int maxResults = 5
+        int maxResults = 5,
+        bool broadenSparseResults = false
     );
-    public Task<string> BuildContext(List<Chunk> chunks);
+    public Task<string> BuildContext(
+        List<Chunk> chunks,
+        bool includeDocumentIds = false,
+        int maxExcerptChars = 0
+    );
 }

--- a/src/Equibles.Sec.BusinessLogic/Search/ISecDocumentService.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/ISecDocumentService.cs
@@ -13,4 +13,16 @@ public interface ISecDocumentService
         int page = 1,
         DocumentType documentType = null
     );
+
+    /// <summary>
+    /// Counts the documents <see cref="GetRecentDocuments"/> would page through for the same
+    /// filters — including the hidden-type exclusion applied when no explicit type is requested —
+    /// so callers can report totals and page counts alongside a page of results.
+    /// </summary>
+    Task<int> CountDocuments(
+        string ticker,
+        DateTime? startDate = null,
+        DateTime? endDate = null,
+        DocumentType documentType = null
+    );
 }

--- a/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Sec.Data.Models;
@@ -82,10 +83,16 @@ public class RagManager : IRagManager
     public async Task<List<Chunk>> SearchRelevantChunksByDocument(
         string query,
         Guid documentId,
-        int maxResults = 5
+        int maxResults = 5,
+        bool broadenSparseResults = false
     )
     {
-        var chunks = await _hybridChunkSearcher.Search(query, maxResults, documentId: documentId);
+        var chunks = await _hybridChunkSearcher.Search(
+            query,
+            maxResults,
+            documentId: documentId,
+            disjunctiveFallback: broadenSparseResults
+        );
 
         _logger.LogInformation(
             "Found {Count} relevant chunks for document {DocumentId}",
@@ -104,7 +111,11 @@ public class RagManager : IRagManager
         return await SearchRelevantChunks(query, maxResults, [documentType]);
     }
 
-    public Task<string> BuildContext(List<Chunk> chunks)
+    public Task<string> BuildContext(
+        List<Chunk> chunks,
+        bool includeDocumentIds = false,
+        int maxExcerptChars = 0
+    )
     {
         if (!chunks.Any())
         {
@@ -115,8 +126,12 @@ public class RagManager : IRagManager
         context.AppendLine("Relevant financial document excerpts:");
         context.AppendLine();
 
+        // Grouping keys on the document ID: two distinct filings of the same type filed the
+        // same day (e.g. two 8-Ks) must render as two documents, especially when the header
+        // carries the ID the caller will drill into.
         var groupedChunks = chunks.GroupBy(c => new
         {
+            c.Document.Id,
             c.Document.CommonStock.Ticker,
             c.Document.DocumentType,
             c.Document.ReportingDate,
@@ -126,21 +141,28 @@ public class RagManager : IRagManager
         {
             var firstChunk = group.First();
             context.AppendLine($"## {firstChunk.Document.CommonStock.Name} ({group.Key.Ticker})");
+            var filedOn = group.Key.ReportingDate.ToString(
+                "yyyy-MM-dd",
+                CultureInfo.InvariantCulture
+            );
             context.AppendLine(
-                $"**Document:** {group.Key.DocumentType} filed on {group.Key.ReportingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"
+                includeDocumentIds
+                    ? $"**Document:** {group.Key.DocumentType} filed on {filedOn} (ID: {group.Key.Id})"
+                    : $"**Document:** {group.Key.DocumentType} filed on {filedOn}"
             );
             context.AppendLine();
 
             foreach (var chunk in group.OrderBy(c => c.StartPosition))
             {
-                if (!string.IsNullOrWhiteSpace(chunk.Content))
+                var content = RenderExcerptContent(chunk.Content, maxExcerptChars);
+                if (!string.IsNullOrWhiteSpace(content))
                 {
                     context.AppendLine(
                         chunk.StartLineNumber > 0
                             ? $"**Excerpt {chunk.Index + 1} (line ~{chunk.StartLineNumber.ToString("N0", CultureInfo.InvariantCulture)}):**"
                             : $"**Excerpt {chunk.Index + 1}:**"
                     );
-                    context.AppendLine(chunk.Content);
+                    context.AppendLine(content);
                     context.AppendLine();
                 }
             }
@@ -150,6 +172,42 @@ public class RagManager : IRagManager
         }
 
         return Task.FromResult(context.ToString());
+    }
+
+    // Markdown image references in chunk content (slide-deck captures embed one per slide)
+    // add tokens without information for a text consumer — the file name is meaningless
+    // outside the original filing. Stripped at render time only; the stored chunk content
+    // is untouched.
+    private static readonly Regex ImageMarkdown = new(
+        @"!\[[^\]]*\]\([^)]*\)",
+        RegexOptions.Compiled
+    );
+
+    private static string RenderExcerptContent(string content, int maxExcerptChars)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return content;
+        }
+
+        content = ImageMarkdown.Replace(content, string.Empty).Trim();
+
+        if (maxExcerptChars <= 0 || content.Length <= maxExcerptChars)
+        {
+            return content;
+        }
+
+        // Cut at the last whitespace inside the budget so the excerpt never ends mid-word,
+        // and say the cut happened — a silently shortened excerpt would read as the chunk's
+        // full text.
+        var cut = content.LastIndexOf(' ', maxExcerptChars - 1);
+        if (cut <= 0)
+        {
+            cut = maxExcerptChars;
+        }
+
+        return content[..cut].TrimEnd()
+            + " […truncated — raise maxExcerptChars or use ReadDocumentLines for the full text]";
     }
 
     private async Task<string> ResolvePrimaryTicker(string ticker)

--- a/src/Equibles.Sec.BusinessLogic/Search/SecDocumentService.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/SecDocumentService.cs
@@ -38,26 +38,7 @@ public class SecDocumentService : ISecDocumentService
         }
         try
         {
-            var query = _documentRepository.GetByTicker(ticker);
-
-            if (startDate.HasValue)
-            {
-                var startDateOnly = DateOnly.FromDateTime(startDate.Value);
-                query = query.Where(d => d.ReportingDate >= startDateOnly);
-            }
-
-            if (endDate.HasValue)
-            {
-                var endDateOnly = DateOnly.FromDateTime(endDate.Value);
-                query = query.Where(d => d.ReportingDate <= endDateOnly);
-            }
-
-            if (documentType != null)
-            {
-                query = query.Where(d => d.DocumentType == documentType);
-            }
-
-            var documents = await query
+            var documents = await BuildDocumentsQuery(ticker, startDate, endDate, documentType)
                 .OrderByDescending(d => d.ReportingDate)
                 .Skip((page - 1) * maxItems)
                 .Take(maxItems)
@@ -85,5 +66,59 @@ public class SecDocumentService : ISecDocumentService
             _logger.LogError(ex, "Error retrieving recent documents for ticker {Ticker}", ticker);
             throw;
         }
+    }
+
+    public async Task<int> CountDocuments(
+        string ticker,
+        DateTime? startDate = null,
+        DateTime? endDate = null,
+        DocumentType documentType = null
+    )
+    {
+        if (ticker == null)
+        {
+            throw new ApplicationException("Ticker cannot be null");
+        }
+
+        return await BuildDocumentsQuery(ticker, startDate, endDate, documentType).CountAsync();
+    }
+
+    private IQueryable<Document> BuildDocumentsQuery(
+        string ticker,
+        DateTime? startDate,
+        DateTime? endDate,
+        DocumentType documentType
+    )
+    {
+        var query = _documentRepository.GetByTicker(ticker);
+
+        if (startDate.HasValue)
+        {
+            var startDateOnly = DateOnly.FromDateTime(startDate.Value);
+            query = query.Where(d => d.ReportingDate >= startDateOnly);
+        }
+
+        if (endDate.HasValue)
+        {
+            var endDateOnly = DateOnly.FromDateTime(endDate.Value);
+            query = query.Where(d => d.ReportingDate <= endDateOnly);
+        }
+
+        if (documentType != null)
+        {
+            return query.Where(d => d.DocumentType == documentType);
+        }
+
+        // No explicit type filter: honor DocumentType.HiddenFromFilingLists — types registered
+        // as hidden (e.g. investor-relations news) are news-like content, not filings, and must
+        // not crowd real filings out of the recent-documents list. They stay reachable through
+        // search and through an explicit documentType request (the branch above).
+        var hiddenTypes = DocumentType.GetAll().Where(t => t.HiddenFromFilingLists).ToList();
+        if (hiddenTypes.Count > 0)
+        {
+            query = query.Where(d => !hiddenTypes.Contains(d.DocumentType));
+        }
+
+        return query;
     }
 }

--- a/src/Equibles.Sec.Data/Models/DocumentType.cs
+++ b/src/Equibles.Sec.Data/Models/DocumentType.cs
@@ -9,10 +9,21 @@ public sealed class DocumentType
     public string Value { get; }
     public string DisplayName { get; }
 
-    public DocumentType(string value, string displayName = null)
+    /// <summary>
+    /// When true, documents of this type are excluded from unfiltered document listings
+    /// (filings lists and filing-type pickers) — they still surface through search and can
+    /// be listed by requesting the type explicitly. Meant for registered types that are not
+    /// SEC filings (e.g. investor-relations news), which would otherwise crowd real filings
+    /// out of "recent documents" lists. Defaults to false, so registering a type without
+    /// setting it changes nothing.
+    /// </summary>
+    public bool HiddenFromFilingLists { get; }
+
+    public DocumentType(string value, string displayName = null, bool hiddenFromFilingLists = false)
     {
         Value = value;
         DisplayName = displayName ?? value;
+        HiddenFromFilingLists = hiddenFromFilingLists;
     }
 
     public static readonly DocumentType TenK = new("TenK", "10-K");

--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -35,12 +35,13 @@ public class DocumentTextTools
 
     [McpServerTool(Name = "SearchDocumentKeyword")]
     [Description(
-        "Perform a case-insensitive keyword search within a specific SEC filing or earnings call transcript by document ID. Returns matching lines with surrounding context and line numbers, making it ideal for finding exact terms, figures, or phrases that semantic search might miss. Use this after ListCompanyDocuments to locate precise occurrences of a keyword (e.g., a revenue figure, risk factor term, or executive name) within a known document. Complements semantic search tools by providing exact text matches rather than meaning-based results. Use ReadDocumentLines to read broader sections around matches."
+        "Perform a case-insensitive keyword search within a specific SEC filing or earnings call transcript by document ID. Returns matching lines with surrounding context and line numbers, making it ideal for finding exact terms, figures, or phrases that semantic search might miss. Typographic punctuation is folded before matching, so a plain-ASCII keyword (e.g. \"world's\") matches the smart punctuation stored in filings. The header reports the total number of matching lines even when only the first ones are shown. Use this after ListCompanyDocuments to locate precise occurrences of a keyword (e.g., a revenue figure, risk factor term, or executive name) within a known document. Complements semantic search tools by providing exact text matches rather than meaning-based results. Use ReadDocumentLines to read broader sections around matches."
     )]
     public Task<string> SearchDocumentKeyword(
         [Description("Document ID obtained from ListCompanyDocuments")] Guid documentId,
         [Description("Keyword or phrase to search for (case-insensitive)")] string keyword,
-        [Description("Maximum number of matches to return (default: 20)")] int maxResults = 20
+        [Description("Maximum number of matching lines to return (default: 20, max: 500)")]
+            int maxResults = 20
     )
     {
         return _runner.Execute(
@@ -50,42 +51,39 @@ public class DocumentTextTools
                 if (error != null)
                     return error;
 
-                var matches = Enumerable
+                maxResults = McpLimit.Clamp(maxResults);
+
+                // Fold typography on BOTH sides: filings store smart punctuation (U+2019
+                // apostrophes, curly quotes) while callers type ASCII, so an unfolded
+                // ordinal Contains reports false negatives for text the document contains.
+                var foldedKeyword = TypographyFold.Fold(keyword);
+                var allMatches = Enumerable
                     .Range(0, lines.Length)
-                    .Where(i => lines[i].Contains(keyword, StringComparison.OrdinalIgnoreCase))
-                    .Take(maxResults)
+                    .Where(i =>
+                        TypographyFold
+                            .Fold(lines[i])
+                            .Contains(foldedKeyword, StringComparison.OrdinalIgnoreCase)
+                    )
                     .ToList();
 
-                if (matches.Count == 0)
+                if (allMatches.Count == 0)
                 {
                     return $"No matches found for \"{keyword}\" in {FormatDocumentHeader(document)}.";
                 }
 
+                // Count BEFORE truncating: presenting the capped count as the total makes
+                // the caller state "the filing mentions X exactly N times" and stop early.
+                var matches = allMatches.Take(maxResults).ToList();
+
                 var result = new StringBuilder();
                 result.AppendLine(
-                    $"Keyword search for \"{keyword}\" in {FormatDocumentHeader(document)} — {matches.Count} matches found:"
+                    $"Keyword search for \"{keyword}\" in {FormatDocumentHeader(document)} — {McpFormat.WholeNumber(allMatches.Count)} matching line(s):"
                 );
                 result.AppendLine();
 
-                foreach (var lineIndex in matches)
-                {
-                    var lineNumber = lineIndex + 1;
+                AppendMatchBlocks(result, lines, matches, keyword);
 
-                    if (lineIndex > 0)
-                    {
-                        result.AppendLine(FormatLine(lineIndex, lines[lineIndex - 1]));
-                    }
-
-                    var highlightedLine = HighlightKeyword(lines[lineIndex], keyword);
-                    result.AppendLine(FormatLine(lineNumber, highlightedLine));
-
-                    if (lineIndex < lines.Length - 1)
-                    {
-                        result.AppendLine(FormatLine(lineNumber + 1, lines[lineIndex + 1]));
-                    }
-
-                    result.AppendLine();
-                }
+                result.AppendLine(McpOutput.TruncationNote(matches.Count, allMatches.Count));
 
                 return result.ToString();
             },
@@ -95,14 +93,60 @@ public class DocumentTextTools
         );
     }
 
+    // Renders each match with one line of context on each side, merging overlapping and
+    // adjacent blocks grep-style so a document line never prints twice; a blank line
+    // separates non-contiguous blocks.
+    private static void AppendMatchBlocks(
+        StringBuilder result,
+        string[] lines,
+        List<int> matches,
+        string keyword
+    )
+    {
+        var matchSet = matches.ToHashSet();
+        var linesToPrint = new SortedSet<int>();
+        foreach (var lineIndex in matches)
+        {
+            if (lineIndex > 0)
+                linesToPrint.Add(lineIndex - 1);
+            linesToPrint.Add(lineIndex);
+            if (lineIndex < lines.Length - 1)
+                linesToPrint.Add(lineIndex + 1);
+        }
+
+        int? previous = null;
+        foreach (var lineIndex in linesToPrint)
+        {
+            if (previous.HasValue && lineIndex > previous.Value + 1)
+                result.AppendLine();
+
+            var content = matchSet.Contains(lineIndex)
+                ? HighlightKeyword(lines[lineIndex], keyword)
+                : lines[lineIndex];
+            result.AppendLine(FormatLine(lineIndex + 1, content));
+            previous = lineIndex;
+        }
+
+        result.AppendLine();
+    }
+
+    // Ceiling on the number of lines a single call returns: prod documents reach 500k+
+    // lines, and an uncapped range request would return megabytes in one MCP response,
+    // blowing the consumer's context window. The truncation note makes continuation
+    // self-describing.
+    private const int MaxLinesPerRead = 2000;
+
     [McpServerTool(Name = "ReadDocumentLines")]
     [Description(
-        "Read a specific range of lines from an SEC filing or earnings call transcript by document ID. Returns numbered lines from the original document text. Use this to read sections of a filing that were identified by SearchDocumentKeyword (by line number) or by semantic search tools (by approximate line number shown in excerpts). Ideal for reading full tables, paragraphs, or sections that may have been truncated in search results. The document ID and line range must be known beforehand — use ListCompanyDocuments to find documents and SearchDocumentKeyword or semantic search to identify relevant line numbers."
+        "Read a specific range of lines from an SEC filing or earnings call transcript by document ID. Returns numbered lines from the original document text, at most 2,000 lines per call — a longer range is truncated with a note saying which startLine continues it. Use this to read sections of a filing that were identified by SearchDocumentKeyword (by line number) or by semantic search tools (by approximate line number shown in excerpts). Ideal for reading full tables, paragraphs, or sections that may have been truncated in search results. The document ID and line range must be known beforehand — use ListCompanyDocuments to find documents and SearchDocumentKeyword or semantic search to identify relevant line numbers."
     )]
     public Task<string> ReadDocumentLines(
         [Description("Document ID obtained from ListCompanyDocuments")] Guid documentId,
         [Description("First line to read (1-based, inclusive)")] int startLine,
-        [Description("Last line to read (1-based, inclusive)")] int endLine
+        [Description(
+            "Last line to read (1-based, inclusive). At most 2,000 lines are returned per call; a longer range is truncated with a note on how to continue."
+        )]
+            int endLine
     )
     {
         return _runner.Execute(
@@ -114,12 +158,31 @@ public class DocumentTextTools
 
                 var totalLines = lines.Length;
 
+                // Validate against the ORIGINAL arguments before any clamping: an error
+                // message quoting a clamped value the caller never sent reads as if the
+                // tool misparsed the request.
+                if (endLine < startLine)
+                {
+                    return $"Invalid line range: {startLine} to {endLine} — startLine is after endLine.";
+                }
+
+                if (startLine > totalLines)
+                {
+                    return $"startLine {McpFormat.WholeNumber(startLine)} is beyond the end of the document ({McpFormat.WholeNumber(totalLines)} lines).";
+                }
+
                 startLine = Math.Max(1, startLine);
                 endLine = Math.Min(totalLines, endLine);
 
-                if (startLine > endLine)
+                if (endLine < startLine)
                 {
                     return $"Invalid line range: {startLine} to {endLine} (document has {McpFormat.WholeNumber(totalLines)} lines).";
+                }
+
+                var truncated = endLine - startLine + 1 > MaxLinesPerRead;
+                if (truncated)
+                {
+                    endLine = startLine + MaxLinesPerRead - 1;
                 }
 
                 var result = new StringBuilder();
@@ -131,6 +194,14 @@ public class DocumentTextTools
                 for (var i = startLine - 1; i < endLine; i++)
                 {
                     result.AppendLine(FormatLine(i + 1, lines[i]));
+                }
+
+                if (truncated)
+                {
+                    result.AppendLine();
+                    result.AppendLine(
+                        $"_Returned the first {McpFormat.WholeNumber(MaxLinesPerRead)} lines of the requested range — continue with startLine={McpFormat.WholeNumber(endLine + 1)}._"
+                    );
                 }
 
                 return result.ToString();
@@ -175,12 +246,22 @@ public class DocumentTextTools
         if (string.IsNullOrEmpty(keyword))
             return line;
 
+        // Match on the folded pair so typography-folded matches still bold; the fold is
+        // one-to-one per char, so folded indices address the same span in the original
+        // line, which is what gets emitted.
+        var foldedLine = TypographyFold.Fold(line);
+        var foldedKeyword = TypographyFold.Fold(keyword);
+
         var result = new StringBuilder();
         var index = 0;
 
         while (index < line.Length)
         {
-            var matchIndex = line.IndexOf(keyword, index, StringComparison.OrdinalIgnoreCase);
+            var matchIndex = foldedLine.IndexOf(
+                foldedKeyword,
+                index,
+                StringComparison.OrdinalIgnoreCase
+            );
             if (matchIndex < 0)
             {
                 result.Append(line, index, line.Length - index);
@@ -189,9 +270,9 @@ public class DocumentTextTools
 
             result.Append(line, index, matchIndex - index);
             result.Append("**");
-            result.Append(line, matchIndex, keyword.Length);
+            result.Append(line, matchIndex, foldedKeyword.Length);
             result.Append("**");
-            index = matchIndex + keyword.Length;
+            index = matchIndex + foldedKeyword.Length;
         }
 
         return result.ToString();

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
@@ -8,6 +9,7 @@ using Equibles.Mcp.Helpers;
 using Equibles.Sec.BusinessLogic.Search;
 using Equibles.Sec.BusinessLogic.Search.Models;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -16,34 +18,54 @@ namespace Equibles.Sec.Mcp.Tools;
 [McpServerToolType]
 public class RagSearchTools
 {
+    // Attribute descriptions are compile-time constants, so they cannot enumerate types
+    // registered at host startup (DocumentType.Register). They name the built-in filing
+    // values plus the most useful registered example, and the strict rejection below
+    // returns the FULL runtime list on any unrecognized value, so a caller self-corrects
+    // in one round-trip. Deliberately: only unconditionally-parseable values are single-
+    // quoted — RagSearchToolsParseDocumentTypeContractTests requires every quoted value
+    // to round-trip through ParseDocumentType in THIS build, and EarningsCallTranscript
+    // is registered by the commercial host only.
     private const string DocumentTypeDescription =
-        "Document type filter. Allowed values: 'TenK', 'TenQ', 'EightK', 'TenKa', 'TenQa', 'EightKa', 'TwentyF', 'SixK', 'FortyF'";
+        "Document type filter. Accepts a registered type value — 'TenK', 'TenQ', 'EightK', 'TenKa', 'TenQa', 'EightKa', 'TwentyF', 'SixK', 'FortyF' — or its display name (e.g. '10-K', '8-K'), plus any deployment-registered type, such as EarningsCallTranscript (display name: Earnings Call) for earnings-call transcripts where available. An unrecognized value returns an error listing every accepted value.";
 
     private const string DocumentTypesDescription =
-        "Document type filter — one value or a comma-separated list (e.g. 'TenK,TenQ'). Allowed values: 'TenK', 'TenQ', 'EightK', 'TenKa', 'TenQa', 'EightKa', 'TwentyF', 'SixK', 'FortyF'";
+        "Document type filter — one value or a comma-separated list (e.g. 'TenK,TenQ'). Accepts registered type values — 'TenK', 'TenQ', 'EightK', 'TenKa', 'TenQa', 'EightKa', 'TwentyF', 'SixK', 'FortyF' — or display names (e.g. '10-K', '8-K'), plus any deployment-registered type, such as EarningsCallTranscript (display name: Earnings Call) for earnings-call transcripts where available. An unrecognized value returns an error listing every accepted value.";
+
+    private const string MaxExcerptCharsDescription =
+        "Maximum characters per excerpt (default: 0 = full excerpt). Set a small value (e.g. 400) for a compact scan across many results; truncated excerpts end with an explicit note.";
 
     private readonly IRagManager _ragManager;
     private readonly ISecDocumentService _secDocumentService;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly DocumentRepository _documentRepository;
     private readonly McpToolRunner _runner;
 
     public RagSearchTools(
         IRagManager ragManager,
         ISecDocumentService secDocumentService,
+        CommonStockRepository commonStockRepository,
+        DocumentRepository documentRepository,
         ErrorManager errorManager,
         ILogger<RagSearchTools> logger
     )
     {
         _ragManager = ragManager;
         _secDocumentService = secDocumentService;
+        _commonStockRepository = commonStockRepository;
+        _documentRepository = documentRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "SearchDocuments")]
     [Description(
-        "Search the Equibles SEC filing database across all companies and document types using hybrid keyword and semantic search. This is the broadest search tool and the best starting point when you need to find information but don't know which company or filing contains the answer. Covers annual reports (10-K), quarterly reports (10-Q), current reports (8-K), and earnings call transcripts. Results can be filtered by filing date range using startDate/endDate. Returns matching excerpts with company name, ticker, document type, and filing date. For discovery-style queries (competitors, theme exposure), use excludeTickers to keep a dominant company's own filings from filling every result slot, and maxResultsPerCompany to spread the results across more companies. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. Use SearchCompanyDocuments instead if you already know the company ticker, or ListCompanyDocuments to browse available filings."
+        "Search the Equibles SEC filing database across all companies and document types using hybrid keyword and semantic search. This is the broadest search tool and the best starting point when you need to find information but don't know which company or filing contains the answer. Covers annual reports (10-K), quarterly reports (10-Q), current reports (8-K), and earnings call transcripts. Results can be filtered by filing date range using startDate/endDate. Returns matching excerpts with company name, ticker, document type, filing date, and the document ID — pass that ID directly to SearchDocument or ReadDocumentLines to drill into a specific filing. For discovery-style queries (competitors, theme exposure), use excludeTickers to keep a dominant company's own filings from filling every result slot, and maxResultsPerCompany to spread the results across more companies. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. Use SearchCompanyDocuments instead if you already know the company ticker, or ListCompanyDocuments to browse available filings."
     )]
     public Task<string> SearchDocuments(
-        [Description("Natural language search query")] string query,
+        [Description(
+            "Search query. Every word must match (AND semantics on the keyword arm), so prefer concise, filing-phrased terms (e.g. 'Data Center revenue') over long natural-language questions."
+        )]
+            string query,
         [Description("Maximum number of results to return (default: 5)")] int maxResults = 5,
         [Description(DocumentTypesDescription)] string documentType = null,
         [Description("Optional start date filter in YYYY-MM-DD format")] DateTime? startDate = null,
@@ -55,23 +77,36 @@ public class RagSearchTools
         [Description(
             "Maximum results from any single company (default: 0 = unlimited). Set a small value (e.g. 2) to spread results across more companies for discovery-style queries."
         )]
-            int maxResultsPerCompany = 0
+            int maxResultsPerCompany = 0,
+        [Description(MaxExcerptCharsDescription)] int maxExcerptChars = 0
     )
     {
         return _runner.Execute(
             async () =>
             {
+                var dateError = ValidateDateRange(startDate, endDate);
+                if (dateError != null)
+                    return dateError;
+
+                if (!TryParseDocumentTypes(documentType, out var parsedTypes, out var typeError))
+                    return typeError;
+
                 maxResults = McpLimit.Clamp(maxResults);
                 var chunks = await _ragManager.SearchRelevantChunks(
                     query,
                     maxResults,
-                    ParseDocumentTypes(documentType),
+                    parsedTypes,
                     ToDateOnly(startDate),
                     ToDateOnly(endDate),
                     ParseTickers(excludeTickers),
                     Math.Max(maxResultsPerCompany, 0)
                 );
-                return await _ragManager.BuildContext(chunks);
+                var context = await _ragManager.BuildContext(
+                    chunks,
+                    includeDocumentIds: true,
+                    maxExcerptChars: maxExcerptChars
+                );
+                return AppendShortfallNote(context, chunks.Count, maxResults);
             },
             "SearchDocuments",
             $"query: {query}"
@@ -80,30 +115,55 @@ public class RagSearchTools
 
     [McpServerTool(Name = "SearchCompanyDocuments")]
     [Description(
-        "Search the Equibles SEC filing database for a specific company by its ticker symbol using hybrid keyword and semantic search. Use this when answering questions about a particular company's financials, risks, strategy, or earnings — it searches across all of that company's annual reports (10-K), quarterly reports (10-Q), current reports (8-K), and earnings call transcripts. Results can be filtered by filing date range using startDate/endDate. Returns matching excerpts with document type and filing date. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. Prefer this over SearchDocuments when the company is known. Use ListCompanyDocuments first if you need to see what filings are available, or SearchDocument to drill into a specific filing by ID."
+        "Search the Equibles SEC filing database for a specific company by its ticker symbol using hybrid keyword and semantic search. Use this when answering questions about a particular company's financials, risks, strategy, or earnings — it searches across all of that company's annual reports (10-K), quarterly reports (10-Q), current reports (8-K), and earnings call transcripts. Results can be filtered by filing date range using startDate/endDate. Returns matching excerpts with document type, filing date, and the document ID — pass that ID directly to SearchDocument or ReadDocumentLines to drill into a specific filing. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. Prefer this over SearchDocuments when the company is known. Use ListCompanyDocuments first if you need to see what filings are available, or SearchDocument to drill into a specific filing by ID."
     )]
     public Task<string> SearchCompanyDocuments(
-        [Description("Natural language search query")] string query,
+        [Description(
+            "Search query. Every word must match (AND semantics on the keyword arm), so prefer concise, filing-phrased terms (e.g. 'Data Center revenue') over long natural-language questions."
+        )]
+            string query,
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
         [Description("Maximum number of results to return (default: 5)")] int maxResults = 5,
         [Description(DocumentTypesDescription)] string documentType = null,
         [Description("Optional start date filter in YYYY-MM-DD format")] DateTime? startDate = null,
-        [Description("Optional end date filter in YYYY-MM-DD format")] DateTime? endDate = null
+        [Description("Optional end date filter in YYYY-MM-DD format")] DateTime? endDate = null,
+        [Description(MaxExcerptCharsDescription)] int maxExcerptChars = 0
     )
     {
         return _runner.Execute(
             async () =>
             {
+                var dateError = ValidateDateRange(startDate, endDate);
+                if (dateError != null)
+                    return dateError;
+
+                if (!TryParseDocumentTypes(documentType, out var parsedTypes, out var typeError))
+                    return typeError;
+
+                // An unknown ticker must not fall through to a search that is guaranteed
+                // empty: "No relevant financial documents found." would read as "this
+                // company's filings say nothing about the topic".
+                var stock = await _commonStockRepository.GetByTicker(
+                    McpToolExecutor.NormalizeTicker(ticker)
+                );
+                if (stock == null)
+                    return McpToolExecutor.StockNotFound(ticker);
+
                 maxResults = McpLimit.Clamp(maxResults);
                 var chunks = await _ragManager.SearchRelevantChunksByCompany(
                     query,
-                    ticker,
+                    stock.Ticker,
                     maxResults,
-                    ParseDocumentTypes(documentType),
+                    parsedTypes,
                     ToDateOnly(startDate),
                     ToDateOnly(endDate)
                 );
-                return await _ragManager.BuildContext(chunks);
+                var context = await _ragManager.BuildContext(
+                    chunks,
+                    includeDocumentIds: true,
+                    maxExcerptChars: maxExcerptChars
+                );
+                return AppendShortfallNote(context, chunks.Count, maxResults);
             },
             "SearchCompanyDocuments",
             $"ticker: {ticker}, query: {query}"
@@ -112,12 +172,19 @@ public class RagSearchTools
 
     [McpServerTool(Name = "SearchDocument")]
     [Description(
-        "Search within a single specific document in the Equibles SEC filing database by its document ID using hybrid keyword and semantic search. Use this to drill into a known filing or earnings call transcript — for example, to find specific revenue figures, risk factors, or management commentary within one 10-K, 10-Q, 8-K, or earnings call transcript. The document ID must be obtained first by calling ListCompanyDocuments. Returns matching excerpts from that document only. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. Typical workflow: call ListCompanyDocuments to find the filing, then call SearchDocument with the returned document ID to extract specific information."
+        "Search within a single specific document in the Equibles SEC filing database by its document ID using hybrid keyword and semantic search. Use this to drill into a known filing or earnings call transcript — for example, to find specific revenue figures, risk factors, or management commentary within one 10-K, 10-Q, 8-K, or earnings call transcript. The document ID comes from ListCompanyDocuments or from the '(ID: ...)' header of SearchDocuments/SearchCompanyDocuments results. Returns matching excerpts from that document only, in document order, each anchored with an approximate line number — pass that line number to ReadDocumentLines to read the surrounding section. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data."
     )]
     public Task<string> SearchDocument(
-        [Description("Natural language search query")] string query,
-        [Description("Document ID obtained from ListCompanyDocuments")] Guid documentId,
-        [Description("Maximum number of results to return (default: 5)")] int maxResults = 5
+        [Description(
+            "Search query — plain keywords or a short natural-language phrase. When too few excerpts match every word, the search automatically broadens to match any of the words."
+        )]
+            string query,
+        [Description(
+            "Document ID obtained from ListCompanyDocuments or from a SearchDocuments/SearchCompanyDocuments result header"
+        )]
+            Guid documentId,
+        [Description("Maximum number of results to return (default: 5)")] int maxResults = 5,
+        [Description(MaxExcerptCharsDescription)] int maxExcerptChars = 0
     )
     {
         return _runner.Execute(
@@ -127,9 +194,28 @@ public class RagSearchTools
                 var chunks = await _ragManager.SearchRelevantChunksByDocument(
                     query,
                     documentId,
-                    maxResults
+                    maxResults,
+                    broadenSparseResults: true
                 );
-                return await _ragManager.BuildContext(chunks);
+
+                if (chunks.Count == 0)
+                {
+                    // Zero matches on a bad ID must not read as "this filing says nothing
+                    // about the topic" — tell the caller the ID itself is wrong.
+                    var document = await _documentRepository.Get(documentId);
+                    if (document == null)
+                        return $"Document {documentId} not found — obtain a valid document ID from ListCompanyDocuments.";
+
+                    return $"No matching excerpts found in this document ({document.DocumentType} filed {McpFormat.Invariant(document.ReportingDate, "yyyy-MM-dd")}). Try SearchDocumentKeyword for exact-term matches.";
+                }
+
+                var context = await _ragManager.BuildContext(
+                    chunks,
+                    includeDocumentIds: true,
+                    maxExcerptChars: maxExcerptChars
+                );
+                return context
+                    + $"_{chunks.Count} excerpt(s) returned (maxResults {maxResults}); excerpts are in document order — pass an excerpt's line number to ReadDocumentLines for surrounding context._";
             },
             "SearchDocument",
             $"documentId: {documentId}, query: {query}"
@@ -138,7 +224,7 @@ public class RagSearchTools
 
     [McpServerTool(Name = "ListCompanyDocuments")]
     [Description(
-        "Browse and discover available SEC filings and earnings call transcripts for a specific company in the Equibles database. Returns a paginated list of documents ordered newest first, including document IDs, type (annual reports 10-K, quarterly reports 10-Q, current reports 8-K, earnings call transcripts), filing date, and reporting period. Supports filtering by date range and document type. Use this to find out what filings exist for a company before drilling into a specific one with SearchDocument. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. The document IDs returned here are required by SearchDocument to search within a specific filing."
+        "Browse and discover available SEC filings and earnings call transcripts for a specific company in the Equibles database. Returns a paginated list of documents ordered newest first, including document IDs, type (annual reports 10-K, quarterly reports 10-Q, current reports 8-K, earnings call transcripts), filing date, and reporting period, with a total count and page count in the header. Supports filtering by date range and document type. Document types registered as hidden from filing lists (e.g. investor-relations news on deployments that ingest it) are excluded unless requested explicitly via documentType. Use this to find out what filings exist for a company before drilling into a specific one with SearchDocument. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. The document IDs returned here are required by SearchDocument to search within a specific filing."
     )]
     public Task<string> ListCompanyDocuments(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -152,13 +238,41 @@ public class RagSearchTools
         return _runner.Execute(
             async () =>
             {
-                var parsedType = ParseDocumentType(documentType);
-                List<SecDocumentInfo> documents;
+                if (page < 1)
+                    return $"Invalid page {page} — pages are numbered from 1.";
 
+                var dateError = ValidateDateRange(startDate, endDate);
+                if (dateError != null)
+                    return dateError;
+
+                DocumentType parsedType = null;
+                if (!string.IsNullOrWhiteSpace(documentType))
+                {
+                    parsedType = ParseDocumentType(documentType);
+                    if (parsedType == null)
+                        return UnknownDocumentType(documentType);
+                }
+
+                var stock = await _commonStockRepository.GetByTicker(
+                    McpToolExecutor.NormalizeTicker(ticker)
+                );
+                if (stock == null)
+                    return McpToolExecutor.StockNotFound(ticker);
+
+                maxItems = McpLimit.Clamp(maxItems);
+
+                int totalCount;
+                List<SecDocumentInfo> documents;
                 try
                 {
+                    totalCount = await _secDocumentService.CountDocuments(
+                        stock.Ticker,
+                        startDate,
+                        endDate,
+                        parsedType
+                    );
                     documents = await _secDocumentService.GetRecentDocuments(
-                        ticker,
+                        stock.Ticker,
                         startDate,
                         endDate,
                         maxItems,
@@ -171,13 +285,24 @@ public class RagSearchTools
                     return ex.Message;
                 }
 
-                if (documents.Count == 0)
+                if (totalCount == 0)
                 {
-                    return $"No documents found for ticker {ticker}";
+                    // Distinguish "the filters excluded everything" from "nothing is
+                    // ingested for this company" — the ticker itself is already known good.
+                    var hasFilters = startDate.HasValue || endDate.HasValue || parsedType != null;
+                    if (!hasFilters)
+                        return $"No documents found for ticker {stock.Ticker}";
+
+                    var unfiltered = await _secDocumentService.CountDocuments(stock.Ticker);
+                    return $"No documents match the given filters for {stock.Ticker} — {McpFormat.WholeNumber(unfiltered)} document(s) exist without them. Relax documentType/startDate/endDate.";
                 }
 
+                var totalPages = (totalCount + maxItems - 1) / maxItems;
+                if (documents.Count == 0)
+                    return $"Page {page} is out of range — {McpFormat.WholeNumber(totalCount)} matching document(s) fill only {McpFormat.WholeNumber(totalPages)} page(s) of {maxItems}.";
+
                 var result = MarkdownTable.Start(
-                    $"Financial documents for {documents.First().CompanyName} ({ticker}) — page {page}:",
+                    $"Financial documents for {stock.Name} ({stock.Ticker}) — page {page} of {McpFormat.WholeNumber(totalPages)} ({McpFormat.WholeNumber(totalCount)} documents):",
                     "ID | Type | Filed | Reporting For | Lines",
                     "---|------|-------|---------------|------"
                 );
@@ -203,23 +328,59 @@ public class RagSearchTools
         return DocumentType.FromDisplayName(documentType) ?? DocumentType.FromValue(documentType);
     }
 
-    // The comma-separated variant for the search tools. Unrecognized entries are
-    // skipped rather than erroring, matching the single-type parameter's established
-    // lenient behavior (an unknown value has always meant "no type filter"); null when
-    // nothing usable remains.
-    private static IReadOnlyCollection<DocumentType> ParseDocumentTypes(string documentTypes)
+    // The comma-separated variant for the search tools. An unrecognized entry REJECTS the
+    // call with the full accepted list instead of silently searching unfiltered: a near-miss
+    // like '10K' or 'Transcript' would otherwise return results the caller believes are
+    // filtered, and the mistake is invisible in the output. The accepted list is built from
+    // DocumentType.GetAll() at call time, so types registered at host startup (e.g.
+    // 'EarningsCallTranscript') are always listed.
+    private static bool TryParseDocumentTypes(
+        string documentTypes,
+        out IReadOnlyCollection<DocumentType> parsed,
+        out string error
+    )
     {
+        parsed = null;
+        error = null;
         if (string.IsNullOrWhiteSpace(documentTypes))
-            return null;
+            return true;
 
-        var parsed = documentTypes
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(ParseDocumentType)
-            .Where(type => type != null)
-            .Distinct()
-            .ToList();
-        return parsed.Count > 0 ? parsed : null;
+        var result = new List<DocumentType>();
+        foreach (
+            var entry in documentTypes.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            )
+        )
+        {
+            var type = ParseDocumentType(entry);
+            if (type == null)
+            {
+                error = UnknownDocumentType(entry);
+                return false;
+            }
+            result.Add(type);
+        }
+
+        parsed = result.Count > 0 ? result.Distinct().ToList() : null;
+        return true;
     }
+
+    private static string UnknownDocumentType(string value) =>
+        McpOutput.InvalidArgument("documentType", value, AcceptedDocumentTypes());
+
+    // Built at call time from the runtime registry so deployment-registered types are
+    // always included. Sorted for a stable, scannable list.
+    private static string AcceptedDocumentTypes() =>
+        string.Join(
+            ", ",
+            DocumentType
+                .GetAll()
+                .OrderBy(t => t.Value, StringComparer.Ordinal)
+                .Select(t =>
+                    t.DisplayName == t.Value ? $"'{t.Value}'" : $"'{t.Value}' ({t.DisplayName})"
+                )
+        );
 
     // Comma-separated tickers for the exclusion filter; null when nothing usable.
     private static IReadOnlyCollection<string> ParseTickers(string tickers)
@@ -233,6 +394,21 @@ public class RagSearchTools
             .ToList();
         return parsed.Count > 0 ? parsed : null;
     }
+
+    // A contradictory window (start after end) must error instead of returning the generic
+    // empty-result message — the caller would conclude no such documents exist.
+    private static string ValidateDateRange(DateTime? startDate, DateTime? endDate) =>
+        startDate.HasValue && endDate.HasValue && startDate.Value > endDate.Value
+            ? $"startDate {McpFormat.Invariant(startDate.Value, "yyyy-MM-dd")} is after endDate {McpFormat.Invariant(endDate.Value, "yyyy-MM-dd")} — swap the values."
+            : null;
+
+    // Signposts a result shortfall so the caller knows relaxing filters (not paging or
+    // retrying) is the next move. Empty results keep the plain empty-state message.
+    private static string AppendShortfallNote(string context, int returned, int requested) =>
+        returned > 0 && returned < requested
+            ? context
+                + $"_Only {returned} excerpt(s) matched the query and filters — broaden the query or relax the filters to find more._"
+            : context;
 
     private static DateOnly? ToDateOnly(DateTime? value) =>
         value.HasValue ? DateOnly.FromDateTime(value.Value) : null;

--- a/src/Equibles.Sec.Mcp/Tools/TypographyFold.cs
+++ b/src/Equibles.Sec.Mcp/Tools/TypographyFold.cs
@@ -1,0 +1,62 @@
+namespace Equibles.Sec.Mcp.Tools;
+
+/// <summary>
+/// Folds typographic punctuation to its ASCII equivalent for text matching. Stored SEC
+/// filings and transcripts carry smart punctuation (U+2019 apostrophes, curly quotes,
+/// en/em dashes) while tool callers type ASCII, so an ordinal substring search without
+/// this fold silently misses text the document visibly contains.
+///
+/// The mapping is strictly one-to-one per char — folding never changes string length —
+/// so an index found in a folded string addresses the same characters in the original.
+/// Callers rely on that to highlight matches in the original text.
+/// </summary>
+public static class TypographyFold
+{
+    public static string Fold(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        // Common case: nothing to fold — skip the allocation.
+        var needsFold = false;
+        foreach (var c in value)
+        {
+            if (FoldChar(c) != c)
+            {
+                needsFold = true;
+                break;
+            }
+        }
+
+        if (!needsFold)
+            return value;
+
+        return string.Create(
+            value.Length,
+            value,
+            (span, source) =>
+            {
+                for (var i = 0; i < source.Length; i++)
+                    span[i] = FoldChar(source[i]);
+            }
+        );
+    }
+
+    // Char classes mirror the typography fold used by the extraction lanes' grounding
+    // normalizers: single-quote variants to ', double-quote variants to ", dash variants
+    // to -, plus the non-breaking space to a plain space. Escapes, not literals, so the
+    // mapping is reviewable at a glance.
+    private static char FoldChar(char c) =>
+        c switch
+        {
+            // left/right single quote, low-9 quote, reversed-9 quote, prime, backtick, acute
+            '\u2018' or '\u2019' or '\u201A' or '\u201B' or '\u2032' or '`' or '\u00B4' => '\'',
+            // left/right double quote, low-9 double quote, reversed-9 double quote, double prime
+            '\u201C' or '\u201D' or '\u201E' or '\u201F' or '\u2033' => '"',
+            // hyphen, non-breaking hyphen, figure dash, en dash, em dash, horizontal bar, minus
+            '\u2010' or '\u2011' or '\u2012' or '\u2013' or '\u2014' or '\u2015' or '\u2212' => '-',
+            // non-breaking space
+            '\u00A0' => ' ',
+            _ => c,
+        };
+}

--- a/src/Equibles.Sec.Repositories/ChunkRepository.cs
+++ b/src/Equibles.Sec.Repositories/ChunkRepository.cs
@@ -27,6 +27,7 @@ public class ChunkRepository : BaseRepository<Chunk>
         IReadOnlyCollection<DocumentType> documentTypes = null,
         DateOnly? startDate = null,
         DateOnly? endDate = null,
+        bool conjunctive = true,
         CancellationToken cancellationToken = default
     )
     {
@@ -35,9 +36,13 @@ public class ChunkRepository : BaseRepository<Chunk>
         // Layering them as SQL .Where(...) predicates instead made Postgres score every
         // text match first and post-filter the result on the heap (heap_filter) — for a
         // high-coverage ticker that scored set is enormous and blew the 5s budget (#2157).
+        //
+        // conjunctive: true ANDs every query token (the precise default); false ORs them —
+        // used as a recall fallback when the conjunctive pass starves (natural-language
+        // queries where one non-matching word excludes every on-point chunk).
         var clauses = new List<ParadeDbJsonQuery>
         {
-            ParadeDbJsonQuery.Parse(searchText, lenient: true, conjunctionMode: true),
+            ParadeDbJsonQuery.Parse(searchText, lenient: true, conjunctionMode: conjunctive),
         };
 
         // Ticker (raw tokenizer) and DocumentType (single-token enum values) are stored

--- a/tests/Equibles.IntegrationTests/Mcp/DocumentTextToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/DocumentTextToolsTests.cs
@@ -84,7 +84,7 @@ public class DocumentTextToolsTests : ParadeDbMcpTestBase
         var result = await Sut().SearchDocumentKeyword(doc.Id, "Revenue");
 
         result.Should().Contain("Revenue");
-        result.Should().Contain("2 matches found");
+        result.Should().Contain("2 matching line(s)");
         result.Should().Contain("**Revenue**");
     }
 
@@ -95,7 +95,7 @@ public class DocumentTextToolsTests : ParadeDbMcpTestBase
 
         var result = await Sut().SearchDocumentKeyword(doc.Id, "revenue");
 
-        result.Should().Contain("1 matches found");
+        result.Should().Contain("1 matching line(s)");
         result.Should().Contain("**REVENUE**");
     }
 
@@ -121,14 +121,72 @@ public class DocumentTextToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task SearchDocumentKeyword_MaxResultsRespected_LimitsMatches()
+    public async Task SearchDocumentKeyword_MaxResultsRespected_ReportsTrueTotalAndTruncation()
     {
         var lines = Enumerable.Range(1, 50).Select(i => $"Revenue line {i}").ToArray();
         var doc = await SeedDocument(string.Join("\n", lines));
 
         var result = await Sut().SearchDocumentKeyword(doc.Id, "Revenue", maxResults: 3);
 
-        result.Should().Contain("3 matches found");
+        // The header must report the TRUE total, not the capped count: "3 matches found"
+        // for a keyword that appears 50 times makes the caller state a wrong count.
+        result.Should().Contain("50 matching line(s)");
+        result.Should().Contain("Showing first 3 of 50");
+        result.Should().NotContain("Revenue line 5\n".TrimEnd());
+    }
+
+    [Fact]
+    public async Task SearchDocumentKeyword_TypographicApostropheInDocument_MatchesAsciiKeyword()
+    {
+        // Stored filings carry smart punctuation (U+2019); callers type ASCII. Without
+        // the typography fold this search silently returns "No matches found" for text
+        // the document visibly contains.
+        var doc = await SeedDocument("First line\nThe world’s largest supplier\nLast line");
+
+        var result = await Sut().SearchDocumentKeyword(doc.Id, "world's largest");
+
+        result.Should().Contain("1 matching line(s)");
+        result.Should().Contain("**world’s largest**");
+    }
+
+    [Fact]
+    public async Task SearchDocumentKeyword_AdjacentMatches_DoNotRepeatContextLines()
+    {
+        // Two consecutive matching lines used to print two overlapping 3-line blocks,
+        // duplicating the shared lines; merged blocks print each line at most once.
+        var doc = await SeedDocument("Alpha\nRevenue one\nRevenue two\nOmega");
+
+        var result = await Sut().SearchDocumentKeyword(doc.Id, "Revenue");
+
+        CountOccurrences(result, "Alpha").Should().Be(1);
+        CountOccurrences(result, "Omega").Should().Be(1);
+        CountOccurrences(result, "**Revenue** one").Should().Be(1);
+        CountOccurrences(result, "**Revenue** two").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SearchDocumentKeyword_NonPositiveMaxResults_StillReturnsAMatch()
+    {
+        // maxResults=0 used to Take(0) every real match and then claim "No matches
+        // found" — a factually wrong message. The clamp floors it at 1.
+        var doc = await SeedDocument("Revenue line\nOther line");
+
+        var result = await Sut().SearchDocumentKeyword(doc.Id, "Revenue", maxResults: 0);
+
+        result.Should().NotContain("No matches found");
+        result.Should().Contain("**Revenue**");
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+        return count;
     }
 
     [Fact]
@@ -268,5 +326,32 @@ public class DocumentTextToolsTests : ParadeDbMcpTestBase
         result.Should().Contain("lines 2 to 2 of 3");
         result.Should().NotContain("Line 1");
         result.Should().NotContain("Line 3");
+    }
+
+    [Fact]
+    public async Task ReadDocumentLines_RangeBeyondCap_TruncatesWithContinuationNote()
+    {
+        // Prod documents reach 500k+ lines; an uncapped range request would return the
+        // whole document in one MCP response. The cap must be honest and self-describing.
+        var lines = Enumerable.Range(1, 2050).Select(i => $"Row {i}").ToArray();
+        var doc = await SeedDocument(string.Join("\n", lines));
+
+        var result = await Sut().ReadDocumentLines(doc.Id, 1, 999_999);
+
+        result.Should().Contain("lines 1 to 2,000 of 2,050");
+        result.Should().Contain("Row 2000");
+        result.Should().NotContain("Row 2001\n".TrimEnd());
+        result.Should().Contain("continue with startLine=2,001");
+    }
+
+    [Fact]
+    public async Task ReadDocumentLines_InvertedRange_QuotesOriginalArguments()
+    {
+        var doc = await SeedDocument("Line 1\nLine 2\nLine 3");
+
+        var result = await Sut().ReadDocumentLines(doc.Id, 50, 10);
+
+        // The message must quote the caller's own values, not clamped ones.
+        result.Should().Be("Invalid line range: 50 to 10 — startLine is after endLine.");
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsListCompanyDocumentsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsListCompanyDocumentsCultureInvarianceTests.cs
@@ -32,6 +32,8 @@ public class RagSearchToolsListCompanyDocumentsCultureInvarianceTests : ParadeDb
         return new RagSearchTools(
             ragManager,
             secDocumentService,
+            new CommonStockRepository(DbContext),
+            new DocumentRepository(DbContext),
             ErrorManager,
             NullLogger<RagSearchTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
@@ -46,6 +46,8 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
         return new RagSearchTools(
             ragManager,
             secDocumentService,
+            new CommonStockRepository(DbContext),
+            new DocumentRepository(DbContext),
             ErrorManager,
             NullLogger<RagSearchTools>()
         );
@@ -265,18 +267,66 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task SearchCompanyDocuments_UnknownTicker_StillReturnsEmptyMessage()
+    public async Task SearchCompanyDocuments_UnknownTicker_ReturnsStockNotFound()
     {
         await SeedDocumentWithChunks(
             ticker: "AAPL",
             chunkContents: new[] { "Cloud revenue increased." }
         );
 
-        // ResolvePrimaryTicker falls back to the input ticker on miss; BM25 then finds zero rows
-        // because no chunk has Ticker = "ZZZZ".
+        // A mistyped ticker must be distinguishable from "this company's filings say
+        // nothing about the topic": the tool checks the stock exists before searching.
         var result = await Sut().SearchCompanyDocuments("cloud revenue", "ZZZZ");
 
-        result.Should().Be("No relevant financial documents found.");
+        result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+
+    [Fact]
+    public async Task SearchCompanyDocuments_UnknownDocumentType_ReturnsAcceptedValues()
+    {
+        await SeedDocumentWithChunks(
+            ticker: "AAPL",
+            chunkContents: new[] { "Cloud revenue increased." }
+        );
+
+        // A near-miss type ('10K', 'Transcript') must not silently search unfiltered —
+        // the caller would present mixed-type results as filtered ones.
+        var result = await Sut()
+            .SearchCompanyDocuments("cloud revenue", "AAPL", documentType: "10K");
+
+        result.Should().StartWith("Unknown documentType '10K'.");
+        result.Should().Contain("'TenK' (10-K)");
+    }
+
+    [Fact]
+    public async Task SearchDocuments_InvertedDateRange_ReturnsExplicitError()
+    {
+        await SeedDocumentWithChunks(chunkContents: new[] { "Revenue increased." });
+
+        // start > end must not collapse into the generic empty-result message — the
+        // caller would conclude no such documents exist.
+        var result = await Sut()
+            .SearchDocuments(
+                "revenue",
+                startDate: new DateTime(2026, 1, 1),
+                endDate: new DateTime(2020, 1, 1)
+            );
+
+        result.Should().Be("startDate 2026-01-01 is after endDate 2020-01-01 — swap the values.");
+    }
+
+    [Fact]
+    public async Task SearchDocuments_ResultHeaders_IncludeDocumentId()
+    {
+        var (_, document, _) = await SeedDocumentWithChunks(
+            chunkContents: new[] { "Services segment revenue grew strongly." }
+        );
+
+        var result = await Sut().SearchDocuments("services segment revenue");
+
+        // The ID feeds SearchDocument/ReadDocumentLines directly — without it the caller
+        // must re-derive it from ListCompanyDocuments by fuzzy type+date matching.
+        result.Should().Contain($"(ID: {document.Id})");
     }
 
     // ── SearchDocument ──────────────────────────────────────────────────
@@ -301,23 +351,193 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task SearchDocument_UnknownDocumentId_ReturnsEmptyMessage()
+    public async Task SearchDocument_UnknownDocumentId_ReturnsDocumentNotFound()
     {
         await SeedDocumentWithChunks(chunkContents: new[] { "Some content." });
 
-        var result = await Sut().SearchDocument("anything", Guid.NewGuid());
+        var missingId = Guid.NewGuid();
+        var result = await Sut().SearchDocument("anything", missingId);
 
-        result.Should().Be("No relevant financial documents found.");
+        // A stale or mistyped ID must not read as "this filing says nothing about the
+        // topic" — the caller needs to know the ID itself is wrong.
+        result
+            .Should()
+            .Be(
+                $"Document {missingId} not found — obtain a valid document ID from ListCompanyDocuments."
+            );
+    }
+
+    [Fact]
+    public async Task SearchDocument_ExistingDocumentNoMatches_ReturnsNoExcerptsMessage()
+    {
+        var (_, document, _) = await SeedDocumentWithChunks(
+            chunkContents: new[] { "Consumer electronics revenue." }
+        );
+
+        var result = await Sut().SearchDocument("blockchain cryptocurrency mining", document.Id);
+
+        // Same empty outcome, different cause: the document exists but has no matching
+        // content — distinguishable from the bad-ID case above.
+        result.Should().StartWith("No matching excerpts found in this document");
+        result.Should().Contain("10-K");
+    }
+
+    [Fact]
+    public async Task SearchDocument_WordyQueryWithOneNonMatchingToken_StillReturnsExcerpts()
+    {
+        // Conjunctive BM25 ANDs every token: "drivers" appears nowhere in the chunk, so
+        // the strict pass returns nothing. The document-scoped tool opts into the
+        // disjunctive fallback, which must recover the on-point chunk.
+        var (_, document, _) = await SeedDocumentWithChunks(
+            chunkContents: new[]
+            {
+                "Revenue from Data Center computing grew 59% driven by demand.",
+                "Gaming revenue was flat compared to the prior year.",
+            }
+        );
+
+        var result = await Sut().SearchDocument("data center revenue growth drivers", document.Id);
+
+        result.Should().Contain("Data Center computing grew");
     }
 
     // ── ListCompanyDocuments ────────────────────────────────────────────
 
     [Fact]
-    public async Task ListCompanyDocuments_UnknownTicker_ReturnsNotFoundMessage()
+    public async Task ListCompanyDocuments_UnknownTicker_ReturnsStockNotFound()
     {
         var result = await Sut().ListCompanyDocuments("ZZZZ");
 
-        result.Should().Contain("No documents found for ticker ZZZZ");
+        // An unknown ticker is not the same empty state as "known company, nothing
+        // ingested" — the caller must be told the ticker itself missed.
+        result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+
+    [Fact]
+    public async Task ListCompanyDocuments_KnownTickerNoDocuments_ReturnsNoDocumentsMessage()
+    {
+        DbContext
+            .Set<CommonStock>()
+            .Add(
+                new CommonStock
+                {
+                    Ticker = "NODOC",
+                    Name = "Empty Corp",
+                    Cik = Random.Shared.NextInt64(1_000_000_000L, 9_999_999_999L).ToString(),
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().ListCompanyDocuments("NODOC");
+
+        result.Should().Contain("No documents found for ticker NODOC");
+    }
+
+    [Fact]
+    public async Task ListCompanyDocuments_FiltersExcludeEverything_SaysDocumentsExistWithoutThem()
+    {
+        await SeedDocumentWithChunks(
+            ticker: "AAPL",
+            documentType: DocumentType.TenK,
+            reportingDate: new DateOnly(2026, 3, 15),
+            chunkContents: new[] { "Annual report content." }
+        );
+
+        var result = await Sut()
+            .ListCompanyDocuments(
+                "AAPL",
+                startDate: new DateTime(1990, 1, 1),
+                endDate: new DateTime(1990, 12, 31)
+            );
+
+        // Distinguish "the filters excluded everything" from "nothing is ingested".
+        result.Should().Contain("No documents match the given filters for AAPL");
+        result.Should().Contain("1 document(s) exist without them");
+    }
+
+    [Fact]
+    public async Task ListCompanyDocuments_UnknownDocumentType_ReturnsAcceptedValues()
+    {
+        await SeedDocumentWithChunks(
+            ticker: "AAPL",
+            chunkContents: new[] { "Annual report content." }
+        );
+
+        // The old lenient behavior returned an UNFILTERED list for a near-miss like
+        // 'AnnualReport' — indistinguishable from a correctly filtered one.
+        var result = await Sut().ListCompanyDocuments("AAPL", documentType: "AnnualReport");
+
+        result.Should().StartWith("Unknown documentType 'AnnualReport'.");
+        result.Should().Contain("'TenK' (10-K)");
+    }
+
+    [Fact]
+    public async Task ListCompanyDocuments_PageZero_ReturnsExplicitError()
+    {
+        await SeedDocumentWithChunks(
+            ticker: "AAPL",
+            chunkContents: new[] { "Annual report content." }
+        );
+
+        // page=0 used to flow into Skip(-maxItems) — a negative OFFSET PostgreSQL rejects,
+        // surfacing as the generic internal-error sentinel.
+        var result = await Sut().ListCompanyDocuments("AAPL", page: 0);
+
+        result.Should().Be("Invalid page 0 — pages are numbered from 1.");
+    }
+
+    [Fact]
+    public async Task ListCompanyDocuments_PagePastEnd_ReturnsOutOfRangeMessage()
+    {
+        await SeedDocumentWithChunks(
+            ticker: "AAPL",
+            chunkContents: new[] { "Annual report content." }
+        );
+
+        // Paging past the end used to return "No documents found for ticker AAPL" even
+        // though documents plainly exist — the caller would conclude the company has none.
+        var result = await Sut().ListCompanyDocuments("AAPL", page: 5);
+
+        result.Should().Contain("Page 5 is out of range");
+        result.Should().Contain("1 matching document(s)");
+    }
+
+    [Fact]
+    public async Task ListCompanyDocuments_HiddenDocumentType_ExcludedUnlessExplicitlyRequested()
+    {
+        // Registration is process-global and idempotent (TryAdd); the type is test-only
+        // and no other test filters on it.
+        var hiddenType = new DocumentType(
+            "TestHiddenNews",
+            "Test Hidden News",
+            hiddenFromFilingLists: true
+        );
+        DocumentType.Register(hiddenType);
+
+        await SeedDocumentWithChunks(
+            ticker: "AAPL",
+            documentType: DocumentType.TenK,
+            reportingDate: new DateOnly(2026, 3, 15),
+            chunkContents: new[] { "Annual report content." }
+        );
+        await SeedDocumentWithChunks(
+            ticker: "AAPL",
+            documentType: hiddenType,
+            reportingDate: new DateOnly(2026, 4, 1),
+            chunkContents: new[] { "News item content." }
+        );
+
+        var unfiltered = await Sut().ListCompanyDocuments("AAPL");
+        var explicitlyRequested = await Sut()
+            .ListCompanyDocuments("AAPL", documentType: "TestHiddenNews");
+
+        // Hidden types are news, not filings: they must not crowd the unfiltered list,
+        // but an explicit request for the type still returns them.
+        unfiltered.Should().Contain("10-K");
+        unfiltered.Should().NotContain("Test Hidden News");
+        unfiltered.Should().Contain("(1 documents)");
+        explicitlyRequested.Should().Contain("Test Hidden News");
+        explicitlyRequested.Should().NotContain("10-K");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesInvalidRangeTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesInvalidRangeTests.cs
@@ -14,12 +14,11 @@ using File = Equibles.Media.Data.Models.File;
 namespace Equibles.IntegrationTests.Sec;
 
 /// <summary>
-/// Contract: ReadDocumentLines clamps the requested window (startLine to ≥1, endLine
-/// to ≤totalLines); when a start beyond the document makes the clamped range empty
-/// (startLine > endLine), it must return a clear "Invalid line range" message naming
-/// the clamped bounds and total — never throw IndexOutOfRange or emit an empty table.
-/// Sibling tests pin the clamp-and-return path; this pins the invalid-range branch.
-/// Oracle derived from the clamping contract before reading the body.
+/// Contract: ReadDocumentLines validates the ORIGINAL arguments before clamping; a start
+/// beyond the document must be named as such ("startLine N is beyond the end") quoting
+/// the caller's own values — the earlier clamp-then-validate order produced "Invalid
+/// line range: 5 to 3" for a request of 5 to 10, quoting a bound the caller never sent.
+/// Never throws IndexOutOfRange or emits an empty table.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class DocumentTextToolsReadLinesInvalidRangeTests : ParadeDbMcpTestBase
@@ -63,10 +62,10 @@ public class DocumentTextToolsReadLinesInvalidRangeTests : ParadeDbMcpTestBase
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 
-        // Request lines 5-10 in a 3-line doc: startLine (5) clamps to 5, endLine (10)
-        // clamps to 3, so 5 > 3 — the window is empty and the tool must say so.
+        // Request lines 5-10 in a 3-line doc: the whole window is past the end, and the
+        // error must quote the caller's startLine, not a clamped endLine they never sent.
         var output = await sut.ReadDocumentLines(document.Id, startLine: 5, endLine: 10);
 
-        output.Should().Be("Invalid line range: 5 to 3 (document has 3 lines).");
+        output.Should().Be("startLine 5 is beyond the end of the document (3 lines).");
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordTests.cs
@@ -72,7 +72,7 @@ public class DocumentTextToolsSearchKeywordTests : ParadeDbMcpTestBase
         // search — a regression to OrdinalCase would return "No matches found".
         var output = await sut.SearchDocumentKeyword(document.Id, "revenue");
 
-        output.Should().Contain("1 matches found");
+        output.Should().Contain("1 matching line(s)");
         output.Should().Contain("**Revenue**"); // preserves original casing inside markers
         output.Should().Contain("First line of the filing."); // line before
         output.Should().Contain("Operating expenses remained stable."); // line after

--- a/tests/Equibles.IntegrationTests/Sec/HybridChunkSearcherDisjunctiveFallbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/HybridChunkSearcherDisjunctiveFallbackTests.cs
@@ -1,0 +1,161 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins <see cref="Equibles.Sec.BusinessLogic.Search.HybridChunkSearcher"/>'s opt-in
+/// disjunctive fallback over the real BM25 ranking. The conjunctive default ANDs every
+/// query token, so a wordy natural-language query with one non-matching token ("drivers"
+/// vs the filing's "driven") returns nothing; with the fallback enabled the searcher
+/// re-runs the pass in any-token mode and tops the result up. The default path must be
+/// byte-for-byte unchanged — ALVIS and the portal RAG share this searcher.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HybridChunkSearcherDisjunctiveFallbackTests : ParadeDbMcpTestBase
+{
+    public HybridChunkSearcherDisjunctiveFallbackTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    // One query token ("drivers") appears nowhere in the chunk, so the conjunctive pass
+    // matches nothing even though the chunk is on-point for the remaining tokens.
+    private const string WordyQuery = "data center revenue growth drivers";
+    private const string OnPointContent =
+        "Revenue from the Data Center segment was strong this quarter.";
+
+    [Fact]
+    public async Task Search_DefaultConjunctive_OneNonMatchingTokenReturnsNothing()
+    {
+        await SeedOnPointChunk();
+        var sut = HybridChunkSearcherFactory.Bm25Only(DbContext);
+
+        var results = await sut.Search(WordyQuery, maxResults: 5);
+
+        // Pins the premise the fallback test rests on AND the unchanged default for the
+        // shared consumers: without opting in, conjunctive semantics still apply.
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Search_DisjunctiveFallback_RecoversChunksTheConjunctivePassStarved()
+    {
+        var document = await SeedOnPointChunk();
+        var sut = HybridChunkSearcherFactory.Bm25Only(DbContext);
+
+        var results = await sut.Search(
+            WordyQuery,
+            maxResults: 5,
+            documentId: document.Id,
+            disjunctiveFallback: true
+        );
+
+        results.Should().NotBeEmpty();
+        results.Should().AllSatisfy(c => c.DocumentId.Should().Be(document.Id));
+    }
+
+    [Fact]
+    public async Task Search_DisjunctiveFallback_ConjunctiveHitsKeepTheirRankAheadOfBroadHits()
+    {
+        var stock = SeedStock();
+        var document = SeedDocument(stock);
+        // Chunk 0 matches every token; chunk 1 only some — the fallback must append the
+        // broad hit AFTER the precise one, never displace it.
+        SeedChunk(
+            document,
+            "Data center revenue growth drivers include accelerated computing.",
+            stock.Ticker,
+            0
+        );
+        SeedChunk(document, OnPointContent, stock.Ticker, 1);
+        await DbContext.SaveChangesAsync();
+
+        var sut = HybridChunkSearcherFactory.Bm25Only(DbContext);
+
+        var results = await sut.Search(
+            WordyQuery,
+            maxResults: 5,
+            documentId: document.Id,
+            disjunctiveFallback: true
+        );
+
+        results.Should().HaveCount(2);
+        results[0].Index.Should().Be(0);
+        results[1].Index.Should().Be(1);
+    }
+
+    private async Task<Document> SeedOnPointChunk()
+    {
+        var stock = SeedStock();
+        var document = SeedDocument(stock);
+        SeedChunk(document, OnPointContent, stock.Ticker);
+        await DbContext.SaveChangesAsync();
+        return document;
+    }
+
+    private CommonStock SeedStock()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "Nvidia Corp.",
+            Cik = Random.Shared.NextInt64(1_000_000_000L, 9_999_999_999L).ToString(),
+        };
+        DbContext.Add(stock);
+        return stock;
+    }
+
+    private Document SeedDocument(CommonStock stock)
+    {
+        var fileContent = new FileContent { Bytes = "placeholder"u8.ToArray() };
+        var file = new File
+        {
+            Name = "filing",
+            Extension = "txt",
+            ContentType = "text/plain",
+            Size = fileContent.Bytes.Length,
+            FileContent = fileContent,
+        };
+        fileContent.FileId = file.Id;
+        DbContext.Add(file);
+
+        var document = new Document
+        {
+            CommonStock = stock,
+            CommonStockId = stock.Id,
+            Content = file,
+            ContentId = file.Id,
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2026, 2, 25),
+            ReportingForDate = new DateOnly(2026, 1, 25),
+            LineCount = 1,
+        };
+        DbContext.Add(document);
+        return document;
+    }
+
+    private void SeedChunk(Document document, string content, string ticker, int index = 0)
+    {
+        DbContext.Add(
+            new Chunk
+            {
+                Document = document,
+                DocumentId = document.Id,
+                Index = index,
+                StartPosition = index * 100,
+                EndPosition = index * 100 + content.Length,
+                StartLineNumber = index + 1,
+                Content = content,
+                DocumentType = document.DocumentType,
+                Ticker = ticker,
+                ReportingDate = DateTime.SpecifyKind(
+                    document.ReportingDate.ToDateTime(TimeOnly.MinValue),
+                    DateTimeKind.Utc
+                ),
+            }
+        );
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/RagManagerBuildContextDocumentIdTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagManagerBuildContextDocumentIdTests.cs
@@ -1,0 +1,135 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.BusinessLogic.Search;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+
+namespace Equibles.UnitTests.Sec;
+
+// BuildContext render additions shipped with the MCP documents-search audit:
+// (1) includeDocumentIds stamps the document GUID into each per-document header so the
+//     MCP search tools' results feed SearchDocument/ReadDocumentLines directly;
+// (2) grouping keys on Document.Id, so two distinct same-type same-day filings render as
+//     two documents instead of merging under one header (which would attach one ID to
+//     excerpts of another document);
+// (3) image-markdown references are stripped at render time (slide-deck captures embed
+//     one per slide — tokens without information for a text consumer);
+// (4) maxExcerptChars caps each excerpt with an explicit truncation note, never silently.
+public class RagManagerBuildContextDocumentIdTests
+{
+    private static RagManager Sut() =>
+        new(hybridChunkSearcher: null, commonStockRepository: null, logger: null);
+
+    private static Document NewDocument(Guid? id = null)
+    {
+        var document = new Document
+        {
+            CommonStock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." },
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 12, 31),
+        };
+        if (id.HasValue)
+        {
+            document.Id = id.Value;
+        }
+        return document;
+    }
+
+    private static Chunk NewChunk(Document document, string content, int index = 0) =>
+        new()
+        {
+            Index = index,
+            StartPosition = index * 100,
+            StartLineNumber = index + 1,
+            Content = content,
+            Document = document,
+        };
+
+    [Fact]
+    public async Task BuildContext_IncludeDocumentIds_StampsIdIntoDocumentHeader()
+    {
+        var documentId = Guid.NewGuid();
+        var document = NewDocument(documentId);
+
+        var result = await Sut()
+            .BuildContext([NewChunk(document, "Revenue grew.")], includeDocumentIds: true);
+
+        result.Should().Contain($"**Document:** 10-K filed on 2024-12-31 (ID: {documentId})");
+    }
+
+    [Fact]
+    public async Task BuildContext_DefaultArguments_OmitsDocumentId()
+    {
+        var document = NewDocument(Guid.NewGuid());
+
+        var result = await Sut().BuildContext([NewChunk(document, "Revenue grew.")]);
+
+        result.Should().NotContain("(ID:");
+        result.Should().Contain("**Document:** 10-K filed on 2024-12-31");
+    }
+
+    [Fact]
+    public async Task BuildContext_TwoSameTypeSameDayDocuments_RenderAsSeparateGroups()
+    {
+        var docOne = NewDocument(Guid.NewGuid());
+        var docTwo = NewDocument(Guid.NewGuid());
+
+        var result = await Sut()
+            .BuildContext(
+                [
+                    NewChunk(docOne, "First filing content."),
+                    NewChunk(docTwo, "Second filing content."),
+                ],
+                includeDocumentIds: true
+            );
+
+        // Grouping by (ticker, type, date) alone would merge the two filings under one
+        // header — and attach one document's ID to the other's excerpts.
+        result.Should().Contain($"(ID: {docOne.Id})");
+        result.Should().Contain($"(ID: {docTwo.Id})");
+    }
+
+    [Fact]
+    public async Task BuildContext_ImageMarkdownInContent_IsStrippedAtRenderTime()
+    {
+        var document = NewDocument();
+        var chunk = NewChunk(
+            document,
+            "Revenue grew. ![](investorpresentationfina015.jpg \"slide14\") Margins expanded."
+        );
+
+        var result = await Sut().BuildContext([chunk]);
+
+        result.Should().NotContain("investorpresentationfina015.jpg");
+        result.Should().Contain("Revenue grew.");
+        result.Should().Contain("Margins expanded.");
+    }
+
+    [Fact]
+    public async Task BuildContext_MaxExcerptChars_TruncatesAtWordBoundaryWithNote()
+    {
+        var document = NewDocument();
+        var chunk = NewChunk(
+            document,
+            "Revenue from the Data Center segment grew substantially during the fiscal year."
+        );
+
+        var result = await Sut().BuildContext([chunk], maxExcerptChars: 30);
+
+        result.Should().Contain("truncated");
+        result.Should().NotContain("during the fiscal year");
+        // Cut lands on a word boundary, never mid-word.
+        result.Should().Contain("Revenue from the Data Center");
+    }
+
+    [Fact]
+    public async Task BuildContext_MaxExcerptCharsZero_ReturnsFullExcerpt()
+    {
+        var document = NewDocument();
+        var content = "Revenue grew substantially during the fiscal year under review.";
+
+        var result = await Sut().BuildContext([NewChunk(document, content)], maxExcerptChars: 0);
+
+        result.Should().Contain(content);
+        result.Should().NotContain("truncated");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/TypographyFoldTests.cs
+++ b/tests/Equibles.UnitTests/Sec/TypographyFoldTests.cs
@@ -1,0 +1,65 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+// TypographyFold backs SearchDocumentKeyword's matching: filings store smart punctuation
+// (U+2019 apostrophes, curly quotes, en/em dashes) while callers type ASCII, so both the
+// keyword and the searched line are folded before the ordinal comparison. The 1:1 length
+// invariant is load-bearing — HighlightKeyword maps folded match indices back onto the
+// ORIGINAL line to bold it, which breaks the moment folding changes string length.
+public class TypographyFoldTests
+{
+    [Theory]
+    [InlineData("world’s largest", "world's largest")] // right single quote
+    [InlineData("‘quoted’", "'quoted'")] // curly single quotes
+    [InlineData("“Big Bang”", "\"Big Bang\"")] // curly double quotes
+    [InlineData("2019–2024", "2019-2024")] // en dash
+    [InlineData("revenue — up 10%", "revenue - up 10%")] // em dash
+    [InlineData("−5%", "-5%")] // minus sign
+    [InlineData("non\u00A0breaking", "non breaking")] // no-break space
+    public void Fold_TypographicPunctuation_FoldsToAscii(string input, string expected)
+    {
+        TypographyFold.Fold(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Fold_PlainAsciiText_ReturnsSameInstance()
+    {
+        const string input = "Total revenue was $100M in fiscal 2026.";
+
+        TypographyFold.Fold(input).Should().BeSameAs(input);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Fold_NullOrEmpty_ReturnsInput(string input)
+    {
+        TypographyFold.Fold(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Fold_NeverChangesLength()
+    {
+        // The 1:1 invariant HighlightKeyword depends on: folded indices must address the
+        // same characters in the original string.
+        const string input = "It’s “official” — 2019–2024 results";
+
+        TypographyFold.Fold(input).Length.Should().Be(input.Length);
+    }
+
+    [Fact]
+    public void DocumentType_HiddenFromFilingLists_DefaultsToFalse()
+    {
+        // Registering a type without the flag must change nothing: every built-in filing
+        // type stays visible in document lists.
+        new DocumentType("SomeType")
+            .HiddenFromFilingLists.Should()
+            .BeFalse();
+        DocumentType.TenK.HiddenFromFilingLists.Should().BeFalse();
+        new DocumentType("SomeNews", "Some News", hiddenFromFilingLists: true)
+            .HiddenFromFilingLists.Should()
+            .BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes all audit findings for the six document/search MCP tools (ListCompanyDocuments, ReadDocumentLines, SearchCompanyDocuments, SearchDocument, SearchDocumentKeyword, SearchDocuments):

- **Truncated count presented as the total** (SearchDocumentKeyword): matching lines are now counted before `Take`, the header reports the true total, and a truncation note says how to see more.
- **Silent false negatives on smart punctuation** (SearchDocumentKeyword): new `TypographyFold` (strictly 1:1 per char) folds curly quotes/apostrophes/dashes/NBSP on both the keyword and the text before matching, and highlighting maps folded match indices back onto the original line.
- **Recall starvation for natural-language queries** (SearchDocument): conjunctive BM25 ANDs every token, so one non-matching word ("drivers" vs the filing's "driven") excluded every on-point chunk. `HybridChunkSearcher` gains an opt-in `disjunctiveFallback` that tops a sparse conjunctive pass up from an any-token pass — conjunctive hits keep their rank; the default path is byte-for-byte unchanged for the shared consumers (ALVIS, portal RAG, REST search). Only the MCP `SearchDocument` opts in.
- **Unreachable drill-downs**: `BuildContext` can stamp the document GUID into each per-document header (`includeDocumentIds`, MCP search tools opt in), groups by document ID so two same-type same-day filings never merge, strips image-markdown noise at render time, and gains a `maxExcerptChars` word-boundary excerpt cap with an explicit note (exposed as a new optional tool parameter).
- **Strict arguments, no silent fallbacks**: unknown `documentType` values now error with the full accepted list built from `DocumentType.GetAll()` at call time (runtime-registered types like `EarningsCallTranscript` always listed); inverted date ranges error instead of returning the generic empty message; `page`/`maxItems`/`maxResults` are validated/clamped.
- **Distinguishable empty states**: unknown ticker → `Stock 'X' not found.`; bad `documentId` → `Document <id> not found — obtain a valid document ID from ListCompanyDocuments.`; filters-excluded-everything vs nothing-ingested; page-out-of-range names the real page count. `ListCompanyDocuments` headers now carry `page X of Y (N documents)`.
- **Uncapped line reads** (ReadDocumentLines): a single call returns at most 2,000 lines with a self-describing continuation note; range errors validate the caller's original arguments instead of quoting clamped bounds.
- **Hidden document types**: `DocumentType` gains `HiddenFromFilingLists` (default false, additive). `SecDocumentService` excludes hidden types from unfiltered listings while keeping them searchable and explicitly filterable, and gains `CountDocuments` with identical filter semantics. The commercial host can now register its investor-relations-news type with the flag so news stops crowding filings out of `ListCompanyDocuments`.
- Tool/parameter descriptions updated to match all of the above.

## Code changes

- `src/Equibles.Sec.Data/Models/DocumentType.cs` — `HiddenFromFilingLists` flag (safe default).
- `src/Equibles.Sec.BusinessLogic/Search/{ISecDocumentService,SecDocumentService}.cs` — hidden-type exclusion + `CountDocuments`.
- `src/Equibles.Sec.Repositories/ChunkRepository.cs` — `conjunctive` parameter on `HybridSearch` (default unchanged).
- `src/Equibles.Sec.BusinessLogic/Search/{HybridChunkSearcher,RagManager,IRagManager}.cs` — opt-in disjunctive fallback; `BuildContext(includeDocumentIds, maxExcerptChars)`; document-ID grouping; image-markdown stripping.
- `src/Equibles.Sec.Mcp/Tools/{RagSearchTools,DocumentTextTools,TypographyFold}.cs` — the tool-surface fixes above.
- Tests: new `HybridChunkSearcherDisjunctiveFallbackTests` (pins that the conjunctive pass alone returns nothing for the wordy query, the fallback recovers it, and precise hits keep their rank), `RagManagerBuildContextDocumentIdTests`, `TypographyFoldTests`; updated `RagSearchToolsTests`, `DocumentTextToolsTests`, and the culture-invariance/read-lines/keyword integration pins.

All MCP tool names and existing parameter names/semantics preserved; every new parameter is optional with a safe default.

Test runs: full `Equibles.UnitTests` (3,508 passed) and all `Equibles.IntegrationTests` under `Sec.`/`Mcp.` (789 passed) locally against the ParadeDB container.