### PR TITLE
fix(mcp): fred economic tools audit fixes (calendar importer, strict args, truncation, category search)

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/CuratedSeriesRegistry.cs
+++ b/src/Equibles.Fred.HostedService/Services/CuratedSeriesRegistry.cs
@@ -55,7 +55,9 @@ public static class CuratedSeriesRegistry
         new("SP500", FredSeriesCategory.Market),
         new("VIXCLS", FredSeriesCategory.Market),
         new("NFCI", FredSeriesCategory.Market),
-        new("STLFSI2", FredSeriesCategory.Market),
+        // STLFSI4 supersedes the discontinued STLFSI2 (frozen at 2022-01-07), whose
+        // stale value polluted the "current macro conditions" snapshot.
+        new("STLFSI4", FredSeriesCategory.Market),
     ];
 }
 

--- a/src/Equibles.Fred.HostedService/Services/FredReleaseCalendarImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredReleaseCalendarImportService.cs
@@ -5,6 +5,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Fred.Data.Models;
 using Equibles.Fred.Repositories;
 using Equibles.Integrations.Fred.Contracts;
+using Equibles.Integrations.Fred.Models;
 using Equibles.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -171,25 +172,49 @@ public class FredReleaseCalendarImportService : IImporter
             return;
         }
 
-        var records = await _fredClient.GetReleaseDates();
+        // One cheap per-release call per tracked release instead of paging the global
+        // /fred/releases/dates feed: FRED reliably 504s that feed at offset >= 1000, and
+        // a single failed page aborted the whole cycle — the calendar then froze at its
+        // last successful import. The per-release endpoint answers instantly, and a
+        // failing release only skips that release, never the cycle. realtimeStart mirrors
+        // the global feed's default window (first day of the current month onward);
+        // without it the per-release endpoint returns all history back to 1776.
+        var utcToday = DateTime.UtcNow;
+        var realtimeStart = new DateOnly(utcToday.Year, utcToday.Month, 1);
 
-        // The endpoint returns dates for every FRED release; keep only the ones
-        // belonging to releases our series actually link to.
         var parsed = new List<(Guid ReleaseId, DateOnly Date)>();
-        foreach (var record in records)
+        foreach (var (fredReleaseId, releaseId) in trackedReleases.OrderBy(r => r.Key))
         {
-            if (!trackedReleases.TryGetValue(record.ReleaseId, out var releaseId))
+            cancellationToken.ThrowIfCancellationRequested();
+
+            List<FredReleaseDateRecord> records;
+            try
+            {
+                records = await _fredClient.GetReleaseDates(fredReleaseId, realtimeStart);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to fetch FRED release dates for release {ReleaseId}, skipping it this cycle",
+                    fredReleaseId
+                );
                 continue;
-            if (
-                !DateOnly.TryParse(
-                    record.Date,
-                    CultureInfo.InvariantCulture,
-                    DateTimeStyles.None,
-                    out var date
+            }
+
+            foreach (var record in records)
+            {
+                if (
+                    !DateOnly.TryParse(
+                        record.Date,
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.None,
+                        out var date
+                    )
                 )
-            )
-                continue;
-            parsed.Add((releaseId, date));
+                    continue;
+                parsed.Add((releaseId, date));
+            }
         }
 
         if (parsed.Count == 0)

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -36,16 +36,18 @@ public class FredTools
 
     [McpServerTool(Name = "GetEconomicIndicator")]
     [Description(
-        "Get time series data for a FRED economic indicator. Returns historical observations for indicators like FEDFUNDS (fed funds rate), CPIAUCSL (CPI inflation), UNRATE (unemployment), GDP, T10Y2Y (yield spread), VIXCLS (VIX), SP500, MORTGAGE30US, M2SL (money supply), and more. Use SearchEconomicIndicators to find available series."
+        "Get time series data for a FRED economic indicator. Returns historical observations for indicators like FEDFUNDS (fed funds rate), CPIAUCSL (CPI inflation), UNRATE (unemployment), GDP, T10Y2Y (yield spread), VIXCLS (VIX), SP500, MORTGAGE30US, M2SL (money supply), and more. Covers the curated ~40-series set Equibles tracks, not the full FRED catalog — use SearchEconomicIndicators to find available series."
     )]
     public Task<string> GetEconomicIndicator(
         [Description("FRED series ID (e.g., FEDFUNDS, CPIAUCSL, UNRATE, GDP, T10Y2Y, VIXCLS)")]
             string seriesId,
-        [Description("Start date in YYYY-MM-DD format (defaults to 1 year ago)")]
+        [Description("Start date in YYYY-MM-DD format (defaults to 1 year before the end date)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of observations to return (default: 100, newest first)")]
+        [Description(
+            "Maximum number of observations to return (default: 100, max: 500). When the range holds more, the newest maxResults are kept; rows are always listed in ascending date order."
+        )]
             int maxResults = 100
     )
     {
@@ -59,21 +61,38 @@ public class FredTools
                 if (series == null)
                     return $"Series '{seriesId}' not found. Use SearchEconomicIndicators to find available series.";
 
-                var (start, end) = McpToolExecutor.ParseDateRange(
-                    startDate,
-                    endDate,
-                    McpToolExecutor.UtcYearsAgo(1)
-                );
+                var end = DateOnly.FromDateTime(DateTime.UtcNow);
+                if (!string.IsNullOrWhiteSpace(endDate))
+                {
+                    if (!McpOutput.TryParseDate(endDate, out var parsedEnd))
+                        return McpOutput.InvalidArgument("endDate", endDate, "yyyy-MM-dd");
+                    end = DateOnly.FromDateTime(parsedEnd);
+                }
+
+                // Default the start RELATIVE to the (possibly historical) end date, so
+                // "endDate=2020-12-31" alone means the year up to then — not an empty
+                // range against a start defaulted off today.
+                var start = end.AddYears(-1);
+                if (!string.IsNullOrWhiteSpace(startDate))
+                {
+                    if (!McpOutput.TryParseDate(startDate, out var parsedStart))
+                        return McpOutput.InvalidArgument("startDate", startDate, "yyyy-MM-dd");
+                    start = DateOnly.FromDateTime(parsedStart);
+                }
+
+                if (start > end)
+                    return $"startDate ({start:yyyy-MM-dd}) is after endDate ({end:yyyy-MM-dd}). Swap or correct the dates.";
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var observations = await _observationRepository
-                    .GetBySeries(series, start, end)
+                var rangeQuery = _observationRepository.GetBySeries(series, start, end);
+                var total = await rangeQuery.CountAsync();
+                var observations = await rangeQuery
                     .OrderByDescending(o => o.Date)
                     .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     observations.OrderBy(o => o.Date).ToList(),
                     $"No observations found for {series.SeriesId} ({series.Title}) in the specified date range.",
                     $"{series.Title} ({series.SeriesId})",
@@ -90,6 +109,21 @@ public class FredTools
                         return $"| {obs.Date:yyyy-MM-dd} | {valueStr} |";
                     }
                 );
+
+                // The kept rows are the NEWEST maxResults of the range (rendered
+                // ascending), so the shared "first N" truncation note would mislabel
+                // them — spell the newest-kept semantics out instead. Without a note a
+                // long range over a daily series silently loses its start and reads as
+                // if the older data does not exist.
+                if (observations.Count < total)
+                {
+                    table +=
+                        Environment.NewLine
+                        + $"_Showing the newest {observations.Count} of {total} observations in the range - raise maxResults (max {McpLimit.MaxResults}) or narrow the date range for earlier data._"
+                        + Environment.NewLine;
+                }
+
+                return table;
             },
             "GetEconomicIndicator",
             $"seriesId: {seriesId}"
@@ -98,7 +132,7 @@ public class FredTools
 
     [McpServerTool(Name = "GetLatestEconomicData")]
     [Description(
-        "Get the latest values for key economic indicators across categories: interest rates, yield spreads, inflation, employment, GDP, money supply, sentiment, housing, exchange rates, and market indicators. Returns a snapshot of current macro conditions."
+        "Get the latest values for key economic indicators across categories: interest rates, yield spreads, inflation, employment, GDP, money supply, sentiment, housing, exchange rates, and market indicators. Each row shows a series' latest stored observation with its date, plus the previous observation and the change between them for direction — check the Latest Date column for freshness. Returns a snapshot of current macro conditions."
     )]
     public Task<string> GetLatestEconomicData(
         [Description(
@@ -112,11 +146,30 @@ public class FredTools
             {
                 IQueryable<FredSeries> seriesQuery;
 
-                if (
-                    !string.IsNullOrEmpty(category)
-                    && Enum.TryParse<FredSeriesCategory>(category, true, out var parsedCategory)
-                )
+                if (!string.IsNullOrWhiteSpace(category))
                 {
+                    // Reject anything that does not name a category instead of silently
+                    // returning the unfiltered snapshot: a near-miss guess ("Rates",
+                    // "GDP") must surface, not read as if the filter applied. The
+                    // int guard exists because Enum.TryParse accepts numeric strings
+                    // ("5") and would select a category by ordinal.
+                    if (
+                        int.TryParse(category, out _)
+                        || !Enum.TryParse<FredSeriesCategory>(
+                            category,
+                            true,
+                            out var parsedCategory
+                        )
+                        || !Enum.IsDefined(parsedCategory)
+                    )
+                    {
+                        return McpOutput.InvalidArgument(
+                            "category",
+                            category,
+                            string.Join(", ", Enum.GetNames<FredSeriesCategory>())
+                        );
+                    }
+
                     seriesQuery = _seriesRepository.GetByCategory(parsedCategory);
                 }
                 else
@@ -136,10 +189,14 @@ public class FredTools
                     .GetLatestPerSeries()
                     .ToDictionaryAsync(o => o.FredSeriesId);
 
+                var previousObservations = await _observationRepository
+                    .GetPreviousPerSeries()
+                    .ToDictionaryAsync(o => o.FredSeriesId);
+
                 var result = MarkdownTable.Start(
                     "Latest Economic Indicators:",
-                    "| Series | Title | Latest Date | Value | Units |",
-                    "|--------|-------|-------------|-------|-------|"
+                    "| Series | Title | Latest Date | Value | Previous | Change | Units |",
+                    "|--------|-------|-------------|-------|----------|--------|-------|"
                 );
 
                 var currentCategory = (FredSeriesCategory?)null;
@@ -149,16 +206,27 @@ public class FredTools
                     if (currentCategory != series.Category)
                     {
                         currentCategory = series.Category;
-                        result.AppendLine($"| **{series.Category}** | | | | |");
+                        result.AppendLine($"| **{series.Category}** | | | | | | |");
                     }
 
                     latestObservations.TryGetValue(series.Id, out var latestObs);
+                    previousObservations.TryGetValue(series.Id, out var previousObs);
 
                     var dateStr = McpFormat.OrDash(latestObs?.Date, "yyyy-MM-dd");
                     var valueStr = McpFormat.OrDash(latestObs?.Value, "G");
+                    var previousStr = McpFormat.OrDash(previousObs?.Value, "G");
+
+                    decimal? change =
+                        latestObs?.Value != null && previousObs?.Value != null
+                            ? latestObs.Value.Value - previousObs.Value.Value
+                            : null;
+                    var changeStr =
+                        change > 0
+                            ? "+" + McpFormat.Invariant(change.Value, "G")
+                            : McpFormat.OrDash(change, "G");
 
                     result.AppendLine(
-                        $"| {series.SeriesId} | {series.Title} | {dateStr} | {valueStr} | {series.Units} |"
+                        $"| {series.SeriesId} | {series.Title} | {dateStr} | {valueStr} | {previousStr} | {changeStr} | {series.Units} |"
                     );
                 }
 
@@ -171,14 +239,15 @@ public class FredTools
 
     [McpServerTool(Name = "SearchEconomicIndicators")]
     [Description(
-        "Search for available FRED economic indicator series by name or series ID. Returns matching series with their metadata. Use this to discover what economic data is available before calling GetEconomicIndicator."
+        "Search the curated set of ~40 US macro FRED series Equibles tracks (rates, inflation, employment, GDP, housing, market indicators) — not the full FRED catalog. Matches series ID, title, and category name: a category query like 'inflation' returns that whole category (CPI, PCE, PPI, breakevens), and an empty query lists every tracked series. Use this to discover what economic data is available before calling GetEconomicIndicator."
     )]
     public Task<string> SearchEconomicIndicators(
         [Description(
-            "Search query — series ID or title keyword (e.g., 'inflation', 'unemployment', 'GDP', 'FEDFUNDS')"
+            "Search query — series ID, title keyword, or category name (e.g., 'inflation', 'unemployment', 'GDP', 'FEDFUNDS'). Empty lists all tracked series."
         )]
             string query,
-        [Description("Maximum number of results to return (default: 20)")] int maxResults = 20
+        [Description("Maximum number of results to return (default: 20, max: 500)")]
+            int maxResults = 20
     )
     {
         return _runner.Execute(
@@ -186,21 +255,34 @@ public class FredTools
             {
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var series = await _seriesRepository
-                    .Search(query)
+                var matches = _seriesRepository.Search(query);
+                var total = await matches.CountAsync();
+                var series = await matches
                     .OrderBy(s => s.Category)
                     .ThenBy(s => s.SeriesId)
                     .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var title = string.IsNullOrWhiteSpace(query)
+                    ? "All tracked economic indicator series:"
+                    : $"Economic indicators matching '{query}':";
+
+                var table = MarkdownTable.Render(
                     series,
-                    $"No series found matching '{query}'.",
-                    $"Economic indicators matching '{query}':",
+                    $"No tracked series match '{query}'. Equibles tracks a curated ~40-series US macro set - FRED series outside it are not available. Try a category name (Inflation, Employment, InterestRates, ...) or an empty query to list all tracked series.",
+                    title,
                     "| Series ID | Title | Category | Frequency | Units |",
                     "|-----------|-------|----------|-----------|-------|",
                     s => $"| {s.SeriesId} | {s.Title} | {s.Category} | {s.Frequency} | {s.Units} |"
                 );
+
+                var truncation = McpOutput.TruncationNote(series.Count, total);
+                if (truncation.Length > 0)
+                {
+                    table += Environment.NewLine + truncation + Environment.NewLine;
+                }
+
+                return table;
             },
             "SearchEconomicIndicators",
             $"query: {query}"
@@ -209,7 +291,7 @@ public class FredTools
 
     [McpServerTool(Name = "GetEconomicCalendar")]
     [Description(
-        "Get the economic release calendar — scheduled (upcoming) and recent publication dates of US macro data releases, with the FRED series each release updates and an importance tier per release (High = the tier-1 scheduled market movers: CPI, PPI, Employment Situation, GDP, PCE, retail sales, FOMC; Medium = other genuine scheduled prints; Low = daily rate/market levels like SOFR or VIX). Defaults to the next 30 days. Use minImportance=high to see only the market movers, and GetEconomicIndicator to fetch a series' data after it prints."
+        "Get the economic release calendar — scheduled (upcoming) and recent publication dates of US macro data releases, with the FRED series each release updates and an importance tier per release (High = the tier-1 scheduled market movers: CPI, PPI, Employment Situation, GDP, PCE, retail sales; Medium = other genuine scheduled prints; Low = daily rate/market levels like SOFR or VIX). FOMC meetings are NOT included — FRED's release feed has no real FOMC meeting dates; use the Federal Reserve's published meeting calendar for those. Defaults to the next 30 days. Use minImportance=high to see only the market movers, and GetEconomicIndicator to fetch a series' data after it prints."
     )]
     public Task<string> GetEconomicCalendar(
         [Description("Start date in YYYY-MM-DD format (defaults to today, UTC)")]
@@ -220,31 +302,64 @@ public class FredTools
             "Minimum importance tier to include: low, medium, or high (defaults to low = everything)"
         )]
             string minImportance = null,
-        [Description("Maximum number of release dates to return (default: 100, chronological)")]
+        [Description(
+            "Maximum number of release dates to return (default: 100, max: 500, chronological)"
+        )]
             int maxResults = 100
     )
     {
         return _runner.Execute(
             async () =>
             {
+                // The int guard exists because Enum.TryParse accepts numeric strings:
+                // minImportance="5" would parse to an undefined tier that filters out
+                // everything and reads as a factual "no releases" answer.
                 var minTier = FredReleaseImportance.Low;
                 if (
                     !string.IsNullOrWhiteSpace(minImportance)
-                    && !Enum.TryParse(minImportance, true, out minTier)
+                    && (
+                        int.TryParse(minImportance, out _)
+                        || !Enum.TryParse(minImportance, true, out minTier)
+                        || !Enum.IsDefined(minTier)
+                    )
                 )
                 {
-                    return $"Invalid minImportance '{minImportance}'. Valid tiers: low, medium, high.";
+                    return McpOutput.InvalidArgument(
+                        "minImportance",
+                        minImportance,
+                        "low, medium, high"
+                    );
                 }
 
                 var today = DateOnly.FromDateTime(DateTime.UtcNow);
-                var start = McpToolExecutor.ParseDateOr(startDate, today);
-                var end = McpToolExecutor.ParseDateOr(endDate, start.AddDays(30));
+                var start = today;
+                if (!string.IsNullOrWhiteSpace(startDate))
+                {
+                    if (!McpOutput.TryParseDate(startDate, out var parsedStart))
+                        return McpOutput.InvalidArgument("startDate", startDate, "yyyy-MM-dd");
+                    start = DateOnly.FromDateTime(parsedStart);
+                }
+
+                var end = start.AddDays(30);
+                if (!string.IsNullOrWhiteSpace(endDate))
+                {
+                    if (!McpOutput.TryParseDate(endDate, out var parsedEnd))
+                        return McpOutput.InvalidArgument("endDate", endDate, "yyyy-MM-dd");
+                    end = DateOnly.FromDateTime(parsedEnd);
+                }
+
+                if (start > end)
+                    return $"startDate ({start:yyyy-MM-dd}) is after endDate ({end:yyyy-MM-dd}). Swap or correct the dates.";
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var entries = await _releaseDateRepository
+                var inRange = _releaseDateRepository
                     .GetInRange(start, end)
-                    .Where(d => d.FredRelease.Importance >= minTier)
+                    .Where(d => d.FredRelease.Importance >= minTier);
+
+                var total = await inRange.CountAsync();
+
+                var entries = await inRange
                     .OrderBy(d => d.Date)
                     .ThenByDescending(d => d.FredRelease.Importance)
                     .ThenBy(d => d.FredRelease.Name)
@@ -261,15 +376,34 @@ public class FredTools
                     })
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                // A truncated calendar must not present the requested range as fully
+                // covered — otherwise the tail of the window silently reads as
+                // "nothing scheduled". Name the last date actually shown in the header
+                // and add the standard footer.
+                var truncated = entries.Count < total;
+                var title = truncated
+                    ? $"Economic release calendar ({start:yyyy-MM-dd} to {end:yyyy-MM-dd} requested; truncated at {entries.Count} rows, shown only through {entries[^1].Date:yyyy-MM-dd}):"
+                    : $"Economic release calendar ({start:yyyy-MM-dd} to {end:yyyy-MM-dd}):";
+
+                var table = MarkdownTable.Render(
                     entries,
                     $"No economic releases between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
-                    $"Economic release calendar ({start:yyyy-MM-dd} to {end:yyyy-MM-dd}):",
+                    title,
                     "| Date | Release | Importance | Series Updated |",
                     "|------|---------|------------|----------------|",
                     e =>
                         $"| {e.Date:yyyy-MM-dd} | {e.ReleaseName} | {e.Importance} | {string.Join(", ", e.Series)} |"
                 );
+
+                if (truncated)
+                {
+                    table +=
+                        Environment.NewLine
+                        + McpOutput.TruncationNote(entries.Count, total)
+                        + Environment.NewLine;
+                }
+
+                return table;
             },
             "GetEconomicCalendar",
             $"startDate: {startDate}, endDate: {endDate}, minImportance: {minImportance}"

--- a/src/Equibles.Fred.Repositories/FredObservationRepository.cs
+++ b/src/Equibles.Fred.Repositories/FredObservationRepository.cs
@@ -36,4 +36,18 @@ public class FredObservationRepository : BaseRepository<FredObservation>
             .GroupBy(o => o.FredSeriesId)
             .Select(g => g.OrderByDescending(o => o.Date).First());
     }
+
+    // The observation immediately before the latest one, per series — the "previous"
+    // column of the latest-data snapshot. The Count() > 1 guard is load-bearing:
+    // without it EF materializes a NULL element for every single-observation series
+    // (LEFT JOIN LATERAL with an empty OFFSET 1 subquery), which would NRE any
+    // ToDictionary over the results.
+    public IQueryable<FredObservation> GetPreviousPerSeries()
+    {
+        return GetAll()
+            .Where(o => o.Value != null)
+            .GroupBy(o => o.FredSeriesId)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.OrderByDescending(o => o.Date).Skip(1).First());
+    }
 }

--- a/src/Equibles.Fred.Repositories/FredSeriesRepository.cs
+++ b/src/Equibles.Fred.Repositories/FredSeriesRepository.cs
@@ -20,8 +20,43 @@ public class FredSeriesRepository : BaseRepository<FredSeries>
 
     public IQueryable<FredSeries> Search(string query)
     {
-        var lower = query.ToLower();
+        var lower = (query ?? string.Empty).Trim().ToLower();
+        if (lower.Length == 0)
+            return GetAll();
+
+        // Category-name matches widen recall: "inflation" must return the whole
+        // Inflation category (CPI, PCE, PPI, breakevens), not only the titles that
+        // happen to contain the word. Matched categories are computed client-side
+        // (the universe is a fixed enum) so the EF query stays a translatable
+        // Contains over SeriesId/Title plus a constant category list.
+        var matchedCategories = MatchCategories(lower);
         return GetAll()
-            .Where(s => s.SeriesId.ToLower().Contains(lower) || s.Title.ToLower().Contains(lower));
+            .Where(s =>
+                s.SeriesId.ToLower().Contains(lower)
+                || s.Title.ToLower().Contains(lower)
+                || matchedCategories.Contains(s.Category)
+            );
     }
+
+    // A category matches when its name contains the query ("inflation" -> Inflation,
+    // "rates" -> InterestRates/ExchangeRates) or the query contains the name
+    // ("unemployment" contains "employment" -> Employment). Both sides are reduced
+    // to lowercase alphanumerics so "interest rates" still matches InterestRates.
+    private static List<FredSeriesCategory> MatchCategories(string lowerQuery)
+    {
+        var normalizedQuery = NormalizeForCategoryMatch(lowerQuery);
+        if (normalizedQuery.Length == 0)
+            return [];
+
+        return Enum.GetValues<FredSeriesCategory>()
+            .Where(c =>
+            {
+                var name = NormalizeForCategoryMatch(c.ToString().ToLower());
+                return name.Contains(normalizedQuery) || normalizedQuery.Contains(name);
+            })
+            .ToList();
+    }
+
+    private static string NormalizeForCategoryMatch(string text) =>
+        new(text.Where(char.IsLetterOrDigit).ToArray());
 }

--- a/src/Equibles.Integrations.Fred/Contracts/IFredClient.cs
+++ b/src/Equibles.Integrations.Fred/Contracts/IFredClient.cs
@@ -8,5 +8,8 @@ public interface IFredClient
     Task<FredSeriesRecord> GetSeriesMetadata(string seriesId);
     Task<List<FredObservationRecord>> GetObservations(string seriesId, DateOnly? startDate = null);
     Task<FredReleaseRecord> GetSeriesRelease(string seriesId);
-    Task<List<FredReleaseDateRecord>> GetReleaseDates(DateOnly? realtimeStart = null);
+    Task<List<FredReleaseDateRecord>> GetReleaseDates(
+        int releaseId,
+        DateOnly? realtimeStart = null
+    );
 }

--- a/src/Equibles.Integrations.Fred/FredClient.cs
+++ b/src/Equibles.Integrations.Fred/FredClient.cs
@@ -18,7 +18,8 @@ public class FredClient : IFredClient
     private const int MaxRetries = 3;
     private const int MaxObservationsPerRequest = 100000;
 
-    // The /fred/releases/dates endpoint caps its page size at 1000.
+    // Page size for /fred/release/dates. A month-forward per-release window is a
+    // handful of rows, so one page normally suffices; the loop below is a safety net.
     private const int MaxReleaseDatesPerRequest = 1000;
 
     // FRED allows 120 requests/minute — use 100 to stay safely under
@@ -121,20 +122,32 @@ public class FredClient : IFredClient
         return response?.Releases?.FirstOrDefault();
     }
 
-    public async Task<List<FredReleaseDateRecord>> GetReleaseDates(DateOnly? realtimeStart = null)
+    public async Task<List<FredReleaseDateRecord>> GetReleaseDates(
+        int releaseId,
+        DateOnly? realtimeStart = null
+    )
     {
-        _logger.LogDebug("Fetching FRED release dates from {RealtimeStart}", realtimeStart);
+        _logger.LogDebug(
+            "Fetching FRED release dates for release {ReleaseId} from {RealtimeStart}",
+            releaseId,
+            realtimeStart
+        );
 
         var allReleaseDates = new List<FredReleaseDateRecord>();
         var offset = 0;
 
         while (true)
         {
+            // Per-release endpoint on purpose: the global /fred/releases/dates feed
+            // reliably 504s at offset >= 1000, so paging it aborts the whole import.
             // include_release_dates_with_no_data=true is what surfaces future scheduled
             // dates from the FRED release calendar — without it only realized dates return.
+            // NOTE: this endpoint defaults realtime_start to 1776-07-04 (all history);
+            // callers should pass realtimeStart to bound the window.
             var url =
-                $"{ApiBaseUrl}/fred/releases/dates"
-                + $"?api_key={_options.ApiKey}"
+                $"{ApiBaseUrl}/fred/release/dates"
+                + $"?release_id={releaseId}"
+                + $"&api_key={_options.ApiKey}"
                 + $"&file_type=json"
                 + $"&include_release_dates_with_no_data=true"
                 + $"&sort_order=asc"
@@ -159,7 +172,11 @@ public class FredClient : IFredClient
             offset += response.ReleaseDates.Count;
         }
 
-        _logger.LogDebug("Fetched {Count} FRED release dates", allReleaseDates.Count);
+        _logger.LogDebug(
+            "Fetched {Count} FRED release dates for release {ReleaseId}",
+            allReleaseDates.Count,
+            releaseId
+        );
         return allReleaseDates;
     }
 

--- a/tests/Equibles.IntegrationTests/Fred/FredClientGetReleaseDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredClientGetReleaseDatesTests.cs
@@ -8,27 +8,30 @@ using NSubstitute;
 namespace Equibles.IntegrationTests.Fred;
 
 /// <summary>
-/// `GetReleaseDates` feeds the economic release calendar. Pin three contracts:
-/// the URL must request `include_release_dates_with_no_data=true` (that flag is
-/// what surfaces FUTURE scheduled dates — dropping it silently empties the
-/// upcoming calendar), the optional `realtime_start` must be appended in
-/// yyyy-MM-dd, and the offset pagination must accumulate across pages (the
-/// endpoint caps pages at 1000 rows).
+/// `GetReleaseDates` feeds the economic release calendar. It must hit the cheap
+/// PER-RELEASE endpoint `/fred/release/dates?release_id=N` — the global
+/// `/fred/releases/dates` feed reliably 504s at offset >= 1000, which froze the
+/// calendar for a month in production. Pin three contracts: the URL must scope to
+/// the requested release and request `include_release_dates_with_no_data=true`
+/// (that flag is what surfaces FUTURE scheduled dates — dropping it silently
+/// empties the upcoming calendar), the optional `realtime_start` must be appended
+/// in yyyy-MM-dd (without it this endpoint returns all history back to 1776), and
+/// the offset pagination must accumulate across pages.
 /// </summary>
 public class FredClientGetReleaseDatesTests
 {
     [Fact]
-    public async Task GetReleaseDates_RequestsFutureDates_AndPaginatesUntilCountReached()
+    public async Task GetReleaseDates_RequestsPerReleaseFutureDates_AndPaginatesUntilCountReached()
     {
         var page1 = """
             {"count":3,"offset":0,"limit":1000,"release_dates":[
-                {"release_id":10,"release_name":"Consumer Price Index","date":"2026-06-11"},
-                {"release_id":50,"release_name":"Employment Situation","date":"2026-06-12"}
+                {"release_id":46,"date":"2026-08-13"},
+                {"release_id":46,"date":"2026-09-10"}
             ]}
             """;
         var page2 = """
             {"count":3,"offset":2,"limit":1000,"release_dates":[
-                {"release_id":53,"release_name":"Gross Domestic Product","date":"2026-06-25"}
+                {"release_id":46,"date":"2026-10-15"}
             ]}
             """;
         var handler = new ScriptedHandler(page1, page2);
@@ -36,16 +39,16 @@ public class FredClientGetReleaseDatesTests
         var options = Options.Create(new FredOptions { ApiKey = "test-key" });
         var sut = new FredClient(httpClient, Substitute.For<ILogger<FredClient>>(), options);
 
-        var result = await sut.GetReleaseDates();
+        var result = await sut.GetReleaseDates(46);
 
         result.Should().HaveCount(3);
-        result.Select(d => d.ReleaseId).Should().Equal(10, 50, 53);
-        result.Select(d => d.Date).Should().Equal("2026-06-11", "2026-06-12", "2026-06-25");
-        result[0].ReleaseName.Should().Be("Consumer Price Index");
+        result.Select(d => d.ReleaseId).Should().Equal(46, 46, 46);
+        result.Select(d => d.Date).Should().Equal("2026-08-13", "2026-09-10", "2026-10-15");
 
         handler.Requests.Should().HaveCount(2);
         var firstQuery = handler.Requests[0].RequestUri!.Query;
-        handler.Requests[0].RequestUri!.AbsolutePath.Should().Be("/fred/releases/dates");
+        handler.Requests[0].RequestUri!.AbsolutePath.Should().Be("/fred/release/dates");
+        firstQuery.Should().Contain("release_id=46");
         firstQuery.Should().Contain("include_release_dates_with_no_data=true");
         firstQuery.Should().NotContain("realtime_start");
         handler.Requests[1].RequestUri!.Query.Should().Contain("offset=2");
@@ -60,10 +63,11 @@ public class FredClientGetReleaseDatesTests
         var options = Options.Create(new FredOptions { ApiKey = "test-key" });
         var sut = new FredClient(httpClient, Substitute.For<ILogger<FredClient>>(), options);
 
-        var result = await sut.GetReleaseDates(new DateOnly(2026, 1, 1));
+        var result = await sut.GetReleaseDates(10, new DateOnly(2026, 1, 1));
 
         result.Should().BeEmpty();
         handler.Requests.Should().HaveCount(1);
+        handler.Requests[0].RequestUri!.Query.Should().Contain("release_id=10");
         handler.Requests[0].RequestUri!.Query.Should().Contain("realtime_start=2026-01-01");
     }
 

--- a/tests/Equibles.IntegrationTests/Fred/FredObservationRepositoryGetLatestTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredObservationRepositoryGetLatestTests.cs
@@ -84,4 +84,63 @@ public class FredObservationRepositoryGetLatestTests : ParadeDbMcpTestBase
         latest[seriesB.Id].Date.Should().Be(new DateOnly(2024, 12, 1));
         latest[seriesB.Id].Value.Should().Be(4.2m);
     }
+
+    [Fact]
+    public async Task GetPreviousPerSeries_SkipsNullsAndSingleObservationSeries_ReturnsSecondNewest()
+    {
+        var seriesA = new FredSeries { SeriesId = "DGS10", Title = "10-Year Treasury" };
+        var seriesB = new FredSeries { SeriesId = "UNRATE", Title = "Unemployment Rate" };
+        DbContext.Add(seriesA);
+        DbContext.Add(seriesB);
+
+        // seriesA: three rows — newest is null (FRED "."), so "previous" must be
+        // the second-newest REAL value, counting only non-null rows.
+        DbContext.Add(
+            new FredObservation
+            {
+                FredSeriesId = seriesA.Id,
+                Date = new DateOnly(2024, 11, 1),
+                Value = 4.0m,
+            }
+        );
+        DbContext.Add(
+            new FredObservation
+            {
+                FredSeriesId = seriesA.Id,
+                Date = new DateOnly(2024, 12, 1),
+                Value = 4.25m,
+            }
+        );
+        DbContext.Add(
+            new FredObservation
+            {
+                FredSeriesId = seriesA.Id,
+                Date = new DateOnly(2024, 12, 8),
+                Value = null,
+            }
+        );
+
+        // seriesB: a single observation — no previous row must be produced for it.
+        DbContext.Add(
+            new FredObservation
+            {
+                FredSeriesId = seriesB.Id,
+                Date = new DateOnly(2024, 12, 1),
+                Value = 4.2m,
+            }
+        );
+
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new FredObservationRepository(verify);
+
+        var previous = await sut.GetPreviousPerSeries().AsNoTracking().ToListAsync();
+
+        previous.Should().ContainSingle();
+        previous[0].FredSeriesId.Should().Be(seriesA.Id);
+        previous[0].Date.Should().Be(new DateOnly(2024, 11, 1));
+        previous[0].Value.Should().Be(4.0m);
+    }
 }

--- a/tests/Equibles.IntegrationTests/Fred/FredReleaseCalendarImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredReleaseCalendarImportServiceTests.cs
@@ -55,6 +55,18 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
 
     public void Dispose() => _dbContext.Dispose();
 
+    // The importer fetches dates per tracked release (the global feed 504s under
+    // paging); the substitute answers each per-release call with the matching
+    // subset, mirroring the real endpoint's release_id scoping.
+    private void SetupReleaseDates(params FredReleaseDateRecord[] records)
+    {
+        _fredClient
+            .GetReleaseDates(Arg.Any<int>(), Arg.Any<DateOnly?>())
+            .Returns(ci =>
+                Task.FromResult(records.Where(r => r.ReleaseId == ci.Arg<int>()).ToList())
+            );
+    }
+
     [Fact]
     public async Task Import_TwoSeriesSharingARelease_CreatesOneReleaseAndKeepsOnlyTrackedDates()
     {
@@ -71,43 +83,41 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
         };
         _fredClient.GetSeriesRelease("CPIAUCSL").Returns(Task.FromResult(cpiRelease));
         _fredClient.GetSeriesRelease("CPILFESL").Returns(Task.FromResult(cpiRelease));
-        _fredClient
-            .GetReleaseDates(Arg.Any<DateOnly?>())
-            .Returns(
-                Task.FromResult(
-                    new List<FredReleaseDateRecord>
-                    {
-                        new()
-                        {
-                            ReleaseId = 10,
-                            ReleaseName = "Consumer Price Index",
-                            Date = "2026-06-11",
-                        },
-                        new()
-                        {
-                            ReleaseId = 10,
-                            ReleaseName = "Consumer Price Index",
-                            Date = "2026-07-14",
-                        },
-                        // Untracked release — no series of ours links to it.
-                        new()
-                        {
-                            ReleaseId = 99,
-                            ReleaseName = "Some Other Release",
-                            Date = "2026-06-12",
-                        },
-                        // Malformed date — must be skipped, not crash the cycle.
-                        new()
-                        {
-                            ReleaseId = 10,
-                            ReleaseName = "Consumer Price Index",
-                            Date = "not-a-date",
-                        },
-                    }
-                )
-            );
+        SetupReleaseDates(
+            new FredReleaseDateRecord
+            {
+                ReleaseId = 10,
+                ReleaseName = "Consumer Price Index",
+                Date = "2026-06-11",
+            },
+            new FredReleaseDateRecord
+            {
+                ReleaseId = 10,
+                ReleaseName = "Consumer Price Index",
+                Date = "2026-07-14",
+            },
+            // Untracked release — no series of ours links to it, so the importer
+            // must never even request it.
+            new FredReleaseDateRecord
+            {
+                ReleaseId = 99,
+                ReleaseName = "Some Other Release",
+                Date = "2026-06-12",
+            },
+            // Malformed date — must be skipped, not crash the cycle.
+            new FredReleaseDateRecord
+            {
+                ReleaseId = 10,
+                ReleaseName = "Consumer Price Index",
+                Date = "not-a-date",
+            }
+        );
 
         await _sut.Import(CancellationToken.None);
+
+        // Per-release fetching only ever requests tracked releases.
+        await _fredClient.Received(1).GetReleaseDates(10, Arg.Any<DateOnly?>());
+        await _fredClient.DidNotReceive().GetReleaseDates(99, Arg.Any<DateOnly?>());
 
         var releases = _releaseRepo.GetAll().ToList();
         releases.Should().HaveCount(1, "both series share FRED release 10");
@@ -157,22 +167,15 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
         };
         _fredClient.GetSeriesRelease("DFEDTARU").Returns(Task.FromResult(fomcRelease));
         _fredClient.GetSeriesRelease("CPIAUCSL").Returns(Task.FromResult(cpiRelease));
-        _fredClient
-            .GetReleaseDates(Arg.Any<DateOnly?>())
-            .Returns(
-                Task.FromResult(
-                    new List<FredReleaseDateRecord>
-                    {
-                        // FOMC carried forward every day, incl. a Sat (20th) and Sun (21st).
-                        new() { ReleaseId = 101, Date = "2026-06-19" }, // Fri
-                        new() { ReleaseId = 101, Date = "2026-06-20" }, // Sat
-                        new() { ReleaseId = 101, Date = "2026-06-21" }, // Sun
-                        new() { ReleaseId = 101, Date = "2026-06-22" }, // Mon
-                        // Genuine CPI print on one real weekday date.
-                        new() { ReleaseId = 10, Date = "2026-06-11" },
-                    }
-                )
-            );
+        SetupReleaseDates(
+            // FOMC carried forward every day, incl. a Sat (20th) and Sun (21st).
+            new FredReleaseDateRecord { ReleaseId = 101, Date = "2026-06-19" }, // Fri
+            new FredReleaseDateRecord { ReleaseId = 101, Date = "2026-06-20" }, // Sat
+            new FredReleaseDateRecord { ReleaseId = 101, Date = "2026-06-21" }, // Sun
+            new FredReleaseDateRecord { ReleaseId = 101, Date = "2026-06-22" }, // Mon
+            // Genuine CPI print on one real weekday date.
+            new FredReleaseDateRecord { ReleaseId = 10, Date = "2026-06-11" }
+        );
 
         await _sut.Import(CancellationToken.None);
 
@@ -216,27 +219,20 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
         _dateRepo.Add(new FredReleaseDate { FredReleaseId = release.Id, Date = new(2026, 6, 11) });
         await _dateRepo.SaveChanges();
 
-        _fredClient
-            .GetReleaseDates(Arg.Any<DateOnly?>())
-            .Returns(
-                Task.FromResult(
-                    new List<FredReleaseDateRecord>
-                    {
-                        new()
-                        {
-                            ReleaseId = 10,
-                            ReleaseName = "Consumer Price Index",
-                            Date = "2026-06-11",
-                        },
-                        new()
-                        {
-                            ReleaseId = 10,
-                            ReleaseName = "Consumer Price Index",
-                            Date = "2026-07-14",
-                        },
-                    }
-                )
-            );
+        SetupReleaseDates(
+            new FredReleaseDateRecord
+            {
+                ReleaseId = 10,
+                ReleaseName = "Consumer Price Index",
+                Date = "2026-06-11",
+            },
+            new FredReleaseDateRecord
+            {
+                ReleaseId = 10,
+                ReleaseName = "Consumer Price Index",
+                Date = "2026-07-14",
+            }
+        );
 
         await _sut.Import(CancellationToken.None);
 
@@ -285,18 +281,11 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
         _dateRepo.Add(new FredReleaseDate { FredReleaseId = cpi.Id, Date = new(2026, 6, 11) });
         await _dateRepo.SaveChanges();
 
-        _fredClient
-            .GetReleaseDates(Arg.Any<DateOnly?>())
-            .Returns(
-                Task.FromResult(
-                    new List<FredReleaseDateRecord>
-                    {
-                        new() { ReleaseId = 101, Date = "2026-06-19" }, // Fri
-                        new() { ReleaseId = 101, Date = "2026-06-20" }, // Sat — carry-forward tell
-                        new() { ReleaseId = 10, Date = "2026-07-14" },
-                    }
-                )
-            );
+        SetupReleaseDates(
+            new FredReleaseDateRecord { ReleaseId = 101, Date = "2026-06-19" }, // Fri
+            new FredReleaseDateRecord { ReleaseId = 101, Date = "2026-06-20" }, // Sat — carry-forward tell
+            new FredReleaseDateRecord { ReleaseId = 10, Date = "2026-07-14" }
+        );
 
         await _sut.Import(CancellationToken.None);
 
@@ -337,9 +326,7 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
         );
         await _seriesRepo.SaveChanges();
 
-        _fredClient
-            .GetReleaseDates(Arg.Any<DateOnly?>())
-            .Returns(Task.FromResult(new List<FredReleaseDateRecord>()));
+        SetupReleaseDates();
 
         await _sut.Import(CancellationToken.None);
 
@@ -348,6 +335,59 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
             .Single(r => r.ReleaseId == 10)
             .Importance.Should()
             .Be(FredReleaseImportance.High);
+    }
+
+    [Fact]
+    public async Task Import_OneReleaseFetchFails_OtherReleasesStillImport()
+    {
+        // The production freeze root cause: one failed fetch aborted the whole
+        // cycle, so NOTHING imported for weeks. A failing release must only skip
+        // itself — every other tracked release still lands its dates.
+        var ppi = new FredRelease { ReleaseId = 46, Name = "Producer Price Index" };
+        var cpi = new FredRelease { ReleaseId = 10, Name = "Consumer Price Index" };
+        _releaseRepo.Add(ppi);
+        _releaseRepo.Add(cpi);
+        await _releaseRepo.SaveChanges();
+        _seriesRepo.Add(
+            new FredSeries
+            {
+                SeriesId = "PPIFIS",
+                Title = "PPI Final Demand",
+                FredReleaseId = ppi.Id,
+            }
+        );
+        _seriesRepo.Add(
+            new FredSeries
+            {
+                SeriesId = "CPIAUCSL",
+                Title = "CPI All Items",
+                FredReleaseId = cpi.Id,
+            }
+        );
+        await _seriesRepo.SaveChanges();
+
+        _fredClient
+            .GetReleaseDates(46, Arg.Any<DateOnly?>())
+            .Returns<Task<List<FredReleaseDateRecord>>>(_ =>
+                throw new HttpRequestException("FRED 504")
+            );
+        _fredClient
+            .GetReleaseDates(10, Arg.Any<DateOnly?>())
+            .Returns(
+                Task.FromResult(
+                    new List<FredReleaseDateRecord>
+                    {
+                        new() { ReleaseId = 10, Date = "2026-07-14" },
+                    }
+                )
+            );
+
+        await _sut.Import(CancellationToken.None);
+
+        var dates = _dateRepo.GetAll().ToList();
+        dates.Should().ContainSingle("the CPI date must land even though the PPI fetch failed");
+        dates[0].FredReleaseId.Should().Be(cpi.Id);
+        dates[0].Date.Should().Be(new DateOnly(2026, 7, 14));
     }
 
     [Fact]
@@ -367,18 +407,11 @@ public class FredReleaseCalendarImportServiceTests : IDisposable
             PressRelease = true,
         };
         _fredClient.GetSeriesRelease("DFEDTARU").Returns(Task.FromResult(fomcRelease));
-        _fredClient
-            .GetReleaseDates(Arg.Any<DateOnly?>())
-            .Returns(
-                Task.FromResult(
-                    new List<FredReleaseDateRecord>
-                    {
-                        new() { ReleaseId = 101, Date = "2026-06-19" }, // Fri
-                        new() { ReleaseId = 101, Date = "2026-06-20" }, // Sat
-                        new() { ReleaseId = 101, Date = "2026-06-22" }, // Mon
-                    }
-                )
-            );
+        SetupReleaseDates(
+            new FredReleaseDateRecord { ReleaseId = 101, Date = "2026-06-19" }, // Fri
+            new FredReleaseDateRecord { ReleaseId = 101, Date = "2026-06-20" }, // Sat
+            new FredReleaseDateRecord { ReleaseId = 101, Date = "2026-06-22" } // Mon
+        );
 
         var import = async () => await _sut.Import(CancellationToken.None);
 

--- a/tests/Equibles.IntegrationTests/Mcp/FredToolsGetEconomicCalendarTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FredToolsGetEconomicCalendarTests.cs
@@ -154,8 +154,73 @@ public class FredToolsGetEconomicCalendarTests : ParadeDbMcpTestBase
         var result = await Sut()
             .GetEconomicCalendar("2026-06-01", "2026-06-30", minImportance: "critical");
 
-        result.Should().Contain("Invalid minImportance 'critical'");
+        result.Should().Contain("Unknown minImportance 'critical'");
+        result.Should().Contain("low, medium, high");
         result.Should().NotContain("Consumer Price Index");
+    }
+
+    [Fact]
+    public async Task GetEconomicCalendar_NumericMinImportance_IsRejectedNotParsedByOrdinal()
+    {
+        // Enum.TryParse accepts "5", yielding an undefined tier that filters out
+        // everything and would read as a factual "no releases" answer.
+        var result = await Sut()
+            .GetEconomicCalendar("2026-06-01", "2026-06-30", minImportance: "5");
+
+        result.Should().Contain("Unknown minImportance '5'");
+        result.Should().NotContain("No economic releases");
+    }
+
+    [Fact]
+    public async Task GetEconomicCalendar_MalformedStartDate_ReturnsExplicitError()
+    {
+        // The old behavior silently swapped an unparseable date for the default
+        // window and answered as if that was what the caller asked for.
+        var result = await Sut().GetEconomicCalendar("next week");
+
+        result.Should().Contain("Unknown startDate 'next week'");
+        result.Should().Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task GetEconomicCalendar_MalformedEndDate_ReturnsExplicitError()
+    {
+        var result = await Sut().GetEconomicCalendar("2026-06-01", "06/30/2026");
+
+        result.Should().Contain("Unknown endDate '06/30/2026'");
+        result.Should().Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task GetEconomicCalendar_InvertedRange_NamesTheUserError()
+    {
+        var result = await Sut().GetEconomicCalendar("2026-08-01", "2026-07-01");
+
+        result.Should().Contain("startDate (2026-08-01) is after endDate (2026-07-01)");
+        result.Should().NotContain("No economic releases", "the error is the swap, not a data gap");
+    }
+
+    [Fact]
+    public async Task GetEconomicCalendar_Truncated_HeaderNamesCoveredRangeAndFooterNotes()
+    {
+        // Three rows in June; a cap of 2 cuts the SOFR row. The header must not
+        // claim the full requested range as covered, and the footer must say how
+        // to see the rest — otherwise the tail silently reads as "nothing scheduled".
+        var result = await Sut().GetEconomicCalendar("2026-06-01", "2026-06-30", maxResults: 2);
+
+        result.Should().Contain("truncated at 2 rows, shown only through 2026-06-11");
+        result.Should().Contain("Showing first 2 of 3 results");
+        result.Should().NotContain("Secured Overnight Financing Rate Data");
+    }
+
+    [Fact]
+    public async Task GetEconomicCalendar_NotTruncated_HeaderClaimsFullRangeWithoutNotes()
+    {
+        var result = await Sut().GetEconomicCalendar("2026-06-01", "2026-06-30");
+
+        result.Should().Contain("Economic release calendar (2026-06-01 to 2026-06-30):");
+        result.Should().NotContain("truncated");
+        result.Should().NotContain("Showing first");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/FredToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FredToolsTests.cs
@@ -216,6 +216,66 @@ public class FredToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task GetEconomicIndicator_MalformedStartDate_ReturnsExplicitError()
+    {
+        var result = await Sut().GetEconomicIndicator("FEDFUNDS", "01/15/2025");
+
+        result.Should().Contain("Unknown startDate '01/15/2025'");
+        result.Should().Contain("yyyy-MM-dd");
+        result.Should().NotContain("| 2025-", "a rejected date must not silently return data");
+    }
+
+    [Fact]
+    public async Task GetEconomicIndicator_MalformedEndDate_ReturnsExplicitError()
+    {
+        var result = await Sut().GetEconomicIndicator("FEDFUNDS", "2025-01-01", "last year");
+
+        result.Should().Contain("Unknown endDate 'last year'");
+        result.Should().Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task GetEconomicIndicator_InvertedRange_NamesTheUserError()
+    {
+        var result = await Sut().GetEconomicIndicator("FEDFUNDS", "2025-12-31", "2025-01-01");
+
+        result.Should().Contain("startDate (2025-12-31) is after endDate (2025-01-01)");
+        result
+            .Should()
+            .NotContain("No observations found", "the error is the swap, not a data gap");
+    }
+
+    [Fact]
+    public async Task GetEconomicIndicator_EndDateOnly_DefaultsStartRelativeToEnd()
+    {
+        // endDate alone must mean "the year up to then", not an empty range against
+        // a start defaulted off today.
+        var result = await Sut().GetEconomicIndicator("FEDFUNDS", endDate: "2025-03-31");
+
+        result.Should().Contain("2025-01-01");
+        result.Should().Contain("2025-03-01");
+        result.Should().NotContain("2025-06-01");
+    }
+
+    [Fact]
+    public async Task GetEconomicIndicator_TruncatedRange_AppendsNewestKeptNote()
+    {
+        var result = await Sut()
+            .GetEconomicIndicator("FEDFUNDS", "2025-01-01", "2025-12-31", maxResults: 2);
+
+        result.Should().Contain("Showing the newest 2 of 5 observations");
+        result.Should().Contain("raise maxResults");
+    }
+
+    [Fact]
+    public async Task GetEconomicIndicator_CompleteRange_HasNoTruncationNote()
+    {
+        var result = await Sut().GetEconomicIndicator("FEDFUNDS", "2025-01-01", "2025-12-31");
+
+        result.Should().NotContain("Showing the newest");
+    }
+
+    [Fact]
     public async Task GetEconomicIndicator_ObservationsOrderedByDateAscending()
     {
         var result = await Sut().GetEconomicIndicator("FEDFUNDS", "2025-01-01", "2025-12-31");
@@ -298,13 +358,25 @@ public class FredToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task GetLatestEconomicData_InvalidCategory_ReturnsAllSeries()
+    public async Task GetLatestEconomicData_InvalidCategory_ReturnsExplicitErrorNotEverything()
     {
+        // A failed filter must surface, not silently return the unfiltered snapshot.
         var result = await Sut().GetLatestEconomicData("InvalidCategory");
 
-        result.Should().Contain("FEDFUNDS");
-        result.Should().Contain("CPIAUCSL");
-        result.Should().Contain("GDP");
+        result.Should().Contain("Unknown category 'InvalidCategory'");
+        result.Should().Contain("InterestRates");
+        result.Should().Contain("Inflation");
+        result.Should().NotContain("FEDFUNDS");
+    }
+
+    [Fact]
+    public async Task GetLatestEconomicData_NumericCategory_IsRejectedNotParsedByOrdinal()
+    {
+        // Enum.TryParse would accept "5" as an ordinal; the tool must reject it.
+        var result = await Sut().GetLatestEconomicData("5");
+
+        result.Should().Contain("Unknown category '5'");
+        result.Should().NotContain("FEDFUNDS");
     }
 
     [Fact]
@@ -312,8 +384,24 @@ public class FredToolsTests : ParadeDbMcpTestBase
     {
         var result = await Sut().GetLatestEconomicData();
 
-        result.Should().Contain("| Series | Title | Latest Date | Value | Units |");
-        result.Should().Contain("|--------|-------|-------------|-------|-------|");
+        result
+            .Should()
+            .Contain("| Series | Title | Latest Date | Value | Previous | Change | Units |");
+        result
+            .Should()
+            .Contain("|--------|-------|-------------|-------|----------|--------|-------|");
+    }
+
+    [Fact]
+    public async Task GetLatestEconomicData_ShowsPreviousValueAndChange()
+    {
+        var result = await Sut().GetLatestEconomicData();
+
+        // FEDFUNDS: latest 4.00 (2025-09-01), previous 4.25 (2025-06-01) → -0.25.
+        result.Should().Contain("-0.25");
+        result.Should().Contain("4.25");
+        // GDP: latest 28800 (2025-04-01), previous 28500 → positive change carries a sign.
+        result.Should().Contain("+300");
     }
 
     [Fact]
@@ -357,12 +445,58 @@ public class FredToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task SearchEconomicIndicators_NoMatches_ReturnsNotFoundMessage()
+    public async Task SearchEconomicIndicators_NoMatches_ExplainsCuratedScope()
     {
         var result = await Sut().SearchEconomicIndicators("zzzznonexistent");
 
-        result.Should().Contain("No series found matching");
+        result.Should().Contain("No tracked series match");
         result.Should().Contain("zzzznonexistent");
+        result
+            .Should()
+            .Contain(
+                "curated",
+                "the empty state must say the universe is curated, not all of FRED"
+            );
+    }
+
+    [Fact]
+    public async Task SearchEconomicIndicators_CategoryNameQuery_ReturnsWholeCategory()
+    {
+        // "inflation" appears in neither the CPI series id nor its title — only the
+        // category match can surface it. This is the audit's headline recall gap.
+        var result = await Sut().SearchEconomicIndicators("inflation");
+
+        result.Should().Contain("CPIAUCSL");
+        result.Should().NotContain("FEDFUNDS");
+        result.Should().NotContain("| GDP |");
+    }
+
+    [Fact]
+    public async Task SearchEconomicIndicators_EmptyQuery_ListsAllTrackedSeries()
+    {
+        var result = await Sut().SearchEconomicIndicators("");
+
+        result.Should().Contain("All tracked economic indicator series:");
+        result.Should().Contain("FEDFUNDS");
+        result.Should().Contain("CPIAUCSL");
+        result.Should().Contain("GDP");
+    }
+
+    [Fact]
+    public async Task SearchEconomicIndicators_Truncated_AppendsTruncationNote()
+    {
+        var result = await Sut().SearchEconomicIndicators("", maxResults: 1);
+
+        result.Should().Contain("Showing first 1 of 3 results");
+        result.Should().Contain("raise maxResults");
+    }
+
+    [Fact]
+    public async Task SearchEconomicIndicators_CompleteResult_HasNoTruncationNote()
+    {
+        var result = await Sut().SearchEconomicIndicators("FEDFUNDS");
+
+        result.Should().NotContain("Showing first");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Fred/CuratedSeriesRegistryTests.cs
+++ b/tests/Equibles.UnitTests/Fred/CuratedSeriesRegistryTests.cs
@@ -82,6 +82,17 @@ public class CuratedSeriesRegistryTests
     }
 
     [Fact]
+    public void Series_TracksStlfsi4NotTheDiscontinuedStlfsi2()
+    {
+        // STLFSI2 was discontinued by FRED (frozen at 2022-01-07); its stale value
+        // polluted the "current macro conditions" snapshot. STLFSI4 supersedes it.
+        CuratedSeriesRegistry
+            .Series.Should()
+            .Contain(s => s.SeriesId == "STLFSI4" && s.Category == FredSeriesCategory.Market);
+        CuratedSeriesRegistry.Series.Should().NotContain(s => s.SeriesId == "STLFSI2");
+    }
+
+    [Fact]
     public void AllCategories_HaveAtLeastOneSeries()
     {
         var allCategories = Enum.GetValues<FredSeriesCategory>();


### PR DESCRIPTION
## Summary

Fixes all audit findings for the four FRED MCP tools (GetEconomicCalendar, GetEconomicIndicator, GetLatestEconomicData, SearchEconomicIndicators), including the root cause of the frozen release calendar.

### Frozen calendar (high)
The importer paged the global `/fred/releases/dates` feed, which FRED reliably 504s at `offset >= 1000`; one failed page aborted the whole cycle, so no release dates imported since 2026-06-12 and the PPI release (created 2026-07-10) never got any dates. The client now hits the cheap per-release `/fred/release/dates?release_id=N` endpoint (bounded by `realtime_start` = first of the current month, mirroring the old window), and the importer iterates the tracked releases so a failing release only skips itself. PPI backfills automatically on the next worker cycle after deploy.

### GetEconomicCalendar
- Description no longer promises FOMC (deliberately suppressed carry-forward release; FRED's feed has no real meeting dates) and says where to find FOMC dates instead.
- Truncated results no longer present the requested range as fully covered: the header names the last date actually shown and the standard truncation footer is appended.
- Strict `yyyy-MM-dd` date parsing (no silent default fallback), numeric/undefined `minImportance` rejected, inverted ranges name the user error.

### GetEconomicIndicator
- Truncation signposted with newest-kept semantics ("Showing the newest N of M observations...").
- Malformed dates return an explicit error; `startDate` defaults relative to the requested `endDate`; inverted ranges name the user error.
- `maxResults` description documents the 500 cap and ascending render order.

### GetLatestEconomicData
- Unknown/numeric `category` returns the accepted-values error instead of silently returning all categories.
- New Previous/Change columns so level-only series convey direction (new `GetPreviousPerSeries` repository query; `Count() > 1` guard prevents NULL rows for single-observation series).
- Discontinued STLFSI2 replaced by STLFSI4 in the curated registry (needs a one-time prod cleanup of the stale STLFSI2 rows, handled centrally).

### SearchEconomicIndicators
- Matching extends to the category name: 'inflation' returns the whole Inflation category (CPI, PCE, PPI, breakevens), 'unemployment' the Employment category.
- Empty query lists all tracked series; description + empty state state the curated ~40-series scope; truncation signposted.

## Code changes
- `src/Equibles.Integrations.Fred/FredClient.cs` + `Contracts/IFredClient.cs` — per-release `GetReleaseDates(int releaseId, DateOnly? realtimeStart)`.
- `src/Equibles.Fred.HostedService/Services/FredReleaseCalendarImportService.cs` — per-release iteration with per-release failure isolation.
- `src/Equibles.Fred.HostedService/Services/CuratedSeriesRegistry.cs` — STLFSI2 → STLFSI4.
- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — all four tools per above.
- `src/Equibles.Fred.Repositories/FredSeriesRepository.cs` — category-aware `Search` (client-side enum match, translatable query).
- `src/Equibles.Fred.Repositories/FredObservationRepository.cs` — `GetPreviousPerSeries`.
- Tests: rewritten `FredClientGetReleaseDatesTests`, per-release mocks + failure-isolation test in `FredReleaseCalendarImportServiceTests`, new strict-args/truncation/category-search coverage in `FredToolsTests` + `FredToolsGetEconomicCalendarTests`, `GetPreviousPerSeries` pin, STLFSI4 registry pin.

Unit (94 Fred), integration (122 Fred, real ParadeDB), and functional (Economic + MCP correctness) suites green.