### PR TITLE
fix(errors): report the full exception at scraper call sites so the inner chain is recorded

### DIFF
--- a/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
+++ b/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
@@ -144,8 +144,7 @@ public class CboeImportService : IImporter
                 await _errorReporter.Report(
                     ErrorSource.CboeScraper,
                     "CboeImport.ImportPutCallRatio",
-                    ex.Message,
-                    ex.StackTrace,
+                    ex,
                     $"date: {date}"
                 );
                 break;
@@ -268,12 +267,7 @@ public class CboeImportService : IImporter
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error importing CBOE VIX history");
-            await _errorReporter.Report(
-                ErrorSource.CboeScraper,
-                "CboeImport.ImportVixHistory",
-                ex.Message,
-                ex.StackTrace
-            );
+            await _errorReporter.Report(ErrorSource.CboeScraper, "CboeImport.ImportVixHistory", ex);
         }
     }
 }

--- a/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
@@ -82,8 +82,7 @@ public class CftcImportService : IImporter
                 await _errorReporter.Report(
                     ErrorSource.CftcScraper,
                     "CftcImport.ImportYear",
-                    ex.Message,
-                    ex.StackTrace,
+                    ex,
                     $"year: {year}"
                 );
             }

--- a/src/Equibles.CommonStocks.HostedService/Services/WebsiteDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/WebsiteDiscoveryService.cs
@@ -114,8 +114,7 @@ public class WebsiteDiscoveryService : IImporter
                 await _errorReporter.Report(
                     ErrorSource.WebsiteDiscovery,
                     $"FindWebsites({source.Name})",
-                    ex.Message,
-                    ex.StackTrace
+                    ex
                 );
                 continue;
             }

--- a/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
@@ -128,12 +128,7 @@ public class CongressionalAnnualDisclosureSyncService
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to fetch {Source} annual disclosure data", sourceLabel);
-            await _errorReporter.Report(
-                ErrorSource.CongressScraper,
-                errorContext,
-                ex.Message,
-                ex.StackTrace
-            );
+            await _errorReporter.Report(ErrorSource.CongressScraper, errorContext, ex);
         }
     }
 

--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -109,12 +109,7 @@ public class CongressionalTradeSyncService
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to fetch {Source} disclosure data", sourceLabel);
-            await _errorReporter.Report(
-                ErrorSource.CongressScraper,
-                errorContext,
-                ex.Message,
-                ex.StackTrace
-            );
+            await _errorReporter.Report(ErrorSource.CongressScraper, errorContext, ex);
         }
     }
 

--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
@@ -158,8 +158,7 @@ public class OffExchangeVolumeImportService
             await _errorReporter.Report(
                 ErrorSource.FinraScraper,
                 "OffExchangeVolume.ImportWeek",
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"week: {weekStartDate}"
             );
         }

--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -111,8 +111,7 @@ public class ShortInterestImportService
             await _errorReporter.Report(
                 ErrorSource.FinraScraper,
                 "ShortInterest.DiscoverDates",
-                ex.Message,
-                ex.StackTrace
+                ex
             );
             return;
         }
@@ -247,8 +246,7 @@ public class ShortInterestImportService
             await _errorReporter.Report(
                 ErrorSource.FinraScraper,
                 "ShortInterest.ImportDate",
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"date: {date}"
             );
             return 0;

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -176,8 +176,7 @@ public class ShortVolumeImportService
             await _errorReporter.Report(
                 ErrorSource.FinraScraper,
                 "ShortVolume.ImportDate",
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"date: {date}"
             );
         }

--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -65,8 +65,7 @@ public class FredImportService : IImporter
                 await _errorReporter.Report(
                     ErrorSource.FredScraper,
                     "FredImport.ImportSeries",
-                    ex.Message,
-                    ex.StackTrace,
+                    ex,
                     $"seriesId: {curated.SeriesId}"
                 );
             }

--- a/src/Equibles.Fred.HostedService/Services/FredReleaseCalendarImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredReleaseCalendarImportService.cs
@@ -63,8 +63,7 @@ public class FredReleaseCalendarImportService : IImporter
             await _errorReporter.Report(
                 ErrorSource.FredScraper,
                 "FredReleaseCalendarImport.Import",
-                ex.Message,
-                ex.StackTrace
+                ex
             );
         }
     }

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -108,8 +108,7 @@ public class GovernmentContractsImportService : IImporter
                 await _errorReporter.Report(
                     ErrorSource.GovernmentContractsScraper,
                     "GovernmentContractsImport.ImportWindow",
-                    ex.Message,
-                    ex.StackTrace,
+                    ex,
                     $"window: {windowStart}..{windowEnd}"
                 );
 

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -379,8 +379,7 @@ public class HoldingsScraperWorker : BaseScraperWorker
                 await ErrorReporter.Report(
                     ErrorSource,
                     "Holdings.ProcessDataSet",
-                    ex.Message,
-                    ex.StackTrace,
+                    ex,
                     $"file: {fileName}"
                 );
                 return false;

--- a/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsParseWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsParseWorker.cs
@@ -97,8 +97,7 @@ public class ReportedStatementsParseWorker : BaseScraperWorker
                     await ErrorReporter.Report(
                         ErrorSource,
                         "ReportedStatementsParse.Parse",
-                        ex.Message,
-                        ex.StackTrace,
+                        ex,
                         $"documentId: {document.Id}, accession: {document.AccessionNumber}"
                     );
                 }

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -1122,8 +1122,7 @@ public class DocumentScraper : IDocumentScraper
         _errorReporter.Report(
             ErrorSource.DocumentScraper,
             $"DocumentScraper.{operation}",
-            ex.Message,
-            ex.StackTrace,
+            ex,
             requestSummary
         );
 

--- a/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
@@ -87,8 +87,7 @@ internal static class EdgarXmlSubmissionParser
             await errorReporter.Report(
                 ErrorSource.DocumentScraper,
                 errorContext,
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
             );
             return null;

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -768,13 +768,7 @@ public class CompanySyncService : ICompanySyncService
     }
 
     private Task ReportError(string operation, Exception ex, string context) =>
-        _errorReporter.Report(
-            ErrorSource.DocumentScraper,
-            operation,
-            ex.Message,
-            ex.StackTrace,
-            context
-        );
+        _errorReporter.Report(ErrorSource.DocumentScraper, operation, ex, context);
 
     private class StockSyncState
     {

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -119,8 +119,7 @@ public class FtdImportService
                 await _errorReporter.Report(
                     ErrorSource.FtdScraper,
                     "FtdImport.ProcessFile",
-                    ex.Message,
-                    ex.StackTrace,
+                    ex,
                     $"file: {fileName}"
                 );
             }

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -587,8 +587,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             await _errorReporter.Report(
                 ErrorSource.DocumentScraper,
                 "InsiderTrading.ParseXml",
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
             );
             return (null, null);

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -219,7 +219,14 @@ public abstract class BaseScraperWorker : BackgroundService
                 // a brief, self-healing blip on a worker that opts into a higher threshold — we
                 // log a warning and let the backoff retry, keeping transient restarts out of the
                 // Errors page operators watch for real defects. A clean cycle resets the streak.
-                if (_consecutiveFailures >= ErrorReportThreshold && !_errorReportedForStreak)
+                // A cancellation must not consume the once-per-streak flag: ErrorReporter
+                // drops OperationCanceledException by type, so "reporting" it would write
+                // nothing yet still mask a later genuine fault in the same streak.
+                if (
+                    _consecutiveFailures >= ErrorReportThreshold
+                    && !_errorReportedForStreak
+                    && ex is not OperationCanceledException
+                )
                 {
                     _errorReportedForStreak = true;
                     Logger.LogCritical(ex, "Critical error in {Worker}", WorkerName);

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -226,12 +226,7 @@ public abstract class BaseScraperWorker : BackgroundService
                     // ErrorReporter publishes its own ScraperActivity with the same
                     // source + the error message, so the activity feed gets a row
                     // without double-emitting here.
-                    await ErrorReporter.Report(
-                        ErrorSource,
-                        $"{WorkerName}.DoWork",
-                        ex.Message,
-                        ex.StackTrace
-                    );
+                    await ErrorReporter.Report(ErrorSource, $"{WorkerName}.DoWork", ex);
                 }
                 else
                 {

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -122,8 +122,7 @@ public class YahooPriceImportService
                 await _errorReporter.Report(
                     ErrorSource.YahooPriceScraper,
                     $"ImportTicker({ticker})",
-                    ex.Message,
-                    ex.StackTrace
+                    ex
                 );
             }
         }

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerCancellationStreakFlagTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerCancellationStreakFlagTests.cs
@@ -1,0 +1,105 @@
+#nullable enable
+
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Worker;
+
+// ErrorReporter drops OperationCanceledException by type, so a fault streak led by a
+// non-shutdown cancellation (an inner HTTP/command timeout that slips past the dedicated
+// shutdown catch) must not consume the once-per-streak report flag: "reporting" it writes
+// nothing, and a later genuine fault in the same streak would then never reach the Errors
+// page. This test pins the gate the same way the threshold tests do — via the log level
+// the loop emits (Critical = reported, Warning = deferred).
+public class BaseScraperWorkerCancellationStreakFlagTests
+{
+    [Fact]
+    public async Task CancellationLedStreak_StillReportsTheLaterGenuineFault()
+    {
+        var logger = Substitute.For<ILogger>();
+        var parked = new TaskCompletionSource();
+        using var worker = new CancellationStreakTestWorker(
+            logger,
+            doWork: (cycle, stoppingToken) =>
+            {
+                // Cycle 1: a cancellation NOT tied to the stopping token — the reporter
+                // drops it, so it must not consume the streak flag. Cycle 2: a genuine
+                // fault in the same streak that must still be reported.
+                if (cycle == 1)
+                    throw new OperationCanceledException("inner timeout");
+                if (cycle == 2)
+                    throw new InvalidOperationException("genuine fault");
+                parked.TrySetResult();
+                return Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await parked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        // Exactly one Errors-table report — the genuine fault; the lead-off cancellation
+        // neither reported nor blocked it.
+        logger
+            .Received(1)
+            .Log(
+                LogLevel.Critical,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("Critical error in")),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+        // The cancelled cycle itself stays a deferred warning.
+        logger
+            .Received()
+            .Log(
+                LogLevel.Warning,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("faulted")),
+                Arg.Is<Exception?>(e => e is OperationCanceledException),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+    }
+
+    // Deterministic loop driver, mirroring ThresholdTestWorker: threshold 1 so the very
+    // first reportable fault escalates, no real waiting between cycles.
+    private sealed class CancellationStreakTestWorker : BaseScraperWorker
+    {
+        private readonly Func<int, CancellationToken, Task> _doWork;
+        private int _cycle;
+
+        public CancellationStreakTestWorker(
+            ILogger logger,
+            Func<int, CancellationToken, Task> doWork
+        )
+            : base(
+                logger,
+                Substitute.For<IServiceScopeFactory>(),
+                new ErrorReporter(
+                    Substitute.For<IServiceScopeFactory>(),
+                    Substitute.For<ILogger<ErrorReporter>>()
+                )
+            )
+        {
+            _doWork = doWork;
+        }
+
+        protected override string WorkerName => "Cancellation streak test";
+        protected override TimeSpan SleepInterval => TimeSpan.FromMilliseconds(1);
+        protected override TimeSpan ErrorBackoffInterval => TimeSpan.FromMilliseconds(1);
+        protected override int ErrorReportThreshold => 1;
+        protected override ErrorSource ErrorSource => ErrorSource.Other;
+
+        protected override Task DoWork(CancellationToken stoppingToken) =>
+            _doWork(++_cycle, stoppingToken);
+
+        protected override Task WaitForNextCycle(
+            TimeSpan interval,
+            CancellationToken stoppingToken
+        ) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
The Errors dashboard kept listing undiagnosable rows like `An error occurred while saving the entity changes. See the inner exception for details.` (DbUpdateException) and `An error occurred while sending the request.` (HttpRequestException) — 22 call sites passed `ex.Message` + `ex.StackTrace` to ErrorReporter's string overload, bypassing the inner-exception flattening the exception overload gained in #4127. Diagnosing the recent proxy-backfill save failures required git archaeology because the actual Postgres error was never recorded.

## Code changes
- 22 call sites across the scraper hosted services, `BaseScraperWorker`, and SEC helpers now pass the exception itself: the recorded Message carries the flattened inner chain and the StackTrace column the full `ToString()` (all inner stacks).
- Side effect, by design: `OperationCanceledException` at these sites is now dropped by type (#4126's policy), so deploy/shutdown cancellations no longer land as noise rows.