### PR TITLE
fix(sec): drain as-filed HTML backfill below the live-scraper sync floor

### DIFF
--- a/src/Equibles.Sec.HostedService/AsFiledHtmlBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/AsFiledHtmlBackfillWorker.cs
@@ -1,4 +1,3 @@
-using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Sec.HostedService.Configuration;
@@ -23,7 +22,6 @@ public class AsFiledHtmlBackfillWorker : BaseScraperWorker
 {
     private readonly IConfiguration _configuration;
     private readonly AsFiledHtmlCaptureOptions _captureOptions;
-    private readonly WorkerOptions _workerOptions;
 
     protected override string WorkerName => "As-filed HTML backfill";
 
@@ -46,13 +44,11 @@ public class AsFiledHtmlBackfillWorker : BaseScraperWorker
         IServiceScopeFactory scopeFactory,
         ErrorReporter errorReporter,
         IOptions<AsFiledHtmlCaptureOptions> captureOptions,
-        IOptions<WorkerOptions> workerOptions,
         IConfiguration configuration
     )
         : base(logger, scopeFactory, errorReporter)
     {
         _captureOptions = captureOptions.Value;
-        _workerOptions = workerOptions.Value;
         _configuration = configuration;
     }
 
@@ -71,15 +67,16 @@ public class AsFiledHtmlBackfillWorker : BaseScraperWorker
             return;
         }
 
-        var minReportingDate = _workerOptions.MinSyncDate.HasValue
-            ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
-            : (DateOnly?)null;
-
+        // No reporting-date floor: this is a historical sweep that must drain every 8-K still
+        // below the current builder version. The live-scraper MinSyncDate floor (shared with the
+        // SEC/Holdings/Congress scrapers and the public-site history clamp) is deliberately not
+        // applied here — bounding the backfill by it permanently stranded the pre-floor backlog as
+        // pending-but-never-selected, which is exactly what the dashboard's "pending" metric counts.
         var batchSize = _captureOptions.BackfillBatchSize;
         await using var scope = ScopeFactory.CreateAsyncScope();
         var backfillService =
             scope.ServiceProvider.GetRequiredService<AsFiledHtmlBackfillService>();
-        var result = await backfillService.Backfill(batchSize, minReportingDate, stoppingToken);
+        var result = await backfillService.Backfill(batchSize, stoppingToken);
 
         // A full batch that made forward progress means the newest-first queue still has
         // selectable documents, so drain the next batch after the short ContinuationInterval.

--- a/src/Equibles.Sec.HostedService/Services/AsFiledHtmlBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/AsFiledHtmlBackfillService.cs
@@ -48,7 +48,6 @@ public class AsFiledHtmlBackfillService
 
     public async Task<AsFiledHtmlBackfillResult> Backfill(
         int batchSize,
-        DateOnly? minReportingDate,
         CancellationToken cancellationToken = default
     )
     {
@@ -58,12 +57,11 @@ public class AsFiledHtmlBackfillService
             return result;
         }
 
+        // GetPendingAsFiledHtml is the single definition of the work-set, shared with the
+        // backoffice "pending" metric. It is used unnarrowed on purpose: any extra filter here
+        // (a reporting-date floor was the one that bit us) strands the excluded rows as pending
+        // forever, because nothing else ever advances their attempt count.
         var query = _documentRepository.GetPendingAsFiledHtml();
-
-        if (minReportingDate.HasValue)
-        {
-            query = query.Where(d => d.ReportingDate >= minReportingDate.Value);
-        }
 
         // Ids only: each document is loaded fresh inside the loop, so a failed capture's
         // half-applied change-tracker state can be discarded wholesale without detaching

--- a/tests/Equibles.IntegrationTests/Sec/AsFiledHtmlBackfillServiceReportingDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/AsFiledHtmlBackfillServiceReportingDateTests.cs
@@ -1,0 +1,131 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+// The as-filed HTML backfill's work-set is defined once by
+// DocumentRepository.GetPendingAsFiledHtml and shared with the backoffice "pending" metric.
+// The backfill used to narrow that set by Worker.MinSyncDate — the live-scraper floor also used
+// by the public-site history clamp — so every 8-K reported before the floor was counted as
+// pending on the dashboard but never selected by the worker. Those rows sat at zero attempts
+// indefinitely and the metric could never drain (420 stranded 8-Ks in production). The same
+// defect was fixed once in the sibling XBRL backfill and reintroduced here by copy. Selection
+// must not depend on ReportingDate.
+public class AsFiledHtmlBackfillServiceReportingDateTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly DocumentRepository _repository;
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly AsFiledHtmlBackfillService _service;
+    private readonly CommonStock _company;
+
+    public AsFiledHtmlBackfillServiceReportingDateTests()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        _dbContext = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new MediaModuleConfiguration(),
+                new SecTestModuleConfiguration(),
+            }
+        );
+        _dbContext.Database.EnsureCreated();
+        _repository = new DocumentRepository(_dbContext);
+
+        _company = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        _dbContext.Add(_company);
+        _dbContext.SaveChanges();
+
+        // The fetch is stubbed to fail: the backfill counts an attempt as Processed BEFORE it
+        // reaches EDGAR, so a failing fetch still proves the document was SELECTED — which is the
+        // only thing this test is about. It also keeps the real stitcher (and its image
+        // downloads) out of the test entirely.
+        _secEdgarClient = Substitute.For<ISecEdgarClient>();
+        _secEdgarClient
+            .GetDocumentContent(Arg.Any<string>(), Arg.Any<string>())
+            .Returns<Task<string>>(_ => throw new InvalidOperationException("EDGAR unavailable"));
+
+        var captureService = new AsFiledHtmlCaptureService(
+            Options.Create(new AsFiledHtmlCaptureOptions()),
+            _secEdgarClient,
+            Substitute.For<ILogger<AsFiledHtmlCaptureService>>()
+        );
+
+        _service = new AsFiledHtmlBackfillService(
+            _repository,
+            _secEdgarClient,
+            captureService,
+            Substitute.For<IDocumentPersistenceService>(),
+            Substitute.For<ILogger<AsFiledHtmlBackfillService>>()
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    private void SeedPendingEightK(DateOnly reportingDate, string accessionNumber)
+    {
+        _dbContext.Add(
+            new Document
+            {
+                Id = Guid.NewGuid(),
+                CommonStockId = _company.Id,
+                DocumentType = DocumentType.EightK,
+                ReportingDate = reportingDate,
+                AccessionNumber = accessionNumber,
+                SourceUrl =
+                    $"https://www.sec.gov/Archives/edgar/data/320193/{accessionNumber}.txt",
+                AsFiledHtmlVersion = 0,
+                AsFiledHtmlAttempts = 0,
+            }
+        );
+        _dbContext.SaveChanges();
+    }
+
+    [Fact]
+    public async Task Backfill_SelectsPendingEightKsFiledBeforeTheLiveScraperSyncFloor()
+    {
+        // Worker.MinSyncDate is 2020-01-01 in production; both of these must be selected.
+        SeedPendingEightK(new DateOnly(2015, 6, 1), "0001193125-15-000001");
+        SeedPendingEightK(new DateOnly(2025, 6, 1), "0001193125-25-000001");
+
+        var result = await _service.Backfill(batchSize: 10);
+
+        Assert.Equal(2, result.Processed);
+    }
+
+    [Fact]
+    public async Task Backfill_SelectsAPendingEightKEvenWhenEveryCandidatePredatesTheSyncFloor()
+    {
+        // The production shape: the post-floor corpus is fully stitched, so the only rows left
+        // are pre-floor ones. Under the old floor this batch came back empty forever.
+        SeedPendingEightK(new DateOnly(2000, 7, 14), "0001193125-00-000001");
+        SeedPendingEightK(new DateOnly(2019, 12, 3), "0001193125-19-000001");
+
+        var result = await _service.Backfill(batchSize: 10);
+
+        Assert.Equal(2, result.Processed);
+    }
+}


### PR DESCRIPTION
## Summary

The backoffice dashboard has shown a permanently frozen `420` under **8-K exhibit backfill pending**. The count never moves because the metric and the worker disagree on what "pending" means:

- `DocumentRepository.GetPendingAsFiledHtml()` — the documented *single definition* of the work-set, and what the dashboard counts — has no reporting-date bound.
- `AsFiledHtmlBackfillWorker` narrowed that set by `Worker.MinSyncDate` (`2020-01-01`), the global floor shared with the live SEC/Holdings/Congress scrapers and the public-site history clamp.

So every 8-K reported before the floor was counted as pending but never selected. Confirmed in production: all 420 stranded rows are 8-Ks reported between 2000 and 2019, every one of them at `AsFiledHtmlAttempts = 0` — the worker had never touched a single one.

This is the same defect fixed once in the sibling XBRL backfill (126a71d1, *"drain all pending XBRL backfill, ignore live-scraper sync floor"*); the as-filed lane was branched off that code before the fix and kept the bug.

## Code changes

- **`AsFiledHtmlBackfillWorker.cs`** — stop deriving a floor from `Worker.MinSyncDate`; drop the now-unused `WorkerOptions` dependency. Comment records why the floor must not come back.
- **`AsFiledHtmlBackfillService.cs`** — remove the `minReportingDate` parameter outright rather than passing `null`, so the repository query is structurally the only definition of the work-set and no caller can narrow it again.
- **`AsFiledHtmlBackfillServiceReportingDateTests.cs`** (new) — two regression tests: pre-floor and post-floor filings are both selected, and a batch made up entirely of pre-floor filings is still processed (the production shape that used to come back empty forever).

The per-document retry ceiling (`MaxAsFiledHtmlAttempts = 5`) still bounds unfetchable rows, so the sweep remains self-quenching. Bounded, one-off cost: 420 documents.

## Verification

- `dotnet build Equibles.sln -c Release` — clean.
- Full unit suite: **3654 passed, 0 failed**.
- New regression tests pass; both would fail under the old floor.