### PR TITLE
fix(government-contracts): unfreeze the import cursor and make the MCP tools truthful

### DIFF
--- a/src/Equibles.GovernmentContracts.Data/Models/GovernmentContract.cs
+++ b/src/Equibles.GovernmentContracts.Data/Models/GovernmentContract.cs
@@ -53,13 +53,18 @@ public class GovernmentContract
     /// <summary>Total outlays disbursed against the award to date, in US dollars.</summary>
     public decimal? TotalOutlays { get; set; }
 
-    /// <summary>The award action date — the period-of-performance start.</summary>
+    /// <summary>
+    /// The award's action date — USAspending's base obligation date, i.e. the date the base
+    /// award was signed/first obligated. Drives the incremental import cursor, so it must
+    /// never hold a future date (the period-of-performance start, which can sit years in
+    /// the future, once poisoned this column and froze ingestion).
+    /// </summary>
     public DateOnly? ActionDate { get; set; }
 
     /// <summary>The period-of-performance current end date.</summary>
     public DateOnly? EndDate { get; set; }
 
-    /// <summary>USAspending's last-modified date for the award; drives incremental scraping.</summary>
+    /// <summary>USAspending's last-modified date for the award, for cross-reference.</summary>
     public DateOnly? LastModifiedDate { get; set; }
 
     [MaxLength(8)]

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -208,11 +208,32 @@ public class GovernmentContractsImportService : IImporter
     {
         using var scope = _scopeFactory.CreateScope();
         var repository = scope.ServiceProvider.GetRequiredService<GovernmentContractRepository>();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        // Future action dates are excluded from the cursor: a single mis-dated row would
+        // otherwise push the resume point past today and freeze the import forever (this
+        // happened in prod when period-of-performance starts were stored as ActionDate).
         var latest = await repository
             .GetAll()
-            .Where(c => c.ActionDate != null)
+            .Where(c => c.ActionDate != null && c.ActionDate <= today)
             .MaxAsync(c => c.ActionDate, cancellationToken);
 
-        return SyncDateResolver.Resolve(latest ?? default, _workerOptions);
+        return ResolveStartDate(latest, today, _workerOptions);
+    }
+
+    /// <summary>
+    /// Resume the day after the newest credible action date, clamped to today so an
+    /// outlier can never push the incremental cursor into the future. Pure so the
+    /// cursor policy is unit-testable.
+    /// </summary>
+    public static DateOnly ResolveStartDate(
+        DateOnly? latestActionDate,
+        DateOnly today,
+        WorkerOptions workerOptions
+    )
+    {
+        if (latestActionDate > today)
+            latestActionDate = today;
+
+        return SyncDateResolver.Resolve(latestActionDate ?? default, workerOptions);
     }
 }

--- a/src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs
@@ -32,7 +32,12 @@ public static class UsaSpendingAwardMapper
             AwardingAgency = Truncate(record.AwardingAgency, 256),
             Amount = record.Amount ?? 0m,
             TotalOutlays = record.TotalOutlays,
-            ActionDate = ParseDate(record.StartDate),
+            // The award action date must come from Base Obligation Date (the date the base
+            // award was signed), never from Start Date: the period-of-performance start can
+            // sit years in the future, and a future ActionDate freezes the incremental
+            // import cursor (max(ActionDate)+1 overshoots today) — this stalled prod
+            // ingestion at Feb 2024.
+            ActionDate = ParseDate(record.BaseObligationDate),
             EndDate = ParseDate(record.EndDate),
             LastModifiedDate = ParseDate(record.LastModifiedDate),
             NaicsCode = LeadingToken(record.Naics, 8),
@@ -56,19 +61,26 @@ public static class UsaSpendingAwardMapper
         };
     }
 
+    // Date fields arrive as bare ISO dates, except Last Modified Date which carries a
+    // timestamp ("2026-07-07 17:57:06") — the date-only strict parse silently nulled it
+    // on every row, so both formats are accepted.
+    private static readonly string[] WireDateFormats = ["yyyy-MM-dd", "yyyy-MM-dd HH:mm:ss"];
+
+    // DateTime rather than DateOnly parsing: DateOnly.TryParseExact rejects any format
+    // that carries a time component, which would re-null the timestamped variant.
     private static DateOnly? ParseDate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
             return null;
 
-        return DateOnly.TryParseExact(
+        return DateTime.TryParseExact(
             value.Trim(),
-            "yyyy-MM-dd",
+            WireDateFormats,
             CultureInfo.InvariantCulture,
             DateTimeStyles.None,
             out var date
         )
-            ? date
+            ? DateOnly.FromDateTime(date)
             : null;
     }
 

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Globalization;
+using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
@@ -18,6 +19,10 @@ namespace Equibles.GovernmentContracts.Mcp.Tools;
 [McpServerToolType]
 public class GovernmentContractsTools
 {
+    // Awards whose latest ingested action date lags today by more than this are a data
+    // gap the caller must see: the footer states the (data-driven) max ingested date.
+    private const int StaleCoverageDays = 60;
+
     private readonly GovernmentContractRepository _contractRepository;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly McpToolRunner _runner;
@@ -37,17 +42,28 @@ public class GovernmentContractsTools
     [McpServerTool(Name = "GetGovernmentContracts")]
     [Description(
         "Get federal government contract awards (from USAspending.gov) won by a specific public company. "
-            + "Shows the awarding agency, award amount, period dates, and description — useful for gauging a "
-            + "company's reliance on federal spending."
+            + "Shows the award (action) date, awarding agency, total value (obligated dollars plus "
+            + "unexercised ceiling — not revenue received), period-of-performance end date, and description. "
+            + "Coverage: only prime contract awards of $1M or more that resolve to a listed company are "
+            + "included, so sums understate total federal revenue. Useful for gauging a company's reliance "
+            + "on federal spending; use GetTopGovernmentContractors to rank companies market-wide."
     )]
     public Task<string> GetGovernmentContracts(
         [Description("Stock ticker symbol (e.g., LMT, RTX, BA)")] string ticker,
-        [Description("Start date in YYYY-MM-DD format (defaults to 1 year ago)")]
+        [Description(
+            "Start date in YYYY-MM-DD format, filtering on the award action date (defaults to 1 year ago)"
+        )]
             string startDate = null,
-        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
-            string endDate = null,
-        [Description("Maximum number of awards to return (default: 50, largest first)")]
-            int maxResults = 50
+        [Description("End date in YYYY-MM-DD format (defaults to today)")] string endDate = null,
+        [Description("Maximum number of awards to return (default: 50)")] int maxResults = 50,
+        [Description(
+            "Sort order: 'amount' (largest total value first, default) or 'date' (most recent award first)"
+        )]
+            string sortBy = "amount",
+        [Description(
+            "Optional case-insensitive substring filter on the awarding agency (e.g., 'Defense')"
+        )]
+            string agency = null
     )
     {
         return _runner.Execute(
@@ -57,30 +73,50 @@ public class GovernmentContractsTools
                 if (stockError != null)
                     return stockError;
 
-                var (start, end) = McpToolExecutor.ParseDateRange(
-                    startDate,
-                    endDate,
-                    McpToolExecutor.UtcYearsAgo(1)
-                );
+                var (start, end, rangeError) = ParseAwardDateRange(startDate, endDate);
+                if (rangeError != null)
+                    return rangeError;
+
+                var (sortByDate, sortError) = ParseSortBy(sortBy);
+                if (sortError != null)
+                    return sortError;
+
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var awards = await _contractRepository
+                var query = _contractRepository
                     .GetByCommonStock(stock)
-                    .Where(c => c.ActionDate >= start && c.ActionDate <= end)
-                    .OrderByDescending(c => c.Amount)
-                    .Take(maxResults)
-                    .ToListAsync();
+                    .Where(c => c.ActionDate >= start && c.ActionDate <= end);
 
-                return MarkdownTable.Render(
+                if (!string.IsNullOrWhiteSpace(agency))
+                {
+                    var agencyTerm = agency.Trim().ToLower();
+                    query = query.Where(c =>
+                        c.AwardingAgency != null && c.AwardingAgency.ToLower().Contains(agencyTerm)
+                    );
+                }
+
+                var totalCount = await query.CountAsync();
+                var totalValue = totalCount == 0 ? 0m : await query.SumAsync(c => c.Amount);
+
+                var ordered = sortByDate
+                    ? query.OrderByDescending(c => c.ActionDate).ThenByDescending(c => c.Amount)
+                    : query.OrderByDescending(c => c.Amount);
+                var awards = await ordered.Take(maxResults).ToListAsync();
+
+                var table = MarkdownTable.Render(
                     awards,
-                    $"No federal contract awards found for {stock.Ticker} in the specified date range.",
-                    $"Federal contract awards for {stock.Ticker} ({stock.Name}):",
-                    "| Action Date | Agency | Type | Amount | Award ID | Description |",
-                    "|-------------|--------|------|--------|----------|-------------|",
+                    $"No federal contract awards found for {stock.Ticker} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
+                    $"Federal contract awards for {stock.Ticker} ({stock.Name}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd} "
+                        + $"— {totalCount} awards totaling {FormatUsd(totalValue)}:",
+                    "| Award Date | Agency | Type | Total Value (obligated + ceiling) | Period End | Award ID | Description |",
+                    "|------------|--------|------|-----------------------------------|------------|----------|-------------|",
                     c =>
                         $"| {Format(c.ActionDate)} | {Escape(c.AwardingAgency)} | {AwardTypeLabel(c.AwardType)} "
-                        + $"| {FormatUsd(c.Amount)} | {Escape(c.AwardId)} | {Escape(Shorten(c.Description, 80))} |"
+                        + $"| {FormatUsd(c.Amount)} | {Format(c.EndDate)} | {Escape(c.AwardId)} "
+                        + $"| {Escape(Shorten(c.Description, 80))} |"
                 );
+
+                return await AppendFooters(table, awards.Count, totalCount, end);
             },
             "GetGovernmentContracts",
             $"ticker: {ticker}"
@@ -90,14 +126,17 @@ public class GovernmentContractsTools
     [McpServerTool(Name = "GetTopGovernmentContractors")]
     [Description(
         "Rank public companies by total federal contract dollars awarded over a date range (from "
-            + "USAspending.gov). Answers questions like 'which public companies won the most federal contracts "
-            + "last quarter'."
+            + "USAspending.gov). Sums the total award value (obligated dollars plus unexercised ceiling) of "
+            + "prime contract awards of $1M or more that resolve to a listed company; smaller awards and "
+            + "unlisted recipients are excluded. Answers questions like 'which public companies won the most "
+            + "federal contracts last quarter'. Use GetGovernmentContracts for one company's individual awards."
     )]
     public Task<string> GetTopGovernmentContractors(
-        [Description("Start date in YYYY-MM-DD format (defaults to 1 year ago)")]
+        [Description(
+            "Start date in YYYY-MM-DD format, filtering on the award action date (defaults to 1 year ago)"
+        )]
             string startDate = null,
-        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
-            string endDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to today)")] string endDate = null,
         [Description("Maximum number of companies to return (default: 25, largest first)")]
             int maxResults = 25
     )
@@ -105,16 +144,22 @@ public class GovernmentContractsTools
         return _runner.Execute(
             async () =>
             {
-                var (start, end) = McpToolExecutor.ParseDateRange(
-                    startDate,
-                    endDate,
-                    McpToolExecutor.UtcYearsAgo(1)
-                );
+                var (start, end, rangeError) = ParseAwardDateRange(startDate, endDate);
+                if (rangeError != null)
+                    return rangeError;
+
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var ranked = await _contractRepository
+                var window = _contractRepository
                     .GetAll()
-                    .Where(c => c.ActionDate >= start && c.ActionDate <= end)
+                    .Where(c => c.ActionDate >= start && c.ActionDate <= end);
+
+                var totalCompanies = await window
+                    .Select(c => c.CommonStockId)
+                    .Distinct()
+                    .CountAsync();
+
+                var ranked = await window
                     .GroupBy(c => new
                     {
                         c.CommonStockId,
@@ -133,19 +178,132 @@ public class GovernmentContractsTools
                     .ToListAsync();
 
                 var rank = 0;
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     ranked,
-                    "No federal contract awards found in the specified date range.",
+                    $"No federal contract awards found between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
                     $"Top federal contractors ({start:yyyy-MM-dd} to {end:yyyy-MM-dd}):",
-                    "| Rank | Ticker | Company | Total Awarded | Awards |",
-                    "|------|--------|---------|---------------|--------|",
+                    "| Rank | Ticker | Company | Total Value (obligated + ceiling) | Awards |",
+                    "|------|--------|---------|-----------------------------------|--------|",
                     r =>
                         $"| {++rank} | {Escape(r.Ticker)} | {Escape(r.Name)} | {FormatUsd(r.Total)} | {r.Count} |"
                 );
+
+                return await AppendFooters(table, ranked.Count, totalCompanies, end);
             },
             "GetTopGovernmentContractors",
             $"range: {startDate}..{endDate}"
         );
+    }
+
+    // Every result carries the dataset's coverage limits and its true recency, so a sparse
+    // window reads as a data gap rather than as an absence of awards.
+    private async Task<string> AppendFooters(string table, int shown, int total, DateOnly rangeEnd)
+    {
+        var sb = new StringBuilder(table.TrimEnd('\n', '\r'));
+        sb.AppendLine();
+        sb.AppendLine();
+
+        var truncationNote = McpOutput.TruncationNote(shown, total);
+        if (truncationNote.Length > 0)
+            sb.AppendLine(truncationNote);
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        // Future action dates are upstream glitches, not evidence of coverage — the
+        // freshness statement keys on the newest credible (non-future) action date.
+        var latestIngested = await _contractRepository
+            .GetAll()
+            .Where(c => c.ActionDate != null && c.ActionDate <= today)
+            .MaxAsync(c => c.ActionDate);
+
+        sb.AppendLine(
+            "_Coverage: prime federal contract awards of $1M+ matched to listed companies; "
+                + "Total Value is obligated dollars plus unexercised option ceiling, not revenue received. "
+                + $"Latest ingested award action date: {Format(latestIngested)}._"
+        );
+
+        if (latestIngested == null)
+        {
+            sb.AppendLine("_Data coverage warning: no award data has been ingested yet._");
+        }
+        else if (latestIngested < today.AddDays(-StaleCoverageDays) && rangeEnd > latestIngested)
+        {
+            sb.AppendLine(
+                $"_Data coverage warning: no awards have been ingested after {Format(latestIngested)}; "
+                    + "results after that date are incomplete._"
+            );
+        }
+
+        return sb.ToString();
+    }
+
+    // Strict date arguments: a malformed date must correct the caller, never silently fall
+    // back to the default window — the caller could not tell which range was actually applied.
+    private static (DateOnly Date, string Error) ParseDateArgument(
+        string value,
+        string argumentName,
+        DateOnly fallback
+    )
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return (fallback, null);
+        if (McpOutput.TryParseDate(value, out var parsed))
+            return (DateOnly.FromDateTime(parsed), null);
+        return (default, McpOutput.InvalidArgument(argumentName, value, "yyyy-MM-dd"));
+    }
+
+    private static (DateOnly Start, DateOnly End, string Error) ParseAwardDateRange(
+        string startDate,
+        string endDate
+    )
+    {
+        var (start, startError) = ParseDateArgument(
+            startDate,
+            "startDate",
+            McpToolExecutor.UtcYearsAgo(1)
+        );
+        if (startError != null)
+            return (default, default, startError);
+
+        var (end, endError) = ParseDateArgument(
+            endDate,
+            "endDate",
+            DateOnly.FromDateTime(DateTime.UtcNow)
+        );
+        if (endError != null)
+            return (default, default, endError);
+
+        // An inverted range must error, never return the generic empty-result message —
+        // the caller would misread it as "the company won no awards".
+        if (start > end)
+            return (
+                default,
+                default,
+                $"Invalid date range: startDate {start:yyyy-MM-dd} is after endDate {end:yyyy-MM-dd}."
+            );
+
+        return (start, end, null);
+    }
+
+    // An unrecognised sort must error, never silently fall back to amount ordering: a
+    // caller asking for recent awards would misread the largest-first rows as the newest.
+    private static (bool ByDate, string Error) ParseSortBy(string sortBy)
+    {
+        if (string.IsNullOrWhiteSpace(sortBy))
+            return (false, null);
+
+        return sortBy.Trim().ToLowerInvariant() switch
+        {
+            "amount" => (false, null),
+            "date" => (true, null),
+            _ => (
+                false,
+                McpOutput.InvalidArgument(
+                    "sortBy",
+                    sortBy,
+                    "'amount' (largest first) or 'date' (most recent first)"
+                )
+            ),
+        };
     }
 
     private static string AwardTypeLabel(GovernmentContractAwardType type) =>

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardRecord.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardRecord.cs
@@ -35,6 +35,14 @@ public class UsaSpendingAwardRecord
     [JsonProperty("Contract Award Type")]
     public string ContractAwardType { get; set; }
 
+    /// <summary>
+    /// The date the base award was signed/first obligated — the award's action date.
+    /// Unlike <see cref="StartDate"/> (period-of-performance start, which can sit years
+    /// in the future), this is never a future date.
+    /// </summary>
+    [JsonProperty("Base Obligation Date")]
+    public string BaseObligationDate { get; set; }
+
     [JsonProperty("Start Date")]
     public string StartDate { get; set; }
 

--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -36,6 +36,7 @@ public class UsaSpendingClient : IUsaSpendingClient
         "Total Outlays",
         "Awarding Agency",
         "Contract Award Type",
+        "Base Obligation Date",
         "Start Date",
         "End Date",
         "Last Modified Date",

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCursorTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCursorTests.cs
@@ -1,0 +1,88 @@
+using Equibles.Core.Configuration;
+using Equibles.GovernmentContracts.HostedService.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// Contract: the incremental import cursor resumes the day after the newest credible
+// action date and can never point past today — a single mis-dated future row froze
+// prod ingestion for over two years when the cursor keyed on raw max(ActionDate).
+public class GovernmentContractsImportServiceCursorTests
+{
+    private static readonly DateOnly Today = new(2026, 7, 17);
+
+    [Fact]
+    public void Resumes_the_day_after_the_latest_action_date()
+    {
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            new DateOnly(2026, 6, 1),
+            Today,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(new DateOnly(2026, 6, 2));
+    }
+
+    [Fact]
+    public void Clamps_a_future_action_date_to_today_instead_of_freezing()
+    {
+        // Regression: a 2028-12-31 outlier must not push the cursor into 2029 — the
+        // worst allowed effect is "synced through today" (resume tomorrow).
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            new DateOnly(2028, 12, 31),
+            Today,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(Today.AddDays(1));
+    }
+
+    [Fact]
+    public void Clamps_date_only_max_value_without_overflowing()
+    {
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            DateOnly.MaxValue,
+            Today,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(Today.AddDays(1));
+    }
+
+    [Fact]
+    public void Falls_back_to_the_configured_min_sync_date_when_the_table_is_empty()
+    {
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            null,
+            Today,
+            new WorkerOptions { MinSyncDate = new DateTime(2021, 3, 1) }
+        );
+
+        start.Should().Be(new DateOnly(2021, 3, 1));
+    }
+
+    [Fact]
+    public void Falls_back_to_the_default_floor_when_the_table_is_empty_and_unconfigured()
+    {
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            null,
+            Today,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(new DateOnly(2020, 1, 1));
+    }
+
+    [Fact]
+    public void An_action_date_of_today_resumes_tomorrow()
+    {
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            Today,
+            Today,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(Today.AddDays(1));
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsArgumentParsingTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsArgumentParsingTests.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using Equibles.GovernmentContracts.Mcp.Tools;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// Contract (audit): malformed dates and inverted ranges must return a correcting
+// one-line error, never silently fall back to the default window or the generic
+// "no awards found" message — both mislead the caller into "the company won nothing".
+// Reflection-invoke since the parsers are private static (same pattern as the
+// sibling Shorten surrogate test).
+public class GovernmentContractsToolsArgumentParsingTests
+{
+    private static (DateOnly Start, DateOnly End, string Error) ParseAwardDateRange(
+        string startDate,
+        string endDate
+    )
+    {
+        var method = typeof(GovernmentContractsTools).GetMethod(
+            "ParseAwardDateRange",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        return ((DateOnly, DateOnly, string))method!.Invoke(null, [startDate, endDate]);
+    }
+
+    private static (bool ByDate, string Error) ParseSortBy(string sortBy)
+    {
+        var method = typeof(GovernmentContractsTools).GetMethod(
+            "ParseSortBy",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        return ((bool, string))method!.Invoke(null, [sortBy]);
+    }
+
+    [Fact]
+    public void A_valid_range_parses_without_error()
+    {
+        var (start, end, error) = ParseAwardDateRange("2024-01-01", "2024-12-31");
+
+        error.Should().BeNull();
+        start.Should().Be(new DateOnly(2024, 1, 1));
+        end.Should().Be(new DateOnly(2024, 12, 31));
+    }
+
+    [Fact]
+    public void An_inverted_range_returns_an_explicit_error_naming_both_dates()
+    {
+        var (_, _, error) = ParseAwardDateRange("2026-06-01", "2025-06-01");
+
+        error.Should().Contain("startDate 2026-06-01").And.Contain("endDate 2025-06-01");
+    }
+
+    [Theory]
+    [InlineData("last year")]
+    [InlineData("2026-13-45")]
+    [InlineData("01/02/2026")]
+    public void A_malformed_start_date_is_rejected_not_silently_defaulted(string startDate)
+    {
+        var (_, _, error) = ParseAwardDateRange(startDate, null);
+
+        error.Should().Contain($"Unknown startDate '{startDate}'").And.Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public void A_malformed_end_date_is_rejected_not_silently_defaulted()
+    {
+        var (_, _, error) = ParseAwardDateRange(null, "yesterday");
+
+        error.Should().Contain("Unknown endDate 'yesterday'").And.Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public void Omitted_dates_default_to_the_trailing_year_ending_today()
+    {
+        var (start, end, error) = ParseAwardDateRange(null, null);
+
+        error.Should().BeNull();
+        end.Should().Be(DateOnly.FromDateTime(DateTime.UtcNow));
+        start.Should().Be(end.AddYears(-1));
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("amount", false)]
+    [InlineData("AMOUNT", false)]
+    [InlineData("date", true)]
+    [InlineData(" Date ", true)]
+    public void Sort_by_accepts_amount_and_date_case_insensitively(string sortBy, bool byDate)
+    {
+        var (parsedByDate, error) = ParseSortBy(sortBy);
+
+        error.Should().BeNull();
+        parsedByDate.Should().Be(byDate);
+    }
+
+    [Fact]
+    public void An_unknown_sort_is_rejected_listing_the_accepted_values()
+    {
+        var (_, error) = ParseSortBy("recent");
+
+        error
+            .Should()
+            .Contain("Unknown sortBy 'recent'")
+            .And.Contain("'amount'")
+            .And.Contain("'date'");
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs
@@ -19,6 +19,7 @@ public class UsaSpendingAwardMapperTests
             TotalOutlays = 500_000m,
             AwardingAgency = "Department of Defense",
             ContractAwardType = "DEFINITIVE CONTRACT",
+            BaseObligationDate = "2024-02-20",
             StartDate = "2024-03-15",
             EndDate = "2027-03-14",
             LastModifiedDate = "2024-04-01",
@@ -42,7 +43,7 @@ public class UsaSpendingAwardMapperTests
         entity.AwardType.Should().Be(GovernmentContractAwardType.DefinitiveContract);
         entity.Amount.Should().Be(1_234_567.89m);
         entity.TotalOutlays.Should().Be(500_000m);
-        entity.ActionDate.Should().Be(new DateOnly(2024, 3, 15));
+        entity.ActionDate.Should().Be(new DateOnly(2024, 2, 20));
         entity.EndDate.Should().Be(new DateOnly(2027, 3, 14));
         entity.LastModifiedDate.Should().Be(new DateOnly(2024, 4, 1));
         entity.NaicsCode.Should().Be("336411");
@@ -70,6 +71,45 @@ public class UsaSpendingAwardMapperTests
         record.AwardId = null;
 
         UsaSpendingAwardMapper.Map(record, Guid.NewGuid()).Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_takes_action_date_from_base_obligation_date_not_performance_start()
+    {
+        // Regression (prod incident): mapping the period-of-performance start into
+        // ActionDate stores future dates (PoP starts reach 2028+), and the incremental
+        // import cursor (max(ActionDate)+1) then overshoots today and freezes ingestion.
+        var record = SampleRecord();
+        record.BaseObligationDate = "2024-02-20";
+        record.StartDate = "2028-12-31"; // future PoP start must never become ActionDate
+
+        var entity = UsaSpendingAwardMapper.Map(record, Guid.NewGuid());
+
+        entity.ActionDate.Should().Be(new DateOnly(2024, 2, 20));
+    }
+
+    [Fact]
+    public void Map_parses_the_timestamped_last_modified_date_wire_format()
+    {
+        // USAspending sends Last Modified Date with a time component
+        // ("2026-07-07 17:57:06"); a strict yyyy-MM-dd parse nulled it on every row.
+        var record = SampleRecord();
+        record.LastModifiedDate = "2026-07-07 17:57:06";
+
+        var entity = UsaSpendingAwardMapper.Map(record, Guid.NewGuid());
+
+        entity.LastModifiedDate.Should().Be(new DateOnly(2026, 7, 7));
+    }
+
+    [Fact]
+    public void Map_leaves_action_date_null_when_base_obligation_date_is_missing()
+    {
+        var record = SampleRecord();
+        record.BaseObligationDate = null;
+
+        var entity = UsaSpendingAwardMapper.Map(record, Guid.NewGuid());
+
+        entity.ActionDate.Should().BeNull();
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Fixes all audit findings for the `GetGovernmentContracts` / `GetTopGovernmentContractors` MCP tools. The root cause chain: `UsaSpendingAwardMapper` stored USAspending's **Start Date** (period-of-performance start, which reaches 2028 in prod) as `ActionDate`, and the incremental import cursor keys on `max(ActionDate)+1` — so the cursor overshot today and ingestion froze at ~Feb 2024, leaving the tools serving a one-company "ranking" with full confidence.

## Code changes

**Importer (root cause)**
- `UsaSpendingClient`: requests the **Base Obligation Date** field; `UsaSpendingAwardRecord` carries it.
- `UsaSpendingAwardMapper`: `ActionDate` now maps from Base Obligation Date (the date the base award was signed — never a future date). Period-of-performance end stays in `EndDate`.
- `UsaSpendingAwardMapper.ParseDate`: also accepts the timestamped `Last Modified Date` wire format ("yyyy-MM-dd HH:mm:ss") that the strict date-only parse silently nulled on every prod row.
- `GovernmentContractsImportService`: the cursor query ignores future action dates, and the new pure `ResolveStartDate` clamps to today — a mis-dated row can never freeze imports again. Unit-tested (`GovernmentContractsImportServiceCursorTests`).
- `GovernmentContract` doc comments corrected (`ActionDate`, `LastModifiedDate`).

**MCP tools**
- Strict arguments: malformed `startDate`/`endDate` and unknown `sortBy` values return correcting one-line errors (via `McpOutput`); inverted ranges error explicitly instead of returning the generic empty-result message.
- True totals + truncation: both tools count/sum the full matching set before `Take`, show it in the header, and append the standard truncation note.
- Truthful columns: `Award Date`, `Total Value (obligated + ceiling)`, and a new `Period End` column so the promised period dates actually render.
- Coverage footer on every reply: $1M prime-award floor, listed-company matching, the latest ingested award action date (data-driven), and a staleness warning when the requested window extends more than 60 days past it.
- New optional parameters (additive only): `sortBy` ('amount' default | 'date') and `agency` substring filter on `GetGovernmentContracts`.
- Tool/parameter descriptions updated: $1M floor, sibling-tool cross-references, "defaults to today".

## Tests
- 68 GovernmentContracts-scoped unit tests green (17 new: mapper regression, cursor policy, argument parsing).
- `Equibles.Mcp.Server` and `Equibles.Worker.Host` build clean.