### PR TITLE
fix(mcp): honest short-data output — FINRA cap sentinel, strict dates, truncation notes, facility-volume labels

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
@@ -35,9 +35,10 @@ public class OffExchangeVolumeTools
     [McpServerTool(Name = "GetOffExchangeVolume")]
     [Description(
         "Get weekly off-exchange (dark pool / OTC) trading volume for a stock from the FINRA OTC/ATS Transparency data. "
-            + "Each week shows ATS (alternating trading system / dark pool) volume and trade count, non-ATS OTC volume and trade count, "
+            + "Each week shows ATS (alternative trading system / dark pool) volume and trade count, non-ATS OTC volume and trade count, "
             + "and the total off-exchange volume (ATS + non-ATS OTC). The FINRA file does not include consolidated tape volume, so the "
-            + "off-exchange share of total market volume is not reported here; compute that share elsewhere against a consolidated-volume source."
+            + "off-exchange share of total market volume is not reported here; compute that share elsewhere against a consolidated-volume source. "
+            + "FINRA publishes each week on a delay (2 weeks for Tier 1 NMS stocks, longer for other tiers), so the latest week lags today."
     )]
     public Task<string> GetOffExchangeVolume(
         [Description("Stock ticker symbol (e.g., AAPL, GME, TSLA)")] string ticker,
@@ -45,7 +46,9 @@ public class OffExchangeVolumeTools
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of weeks to return (default: 26, newest first)")]
+        [Description(
+            "Maximum number of weeks to return — keeps the most recent N weeks in the range, displayed oldest to newest (default: 26, max: 500)"
+        )]
             int maxResults = 26
     )
     {
@@ -56,25 +59,27 @@ public class OffExchangeVolumeTools
                 if (stockError != null)
                     return stockError;
 
-                var (start, end) = McpToolExecutor.ParseDateRange(
+                var (startWeek, endWeek, rangeError) = ParseStrictDateRange(
                     startDate,
                     endDate,
                     McpToolExecutor.UtcMonthsAgo(6)
                 );
-
-                var startWeek = DateOnly.FromDateTime(start.ToDateTime(TimeOnly.MinValue));
-                var endWeek = DateOnly.FromDateTime(end.ToDateTime(TimeOnly.MinValue));
+                if (rangeError != null)
+                    return rangeError;
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var records = await _offExchangeVolumeRepository
+                var query = _offExchangeVolumeRepository
                     .GetHistoryByStock(stock)
-                    .Where(d => d.WeekStartDate >= startWeek && d.WeekStartDate <= endWeek)
+                    .Where(d => d.WeekStartDate >= startWeek && d.WeekStartDate <= endWeek);
+
+                var total = await query.CountAsync();
+                var records = await query
                     .OrderByDescending(d => d.WeekStartDate)
                     .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     records.OrderBy(r => r.WeekStartDate).ToList(),
                     $"No off-exchange volume data found for {stock.Ticker} in the specified date range.",
                     $"Weekly off-exchange (dark pool / OTC) volume for {stock.Ticker} ({stock.Name}):",
@@ -82,11 +87,70 @@ public class OffExchangeVolumeTools
                     "|------------|-----------|-----------|-------------------|-------------------|--------------------------|",
                     r => RenderOffExchangeRow($"{r.WeekStartDate:yyyy-MM-dd}", r)
                 );
+
+                return AppendNote(table, NewestKeptNote(records.Count, total, "weeks"));
             },
             "GetOffExchangeVolume",
             $"ticker: {ticker}"
         );
     }
+
+    // Strict replacement for McpToolExecutor.ParseDateRange: a supplied date must be ISO
+    // yyyy-MM-dd (no silent fallback onto the default window) and the range must not be
+    // inverted — a caller typo must never silently answer for a window it did not ask about,
+    // and an inverted range must never masquerade as a factual "no data" claim.
+    private static (DateOnly Start, DateOnly End, string Error) ParseStrictDateRange(
+        string startDate,
+        string endDate,
+        DateOnly defaultStart
+    )
+    {
+        var start = defaultStart;
+        if (!string.IsNullOrWhiteSpace(startDate))
+        {
+            if (!McpOutput.TryParseDate(startDate, out var parsedStart))
+                return (
+                    default,
+                    default,
+                    McpOutput.InvalidArgument("startDate", startDate, "yyyy-MM-dd")
+                );
+            start = DateOnly.FromDateTime(parsedStart);
+        }
+
+        var end = DateOnly.FromDateTime(DateTime.UtcNow);
+        if (!string.IsNullOrWhiteSpace(endDate))
+        {
+            if (!McpOutput.TryParseDate(endDate, out var parsedEnd))
+                return (
+                    default,
+                    default,
+                    McpOutput.InvalidArgument("endDate", endDate, "yyyy-MM-dd")
+                );
+            end = DateOnly.FromDateTime(parsedEnd);
+        }
+
+        if (start > end)
+            return (
+                default,
+                default,
+                $"startDate {start:yyyy-MM-dd} is after endDate {end:yyyy-MM-dd} — startDate must be on or before endDate."
+            );
+
+        return (start, end, null);
+    }
+
+    // Sibling of McpOutput.TruncationNote for a table that KEEPS the newest N weeks but
+    // DISPLAYS them oldest-first: "first N" would read as the oldest N, so the note names
+    // the kept end explicitly. Empty when nothing was cut.
+    private static string NewestKeptNote(int shown, int total, string unit) =>
+        shown >= total
+            ? string.Empty
+            : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
+
+    // Appends a note line under a rendered table (blank line first so strict CommonMark
+    // renderers keep the table intact); a no-op for the empty note or an empty-state message.
+    private static string AppendNote(string table, string note) =>
+        note.Length == 0 ? table : $"{table}\n{note}\n";
 
     // Render with InvariantCulture so the MCP markdown does not fork the separators by host
     // locale (e.g. de-DE would render 5.000.000 instead of 5,000,000). Total off-exchange

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -24,6 +24,11 @@ namespace Equibles.Finra.Mcp.Tools;
 [McpServerToolType]
 public class ShortDataTools
 {
+    // FINRA reports days to cover capped at 999.99 — a stored 999.99 means "999.99 or
+    // more", not a real reading. Rendered and ranked as a sentinel, never as a genuine
+    // extreme value (an "F1" format would round it to a fictitious "1000.0").
+    private const decimal FinraDaysToCoverCap = 999.99m;
+
     private readonly DailyShortVolumeRepository _shortVolumeRepository;
     private readonly ShortInterestRepository _shortInterestRepository;
     private readonly CommonStockRepository _commonStockRepository;
@@ -51,7 +56,7 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortVolume")]
     [Description(
-        "Get daily short volume data for a stock from FINRA. Shows short volume, exempt volume, total volume, and short volume percentage. High short volume % (>50%) may indicate bearish pressure."
+        "Get daily short sale volume history for a stock from FINRA's short sale volume files. Shows short volume, short-exempt volume, total volume, and short volume percentage per trading day. Volumes cover trades reported to FINRA facilities (off-exchange/TRF) only — NOT consolidated tape volume — and a 40-50% Short % is the normal baseline from market-maker liquidity provision, so it must not be quoted as a share of the stock's total traded volume. This daily flow metric is distinct from bi-monthly short interest positions: use GetShortInterest for positions, GetLargestShortVolume for a market-wide single-day ranking, and GetShortSqueezeScores for squeeze candidates."
     )]
     public Task<string> GetShortVolume(
         [Description("Stock ticker symbol (e.g., AAPL, GME, AMC)")] string ticker,
@@ -59,7 +64,9 @@ public class ShortDataTools
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of records to return (default: 90, newest first)")]
+        [Description(
+            "Maximum number of records to return — keeps the most recent N trading days in the range, displayed oldest to newest (default: 90, max: 500)"
+        )]
             int maxResults = 90
     )
     {
@@ -70,22 +77,41 @@ public class ShortDataTools
                 if (stockError != null)
                     return stockError;
 
-                var query = _shortVolumeRepository.GetHistoryByStock(stock);
-
-                var (start, end) = McpToolExecutor.ParseDateRange(
+                var (start, end, rangeError) = ParseStrictDateRange(
                     startDate,
                     endDate,
                     McpToolExecutor.UtcMonthsAgo(3)
                 );
+                if (rangeError != null)
+                    return rangeError;
 
-                query = query.Where(d => d.Date >= start && d.Date <= end);
+                var query = _shortVolumeRepository
+                    .GetHistoryByStock(stock)
+                    .Where(d => d.Date >= start && d.Date <= end);
 
                 maxResults = McpLimit.Clamp(maxResults);
 
+                var total = await query.CountAsync();
                 var records = await query
                     .OrderByDescending(d => d.Date)
                     .Take(maxResults)
                     .ToListAsync();
+
+                if (records.Count == 0)
+                {
+                    // Distinguish "range predates coverage" from a genuine per-stock gap —
+                    // the full-universe FINRA daily files were only loaded from a fixed
+                    // floor, so an older range would otherwise read as a false factual
+                    // "this stock had no short volume" claim.
+                    var earliest = await _shortVolumeRepository
+                        .GetHistoryByStock(stock)
+                        .OrderBy(d => d.Date)
+                        .Select(d => (DateOnly?)d.Date)
+                        .FirstOrDefaultAsync();
+                    if (earliest != null && end < earliest.Value)
+                        return $"No short volume data for {stock.Ticker} before {earliest:yyyy-MM-dd} — coverage starts on {earliest:yyyy-MM-dd}. Adjust the date range.";
+                    return $"No short volume data found for {stock.Ticker} in the specified date range.";
+                }
 
                 // Restate each day's volumes onto today's split basis so the series is
                 // continuous across a split (a raw pre-split day would otherwise show a
@@ -93,12 +119,13 @@ public class ShortDataTools
                 // two counts on the same date, so it is split-invariant and left as-is.
                 var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     records.OrderBy(r => r.Date).ToList(),
                     $"No short volume data found for {stock.Ticker} in the specified date range.",
                     $"Daily short volume for {stock.Ticker} ({stock.Name}):",
-                    "| Date | Short Volume | Exempt | Total Volume | Short % |",
-                    "|------|-------------|--------|-------------|---------|",
+                    "_Volumes are trades reported to FINRA facilities (off-exchange/TRF) only — not consolidated tape volume; a 40-50% Short % is the normal baseline. Short Exempt = short sales exempt from Reg SHO price-test restrictions. Share counts are restated onto today's split basis._",
+                    "| Date | Short Volume | Short Exempt | Total Volume | Short % |",
+                    "|------|-------------|--------------|-------------|---------|",
                     r =>
                         RenderShortVolumeRow(
                             $"{r.Date:yyyy-MM-dd}",
@@ -106,6 +133,8 @@ public class ShortDataTools
                             SplitAdjustment.ShareCountFactor(r.Date, splits)
                         )
                 );
+
+                return AppendNote(table, NewestKeptNote(records.Count, total, "trading days"));
             },
             "GetShortVolume",
             $"ticker: {ticker}"
@@ -114,7 +143,7 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortInterest")]
     [Description(
-        "Get short interest data for a stock from FINRA. Shows current short position, change from previous period, average daily volume, and days to cover. Published bi-monthly. High days-to-cover (>5) suggests a potential short squeeze."
+        "Get bi-monthly short interest history for a stock from FINRA. Shows the reported short position, change from the previous settlement, average daily volume, and days to cover per settlement date. Share counts are restated onto today's split basis so the series stays continuous across stock splits; days to cover is as reported (FINRA caps it at 999.99). High days-to-cover (>5) suggests a potential short squeeze — for short interest as a % of shares outstanding and an actual squeeze-candidate ranking use GetShortSqueezeScores; for the market-wide latest settlement use GetShortInterestSnapshot."
     )]
     public Task<string> GetShortInterest(
         [Description("Stock ticker symbol (e.g., AAPL, GME, TSLA)")] string ticker,
@@ -122,7 +151,9 @@ public class ShortDataTools
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of records to return (default: 24, newest first)")]
+        [Description(
+            "Maximum number of records to return — keeps the most recent N settlements in the range, displayed oldest to newest (default: 24, max: 500)"
+        )]
             int maxResults = 24
     )
     {
@@ -135,20 +166,28 @@ public class ShortDataTools
                 if (stockError != null)
                     return stockError;
 
-                var query = _shortInterestRepository.GetHistoryByStock(stock);
-
-                var (start, end) = McpToolExecutor.ParseDateRange(
+                var (start, end, rangeError) = ParseStrictDateRange(
                     startDate,
                     endDate,
                     McpToolExecutor.UtcYearsAgo(1)
                 );
+                if (rangeError != null)
+                    return rangeError;
 
-                query = query.Where(s => s.SettlementDate >= start && s.SettlementDate <= end);
+                var query = _shortInterestRepository
+                    .GetHistoryByStock(stock)
+                    .Where(s => s.SettlementDate >= start && s.SettlementDate <= end);
 
-                var records = await query
+                var total = await query.CountAsync();
+
+                // One extra settlement past the window so the oldest DISPLAYED row still has
+                // its predecessor available for the split-consistent Change computation below.
+                var fetched = await query
                     .OrderByDescending(s => s.SettlementDate)
-                    .Take(maxResults)
+                    .Take(maxResults + 1)
                     .ToListAsync();
+
+                var display = fetched.Take(maxResults).OrderBy(r => r.SettlementDate).ToList();
 
                 // Restate each settlement's share counts (short position, change, average
                 // daily volume) onto today's split basis so the series is continuous across a
@@ -157,19 +196,46 @@ public class ShortDataTools
                 // leaves it unchanged anyway.
                 var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
 
-                return MarkdownTable.Render(
-                    records.OrderBy(r => r.SettlementDate).ToList(),
+                // FINRA's raw change is (current − previous) where the previous position is on
+                // the PREVIOUS settlement's split basis, so scaling it by the current factor
+                // renders a cross-basis number at the settlement straddling a split. Whenever
+                // the predecessor settlement is on file (and FINRA's change really references
+                // it), display the difference of the two restated positions instead, so the
+                // Change column reconciles row-to-row across a split boundary.
+                var ascAll = fetched.OrderBy(r => r.SettlementDate).ToList();
+                var changeById = new Dictionary<Guid, long>(ascAll.Count);
+                for (var i = 0; i < ascAll.Count; i++)
+                {
+                    var cur = ascAll[i];
+                    var factor = SplitAdjustment.ShareCountFactor(cur.SettlementDate, splits);
+                    var prev = i > 0 ? ascAll[i - 1] : null;
+                    changeById[cur.Id] =
+                        prev != null && prev.CurrentShortPosition == cur.PreviousShortPosition
+                            ? SplitAdjustment.AdjustShareCount(cur.CurrentShortPosition, factor)
+                                - SplitAdjustment.AdjustShareCount(
+                                    prev.CurrentShortPosition,
+                                    SplitAdjustment.ShareCountFactor(prev.SettlementDate, splits)
+                                )
+                            : SplitAdjustment.AdjustShareCount(cur.ChangeInShortPosition, factor);
+                }
+
+                var table = MarkdownTable.Render(
+                    display,
                     $"No short interest data found for {stock.Ticker} in the specified date range.",
                     $"Short interest for {stock.Ticker} ({stock.Name}):",
+                    "_Share counts are restated onto today's split basis so the series is continuous across splits; Days to Cover is as reported by FINRA (capped at 999.99)._",
                     "| Settlement Date | Short Position | Change | Avg Daily Volume | Days to Cover |",
                     "|----------------|---------------|--------|-----------------|---------------|",
                     r =>
                         RenderShortInterestRow(
                             $"{r.SettlementDate:yyyy-MM-dd}",
                             r,
-                            SplitAdjustment.ShareCountFactor(r.SettlementDate, splits)
+                            SplitAdjustment.ShareCountFactor(r.SettlementDate, splits),
+                            changeById[r.Id]
                         )
                 );
+
+                return AppendNote(table, NewestKeptNote(display.Count, total, "settlements"));
             },
             "GetShortInterest",
             $"ticker: {ticker}"
@@ -178,11 +244,20 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortInterestSnapshot")]
     [Description(
-        "Get the latest short interest data across all stocks, sorted by days to cover (descending). Useful for finding stocks with high short interest that may be prone to short squeezes."
+        "Market-wide snapshot of the latest FINRA bi-monthly short interest settlement — one row per stock, sorted by days to cover (descending) by default. FINRA caps days to cover at 999.99: capped rows are a sentinel (almost always illiquid names with a tiny average-daily-volume denominator) and are ranked after real readings; pass minAvgDailyVolume (e.g. 100000) to drop illiquid names entirely. This is the raw FINRA snapshot — for genuine short-squeeze candidate ranking use GetShortSqueezeScores; for one stock's history use GetShortInterest; for daily short-sale flow use GetShortVolume/GetLargestShortVolume."
     )]
     public Task<string> GetShortInterestSnapshot(
         [Description("Minimum days to cover filter (default: 0)")] decimal minDaysToCover = 0,
-        [Description("Maximum number of results to return (default: 50)")] int maxResults = 50
+        [Description("Maximum number of results to return (default: 50, max: 500)")]
+            int maxResults = 50,
+        [Description(
+            "Minimum average daily share volume — set a floor (e.g. 100000) to drop illiquid names whose days-to-cover is inflated by a tiny volume denominator (default: 0 = no floor)"
+        )]
+            long minAvgDailyVolume = 0,
+        [Description(
+            "Sort key: daysToCover (default; FINRA-capped 999.99 sentinel rows ranked last), shortPosition, or change (largest increase in short position first)"
+        )]
+            string sortBy = "daysToCover"
     )
     {
         return _runner.Execute(
@@ -205,34 +280,91 @@ public class ShortDataTools
                     query = query.Where(s => s.DaysToCover >= minDaysToCover);
                 }
 
-                var records = await query
-                    .OrderByDescending(s => s.DaysToCover)
-                    .Take(McpLimit.Clamp(maxResults))
-                    .ToListAsync();
+                if (minAvgDailyVolume > 0)
+                {
+                    query = query.Where(s => s.AverageDailyVolume >= minAvgDailyVolume);
+                }
 
-                return MarkdownTable.Render(
+                // Every ordering ends on the ticker so the ranking is deterministic — the
+                // 999.99 cap tier alone holds ~180 tied rows, and an ORDER BY that ends on a
+                // tie lets Postgres return a different "top" set on every call.
+                var sortKey = string.IsNullOrWhiteSpace(sortBy) ? "daysToCover" : sortBy.Trim();
+                IOrderedQueryable<ShortInterest> ordered;
+                if (sortKey.Equals("daysToCover", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Rows at FINRA's cap are a sentinel tier, not real readings — rank them
+                    // after genuine values so the default view is not 100% illiquid capped
+                    // names (which would bury every actionable row).
+                    ordered = query
+                        .OrderBy(s => s.DaysToCover >= FinraDaysToCoverCap ? 1 : 0)
+                        .ThenByDescending(s => s.DaysToCover)
+                        .ThenByDescending(s => s.CurrentShortPosition)
+                        .ThenBy(s => s.CommonStock.Ticker);
+                }
+                else if (sortKey.Equals("shortPosition", StringComparison.OrdinalIgnoreCase))
+                {
+                    ordered = query
+                        .OrderByDescending(s => s.CurrentShortPosition)
+                        .ThenBy(s => s.CommonStock.Ticker);
+                }
+                else if (sortKey.Equals("change", StringComparison.OrdinalIgnoreCase))
+                {
+                    ordered = query
+                        .OrderByDescending(s => s.ChangeInShortPosition)
+                        .ThenByDescending(s => s.CurrentShortPosition)
+                        .ThenBy(s => s.CommonStock.Ticker);
+                }
+                else
+                {
+                    return McpOutput.InvalidArgument(
+                        "sortBy",
+                        sortBy,
+                        "daysToCover, shortPosition, change"
+                    );
+                }
+
+                var total = await query.CountAsync();
+                var records = await ordered.Take(McpLimit.Clamp(maxResults)).ToListAsync();
+
+                var volumeClause =
+                    minAvgDailyVolume > 0
+                        ? $" and average daily volume >= {McpFormat.WholeNumber(minAvgDailyVolume)}"
+                        : "";
+                var table = MarkdownTable.Render(
                     records,
-                    $"No short interest data found for settlement date {latestDate:yyyy-MM-dd} with days to cover >= {minDaysToCover.ToString(CultureInfo.InvariantCulture)}.",
-                    $"Short interest snapshot — settlement date {latestDate:yyyy-MM-dd}:",
+                    $"No short interest data found for settlement date {latestDate:yyyy-MM-dd} with days to cover >= {minDaysToCover.ToString(CultureInfo.InvariantCulture)}{volumeClause}.",
+                    $"Short interest snapshot — settlement date {latestDate:yyyy-MM-dd} (sorted by {sortKey}, descending):",
+                    "_FINRA caps Days to Cover at 999.99 — \">=999.99 (FINRA cap)\" rows are that sentinel (true value unknown, typically illiquid names) and rank after real readings in the default sort._",
                     "| Ticker | Short Position | Change | Avg Daily Volume | Days to Cover |",
                     "|--------|---------------|--------|-----------------|---------------|",
                     r => RenderShortInterestRow(r.CommonStock.Ticker, r)
                 );
+
+                return AppendNote(table, McpOutput.TruncationNote(records.Count, total));
             },
             "GetShortInterestSnapshot",
-            $"minDaysToCover: {minDaysToCover}"
+            $"minDaysToCover: {minDaysToCover}, minAvgDailyVolume: {minAvgDailyVolume}, sortBy: {sortBy}"
         );
     }
 
     [McpServerTool(Name = "GetLargestShortVolume")]
     [Description(
-        "Get the stocks with the largest daily short volume for a single trading day (defaults to the latest available), sorted by short volume descending. Useful for spotting where short selling was most concentrated on a given day."
+        "Get the stocks with the largest daily short sale volume for a single trading day (defaults to the latest available), from FINRA's daily short sale volume files, sorted by short volume descending. Short % is the share of that day's FINRA-facility (off-exchange/TRF) volume sold short — 40-50% is a normal market-making baseline — NOT short interest (the open short position; use GetShortInterest/GetShortInterestSnapshot for positions and GetShortSqueezeScores for squeeze candidates; use GetShortVolume for one stock's daily history). Pass sortBy=shortPercent with a minTotalVolume floor to rank by short intensity instead of raw size."
     )]
     public Task<string> GetLargestShortVolume(
         [Description("Trading day in YYYY-MM-DD format (defaults to the latest available day)")]
             string date = null,
         [Description("Minimum short volume filter (default: 0)")] long minShortVolume = 0,
-        [Description("Maximum number of results to return (default: 50)")] int maxResults = 50
+        [Description("Maximum number of results to return (default: 50, max: 500)")]
+            int maxResults = 50,
+        [Description(
+            "Sort key: shortVolume (default) or shortPercent — with shortPercent set a minTotalVolume floor, otherwise illiquid names dominate"
+        )]
+            string sortBy = "shortVolume",
+        [Description(
+            "Minimum total FINRA-reported volume filter, in shares (default: 0 = no floor)"
+        )]
+            long minTotalVolume = 0
     )
     {
         return _runner.Execute(
@@ -242,7 +374,13 @@ public class ShortDataTools
                 if (latestDate == default)
                     return "No short volume data available.";
 
-                var tradingDay = McpToolExecutor.ParseDateOr(date, latestDate);
+                var tradingDay = latestDate;
+                if (!string.IsNullOrWhiteSpace(date))
+                {
+                    if (!McpOutput.TryParseDate(date, out var parsedDay))
+                        return McpOutput.InvalidArgument("date", date, "yyyy-MM-dd");
+                    tradingDay = DateOnly.FromDateTime(parsedDay);
+                }
 
                 var query = _shortVolumeRepository
                     .GetByDate(tradingDay)
@@ -254,22 +392,56 @@ public class ShortDataTools
                     query = query.Where(d => d.ShortVolume >= minShortVolume);
                 }
 
-                var records = await query
-                    .OrderByDescending(d => d.ShortVolume)
-                    .Take(McpLimit.Clamp(maxResults))
-                    .ToListAsync();
+                if (minTotalVolume > 0)
+                {
+                    query = query.Where(d => d.TotalVolume >= minTotalVolume);
+                }
 
-                return MarkdownTable.Render(
+                // Orderings end on the ticker so a re-call pages the same ranking even when
+                // rows tie on the sort key.
+                var sortKey = string.IsNullOrWhiteSpace(sortBy) ? "shortVolume" : sortBy.Trim();
+                IOrderedQueryable<DailyShortVolume> ordered;
+                if (sortKey.Equals("shortVolume", StringComparison.OrdinalIgnoreCase))
+                {
+                    ordered = query
+                        .OrderByDescending(d => d.ShortVolume)
+                        .ThenBy(d => d.CommonStock.Ticker);
+                }
+                else if (sortKey.Equals("shortPercent", StringComparison.OrdinalIgnoreCase))
+                {
+                    ordered = query
+                        .OrderByDescending(d => (double)d.ShortVolume / d.TotalVolume)
+                        .ThenByDescending(d => d.ShortVolume)
+                        .ThenBy(d => d.CommonStock.Ticker);
+                }
+                else
+                {
+                    return McpOutput.InvalidArgument("sortBy", sortBy, "shortVolume, shortPercent");
+                }
+
+                var total = await query.CountAsync();
+                var records = await ordered.Take(McpLimit.Clamp(maxResults)).ToListAsync();
+
+                var totalVolumeClause =
+                    minTotalVolume > 0
+                        ? $" and total volume >= {McpFormat.WholeNumber(minTotalVolume)}"
+                        : "";
+                var table = MarkdownTable.Render(
                     records,
-                    $"No short volume data found for trading day {tradingDay:yyyy-MM-dd} with short volume >= {McpFormat.WholeNumber(minShortVolume)}.",
-                    $"Largest short volume — trading day {tradingDay:yyyy-MM-dd}:",
-                    "| Ticker | Short Volume | Exempt | Total Volume | Short % |",
-                    "|--------|-------------|--------|-------------|---------|",
-                    r => RenderShortVolumeRow(r.CommonStock.Ticker, r)
+                    $"No short volume data found for trading day {tradingDay:yyyy-MM-dd} with short volume >= {McpFormat.WholeNumber(minShortVolume)}{totalVolumeClause}.",
+                    $"Largest short volume — trading day {tradingDay:yyyy-MM-dd} (sorted by {sortKey}, descending):",
+                    "_Volumes are trades reported to FINRA facilities (off-exchange/TRF) only — not consolidated tape volume; a 40-50% Short % is the normal baseline. Short Exempt = short sales exempt from Reg SHO price-test restrictions._",
+                    "| Ticker | Company | Short Volume | Short Exempt | Total Volume | Short % |",
+                    "|--------|---------|-------------|--------------|-------------|---------|",
+                    // The lead "cell" carries both the ticker and company columns — the shared
+                    // renderer splices it in front of the volume cells verbatim.
+                    r => RenderShortVolumeRow($"{r.CommonStock.Ticker} | {r.CommonStock.Name}", r)
                 );
+
+                return AppendNote(table, McpOutput.TruncationNote(records.Count, total));
             },
             "GetLargestShortVolume",
-            $"date: {date}"
+            $"date: {date}, sortBy: {sortBy}, minTotalVolume: {minTotalVolume}"
         );
     }
 
@@ -294,15 +466,18 @@ public class ShortDataTools
     // Render with InvariantCulture so the MCP markdown does not fork the separators by host
     // locale (e.g. de-DE would render 1.234.567 / 12,3). `shareFactor` restates the share
     // counts onto today's split basis (1 = no adjustment, the single-date snapshot tools).
+    // `changeOverride` replaces the default factor-scaled raw change with a value already
+    // computed on a consistent basis (see GetShortInterest's split-boundary reconciliation).
     private static string RenderShortInterestRow(
         string leadCell,
         ShortInterest r,
-        decimal shareFactor = 1m
+        decimal shareFactor = 1m,
+        long? changeOverride = null
     )
     {
         var position = SplitAdjustment.AdjustShareCount(r.CurrentShortPosition, shareFactor);
         var changeStr = FormatSignedChange(
-            SplitAdjustment.AdjustShareCount(r.ChangeInShortPosition, shareFactor)
+            changeOverride ?? SplitAdjustment.AdjustShareCount(r.ChangeInShortPosition, shareFactor)
         );
         // Average daily volume is a share count as-of the settlement; restate it too so the
         // row stays self-consistent (position ÷ ADV still reconciles to Days to Cover).
@@ -311,9 +486,72 @@ public class ShortDataTools
             : (long?)null;
         var advStr = McpFormat.OrDash(adv, "N0");
         // Days to cover is a same-settlement ratio — left as reported (split-invariant).
-        var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
+        // FINRA stores 999.99 as a cap sentinel meaning "999.99 or more"; render it
+        // distinctly so an "F1" round-up never presents a fictitious "1000.0" as real data.
+        var dtcStr =
+            r.DaysToCover >= FinraDaysToCoverCap
+                ? ">=999.99 (FINRA cap)"
+                : McpFormat.OrDash(r.DaysToCover, "F1");
         return $"| {leadCell} | {McpFormat.WholeNumber(position)} | {changeStr} | {advStr} | {dtcStr} |";
     }
+
+    // Strict replacement for McpToolExecutor.ParseDateRange: a supplied date must be ISO
+    // yyyy-MM-dd (no silent fallback onto the default window) and the range must not be
+    // inverted — a caller typo must never silently answer for a window it did not ask about,
+    // and an inverted range must never masquerade as a factual "no data" claim.
+    private static (DateOnly Start, DateOnly End, string Error) ParseStrictDateRange(
+        string startDate,
+        string endDate,
+        DateOnly defaultStart
+    )
+    {
+        var start = defaultStart;
+        if (!string.IsNullOrWhiteSpace(startDate))
+        {
+            if (!McpOutput.TryParseDate(startDate, out var parsedStart))
+                return (
+                    default,
+                    default,
+                    McpOutput.InvalidArgument("startDate", startDate, "yyyy-MM-dd")
+                );
+            start = DateOnly.FromDateTime(parsedStart);
+        }
+
+        var end = DateOnly.FromDateTime(DateTime.UtcNow);
+        if (!string.IsNullOrWhiteSpace(endDate))
+        {
+            if (!McpOutput.TryParseDate(endDate, out var parsedEnd))
+                return (
+                    default,
+                    default,
+                    McpOutput.InvalidArgument("endDate", endDate, "yyyy-MM-dd")
+                );
+            end = DateOnly.FromDateTime(parsedEnd);
+        }
+
+        if (start > end)
+            return (
+                default,
+                default,
+                $"startDate {start:yyyy-MM-dd} is after endDate {end:yyyy-MM-dd} — startDate must be on or before endDate."
+            );
+
+        return (start, end, null);
+    }
+
+    // Sibling of McpOutput.TruncationNote for the history tools that KEEP the newest N rows
+    // but DISPLAY them oldest-first: "first N" would read as the oldest N (the table appears
+    // to start where the range starts), so the note names the kept end explicitly. Empty
+    // when nothing was cut, so callers can append it unconditionally via AppendNote.
+    private static string NewestKeptNote(int shown, int total, string unit) =>
+        shown >= total
+            ? string.Empty
+            : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
+
+    // Appends a note line under a rendered table (blank line first so strict CommonMark
+    // renderers keep the table intact); a no-op for the empty note or an empty-state message.
+    private static string AppendNote(string table, string note) =>
+        note.Length == 0 ? table : $"{table}\n{note}\n";
 
     private static string FormatSignedChange(long change) =>
         change >= 0 ? $"+{McpFormat.WholeNumber(change)}" : McpFormat.WholeNumber(change);

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -34,7 +34,7 @@ public class FailToDeliverTools
 
     [McpServerTool(Name = "GetFailsToDeliver")]
     [Description(
-        "Get fails-to-deliver (FTD) data for a stock from SEC. Shows settlement dates, quantities of shares that failed to deliver, and price at settlement. High FTD counts may indicate naked short selling or settlement issues."
+        "Get fails-to-deliver (FTD) data for a stock from the SEC's twice-monthly FTD files. Quantity is the aggregate net fail-to-deliver position OUTSTANDING on each settlement date — a balance, not that day's new fails, so never sum Quantity across dates. Price is the previous trading day's closing price (SEC file convention, not a settlement price) and Value = Quantity × Price. Dates absent from the table had no reported fails; the SEC publishes each half-month batch with roughly a two-week lag, so the newest rows trail today. High or persistent FTD balances may indicate naked short selling or settlement issues."
     )]
     public Task<string> GetFailsToDeliver(
         [Description("Stock ticker symbol (e.g., AAPL, GME, AMC)")] string ticker,
@@ -42,7 +42,9 @@ public class FailToDeliverTools
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of records to return (default: 90, newest first)")]
+        [Description(
+            "Maximum number of records to return — keeps the most recent N settlement dates in the range, displayed oldest to newest (default: 90, max: 500)"
+        )]
             int maxResults = 90
     )
     {
@@ -53,36 +55,102 @@ public class FailToDeliverTools
                 if (stockError != null)
                     return stockError;
 
-                var (start, end) = McpToolExecutor.ParseDateRange(
+                var (start, end, rangeError) = ParseStrictDateRange(
                     startDate,
                     endDate,
                     McpToolExecutor.UtcMonthsAgo(3)
                 );
+                if (rangeError != null)
+                    return rangeError;
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var records = await _ftdRepository
+                var query = _ftdRepository
                     .GetByStock(stock)
-                    .Where(f => f.SettlementDate >= start && f.SettlementDate <= end)
+                    .Where(f => f.SettlementDate >= start && f.SettlementDate <= end);
+
+                var total = await query.CountAsync();
+                var records = await query
                     .OrderByDescending(f => f.SettlementDate)
                     .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     records.OrderBy(f => f.SettlementDate).ToList(),
                     $"No FTD data found for {stock.Ticker} in the specified date range.",
                     $"Fails-to-deliver for {stock.Ticker} ({stock.Name}):",
-                    "| Settlement Date | Quantity | Price | Value |",
-                    "|----------------|---------|-------|-------|",
+                    "_Quantity is the outstanding FTD position on each settlement date (a balance — do not sum across dates); Prior Close is the previous trading day's closing price per SEC convention; Value = Quantity × Prior Close. Dates absent from the table had no reported fails; the SEC publishes in half-month batches with a ~2-week lag._",
+                    "| Settlement Date | Quantity | Prior Close | Value |",
+                    "|----------------|---------|-------------|-------|",
                     f =>
                     {
                         var value = f.Quantity * f.Price;
                         return $"| {f.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(f.Quantity)} | ${McpFormat.Invariant(f.Price, "F2")} | ${McpFormat.WholeNumber(value)} |";
                     }
                 );
+
+                return AppendNote(table, NewestKeptNote(records.Count, total, "settlement dates"));
             },
             "GetFailsToDeliver",
             $"ticker: {ticker}"
         );
     }
+
+    // Strict replacement for McpToolExecutor.ParseDateRange: a supplied date must be ISO
+    // yyyy-MM-dd (no silent fallback onto the default window) and the range must not be
+    // inverted — a caller typo must never silently answer for a window it did not ask about,
+    // and an inverted range must never masquerade as a factual "no data" claim.
+    private static (DateOnly Start, DateOnly End, string Error) ParseStrictDateRange(
+        string startDate,
+        string endDate,
+        DateOnly defaultStart
+    )
+    {
+        var start = defaultStart;
+        if (!string.IsNullOrWhiteSpace(startDate))
+        {
+            if (!McpOutput.TryParseDate(startDate, out var parsedStart))
+                return (
+                    default,
+                    default,
+                    McpOutput.InvalidArgument("startDate", startDate, "yyyy-MM-dd")
+                );
+            start = DateOnly.FromDateTime(parsedStart);
+        }
+
+        var end = DateOnly.FromDateTime(DateTime.UtcNow);
+        if (!string.IsNullOrWhiteSpace(endDate))
+        {
+            if (!McpOutput.TryParseDate(endDate, out var parsedEnd))
+                return (
+                    default,
+                    default,
+                    McpOutput.InvalidArgument("endDate", endDate, "yyyy-MM-dd")
+                );
+            end = DateOnly.FromDateTime(parsedEnd);
+        }
+
+        if (start > end)
+            return (
+                default,
+                default,
+                $"startDate {start:yyyy-MM-dd} is after endDate {end:yyyy-MM-dd} — startDate must be on or before endDate."
+            );
+
+        return (start, end, null);
+    }
+
+    // Sibling of McpOutput.TruncationNote for a table that KEEPS the newest N rows but
+    // DISPLAYS them oldest-first: "first N" would read as the oldest N (the table appears
+    // to start where the range starts), so the note names the kept end explicitly. Empty
+    // when nothing was cut.
+    private static string NewestKeptNote(int shown, int total, string unit) =>
+        shown >= total
+            ? string.Empty
+            : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
+
+    // Appends a note line under a rendered table (blank line first so strict CommonMark
+    // renderers keep the table intact); a no-op for the empty note or an empty-state message.
+    private static string AppendNote(string table, string note) =>
+        note.Length == 0 ? table : $"{table}\n{note}\n";
 }

--- a/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsStrictDatesAndTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsStrictDatesAndTruncationTests.cs
@@ -1,0 +1,132 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Adversarial cover for GetFailsToDeliver's date arguments and truncation signpost. The
+/// old path silently substituted the default 3-month window for an unparseable date and
+/// answered an inverted range with a factual-sounding "no data" claim; maxResults kept the
+/// NEWEST rows while rendering oldest-first with no marker, so a truncated six-month range
+/// read as "zero FTDs before the first displayed row".
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FailToDeliverToolsStrictDatesAndTruncationTests : ParadeDbMcpTestBase
+{
+    private FailToDeliverTools Sut() =>
+        new(
+            new FailToDeliverRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<FailToDeliverTools>()
+        );
+
+    public FailToDeliverToolsStrictDatesAndTruncationTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private CommonStock AddGme()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GME",
+            Name = "GameStop Corp",
+            Cik = "0001326380",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        return stock;
+    }
+
+    private void AddFtd(CommonStock stock, DateOnly settlementDate) =>
+        DbContext
+            .Set<FailToDeliver>()
+            .Add(
+                new FailToDeliver
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    SettlementDate = settlementDate,
+                    Quantity = 100_000,
+                    Price = 25.50m,
+                }
+            );
+
+    [Fact]
+    public async Task GetFailsToDeliver_UnparseableStartDate_ReturnsError()
+    {
+        AddGme();
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFailsToDeliver("GME", startDate: "2026-1-32");
+
+        result.Should().Be("Unknown startDate '2026-1-32'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetFailsToDeliver_UnparseableEndDate_ReturnsError()
+    {
+        AddGme();
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFailsToDeliver("GME", endDate: "next week");
+
+        result.Should().Be("Unknown endDate 'next week'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetFailsToDeliver_InvertedRange_ReturnsExplicitError()
+    {
+        var stock = AddGme();
+        AddFtd(stock, new DateOnly(2026, 4, 1));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetFailsToDeliver("GME", startDate: "2026-06-30", endDate: "2026-01-01");
+
+        result
+            .Should()
+            .Contain("startDate 2026-06-30 is after endDate 2026-01-01")
+            .And.NotContain("No FTD data");
+    }
+
+    [Fact]
+    public async Task GetFailsToDeliver_TruncatedRange_AppendsNewestKeptNote()
+    {
+        var stock = AddGme();
+        AddFtd(stock, new DateOnly(2026, 4, 1));
+        AddFtd(stock, new DateOnly(2026, 4, 2));
+        AddFtd(stock, new DateOnly(2026, 4, 3));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetFailsToDeliver(
+                "GME",
+                startDate: "2026-04-01",
+                endDate: "2026-04-30",
+                maxResults: 2
+            );
+
+        // The kept rows are the NEWEST two, displayed oldest-first — the note must say so,
+        // or the table reads as "GME had no fails before 2026-04-02".
+        result.Should().Contain("Showing the newest 2 of 3 settlement dates");
+        result.Should().Contain("2026-04-02");
+        result.Should().NotContain("2026-04-01 |");
+    }
+
+    [Fact]
+    public async Task GetFailsToDeliver_CompleteRange_HasNoTruncationNote()
+    {
+        var stock = AddGme();
+        AddFtd(stock, new DateOnly(2026, 4, 1));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetFailsToDeliver("GME", startDate: "2026-04-01", endDate: "2026-04-30");
+
+        result.Should().NotContain("Showing the newest");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsStrictDatesAndTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsStrictDatesAndTruncationTests.cs
@@ -1,0 +1,121 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Adversarial cover for GetOffExchangeVolume's date arguments and truncation signpost.
+/// The old path silently substituted the default window for an unparseable date and
+/// answered an inverted range with a factual-sounding "no data" claim; maxResults cut
+/// weeks inside the requested range with no marker (the table renders oldest-first, so it
+/// appeared to start where the range starts).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class OffExchangeVolumeToolsStrictDatesAndTruncationTests : ParadeDbMcpTestBase
+{
+    private OffExchangeVolumeTools Sut() =>
+        new(
+            new OffExchangeVolumeRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<OffExchangeVolumeTools>()
+        );
+
+    public OffExchangeVolumeToolsStrictDatesAndTruncationTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private CommonStock AddGme()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GME",
+            Name = "GameStop Corp",
+            Cik = "0001326380",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        return stock;
+    }
+
+    private void AddWeek(CommonStock stock, DateOnly weekStart) =>
+        DbContext
+            .Set<OffExchangeVolume>()
+            .Add(
+                new OffExchangeVolume
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    WeekStartDate = weekStart,
+                    AtsVolume = 5_000_000,
+                    AtsTradeCount = 11_111,
+                    NonAtsOtcVolume = 3_000_000,
+                    NonAtsOtcTradeCount = 22_222,
+                }
+            );
+
+    [Fact]
+    public async Task GetOffExchangeVolume_UnparseableStartDate_ReturnsError()
+    {
+        AddGme();
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetOffExchangeVolume("GME", startDate: "2026-06-31");
+
+        result.Should().Be("Unknown startDate '2026-06-31'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetOffExchangeVolume_InvertedRange_ReturnsExplicitError()
+    {
+        var stock = AddGme();
+        AddWeek(stock, new DateOnly(2026, 3, 16));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOffExchangeVolume("GME", startDate: "2026-06-30", endDate: "2026-01-01");
+
+        result
+            .Should()
+            .Contain("startDate 2026-06-30 is after endDate 2026-01-01")
+            .And.NotContain("No off-exchange volume data");
+    }
+
+    [Fact]
+    public async Task GetOffExchangeVolume_TruncatedRange_AppendsNewestKeptNote()
+    {
+        var stock = AddGme();
+        AddWeek(stock, new DateOnly(2026, 3, 2));
+        AddWeek(stock, new DateOnly(2026, 3, 9));
+        AddWeek(stock, new DateOnly(2026, 3, 16));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOffExchangeVolume(
+                "GME",
+                startDate: "2026-03-01",
+                endDate: "2026-03-31",
+                maxResults: 2
+            );
+
+        result.Should().Contain("Showing the newest 2 of 3 weeks");
+        result.Should().Contain("2026-03-09");
+        result.Should().NotContain("2026-03-02");
+    }
+
+    [Fact]
+    public async Task GetOffExchangeVolume_CompleteRange_HasNoTruncationNote()
+    {
+        var stock = AddGme();
+        AddWeek(stock, new DateOnly(2026, 3, 16));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOffExchangeVolume("GME", startDate: "2026-03-01", endDate: "2026-03-31");
+
+        result.Should().NotContain("Showing the newest");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
@@ -1,0 +1,245 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Cover for the short-data history tools' output notes: the truncation signpost when
+/// maxResults cuts rows inside the requested range (silently keeping the NEWEST rows while
+/// rendering oldest-first previously read as "the range starts here"), the coverage-edge
+/// message when the requested range predates the dataset floor, and the split-boundary
+/// Change reconciliation in GetShortInterest.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class ShortDataToolsHistoryOutputNotesTests : ParadeDbMcpTestBase
+{
+    private ShortDataTools Sut() =>
+        new(
+            new DailyShortVolumeRepository(DbContext),
+            new ShortInterestRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext),
+                []
+            ),
+            new StockSplitRepository(DbContext),
+            ErrorManager,
+            NullLogger<ShortDataTools>()
+        );
+
+    public ShortDataToolsHistoryOutputNotesTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private CommonStock AddGme()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GME",
+            Name = "GameStop Corp",
+            Cik = "0001326380",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        return stock;
+    }
+
+    private void AddVolume(CommonStock stock, DateOnly date) =>
+        DbContext
+            .Set<DailyShortVolume>()
+            .Add(
+                new DailyShortVolume
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    Date = date,
+                    ShortVolume = 1_000_000,
+                    ShortExemptVolume = 0,
+                    TotalVolume = 2_000_000,
+                    Market = "ALL",
+                }
+            );
+
+    private void AddShortInterest(
+        CommonStock stock,
+        DateOnly settlementDate,
+        long position,
+        long previous,
+        long change
+    ) =>
+        DbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    SettlementDate = settlementDate,
+                    CurrentShortPosition = position,
+                    PreviousShortPosition = previous,
+                    ChangeInShortPosition = change,
+                    AverageDailyVolume = 1_000_000,
+                    DaysToCover = 2.0m,
+                }
+            );
+
+    [Fact]
+    public async Task GetShortVolume_TruncatedRange_AppendsNewestKeptNote()
+    {
+        var stock = AddGme();
+        for (var day = 1; day <= 5; day++)
+            AddVolume(stock, new DateOnly(2026, 4, day));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetShortVolume("GME", startDate: "2026-04-01", endDate: "2026-04-30", maxResults: 2);
+
+        // "first 2 of 5" would misread — the kept rows are the NEWEST, displayed oldest-first.
+        result.Should().Contain("Showing the newest 2 of 5 trading days");
+    }
+
+    [Fact]
+    public async Task GetShortVolume_CompleteRange_HasNoTruncationNote()
+    {
+        var stock = AddGme();
+        AddVolume(stock, new DateOnly(2026, 4, 1));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetShortVolume("GME", startDate: "2026-04-01", endDate: "2026-04-30");
+
+        result.Should().NotContain("Showing the newest");
+    }
+
+    [Fact]
+    public async Task GetShortVolume_RangeBeforeCoverage_NamesTheCoverageFloor()
+    {
+        // Full-universe FINRA daily files were only loaded from a fixed floor; a range
+        // before it must say so instead of the generic (false-reading) "no data for GME".
+        var stock = AddGme();
+        AddVolume(stock, new DateOnly(2026, 4, 6));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetShortVolume("GME", startDate: "2026-01-05", endDate: "2026-01-09");
+
+        result.Should().Contain("coverage starts on 2026-04-06");
+    }
+
+    [Fact]
+    public async Task GetShortVolume_EmptyRangeInsideCoverage_KeepsGenericMessage()
+    {
+        var stock = AddGme();
+        AddVolume(stock, new DateOnly(2026, 4, 6));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetShortVolume("GME", startDate: "2026-04-11", endDate: "2026-04-12");
+
+        result.Should().Contain("No short volume data found for GME");
+        result.Should().NotContain("coverage starts");
+    }
+
+    [Fact]
+    public async Task GetShortInterest_TruncatedRange_AppendsNewestKeptNote()
+    {
+        var stock = AddGme();
+        AddShortInterest(stock, new DateOnly(2026, 2, 13), 100, 90, 10);
+        AddShortInterest(stock, new DateOnly(2026, 2, 27), 110, 100, 10);
+        AddShortInterest(stock, new DateOnly(2026, 3, 13), 120, 110, 10);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetShortInterest("GME", startDate: "2026-01-01", endDate: "2026-03-31", maxResults: 2);
+
+        result.Should().Contain("Showing the newest 2 of 3 settlements");
+        result.Should().Contain("2026-02-27");
+        result.Should().NotContain("| 2026-02-13");
+    }
+
+    [Fact]
+    public async Task GetShortInterest_SplitStraddlingSettlement_ChangeReconcilesAcrossRows()
+    {
+        // A 10:1 split between the two settlements: FINRA's raw change (=current − previous)
+        // mixes a pre-split previous position with a post-split current one. The displayed
+        // Change must equal the difference of the two DISPLAYED (restated) positions —
+        // 5,500,000 − 5,000,000 = +500,000 — not the raw 5,500,000 − 500,000 = +5,000,000.
+        var stock = AddGme();
+        AddShortInterest(
+            stock,
+            new DateOnly(2026, 2, 27),
+            position: 500_000,
+            previous: 450_000,
+            change: 50_000
+        );
+        AddShortInterest(
+            stock,
+            new DateOnly(2026, 3, 13),
+            position: 5_500_000,
+            previous: 500_000,
+            change: 5_000_000
+        );
+        DbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    EffectiveDate = new DateOnly(2026, 3, 1),
+                    Numerator = 10m,
+                    Denominator = 1m,
+                    Source = StockSplitSource.Manual,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetShortInterest("GME", startDate: "2026-01-01", endDate: "2026-03-31");
+
+        // Pre-split settlement restated onto today's basis.
+        result.Should().Contain("| 5,000,000 |");
+        // The straddle row's Change reconciles with the adjacent restated positions.
+        result.Should().Contain("+500,000");
+        result.Should().NotContain("+5,000,000");
+    }
+
+    [Fact]
+    public async Task GetShortInterest_CappedDaysToCover_RendersSentinel()
+    {
+        var stock = AddGme();
+        DbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    SettlementDate = new DateOnly(2026, 3, 13),
+                    CurrentShortPosition = 1_000,
+                    ChangeInShortPosition = 0,
+                    AverageDailyVolume = 1,
+                    DaysToCover = 999.99m,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterest("GME");
+
+        result.Should().Contain(">=999.99 (FINRA cap)");
+        result.Should().NotContain("1000.0");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsLargestShortVolumeSortAndLegendTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsLargestShortVolumeSortAndLegendTests.cs
@@ -1,0 +1,128 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Cover for GetLargestShortVolume's additive levers and identification columns: the
+/// shortPercent sort with the minTotalVolume liquidity floor, the Company column (obscure
+/// leaders like RGBP gave the model nothing to identify the issuer with), and the
+/// truncation signpost.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class ShortDataToolsLargestShortVolumeSortAndLegendTests : ParadeDbMcpTestBase
+{
+    private ShortDataTools Sut() =>
+        new(
+            new DailyShortVolumeRepository(DbContext),
+            new ShortInterestRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext),
+                []
+            ),
+            new StockSplitRepository(DbContext),
+            ErrorManager,
+            NullLogger<ShortDataTools>()
+        );
+
+    public ShortDataToolsLargestShortVolumeSortAndLegendTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static readonly DateOnly Day = new(2026, 4, 2);
+
+    private int _nextCik = 1;
+
+    private CommonStock AddStock(string ticker, string name)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = name,
+            Cik = (_nextCik++).ToString("D10"),
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        return stock;
+    }
+
+    private void AddVolume(CommonStock stock, long shortVolume, long totalVolume) =>
+        DbContext
+            .Set<DailyShortVolume>()
+            .Add(
+                new DailyShortVolume
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    Date = Day,
+                    ShortVolume = shortVolume,
+                    ShortExemptVolume = 0,
+                    TotalVolume = totalVolume,
+                    Market = "ALL",
+                }
+            );
+
+    [Fact]
+    public async Task LargestShortVolume_RowsCarryCompanyName()
+    {
+        AddVolume(AddStock("RGBP", "Regen BioPharma Inc"), 5_000_000, 8_000_000);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume();
+
+        result.Should().Contain("| RGBP | Regen BioPharma Inc |");
+    }
+
+    [Fact]
+    public async Task LargestShortVolume_SortByShortPercent_RanksByIntensity()
+    {
+        // GME: 90% of a small tape; AMC: 45% of a big one. Percent sort must lead with GME
+        // even though AMC's absolute short volume is larger.
+        AddVolume(AddStock("GME", "GameStop Corp"), 900_000, 1_000_000);
+        AddVolume(AddStock("AMC", "AMC Entertainment"), 9_000_000, 20_000_000);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume(sortBy: "shortPercent");
+
+        result.IndexOf("GME").Should().BeLessThan(result.IndexOf("AMC"));
+    }
+
+    [Fact]
+    public async Task LargestShortVolume_MinTotalVolume_DropsIlliquidNames()
+    {
+        AddVolume(AddStock("GME", "GameStop Corp"), 900_000, 1_000_000);
+        AddVolume(AddStock("TINY", "Tiny Illiquid Corp"), 98, 100);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetLargestShortVolume(sortBy: "shortPercent", minTotalVolume: 500_000);
+
+        result.Should().Contain("GME");
+        result.Should().NotContain("TINY");
+    }
+
+    [Fact]
+    public async Task LargestShortVolume_TruncatedResults_AppendTruncationNote()
+    {
+        AddVolume(AddStock("GME", "GameStop Corp"), 5_000_000, 8_000_000);
+        AddVolume(AddStock("AMC", "AMC Entertainment"), 9_000_000, 20_000_000);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume(maxResults: 1);
+
+        result.Should().Contain("Showing first 1 of 2 results");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsSnapshotSentinelTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsSnapshotSentinelTests.cs
@@ -1,0 +1,187 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Cover for GetShortInterestSnapshot's handling of FINRA's 999.99 days-to-cover cap. The
+/// cap is a sentinel ("999.99 or more"), not a reading: in prod ~180 illiquid OTC rows tie
+/// at it, so a plain days-to-cover-descending sort made the entire default response capped
+/// noise (rendered as a fictitious "1000.0", in nondeterministic order). Contract: capped
+/// rows render as the explicit sentinel, rank AFTER real readings, ties break
+/// deterministically, and minAvgDailyVolume can drop illiquid names outright.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class ShortDataToolsSnapshotSentinelTests : ParadeDbMcpTestBase
+{
+    private ShortDataTools Sut() =>
+        new(
+            new DailyShortVolumeRepository(DbContext),
+            new ShortInterestRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext),
+                []
+            ),
+            new StockSplitRepository(DbContext),
+            ErrorManager,
+            NullLogger<ShortDataTools>()
+        );
+
+    public ShortDataToolsSnapshotSentinelTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static readonly DateOnly Settlement = new(2026, 6, 30);
+
+    private int _nextCik = 1;
+
+    private CommonStock AddStock(string ticker, string name)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = name,
+            Cik = (_nextCik++).ToString("D10"),
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        return stock;
+    }
+
+    private void AddShortInterest(
+        CommonStock stock,
+        decimal daysToCover,
+        long position = 1_000_000,
+        long avgDailyVolume = 100_000,
+        long change = 0
+    ) =>
+        DbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    SettlementDate = Settlement,
+                    CurrentShortPosition = position,
+                    ChangeInShortPosition = change,
+                    AverageDailyVolume = avgDailyVolume,
+                    DaysToCover = daysToCover,
+                }
+            );
+
+    [Fact]
+    public async Task Snapshot_CappedDaysToCover_RendersSentinelNotRoundedThousand()
+    {
+        var illiquid = AddStock("CODQL", "Compagnie OTC");
+        AddShortInterest(illiquid, daysToCover: 999.99m, avgDailyVolume: 4);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterestSnapshot();
+
+        // "F1" would round FINRA's 999.99 cap to a fictitious "1000.0" that exceeds the
+        // source's own maximum and hides that the value is a sentinel.
+        result.Should().Contain(">=999.99 (FINRA cap)");
+        result.Should().NotContain("1000.0");
+    }
+
+    [Fact]
+    public async Task Snapshot_CappedRows_RankAfterRealReadings()
+    {
+        var real = AddStock("GME", "GameStop Corp");
+        AddShortInterest(real, daysToCover: 8.0m, avgDailyVolume: 5_000_000);
+        var capped = AddStock("CODQL", "Compagnie OTC");
+        AddShortInterest(capped, daysToCover: 999.99m, avgDailyVolume: 4);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterestSnapshot();
+
+        // The cap sentinel is numerically the maximum but must NOT outrank genuine
+        // readings — otherwise the default view is 100% illiquid capped names.
+        result.IndexOf("GME").Should().BeLessThan(result.IndexOf("CODQL"));
+    }
+
+    [Fact]
+    public async Task Snapshot_TiedCappedRows_OrderDeterministicallyByPositionThenTicker()
+    {
+        // Three rows tied at the cap: the ordering must be reproducible across calls
+        // (position descending, then ticker) instead of Postgres' arbitrary tie order.
+        AddShortInterest(AddStock("BBB", "Bravo Corp"), 999.99m, position: 500, avgDailyVolume: 2);
+        AddShortInterest(AddStock("AAA", "Alpha Corp"), 999.99m, position: 500, avgDailyVolume: 2);
+        AddShortInterest(AddStock("CCC", "Chase Corp"), 999.99m, position: 900, avgDailyVolume: 2);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterestSnapshot();
+
+        // CCC leads on the larger position; AAA/BBB tie on position and break on ticker.
+        result.IndexOf("CCC").Should().BeLessThan(result.IndexOf("AAA"));
+        result.IndexOf("AAA").Should().BeLessThan(result.IndexOf("BBB"));
+    }
+
+    [Fact]
+    public async Task Snapshot_MinAvgDailyVolume_DropsIlliquidNames()
+    {
+        var liquid = AddStock("GME", "GameStop Corp");
+        AddShortInterest(liquid, daysToCover: 8.0m, avgDailyVolume: 5_000_000);
+        var illiquid = AddStock("CODQL", "Compagnie OTC");
+        AddShortInterest(illiquid, daysToCover: 999.99m, avgDailyVolume: 4);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterestSnapshot(minAvgDailyVolume: 100_000);
+
+        result.Should().Contain("GME");
+        result.Should().NotContain("CODQL");
+    }
+
+    [Fact]
+    public async Task Snapshot_SortByShortPosition_RanksByPosition()
+    {
+        var small = AddStock("GME", "GameStop Corp");
+        AddShortInterest(small, daysToCover: 9.0m, position: 1_000, avgDailyVolume: 100);
+        var big = AddStock("AMC", "AMC Entertainment");
+        AddShortInterest(big, daysToCover: 1.0m, position: 90_000_000, avgDailyVolume: 90_000_000);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterestSnapshot(sortBy: "shortPosition");
+
+        // Under the position sort the big position leads even with the lower days-to-cover.
+        result.IndexOf("AMC").Should().BeLessThan(result.IndexOf("GME"));
+    }
+
+    [Fact]
+    public async Task Snapshot_TruncatedResults_AppendTruncationNote()
+    {
+        AddShortInterest(AddStock("AAA", "Alpha Corp"), 5.0m);
+        AddShortInterest(AddStock("BBB", "Bravo Corp"), 4.0m);
+        AddShortInterest(AddStock("CCC", "Chase Corp"), 3.0m);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterestSnapshot(maxResults: 2);
+
+        result.Should().Contain("Showing first 2 of 3 results");
+    }
+
+    [Fact]
+    public async Task Snapshot_CompleteResults_HaveNoTruncationNote()
+    {
+        AddShortInterest(AddStock("AAA", "Alpha Corp"), 5.0m);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterestSnapshot();
+
+        result.Should().NotContain("Showing first");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsStrictDateArgumentsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsStrictDateArgumentsTests.cs
@@ -1,0 +1,207 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Adversarial cover for the short-data tools' date arguments. The old
+/// <c>McpToolExecutor.ParseDateOr</c> path silently substituted the default window for any
+/// unparseable date and rendered a factual-sounding "no data" for an inverted range — both
+/// make the tool answer a question the caller never asked. The strict contract is: a supplied
+/// date must be ISO yyyy-MM-dd or the tool returns a one-line correction, and start &gt; end
+/// is an explicit error, never an empty-range claim.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class ShortDataToolsStrictDateArgumentsTests : ParadeDbMcpTestBase
+{
+    private ShortDataTools Sut() =>
+        new(
+            new DailyShortVolumeRepository(DbContext),
+            new ShortInterestRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext),
+                new StockSplitRepository(DbContext),
+                new FailToDeliverRepository(DbContext),
+                new DailyStockPriceRepository(DbContext),
+                []
+            ),
+            new StockSplitRepository(DbContext),
+            ErrorManager,
+            NullLogger<ShortDataTools>()
+        );
+
+    public ShortDataToolsStrictDateArgumentsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private async Task<CommonStock> SeedGmeWithVolume()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GME",
+            Name = "GameStop Corp",
+            Cik = "0001326380",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<DailyShortVolume>()
+            .Add(
+                new DailyShortVolume
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    Date = new DateOnly(2026, 4, 1),
+                    ShortVolume = 1_000_000,
+                    ShortExemptVolume = 0,
+                    TotalVolume = 2_000_000,
+                    Market = "ALL",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+        return stock;
+    }
+
+    [Fact]
+    public async Task GetShortVolume_UnparseableStartDate_ReturnsError()
+    {
+        await SeedGmeWithVolume();
+
+        var result = await Sut().GetShortVolume("GME", startDate: "last month");
+
+        result.Should().Be("Unknown startDate 'last month'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetShortVolume_UnparseableEndDate_ReturnsError()
+    {
+        await SeedGmeWithVolume();
+
+        var result = await Sut().GetShortVolume("GME", endDate: "2026-13-05");
+
+        result.Should().Be("Unknown endDate '2026-13-05'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetShortVolume_InvertedRange_ReturnsExplicitError()
+    {
+        await SeedGmeWithVolume();
+
+        var result = await Sut()
+            .GetShortVolume("GME", startDate: "2026-04-30", endDate: "2026-04-01");
+
+        result
+            .Should()
+            .Contain("startDate 2026-04-30 is after endDate 2026-04-01")
+            .And.NotContain("No short volume data");
+    }
+
+    [Fact]
+    public async Task GetShortInterest_UnparseableStartDate_ReturnsError()
+    {
+        DbContext
+            .Set<CommonStock>()
+            .Add(
+                new CommonStock
+                {
+                    Ticker = "GME",
+                    Name = "GameStop Corp",
+                    Cik = "0001326380",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterest("GME", startDate: "garbage");
+
+        result.Should().Be("Unknown startDate 'garbage'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetShortInterest_InvertedRange_ReturnsExplicitError()
+    {
+        DbContext
+            .Set<CommonStock>()
+            .Add(
+                new CommonStock
+                {
+                    Ticker = "GME",
+                    Name = "GameStop Corp",
+                    Cik = "0001326380",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetShortInterest("GME", startDate: "2026-06-01", endDate: "2026-01-01");
+
+        result
+            .Should()
+            .Contain("startDate 2026-06-01 is after endDate 2026-01-01")
+            .And.NotContain("No short interest data");
+    }
+
+    [Fact]
+    public async Task GetLargestShortVolume_UnparseableDate_ReturnsErrorInsteadOfLatestDay()
+    {
+        // The old ParseDateOr fallback answered with the LATEST day's leaderboard for a
+        // typo'd date — the caller would present another day's data as the requested one.
+        await SeedGmeWithVolume();
+
+        var result = await Sut().GetLargestShortVolume(date: "garbage-date");
+
+        result.Should().Be("Unknown date 'garbage-date'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetLargestShortVolume_UnknownSortBy_ReturnsError()
+    {
+        await SeedGmeWithVolume();
+
+        var result = await Sut().GetLargestShortVolume(sortBy: "volume");
+
+        result.Should().Be("Unknown sortBy 'volume'. Accepted: shortVolume, shortPercent.");
+    }
+
+    [Fact]
+    public async Task GetShortInterestSnapshot_UnknownSortBy_ReturnsError()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GME",
+            Name = "GameStop Corp",
+            Cik = "0001326380",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    SettlementDate = new DateOnly(2026, 3, 15),
+                    CurrentShortPosition = 1_000,
+                    ChangeInShortPosition = 0,
+                    AverageDailyVolume = 100,
+                    DaysToCover = 10m,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterestSnapshot(sortBy: "position");
+
+        result
+            .Should()
+            .Be("Unknown sortBy 'position'. Accepted: daysToCover, shortPosition, change.");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes all audit findings for the six short-data MCP tools (GetShortVolume, GetShortInterest, GetShortInterestSnapshot, GetLargestShortVolume, GetOffExchangeVolume, GetFailsToDeliver):

- **GetShortInterestSnapshot (high)**: the default output was 100% FINRA 999.99 days-to-cover cap-sentinel rows on illiquid OTC names, rendered as a fictitious `1000.0` in nondeterministic order — defeating the advertised squeeze-hunting purpose. The cap now renders as `>=999.99 (FINRA cap)`, ranks after real readings, all sorts end on a deterministic tie-break (position desc → ticker), and new optional `minAvgDailyVolume` / `sortBy` (daysToCover|shortPosition|change) arguments let callers drop illiquid noise. The description repositions the tool as the raw FINRA snapshot and routes squeeze hunting to GetShortSqueezeScores.
- **Strict date arguments (all tools)**: unparseable dates now return `Unknown startDate 'X'. Accepted: yyyy-MM-dd.` instead of silently answering for the default window, and an inverted range returns an explicit error instead of a factual-sounding "no data" claim.
- **Truncation signposts (all tools)**: totals are counted before `Take`, and a truncated result appends a note. History tools keep the NEWEST N rows but render oldest-first, so their note says "Showing the newest N of M …" (a plain "first N of M" would misread); ranked tools use the shared `McpOutput.TruncationNote`.
- **GetShortVolume / GetLargestShortVolume**: volumes are now labelled FINRA-facility (off-exchange/TRF) only — with the 40-50% normal-baseline caveat — in both descriptions and table legends, so Short % is never quoted as a share of consolidated volume; `Exempt` renamed to `Short Exempt` with a legend. GetShortVolume names the coverage floor when the requested range predates the dataset ("coverage starts on 2026-04-06") instead of a generic empty message. GetLargestShortVolume rows carry the company name, and new optional `sortBy=shortPercent` + `minTotalVolume` rank by intensity.
- **GetShortInterest**: split-basis restatement is now disclosed (description + legend), and the Change column reconciles across a split-straddling settlement by differencing the two restated positions (FINRA's raw change mixes pre-/post-split bases there) whenever the predecessor settlement is on file.
- **GetOffExchangeVolume**: "alternating trading system" → "alternative trading system"; publication-delay note added.
- **GetFailsToDeliver**: description/legend now state that Quantity is the outstanding FTD balance per settlement date (never summable across dates) and Price is the prior day's close (column renamed `Prior Close`); half-month publication lag and absent-date semantics documented.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — all four short tools reworked as above; `RenderShortInterestRow` gains the cap sentinel and a `changeOverride`; private `ParseStrictDateRange`/`NewestKeptNote`/`AppendNote` helpers.
- `src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs` — strict dates, truncation note, description fixes.
- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — strict dates, truncation note, FTD semantics in description/legend.
- `tests/Equibles.IntegrationTests/Mcp/` — 6 new test classes (35 tests) pinning the strict-argument errors, truncation notes, cap-sentinel rendering/ordering/tie-breaks, liquidity/sort levers, coverage-floor message, split-boundary Change reconciliation, and company column.

All 77 short-data/off-exchange/FTD MCP integration tests pass; unit suites for the MCP module contracts pass; changed files formatted with the pinned csharpier.