### PR TITLE
fix(mcp): market-data tool audit fixes (Yahoo price/indicators, CBOE, CFTC) + CFTC registry mislabel correction

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -35,7 +35,11 @@ public class CboeTools
 
     [McpServerTool(Name = "GetPutCallRatios")]
     [Description(
-        "Get CBOE put/call ratio data showing market sentiment. Available types: Total (all exchange), Equity, Index, Vix, Etp. High ratios (>1.0) indicate bearish sentiment; low ratios (<0.7) indicate bullish sentiment."
+        "Get CBOE put/call ratio data showing market sentiment. Available types: Total (all "
+            + "exchange), Equity, Index, Vix, Etp. High ratios (>1.0) indicate bearish sentiment; "
+            + "low ratios (<0.7) indicate bullish sentiment. Volumes are contract counts. Data "
+            + "available from November 2006 to present (the Vix type from October 2019); "
+            + "pre-2013 history is sampled roughly weekly rather than daily."
     )]
     public Task<string> GetPutCallRatios(
         [Description("Ratio type: Total, Equity, Index, Vix, Etp (default: Equity)")]
@@ -44,7 +48,9 @@ public class CboeTools
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of records to return (default: 60, newest first)")]
+        [Description(
+            "Maximum number of records to return (default: 60, max: 500). When the range holds more rows the newest are kept; rows are always listed oldest to newest."
+        )]
             int maxResults = 60
     )
     {
@@ -54,22 +60,29 @@ public class CboeTools
                 if (!Enum.TryParse<CboePutCallRatioType>(type, true, out var ratioType))
                     return $"Invalid type '{type}'. Valid types: Total, Equity, Index, Vix, Etp";
 
-                var (start, end) = McpToolExecutor.ParseDateRange(
+                var rangeError = ParseRangeStrict(
                     startDate,
                     endDate,
-                    McpToolExecutor.UtcMonthsAgo(3)
+                    McpToolExecutor.UtcMonthsAgo(3),
+                    out var start,
+                    out var end
                 );
+                if (rangeError != null)
+                    return rangeError;
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var records = await _putCallRepository
+                var rangeQuery = _putCallRepository
                     .GetByType(ratioType, start, end)
-                    .OnlyReconcilable()
+                    .OnlyReconcilable();
+                var total = await rangeQuery.CountAsync();
+
+                var records = await rangeQuery
                     .OrderByDescending(r => r.Date)
                     .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     records.OrderBy(r => r.Date).ToList(),
                     $"No put/call ratio data found for {ratioType.NameForHumans()} in the specified date range.",
                     $"CBOE {ratioType.NameForHumans()} Put/Call Ratios:",
@@ -84,6 +97,8 @@ public class CboeTools
                         return $"| {r.Date:yyyy-MM-dd} | {callStr} | {putStr} | {totalStr} | {ratioStr} |";
                     }
                 );
+
+                return AppendNewestKeptTruncationNote(table, records.Count, total);
             },
             "GetPutCallRatios",
             $"type: {type}"
@@ -92,35 +107,45 @@ public class CboeTools
 
     [McpServerTool(Name = "GetVixHistory")]
     [Description(
-        "Get CBOE Volatility Index (VIX) historical daily OHLC data. VIX measures expected 30-day S&P 500 volatility. Below 15 = low volatility/complacency, above 30 = high fear/uncertainty. Data available from 1990 to present."
+        "Get CBOE Volatility Index (VIX) historical daily OHLC data. VIX measures expected "
+            + "30-day S&P 500 volatility. Below 15 = low volatility/complacency, above 30 = "
+            + "high fear/uncertainty. Data available from 1990 to present."
     )]
     public Task<string> GetVixHistory(
         [Description("Start date in YYYY-MM-DD format (defaults to 3 months ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of records to return (default: 60, newest first)")]
+        [Description(
+            "Maximum number of records to return (default: 60, max: 500). When the range holds more rows the newest are kept; rows are always listed oldest to newest."
+        )]
             int maxResults = 60
     )
     {
         return _runner.Execute(
             async () =>
             {
-                var (start, end) = McpToolExecutor.ParseDateRange(
+                var rangeError = ParseRangeStrict(
                     startDate,
                     endDate,
-                    McpToolExecutor.UtcMonthsAgo(3)
+                    McpToolExecutor.UtcMonthsAgo(3),
+                    out var start,
+                    out var end
                 );
+                if (rangeError != null)
+                    return rangeError;
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var records = await _vixRepository
-                    .GetByDateRange(start, end)
+                var rangeQuery = _vixRepository.GetByDateRange(start, end);
+                var total = await rangeQuery.CountAsync();
+
+                var records = await rangeQuery
                     .OrderByDescending(v => v.Date)
                     .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     records.OrderBy(v => v.Date).ToList(),
                     "No VIX data found in the specified date range.",
                     "CBOE Volatility Index (VIX):",
@@ -129,9 +154,56 @@ public class CboeTools
                     v =>
                         $"| {v.Date:yyyy-MM-dd} | {McpFormat.Invariant(v.Open, "F2")} | {McpFormat.Invariant(v.High, "F2")} | {McpFormat.Invariant(v.Low, "F2")} | {McpFormat.Invariant(v.Close, "F2")} |"
                 );
+
+                return AppendNewestKeptTruncationNote(table, records.Count, total);
             },
             "GetVixHistory",
             $"startDate: {startDate}"
         );
+    }
+
+    // Strict argument parsing shared by the date-ranged CBOE tools: a non-empty date must
+    // be exactly yyyy-MM-dd (no silent fallback to the default window), and an inverted
+    // range is a caller error rather than an empty-looking result.
+    private static string ParseRangeStrict(
+        string startDate,
+        string endDate,
+        DateOnly defaultStart,
+        out DateOnly start,
+        out DateOnly end
+    )
+    {
+        start = defaultStart;
+        end = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        if (!string.IsNullOrWhiteSpace(startDate))
+        {
+            if (!McpOutput.TryParseDate(startDate, out var parsedStart))
+                return McpOutput.InvalidArgument("startDate", startDate, "yyyy-MM-dd");
+            start = DateOnly.FromDateTime(parsedStart);
+        }
+
+        if (!string.IsNullOrWhiteSpace(endDate))
+        {
+            if (!McpOutput.TryParseDate(endDate, out var parsedEnd))
+                return McpOutput.InvalidArgument("endDate", endDate, "yyyy-MM-dd");
+            end = DateOnly.FromDateTime(parsedEnd);
+        }
+
+        if (start > end)
+            return $"startDate ({start:yyyy-MM-dd}) is after endDate ({end:yyyy-MM-dd}) - swap the dates.";
+
+        return null;
+    }
+
+    // Appended after tables that keep the NEWEST rows but render oldest-to-newest, where
+    // the shared "Showing first N" wording would point at the wrong end of the table.
+    private static string AppendNewestKeptTruncationNote(string table, int shown, int total)
+    {
+        if (shown >= total)
+            return table;
+        return table
+            + Environment.NewLine
+            + $"_Showing the newest {shown} of {total} records in the range - raise maxResults or narrow the date range to see older rows._";
     }
 }

--- a/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
@@ -97,17 +97,38 @@ public class CftcImportService : IImporter
     {
         using var scope = _scopeFactory.CreateScope();
         var contractRepo = scope.ServiceProvider.GetRequiredService<CftcContractRepository>();
-        var existingCodes = await contractRepo
-            .GetAll()
-            .Select(c => c.MarketCode)
-            .ToListAsync(cancellationToken);
+        var existing = await contractRepo.GetAll().ToListAsync(cancellationToken);
 
-        var existingSet = existingCodes.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var existingByCode = new Dictionary<string, CftcContract>(StringComparer.OrdinalIgnoreCase);
+        foreach (var contract in existing)
+            existingByCode[contract.MarketCode.Trim()] = contract;
 
         foreach (var curated in curatedLookup.Values)
         {
-            if (existingSet.Contains(curated.MarketCode))
+            if (existingByCode.TryGetValue(curated.MarketCode.Trim(), out var contract))
+            {
+                // The registry is the source of truth for what a market code IS. An earlier
+                // registry revision mislabeled several codes (see CuratedContractRegistry),
+                // so drifted rows must be re-synced, not preserved — the position reports
+                // under the code are the CFTC's real data for that market either way.
+                if (
+                    contract.MarketName != curated.DisplayName
+                    || contract.Category != curated.Category
+                )
+                {
+                    _logger.LogInformation(
+                        "Re-syncing CFTC contract {MarketCode}: '{OldName}' ({OldCategory}) -> '{NewName}' ({NewCategory})",
+                        curated.MarketCode,
+                        contract.MarketName,
+                        contract.Category,
+                        curated.DisplayName,
+                        curated.Category
+                    );
+                    contract.MarketName = curated.DisplayName;
+                    contract.Category = curated.Category;
+                }
                 continue;
+            }
 
             contractRepo.Add(
                 new CftcContract
@@ -132,19 +153,31 @@ public class CftcImportService : IImporter
     {
         using var scope = _scopeFactory.CreateScope();
         var reportRepo = scope.ServiceProvider.GetRequiredService<CftcPositionReportRepository>();
-        var latestDate = await reportRepo
-            .GetGlobalLatestDate()
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (latestDate != default)
-            return latestDate.Year;
+        var contractRepo = scope.ServiceProvider.GetRequiredService<CftcContractRepository>();
 
         var minDate =
             _workerOptions.MinSyncDate != null
                 ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
                 : new DateOnly(2020, 1, 1);
+        var fullWalkYear = Math.Max(minDate.Year, EarliestCftcYear);
 
-        return Math.Max(minDate.Year, EarliestCftcYear);
+        var latestDate = await reportRepo
+            .GetGlobalLatestDate()
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (latestDate == default)
+            return fullWalkYear;
+
+        // A contract with no reports at all — i.e. a code newly added to the curated
+        // registry — needs a full-history walk, or it would only ever accumulate data
+        // from the current year's file onward. Re-walking already-imported years is
+        // insert-free thanks to the (contract, date) existence check, and the walk
+        // stops recurring as soon as the new contract's data lands.
+        var hasEmptyContract = await contractRepo
+            .GetAll()
+            .AnyAsync(c => c.LatestReportDate == null, cancellationToken);
+
+        return hasEmptyContract ? fullWalkYear : latestDate.Year;
     }
 
     private async Task ImportYear(

--- a/src/Equibles.Cftc.HostedService/Services/CuratedContractRegistry.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CuratedContractRegistry.cs
@@ -2,6 +2,14 @@ using Equibles.Cftc.Data.Models;
 
 namespace Equibles.Cftc.HostedService.Services;
 
+// Display names MUST match what the CFTC assigns to each contract market code — the code
+// is the identity the importer filters the COT files by, so a wrong name silently labels
+// one market's real data as another market. Every code below was verified against the
+// CFTC public reporting API (publicreporting.cftc.gov, legacy futures-only dataset
+// 6dca-aqww, field cftc_contract_market_code → market_and_exchange_names). An earlier
+// revision of this registry carried ten mislabeled codes (e.g. 057642 said "Lean Hogs"
+// while the CFTC assigns it to Live Cattle; 075651/076651 had Platinum and Palladium
+// swapped); CftcImportService.EnsureContractsExist re-syncs drifted names on boot.
 public static class CuratedContractRegistry
 {
     public static readonly IReadOnlyList<CuratedContract> Contracts =
@@ -10,11 +18,13 @@ public static class CuratedContractRegistry
         new("001602", "Wheat-SRW (CBOT)", CftcContractCategory.Agriculture),
         new("002602", "Corn (CBOT)", CftcContractCategory.Agriculture),
         new("005602", "Soybeans (CBOT)", CftcContractCategory.Agriculture),
-        new("073732", "Cotton No. 2 (ICE)", CftcContractCategory.Agriculture),
+        new("033661", "Cotton No. 2 (ICE)", CftcContractCategory.Agriculture),
+        new("073732", "Cocoa (ICE)", CftcContractCategory.Agriculture),
         new("083731", "Coffee C (ICE)", CftcContractCategory.Agriculture),
         new("080732", "Sugar No. 11 (ICE)", CftcContractCategory.Agriculture),
-        new("057642", "Lean Hogs (CME)", CftcContractCategory.Agriculture),
-        new("061641", "Live Cattle (CME)", CftcContractCategory.Agriculture),
+        new("054642", "Lean Hogs (CME)", CftcContractCategory.Agriculture),
+        new("057642", "Live Cattle (CME)", CftcContractCategory.Agriculture),
+        new("061641", "Feeder Cattle (CME)", CftcContractCategory.Agriculture),
         // Energy
         new("067651", "Crude Oil, Light Sweet (NYMEX)", CftcContractCategory.Energy),
         new("023651", "Natural Gas (NYMEX)", CftcContractCategory.Energy),
@@ -24,8 +34,8 @@ public static class CuratedContractRegistry
         new("088691", "Gold (COMEX)", CftcContractCategory.Metals),
         new("084691", "Silver (COMEX)", CftcContractCategory.Metals),
         new("085692", "Copper Grade #1 (COMEX)", CftcContractCategory.Metals),
-        new("075651", "Platinum (NYMEX)", CftcContractCategory.Metals),
-        new("076651", "Palladium (NYMEX)", CftcContractCategory.Metals),
+        new("076651", "Platinum (NYMEX)", CftcContractCategory.Metals),
+        new("075651", "Palladium (NYMEX)", CftcContractCategory.Metals),
         // Equity Indices
         new("13874A", "E-mini S&P 500 (CME)", CftcContractCategory.EquityIndices),
         new("209742", "E-mini Nasdaq-100 (CME)", CftcContractCategory.EquityIndices),
@@ -35,14 +45,15 @@ public static class CuratedContractRegistry
         // Interest Rates
         new("043602", "10-Year T-Notes (CBOT)", CftcContractCategory.InterestRates),
         new("020601", "30-Year T-Bonds (CBOT)", CftcContractCategory.InterestRates),
-        new("042601", "5-Year T-Notes (CBOT)", CftcContractCategory.InterestRates),
-        new("044601", "2-Year T-Notes (CBOT)", CftcContractCategory.InterestRates),
+        new("044601", "5-Year T-Notes (CBOT)", CftcContractCategory.InterestRates),
+        new("042601", "2-Year T-Notes (CBOT)", CftcContractCategory.InterestRates),
         // Currencies
         new("099741", "Euro FX (CME)", CftcContractCategory.Currencies),
-        new("096742", "Japanese Yen (CME)", CftcContractCategory.Currencies),
-        new("092741", "British Pound (CME)", CftcContractCategory.Currencies),
+        new("097741", "Japanese Yen (CME)", CftcContractCategory.Currencies),
+        new("096742", "British Pound (CME)", CftcContractCategory.Currencies),
         new("090741", "Canadian Dollar (CME)", CftcContractCategory.Currencies),
-        new("095741", "Swiss Franc (CME)", CftcContractCategory.Currencies),
+        new("092741", "Swiss Franc (CME)", CftcContractCategory.Currencies),
+        new("095741", "Mexican Peso (CME)", CftcContractCategory.Currencies),
         new("232741", "Australian Dollar (CME)", CftcContractCategory.Currencies),
     ];
 }

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -16,6 +16,9 @@ namespace Equibles.Cftc.Mcp.Tools;
 [McpServerToolType]
 public class CftcTools
 {
+    private const string AcceptedCategories =
+        "Agriculture, Energy, Metals, EquityIndices, InterestRates, Currencies";
+
     private readonly CftcContractRepository _contractRepository;
     private readonly CftcPositionReportRepository _reportRepository;
     private readonly McpToolRunner _runner;
@@ -34,7 +37,10 @@ public class CftcTools
 
     [McpServerTool(Name = "GetCftcPositioning")]
     [Description(
-        "Get Commitments of Traders (COT) positioning data for a specific futures contract. Shows commercial and non-commercial positions over time. Use SearchCftcMarkets to find available market codes."
+        "Get Commitments of Traders (COT) positioning data for a specific futures contract. "
+            + "Shows commercial and non-commercial positions over time. Values are contract "
+            + "counts from the legacy futures-only COT report (positions as of each Tuesday, "
+            + "published Friday). Use SearchCftcMarkets to find available market codes."
     )]
     public Task<string> GetCftcPositioning(
         [Description(
@@ -45,7 +51,9 @@ public class CftcTools
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of reports to return (default: 52, newest first)")]
+        [Description(
+            "Maximum number of reports to return (default: 52, max: 500). When the range holds more reports the newest are kept; rows are always listed oldest to newest."
+        )]
             int maxResults = 52
     )
     {
@@ -59,19 +67,27 @@ public class CftcTools
                 if (contract == null)
                     return $"Contract '{marketCode}' not found. Use SearchCftcMarkets to find available contracts.";
 
-                var (start, end) = McpToolExecutor.ParseDateRange(
+                var rangeError = ParseRangeStrict(
                     startDate,
                     endDate,
-                    McpToolExecutor.UtcYearsAgo(1)
+                    McpToolExecutor.UtcYearsAgo(1),
+                    out var start,
+                    out var end
                 );
+                if (rangeError != null)
+                    return rangeError;
 
-                var reports = await _reportRepository
-                    .GetByContract(contract, start, end)
+                maxResults = McpLimit.Clamp(maxResults);
+
+                var rangeQuery = _reportRepository.GetByContract(contract, start, end);
+                var total = await rangeQuery.CountAsync();
+
+                var reports = await rangeQuery
                     .OrderByDescending(r => r.ReportDate)
-                    .Take(McpLimit.Clamp(maxResults))
+                    .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     reports.OrderBy(r => r.ReportDate).ToList(),
                     $"No COT reports found for {contract.MarketName} ({contract.MarketCode}) in the specified date range.",
                     $"{contract.MarketName} ({contract.MarketCode}) — {contract.Category.NameForHumans()}",
@@ -80,6 +96,13 @@ public class CftcTools
                     r =>
                         $"| {r.ReportDate:yyyy-MM-dd} | {McpFormat.WholeNumber(r.OpenInterest)} | {McpFormat.WholeNumber(r.CommLong)} | {McpFormat.WholeNumber(r.CommShort)} | {McpFormat.WholeNumber(r.NonCommLong)} | {McpFormat.WholeNumber(r.NonCommShort)} | {McpFormat.WholeNumber(r.NonCommSpreads)} |"
                 );
+
+                if (reports.Count < total)
+                    table +=
+                        Environment.NewLine
+                        + $"_Showing the newest {reports.Count} of {total} reports in the range - raise maxResults or narrow the date range to see older reports._";
+
+                return table;
             },
             "GetCftcPositioning",
             $"marketCode: {marketCode}"
@@ -88,7 +111,11 @@ public class CftcTools
 
     [McpServerTool(Name = "GetLatestCftcData")]
     [Description(
-        "Get the latest COT positioning snapshot across all tracked futures contracts, grouped by category (Agriculture, Energy, Metals, Equity Indices, Interest Rates, Currencies). Shows commercial and non-commercial net positions."
+        "Get the latest COT positioning snapshot across all tracked futures contracts, grouped "
+            + "by category (Agriculture, Energy, Metals, Equity Indices, Interest Rates, "
+            + "Currencies). Shows commercial and non-commercial net positions in contract "
+            + "counts from the legacy futures-only COT report (positions as of each Tuesday, "
+            + "published Friday). Each row carries the market code accepted by GetCftcPositioning."
     )]
     public Task<string> GetLatestCftcData(
         [Description(
@@ -101,13 +128,14 @@ public class CftcTools
             async () =>
             {
                 IQueryable<CftcContract> contractQuery;
+                CftcContractCategory? parsedCategory = null;
 
-                if (
-                    !string.IsNullOrEmpty(category)
-                    && Enum.TryParse<CftcContractCategory>(category, true, out var parsedCategory)
-                )
+                if (!string.IsNullOrWhiteSpace(category))
                 {
-                    contractQuery = _contractRepository.GetByCategory(parsedCategory);
+                    parsedCategory = ParseCategory(category);
+                    if (parsedCategory == null)
+                        return McpOutput.InvalidArgument("category", category, AcceptedCategories);
+                    contractQuery = _contractRepository.GetByCategory(parsedCategory.Value);
                 }
                 else
                 {
@@ -120,7 +148,9 @@ public class CftcTools
                     .ToListAsync();
 
                 if (contracts.Count == 0)
-                    return "No CFTC contracts found in the database.";
+                    return parsedCategory != null
+                        ? $"No tracked contracts in the {parsedCategory.Value.NameForHumans()} category."
+                        : "No CFTC contracts found in the database.";
 
                 var latestReports = await _reportRepository
                     .GetLatestPerContract()
@@ -128,8 +158,8 @@ public class CftcTools
 
                 var result = MarkdownTable.Start(
                     "Latest COT Positioning:",
-                    "| Market | Date | Open Interest | Comm Net | Non-Comm Net |",
-                    "|--------|------|--------------|----------|--------------|"
+                    "| Market | Code | Date | Open Interest | Comm Net | Non-Comm Net |",
+                    "|--------|------|------|--------------|----------|--------------|"
                 );
 
                 CftcContractCategory? currentCategory = null;
@@ -139,7 +169,7 @@ public class CftcTools
                     if (currentCategory != contract.Category)
                     {
                         currentCategory = contract.Category;
-                        result.AppendLine($"| **{contract.Category.NameForHumans()}** | | | | |");
+                        result.AppendLine($"| **{contract.Category.NameForHumans()}** | | | | | |");
                     }
 
                     latestReports.TryGetValue(contract.Id, out var report);
@@ -156,9 +186,14 @@ public class CftcTools
                             : "—";
 
                     result.AppendLine(
-                        $"| {contract.MarketName} | {dateStr} | {oiStr} | {commNet} | {nonCommNet} |"
+                        $"| {contract.MarketName} | {contract.MarketCode} | {dateStr} | {oiStr} | {commNet} | {nonCommNet} |"
                     );
                 }
+
+                result.AppendLine();
+                result.AppendLine(
+                    "_Values are contract counts. Use GetCftcPositioning(marketCode) for a contract's positioning history._"
+                );
 
                 return result.ToString();
             },
@@ -169,14 +204,20 @@ public class CftcTools
 
     [McpServerTool(Name = "SearchCftcMarkets")]
     [Description(
-        "Search for available CFTC futures contracts by name or market code. Returns matching contracts with their codes and categories. Use this to discover what COT data is available before calling GetCftcPositioning."
+        "Search the tracked CFTC futures contracts by name or market code, or omit the query "
+            + "to list every tracked contract. Coverage is a curated set of ~35 major contracts "
+            + "across Agriculture, Energy, Metals, Equity Indices, Interest Rates, and "
+            + "Currencies - markets outside this set have no COT data here. Returns matching "
+            + "contracts with their codes and categories; use this to discover market codes "
+            + "before calling GetCftcPositioning."
     )]
     public Task<string> SearchCftcMarkets(
         [Description(
-            "Search query — market code or name keyword (e.g., 'gold', 'crude', 'S&P', '088691')"
+            "Search query — market code or name keyword (e.g., 'gold', 'crude', 'S&P', '088691'). Omit to list all tracked contracts."
         )]
-            string query,
-        [Description("Maximum number of results to return (default: 20)")] int maxResults = 20
+            string query = null,
+        [Description("Maximum number of results to return (default: 50, max: 500)")]
+            int maxResults = 50
     )
     {
         return _runner.Execute(
@@ -184,24 +225,88 @@ public class CftcTools
             {
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var contracts = await _contractRepository
-                    .Search(query)
+                var matchQuery = string.IsNullOrWhiteSpace(query)
+                    ? _contractRepository.GetAll()
+                    : _contractRepository.Search(query.Trim());
+
+                var total = await matchQuery.CountAsync();
+
+                var contracts = await matchQuery
                     .OrderBy(c => c.Category)
                     .ThenBy(c => c.MarketName)
                     .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                var table = MarkdownTable.Render(
                     contracts,
-                    $"No contracts found matching '{query}'.",
-                    $"CFTC contracts matching '{query}':",
+                    string.IsNullOrWhiteSpace(query)
+                        ? "No CFTC contracts found in the database."
+                        : $"No tracked contracts match '{query}'. Coverage is a curated set of ~35 major contracts - omit the query to list them all.",
+                    string.IsNullOrWhiteSpace(query)
+                        ? "Tracked CFTC contracts:"
+                        : $"CFTC contracts matching '{query}':",
                     "| Market Code | Name | Category |",
                     "|-------------|------|----------|",
                     c => $"| {c.MarketCode} | {c.MarketName} | {c.Category.NameForHumans()} |"
                 );
+
+                var note = McpOutput.TruncationNote(contracts.Count, total);
+                if (note.Length > 0)
+                    table += Environment.NewLine + note;
+
+                return table;
             },
             "SearchCftcMarkets",
             $"query: {query}"
         );
+    }
+
+    // Maps the caller's category to the enum, accepting both the enum spelling
+    // (InterestRates) and the display spelling the tool's own output prints
+    // ("Interest Rates"). Matches by name so numeric strings never slip through
+    // Enum.TryParse into an unfiltered or undefined query.
+    private static CftcContractCategory? ParseCategory(string category)
+    {
+        var normalized = category.Replace(" ", "").Trim();
+        foreach (var candidate in Enum.GetValues<CftcContractCategory>())
+        {
+            if (string.Equals(candidate.ToString(), normalized, StringComparison.OrdinalIgnoreCase))
+                return candidate;
+        }
+        return null;
+    }
+
+    // Strict argument parsing shared by the date-ranged CFTC tools: a non-empty date must
+    // be exactly yyyy-MM-dd (no silent fallback to the default window), and an inverted
+    // range is a caller error rather than an empty-looking result.
+    private static string ParseRangeStrict(
+        string startDate,
+        string endDate,
+        DateOnly defaultStart,
+        out DateOnly start,
+        out DateOnly end
+    )
+    {
+        start = defaultStart;
+        end = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        if (!string.IsNullOrWhiteSpace(startDate))
+        {
+            if (!McpOutput.TryParseDate(startDate, out var parsedStart))
+                return McpOutput.InvalidArgument("startDate", startDate, "yyyy-MM-dd");
+            start = DateOnly.FromDateTime(parsedStart);
+        }
+
+        if (!string.IsNullOrWhiteSpace(endDate))
+        {
+            if (!McpOutput.TryParseDate(endDate, out var parsedEnd))
+                return McpOutput.InvalidArgument("endDate", endDate, "yyyy-MM-dd");
+            end = DateOnly.FromDateTime(parsedEnd);
+        }
+
+        if (start > end)
+            return $"startDate ({start:yyyy-MM-dd}) is after endDate ({end:yyyy-MM-dd}) - swap the dates.";
+
+        return null;
     }
 }

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -37,35 +37,48 @@ public class StockPriceTools
 
     [McpServerTool(Name = "GetStockPrices")]
     [Description(
-        "Get daily OHLCV (Open, High, Low, Close, Volume) price history for a stock. Useful for technical analysis, charting, and price trend analysis."
+        "Get daily OHLCV (Open, High, Low, Close, Volume) price history for a stock. Useful for "
+            + "technical analysis, charting, and price trend analysis. Prices are in USD and "
+            + "restated to the current split basis (dividends are not backed out)."
     )]
     public Task<string> GetStockPrices(
-        [Description("Stock ticker symbol (e.g., AAPL, MSFT, TSLA)")] string ticker,
+        [Description(
+            "Stock ticker symbol (e.g., AAPL, MSFT, TSLA). Class shares use a dash (BRK-B); the dot form (BRK.B) is also accepted."
+        )]
+            string ticker,
         [Description("Start date in YYYY-MM-DD format (defaults to 1 year ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of records to return (default: 250, newest first)")]
+        [Description(
+            "Maximum number of records to return (default: 250, max: 500). When the range holds more rows the newest are kept; rows are always listed oldest to newest."
+        )]
             int maxResults = 250
     )
     {
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                var (stock, stockError) = await ResolveTicker(ticker);
                 if (stockError != null)
                     return stockError;
 
-                var (start, end) = McpToolExecutor.ParseDateRange(
+                var rangeError = ParseRangeStrict(
                     startDate,
                     endDate,
-                    McpToolExecutor.UtcYearsAgo(1)
+                    McpToolExecutor.UtcYearsAgo(1),
+                    out var start,
+                    out var end
                 );
+                if (rangeError != null)
+                    return rangeError;
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var records = await _priceRepository
-                    .GetByStock(stock, start, end)
+                var rangeQuery = _priceRepository.GetByStock(stock, start, end);
+                var total = await rangeQuery.CountAsync();
+
+                var records = await rangeQuery
                     .OrderByDescending(p => p.Date)
                     .Take(maxResults)
                     .ToListAsync();
@@ -85,6 +98,8 @@ public class StockPriceTools
                         $"| {p.Date:yyyy-MM-dd} | {McpFormat.Invariant(p.Open, "F2")} | {McpFormat.Invariant(p.High, "F2")} | {McpFormat.Invariant(p.Low, "F2")} | {McpFormat.Invariant(p.Close, "F2")} | {McpFormat.WholeNumber(p.Volume)} |"
                 );
 
+                AppendNewestKeptTruncationNote(result, records.Count, total);
+
                 return result.ToString();
             },
             "GetStockPrices",
@@ -94,10 +109,13 @@ public class StockPriceTools
 
     [McpServerTool(Name = "GetLatestPrices")]
     [Description(
-        "Get the most recent closing price and volume for one or more stocks. Useful for quick price checks across a portfolio or watchlist."
+        "Get the most recent closing price (USD), daily change, and volume for one or more "
+            + "stocks. Useful for quick price checks across a portfolio or watchlist."
     )]
     public Task<string> GetLatestPrices(
-        [Description("Comma-separated list of ticker symbols (e.g., 'AAPL,MSFT,GOOG,TSLA')")]
+        [Description(
+            "Comma-separated list of ticker symbols (e.g., 'AAPL,MSFT,GOOG,TSLA'). Maximum 25 per request. Class shares use a dash (BRK-B); the dot form (BRK.B) is also accepted."
+        )]
             string tickers
     )
     {
@@ -120,39 +138,49 @@ public class StockPriceTools
 
                 var result = StartTable(
                     "Latest prices:",
-                    "| Ticker | Date | Close | Volume |",
-                    "|--------|------|-------|--------|"
+                    "| Ticker | Date | Close | Change | Change % | Volume |",
+                    "|--------|------|-------|--------|----------|--------|"
                 );
 
                 foreach (var ticker in tickerList)
                 {
-                    var stock = await _commonStockRepository.GetByTicker(ticker);
+                    var (stock, _) = await ResolveTicker(ticker);
                     if (stock == null)
                     {
                         result.AppendLine(PlaceholderRow(ticker, "Not found"));
                         continue;
                     }
 
-                    var latestDate = await _priceRepository
-                        .GetLatestDate(stock)
-                        .FirstOrDefaultAsync();
-                    if (latestDate == default)
+                    // Newest two bars in one query: the latest row plus the prior close
+                    // needed for the day-over-day change columns.
+                    var latestTwo = await _priceRepository
+                        .GetByStock(stock)
+                        .OrderByDescending(p => p.Date)
+                        .Take(2)
+                        .ToListAsync();
+                    if (latestTwo.Count == 0)
                     {
                         result.AppendLine(PlaceholderRow(ticker, "No data"));
                         continue;
                     }
 
-                    var price = await _priceRepository
-                        .GetByStock(stock, latestDate, latestDate)
-                        .FirstOrDefaultAsync();
-                    if (price == null)
+                    var price = latestTwo[0];
+                    var previousClose = latestTwo.Count > 1 ? latestTwo[1].Close : (decimal?)null;
+                    var changeCell = "—";
+                    var changePctCell = "—";
+                    if (previousClose != null && previousClose.Value > 0)
                     {
-                        result.AppendLine(PlaceholderRow(ticker, "No data"));
-                        continue;
+                        var change = price.Close - previousClose.Value;
+                        changeCell = McpFormat.Invariant(change, "+0.00;-0.00;0.00");
+                        changePctCell =
+                            McpFormat.Invariant(
+                                change / previousClose.Value * 100m,
+                                "+0.00;-0.00;0.00"
+                            ) + "%";
                     }
 
                     result.AppendLine(
-                        $"| {ticker} | {price.Date:yyyy-MM-dd} | {McpFormat.Invariant(price.Close, "F2")} | {McpFormat.WholeNumber(price.Volume)} |"
+                        $"| {ticker} | {price.Date:yyyy-MM-dd} | {McpFormat.Invariant(price.Close, "F2")} | {changeCell} | {changePctCell} | {McpFormat.WholeNumber(price.Volume)} |"
                     );
                 }
 
@@ -168,17 +196,23 @@ public class StockPriceTools
         "Stochastic Oscillator (%K and %D) for a stock. %K measures the close relative to "
             + "the high/low range over the lookback window; %D is the smoothed signal line "
             + "(simple moving average of %K). Useful for spotting overbought (>80) and "
-            + "oversold (<20) conditions."
+            + "oversold (<20) conditions. The lookback window is warmed up on price history "
+            + "fetched before startDate, so values do not depend on the requested range's left edge."
     )]
     public Task<string> GetStochasticOscillator(
-        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description(
+            "Stock ticker symbol (e.g., AAPL, MSFT). Class shares use a dash (BRK-B); the dot form (BRK.B) is also accepted."
+        )]
+            string ticker,
         [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
         [Description("Lookback window for %K (default: 14)")] int kPeriod = 14,
         [Description("Smoothing window for %D (default: 3)")] int dPeriod = 3,
-        [Description("Maximum number of records to return (default: 60, newest first)")]
+        [Description(
+            "Maximum number of records to return (default: 60, max: 500); the newest rows are kept and listed newest first."
+        )]
             int maxResults = 60
     )
     {
@@ -188,10 +222,15 @@ public class StockPriceTools
                 if (kPeriod < 2 || dPeriod < 1)
                     return "kPeriod must be at least 2 and dPeriod at least 1.";
 
-                var (stock, records, error) = await LoadAscendingPriceWindow(
+                maxResults = McpLimit.Clamp(maxResults);
+
+                // %K needs kPeriod bars and %D another dPeriod - 1 %K values, so this many
+                // extra bars before startDate make the first in-range row fully computable.
+                var (stock, records, renderFrom, error) = await LoadAscendingPriceWindow(
                     ticker,
                     startDate,
-                    endDate
+                    endDate,
+                    warmupBars: kPeriod + dPeriod - 2
                 );
                 if (error != null)
                     return error;
@@ -210,13 +249,15 @@ public class StockPriceTools
                     "| Date | Close | %K | %D |",
                     "|------|-------|----|----|",
                     records.Count,
+                    renderFrom,
                     maxResults,
                     i =>
                     {
                         var kCell = McpFormat.OrDash(k[i], "F2");
                         var dCell = McpFormat.OrDash(d[i], "F2");
                         return $"| {DateAndCloseCells(records[i])} | {kCell} | {dCell} |";
-                    }
+                    },
+                    "_'—' marks rows with too little prior price history to fill the lookback window._"
                 );
             },
             "GetStochasticOscillator",
@@ -229,16 +270,23 @@ public class StockPriceTools
         "Average True Range (ATR) for a stock. Wilder's volatility measure built from "
             + "the True Range (max of high-low, |high-prev_close|, |low-prev_close|) and "
             + "smoothed recursively. Higher ATR means wider daily moves; commonly used "
-            + "for position sizing and stop placement."
+            + "for position sizing and stop placement. ATR is denominated in the stock's "
+            + "price units (USD). The smoothing is warmed up on price history fetched before "
+            + "startDate, so values do not depend on the requested range's left edge."
     )]
     public Task<string> GetAverageTrueRange(
-        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description(
+            "Stock ticker symbol (e.g., AAPL, MSFT). Class shares use a dash (BRK-B); the dot form (BRK.B) is also accepted."
+        )]
+            string ticker,
         [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
         [Description("Smoothing window (default: 14)")] int period = 14,
-        [Description("Maximum number of records to return (default: 60, newest first)")]
+        [Description(
+            "Maximum number of records to return (default: 60, max: 500); the newest rows are kept and listed newest first."
+        )]
             int maxResults = 60
     )
     {
@@ -248,10 +296,16 @@ public class StockPriceTools
                 if (period < 2)
                     return "period must be at least 2.";
 
-                var (stock, records, error) = await LoadAscendingPriceWindow(
+                maxResults = McpLimit.Clamp(maxResults);
+
+                // Wilder smoothing is recursive, so the seed's influence decays rather than
+                // ends: two extra periods of pre-range bars push the seed far enough back
+                // that in-range values no longer depend on where the caller put startDate.
+                var (stock, records, renderFrom, error) = await LoadAscendingPriceWindow(
                     ticker,
                     startDate,
-                    endDate
+                    endDate,
+                    warmupBars: period * 2
                 );
                 if (error != null)
                     return error;
@@ -264,12 +318,14 @@ public class StockPriceTools
                     "| Date | Close | ATR |",
                     "|------|-------|-----|",
                     records.Count,
+                    renderFrom,
                     maxResults,
                     i =>
                     {
                         var atrCell = McpFormat.OrDash(atr[i], "F4");
                         return $"| {DateAndCloseCells(records[i])} | {atrCell} |";
-                    }
+                    },
+                    "_ATR is in the stock's price units (USD). '—' marks rows with too little prior price history to fill the smoothing window._"
                 );
             },
             "GetAverageTrueRange",
@@ -282,25 +338,37 @@ public class StockPriceTools
         "On-Balance Volume (OBV) for a stock. Running cumulative volume that adds the "
             + "bar's volume on up-closes, subtracts on down-closes, and stays flat on "
             + "equal closes. Useful for confirming or diverging from price trends with "
-            + "volume flow."
+            + "volume flow. OBV is anchored at 0 on the first bar of the requested range, "
+            + "so absolute values shift with startDate and are not comparable across calls "
+            + "- read the slope and divergences, not the level."
     )]
     public Task<string> GetOnBalanceVolume(
-        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description(
+            "Stock ticker symbol (e.g., AAPL, MSFT). Class shares use a dash (BRK-B); the dot form (BRK.B) is also accepted."
+        )]
+            string ticker,
         [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
-        [Description("Maximum number of records to return (default: 60, newest first)")]
+        [Description(
+            "Maximum number of records to return (default: 60, max: 500); the newest rows are kept and listed newest first."
+        )]
             int maxResults = 60
     )
     {
         return _runner.Execute(
             async () =>
             {
-                var (stock, records, error) = await LoadAscendingPriceWindow(
+                maxResults = McpLimit.Clamp(maxResults);
+
+                // No warm-up: OBV is a running sum with no lookback window, and the tool
+                // contract deliberately anchors it at 0 on the range's first bar.
+                var (stock, records, _, error) = await LoadAscendingPriceWindow(
                     ticker,
                     startDate,
-                    endDate
+                    endDate,
+                    warmupBars: 0
                 );
                 if (error != null)
                     return error;
@@ -314,9 +382,11 @@ public class StockPriceTools
                     "| Date | Close | Volume | OBV |",
                     "|------|-------|--------|-----|",
                     records.Count,
+                    renderFrom: 0,
                     maxResults,
                     i =>
-                        $"| {DateAndCloseCells(records[i])} | {McpFormat.WholeNumber(records[i].Volume)} | {McpFormat.WholeNumber(obv[i])} |"
+                        $"| {DateAndCloseCells(records[i])} | {McpFormat.WholeNumber(records[i].Volume)} | {McpFormat.WholeNumber(obv[i])} |",
+                    $"_OBV is anchored at 0 on {records[0].Date:yyyy-MM-dd} (the first bar of the requested range); absolute values shift with startDate, so compare slopes, not levels._"
                 );
             },
             "GetOnBalanceVolume",
@@ -329,10 +399,16 @@ public class StockPriceTools
         "Bollinger Bands for a stock. A middle band (simple moving average of close) with "
             + "upper and lower bands set a number of standard deviations above and below it. "
             + "Bands widen when volatility rises and contract when it falls; price touching "
-            + "the upper/lower band is a common overbought/oversold cue."
+            + "the upper/lower band is a common overbought/oversold cue. Includes %B "
+            + "((close-lower)/(upper-lower)) and bandwidth ((upper-lower)/middle) columns. "
+            + "The moving-average window is warmed up on price history fetched before "
+            + "startDate, so values do not depend on the requested range's left edge."
     )]
     public Task<string> GetBollingerBands(
-        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description(
+            "Stock ticker symbol (e.g., AAPL, MSFT). Class shares use a dash (BRK-B); the dot form (BRK.B) is also accepted."
+        )]
+            string ticker,
         [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
@@ -340,7 +416,9 @@ public class StockPriceTools
         [Description("Moving-average window (default: 20)")] int period = 20,
         [Description("Standard deviations for the upper/lower bands (default: 2)")]
             decimal stdDev = 2m,
-        [Description("Maximum number of records to return (default: 60, newest first)")]
+        [Description(
+            "Maximum number of records to return (default: 60, max: 500); the newest rows are kept and listed newest first."
+        )]
             int maxResults = 60
     )
     {
@@ -352,10 +430,15 @@ public class StockPriceTools
                 if (stdDev <= 0)
                     return "stdDev must be greater than 0.";
 
-                var (stock, records, error) = await LoadAscendingPriceWindow(
+                maxResults = McpLimit.Clamp(maxResults);
+
+                // The SMA window is exactly period bars, so period - 1 extra bars before
+                // startDate make the first in-range row fully computable.
+                var (stock, records, renderFrom, error) = await LoadAscendingPriceWindow(
                     ticker,
                     startDate,
-                    endDate
+                    endDate,
+                    warmupBars: period - 1
                 );
                 if (error != null)
                     return error;
@@ -369,17 +452,21 @@ public class StockPriceTools
 
                 return RenderNewestFirst(
                     $"Bollinger Bands (period={period}, stdDev={McpFormat.Invariant(stdDev, "0.#")}) for {stock.Ticker} ({stock.Name}):",
-                    "| Date | Close | Lower | Middle | Upper |",
-                    "|------|-------|-------|--------|-------|",
+                    "| Date | Close | Lower | Middle | Upper | %B | Bandwidth |",
+                    "|------|-------|-------|--------|-------|----|-----------|",
                     records.Count,
+                    renderFrom,
                     maxResults,
                     i =>
                     {
                         var lowerCell = McpFormat.OrDash(lower[i], "F2");
                         var middleCell = McpFormat.OrDash(middle[i], "F2");
                         var upperCell = McpFormat.OrDash(upper[i], "F2");
-                        return $"| {DateAndCloseCells(records[i])} | {lowerCell} | {middleCell} | {upperCell} |";
-                    }
+                        var percentB = PercentB(closes[i], upper[i], lower[i]);
+                        var bandwidth = Bandwidth(middle[i], upper[i], lower[i]);
+                        return $"| {DateAndCloseCells(records[i])} | {lowerCell} | {middleCell} | {upperCell} | {McpFormat.OrDash(percentB, "F2")} | {McpFormat.OrDash(bandwidth, "F4")} |";
+                    },
+                    "_'—' marks rows with too little prior price history to fill the moving-average window._"
                 );
             },
             "GetBollingerBands",
@@ -387,21 +474,106 @@ public class StockPriceTools
         );
     }
 
+    // %B = (close - lower) / (upper - lower). Null while the band window is still filling
+    // or when the bands collapse to a zero-width range (flat prices).
+    private static decimal? PercentB(decimal close, decimal? upper, decimal? lower)
+    {
+        if (upper == null || lower == null || upper == lower)
+            return null;
+        return Math.Round((close - lower.Value) / (upper.Value - lower.Value), 4);
+    }
+
+    // Bandwidth = (upper - lower) / middle. Null while the band window is still filling.
+    private static decimal? Bandwidth(decimal? middle, decimal? upper, decimal? lower)
+    {
+        if (middle == null || middle.Value == 0 || upper == null || lower == null)
+            return null;
+        return Math.Round((upper.Value - lower.Value) / middle.Value, 4);
+    }
+
+    // Resolves a ticker to a stock, additionally accepting the dot class-share notation
+    // (BRK.B) for the dash form the price data stores (BRK-B). This is a mechanical
+    // format conversion between two spellings of the same symbol, not a heuristic.
+    private async Task<(CommonStock Stock, string Error)> ResolveTicker(string ticker)
+    {
+        var (stock, error) = await _commonStockRepository.ResolveByTicker(ticker);
+        if (stock == null && ticker != null && ticker.Contains('.'))
+        {
+            var (dashed, _) = await _commonStockRepository.ResolveByTicker(
+                ticker.Replace('.', '-')
+            );
+            if (dashed != null)
+                return (dashed, null);
+        }
+        return (stock, error);
+    }
+
+    // Strict argument parsing shared by the date-ranged price tools: a non-empty date must
+    // be exactly yyyy-MM-dd (no silent fallback to the default window), and an inverted
+    // range is a caller error rather than an empty-looking result.
+    private static string ParseRangeStrict(
+        string startDate,
+        string endDate,
+        DateOnly defaultStart,
+        out DateOnly start,
+        out DateOnly end
+    )
+    {
+        start = defaultStart;
+        end = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        if (!string.IsNullOrWhiteSpace(startDate))
+        {
+            if (!McpOutput.TryParseDate(startDate, out var parsedStart))
+                return McpOutput.InvalidArgument("startDate", startDate, "yyyy-MM-dd");
+            start = DateOnly.FromDateTime(parsedStart);
+        }
+
+        if (!string.IsNullOrWhiteSpace(endDate))
+        {
+            if (!McpOutput.TryParseDate(endDate, out var parsedEnd))
+                return McpOutput.InvalidArgument("endDate", endDate, "yyyy-MM-dd");
+            end = DateOnly.FromDateTime(parsedEnd);
+        }
+
+        if (start > end)
+            return $"startDate ({start:yyyy-MM-dd}) is after endDate ({end:yyyy-MM-dd}) - swap the dates.";
+
+        return null;
+    }
+
+    // Appended after tables that keep the NEWEST rows but render oldest-to-newest, where
+    // the shared "Showing first N" wording would point at the wrong end of the table.
+    private static void AppendNewestKeptTruncationNote(StringBuilder result, int shown, int total)
+    {
+        if (shown >= total)
+            return;
+        result.AppendLine();
+        result.AppendLine(
+            $"_Showing the newest {shown} of {total} records in the range - raise maxResults or narrow the date range to see older rows._"
+        );
+    }
+
     private async Task<(
         CommonStock Stock,
         List<DailyStockPrice> Records,
+        int RenderFrom,
         string Error
-    )> LoadAscendingPriceWindow(string ticker, string startDate, string endDate)
+    )> LoadAscendingPriceWindow(string ticker, string startDate, string endDate, int warmupBars)
     {
-        var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+        var (stock, stockError) = await ResolveTicker(ticker);
         if (stockError != null)
-            return (null, null, stockError);
+            return (null, null, 0, stockError);
 
-        var (start, end) = McpToolExecutor.ParseDateRange(
+        var rangeError = ParseRangeStrict(
             startDate,
             endDate,
-            McpToolExecutor.UtcMonthsAgo(6)
+            McpToolExecutor.UtcMonthsAgo(6),
+            out var start,
+            out var end
         );
+        if (rangeError != null)
+            return (stock, null, 0, rangeError);
 
         var records = await _priceRepository
             .GetByStock(stock, start, end)
@@ -412,10 +584,31 @@ public class StockPriceTools
             return (
                 stock,
                 null,
+                0,
                 $"No price data found for {stock.Ticker} in the specified date range."
             );
 
-        return (stock, records, null);
+        // Warm-up look-back: indicators with a lookback window are computed over extra
+        // bars fetched BEFORE the requested start so the early in-range rows aren't
+        // null-padded warm-up dashes; only rows from RenderFrom onward are rendered.
+        var renderFrom = 0;
+        if (warmupBars > 0)
+        {
+            var warmup = await _priceRepository
+                .GetByStock(stock)
+                .Where(p => p.Date < start)
+                .OrderByDescending(p => p.Date)
+                .Take(warmupBars)
+                .ToListAsync();
+            if (warmup.Count > 0)
+            {
+                warmup.Reverse();
+                records.InsertRange(0, warmup);
+                renderFrom = warmup.Count;
+            }
+        }
+
+        return (stock, records, renderFrom, null);
     }
 
     // Thin forwarder to the shared helper so the load-bearing title/blank/header/separator
@@ -425,30 +618,50 @@ public class StockPriceTools
         MarkdownTable.Start(title, columnsRow, separatorRow);
 
     // Renders the newest-first indicator table shared by the technical-indicator tools:
-    // the load-bearing title/header/separator start, the newest-first row loop, then ToString.
+    // the load-bearing title/header/separator start, the newest-first row loop from
+    // renderFrom (warm-up rows before it stay hidden), a truncation note when maxResults
+    // cut the renderable rows, then an optional footnote.
     private static string RenderNewestFirst(
         string title,
         string columnsRow,
         string separatorRow,
         int count,
+        int renderFrom,
         int maxResults,
-        Func<int, string> formatRow
+        Func<int, string> formatRow,
+        string footnote = null
     )
     {
         var result = StartTable(title, columnsRow, separatorRow);
-        AppendNewestFirstRows(result, count, maxResults, formatRow);
+        AppendNewestFirstRows(result, count, renderFrom, maxResults, formatRow);
+
+        var available = count - renderFrom;
+        var note = McpOutput.TruncationNote(Math.Min(available, maxResults), available);
+        if (note.Length > 0)
+        {
+            result.AppendLine();
+            result.AppendLine(note);
+        }
+
+        if (footnote != null)
+        {
+            result.AppendLine();
+            result.AppendLine(footnote);
+        }
+
         return result.ToString();
     }
 
     private static void AppendNewestFirstRows(
         StringBuilder result,
         int count,
+        int renderFrom,
         int maxResults,
         Func<int, string> formatRow
     )
     {
         var emitted = 0;
-        for (var i = count - 1; i >= 0 && emitted < maxResults; i--)
+        for (var i = count - 1; i >= renderFrom && emitted < maxResults; i--)
         {
             result.AppendLine(formatRow(i));
             emitted++;
@@ -458,7 +671,7 @@ public class StockPriceTools
     // Placeholder row for a ticker with no price to show (unknown symbol or no data),
     // keeping the em-dash columns identical across the per-ticker fallback branches.
     private static string PlaceholderRow(string ticker, string status) =>
-        $"| {ticker} | — | {status} | — |";
+        $"| {ticker} | — | {status} | — | — | — |";
 
     // Leading "Date | Close" cells shared by every technical-indicator table row;
     // keeps the date format and close precision in sync across the four tables.

--- a/tests/Equibles.IntegrationTests/Cftc/CftcImportServiceRegistryResyncTests.cs
+++ b/tests/Equibles.IntegrationTests/Cftc/CftcImportServiceRegistryResyncTests.cs
@@ -1,0 +1,241 @@
+using Equibles.Cftc.Data.Models;
+using Equibles.Cftc.HostedService.Services;
+using Equibles.Cftc.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Cftc.Contracts;
+using Equibles.Integrations.Cftc.Models;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Cftc;
+
+/// <summary>
+/// Pins the two registry-driven repair behaviors added with the market-code mislabel
+/// fix (an earlier <see cref="CuratedContractRegistry"/> revision carried ten wrong
+/// display names, e.g. code 057642 said "Lean Hogs" while the CFTC assigns it to
+/// Live Cattle):
+///
+///   1. <c>EnsureContractsExist</c> re-syncs a stored contract's MarketName/Category
+///      when they drift from the registry entry for the same code, so deploying a
+///      registry correction repairs the production rows without manual SQL.
+///   2. <c>DetermineStartYear</c> falls back to a full-history walk while any contract
+///      has no reports at all, so a code newly added to the registry backfills its
+///      history instead of accumulating only current-year data.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class CftcImportServiceRegistryResyncTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public CftcImportServiceRegistryResyncTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.ResetAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(CftcContractRepository))
+                    .Returns(new CftcContractRepository(ctx));
+                sp.GetService(typeof(CftcPositionReportRepository))
+                    .Returns(new CftcPositionReportRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private CftcImportService CreateImporter(
+        ICftcClient cftcClient,
+        WorkerOptions workerOptions = null
+    )
+    {
+        return new CftcImportService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<CftcImportService>>(),
+            cftcClient,
+            Options.Create(workerOptions ?? new WorkerOptions()),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+    }
+
+    private static ICftcClient EmptyClient()
+    {
+        var cftcClient = Substitute.For<ICftcClient>();
+        cftcClient.DownloadYearlyReport(Arg.Any<int>()).Returns([]);
+        return cftcClient;
+    }
+
+    /// <summary>
+    /// Seeds every curated contract with registry-true metadata, a LatestReportDate,
+    /// and one anchoring position report so DetermineStartYear sees a fully-populated
+    /// universe (no empty contract → no full-history walk).
+    /// </summary>
+    private async Task SeedFullyPopulatedUniverse(DateOnly latestReportDate)
+    {
+        using var seed = FreshContext();
+        CftcContract first = null;
+        foreach (var curated in CuratedContractRegistry.Contracts)
+        {
+            var contract = new CftcContract
+            {
+                MarketCode = curated.MarketCode,
+                MarketName = curated.DisplayName,
+                Category = curated.Category,
+                LatestReportDate = latestReportDate,
+            };
+            first ??= contract;
+            seed.Set<CftcContract>().Add(contract);
+        }
+        seed.Set<CftcPositionReport>()
+            .Add(
+                new CftcPositionReport
+                {
+                    CftcContract = first,
+                    CftcContractId = first.Id,
+                    ReportDate = latestReportDate,
+                }
+            );
+        await seed.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Import_ContractNameDriftedFromRegistry_ResyncsNameAndCategory()
+    {
+        // A production row created by the mislabeled registry revision: code 057642
+        // stored as "Lean Hogs (CME)" although the CFTC assigns that code to Live
+        // Cattle. The position reports under the code are Live Cattle's real data,
+        // so the repair is a rename of the contract row — Import must apply it.
+        using (var seed = FreshContext())
+        {
+            seed.Set<CftcContract>()
+                .Add(
+                    new CftcContract
+                    {
+                        MarketCode = "057642",
+                        MarketName = "Lean Hogs (CME)",
+                        Category = CftcContractCategory.Agriculture,
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var sut = CreateImporter(
+            EmptyClient(),
+            new WorkerOptions { MinSyncDate = new DateTime(DateTime.UtcNow.Year, 1, 1) }
+        );
+
+        await sut.Import(CancellationToken.None);
+
+        using var verify = FreshContext();
+        var contract = await verify.Set<CftcContract>().SingleAsync(c => c.MarketCode == "057642");
+        contract.MarketName.Should().Be("Live Cattle (CME)");
+        contract.Category.Should().Be(CftcContractCategory.Agriculture);
+    }
+
+    [Fact]
+    public async Task Import_ContractWithNoReports_TriggersFullHistoryWalk()
+    {
+        // Universe fully populated except one curated code missing entirely — Import
+        // creates it (with no reports), which must widen the year walk back to
+        // MinSyncDate so the new contract backfills its history. Without the widening,
+        // DetermineStartYear would return the global-latest year (2026 here) and the
+        // new code would never receive pre-2026 reports.
+        var currentYear = DateTime.UtcNow.Year;
+        using (var seed = FreshContext())
+        {
+            CftcContract first = null;
+            foreach (var curated in CuratedContractRegistry.Contracts.Skip(1))
+            {
+                var contract = new CftcContract
+                {
+                    MarketCode = curated.MarketCode,
+                    MarketName = curated.DisplayName,
+                    Category = curated.Category,
+                    LatestReportDate = new DateOnly(currentYear, 1, 6),
+                };
+                first ??= contract;
+                seed.Set<CftcContract>().Add(contract);
+            }
+            seed.Set<CftcPositionReport>()
+                .Add(
+                    new CftcPositionReport
+                    {
+                        CftcContract = first,
+                        CftcContractId = first.Id,
+                        ReportDate = new DateOnly(currentYear, 1, 6),
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var cftcClient = EmptyClient();
+        var sut = CreateImporter(
+            cftcClient,
+            new WorkerOptions { MinSyncDate = new DateTime(currentYear - 2, 1, 1) }
+        );
+
+        await sut.Import(CancellationToken.None);
+
+        await cftcClient.Received(1).DownloadYearlyReport(currentYear - 2);
+        await cftcClient.Received(1).DownloadYearlyReport(currentYear - 1);
+        await cftcClient.Received(1).DownloadYearlyReport(currentYear);
+    }
+
+    [Fact]
+    public async Task Import_AllContractsHaveReports_WalksOnlyFromGlobalLatestYear()
+    {
+        // Control for the full-walk trigger: with every curated contract populated,
+        // the incremental behavior must stay put — only the global-latest year is
+        // re-walked, not the whole MinSyncDate window.
+        var currentYear = DateTime.UtcNow.Year;
+        await SeedFullyPopulatedUniverse(new DateOnly(currentYear, 1, 6));
+
+        var cftcClient = EmptyClient();
+        var sut = CreateImporter(
+            cftcClient,
+            new WorkerOptions { MinSyncDate = new DateTime(currentYear - 2, 1, 1) }
+        );
+
+        await sut.Import(CancellationToken.None);
+
+        await cftcClient.DidNotReceive().DownloadYearlyReport(currentYear - 1);
+        await cftcClient.Received(1).DownloadYearlyReport(currentYear);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/CboeToolsStrictArgsAndTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CboeToolsStrictArgsAndTruncationTests.cs
@@ -1,0 +1,135 @@
+using Equibles.Cboe.Data.Models;
+using Equibles.Cboe.Mcp.Tools;
+using Equibles.Cboe.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the MCP-audit fixes on the CBOE tools: strict yyyy-MM-dd date parsing (no
+/// silent fallback to the default window), inverted-range errors, and the
+/// newest-kept truncation note when maxResults cuts the requested range.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class CboeToolsStrictArgsAndTruncationTests : ParadeDbMcpTestBase
+{
+    private CboeTools Sut() =>
+        new(
+            new CboePutCallRatioRepository(DbContext),
+            new CboeVixDailyRepository(DbContext),
+            ErrorManager,
+            NullLogger<CboeTools>()
+        );
+
+    public CboeToolsStrictArgsAndTruncationTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static CboeVixDaily VixFor(DateOnly date) =>
+        new()
+        {
+            Date = date,
+            Open = 14.20m,
+            High = 15.30m,
+            Low = 13.80m,
+            Close = 14.95m,
+        };
+
+    private static CboePutCallRatio ReconcilableRatioFor(DateOnly date) =>
+        new()
+        {
+            RatioType = CboePutCallRatioType.Equity,
+            Date = date,
+            CallVolume = 1_200_000,
+            PutVolume = 800_000,
+            TotalVolume = 2_000_000,
+            PutCallRatio = 0.67m,
+        };
+
+    [Fact]
+    public async Task GetVixHistory_MalformedStartDate_ReturnsInvalidArgumentError()
+    {
+        // ParseDateOr used to silently replace an unparseable date with "3 months ago",
+        // returning plausible recent data as if the request had been honored.
+        var result = await Sut().GetVixHistory(startDate: "2020-13-01");
+
+        result.Should().Be("Unknown startDate '2020-13-01'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetVixHistory_InvertedRange_ReturnsSwapErrorNotEmptyRange()
+    {
+        var result = await Sut().GetVixHistory(startDate: "2026-07-01", endDate: "2026-01-01");
+
+        result
+            .Should()
+            .Be("startDate (2026-07-01) is after endDate (2026-01-01) - swap the dates.");
+    }
+
+    [Fact]
+    public async Task GetVixHistory_RangeExceedsMaxResults_AppendsNewestKeptNote()
+    {
+        // The query keeps the newest maxResults rows but renders oldest→newest, so a
+        // truncated March-2020 style query silently dropped the spike the caller asked
+        // about. The note must name both counts and say the NEWEST rows were kept.
+        for (var day = 1; day <= 5; day++)
+            DbContext.Set<CboeVixDaily>().Add(VixFor(new DateOnly(2026, 4, day)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetVixHistory(startDate: "2026-04-01", endDate: "2026-04-30", maxResults: 2);
+
+        result.Should().Contain("Showing the newest 2 of 5 records");
+        result.Should().Contain("2026-04-05");
+        result.Should().NotContain("2026-04-03");
+    }
+
+    [Fact]
+    public async Task GetVixHistory_AllRowsShown_OmitsTruncationNote()
+    {
+        DbContext.Set<CboeVixDaily>().Add(VixFor(new DateOnly(2026, 4, 1)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetVixHistory(startDate: "2026-04-01", endDate: "2026-04-30");
+
+        result.Should().NotContain("Showing the newest");
+    }
+
+    [Fact]
+    public async Task GetPutCallRatios_MalformedEndDate_ReturnsInvalidArgumentError()
+    {
+        var result = await Sut().GetPutCallRatios(endDate: "last month");
+
+        result.Should().Be("Unknown endDate 'last month'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetPutCallRatios_InvertedRange_ReturnsSwapErrorNotEmptyRange()
+    {
+        var result = await Sut().GetPutCallRatios(startDate: "2026-07-10", endDate: "2026-06-01");
+
+        result
+            .Should()
+            .Be("startDate (2026-07-10) is after endDate (2026-06-01) - swap the dates.");
+    }
+
+    [Fact]
+    public async Task GetPutCallRatios_RangeExceedsMaxResults_AppendsNewestKeptNote()
+    {
+        for (var day = 1; day <= 5; day++)
+            DbContext.Set<CboePutCallRatio>().Add(ReconcilableRatioFor(new DateOnly(2026, 4, day)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetPutCallRatios(
+                type: "Equity",
+                startDate: "2026-04-01",
+                endDate: "2026-04-30",
+                maxResults: 2
+            );
+
+        result.Should().Contain("Showing the newest 2 of 5 records");
+        result.Should().Contain("2026-04-05");
+        result.Should().NotContain("2026-04-03");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/CftcToolsStrictArgsAndDiscoveryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CftcToolsStrictArgsAndDiscoveryTests.cs
@@ -1,0 +1,226 @@
+using Equibles.Cftc.Data.Models;
+using Equibles.Cftc.Mcp.Tools;
+using Equibles.Cftc.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the MCP-audit fixes on the CFTC tools: strict category validation on
+/// GetLatestCftcData (no silent all-categories fallback, display spellings accepted,
+/// numeric strings rejected), the market-code column and units footer, the
+/// query-optional list-all mode and truncation note on SearchCftcMarkets, and strict
+/// dates plus the truncation note on GetCftcPositioning.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class CftcToolsStrictArgsAndDiscoveryTests : ParadeDbMcpTestBase
+{
+    private CftcTools Sut() =>
+        new(
+            new CftcContractRepository(DbContext),
+            new CftcPositionReportRepository(DbContext),
+            ErrorManager,
+            NullLogger<CftcTools>()
+        );
+
+    public CftcToolsStrictArgsAndDiscoveryTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static CftcContract Contract(string code, string name, CftcContractCategory category) =>
+        new()
+        {
+            MarketCode = code,
+            MarketName = name,
+            Category = category,
+        };
+
+    private static CftcPositionReport ReportFor(CftcContract contract, DateOnly date) =>
+        new()
+        {
+            CftcContract = contract,
+            CftcContractId = contract.Id,
+            ReportDate = date,
+            OpenInterest = 100_000,
+            CommLong = 60_000,
+            CommShort = 40_000,
+            NonCommLong = 30_000,
+            NonCommShort = 25_000,
+            NonCommSpreads = 5_000,
+            TotalRptLong = 90_000,
+            TotalRptShort = 65_000,
+            NonRptLong = 5_000,
+            NonRptShort = 5_000,
+        };
+
+    // ── GetLatestCftcData category validation ────────────────────────────
+
+    [Fact]
+    public async Task GetLatestCftcData_UnknownCategory_ReturnsErrorListingAccepted()
+    {
+        // An invalid category used to silently fall back to ALL categories — the caller
+        // got the full 30+ row table and could misreport it as the filtered set.
+        DbContext
+            .Set<CftcContract>()
+            .Add(Contract("067651", "Crude Oil, Light Sweet (NYMEX)", CftcContractCategory.Energy));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLatestCftcData(category: "ZZZZZT");
+
+        result
+            .Should()
+            .Be(
+                "Unknown category 'ZZZZZT'. Accepted: Agriculture, Energy, Metals, EquityIndices, InterestRates, Currencies."
+            );
+    }
+
+    [Fact]
+    public async Task GetLatestCftcData_DisplaySpellingWithSpace_IsAccepted()
+    {
+        // The tool's own output prints display names ("Interest Rates"), so a caller
+        // copying that spelling back must not be rejected: whitespace folds before
+        // the enum-name match.
+        DbContext
+            .Set<CftcContract>()
+            .AddRange(
+                Contract("043602", "10-Year T-Notes (CBOT)", CftcContractCategory.InterestRates),
+                Contract("088691", "Gold (COMEX)", CftcContractCategory.Metals)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLatestCftcData(category: "Interest Rates");
+
+        result.Should().Contain("10-Year T-Notes");
+        result.Should().NotContain("Gold");
+    }
+
+    [Fact]
+    public async Task GetLatestCftcData_NumericCategory_IsRejected()
+    {
+        // Enum.TryParse accepts numeric strings (even undefined ones); the name-based
+        // match must reject them so "999" can't slip into a bogus filtered query.
+        DbContext
+            .Set<CftcContract>()
+            .Add(Contract("088691", "Gold (COMEX)", CftcContractCategory.Metals));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLatestCftcData(category: "999");
+
+        result.Should().StartWith("Unknown category '999'");
+    }
+
+    // ── GetLatestCftcData market-code handoff ────────────────────────────
+
+    [Fact]
+    public async Task GetLatestCftcData_RowsCarryMarketCodeForPositioningHandoff()
+    {
+        // GetCftcPositioning requires a market code; the snapshot must include it so a
+        // consumer doesn't need an extra SearchCftcMarkets round-trip per drill-down.
+        var gold = Contract("088691", "Gold (COMEX)", CftcContractCategory.Metals);
+        DbContext.Set<CftcContract>().Add(gold);
+        DbContext.Set<CftcPositionReport>().Add(ReportFor(gold, new DateOnly(2026, 7, 7)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLatestCftcData();
+
+        result.Should().Contain("| Gold (COMEX) | 088691 |");
+        result.Should().Contain("GetCftcPositioning(marketCode)");
+        result.Should().Contain("contract counts");
+    }
+
+    // ── SearchCftcMarkets discovery ──────────────────────────────────────
+
+    [Fact]
+    public async Task SearchCftcMarkets_NoQuery_ListsAllTrackedContracts()
+    {
+        // With a ~35-contract curated universe, enumerating everything is the natural
+        // discovery call; it used to require exploiting the Contains search with "(".
+        DbContext
+            .Set<CftcContract>()
+            .AddRange(
+                Contract("088691", "Gold (COMEX)", CftcContractCategory.Metals),
+                Contract("067651", "Crude Oil, Light Sweet (NYMEX)", CftcContractCategory.Energy)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().SearchCftcMarkets();
+
+        result.Should().Contain("Tracked CFTC contracts:");
+        result.Should().Contain("Gold (COMEX)");
+        result.Should().Contain("Crude Oil");
+    }
+
+    [Fact]
+    public async Task SearchCftcMarkets_MoreMatchesThanMaxResults_AppendsTruncationNote()
+    {
+        // Results are grouped by category, so silent truncation used to drop whole
+        // trailing categories with no signal that more contracts exist.
+        DbContext
+            .Set<CftcContract>()
+            .AddRange(
+                Contract("001602", "Wheat-SRW (CBOT)", CftcContractCategory.Agriculture),
+                Contract("002602", "Corn (CBOT)", CftcContractCategory.Agriculture),
+                Contract("099741", "Euro FX (CME)", CftcContractCategory.Currencies)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().SearchCftcMarkets(maxResults: 2);
+
+        result.Should().Contain("Showing first 2 of 3 results");
+    }
+
+    // ── GetCftcPositioning strict dates + truncation ─────────────────────
+
+    [Fact]
+    public async Task GetCftcPositioning_MalformedStartDate_ReturnsInvalidArgumentError()
+    {
+        DbContext
+            .Set<CftcContract>()
+            .Add(Contract("088691", "Gold (COMEX)", CftcContractCategory.Metals));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetCftcPositioning("088691", startDate: "last year");
+
+        result.Should().Be("Unknown startDate 'last year'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetCftcPositioning_InvertedRange_ReturnsSwapErrorNotEmptyRange()
+    {
+        DbContext
+            .Set<CftcContract>()
+            .Add(Contract("088691", "Gold (COMEX)", CftcContractCategory.Metals));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetCftcPositioning("088691", startDate: "2026-07-01", endDate: "2026-01-01");
+
+        result
+            .Should()
+            .Be("startDate (2026-07-01) is after endDate (2026-01-01) - swap the dates.");
+    }
+
+    [Fact]
+    public async Task GetCftcPositioning_RangeExceedsMaxResults_AppendsNewestKeptNote()
+    {
+        var gold = Contract("088691", "Gold (COMEX)", CftcContractCategory.Metals);
+        DbContext.Set<CftcContract>().Add(gold);
+        for (var week = 1; week <= 3; week++)
+            DbContext
+                .Set<CftcPositionReport>()
+                .Add(ReportFor(gold, new DateOnly(2026, 4, week * 7)));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetCftcPositioning(
+                "088691",
+                startDate: "2026-04-01",
+                endDate: "2026-04-30",
+                maxResults: 2
+            );
+
+        result.Should().Contain("Showing the newest 2 of 3 reports");
+        result.Should().Contain("2026-04-21");
+        result.Should().NotContain("2026-04-07");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/CftcToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CftcToolsTests.cs
@@ -205,14 +205,18 @@ public class CftcToolsTests : ParadeDbMcpTestBase
     // ── SearchCftcMarkets ────────────────────────────────────────────────
 
     [Fact]
-    public async Task SearchCftcMarkets_NoMatches_ReturnsNotFoundMessage()
+    public async Task SearchCftcMarkets_NoMatches_ExplainsCuratedUniverse()
     {
+        // The DB only holds a curated ~35-contract registry, so "no match" must not read
+        // as "no such market exists" — the message names the curated coverage and the
+        // way to enumerate it, or an LLM reports well-known markets as missing data.
         DbContext.Set<CftcContract>().Add(CrudeOilContract());
         await DbContext.SaveChangesAsync();
 
         var result = await Sut().SearchCftcMarkets("PLATINUM");
 
-        result.Should().Be("No contracts found matching 'PLATINUM'.");
+        result.Should().Contain("No tracked contracts match 'PLATINUM'");
+        result.Should().Contain("curated set");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesMaxTickerBoundaryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesMaxTickerBoundaryTests.cs
@@ -39,6 +39,6 @@ public class StockPriceToolsGetLatestPricesMaxTickerBoundaryTests : ParadeDbMcpT
         var result = await Sut().GetLatestPrices(tickers);
 
         result.Should().NotContain("Maximum 25 tickers per request");
-        result.Should().Contain("| Ticker | Date | Close | Volume |");
+        result.Should().Contain("| Ticker | Date | Close | Change | Change % | Volume |");
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStrictArgsAndWarmupTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStrictArgsAndWarmupTests.cs
@@ -1,0 +1,323 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Mcp.Tools;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the MCP-audit fixes on the Yahoo price tools: strict yyyy-MM-dd date parsing
+/// (no silent fallback to the default window), inverted-range errors, newest-kept
+/// truncation notes, the maxResults clamp on the indicator tools, the dot→dash
+/// class-share ticker fold, the day-over-day change columns on GetLatestPrices, the
+/// pre-startDate warm-up look-back on windowed indicators, and the OBV anchor footnote.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class StockPriceToolsStrictArgsAndWarmupTests : ParadeDbMcpTestBase
+{
+    private StockPriceTools Sut() =>
+        new(
+            new DailyStockPriceRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<StockPriceTools>()
+        );
+
+    public StockPriceToolsStrictArgsAndWarmupTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static CommonStock Stock(string ticker = "AAPL", string name = "Apple Inc") =>
+        new()
+        {
+            Ticker = ticker,
+            Name = name,
+            Cik = "0000320193",
+        };
+
+    private static DailyStockPrice PriceFor(
+        CommonStock stock,
+        DateOnly date,
+        decimal close = 150.00m,
+        long volume = 50_000_000
+    ) =>
+        new()
+        {
+            CommonStock = stock,
+            CommonStockId = stock.Id,
+            Date = date,
+            Open = close - 1m,
+            High = close + 1m,
+            Low = close - 2m,
+            Close = close,
+            AdjustedClose = close,
+            Volume = volume,
+        };
+
+    private async Task<CommonStock> SeedDailyCloses(DateOnly firstDate, params decimal[] closes)
+    {
+        var stock = Stock();
+        DbContext.Set<CommonStock>().Add(stock);
+        for (var i = 0; i < closes.Length; i++)
+            DbContext.Set<DailyStockPrice>().Add(PriceFor(stock, firstDate.AddDays(i), closes[i]));
+        await DbContext.SaveChangesAsync();
+        return stock;
+    }
+
+    // ── Strict date arguments ────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStockPrices_MalformedStartDate_ReturnsInvalidArgumentError()
+    {
+        // The old shared ParseDateOr silently replaced "07/15/2026" with the default
+        // 1-year window and returned a plausible table for a range the caller never
+        // asked for. A malformed date must be an explicit, self-correctable error.
+        DbContext.Set<CommonStock>().Add(Stock());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetStockPrices("AAPL", startDate: "07/15/2026");
+
+        result.Should().Be("Unknown startDate '07/15/2026'. Accepted: yyyy-MM-dd.");
+    }
+
+    [Fact]
+    public async Task GetStockPrices_InvertedRange_ReturnsSwapErrorNotEmptyRange()
+    {
+        // startDate > endDate used to fall through to the query and come back as
+        // "No price data found ..." — indistinguishable from a real data gap.
+        DbContext.Set<CommonStock>().Add(Stock());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetStockPrices("AAPL", startDate: "2026-06-10", endDate: "2026-06-01");
+
+        result
+            .Should()
+            .Be("startDate (2026-06-10) is after endDate (2026-06-01) - swap the dates.");
+    }
+
+    [Fact]
+    public async Task GetOnBalanceVolume_MalformedEndDate_ReturnsInvalidArgumentError()
+    {
+        // The same strict parsing must guard the indicator tools' shared window loader.
+        DbContext.Set<CommonStock>().Add(Stock());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetOnBalanceVolume("AAPL", endDate: "last week");
+
+        result.Should().Be("Unknown endDate 'last week'. Accepted: yyyy-MM-dd.");
+    }
+
+    // ── Truncation signposting ───────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStockPrices_RangeExceedsMaxResults_AppendsNewestKeptNote()
+    {
+        // The table keeps the newest rows but renders oldest→newest, so the note must
+        // say "the newest N of M" — the shared "Showing first N" wording would point
+        // at the wrong end of the table.
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), 101m, 102m, 103m, 104m, 105m);
+
+        var result = await Sut()
+            .GetStockPrices("AAPL", startDate: "2026-04-01", endDate: "2026-04-30", maxResults: 2);
+
+        result.Should().Contain("Showing the newest 2 of 5 records");
+        result.Should().Contain("2026-04-05");
+        result.Should().NotContain("2026-04-03");
+    }
+
+    [Fact]
+    public async Task GetStockPrices_AllRowsShown_OmitsTruncationNote()
+    {
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), 101m, 102m);
+
+        var result = await Sut()
+            .GetStockPrices("AAPL", startDate: "2026-04-01", endDate: "2026-04-30");
+
+        result.Should().NotContain("Showing the newest");
+    }
+
+    [Fact]
+    public async Task GetOnBalanceVolume_MoreRowsThanMaxResults_AppendsTruncationNote()
+    {
+        // Indicator tables render newest first, so the shared "Showing first N of M"
+        // wording is accurate there.
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), 101m, 102m, 103m);
+
+        var result = await Sut()
+            .GetOnBalanceVolume(
+                "AAPL",
+                startDate: "2026-04-01",
+                endDate: "2026-04-30",
+                maxResults: 2
+            );
+
+        result.Should().Contain("Showing first 2 of 3 results");
+    }
+
+    // ── maxResults clamp on indicator tools ──────────────────────────────
+
+    [Fact]
+    public async Task GetAverageTrueRange_NonPositiveMaxResults_StillRendersNewestRow()
+    {
+        // maxResults used to bypass McpLimit.Clamp on the indicator tools: an explicit
+        // 0 rendered a header-only table with no rows and no message — a false empty
+        // claim for a stock that has data. The clamp floors it at one row.
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), 101m, 102m, 103m);
+
+        var result = await Sut()
+            .GetAverageTrueRange(
+                "AAPL",
+                startDate: "2026-04-01",
+                endDate: "2026-04-30",
+                maxResults: 0
+            );
+
+        result.Should().Contain("2026-04-03");
+        result.Should().NotContain("2026-04-02");
+    }
+
+    // ── Warm-up look-back before startDate ───────────────────────────────
+
+    [Fact]
+    public async Task GetBollingerBands_ExplicitStartDate_ComputesBandsFromPreRangeHistory()
+    {
+        // The DB holds 25 bars before the requested range, and the SMA window is 20 —
+        // so every in-range row is computable from the pre-startDate warm-up fetch.
+        // Before the fix the loader started exactly at startDate and the whole range
+        // rendered as warm-up dashes despite ample prior history.
+        var closes = Enumerable.Range(0, 30).Select(i => 100m + i % 7).ToArray();
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), closes);
+
+        var result = await Sut()
+            .GetBollingerBands("AAPL", startDate: "2026-04-26", endDate: "2026-04-30", period: 20);
+
+        result.Should().Contain("2026-04-26");
+        // No warm-up dash cells: every in-range row is computable (footnote text quotes
+        // the dash character, so assert on the cell shape, not the bare character).
+        result.Should().NotContain("| — |");
+        // Pre-range warm-up bars must not leak into the rendered table.
+        result.Should().NotContain("2026-04-25");
+    }
+
+    [Fact]
+    public async Task GetStochasticOscillator_ExplicitStartDate_ComputesThroughRangeLeftEdge()
+    {
+        var closes = Enumerable.Range(0, 20).Select(i => 100m + i % 5).ToArray();
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), closes);
+
+        var result = await Sut()
+            .GetStochasticOscillator(
+                "AAPL",
+                startDate: "2026-04-16",
+                endDate: "2026-04-20",
+                kPeriod: 14,
+                dPeriod: 3
+            );
+
+        result.Should().Contain("2026-04-16");
+        result.Should().NotContain("| — |");
+        result.Should().NotContain("2026-04-15");
+    }
+
+    [Fact]
+    public async Task GetAverageTrueRange_NoPriorHistory_StillMarksWarmupRowsWithDash()
+    {
+        // With no bars before the range the warm-up fetch finds nothing and the first
+        // period-1 rows legitimately stay dashes, explained by the footnote.
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), 101m, 102m, 103m);
+
+        var result = await Sut()
+            .GetAverageTrueRange(
+                "AAPL",
+                startDate: "2026-04-01",
+                endDate: "2026-04-30",
+                period: 14
+            );
+
+        result.Should().Contain("| — |");
+        result.Should().Contain("too little prior price history");
+    }
+
+    // ── OBV anchor semantics ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetOnBalanceVolume_FootnoteNamesTheZeroAnchorDate()
+    {
+        // OBV is window-relative: absolute values shift with startDate. The footnote
+        // must name the anchor bar so the level stays interpretable even when
+        // maxResults truncates the zero-anchor row out of the table.
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), 101m, 102m, 103m);
+
+        var result = await Sut()
+            .GetOnBalanceVolume("AAPL", startDate: "2026-04-01", endDate: "2026-04-30");
+
+        result.Should().Contain("OBV is anchored at 0 on 2026-04-01");
+    }
+
+    // ── Dot class-share notation ─────────────────────────────────────────
+
+    [Fact]
+    public async Task GetLatestPrices_DotClassTicker_ResolvesDashStoredForm()
+    {
+        // Price data stores class shares in the Yahoo dash form (BRK-B). The dot form
+        // (BRK.B) is the same symbol in a different notation — a mechanical format
+        // conversion, so the lookup folds '.' to '-' on a miss instead of reporting
+        // the stock as not found.
+        var brk = Stock(ticker: "BRK-B", name: "Berkshire Hathaway Inc");
+        DbContext.Set<CommonStock>().Add(brk);
+        DbContext
+            .Set<DailyStockPrice>()
+            .Add(PriceFor(brk, new DateOnly(2026, 4, 5), close: 412.34m));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLatestPrices("BRK.B");
+
+        result.Should().Contain("412.34");
+        result.Should().NotContain("Not found");
+    }
+
+    [Fact]
+    public async Task GetStockPrices_DotClassTicker_ResolvesDashStoredForm()
+    {
+        var brk = Stock(ticker: "BRK-B", name: "Berkshire Hathaway Inc");
+        DbContext.Set<CommonStock>().Add(brk);
+        DbContext
+            .Set<DailyStockPrice>()
+            .Add(PriceFor(brk, new DateOnly(2026, 4, 5), close: 412.34m));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetStockPrices("BRK.B");
+
+        result.Should().Contain("Daily prices for BRK-B");
+        result.Should().Contain("412.34");
+    }
+
+    // ── GetLatestPrices change columns ───────────────────────────────────
+
+    [Fact]
+    public async Task GetLatestPrices_TwoBars_RendersDayOverDayChange()
+    {
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), 100m, 110m);
+
+        var result = await Sut().GetLatestPrices("AAPL");
+
+        result.Should().Contain("| +10.00 |");
+        result.Should().Contain("| +10.00% |");
+        result.Should().Contain("2026-04-02");
+    }
+
+    [Fact]
+    public async Task GetLatestPrices_SingleBar_RendersDashChangeCells()
+    {
+        // With no prior close the change columns must degrade to dashes, not crash
+        // or fabricate a zero change.
+        await SeedDailyCloses(new DateOnly(2026, 4, 1), 100m);
+
+        var result = await Sut().GetLatestPrices("AAPL");
+
+        result.Should().Contain("| 100.00 | — | — |");
+    }
+}

--- a/tests/Equibles.UnitTests/Cftc/CuratedContractRegistryTests.cs
+++ b/tests/Equibles.UnitTests/Cftc/CuratedContractRegistryTests.cs
@@ -55,4 +55,41 @@ public class CuratedContractRegistryTests
         contract.Should().NotBeNull();
         contract!.DisplayName.Should().Be("E-mini S&P 500 (CME)");
     }
+
+    [Theory]
+    // Every pair below was verified against the CFTC public reporting API
+    // (publicreporting.cftc.gov dataset 6dca-aqww, cftc_contract_market_code →
+    // market_and_exchange_names) on 2026-07-17. An earlier registry revision had
+    // exactly these ten codes mislabeled — three pairwise swaps (Platinum/Palladium,
+    // 2Y/5Y T-Notes, plus the cattle rows) and a shifted currency chain (the code
+    // labeled "Japanese Yen" was really British Pound, "British Pound" really Swiss
+    // Franc, "Swiss Franc" really Mexican Peso) — which served one market's real COT
+    // data under another market's name. Pin code → name so a future edit can't
+    // reintroduce a swap: the code is the identity the importer filters by, and a
+    // wrong name here mislabels genuine data everywhere downstream.
+    [InlineData("057642", "Live Cattle (CME)")]
+    [InlineData("061641", "Feeder Cattle (CME)")]
+    [InlineData("054642", "Lean Hogs (CME)")]
+    [InlineData("073732", "Cocoa (ICE)")]
+    [InlineData("033661", "Cotton No. 2 (ICE)")]
+    [InlineData("076651", "Platinum (NYMEX)")]
+    [InlineData("075651", "Palladium (NYMEX)")]
+    [InlineData("042601", "2-Year T-Notes (CBOT)")]
+    [InlineData("044601", "5-Year T-Notes (CBOT)")]
+    [InlineData("096742", "British Pound (CME)")]
+    [InlineData("092741", "Swiss Franc (CME)")]
+    [InlineData("095741", "Mexican Peso (CME)")]
+    [InlineData("097741", "Japanese Yen (CME)")]
+    public void Contracts_MarketCode_CarriesCftcVerifiedDisplayName(
+        string marketCode,
+        string expectedDisplayName
+    )
+    {
+        var contract = CuratedContractRegistry.Contracts.SingleOrDefault(c =>
+            c.MarketCode == marketCode
+        );
+
+        contract.Should().NotBeNull();
+        contract!.DisplayName.Should().Be(expectedDisplayName);
+    }
 }

--- a/tests/Equibles.UnitTests/Mcp/StockPriceToolsAppendNewestFirstRowsMaxResultsCapTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/StockPriceToolsAppendNewestFirstRowsMaxResultsCapTests.cs
@@ -6,11 +6,17 @@ namespace Equibles.UnitTests.Mcp;
 
 public class StockPriceToolsAppendNewestFirstRowsMaxResultsCapTests
 {
+    private static MethodInfo Method() =>
+        typeof(StockPriceTools).GetMethod(
+            "AppendNewestFirstRows",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
     [Fact]
     public void AppendNewestFirstRows_CountExceedsMaxResults_EmitsExactlyMaxRowsNewestFirst()
     {
-        // AppendNewestFirstRows (StockPriceTools.cs:389-402) iterates
-        // `for (var i = count - 1; i >= 0 && emitted < maxResults; i--)` —
+        // AppendNewestFirstRows iterates
+        // `for (var i = count - 1; i >= renderFrom && emitted < maxResults; i--)` —
         // the maxResults cap exists so the MCP response doesn't blow up
         // when a price-series query returns thousands of rows but the tool
         // contract advertises a small page size. The newest-first ordering
@@ -22,15 +28,32 @@ public class StockPriceToolsAppendNewestFirstRowsMaxResultsCapTests
         // the OLDEST maxResults rows. Pin both: count=5, maxResults=2 →
         // exactly two rows, and they must be the indices 4 and 3 (in that
         // order, newest first).
-        var method = typeof(StockPriceTools).GetMethod(
-            "AppendNewestFirstRows",
-            BindingFlags.NonPublic | BindingFlags.Static
-        );
-
         var result = new StringBuilder();
         Func<int, string> formatRow = i => $"row{i}";
 
-        method!.Invoke(null, [result, 5, 2, formatRow]);
+        Method().Invoke(null, [result, 5, 0, 2, formatRow]);
+
+        var lines = result
+            .ToString()
+            .Split([Environment.NewLine, "\n"], StringSplitOptions.RemoveEmptyEntries);
+        lines.Should().HaveCount(2);
+        lines[0].Should().Be("row4");
+        lines[1].Should().Be("row3");
+    }
+
+    [Fact]
+    public void AppendNewestFirstRows_RenderFromHidesWarmupRows()
+    {
+        // renderFrom is the warm-up boundary: LoadAscendingPriceWindow prefixes bars
+        // fetched BEFORE the requested startDate so indicators compute through the
+        // range's left edge, and those pre-range bars must never render. With count=5,
+        // renderFrom=3 and a generous maxResults, only indices 4 and 3 may emit — a
+        // regression to `i >= 0` would leak the caller's pre-startDate history into
+        // the table and break the advertised date range.
+        var result = new StringBuilder();
+        Func<int, string> formatRow = i => $"row{i}";
+
+        Method().Invoke(null, [result, 5, 3, 10, formatRow]);
 
         var lines = result
             .ToString()


### PR DESCRIPTION
## Summary

Fixes all MCP-audit findings for the market-data tool package: GetStockPrices, GetLatestPrices, GetAverageTrueRange, GetBollingerBands, GetOnBalanceVolume, GetStochasticOscillator, GetPutCallRatios, GetVixHistory, GetCftcPositioning, GetLatestCftcData, SearchCftcMarkets.

**Headline finding confirmed during verification:** the curated CFTC registry had **ten mislabeled market codes** — Platinum/Palladium swapped, 2Y/5Y T-Notes swapped, the cattle rows shifted (057642 'Lean Hogs' is really Live Cattle, 061641 'Live Cattle' is really Feeder Cattle), 'Cotton No. 2' sitting on Cocoa's code, and a shifted currency chain ('Japanese Yen' → really British Pound, 'British Pound' → really Swiss Franc, 'Swiss Franc' → really Mexican Peso). Every code was verified against the CFTC public reporting API (dataset 6dca-aqww). This exactly explains the audit's open-interest anomalies (the 'Live Cattle' row showing Feeder-Cattle-sized OI, 'Platinum' showing Palladium-sized OI).

## Code changes

**Yahoo (StockPriceTools)**
- Indicators (ATR/Bollinger/Stochastic) fetch a warm-up look-back before startDate and render only the requested range — no more warm-up dashes on explicit ranges, values independent of the range's left edge (ATR uses 2×period pre-bars for the recursive seed; Bollinger period−1; Stochastic kPeriod+dPeriod−2)
- OBV documents its range-anchored zero (description + footnote naming the anchor date)
- Strict yyyy-MM-dd date parsing via McpOutput (no silent fallback), inverted-range swap error
- maxResults clamped to [1,500] on all indicator tools; truncation notes everywhere (newest-kept wording for chronological tables)
- Dot class-share fold: BRK.B resolves to the stored BRK-B on lookup miss (mechanical notation conversion)
- GetLatestPrices: Change / Change % columns vs prior close; 25-ticker cap + USD documented
- GetBollingerBands: %B and Bandwidth columns
- Descriptions state USD + current-split-basis semantics

**CBOE (CboeTools)**
- Strict dates + inverted-range error on both tools; newest-kept truncation notes
- GetPutCallRatios description states verified coverage: Nov 2006→present, Vix type from Oct 2019, ~weekly sampling pre-2013
- maxResults descriptions spell out newest-kept + chronological display + 500 cap

**CFTC (CftcTools, CuratedContractRegistry, CftcImportService)**
- Registry: ten names corrected in place (stored reports are that code's real data — pure relabel); true codes added for Lean Hogs (054642), Cotton No. 2 (033661), Japanese Yen (097741); Theory pins every corrected code→name pair
- EnsureContractsExist re-syncs drifted name/category from the registry → the prod rows repair themselves on deploy, no manual SQL
- DetermineStartYear widens to a full-history walk while any contract has no reports → new codes backfill from MinSyncDate (re-walked years are insert-free via the (contract,date) dedup)
- GetLatestCftcData: strict category validation (error lists accepted values; display spellings folded; numeric strings rejected), market-code column for the GetCftcPositioning handoff, contract-counts footer
- SearchCftcMarkets: curated ~35-contract universe documented, query optional (list-all mode), default page 50, truncation note, curated-universe empty-state
- GetCftcPositioning: strict dates, inverted-range error, truncation note, legacy futures-only COT provenance in description

## Tests
- 3,536 unit tests green; scoped ParadeDB integration tests green (98 in the changed areas), incl. new suites: StockPriceToolsStrictArgsAndWarmupTests, CboeToolsStrictArgsAndTruncationTests, CftcToolsStrictArgsAndDiscoveryTests, CftcImportServiceRegistryResyncTests
- Pre-existing failures in YahooPriceImportServiceCompanyProfile* reproduce on unmodified main (no diff vs origin/main in those areas) — unrelated to this PR