### PR TITLE
fix(web): keep the compact-number toggle working when localStorage is blocked

### DIFF
--- a/src/Equibles.Web/src/js/compact-numbers.js
+++ b/src/Equibles.Web/src/js/compact-numbers.js
@@ -35,15 +35,39 @@ function applyFormat(compact) {
     });
 }
 
+// Some browsers expose `window.localStorage` as null (Brave with Shields up, embedded webviews,
+// cookies fully blocked) or throw a SecurityError on first access in private mode. There an
+// unguarded `localStorage.getItem` raises a TypeError, which killed the load-time restore and
+// made the toggle button do nothing at all. Read and write through these instead: a blocked store
+// degrades to "no persisted preference" and the toggle still works for the session.
+function readPreference() {
+    try {
+        return window.localStorage?.getItem(STORAGE_KEY) === 'true';
+    } catch {
+        return false;
+    }
+}
+
+function writePreference(value) {
+    try {
+        window.localStorage?.setItem(STORAGE_KEY, value);
+    } catch {
+        // Persisting is best-effort; the toggle already applied to the page.
+    }
+}
+
+// The live choice, seeded from storage. Kept in memory so the toggle still flips both ways when the
+// store is blocked — reading it back would always report "off" there and the button would stick on.
+let compactEnabled = readPreference();
+
 function toggle() {
-    const current = localStorage.getItem(STORAGE_KEY) === 'true';
-    const next = !current;
-    localStorage.setItem(STORAGE_KEY, next);
-    applyFormat(next);
+    compactEnabled = !compactEnabled;
+    writePreference(compactEnabled);
+    applyFormat(compactEnabled);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    if (localStorage.getItem(STORAGE_KEY) === 'true') {
+    if (compactEnabled) {
         applyFormat(true);
     }
 });


### PR DESCRIPTION
## Summary

`compact-numbers.js` read and wrote `localStorage` directly. Browsers that expose `window.localStorage` as `null` — Brave with Shields up, embedded webviews, cookies fully blocked — raise `TypeError: null is not an object (evaluating 'localStorage.getItem')` there, which showed up in production error tracking on mobile stock pages.

Two user-visible effects: the load-time restore of the saved preference threw, and `toggle()` threw on the very first line, so the compact-number button did nothing at all on those browsers.

## Code changes

- `src/Equibles.Web/src/js/compact-numbers.js` — read and write the preference through small `readPreference` / `writePreference` helpers that guard both the null store and the private-mode `SecurityError`. A blocked store now degrades to "no persisted preference" instead of throwing.
- The live choice is held in a module variable seeded from storage, so the toggle still flips both ways when nothing can be persisted — reading it back would always report "off" there and the button would stick on after the first tap.