### PR TITLE
fix(holdings-mcp): filter per-holder portfolio loads to 13F rows and dedupe consensus funds by holder identity

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1686,6 +1686,14 @@ public class InstitutionalHoldingsTools
                 if (holders.Count < 2)
                     return $"Could not resolve enough institutions. Missing: {string.Join(", ", missing)}.";
 
+                // Two spellings can resolve to the same filer (partial names funnel to the
+                // largest match). Combining the duplicate doubles every combined value and
+                // lets a single real fund satisfy minFunds as a fake consensus, so the
+                // resolved set is deduped by holder identity.
+                holders = holders.DistinctBy(h => h.Id).ToList();
+                if (holders.Count < 2)
+                    return $"The supplied names all resolve to the same institution — {holders[0].Name} (CIK {holders[0].Cik}). Pass at least two distinct institutions.";
+
                 var common = await ComputeCommonReportDates(holders);
                 if (common.Count == 0)
                     return "The selected institutions share no common report dates.";
@@ -1805,10 +1813,14 @@ public class InstitutionalHoldingsTools
         return (holder, matchNote, null);
     }
 
+    // 13F-only: a Schedule 13D/G stake whose event date coincides with a 13F quarter end
+    // shares the holdings table and would double-count the position in every per-holder
+    // portfolio composition built on this load (consensus, overlap, quarterly activity) —
+    // the holder-side twin of GH-4449.
     private Task<List<InstitutionalHolding>> LoadHoldingsByHolderWithStock(
         InstitutionalHolder holder,
         DateOnly reportDate
-    ) => _holdingRepository.GetByHolderWithStock(holder, reportDate).ToListAsync();
+    ) => _holdingRepository.Get13FByHolderWithStock(holder, reportDate).ToListAsync();
 
     private Task<Dictionary<Guid, CommonStock>> LoadStocksByIds(List<Guid> stockIds) =>
         _commonStockRepository.GetByIds(stockIds).ToDictionaryAsync(s => s.Id);


### PR DESCRIPTION
## Summary
- `LoadHoldingsByHolderWithStock` (shared by `GetConsensusHoldings`, `GetFundOverlap`, `GetInstitutionQuarterlyActivity`) loaded the **unfiltered** per-holder rows, so a Schedule 13D/G stake whose event date coincides with a 13F quarter end rendered/aggregated alongside the 13F position and double-counted it — the holder-side twin of GH-4449. It now routes through the existing `Get13FByHolderWithStock`.
- `GetConsensusHoldings` treated two spellings that resolve to the same filer ("Berkshire Hathaway Inc, Berkshire Hathaway" → CIK 1067983 twice) as two distinct funds: every combined value doubled and one real fund satisfied `minFunds` as fake consensus. The resolved set is now deduped by holder id, with a terminal message when fewer than two distinct institutions remain.

## Code changes
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`: helper seam swap to `Get13FByHolderWithStock` + `DistinctBy(h => h.Id)` guard in `GetConsensusHoldings`.

Surfaced by the commercial REST v1 audit (live-confirmed doubled NVDA/AAPL/MSFT rows for CIK 2100119 and exactly-doubled consensus values); the commercial REST controllers get the same fixes against this pin.