### PR TITLE
fix(finra): squeeze-score audit — single-ticker score card, commodity-trust unit exclusion, honest board legend

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -27,3 +27,8 @@ nd
 # "currentY" — the running Y-coordinate cursor when reconstructing the House PTR
 # table from PDF word geometry. codespell suggests "currently".
 currenty
+
+# "IHS" — IHS Markit, the vendor whose US Short Squeeze Model the squeeze-score
+# construction follows (doc comment in ShortSqueezeScoreManager). codespell
+# suggests "HIS".
+ihs

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
@@ -111,7 +112,8 @@ public class ShortSqueezeScoreManager
     /// Classified from the SEC 12(b) cover-page title (see
     /// <see cref="ListedSecurityType"/>); Unknown/Other/Units stay in — MLP
     /// common units are genuine operating equity, and exclusion requires
-    /// positive evidence.
+    /// positive evidence. The one Units carve-out with positive evidence is
+    /// <see cref="CommodityTrustSic"/> (see <see cref="SqueezeCandidateListing"/>).
     /// </summary>
     private static readonly ListedSecurityType[] NonEquityListingTypes =
     [
@@ -120,6 +122,31 @@ public class ShortSqueezeScoreManager
         ListedSecurityType.Warrants,
         ListedSecurityType.Rights,
     ];
+
+    /// <summary>
+    /// SEC SIC 6221 (commodity contracts brokers and dealers) — the standard
+    /// industry classification of exchange-traded physical commodity and
+    /// currency trusts (CurrencyShares, Invesco DB funds, Sprott physical
+    /// trusts). Their 12(b) covers register "units" exactly like MLP common
+    /// units, but trust units are created and redeemed at NAV, so arbitrage
+    /// caps any squeeze — they are structural noise at the top of the board.
+    /// The SIC is the authoritative separator: verified against the live
+    /// universe, every SIC-6221 Units listing is such a trust and no operating
+    /// partnership carries it (MLPs file under their industry SIC; the SEC
+    /// submissions entityType does NOT separate them — the CurrencyShares
+    /// trusts report "operating").
+    /// </summary>
+    public const string CommodityTrustSic = "6221";
+
+    /// <summary>
+    /// The listing-type gate for the scored universe, as a composable query
+    /// filter: the unambiguously non-equity kinds are out, and Units are kept
+    /// (MLPs) EXCEPT the SIC-classified commodity/currency trusts, whose
+    /// creatable units cannot be squeezed. Public so tests pin the gate.
+    /// </summary>
+    public static readonly Expression<Func<CommonStock, bool>> SqueezeCandidateListing = s =>
+        !NonEquityListingTypes.Contains(s.ListedSecurityType)
+        && !(s.ListedSecurityType == ListedSecurityType.Units && s.Sic == CommodityTrustSic);
 
     /// <summary>
     /// Highest short-interest-to-shares-outstanding ratio accepted as a real measurement. No
@@ -195,11 +222,8 @@ public class ShortSqueezeScoreManager
         var stockIds = shortInterests.Select(s => s.CommonStockId).Distinct().ToList();
         var stocks = await _commonStockRepository
             .GetAll()
-            .Where(s =>
-                stockIds.Contains(s.Id)
-                && s.SharesOutStanding > 0
-                && !NonEquityListingTypes.Contains(s.ListedSecurityType)
-            )
+            .Where(s => stockIds.Contains(s.Id) && s.SharesOutStanding > 0)
+            .Where(SqueezeCandidateListing)
             .Select(s => new
             {
                 s.Id,

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -581,7 +581,7 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortSqueezeScores")]
     [Description(
-        "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built as the weighted mean of six factor percentiles across every stock reporting short interest at the latest FINRA settlement date (short interest % of shares 30%, days to cover 20%, price vs trailing VWAP — how far shorts are underwater — 15%, short-volume trend 15%, change in short interest 10%, fails-to-deliver pressure 10%), plus catalyst boosts (+10 for a statistically extreme weekly price spike, +10 for abnormal dollar volume on a positive move, +10 when a scheduled earnings event is within a few weekdays — squeezes cluster around earnings — capped at +20, clamped to 100). Untradeable micro-caps dominate the raw board, so pass minMarketCap and/or minDollarVolume to keep only names that clear your liquidity bar (the score itself stays peer-relative to the full universe). Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
+        "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built as the weighted mean of six factor percentiles across every stock reporting short interest at the latest FINRA settlement date (short interest % of shares 30%, days to cover 20%, price vs trailing VWAP — how far shorts are underwater — 15%, short-volume trend 15%, change in short interest 10%, fails-to-deliver pressure 10%), plus catalyst boosts (+10 for a statistically extreme weekly price spike, +10 for abnormal dollar volume on a positive move, +10 when a scheduled earnings event is within a few weekdays — squeezes cluster around earnings — capped at +20, clamped to 100). Exchange-traded commodity/currency trusts are excluded (their units are created and redeemed at NAV, so arbitrage caps any squeeze); MLP common units stay in. Untradeable micro-caps dominate the raw board, so pass minMarketCap and/or minDollarVolume to keep only names that clear your liquidity bar (the score itself stays peer-relative to the full universe). Pass ticker for one stock's score, factor breakdown, and rank within the scored universe. Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
     )]
     public Task<string> GetShortSqueezeScores(
         [Description(
@@ -592,8 +592,14 @@ public class ShortDataTools
             "Minimum average daily dollar volume in US dollars, approximated as the FINRA average daily share volume times the market-cap-implied share price (e.g. 5000000 = $5M/day; default 0 = no floor). Stocks with unknown volume or market cap are excluded when set."
         )]
             double minDollarVolume = 0,
-        [Description("Maximum number of stocks to return (default: 25, highest score first)")]
-            int maxResults = 25
+        [Description(
+            "Maximum number of stocks to return (default: 25, highest score first; clamped to 1-200)."
+        )]
+            int maxResults = 25,
+        [Description(
+            "Optional stock ticker (e.g. GME): returns that one stock's score, factor breakdown, and rank within the scored universe instead of the board. The liquidity floors do not apply to a single-ticker lookup."
+        )]
+            string ticker = null
     )
     {
         return _runner.Execute(
@@ -604,6 +610,9 @@ public class ShortDataTools
                     return "No short-squeeze scores available — no short interest data on file.";
 
                 var settlementDate = scores[0].SettlementDate;
+
+                if (!string.IsNullOrWhiteSpace(ticker))
+                    return await RenderSingleSqueezeScore(ticker, scores, settlementDate);
 
                 // Liquidity gates are a view over the scored universe, applied after the
                 // peer-relative percentiles so a stock's score never depends on the
@@ -625,7 +634,7 @@ public class ShortDataTools
                 );
                 sb.AppendLine();
                 sb.AppendLine(
-                    "Score = weighted mean of the available factor percentiles (0-100, peer-relative) plus catalyst boosts (price spike / volume surge, capped at +20). Avg $ Volume is approximate (FINRA share volume × market-cap-implied price)."
+                    "Score = weighted mean of the available factor percentiles (0-100, peer-relative) plus catalyst boosts (price spike / volume surge / earnings within a few weekdays, capped at +20). Avg $ Volume is approximate (FINRA share volume × market-cap-implied price)."
                 );
                 sb.AppendLine();
                 sb.AppendLine(
@@ -634,6 +643,7 @@ public class ShortDataTools
                 sb.AppendLine(
                     "|---|--------|-------|-------------------|---------------|--------------------|------------------|-------------|---------------|-----------|------------|--------------|"
                 );
+                var shown = Math.Min(take, filtered.Count);
                 sb.AppendNumberedRows(
                     filtered.Take(take).ToList(),
                     (rank, score) =>
@@ -649,13 +659,86 @@ public class ShortDataTools
                     }
                 );
 
-                if (filtered.Count > take)
-                    sb.AppendLine($"\n({filtered.Count - take} more scored stocks not shown.)");
+                if (shown < filtered.Count)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine(McpOutput.TruncationNote(shown, filtered.Count));
+                }
 
                 return sb.ToString();
             },
             "GetShortSqueezeScores",
-            $"minMarketCap: {minMarketCap}, minDollarVolume: {minDollarVolume}, maxResults: {maxResults}"
+            $"minMarketCap: {minMarketCap}, minDollarVolume: {minDollarVolume}, maxResults: {maxResults}, ticker: {ticker}"
         );
     }
+
+    // One stock's score card: composite, rank in the score-descending universe, and the
+    // factor breakdown (raw reading + universe percentile per factor). The board answers
+    // "what looks squeeze-prone"; this answers "does MY stock look squeeze-prone".
+    private async Task<string> RenderSingleSqueezeScore(
+        string ticker,
+        IReadOnlyList<ShortSqueezeScore> scores,
+        DateOnly settlementDate
+    )
+    {
+        var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+        if (stockError != null)
+            return stockError;
+
+        var index = -1;
+        for (var i = 0; i < scores.Count; i++)
+        {
+            if (scores[i].CommonStockId == stock.Id)
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index < 0)
+            return $"{stock.Ticker} is not in the scored universe at settlement {settlementDate:yyyy-MM-dd} ({scores.Count} stocks scored) — it reported no FINRA short interest, has no usable share count, an implausible short-interest ratio, or a non-equity/trust listing. Use GetShortInterest for its raw series.";
+
+        var score = scores[index];
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine(
+            $"# Short-squeeze score — {score.Ticker} ({stock.Name}) — settlement {settlementDate:yyyy-MM-dd}"
+        );
+        sb.AppendLine();
+        sb.AppendLine(
+            $"- Score: {score.Score.ToString("0", CultureInfo.InvariantCulture)} — rank {index + 1} of {scores.Count} scored stocks (base {score.BaseScore.ToString("0", CultureInfo.InvariantCulture)} + catalyst boost {score.CatalystBoost.ToString("0", CultureInfo.InvariantCulture)})"
+        );
+        sb.AppendLine(
+            $"- Short interest: {score.ShortInterestPercentOfShares.ToString("P1", CultureInfo.InvariantCulture)} of shares outstanding{Percentile(score.ShortInterestPercentile)}"
+        );
+        sb.AppendLine(
+            $"- Days to cover: {score.DaysToCover?.ToString("0.0", CultureInfo.InvariantCulture) ?? "-"}{Percentile(score.DaysToCoverPercentile)}"
+        );
+        sb.AppendLine(
+            $"- Short-volume trend: {FormatSignedPercent(score.ShortVolumeShareTrend)}{Percentile(score.ShortVolumeTrendPercentile)}"
+        );
+        sb.AppendLine(
+            $"- Δ short interest vs prior report: {FormatSignedPercent(score.ShortInterestChangePercent)}{Percentile(score.ShortInterestChangePercentile)}"
+        );
+        sb.AppendLine(
+            $"- Worst FTD % of shares: {McpFormat.OrDash(score.FailsToDeliverPercentOfShares, "P2")}{Percentile(score.FailsToDeliverPercentile)}"
+        );
+        sb.AppendLine(
+            $"- Price vs trailing VWAP: {FormatSignedPercent(score.PriceAboveVwap)}{Percentile(score.PriceAboveVwapPercentile)}"
+        );
+        sb.AppendLine($"- Catalysts: {FormatCatalysts(score)}");
+        sb.AppendLine(
+            $"- Market cap: {McpFormat.CompactUsd(score.MarketCapitalization)}; avg $ volume ≈ {McpFormat.CompactUsd(score.AverageDailyDollarVolume)}/day"
+        );
+        sb.AppendLine();
+        sb.AppendLine(
+            "Score = weighted mean of the available factor percentiles (0-100, peer-relative; a dash means the factor had no data and dropped out) plus catalyst boosts (price spike / volume surge / earnings within a few weekdays, capped at +20). Use GetShortInterest for the underlying series."
+        );
+        return sb.ToString();
+    }
+
+    // A factor's universe percentile as a suffix; empty when the factor dropped out.
+    private static string Percentile(double? percentile) =>
+        percentile == null
+            ? string.Empty
+            : $" (percentile {percentile.Value.ToString("0", CultureInfo.InvariantCulture)})";
 }

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -248,7 +248,8 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
 
         result.Should().Contain("Short-squeeze score — COLD (Cold Corp)");
         result.Should().Contain("rank 2 of 2 scored stocks");
-        result.Should().Contain("Short interest: 5.0%");
+        // Invariant "P1" renders a space before the percent sign.
+        result.Should().Contain("Short interest: 5.0 % of shares outstanding");
         result.Should().Contain("settlement 2026-04-15");
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -201,4 +201,143 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
 
         result.Should().Contain("No scored stocks clear the requested liquidity floor");
     }
+
+    // The single-ticker lookup answers "does MY stock look squeeze-prone": the score,
+    // its rank within the scored universe, and the factor breakdown — data the board
+    // only exposes for the top of the ranking.
+    [Fact]
+    public async Task GetShortSqueezeScores_Ticker_RendersScoreCardWithUniverseRank()
+    {
+        var settlement = new DateOnly(2026, 4, 15);
+        var hot = new CommonStock
+        {
+            Ticker = "HOT",
+            Name = "Hot Corp",
+            Cik = "0000000301",
+            SharesOutStanding = 1_000_000,
+        };
+        var cold = new CommonStock
+        {
+            Ticker = "COLD",
+            Name = "Cold Corp",
+            Cik = "0000000302",
+            SharesOutStanding = 1_000_000,
+        };
+        DbContext.Set<CommonStock>().AddRange(hot, cold);
+        DbContext
+            .Set<ShortInterest>()
+            .AddRange(
+                new ShortInterest
+                {
+                    CommonStockId = hot.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 300_000,
+                    DaysToCover = 8m,
+                },
+                new ShortInterest
+                {
+                    CommonStockId = cold.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 50_000,
+                    DaysToCover = 1m,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortSqueezeScores(ticker: "cold");
+
+        result.Should().Contain("Short-squeeze score — COLD (Cold Corp)");
+        result.Should().Contain("rank 2 of 2 scored stocks");
+        result.Should().Contain("Short interest: 5.0%");
+        result.Should().Contain("settlement 2026-04-15");
+    }
+
+    [Fact]
+    public async Task GetShortSqueezeScores_TickerNotScored_ExplainsWhy()
+    {
+        var settlement = new DateOnly(2026, 4, 15);
+        var scored = new CommonStock
+        {
+            Ticker = "HOT",
+            Name = "Hot Corp",
+            Cik = "0000000303",
+            SharesOutStanding = 1_000_000,
+        };
+        var unscored = new CommonStock
+        {
+            Ticker = "QUIET",
+            Name = "Quiet Corp",
+            Cik = "0000000304",
+            SharesOutStanding = 1_000_000,
+        };
+        DbContext.Set<CommonStock>().AddRange(scored, unscored);
+        DbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStockId = scored.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 300_000,
+                    DaysToCover = 8m,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortSqueezeScores(ticker: "QUIET");
+
+        result.Should().Contain("QUIET is not in the scored universe at settlement 2026-04-15");
+    }
+
+    // A SIC-6221 commodity/currency trust registers "units" on its 12(b) cover exactly
+    // like an MLP, but its creatable units cannot be squeezed — the authoritative
+    // (Units, SIC 6221) pair must keep it off the board while the MLP stays ranked.
+    [Fact]
+    public async Task GetShortSqueezeScores_CommodityTrustUnits_ExcludedWhileMlpUnitsRank()
+    {
+        var settlement = new DateOnly(2026, 4, 15);
+        var mlp = new CommonStock
+        {
+            Ticker = "MLP",
+            Name = "Pipeline Partners LP",
+            Cik = "0000000305",
+            SharesOutStanding = 1_000_000,
+            ListedSecurityType = ListedSecurityType.Units,
+            Sic = "4922",
+        };
+        var trust = new CommonStock
+        {
+            Ticker = "FXZ",
+            Name = "CurrencyShares Test Trust",
+            Cik = "0000000306",
+            SharesOutStanding = 1_000_000,
+            ListedSecurityType = ListedSecurityType.Units,
+            Sic = "6221",
+        };
+        DbContext.Set<CommonStock>().AddRange(mlp, trust);
+        DbContext
+            .Set<ShortInterest>()
+            .AddRange(
+                new ShortInterest
+                {
+                    CommonStockId = mlp.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 200_000,
+                    DaysToCover = 5m,
+                },
+                new ShortInterest
+                {
+                    CommonStockId = trust.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 300_000,
+                    DaysToCover = 9m,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortSqueezeScores();
+
+        result.Should().Contain("MLP", "MLP common units are genuine operating equity");
+        result.Should().NotContain("FXZ", "trust units are created/redeemed at NAV — no squeeze");
+    }
 }

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerSqueezeCandidateListingTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerSqueezeCandidateListingTests.cs
@@ -1,0 +1,53 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Finra.BusinessLogic;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Pins the scored-universe listing gate: the unambiguously non-equity kinds are out,
+/// Units stay in (MLP common units are genuine operating equity), and the single
+/// Units carve-out is the SIC-6221 commodity/currency trust — units created and
+/// redeemed at NAV can never be squeezed, so a CurrencyShares-style trust must not
+/// rank on the board while an MLP with the same 12(b) "units" title must.
+/// </summary>
+public class ShortSqueezeScoreManagerSqueezeCandidateListingTests
+{
+    private static bool IsCandidate(ListedSecurityType type, string sic) =>
+        ShortSqueezeScoreManager.SqueezeCandidateListing.Compile()(
+            new CommonStock { ListedSecurityType = type, Sic = sic }
+        );
+
+    [Theory]
+    [InlineData(ListedSecurityType.CommonShares, "3674")]
+    [InlineData(ListedSecurityType.Unknown, "3674")]
+    [InlineData(ListedSecurityType.Other, "3674")]
+    // MLP common units keep their industry SIC (pipelines, oil & gas, coal) — in.
+    [InlineData(ListedSecurityType.Units, "4922")]
+    [InlineData(ListedSecurityType.Units, "1311")]
+    // A COMMON-shares listing of a SIC-6221 broker is not a trust — the carve-out
+    // requires both signals.
+    [InlineData(ListedSecurityType.CommonShares, "6221")]
+    public void SqueezeCandidateListing_EquityAndMlpUnits_AreCandidates(
+        ListedSecurityType type,
+        string sic
+    )
+    {
+        IsCandidate(type, sic).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(ListedSecurityType.PreferredShares, "3674")]
+    [InlineData(ListedSecurityType.DebtSecurities, "3674")]
+    [InlineData(ListedSecurityType.Warrants, "3674")]
+    [InlineData(ListedSecurityType.Rights, "3674")]
+    // The FXC shape: a currency/commodity trust registers "units" on its 12(b)
+    // cover and carries SIC 6221 — excluded on that authoritative pair.
+    [InlineData(ListedSecurityType.Units, "6221")]
+    public void SqueezeCandidateListing_NonEquityAndCommodityTrustUnits_AreExcluded(
+        ListedSecurityType type,
+        string sic
+    )
+    {
+        IsCandidate(type, sic).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
MCP-audit fixes for `GetShortSqueezeScores`:

- **Single-ticker lookup** — new optional `ticker` argument returns one stock's score, per-factor breakdown (raw reading + universe percentile), catalysts, and its rank within the scored universe. Previously any stock outside the top-200 board slice was unreachable, so "does NVDA/GME look squeeze-prone?" could not be answered. A resolvable but unscored ticker gets an explanatory message naming the settlement date and the possible reasons.
- **Commodity/currency trusts off the board** — exchange-traded physical commodity and currency trusts (CurrencyShares, Invesco DB funds, Sprott physical trusts) register "units" on their 12(b) cover exactly like MLP common units, but trust units are created and redeemed at NAV, so arbitrage caps any squeeze; they were ranking as structural noise (live finding: FXC at #10 with Δ short interest +207%). Excluded via the authoritative (ListedSecurityType.Units, SIC 6221) pair — verified against the live universe that every SIC-6221 Units listing is such a trust and no operating partnership carries it (SEC submissions entityType does NOT separate them: the CurrencyShares trusts report "operating"). MLP common units keep ranking.
- **Honest rendering** — the board legend now names the earnings-proximity catalyst it already displays, the `maxResults` clamp (1-200) is documented in the parameter description, and truncation goes through the shared `McpOutput.TruncationNote`.

## Code changes
- `ShortSqueezeScoreManager`: new `CommodityTrustSic` const + public composable `SqueezeCandidateListing` expression (kept as an expression so the EF query stays translatable and the gate is unit-testable); universe query now applies it.
- `ShortDataTools.GetShortSqueezeScores`: optional `ticker` parameter + `RenderSingleSqueezeScore` card; legend/description updates; `McpOutput.TruncationNote`.
- `.codespellignore`: allow "IHS" (IHS Markit, cited in the manager's doc comment).
- Tests: `ShortSqueezeScoreManagerSqueezeCandidateListingTests` (11 cases pinning the gate) + 3 new integration tests (ticker card with universe rank, unscored-ticker message, trust-vs-MLP unit exclusion).