### PR TITLE
fix(government-contracts): ride out USAspending bad spells with a taller retry ladder

### DIFF
--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -17,7 +17,14 @@ namespace Equibles.Integrations.GovernmentContracts;
 public class UsaSpendingClient : IUsaSpendingClient
 {
     private const string SearchUrl = "https://api.usaspending.gov/api/v2/search/spending_by_award/";
-    private const int MaxRetries = 3;
+
+    // USAspending's search endpoint has intermittent bad spells lasting minutes —
+    // the gateway resets heavy queries mid-flight, which surfaces as an
+    // HttpRequestException on an otherwise healthy API. Three retries rode ~30s of
+    // backoff (2+4+8+16s) and kept losing whole import windows to spells barely
+    // longer than that; six retries back off ~2min (…+32+64s), long enough to
+    // outlast the spell while a genuine outage still fails the window promptly.
+    private const int MaxRetries = 6;
 
     // The API returns at most 100 rows/page and refuses to paginate past the
     // 10,000th record, so 100 pages is the hard ceiling for a single window.


### PR DESCRIPTION
## Summary
The USAspending search endpoint has intermittent bad spells lasting minutes — the gateway resets heavy queries mid-flight while the API is otherwise healthy. Three retries rode only ~30s of backoff (2+4+8+16s), so a spell barely longer than that failed the whole import window, aborted the cycle, and recorded an error roughly hourly during historical backfills (9 rows in the last two days, windows advancing each time — the lane heals, but slowly and loudly).

## Code changes
- `UsaSpendingClient.MaxRetries` 3 → 6: backoff now spans ~2min (…+32+64s), long enough to outlast a spell; a genuine outage still fails the window promptly and the import service's abort-on-transport-failure behavior is unchanged.