### PR TITLE
style: format the as-filed HTML backfill reporting-date test

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/AsFiledHtmlBackfillServiceReportingDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/AsFiledHtmlBackfillServiceReportingDateTests.cs
@@ -95,8 +95,7 @@ public class AsFiledHtmlBackfillServiceReportingDateTests : IDisposable
                 DocumentType = DocumentType.EightK,
                 ReportingDate = reportingDate,
                 AccessionNumber = accessionNumber,
-                SourceUrl =
-                    $"https://www.sec.gov/Archives/edgar/data/320193/{accessionNumber}.txt",
+                SourceUrl = $"https://www.sec.gov/Archives/edgar/data/320193/{accessionNumber}.txt",
                 AsFiledHtmlVersion = 0,
                 AsFiledHtmlAttempts = 0,
             }


### PR DESCRIPTION
## Summary

The lint job has been red on `main` since #4196 landed: `dotnet csharpier check .` rejects `AsFiledHtmlBackfillServiceReportingDateTests.cs`, so `build-and-test` is skipped and every open PR inherits a failing lint check.

This reformats the one offending file so `main` goes green again.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/AsFiledHtmlBackfillServiceReportingDateTests.cs` — collapse a wrapped `SourceUrl` initialiser onto a single line, matching CSharpier output. Whitespace only, no behaviour change.