### PR TITLE
fix(fda-catalysts): render FDA meeting links, strict date args, truncation note, honest coverage in GetFdaCatalysts

### DIFF
--- a/src/Equibles.FdaCatalysts.Mcp/Tools/FdaCatalystTools.cs
+++ b/src/Equibles.FdaCatalysts.Mcp/Tools/FdaCatalystTools.cs
@@ -29,7 +29,7 @@ public class FdaCatalystTools
 
     [McpServerTool(Name = "GetFdaCatalysts")]
     [Description(
-        "Get scheduled FDA advisory-committee (AdComm) meetings — the regulatory catalyst dates that move biotech and pharma stocks. Sourced from the FDA.gov advisory-committee calendar. Defaults to meetings in the next 90 days; pass a date range to look further ahead or back."
+        "Get scheduled FDA advisory-committee (AdComm) meetings, sourced from the FDA.gov advisory-committee calendar, each with a link to its FDA meeting page. Defaults to meetings in the next 90 days; pass a date range to look further ahead. This is a forward-looking calendar of announced meetings, not a historical archive — coverage starts in late 2025 — and entries are the FDA's own listings, not linked to stock tickers."
     )]
     public Task<string> GetFdaCatalysts(
         [Description("Start date in YYYY-MM-DD format (defaults to today)")]
@@ -44,33 +44,69 @@ public class FdaCatalystTools
             async () =>
             {
                 var today = DateOnly.FromDateTime(DateTime.UtcNow);
-                var start = McpToolExecutor.ParseDateOr(startDate, today);
-                var end = McpToolExecutor.ParseDateOr(endDate, start.AddDays(90));
+                var start = today;
+                if (!string.IsNullOrWhiteSpace(startDate))
+                {
+                    if (!McpOutput.TryParseDate(startDate, out var parsedStart))
+                        return McpOutput.InvalidArgument("startDate", startDate, "YYYY-MM-DD");
+                    start = DateOnly.FromDateTime(parsedStart);
+                }
+
+                var end = start.AddDays(90);
+                if (!string.IsNullOrWhiteSpace(endDate))
+                {
+                    if (!McpOutput.TryParseDate(endDate, out var parsedEnd))
+                        return McpOutput.InvalidArgument("endDate", endDate, "YYYY-MM-DD");
+                    end = DateOnly.FromDateTime(parsedEnd);
+                }
+
+                // An inverted range is a caller mistake — clamping it silently searched a
+                // different window than requested and reported a misleading "no meetings".
                 if (end < start)
-                    end = start;
+                    return $"Invalid date range: endDate {end:yyyy-MM-dd} is before startDate {start:yyyy-MM-dd}.";
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var records = await _repository
-                    .GetByDateRange(start, end)
+                var range = _repository.GetByDateRange(start, end);
+                var total = await range.CountAsync();
+                var records = await range
                     .OrderBy(c => c.MeetingDate)
                     .ThenBy(c => c.Title)
                     .Take(maxResults)
                     .ToListAsync();
 
-                return MarkdownTable.Render(
+                if (records.Count == 0)
+                    return await EmptyRangeMessage(start, end);
+
+                var result = MarkdownTable.Render(
                     records,
-                    "No FDA advisory-committee meetings found in the specified date range.",
-                    "FDA Catalyst Calendar (advisory-committee meetings):",
-                    "| Date | Meeting | Center | Type | Through |",
-                    "|------|---------|--------|------|---------|",
+                    string.Empty,
+                    $"FDA Catalyst Calendar (advisory-committee meetings, {start:yyyy-MM-dd} to {end:yyyy-MM-dd}):",
+                    "| Date | Meeting | Center | Type | Through | Details |",
+                    "|------|---------|--------|------|---------|---------|",
                     c =>
-                        $"| {c.MeetingDate:yyyy-MM-dd} | {Clean(c.Title)} | {Clean(c.Center)} | {c.CatalystType.NameForHumans()} | {(c.EndDate.HasValue ? c.EndDate.Value.ToString("yyyy-MM-dd") : "—")} |"
+                        $"| {c.MeetingDate:yyyy-MM-dd} | {Clean(c.Title)} | {Clean(c.Center)} | {c.CatalystType.NameForHumans()} | {(c.EndDate.HasValue ? c.EndDate.Value.ToString("yyyy-MM-dd") : "—")} | {(string.IsNullOrEmpty(c.SourceUrl) ? "—" : c.SourceUrl)} |"
                 );
+                var truncation = McpOutput.TruncationNote(records.Count, total);
+                return truncation.Length == 0 ? result : result + "\n" + truncation + "\n";
             },
             "GetFdaCatalysts",
             $"startDate: {startDate}"
         );
+    }
+
+    // Reports the searched window plus the calendar's actual coverage, so a query
+    // outside the covered span reads as a coverage boundary, never as "no meetings".
+    private async Task<string> EmptyRangeMessage(DateOnly start, DateOnly end)
+    {
+        var oldest = await _repository.GetAll().MinAsync(c => (DateOnly?)c.MeetingDate);
+        var newest = await _repository.GetAll().MaxAsync(c => (DateOnly?)c.MeetingDate);
+        var message =
+            $"No FDA advisory-committee meetings found between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.";
+        return oldest == null || newest == null
+            ? message
+            : message
+                + $" The calendar currently covers {oldest:yyyy-MM-dd} to {newest:yyyy-MM-dd} — meetings outside that span have not been announced or predate coverage.";
     }
 
     // Free-text columns can contain pipes or newlines that would break the markdown row.

--- a/tests/Equibles.UnitTests/FdaCatalysts/FdaCatalystToolsTests.cs
+++ b/tests/Equibles.UnitTests/FdaCatalysts/FdaCatalystToolsTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Threading.Tasks;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.FdaCatalysts.Data;
+using Equibles.FdaCatalysts.Data.Models;
+using Equibles.FdaCatalysts.Mcp.Tools;
+using Equibles.FdaCatalysts.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Equibles.UnitTests.FdaCatalysts;
+
+/// <summary>
+/// Contract: <c>GetFdaCatalysts</c> renders the requested window's meetings with the
+/// per-meeting FDA page link, rejects malformed or inverted date arguments instead of
+/// silently substituting a different window, signposts truncation, and reports the
+/// calendar's covered span when a window turns up nothing.
+/// </summary>
+public class FdaCatalystToolsTests
+{
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[] { new FdaCatalystsModuleConfiguration() }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static FdaCatalyst Meeting(
+        DateOnly date,
+        string title,
+        string slug,
+        string sourceUrl = "https://www.fda.gov/advisory-committees/meeting"
+    ) =>
+        new()
+        {
+            CatalystType = FdaCatalystType.AdvisoryCommittee,
+            MeetingDate = date,
+            Center = "Center for Drug Evaluation and Research",
+            Title = title,
+            SourceReference = slug,
+            SourceUrl = sourceUrl,
+        };
+
+    private static FdaCatalystTools Tools(EquiblesFinancialDbContext ctx) =>
+        new(
+            new FdaCatalystRepository(ctx),
+            new ErrorManager(null!),
+            NullLogger<FdaCatalystTools>.Instance
+        );
+
+    [Fact]
+    public async Task GetFdaCatalysts_RendersTheMeetingWithItsFdaPageLink()
+    {
+        var options = NewDbOptions();
+        await using var ctx = NewContext(options);
+        var date = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(10);
+        ctx.Add(
+            Meeting(
+                date,
+                "Oncologic Drugs Advisory Committee",
+                "odac-slug",
+                "https://www.fda.gov/advisory-committees/odac-meeting"
+            )
+        );
+        await ctx.SaveChangesAsync();
+
+        var result = await Tools(ctx).GetFdaCatalysts();
+
+        result
+            .Should()
+            .Contain(
+                "https://www.fda.gov/advisory-committees/odac-meeting",
+                "the per-meeting FDA page is the only way to resolve which product the meeting concerns"
+            );
+        result.Should().Contain("Oncologic Drugs Advisory Committee");
+        result.Should().Contain("| Details |", "the link needs its own column");
+    }
+
+    [Fact]
+    public async Task GetFdaCatalysts_MalformedStartDate_ReturnsAnErrorInsteadOfSilentlyDefaulting()
+    {
+        var options = NewDbOptions();
+        await using var ctx = NewContext(options);
+        ctx.Add(Meeting(DateOnly.FromDateTime(DateTime.UtcNow).AddDays(5), "Meeting", "slug-1"));
+        await ctx.SaveChangesAsync();
+
+        var result = await Tools(ctx).GetFdaCatalysts(startDate: "23/07/2026");
+
+        result.Should().Contain("Unknown startDate '23/07/2026'");
+        result
+            .Should()
+            .NotContain(
+                "FDA Catalyst Calendar",
+                "a bad argument must never return data for a different window"
+            );
+    }
+
+    [Fact]
+    public async Task GetFdaCatalysts_InvertedRange_ReturnsAnErrorInsteadOfClampingToOneDay()
+    {
+        var options = NewDbOptions();
+        await using var ctx = NewContext(options);
+
+        var result = await Tools(ctx)
+            .GetFdaCatalysts(startDate: "2026-09-01", endDate: "2026-08-01");
+
+        result
+            .Should()
+            .Contain(
+                "Invalid date range",
+                "the old clamp searched a window the caller never asked for"
+            );
+        result.Should().Contain("2026-08-01").And.Contain("2026-09-01");
+    }
+
+    [Fact]
+    public async Task GetFdaCatalysts_EmptyWindow_ReportsTheCalendarsCoveredSpan()
+    {
+        var options = NewDbOptions();
+        await using var ctx = NewContext(options);
+        ctx.Add(Meeting(new DateOnly(2025, 11, 6), "Oldest meeting", "slug-old"));
+        ctx.Add(Meeting(new DateOnly(2026, 7, 30), "Newest meeting", "slug-new"));
+        await ctx.SaveChangesAsync();
+
+        var result = await Tools(ctx)
+            .GetFdaCatalysts(startDate: "2024-01-01", endDate: "2024-12-31");
+
+        result
+            .Should()
+            .Contain("No FDA advisory-committee meetings found between 2024-01-01 and 2024-12-31");
+        result
+            .Should()
+            .Contain(
+                "covers 2025-11-06 to 2026-07-30",
+                "an empty answer outside coverage must read as a coverage boundary, not as no meetings"
+            );
+    }
+
+    [Fact]
+    public async Task GetFdaCatalysts_MaxResultsClip_AppendsTheTruncationNote()
+    {
+        var options = NewDbOptions();
+        await using var ctx = NewContext(options);
+        var start = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(3);
+        for (var i = 0; i < 3; i++)
+            ctx.Add(Meeting(start.AddDays(i), $"Meeting {i}", $"slug-{i}"));
+        await ctx.SaveChangesAsync();
+
+        var result = await Tools(ctx).GetFdaCatalysts(maxResults: 2);
+
+        result.Should().Contain("Showing first 2 of 3 results");
+    }
+
+    [Fact]
+    public async Task GetFdaCatalysts_FullResult_HasNoTruncationNote()
+    {
+        var options = NewDbOptions();
+        await using var ctx = NewContext(options);
+        ctx.Add(Meeting(DateOnly.FromDateTime(DateTime.UtcNow).AddDays(3), "Meeting", "slug-1"));
+        await ctx.SaveChangesAsync();
+
+        var result = await Tools(ctx).GetFdaCatalysts();
+
+        result.Should().NotContain("Showing first");
+    }
+}


### PR DESCRIPTION
## Summary
MCP audit fixes for `GetFdaCatalysts`:

- **Meeting page links**: the per-meeting FDA page (`SourceUrl`, populated on every row) now renders as a Details column — previously the only way to resolve which product/sponsor a meeting concerns was dropped.
- **Strict date arguments**: malformed `startDate`/`endDate` return `Unknown startDate '...'. Accepted: YYYY-MM-DD.` instead of silently falling back to today; an inverted range returns an explicit error instead of being clamped to a single day (which produced false 'no meetings' answers).
- **Effective window echoed** in the result title; an empty window reports the calendar's actual covered span so out-of-coverage queries read as a coverage boundary, not as no meetings.
- **Truncation note** via the shared `McpOutput.TruncationNote` when `maxResults` clips the list.
- **Description honesty**: forward-looking calendar of announced meetings (coverage starts late 2025), no backward archive, no stock-ticker linkage.

## Code changes
- `src/Equibles.FdaCatalysts.Mcp/Tools/FdaCatalystTools.cs` — all of the above.
- `tests/Equibles.UnitTests/FdaCatalysts/FdaCatalystToolsTests.cs` — 6 new tests (link render, malformed date, inverted range, covered-span empty state, truncation note present/absent).

Full `Equibles.UnitTests` suite: 3638 passed.