### PR TITLE
fix(holdings): extend the command timeout for the cold 13F report-dates scan

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -203,6 +203,12 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             }
         }
 
+        // The DISTINCT scan behind this list measures ~28s warm and can cross Npgsql's
+        // default 30s command timeout cold — verified in production: the first
+        // market-activity request after a container recreate (or a cache-TTL expiry)
+        // 500s here before any aggregate even runs. Same headroom as the market-wide
+        // aggregates, so a cold resolve becomes a slow success instead of a failure.
+        ExtendCommandTimeoutForMarketWideAggregates();
         var dates = await Get13FAvailableReportDates().ToListAsync(cancellationToken);
 
         // An empty list is not cached: it only occurs before the first 13F import, and


### PR DESCRIPTION
## Summary
Follow-up to #4186, found during production verification of that change: a cold `GET /v1/13f/market-activity` still 500d — not in the market-wide aggregate (now under the 120s headroom, verified: a cold combined `top-buys` succeeded in ~41s) but in `Get13FAvailableReportDatesCached`'s DISTINCT scan, which measures ~28s warm and crossed the default 30s command timeout on the first call after the container recreate. Every process boot and cache-TTL expiry risks the same failure — matching the recorded pattern of ~5 REST 500s/day.

## Code changes
- `Get13FAvailableReportDatesCached` opts into the same `ExtendCommandTimeoutForMarketWideAggregates()` before materialising the scan, so a cold resolve becomes a slow success instead of a failure.

## Verification
- After deploying the pin: a cold `new-positions` call went 500→200 (retry with warm date cache: 200 in 11s); unit suite green (3653).