### PR TITLE
test(yahoo): register the shares provider in the company-profile fixtures

### DIFF
--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileBlankSectorTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileBlankSectorTests.cs
@@ -9,6 +9,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Yahoo.Contracts;
 using Equibles.Integrations.Yahoo.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.HostedService.Services;
@@ -54,6 +55,10 @@ public class YahooPriceImportServiceCompanyProfileBlankSectorTests : IDisposable
             (typeof(CommonStockRepository), _stockRepo),
             (typeof(IndustryRepository), _industryRepo),
             (typeof(SectorRepository), _sectorRepo),
+            // SyncKeyStatistics resolves the EDGAR shares provider even when Yahoo has no
+            // stats (#4155); a bare substitute (null shares) keeps the "no EDGAR anchor
+            // writes nothing" path so the profile sync still runs.
+            (typeof(ISharesOutstandingProvider), Substitute.For<ISharesOutstandingProvider>()),
             (
                 typeof(SplitPriceReconciliationManager),
                 new SplitPriceReconciliationManager(splitRepo)

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
@@ -10,6 +10,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Yahoo.Contracts;
 using Equibles.Integrations.Yahoo.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.HostedService.Services;
@@ -62,6 +63,10 @@ public class YahooPriceImportServiceCompanyProfileTests : IDisposable
             (typeof(CommonStockRepository), _stockRepo),
             (typeof(IndustryRepository), _industryRepo),
             (typeof(SectorRepository), _sectorRepo),
+            // SyncKeyStatistics resolves the EDGAR shares provider even when Yahoo has no
+            // stats (#4155); a bare substitute (null shares) keeps the "no EDGAR anchor
+            // writes nothing" path so the profile sync still runs.
+            (typeof(ISharesOutstandingProvider), Substitute.For<ISharesOutstandingProvider>()),
             (
                 typeof(SplitPriceReconciliationManager),
                 new SplitPriceReconciliationManager(splitRepo)


### PR DESCRIPTION
## Summary
Main has been red since #4155 (first failing run: `a76b1a5f`, 2026-07-16 20:57 UTC): five `YahooPriceImportServiceCompanyProfile*` integration tests fail with *'Expected sectors to contain a single item, but the collection is empty'*. #4155 made `SyncKeyStatistics` fall through on null Yahoo stats and resolve `ISharesOutstandingProvider` from the scope — the two company-profile fixtures never registered it, so the resolve threw before `SyncCompanyProfile` ran. Production DI is unaffected (the provider is auto-wired there); this is a fixture gap only.

## Code changes
- Both fixtures register a bare `ISharesOutstandingProvider` substitute (null shares → the 'no EDGAR anchor writes nothing' path), mirroring `YahooPriceImportServiceTests`.