### PR TITLE
feat(holdings): market-wide MCP tools, activity page and heat map read the snapshot lanes

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -905,6 +905,54 @@ public class InstitutionalHoldingsTools
         return -1;
     }
 
+    // Snapshot-first loads for the market-wide surfaces: a closed quarter reads the
+    // plain StockQuarterlyActivity snapshot, the open filing window reads the
+    // materialised combined lane — either is ~6k pre-aggregated rows instead of the
+    // live two-quarter scan (+ correlated NOT-EXISTS probes for churn/combined) that
+    // measured ~30s cold. The live aggregation remains only as a fallback for an
+    // empty snapshot: a historical gap before the first-boot backfill, or the window
+    // just opened and the first combined drain has not landed yet.
+    private async Task<List<MarketWideStockActivity>> LoadMarketActivity(
+        DateOnly targetDate,
+        DateOnly previousDate,
+        bool windowOpen
+    )
+    {
+        var snapshot = windowOpen
+            ? (await _holdingRepository.GetStockActivitySnapshotsCombined(targetDate).ToListAsync())
+                .Select(s => s.ToActivity())
+                .ToList()
+            : (await _holdingRepository.GetStockActivitySnapshots(targetDate).ToListAsync())
+                .Select(s => s.ToActivity())
+                .ToList();
+        if (snapshot.Count > 0)
+            return snapshot;
+        return await _holdingRepository
+            .GetQuarterlyActivity(targetDate, previousDate, windowOpen)
+            .ToListAsync();
+    }
+
+    // Churn twin of LoadMarketActivity — same lanes, same empty-snapshot fallback.
+    private async Task<List<MarketWideStockChurn>> LoadMarketChurn(
+        DateOnly targetDate,
+        DateOnly previousDate,
+        bool windowOpen
+    )
+    {
+        var snapshot = windowOpen
+            ? (await _holdingRepository.GetStockActivitySnapshotsCombined(targetDate).ToListAsync())
+                .Select(s => s.ToChurn())
+                .ToList()
+            : (await _holdingRepository.GetStockActivitySnapshots(targetDate).ToListAsync())
+                .Select(s => s.ToChurn())
+                .ToList();
+        if (snapshot.Count > 0)
+            return snapshot;
+        return await _holdingRepository
+            .GetQuarterlyNewSoldOutPositions(targetDate, previousDate, windowOpen)
+            .ToListAsync();
+    }
+
     private async Task<string> RenderMarketActivityMovers(
         string normalizedBucket,
         DateOnly targetDate,
@@ -921,11 +969,7 @@ public class InstitutionalHoldingsTools
         // drives the ordering). The restatement is per-stock, so it cannot translate to SQL.
         // While the filing window is open the combined variant carries non-filers forward at a
         // zero delta, so only real reported moves rank.
-        var activity = await (
-            windowOpen
-                ? _holdingRepository.GetQuarterlyActivityCombined(targetDate, previousDate)
-                : _holdingRepository.GetQuarterlyActivity(targetDate, previousDate)
-        ).ToListAsync();
+        var activity = await LoadMarketActivity(targetDate, previousDate, windowOpen);
         await RestateActivitySharesToTodaysBasis(activity, targetDate, previousDate);
 
         var movers = activity.Where(a => a.CurrentShares != a.PreviousShares);
@@ -962,13 +1006,12 @@ public class InstitutionalHoldingsTools
     {
         // Combined while the window is open: the plain variant counts every fund that has not
         // filed yet as "exited", so sold-out-positions would rank by non-filers, not exits.
-        var churn = windowOpen
-            ? _holdingRepository.GetQuarterlyNewSoldOutPositionsCombined(targetDate, previousDate)
-            : _holdingRepository.GetQuarterlyNewSoldOutPositions(targetDate, previousDate);
-        var rows =
+        var churn = await LoadMarketChurn(targetDate, previousDate, windowOpen);
+        var rows = (
             normalizedBucket == "new-positions"
-                ? await churn.NewPositions().Take(maxResults).ToListAsync()
-                : await churn.SoldOutPositions().Take(maxResults).ToListAsync();
+                ? churn.NewPositions().Take(maxResults)
+                : churn.SoldOutPositions().Take(maxResults)
+        ).ToList();
         if (rows.Count == 0)
             return result + "_No stocks in this bucket this quarter._";
 
@@ -1027,10 +1070,12 @@ public class InstitutionalHoldingsTools
                     return error;
 
                 // Combined while the window is open — the as-filed ranking would order the
-                // whole market by which funds happened to file early.
-                var ranking = windowOpen
-                    ? _holdingRepository.GetMostHeldCombined(targetDate, previousDate)
-                    : _holdingRepository.GetMostHeld(targetDate, previousDate);
+                // whole market by which funds happened to file early. Snapshot-first like
+                // the movers/churn buckets; GetMostHeld's CurrentFilerCount > 0 filter and
+                // the sort run in memory over the ~6k mapped rows.
+                var ranking = (
+                    await LoadMarketActivity(targetDate, previousDate, windowOpen)
+                ).Where(a => a.CurrentFilerCount > 0);
                 ranking = normalizedSort switch
                 {
                     "filersdelta" => ranking
@@ -1046,7 +1091,7 @@ public class InstitutionalHoldingsTools
                         .OrderByDescending(a => a.CurrentFilerCount)
                         .ThenByDescending(a => a.CurrentValue),
                 };
-                var rows = await ranking.Take(McpLimit.Clamp(maxResults)).ToListAsync();
+                var rows = ranking.Take(McpLimit.Clamp(maxResults)).ToList();
                 if (rows.Count == 0)
                     return $"No stocks were held by 13F filers as of {FormatDate(targetDate)}.";
 

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Extensions;
+using Equibles.Holdings.Repositories.Models;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.Extensions;
 using Equibles.Web.ViewModels.Holdings;
@@ -52,32 +53,29 @@ public class HoldingsActivityController : BaseController
         var selectedDate = viewModel.SelectedDate;
         var previousDate = viewModel.PreviousDate.Value;
 
-        var movers = _holdingRepository
-            .GetQuarterlyActivity(selectedDate, previousDate, viewModel.IsCombinedSelected)
-            .Where(a => a.CurrentShares != a.PreviousShares);
-
-        var topBuysAgg = await movers
-            .TopBuyers()
-            .Take(HoldingsActivityViewModel.RowCap)
-            .ToListAsync();
-        var topSellsAgg = await movers
-            .TopSellers()
-            .Take(HoldingsActivityViewModel.RowCap)
-            .ToListAsync();
-
-        var churn = _holdingRepository.GetQuarterlyNewSoldOutPositions(
+        // Snapshot-first: the plain per-quarter snapshot for a closed quarter, the
+        // materialised combined lane while the filing window is open — the live
+        // two-quarter aggregation (~30s cold for the churn/combined shapes) only runs
+        // when the matching snapshot has no rows yet. Buckets and caps then apply in
+        // memory over the ~6k mapped rows, keeping the shared bucket definitions.
+        var (activityRows, churnRows) = await LoadActivityAndChurn(
             selectedDate,
             previousDate,
             viewModel.IsCombinedSelected
         );
-        var newPositionsAgg = await churn
+        var movers = activityRows.Where(a => a.CurrentShares != a.PreviousShares);
+
+        var topBuysAgg = movers.TopBuyers().Take(HoldingsActivityViewModel.RowCap).ToList();
+        var topSellsAgg = movers.TopSellers().Take(HoldingsActivityViewModel.RowCap).ToList();
+
+        var newPositionsAgg = churnRows
             .NewPositions()
             .Take(HoldingsActivityViewModel.RowCap)
-            .ToListAsync();
-        var soldOutPositionsAgg = await churn
+            .ToList();
+        var soldOutPositionsAgg = churnRows
             .SoldOutPositions()
             .Take(HoldingsActivityViewModel.RowCap)
-            .ToListAsync();
+            .ToList();
 
         var stockIds = topBuysAgg
             .Concat(topSellsAgg)
@@ -96,6 +94,52 @@ public class HoldingsActivityController : BaseController
             .ToList();
 
         return View(viewModel);
+    }
+
+    // Snapshot-first load shared by the activity page: plain snapshot for closed
+    // quarters, the combined lane for the open window, live aggregation only when the
+    // matching snapshot is empty (historical gap, or the window just opened and the
+    // first combined drain has not landed).
+    private async Task<(
+        List<MarketWideStockActivity> Activity,
+        List<MarketWideStockChurn> Churn
+    )> LoadActivityAndChurn(DateOnly selectedDate, DateOnly previousDate, bool combined)
+    {
+        if (combined)
+        {
+            var lane = await _holdingRepository
+                .GetStockActivitySnapshotsCombined(selectedDate)
+                .ToListAsync();
+            if (lane.Count > 0)
+            {
+                return (
+                    lane.Select(s => s.ToActivity()).ToList(),
+                    lane.Select(s => s.ToChurn()).ToList()
+                );
+            }
+        }
+        else
+        {
+            var snapshot = await _holdingRepository
+                .GetStockActivitySnapshots(selectedDate)
+                .ToListAsync();
+            if (snapshot.Count > 0)
+            {
+                return (
+                    snapshot.Select(s => s.ToActivity()).ToList(),
+                    snapshot.Select(s => s.ToChurn()).ToList()
+                );
+            }
+        }
+
+        return (
+            await _holdingRepository
+                .GetQuarterlyActivity(selectedDate, previousDate, combined)
+                .ToListAsync(),
+            await _holdingRepository
+                .GetQuarterlyNewSoldOutPositions(selectedDate, previousDate, combined)
+                .ToListAsync()
+        );
     }
 
     [HttpGet("~/holdings/latest-13f-filings")]
@@ -357,19 +401,35 @@ public class HoldingsActivityController : BaseController
         List<HeatMapPoint> points;
         if (viewModel.IsCombinedSelected)
         {
-            // The combined view spans the still-open quarter plus a prior-quarter
-            // fallback for non-filers, which the per-quarter snapshot below does not
-            // materialise — derive it live for this case only.
-            var activity = await _holdingRepository
-                .GetQuarterlyActivity(selectedDate, previousDate, combined: true)
+            // The combined view (still-open quarter + prior-quarter carry-forward for
+            // non-filers) reads its materialised lane, kept fresh by the same drain
+            // that maintains the plain snapshot. Live derivation remains only as the
+            // fallback for an empty lane — the window just opened and the first
+            // combined rebuild has not drained yet.
+            var combinedSnapshot = await _holdingRepository
+                .GetStockActivitySnapshotsCombined(selectedDate)
                 .Where(a => a.CurrentFilerCount >= MinHeatMapFilers)
                 .ToListAsync();
 
-            var churnLookup = (
-                await _holdingRepository
-                    .GetQuarterlyNewSoldOutPositions(selectedDate, previousDate, combined: true)
-                    .ToListAsync()
-            ).ToDictionary(c => c.CommonStockId);
+            List<MarketWideStockActivity> activity;
+            Dictionary<Guid, MarketWideStockChurn> churnLookup;
+            if (combinedSnapshot.Count > 0)
+            {
+                activity = combinedSnapshot.Select(s => s.ToActivity()).ToList();
+                churnLookup = combinedSnapshot.ToDictionary(s => s.CommonStockId, s => s.ToChurn());
+            }
+            else
+            {
+                activity = await _holdingRepository
+                    .GetQuarterlyActivity(selectedDate, previousDate, combined: true)
+                    .Where(a => a.CurrentFilerCount >= MinHeatMapFilers)
+                    .ToListAsync();
+                churnLookup = (
+                    await _holdingRepository
+                        .GetQuarterlyNewSoldOutPositions(selectedDate, previousDate, combined: true)
+                        .ToListAsync()
+                ).ToDictionary(c => c.CommonStockId);
+            }
 
             var stocks = await LoadStockLabels(activity.Select(a => a.CommonStockId).ToList());
             points = activity


### PR DESCRIPTION
## Summary
Second slice of #4187, on top of #4191: the market-wide consumers stop aggregating live. `GetMarketWide13FActivity`, `GetMostHeldStocks`, `/holdings/activity` and the conviction heat map's combined branch now read the plain per-quarter snapshot for closed quarters and the materialised combined lane while the filing window is open — ~6k pre-aggregated rows instead of the ~30s-cold two-quarter scan.

## Code changes
- `InstitutionalHoldingsTools`: shared `LoadMarketActivity`/`LoadMarketChurn` snapshot-first helpers; buckets, most-held filter (`CurrentFilerCount > 0`) and sorts run in memory via the existing `IEnumerable` overloads of the shared bucket definitions, so ordering semantics are unchanged; split restatement ordering untouched.
- `HoldingsActivityController`: `/holdings/activity` loads both lanes snapshot-first (`LoadActivityAndChurn`); the heat map's combined branch reads the lane with the same `MinHeatMapFilers` floor.
- Every path keeps the live aggregation as fallback for an empty snapshot (historical gap before the first-boot backfill, or a window that just opened whose first combined drain has not landed).