### PR TITLE
fix(mcp): record the full exception chain for failed tool calls, drop cancellations

### DIFF
--- a/src/Equibles.Errors.BusinessLogic/Extensions/ErrorManagerExtensions.cs
+++ b/src/Equibles.Errors.BusinessLogic/Extensions/ErrorManagerExtensions.cs
@@ -4,7 +4,19 @@ namespace Equibles.Errors.BusinessLogic.Extensions;
 
 public static class ErrorManagerExtensions
 {
-    public static Func<string, string, string, string, Task> AsMcpErrorReporter(
+    // Takes the exception itself so the recorded Message carries the flattened
+    // inner-exception chain (ToSummaryMessage) and the StackTrace column the full
+    // ToString() — a raw ex.Message left wrapper rows ("likely due to a transient
+    // failure") undiagnosable on the Errors page.
+    public static Func<string, Exception, string, Task> AsMcpErrorReporter(
         this ErrorManager errorManager
-    ) => (tool, msg, stack, ctx) => errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx);
+    ) =>
+        (tool, ex, ctx) =>
+            errorManager.Create(
+                ErrorSource.McpTool,
+                tool,
+                ex.ToSummaryMessage(),
+                ex.ToString(),
+                ctx
+            );
 }

--- a/src/Equibles.Mcp/McpToolExecutor.cs
+++ b/src/Equibles.Mcp/McpToolExecutor.cs
@@ -41,7 +41,7 @@ public static class McpToolExecutor
         ILogger logger,
         string toolName,
         string context,
-        Func<string, string, string, string, Task> reportError,
+        Func<string, Exception, string, Task> reportError,
         string errorMessage = null
     )
     {
@@ -52,11 +52,18 @@ public static class McpToolExecutor
         catch (Exception ex)
         {
             logger.LogError(ex, "{ToolName} failed — {Context}", toolName, context);
-            try
+            // A cancellation (host shutdown winding down an in-flight call, an aborted
+            // client) is not a fault worth an Errors row — same drop-by-type policy as
+            // ErrorReporter. The reporter receives the exception itself so the recorded
+            // row carries the flattened inner chain, not a wrapper's message.
+            if (ex is not OperationCanceledException)
             {
-                await reportError(toolName, ex.Message, ex.StackTrace, context);
+                try
+                {
+                    await reportError(toolName, ex, context);
+                }
+                catch { }
             }
-            catch { }
             return errorMessage
                 ?? $"An error occurred while executing {toolName}. Please try again.";
         }

--- a/src/Equibles.Mcp/McpToolRunner.cs
+++ b/src/Equibles.Mcp/McpToolRunner.cs
@@ -5,9 +5,9 @@ namespace Equibles.Mcp;
 public class McpToolRunner
 {
     private readonly ILogger _logger;
-    private readonly Func<string, string, string, string, Task> _reportError;
+    private readonly Func<string, Exception, string, Task> _reportError;
 
-    public McpToolRunner(ILogger logger, Func<string, string, string, string, Task> reportError)
+    public McpToolRunner(ILogger logger, Func<string, Exception, string, Task> reportError)
     {
         _logger = logger;
         _reportError = reportError;

--- a/tests/Equibles.UnitTests/Mcp/McpToolExecutorTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpToolExecutorTests.cs
@@ -8,12 +8,12 @@ namespace Equibles.UnitTests.Mcp;
 public class McpToolExecutorTests
 {
     private readonly ILogger _logger;
-    private readonly Func<string, string, string, string, Task> _reportError;
+    private readonly Func<string, Exception, string, Task> _reportError;
 
     public McpToolExecutorTests()
     {
         _logger = Substitute.For<ILogger>();
-        _reportError = Substitute.For<Func<string, string, string, string, Task>>();
+        _reportError = Substitute.For<Func<string, Exception, string, Task>>();
     }
 
     [Fact]
@@ -57,9 +57,7 @@ public class McpToolExecutorTests
             _reportError
         );
 
-        await _reportError
-            .Received(1)
-            .Invoke("TestTool", "boom", Arg.Is<string>(s => s != null), "ticker=AAPL");
+        await _reportError.Received(1).Invoke("TestTool", exception, "ticker=AAPL");
     }
 
     [Fact]
@@ -107,7 +105,7 @@ public class McpToolExecutorTests
     public async Task Execute_ReportErrorThrows_ExceptionIsSwallowed()
     {
         _reportError
-            .Invoke(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Invoke(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<string>())
             .ThrowsAsync(new Exception("reporting failed"));
 
         var result = await McpToolExecutor.Execute(
@@ -119,5 +117,23 @@ public class McpToolExecutorTests
         );
 
         result.Should().Be("An error occurred while executing TestTool. Please try again.");
+    }
+
+    [Fact]
+    public async Task Execute_ActionThrowsCancellation_ReturnsMessageWithoutReporting()
+    {
+        var result = await McpToolExecutor.Execute(
+            () => throw new OperationCanceledException("call aborted"),
+            _logger,
+            "TestTool",
+            "ticker=AAPL",
+            _reportError
+        );
+
+        // A wound-down call still answers, but no Errors row: cancellations are noise.
+        result.Should().Be("An error occurred while executing TestTool. Please try again.");
+        await _reportError
+            .DidNotReceive()
+            .Invoke(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<string>());
     }
 }


### PR DESCRIPTION
## Summary
Companion to #4184 for the MCP tool lane: `McpToolExecutor` passed `ex.Message`/`ex.StackTrace` to the error-reporter delegate, so a failed tool call's Errors row read *'An exception has been raised that is likely due to a transient failure.'* with the actual cause (e.g. the Npgsql read timeout behind the GetMarketWide13FActivity 500s) hidden in an inner exception.

## Code changes
- Reporter delegate retyped `Func<string, Exception, string, Task>` (`McpToolRunner`, `McpToolExecutor`); every construction site already goes through `ErrorManager.AsMcpErrorReporter()`, which now records `ToSummaryMessage()` (flattened chain) + `ToString()` (all inner stacks).
- `OperationCanceledException` is no longer reported (host shutdown winding down an in-flight call), matching ErrorReporter's #4126 policy; the call still returns its error message.
- Executor tests updated + a new cancellation-skip test.