### PR TITLE
feat(holdings): materialise the open-window combined 13F lane

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -127,6 +127,11 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
         // is needed beyond registering it.
         builder.Entity<StockQuarterlyActivity>();
 
+        // Combined-lane twin for the open filing window (carry-forward view); same
+        // attribute-declared composite key and index. See the entity for why it is
+        // a separate table rather than a lane column.
+        builder.Entity<StockQuarterlyActivityCombined>();
+
         // HolderQuarterlySnapshot likewise declares its composite
         // (InstitutionalHolderId, ReportDate) key and ReportDate index as
         // attributes.

--- a/src/Equibles.Holdings.Data/Models/StockQuarterlyActivityCombined.cs
+++ b/src/Equibles.Holdings.Data/Models/StockQuarterlyActivityCombined.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Data.Models;
+
+// Combined-lane twin of StockQuarterlyActivity, materialising the open filing window's
+// carry-forward view: "current" figures aggregate the funds that already filed the open
+// quarter PLUS every non-filer carried forward at its prior-quarter position, so the
+// market-wide surfaces don't read half the universe as sellers while filings trickle in.
+//
+// A separate table rather than a lane column on StockQuarterlyActivity: the plain
+// snapshot has many consumers (heat map, REST closed-quarter lane, screener, portal)
+// whose queries must never see a combined row, and the combined lane's lifecycle is
+// different — it only ever holds ONE quarter's rows (the currently open one) and is
+// deleted outright when the 45-day window closes (CombinedQuarterHelper). Rebuilt by
+// HoldingsAggregateRefreshService on the same DirtyAt-coalesced drain that maintains
+// the plain snapshot, since every 13F arriving during the window dirties the open
+// quarter. Consumers read this instead of running the live combined aggregation
+// (GROUP BY over ~3.4M rows + correlated NOT-EXISTS probes, ~30s cold) per request.
+[PrimaryKey(nameof(CommonStockId), nameof(ReportDate))]
+[Index(nameof(ReportDate))]
+public class StockQuarterlyActivityCombined
+{
+    public Guid CommonStockId { get; set; }
+
+    public DateOnly ReportDate { get; set; }
+
+    public DateOnly PreviousReportDate { get; set; }
+
+    public long CurrentShares { get; set; }
+    public long PreviousShares { get; set; }
+    public long CurrentValue { get; set; }
+    public long PreviousValue { get; set; }
+
+    public int CurrentFilerCount { get; set; }
+    public int PreviousFilerCount { get; set; }
+    public int NewFilerCount { get; set; }
+    public int SoldOutFilerCount { get; set; }
+
+    public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models.Taxonomies;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
 using FlexLabs.EntityFrameworkCore.Upsert;
 using Microsoft.EntityFrameworkCore;
@@ -210,6 +211,139 @@ public class HoldingsAggregateRefreshService
         await UpsertSectorSnapshots(dbContext, reportDate, cancellationToken);
         await UpsertStockActivitySnapshots(dbContext, reportDate, cancellationToken);
         await UpsertHolderSnapshots(dbContext, reportDate, cancellationToken);
+        await RefreshCombinedLane(dbContext, reportDate, cancellationToken);
+    }
+
+    // Maintains the open filing window's combined-lane snapshot
+    // (StockQuarterlyActivityCombined). While the newest quarter's 45-day window is
+    // open its market-wide view must carry non-filers forward at their prior-quarter
+    // positions; the live combined aggregation costs ~30s+ (GROUP BY over two quarters
+    // plus correlated NOT-EXISTS probes), so it runs HERE — once per dirty-quarter
+    // drain — and consumers read the materialised rows. Rebuilt when either side of
+    // the comparison changes (the open quarter's own rebuild, or the prior quarter's —
+    // the carry-forward reads prior-quarter rows, so an amendment there shifts the
+    // combined view too). When the window is closed the lane is retired outright: the
+    // plain snapshot is authoritative and a stale carry-forward row must never
+    // survive into the closed quarter (the daily safety net rebuilds the newest
+    // quarters, giving retirement a reliable trigger).
+    private async Task RefreshCombinedLane(
+        EquiblesFinancialDbContext dbContext,
+        DateOnly rebuiltReportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        var latest = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => h.FilingType == FilingType.Form13F)
+            .Select(h => h.ReportDate)
+            .OrderByDescending(d => d)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (latest == default)
+        {
+            return;
+        }
+
+        if (!CombinedQuarterHelper.IsFilingWindowOpen(latest))
+        {
+            await dbContext
+                .Set<StockQuarterlyActivityCombined>()
+                .ExecuteDeleteAsync(cancellationToken);
+            return;
+        }
+
+        var previous = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => h.ReportDate < latest && h.FilingType == FilingType.Form13F)
+            .Select(h => h.ReportDate)
+            .OrderByDescending(d => d)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (previous == default)
+        {
+            // First quarter on record: there is nothing to carry forward, so the
+            // combined view degenerates to the plain snapshot — leave the lane empty
+            // and let consumers fall back.
+            return;
+        }
+
+        // Only the two quarters feeding the comparison affect the combined rows; a
+        // historical quarter's rebuild (backfill, old amendment) must not re-run the
+        // expensive lane.
+        if (rebuiltReportDate != latest && rebuiltReportDate != previous)
+        {
+            return;
+        }
+
+        // The repository owns the combined query shapes (and raises this scope's
+        // command timeout when composing them); constructed directly over the scoped
+        // context — not resolved from DI, so test harnesses that stub the scope with
+        // only a DbContext keep working — it reuses the exact semantics the live lane
+        // serves, so materialised and live figures can never drift apart.
+        var repository = new InstitutionalHoldingRepository(dbContext);
+        var activity = await repository
+            .GetQuarterlyActivityCombined(latest, previous)
+            .ToListAsync(cancellationToken);
+        var churn = (
+            await repository
+                .GetQuarterlyNewSoldOutPositionsCombined(latest, previous)
+                .ToListAsync(cancellationToken)
+        ).ToDictionary(c => c.CommonStockId);
+
+        var computedAt = DateTime.UtcNow;
+        var rows = activity
+            .Select(a =>
+            {
+                churn.TryGetValue(a.CommonStockId, out var c);
+                return new StockQuarterlyActivityCombined
+                {
+                    CommonStockId = a.CommonStockId,
+                    ReportDate = latest,
+                    PreviousReportDate = previous,
+                    CurrentShares = a.CurrentShares,
+                    PreviousShares = a.PreviousShares,
+                    CurrentValue = a.CurrentValue,
+                    PreviousValue = a.PreviousValue,
+                    CurrentFilerCount = a.CurrentFilerCount,
+                    PreviousFilerCount = a.PreviousFilerCount,
+                    NewFilerCount = c?.NewFilerCount ?? 0,
+                    SoldOutFilerCount = c?.SoldOutFilerCount ?? 0,
+                    ComputedAt = computedAt,
+                };
+            })
+            .ToList();
+
+        if (rows.Count > 0)
+        {
+            await dbContext
+                .Set<StockQuarterlyActivityCombined>()
+                .UpsertRange(rows)
+                .On(a => new { a.CommonStockId, a.ReportDate })
+                .WhenMatched(
+                    (_, incoming) =>
+                        new StockQuarterlyActivityCombined
+                        {
+                            PreviousReportDate = incoming.PreviousReportDate,
+                            CurrentShares = incoming.CurrentShares,
+                            PreviousShares = incoming.PreviousShares,
+                            CurrentValue = incoming.CurrentValue,
+                            PreviousValue = incoming.PreviousValue,
+                            CurrentFilerCount = incoming.CurrentFilerCount,
+                            PreviousFilerCount = incoming.PreviousFilerCount,
+                            NewFilerCount = incoming.NewFilerCount,
+                            SoldOutFilerCount = incoming.SoldOutFilerCount,
+                            ComputedAt = incoming.ComputedAt,
+                        }
+                )
+                .RunAsync(cancellationToken);
+        }
+
+        // Rows for stocks no longer in the combined view, and any stale rows from a
+        // PREVIOUS window's quarter (a new quarter opened before the old lane was
+        // retired): one delete covers both.
+        var currentStockIds = rows.Select(r => r.CommonStockId).ToList();
+        await dbContext
+            .Set<StockQuarterlyActivityCombined>()
+            .Where(s => s.ReportDate != latest || !currentStockIds.Contains(s.CommonStockId))
+            .ExecuteDeleteAsync(cancellationToken);
     }
 
     // Per-(holder, quarter) AUM aggregates for the institutions browse ranking

--- a/src/Equibles.Holdings.Repositories/Extensions/StockActivitySnapshotMapping.cs
+++ b/src/Equibles.Holdings.Repositories/Extensions/StockActivitySnapshotMapping.cs
@@ -1,0 +1,52 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Holdings.Repositories.Extensions;
+
+// Maps the materialised per-(stock, quarter) snapshot rows onto the same shapes the
+// live aggregations produce, so the shared bucket definitions (TopBuyers/TopSellers/
+// NewPositions/SoldOutPositions, most-held sorts) apply unchanged whether a surface
+// read the snapshot or ran the query live. One mapper for both lanes — the plain
+// closed-quarter snapshot and its open-window combined twin carry identical columns.
+public static class StockActivitySnapshotMapping
+{
+    public static MarketWideStockActivity ToActivity(this StockQuarterlyActivity s) =>
+        new()
+        {
+            CommonStockId = s.CommonStockId,
+            CurrentShares = s.CurrentShares,
+            PreviousShares = s.PreviousShares,
+            CurrentValue = s.CurrentValue,
+            PreviousValue = s.PreviousValue,
+            CurrentFilerCount = s.CurrentFilerCount,
+            PreviousFilerCount = s.PreviousFilerCount,
+        };
+
+    public static MarketWideStockChurn ToChurn(this StockQuarterlyActivity s) =>
+        new()
+        {
+            CommonStockId = s.CommonStockId,
+            NewFilerCount = s.NewFilerCount,
+            SoldOutFilerCount = s.SoldOutFilerCount,
+        };
+
+    public static MarketWideStockActivity ToActivity(this StockQuarterlyActivityCombined s) =>
+        new()
+        {
+            CommonStockId = s.CommonStockId,
+            CurrentShares = s.CurrentShares,
+            PreviousShares = s.PreviousShares,
+            CurrentValue = s.CurrentValue,
+            PreviousValue = s.PreviousValue,
+            CurrentFilerCount = s.CurrentFilerCount,
+            PreviousFilerCount = s.PreviousFilerCount,
+        };
+
+    public static MarketWideStockChurn ToChurn(this StockQuarterlyActivityCombined s) =>
+        new()
+        {
+            CommonStockId = s.CommonStockId,
+            NewFilerCount = s.NewFilerCount,
+            SoldOutFilerCount = s.SoldOutFilerCount,
+        };
+}

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -404,6 +404,16 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     public IQueryable<StockQuarterlyActivity> GetStockActivitySnapshots(DateOnly reportDate) =>
         DbContext.Set<StockQuarterlyActivity>().Where(s => s.ReportDate == reportDate);
 
+    // Combined-lane twin for the open filing window: the same per-stock figures with
+    // non-filers carried forward at their prior-quarter positions, materialised by
+    // HoldingsAggregateRefreshService while the window is open and deleted when it
+    // closes. May be EMPTY during the transition (window just opened, first rebuild
+    // not yet drained) — consumers must fall back to the live combined aggregation
+    // when no rows match.
+    public IQueryable<StockQuarterlyActivityCombined> GetStockActivitySnapshotsCombined(
+        DateOnly reportDate
+    ) => DbContext.Set<StockQuarterlyActivityCombined>().Where(s => s.ReportDate == reportDate);
+
     // Double-down report: per-(holder, stock) positions where the share-count
     // increase from the prior quarter exceeds a given percentage threshold,
     // ranked by conviction (largest % increase first). Joins holder + stock

--- a/src/Equibles.Migrations/Migrations/20260718163753_AddStockQuarterlyActivityCombined.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260718163753_AddStockQuarterlyActivityCombined.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718163753_AddStockQuarterlyActivityCombined")]
+    partial class AddStockQuarterlyActivityCombined
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260718163753_AddStockQuarterlyActivityCombined.cs
+++ b/src/Equibles.Migrations/Migrations/20260718163753_AddStockQuarterlyActivityCombined.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStockQuarterlyActivityCombined : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StockQuarterlyActivityCombined",
+                columns: table => new
+                {
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    PreviousReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    CurrentShares = table.Column<long>(type: "bigint", nullable: false),
+                    PreviousShares = table.Column<long>(type: "bigint", nullable: false),
+                    CurrentValue = table.Column<long>(type: "bigint", nullable: false),
+                    PreviousValue = table.Column<long>(type: "bigint", nullable: false),
+                    CurrentFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    PreviousFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    NewFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    SoldOutFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    ComputedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StockQuarterlyActivityCombined", x => new { x.CommonStockId, x.ReportDate });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockQuarterlyActivityCombined_ReportDate",
+                table: "StockQuarterlyActivityCombined",
+                column: "ReportDate");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StockQuarterlyActivityCombined");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceCombinedLaneTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceCombinedLaneTests.cs
@@ -1,0 +1,257 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract for the open-window combined lane of
+/// <see cref="HoldingsAggregateRefreshService"/>: while the newest quarter's 45-day
+/// filing window is open, <see cref="StockQuarterlyActivityCombined"/> must carry
+/// non-filers forward at their prior-quarter positions (a fund that has not filed yet
+/// is assumed to still hold), count only genuinely-filed initiations/exits, and be
+/// retired outright once the window closes. Window state is pinned by seeding report
+/// dates relative to today — inside the 45-day deadline for the open cases, far past
+/// it for the closed case (CombinedQuarterHelper owns the rule).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsAggregateRefreshServiceCombinedLaneTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesFinancialDbContext> _contexts = [];
+
+    public HoldingsAggregateRefreshServiceCombinedLaneTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    // Open-window pair: the "quarter end" sits 20 days back, inside the 45-day window.
+    private static readonly DateOnly OpenCur = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-20);
+    private static readonly DateOnly OpenPrev = OpenCur.AddDays(-92);
+    private static readonly DateOnly OpenOld = OpenCur.AddDays(-184);
+
+    // Closed-window quarter: 100 days back, past the 45-day deadline.
+    private static readonly DateOnly ClosedCur = DateOnly
+        .FromDateTime(DateTime.UtcNow)
+        .AddDays(-100);
+
+    private HoldingsAggregateRefreshService BuildService()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(_ => CreateScopeFromFixture());
+        return new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+    }
+
+    private IServiceScope CreateScopeFromFixture()
+    {
+        var ctx = FreshContext();
+        var scope = Substitute.For<IServiceScope>();
+        var provider = Substitute.For<IServiceProvider>();
+        provider.GetService(typeof(Equibles.Data.EquiblesFinancialDbContext)).Returns(ctx);
+        scope.ServiceProvider.Returns(provider);
+        return scope;
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_WindowOpen_CarriesNonFilersForwardAndCountsRealChurn()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var aapl = await SeedStock(seed, "AAPL", industry);
+        var msft = await SeedStock(seed, "MSFT", industry);
+        var holderA = await SeedHolder(seed, "H001"); // filed both quarters
+        var holderB = await SeedHolder(seed, "H002"); // has NOT filed the open quarter → carried forward
+        var holderC = await SeedHolder(seed, "H003"); // new filer this quarter
+        var holderD = await SeedHolder(seed, "H004"); // filed the open quarter but dropped AAPL
+        seed.AddRange(
+            MakeHolding(aapl, holderA, OpenPrev, 100_000, "acc-a-prev"),
+            MakeHolding(aapl, holderB, OpenPrev, 50_000, "acc-b-prev"),
+            MakeHolding(aapl, holderD, OpenPrev, 10_000, "acc-d-prev"),
+            MakeHolding(aapl, holderA, OpenCur, 120_000, "acc-a-cur"),
+            MakeHolding(aapl, holderC, OpenCur, 30_000, "acc-c-cur"),
+            // D's open-quarter filing holds only MSFT — proof D filed, so no AAPL
+            // carry-forward, and D counts as a genuine AAPL exit.
+            MakeHolding(msft, holderD, OpenCur, 40_000, "acc-d-cur")
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(OpenCur, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var row = await read.Set<StockQuarterlyActivityCombined>()
+            .SingleAsync(s => s.CommonStockId == aapl.Id && s.ReportDate == OpenCur);
+
+        row.PreviousReportDate.Should().Be(OpenPrev);
+        // MakeHolding stores Shares = value / 100.
+        row.CurrentShares.Should()
+            .Be(2_000, "A's 1200 + C's 300 + B's 500 carried forward; D filed, so no carry");
+        row.PreviousShares.Should().Be(1_600, "A 1000 + B 500 + D 100 last quarter");
+        row.CurrentValue.Should().Be(200_000);
+        row.PreviousValue.Should().Be(160_000);
+        row.CurrentFilerCount.Should().Be(3, "A and C filed, B is carried forward");
+        row.PreviousFilerCount.Should().Be(3);
+        row.NewFilerCount.Should().Be(1, "only C initiated");
+        row.SoldOutFilerCount.Should()
+            .Be(1, "D filed this quarter without AAPL — a proven exit; B is assumed to hold");
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_WindowClosed_RetiresTheCombinedLane()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var aapl = await SeedStock(seed, "AAPL", industry);
+        var holderA = await SeedHolder(seed, "H001");
+        seed.AddRange(
+            MakeHolding(aapl, holderA, ClosedCur.AddDays(-92), 100_000, "acc-a-prev"),
+            MakeHolding(aapl, holderA, ClosedCur, 120_000, "acc-a-cur"),
+            // A stale combined row from when the window was open — must not survive
+            // a rebuild after the window closed.
+            new StockQuarterlyActivityCombined
+            {
+                CommonStockId = aapl.Id,
+                ReportDate = ClosedCur,
+                PreviousReportDate = ClosedCur.AddDays(-92),
+                CurrentShares = 1,
+                ComputedAt = DateTime.UtcNow,
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(ClosedCur, CancellationToken.None);
+
+        await using var read = FreshContext();
+        (await read.Set<StockQuarterlyActivityCombined>().AnyAsync())
+            .Should()
+            .BeFalse("the closed quarter's plain snapshot is authoritative");
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_HistoricalQuarter_DoesNotTouchTheCombinedLane()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var aapl = await SeedStock(seed, "AAPL", industry);
+        var holderA = await SeedHolder(seed, "H001");
+        seed.AddRange(
+            MakeHolding(aapl, holderA, OpenOld, 80_000, "acc-a-old"),
+            MakeHolding(aapl, holderA, OpenPrev, 100_000, "acc-a-prev"),
+            MakeHolding(aapl, holderA, OpenCur, 120_000, "acc-a-cur"),
+            // Marker row: a historical quarter's rebuild must neither refresh nor
+            // clean the combined lane — only the open/prior quarters' rebuilds (or a
+            // closed window) may touch it.
+            new StockQuarterlyActivityCombined
+            {
+                CommonStockId = aapl.Id,
+                ReportDate = OpenOld,
+                PreviousReportDate = OpenOld.AddDays(-92),
+                CurrentShares = 42,
+                ComputedAt = DateTime.UtcNow,
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(OpenOld, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var marker = await read.Set<StockQuarterlyActivityCombined>().SingleAsync();
+        marker.CurrentShares.Should().Be(42, "the historical rebuild skipped the lane");
+
+        // The open quarter's own rebuild then refreshes the lane and sweeps the
+        // stale off-quarter marker in the same pass.
+        await BuildService().RebuildQuarterAsync(OpenCur, CancellationToken.None);
+        await using var read2 = FreshContext();
+        var rows = await read2.Set<StockQuarterlyActivityCombined>().ToListAsync();
+        rows.Should().OnlyContain(r => r.ReportDate == OpenCur);
+        rows.Should().ContainSingle(r => r.CommonStockId == aapl.Id);
+    }
+
+    private static async Task<Guid> SeedTaxonomy(Equibles.Data.EquiblesFinancialDbContext ctx)
+    {
+        var sector = new Sector { Name = "Technology" };
+        ctx.Add(sector);
+        await ctx.SaveChangesAsync();
+        var industry = new Industry { Name = "Software", SectorId = sector.Id };
+        ctx.Add(industry);
+        await ctx.SaveChangesAsync();
+        return industry.Id;
+    }
+
+    private static async Task<CommonStock> SeedStock(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string ticker,
+        Guid industryId
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Corp.",
+            Cik = $"C{Guid.NewGuid().GetHashCode() & int.MaxValue:D8}",
+            IndustryId = industryId,
+        };
+        ctx.Add(stock);
+        await ctx.SaveChangesAsync();
+        return stock;
+    }
+
+    private static async Task<InstitutionalHolder> SeedHolder(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string cik
+    )
+    {
+        var holder = new InstitutionalHolder { Cik = cik, Name = $"Holder {cik}" };
+        ctx.Add(holder);
+        await ctx.SaveChangesAsync();
+        return holder;
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long value,
+        string accession,
+        FilingType filingType = FilingType.Form13F
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = accession,
+            FilingType = filingType,
+            Cusip =
+                $"{stock.Ticker[..Math.Min(4, stock.Ticker.Length)]}{accession.GetHashCode():X8}"[
+                    ..9
+                ],
+        };
+}


### PR DESCRIPTION
## Summary
First slice of #4187. While the newest quarter's 45-day filing window is open (~180 days/year), the market-wide 13F surfaces must present the combined view (current filers + prior-quarter carry-forward for non-filers) and every consumer aggregates it live — ~30s+ GROUP BY + correlated NOT-EXISTS probes per cold request (#4186/#4189 gave it timeout headroom; this makes the lane snapshot-backed like closed quarters have been since #1262).

## Code changes
- `StockQuarterlyActivityCombined` (Holdings.Data) — combined-lane twin of `StockQuarterlyActivity`; separate table because its lifecycle differs (only ever holds the open quarter, deleted on window close) and no plain-snapshot consumer may ever see a combined row. + migration.
- `HoldingsAggregateRefreshService.RefreshCombinedLane` — new step on the existing DirtyAt-coalesced rebuild: rebuilds the lane when the open or prior quarter rebuilds (the carry-forward reads both), skips historical quarters, retires the lane when the window closes (daily safety net gives retirement a reliable trigger). Reuses the repository's combined queries verbatim so the materialised and live figures cannot drift; repository constructed directly over the scoped DbContext so existing test harnesses that stub the scope with only a context keep working.
- `InstitutionalHoldingRepository.GetStockActivitySnapshotsCombined` + `StockActivitySnapshotMapping` (snapshot rows → the live aggregation shapes) — the read seam consumer PRs will use, documented as may-be-empty (transition before the first drain) ⇒ consumers keep a live fallback.

## Tests
- Integration (ParadeDB): carry-forward arithmetic + genuine-churn counting (non-filer carried, filed-and-dropped counts as exit, non-filer never counts as exit), window-closed retirement sweeps stale rows, historical-quarter rebuild leaves the lane untouched while the open quarter's rebuild sweeps off-quarter strays.

Consumer wiring (MCP tools, heat map, REST) lands in follow-up slices per #4187.