### PR TITLE
feat(mcp): add display titles and read-only hints to every tool

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -33,7 +33,7 @@ public class CboeTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetPutCallRatios")]
+    [McpServerTool(Name = "GetPutCallRatios", Title = "CBOE Put/Call Ratios", ReadOnly = true)]
     [Description(
         "Get CBOE put/call ratio data showing market sentiment. Available types: Total (all "
             + "exchange), Equity, Index, Vix, Etp. High ratios (>1.0) indicate bearish sentiment; "
@@ -105,7 +105,7 @@ public class CboeTools
         );
     }
 
-    [McpServerTool(Name = "GetVixHistory")]
+    [McpServerTool(Name = "GetVixHistory", Title = "VIX Volatility Index History", ReadOnly = true)]
     [Description(
         "Get CBOE Volatility Index (VIX) historical daily OHLC data. VIX measures expected "
             + "30-day S&P 500 volatility. Below 15 = low volatility/complacency, above 30 = "

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -35,7 +35,11 @@ public class CftcTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetCftcPositioning")]
+    [McpServerTool(
+        Name = "GetCftcPositioning",
+        Title = "CFTC Futures Positioning (COT)",
+        ReadOnly = true
+    )]
     [Description(
         "Get Commitments of Traders (COT) positioning data for a specific futures contract. "
             + "Shows commercial and non-commercial positions over time. Values are contract "
@@ -109,7 +113,11 @@ public class CftcTools
         );
     }
 
-    [McpServerTool(Name = "GetLatestCftcData")]
+    [McpServerTool(
+        Name = "GetLatestCftcData",
+        Title = "Latest CFTC Positioning Snapshot",
+        ReadOnly = true
+    )]
     [Description(
         "Get the latest COT positioning snapshot across all tracked futures contracts, grouped "
             + "by category (Agriculture, Energy, Metals, Equity Indices, Interest Rates, "
@@ -202,7 +210,11 @@ public class CftcTools
         );
     }
 
-    [McpServerTool(Name = "SearchCftcMarkets")]
+    [McpServerTool(
+        Name = "SearchCftcMarkets",
+        Title = "Search CFTC Futures Contracts",
+        ReadOnly = true
+    )]
     [Description(
         "Search the tracked CFTC futures contracts by name or market code, or omit the query "
             + "to list every tracked contract. Coverage is a curated set of ~35 major contracts "

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -40,7 +40,11 @@ public class CongressTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetCongressionalTrades")]
+    [McpServerTool(
+        Name = "GetCongressionalTrades",
+        Title = "Congressional Trades by Stock",
+        ReadOnly = true
+    )]
     [Description(
         "Get congressional stock trades for a specific ticker (newest first, last year by default). Shows which members of Congress bought or sold shares, with transaction and filing dates; amounts are the disclosed ranges, not exact values. Use GetMemberTrades for one member's trades across all tickers."
     )]
@@ -106,7 +110,7 @@ public class CongressTools
         );
     }
 
-    [McpServerTool(Name = "GetMemberTrades")]
+    [McpServerTool(Name = "GetMemberTrades", Title = "Trades by Congress Member", ReadOnly = true)]
     [Description(
         "Get a congress member's disclosed stock trades (newest first, last year by default). Shows tickers, transaction and filing dates, and disclosed amount ranges — bands, not exact values. Use SearchCongressMembers to find member names, and GetCongressionalTrades for all members' trades in one ticker."
     )]
@@ -176,7 +180,11 @@ public class CongressTools
         );
     }
 
-    [McpServerTool(Name = "GetMemberNetWorth")]
+    [McpServerTool(
+        Name = "GetMemberNetWorth",
+        Title = "Congress Member Net Worth",
+        ReadOnly = true
+    )]
     [Description(
         "Get a congress member's net worth history from their annual financial disclosures. Disclosed values are ranges, so every year is a band (minimum-maximum), never a point estimate. Only electronically filed reports are read: a missing year means no electronic filing, not zero net worth. Use SearchCongressMembers to find member names."
     )]
@@ -237,7 +245,11 @@ public class CongressTools
     private static string FormatSignedAmount(long value) =>
         value < 0 ? $"-${McpFormat.WholeNumber(-value)}" : $"${McpFormat.WholeNumber(value)}";
 
-    [McpServerTool(Name = "SearchCongressMembers")]
+    [McpServerTool(
+        Name = "SearchCongressMembers",
+        Title = "Search Congress Members",
+        ReadOnly = true
+    )]
     [Description(
         "Search for members of Congress by name. Returns matching members with their position (Senator/Representative). Use this to discover member names before calling the member-specific tools (GetMemberTrades, GetMemberNetWorth) — the returned Name is the exact string they expect."
     )]

--- a/src/Equibles.FdaCatalysts.Mcp/Tools/FdaCatalystTools.cs
+++ b/src/Equibles.FdaCatalysts.Mcp/Tools/FdaCatalystTools.cs
@@ -27,7 +27,11 @@ public class FdaCatalystTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetFdaCatalysts")]
+    [McpServerTool(
+        Name = "GetFdaCatalysts",
+        Title = "FDA Advisory Committee Calendar",
+        ReadOnly = true
+    )]
     [Description(
         "Get scheduled FDA advisory-committee (AdComm) meetings, sourced from the FDA.gov advisory-committee calendar, each with a link to its FDA meeting page. Defaults to meetings in the next 90 days; pass a date range to look further ahead. This is a forward-looking calendar of announced meetings, not a historical archive — coverage starts in late 2025 — and entries are the FDA's own listings, not linked to stock tickers."
     )]

--- a/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
@@ -32,7 +32,11 @@ public class OffExchangeVolumeTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetOffExchangeVolume")]
+    [McpServerTool(
+        Name = "GetOffExchangeVolume",
+        Title = "Off-Exchange (Dark Pool) Volume",
+        ReadOnly = true
+    )]
     [Description(
         "Get weekly off-exchange (dark pool / OTC) trading volume for a stock from the FINRA OTC/ATS Transparency data. "
             + "Each week shows ATS (alternative trading system / dark pool) volume and trade count, non-ATS OTC volume and trade count, "

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -54,7 +54,7 @@ public class ShortDataTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetShortVolume")]
+    [McpServerTool(Name = "GetShortVolume", Title = "Daily Short Sale Volume", ReadOnly = true)]
     [Description(
         "Get daily short sale volume history for a stock from FINRA's short sale volume files. Shows short volume, short-exempt volume, total volume, and short volume percentage per trading day. Volumes cover trades reported to FINRA facilities (off-exchange/TRF) only — NOT consolidated tape volume — and a 40-50% Short % is the normal baseline from market-maker liquidity provision, so it must not be quoted as a share of the stock's total traded volume. This daily flow metric is distinct from bi-monthly short interest positions: use GetShortInterest for positions, GetLargestShortVolume for a market-wide single-day ranking, and GetShortSqueezeScores for squeeze candidates."
     )]
@@ -141,7 +141,7 @@ public class ShortDataTools
         );
     }
 
-    [McpServerTool(Name = "GetShortInterest")]
+    [McpServerTool(Name = "GetShortInterest", Title = "Short Interest History", ReadOnly = true)]
     [Description(
         "Get bi-monthly short interest history for a stock from FINRA. Shows the reported short position, change from the previous settlement, average daily volume, and days to cover per settlement date. Share counts are restated onto today's split basis so the series stays continuous across stock splits; days to cover is as reported (FINRA caps it at 999.99). High days-to-cover (>5) suggests a potential short squeeze — for short interest as a % of shares outstanding and an actual squeeze-candidate ranking use GetShortSqueezeScores; for the market-wide latest settlement use GetShortInterestSnapshot."
     )]
@@ -242,7 +242,11 @@ public class ShortDataTools
         );
     }
 
-    [McpServerTool(Name = "GetShortInterestSnapshot")]
+    [McpServerTool(
+        Name = "GetShortInterestSnapshot",
+        Title = "Market-Wide Short Interest Snapshot",
+        ReadOnly = true
+    )]
     [Description(
         "Market-wide snapshot of the latest FINRA bi-monthly short interest settlement — one row per stock, sorted by days to cover (descending) by default. FINRA caps days to cover at 999.99: capped rows are a sentinel (almost always illiquid names with a tiny average-daily-volume denominator) and are ranked after real readings; pass minAvgDailyVolume (e.g. 100000) to drop illiquid names entirely. This is the raw FINRA snapshot — for genuine short-squeeze candidate ranking use GetShortSqueezeScores; for one stock's history use GetShortInterest; for daily short-sale flow use GetShortVolume/GetLargestShortVolume."
     )]
@@ -347,7 +351,11 @@ public class ShortDataTools
         );
     }
 
-    [McpServerTool(Name = "GetLargestShortVolume")]
+    [McpServerTool(
+        Name = "GetLargestShortVolume",
+        Title = "Largest Short Volume by Day",
+        ReadOnly = true
+    )]
     [Description(
         "Get the stocks with the largest daily short sale volume for a single trading day (defaults to the latest available), from FINRA's daily short sale volume files, sorted by short volume descending. Short % is the share of that day's FINRA-facility (off-exchange/TRF) volume sold short — 40-50% is a normal market-making baseline — NOT short interest (the open short position; use GetShortInterest/GetShortInterestSnapshot for positions and GetShortSqueezeScores for squeeze candidates; use GetShortVolume for one stock's daily history). Pass sortBy=shortPercent with a minTotalVolume floor to rank by short intensity instead of raw size."
     )]
@@ -579,7 +587,7 @@ public class ShortDataTools
     private Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker) =>
         _commonStockRepository.ResolveByTicker(ticker);
 
-    [McpServerTool(Name = "GetShortSqueezeScores")]
+    [McpServerTool(Name = "GetShortSqueezeScores", Title = "Short Squeeze Scores", ReadOnly = true)]
     [Description(
         "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built as the weighted mean of six factor percentiles across every stock reporting short interest at the latest FINRA settlement date (short interest % of shares 30%, days to cover 20%, price vs trailing VWAP — how far shorts are underwater — 15%, short-volume trend 15%, change in short interest 10%, fails-to-deliver pressure 10%), plus catalyst boosts (+10 for a statistically extreme weekly price spike, +10 for abnormal dollar volume on a positive move, +10 when a scheduled earnings event is within a few weekdays — squeezes cluster around earnings — capped at +20, clamped to 100). Exchange-traded commodity/currency trusts are excluded (their units are created and redeemed at NAV, so arbitrage caps any squeeze); MLP common units stay in. Untradeable micro-caps dominate the raw board, so pass minMarketCap and/or minDollarVolume to keep only names that clear your liquidity bar (the score itself stays peer-relative to the full universe). Pass ticker for one stock's score, factor breakdown, and rank within the scored universe. Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
     )]

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -34,7 +34,11 @@ public class FredTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetEconomicIndicator")]
+    [McpServerTool(
+        Name = "GetEconomicIndicator",
+        Title = "Economic Indicator History",
+        ReadOnly = true
+    )]
     [Description(
         "Get time series data for a FRED economic indicator. Returns historical observations for indicators like FEDFUNDS (fed funds rate), CPIAUCSL (CPI inflation), UNRATE (unemployment), GDP, T10Y2Y (yield spread), VIXCLS (VIX), SP500, MORTGAGE30US, M2SL (money supply), and more. Covers the curated ~40-series set Equibles tracks, not the full FRED catalog — use SearchEconomicIndicators to find available series."
     )]
@@ -130,7 +134,11 @@ public class FredTools
         );
     }
 
-    [McpServerTool(Name = "GetLatestEconomicData")]
+    [McpServerTool(
+        Name = "GetLatestEconomicData",
+        Title = "Latest Economic Indicators",
+        ReadOnly = true
+    )]
     [Description(
         "Get the latest values for key economic indicators across categories: interest rates, yield spreads, inflation, employment, GDP, money supply, sentiment, housing, exchange rates, and market indicators. Each row shows a series' latest stored observation with its date, plus the previous observation and the change between them for direction — check the Latest Date column for freshness. Returns a snapshot of current macro conditions."
     )]
@@ -237,7 +245,11 @@ public class FredTools
         );
     }
 
-    [McpServerTool(Name = "SearchEconomicIndicators")]
+    [McpServerTool(
+        Name = "SearchEconomicIndicators",
+        Title = "Search Economic Indicators",
+        ReadOnly = true
+    )]
     [Description(
         "Search the curated set of ~40 US macro FRED series Equibles tracks (rates, inflation, employment, GDP, housing, market indicators) — not the full FRED catalog. Matches series ID, title, and category name: a category query like 'inflation' returns that whole category (CPI, PCE, PPI, breakevens), and an empty query lists every tracked series. Use this to discover what economic data is available before calling GetEconomicIndicator."
     )]
@@ -289,7 +301,11 @@ public class FredTools
         );
     }
 
-    [McpServerTool(Name = "GetEconomicCalendar")]
+    [McpServerTool(
+        Name = "GetEconomicCalendar",
+        Title = "Economic Release Calendar",
+        ReadOnly = true
+    )]
     [Description(
         "Get the economic release calendar — scheduled (upcoming) and recent publication dates of US macro data releases, with the FRED series each release updates and an importance tier per release (High = the tier-1 scheduled market movers: CPI, PPI, Employment Situation, GDP, PCE, retail sales; Medium = other genuine scheduled prints; Low = daily rate/market levels like SOFR or VIX). FOMC meetings are NOT included — FRED's release feed has no real FOMC meeting dates; use the Federal Reserve's published meeting calendar for those. Defaults to the next 30 days. Use minImportance=high to see only the market movers, and GetEconomicIndicator to fetch a series' data after it prints."
     )]

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -39,7 +39,11 @@ public class GovernmentContractsTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetGovernmentContracts")]
+    [McpServerTool(
+        Name = "GetGovernmentContracts",
+        Title = "Federal Contracts by Company",
+        ReadOnly = true
+    )]
     [Description(
         "Get federal government contract awards (from USAspending.gov) won by a specific public company. "
             + "Shows the award (action) date, awarding agency, total value (obligated dollars plus "
@@ -123,7 +127,11 @@ public class GovernmentContractsTools
         );
     }
 
-    [McpServerTool(Name = "GetTopGovernmentContractors")]
+    [McpServerTool(
+        Name = "GetTopGovernmentContractors",
+        Title = "Top Federal Contractors",
+        ReadOnly = true
+    )]
     [Description(
         "Rank public companies by total federal contract dollars awarded over a date range (from "
             + "USAspending.gov). Sums the total award value (obligated dollars plus unexercised ceiling) of "

--- a/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
@@ -37,7 +37,11 @@ public class CloneBacktestTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetFundCloneBacktest")]
+    [McpServerTool(
+        Name = "GetFundCloneBacktest",
+        Title = "13F Portfolio Clone Backtest",
+        ReadOnly = true
+    )]
     [Description(
         "Backtest how cloning an institutional filer's reported 13F portfolio would have performed against a market benchmark, either over a trailing window (windowYears) or an explicit fromDate/toDate range. Reconstructs the filer's portfolio at each quarterly 13F snapshot, rebalances on the SEC filing lag (so the simulation uses only information available at the time), and values it forward against the benchmark. Returns total return, annualized return (CAGR), and max drawdown for both the cloned portfolio and the benchmark, plus the alpha between them. Use this to answer 'how would cloning fund X have performed against the market'."
     )]

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -77,7 +77,7 @@ public class InstitutionalHoldingsTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetTopHolders")]
+    [McpServerTool(Name = "GetTopHolders", Title = "Top Institutional Holders", ReadOnly = true)]
     [Description(
         "Get the top institutional holders (fund managers) of a stock from SEC 13F-HR filings. Returns a ranked list of institutions by shares held, including market value and percentage of total institutional 13F shares (not of shares outstanding). Data is sourced from quarterly 13F filings that large investment managers are required to file with the SEC; while the newest quarter's filing window is open, funds that have not filed yet are carried at their prior-quarter positions (noted in the output). Use this to understand who the major institutional investors in a company are."
     )]
@@ -232,7 +232,11 @@ public class InstitutionalHoldingsTools
         return result.ToString();
     }
 
-    [McpServerTool(Name = "GetOwnershipHistory")]
+    [McpServerTool(
+        Name = "GetOwnershipHistory",
+        Title = "Institutional Ownership History",
+        ReadOnly = true
+    )]
     [Description(
         "Get the historical trend of institutional ownership for a stock across multiple quarters. Shows how total institutional shares, market value, and number of institutional holders have changed over time based on SEC 13F-HR filings. While the newest quarter's 13F filing window is open, that quarter is a provisional combined view (funds that have not filed yet carry their prior-quarter positions — flagged in the output). Use this to understand whether institutional interest in a company is growing or declining."
     )]
@@ -344,7 +348,11 @@ public class InstitutionalHoldingsTools
             ? $"{McpFormat.Invariant((double)(totalShares - previousShares) / previousShares * 100, "+0.0;-0.0;0.0")}%"
             : "—";
 
-    [McpServerTool(Name = "GetInstitutionPortfolio")]
+    [McpServerTool(
+        Name = "GetInstitutionPortfolio",
+        Title = "Institution Portfolio (13F)",
+        ReadOnly = true
+    )]
     [Description(
         "View the stock portfolio of a specific institutional investor (fund manager) from their SEC 13F-HR filing. Shows the institution's largest tracked holdings by market value (default 20, max 500) with share counts, market values, and percent of the 13F-reported portfolio, plus the portfolio's total value and position count. Use this to understand what stocks a particular fund manager or institution is investing in; use SearchInstitutions first when the name is ambiguous."
     )]
@@ -458,7 +466,11 @@ public class InstitutionalHoldingsTools
         return result.ToString();
     }
 
-    [McpServerTool(Name = "SearchInstitutions")]
+    [McpServerTool(
+        Name = "SearchInstitutions",
+        Title = "Search Institutional Investors",
+        ReadOnly = true
+    )]
     [Description(
         "Search for institutional investors (fund managers) by name or SEC CIK number, largest 13F filers first. Returns matching institutions with their SEC CIK number, city, and state/country. Use this to find the correct institution name before calling GetInstitutionPortfolio or to discover which institutions are tracked in the database."
     )]
@@ -504,7 +516,11 @@ public class InstitutionalHoldingsTools
     // sends), so a bare null-coalesce still rendered blank cells instead of the placeholder.
     private static string OrDash(string value) => string.IsNullOrWhiteSpace(value) ? "—" : value;
 
-    [McpServerTool(Name = "GetTopBuyersSellers")]
+    [McpServerTool(
+        Name = "GetTopBuyersSellers",
+        Title = "Top Institutional Buyers and Sellers",
+        ReadOnly = true
+    )]
     [Description(
         "Get the institutions that moved the needle the most on a stock this quarter — biggest absolute share additions (Top Buyers) and biggest absolute share reductions (Top Sellers) versus the previous 13F report date. Includes new positions (Δ = full position) and sold-out positions (Δ = −prior position); a previous holder counts as a seller only if it filed a 13F for the target quarter, so a fund that stopped filing (CIK migration, deregistration) is not shown as a mass seller. While the newest quarter's filing window is open, results cover only the funds that have already filed (noted in the output). Returns a markdown table with two sections. Use this to surface the most actionable quarterly signal from 13F filings."
     )]
@@ -786,7 +802,11 @@ public class InstitutionalHoldingsTools
         }
     }
 
-    [McpServerTool(Name = "GetMarketWide13FActivity")]
+    [McpServerTool(
+        Name = "GetMarketWide13FActivity",
+        Title = "Market-Wide 13F Activity",
+        ReadOnly = true
+    )]
     [Description(
         "Get the market-wide 13F leaderboards for a given quarter — which stocks were most bought, most sold, most initiated, or most exited across all 13F filers vs the prior quarter. The `bucket` argument selects one of: top-buys (Δ shares > 0 ranked by Δ value desc), top-sells (Δ shares < 0 ranked by Δ value asc), new-positions (stocks ranked by count of filers initiating a position), sold-out-positions (stocks ranked by count of filers exiting). Use this to answer 'what's the consensus 13F move this quarter?'"
     )]
@@ -1036,7 +1056,7 @@ public class InstitutionalHoldingsTools
         return result.ToString();
     }
 
-    [McpServerTool(Name = "GetMostHeldStocks")]
+    [McpServerTool(Name = "GetMostHeldStocks", Title = "Most Widely Held Stocks", ReadOnly = true)]
     [Description(
         "Get the cross-sectional ranking of stocks by institutional 13F breadth for a given quarter. Returns the stocks ranked by number of 13F filers reporting them as a holding (default), by quarter-over-quarter change in filer count (warming names — 'filersDelta' — or cooling names — 'filersDeltaAsc'), or by total reported dollar value. Includes Δ filers vs the prior quarter, total value, Δ value, and the stock's share of the 13F universe. Only currently-held stocks rank; fully-sold-out names live in GetMarketWide13FActivity's sold-out-positions bucket. While the newest quarter's filing window is open, funds that have not filed yet are carried at their prior-quarter positions (noted in the output). Use this to answer 'which stocks are most owned by institutions right now, and is breadth expanding or contracting?'"
     )]
@@ -1155,7 +1175,11 @@ public class InstitutionalHoldingsTools
         return result.ToString();
     }
 
-    [McpServerTool(Name = "GetInstitutionSummary")]
+    [McpServerTool(
+        Name = "GetInstitutionSummary",
+        Title = "Institution Portfolio Summary",
+        ReadOnly = true
+    )]
     [Description(
         "Get the portfolio summary header for an institutional 13F filer — 13F reported value (long U.S. positions only, not total firm AUM), position count, top-10 / top-25 concentration, QoQ turnover, and the latest / prior report dates with the count of quarters tracked in this database. Use this to answer 'how big and how concentrated is this fund?' or to compare two funds at a glance. Search resolves by institution name or CIK (largest 13F filer wins on ambiguous names)."
     )]
@@ -1295,7 +1319,11 @@ public class InstitutionalHoldingsTools
         return result.ToString();
     }
 
-    [McpServerTool(Name = "GetInstitutionSectorAllocation")]
+    [McpServerTool(
+        Name = "GetInstitutionSectorAllocation",
+        Title = "Institution Sector Allocation",
+        ReadOnly = true
+    )]
     [Description(
         "Get an institution's 13F portfolio allocation for a given report quarter (defaults to the latest), grouped by fine-grained industry (default) or rolled up by sector via `groupBy`. Returns a markdown table sorted by % of portfolio descending, with stocks lacking a classification collapsed into a single 'Unclassified' row at the end. Ambiguous names resolve to the largest matching 13F filer — use SearchInstitutions to disambiguate. Use this to answer 'is this fund concentrated in tech / energy / generalist?'"
     )]
@@ -1350,7 +1378,11 @@ public class InstitutionalHoldingsTools
         );
     }
 
-    [McpServerTool(Name = "GetInstitutionQuarterlyActivity")]
+    [McpServerTool(
+        Name = "GetInstitutionQuarterlyActivity",
+        Title = "Institution Quarterly Activity",
+        ReadOnly = true
+    )]
     [Description(
         "Get an institution's quarterly position-change activity — Initiated / Increased / Reduced / Exited stocks diffed against the immediately prior quarter. Returns the buckets as one markdown section per bucket, sorted by absolute Δ market-value desc (Δ Value includes price movement, not just trading). Use `bucket` to filter to a single bucket. Use this to answer 'what did this fund do this quarter?'"
     )]
@@ -1516,7 +1548,11 @@ public class InstitutionalHoldingsTools
         return true;
     }
 
-    [McpServerTool(Name = "GetFundOverlap")]
+    [McpServerTool(
+        Name = "GetFundOverlap",
+        Title = "Portfolio Overlap Between Institutions",
+        ReadOnly = true
+    )]
     [Description(
         "Get the 13F portfolio overlap between two institutions for their latest common report date — Jaccard similarity, dollar-weighted overlap ($-weighted = shared dollars, taking the smaller of the two funds' values per stock, as a share of union dollars), per-fund position counts and totals, and a side-by-side table of stocks with per-fund shares + percent of portfolio. Covers 13F institutional managers only — find names with SearchInstitutions; for mutual-fund/ETF (NPORT) portfolios use GetFundHoldings. Use this to answer 'do these two funds own the same stocks?' or 'where do their portfolios diverge?'"
     )]
@@ -1682,7 +1718,11 @@ public class InstitutionalHoldingsTools
         return result.ToString();
     }
 
-    [McpServerTool(Name = "GetConsensusHoldings")]
+    [McpServerTool(
+        Name = "GetConsensusHoldings",
+        Title = "Consensus Holdings Across Institutions",
+        ReadOnly = true
+    )]
     [Description(
         "Get the consensus / combined portfolio of 2-25 institutions for their latest common report date. Returns stocks ranked by how many of the supplied funds hold them (descending), then by combined value. Filter by `minFunds` to only show stocks held by at least that many funds. Use this to answer 'what do these funds agree on?' or 'show me the top picks across these N investors combined.'"
     )]

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -78,7 +78,11 @@ public class InsiderTradingTools
     private const string AcceptedTransactionTypes =
         "Buy, Sell, Award, Conversion, Exercise, TaxPayment, Expiration, Gift, Inheritance, Discretionary, Other";
 
-    [McpServerTool(Name = "GetInsiderTransactions")]
+    [McpServerTool(
+        Name = "GetInsiderTransactions",
+        Title = "Insider Transactions (Form 4)",
+        ReadOnly = true
+    )]
     [Description(
         "Get recent insider trading transactions for a stock from SEC Form 3/4/5 filings, newest first. The Type column carries the SEC transaction code meaning: 'Buy'/'Sell' are open-market purchases/sales only, while Award, Conversion, Exercise, Tax Payment, Expiration, Gift, Inheritance, Discretionary and Other are compensation or derivative mechanics — not conviction trades. The 10b5-1 column marks trades made under a pre-arranged Rule 10b5-1 plan ('-' = filing predates the 2023 checkbox). Per-row Shares/Price/Value are as filed; Owned After is the post-transaction balance restated onto today's split basis, tracked per security kind and ownership form. Supports optional date-range, transaction-type and insider-name filters to reach history beyond the newest rows. Use this to understand insider buying/selling activity."
     )]
@@ -248,7 +252,11 @@ public class InsiderTradingTools
         );
     }
 
-    [McpServerTool(Name = "GetInsiderOwnership")]
+    [McpServerTool(
+        Name = "GetInsiderOwnership",
+        Title = "Insider Ownership Summary",
+        ReadOnly = true
+    )]
     [Description(
         "Get a summary of insider ownership for a stock, ranked by shares held. Each row is as-of that insider's most recent SEC Form 3/4/5 filing (former insiders may linger with stale dates or zero shares), and share counts are restated onto today's split basis, so they can differ from the raw figures in older filings. Returns at most maxResults insiders (default 30). Use this to understand the insider ownership structure of a company; use GetInsiderTransactions for the underlying trades."
     )]
@@ -346,7 +354,11 @@ public class InsiderTradingTools
         );
     }
 
-    [McpServerTool(Name = "GetProposedSales")]
+    [McpServerTool(
+        Name = "GetProposedSales",
+        Title = "Proposed Insider Sales (Form 144)",
+        ReadOnly = true
+    )]
     [Description(
         "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the proposed sale as a share of shares outstanding, the approximate sale date, and the broker. Results are the most recent notices first and a note flags when more exist than were returned; use fromDate/toDate to scope a period (heavy 10b5-1 filers can flood the recency window with small daily notices). Use this to anticipate upcoming insider selling before it shows up as an executed Form 4."
     )]
@@ -447,7 +459,7 @@ public class InsiderTradingTools
         return McpFormat.Invariant(percent, "0.####") + "%";
     }
 
-    [McpServerTool(Name = "SearchInsiders")]
+    [McpServerTool(Name = "SearchInsiders", Title = "Search Corporate Insiders", ReadOnly = true)]
     [Description(
         "Search for corporate insiders (directors, officers, 10% owners) by name. Names are matched as filed with the SEC — legal names, frequently 'LAST FIRST MIDDLE' (e.g. Jensen Huang is filed as 'HUANG JEN HSUN') — and every word of the query must appear in the name, so retry with the surname alone when a full name misses. Returns matching insiders with their CIK, role, the company of their most recent filing, and location, ordered by most recent filing activity. Pivot to the sibling ticker-keyed tools with the returned company ticker (e.g. GetInsiderTransactions with its insiderName filter) to see a person's trades."
     )]

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -47,7 +47,7 @@ public class FinancialFactsTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetFinancialFact")]
+    [McpServerTool(Name = "GetFinancialFact", Title = "Financial Concept Lookup", ReadOnly = true)]
     [Description(
         "Get a single financial concept (e.g. revenue, net income, diluted EPS, total "
             + "assets, operating cash flow) over time for a company, sourced from SEC "
@@ -205,7 +205,11 @@ public class FinancialFactsTools
             .Select(g => g.OrderBy(f => f.FiscalYear).ThenBy(f => f.FiscalPeriod).First())
             .ToList();
 
-    [McpServerTool(Name = "CompareFinancialFact")]
+    [McpServerTool(
+        Name = "CompareFinancialFact",
+        Title = "Compare Financials Across Companies",
+        ReadOnly = true
+    )]
     [Description(
         "Compare one financial concept across several companies for the same fiscal "
             + "period — peer comparison. Returns one row per ticker with the "

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -41,7 +41,7 @@ public class FinancialStatementTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetFinancialStatement")]
+    [McpServerTool(Name = "GetFinancialStatement", Title = "Financial Statements", ReadOnly = true)]
     [Description(
         "Get a company's income statement, balance sheet, or cash-flow statement for a "
             + "given fiscal year and period, sourced from SEC Company Facts (structured XBRL). "

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -75,7 +75,11 @@ public class RevenueBreakdownTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetRevenueBreakdown")]
+    [McpServerTool(
+        Name = "GetRevenueBreakdown",
+        Title = "Revenue Breakdown by Segment",
+        ReadOnly = true
+    )]
     [Description(
         "Get a company's revenue disaggregated by business segment, geography and "
             + "product/service, from the dimensional XBRL facts the issuer tags in its own "

--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -33,7 +33,11 @@ public class DocumentTextTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "SearchDocumentKeyword")]
+    [McpServerTool(
+        Name = "SearchDocumentKeyword",
+        Title = "Keyword Search Within a Filing",
+        ReadOnly = true
+    )]
     [Description(
         "Perform a case-insensitive keyword search within a specific SEC filing or earnings call transcript by document ID. Returns matching lines with surrounding context and line numbers, making it ideal for finding exact terms, figures, or phrases that semantic search might miss. Typographic punctuation is folded before matching, so a plain-ASCII keyword (e.g. \"world's\") matches the smart punctuation stored in filings. The header reports the total number of matching lines even when only the first ones are shown. Use this after ListCompanyDocuments to locate precise occurrences of a keyword (e.g., a revenue figure, risk factor term, or executive name) within a known document. Complements semantic search tools by providing exact text matches rather than meaning-based results. Use ReadDocumentLines to read broader sections around matches."
     )]
@@ -136,7 +140,7 @@ public class DocumentTextTools
     // self-describing.
     private const int MaxLinesPerRead = 2000;
 
-    [McpServerTool(Name = "ReadDocumentLines")]
+    [McpServerTool(Name = "ReadDocumentLines", Title = "Read Filing Lines", ReadOnly = true)]
     [Description(
         "Read a specific range of lines from an SEC filing or earnings call transcript by document ID. Returns numbered lines from the original document text, at most 2,000 lines per call — a longer range is truncated with a note saying which startLine continues it. Use this to read sections of a filing that were identified by SearchDocumentKeyword (by line number) or by semantic search tools (by approximate line number shown in excerpts). Ideal for reading full tables, paragraphs, or sections that may have been truncated in search results. The document ID and line range must be known beforehand — use ListCompanyDocuments to find documents and SearchDocumentKeyword or semantic search to identify relevant line numbers."
     )]

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -32,7 +32,7 @@ public class FailToDeliverTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetFailsToDeliver")]
+    [McpServerTool(Name = "GetFailsToDeliver", Title = "Fails-to-Deliver Data", ReadOnly = true)]
     [Description(
         "Get fails-to-deliver (FTD) data for a stock from the SEC's twice-monthly FTD files. Quantity is the aggregate net fail-to-deliver position OUTSTANDING on each settlement date — a balance, not that day's new fails, so never sum Quantity across dates. Price is the previous trading day's closing price (SEC file convention, not a settlement price) and Value = Quantity × Price. Dates absent from the table had no reported fails; the SEC publishes each half-month batch with roughly a two-week lag, so the newest rows trail today. High or persistent FTD balances may indicate naked short selling or settlement issues."
     )]

--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -33,7 +33,11 @@ public class FormDTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetExemptOfferings")]
+    [McpServerTool(
+        Name = "GetExemptOfferings",
+        Title = "Exempt Offerings (Form D)",
+        ReadOnly = true
+    )]
     [Description(
         "Get recent exempt securities offerings (private placements) for a company from SEC Form D notices. Each Form D reports a Regulation D offering, showing the issuer, the date of first sale, the total offering amount (a dollar figure or \"Indefinite\"), the amounts sold and remaining, the minimum investment, the number of investors, the claimed exemptions, whether the notice is an amendment (D/A), and its SEC accession number. Ongoing offerings are re-noticed through D/A amendments that RESTATE the same offering — group rows by first-sale date and offering amount and use only the latest notice of each chain, or capital raised will be counted several times over. Use this to track how a company is raising private capital alongside its public filings."
     )]

--- a/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
@@ -35,7 +35,7 @@ public class FundDirectoryTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "SearchFunds")]
+    [McpServerTool(Name = "SearchFunds", Title = "Search Funds and ETFs", ReadOnly = true)]
     [Description(
         "Search the directory of registered investment companies (mutual funds and ETFs) that file SEC Form NPORT-P, by fund name, ticker or registrant. Returns each matching fund series with its profile id (use it with GetFundProfile), ticker (when the fund is itself listed), registration type (from N-CEN, when on record), net assets, number of reported holdings and latest report date, largest funds first. Covers the large multi-series trusts (iShares, Vanguard, Fidelity) that have no ticker of their own. Only a fund's own series-level ticker matches (e.g. IWM, SPY); share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) are not indexed — search those by fund name instead (e.g. 'Vanguard 500')."
     )]
@@ -95,7 +95,11 @@ public class FundDirectoryTools
         );
     }
 
-    [McpServerTool(Name = "GetFundProfile")]
+    [McpServerTool(
+        Name = "GetFundProfile",
+        Title = "Fund Profile and Top Holdings",
+        ReadOnly = true
+    )]
     [Description(
         "Get a registered fund's profile and largest holdings from its most recent SEC Form NPORT-P report. Accepts a fund profile id from SearchFunds or a fund's own ticker. Returns the fund's registrant and series, reporting period, net and total assets, then its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value, share of net assets and asset category. Prefer this after SearchFunds: the profile id reaches the many fund series that have no ticker of their own; GetFundHoldings is the equivalent view, and GetFundsHoldingStock answers the inverse question (which funds own a stock). For the large multi-series trusts only positions in tracked stocks are stored, so the holdings shown are the fund's tracked-stock positions; the net-asset totals are the fund's real totals."
     )]

--- a/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
@@ -28,7 +28,11 @@ public class InvestmentAdviserTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "SearchInvestmentAdvisers")]
+    [McpServerTool(
+        Name = "SearchInvestmentAdvisers",
+        Title = "Search Investment Advisers",
+        ReadOnly = true
+    )]
     [Description(
         "Search SEC-registered investment advisers (Form ADV) by firm name. Returns matching advisory firms with their CRD number, main office location, regulatory assets under management, employee count and the as-of date of their latest Form ADV data, largest by assets first. Use the CRD number with GetInvestmentAdviser for full detail."
     )]
@@ -95,7 +99,11 @@ public class InvestmentAdviserTools
             : legal;
     }
 
-    [McpServerTool(Name = "GetInvestmentAdviser")]
+    [McpServerTool(
+        Name = "GetInvestmentAdviser",
+        Title = "Investment Adviser Profile (Form ADV)",
+        ReadOnly = true
+    )]
     [Description(
         "Get the full Form ADV profile for a single SEC-registered investment adviser by its Organization CRD number: legal and business names, SEC file number, main office, website, regulatory assets under management (discretionary, non-discretionary and total), employee count, and how the firm is compensated (fee structure). Find CRD numbers with SearchInvestmentAdvisers."
     )]

--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -33,7 +33,11 @@ public class NCenTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetFundOperations")]
+    [McpServerTool(
+        Name = "GetFundOperations",
+        Title = "Fund Operations (Form N-CEN)",
+        ReadOnly = true
+    )]
     [Description(
         "Get operational data for a registered investment company from its SEC Form N-CEN annual reports. Resolves exchange-listed tickers only — ETFs, closed-end funds and unit investment trusts; an unlisted mutual-fund share-class ticker (e.g. VFIAX) will not resolve, so find that fund via SearchFunds/GetFundProfile instead. Each N-CEN shows the registrant's classification (e.g. N-1A open-end, N-2 closed-end, S-6 unit investment trust), Investment Company Act file number, reporting period, and whether it was the fund's first or last filing, followed by the service providers named on the most recent report only — investment advisers, sub-advisers, custodians, transfer agents, administrators, auditors and underwriters. Use this to see who runs and services a fund. Only registered funds file N-CEN; operating companies will return no data."
     )]

--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -36,7 +36,7 @@ public class NportTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetFundHoldings")]
+    [McpServerTool(Name = "GetFundHoldings", Title = "Fund Portfolio Holdings", ReadOnly = true)]
     [Description(
         "Get the portfolio holdings of a registered investment company (mutual fund or ETF) from its most recent SEC Form NPORT-P monthly report. Accepts the fund's own ticker or a fund profile id from SearchFunds, so it also reaches the many fund series that have no ticker of their own. Returns the fund's series, reporting period and net assets, followed by its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value and share of net assets, with the asset category. Use SearchFunds to discover funds, GetFundProfile for the same view with the fund's registrant and total assets, and GetFundsHoldingStock for the inverse question (which funds own a stock). Only registered funds file NPORT-P; operating companies will return no data. Share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) do not resolve — find those funds by name via SearchFunds."
     )]
@@ -154,7 +154,7 @@ public class NportTools
             : (latest, series.SeriesName ?? series.RegistrantName, null);
     }
 
-    [McpServerTool(Name = "GetFundsHoldingStock")]
+    [McpServerTool(Name = "GetFundsHoldingStock", Title = "Funds Holding a Stock", ReadOnly = true)]
     [Description(
         "Get the registered investment companies (mutual funds and ETFs) holding a given stock, from SEC Form NPORT-P portfolio reports. The stock's CUSIP is matched against the holding rows on each fund series' most recent report (series that stopped filing more than 18 months ago are excluded), so an exited position never shows as current. Returns the fund's registrant and series, the reporting period, the position size, its U.S.-dollar value, its share of the fund's net assets and the payoff profile (Long/Short), largest positions first. Report dates differ per fund series (each files on its own fiscal quarter), so values are as of each row's report date and cross-row totals mix as-of dates. Use this to see which funds and ETFs own a stock and how concentrated each position is."
     )]

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -57,7 +57,7 @@ public class RagSearchTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "SearchDocuments")]
+    [McpServerTool(Name = "SearchDocuments", Title = "Search SEC Filings", ReadOnly = true)]
     [Description(
         "Search the Equibles SEC filing database across all companies and document types using hybrid keyword and semantic search. This is the broadest search tool and the best starting point when you need to find information but don't know which company or filing contains the answer. Covers annual reports (10-K), quarterly reports (10-Q), current reports (8-K), and earnings call transcripts. Results can be filtered by filing date range using startDate/endDate. Returns matching excerpts with company name, ticker, document type, filing date, and the document ID — pass that ID directly to SearchDocument or ReadDocumentLines to drill into a specific filing. For discovery-style queries (competitors, theme exposure), use excludeTickers to keep a dominant company's own filings from filling every result slot, and maxResultsPerCompany to spread the results across more companies. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. Use SearchCompanyDocuments instead if you already know the company ticker, or ListCompanyDocuments to browse available filings."
     )]
@@ -113,7 +113,11 @@ public class RagSearchTools
         );
     }
 
-    [McpServerTool(Name = "SearchCompanyDocuments")]
+    [McpServerTool(
+        Name = "SearchCompanyDocuments",
+        Title = "Search a Company's Filings",
+        ReadOnly = true
+    )]
     [Description(
         "Search the Equibles SEC filing database for a specific company by its ticker symbol using hybrid keyword and semantic search. Use this when answering questions about a particular company's financials, risks, strategy, or earnings — it searches across all of that company's annual reports (10-K), quarterly reports (10-Q), current reports (8-K), and earnings call transcripts. Results can be filtered by filing date range using startDate/endDate. Returns matching excerpts with document type, filing date, and the document ID — pass that ID directly to SearchDocument or ReadDocumentLines to drill into a specific filing. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. Prefer this over SearchDocuments when the company is known. Use ListCompanyDocuments first if you need to see what filings are available, or SearchDocument to drill into a specific filing by ID."
     )]
@@ -170,7 +174,7 @@ public class RagSearchTools
         );
     }
 
-    [McpServerTool(Name = "SearchDocument")]
+    [McpServerTool(Name = "SearchDocument", Title = "Search Within One Filing", ReadOnly = true)]
     [Description(
         "Search within a single specific document in the Equibles SEC filing database by its document ID using hybrid keyword and semantic search. Use this to drill into a known filing or earnings call transcript — for example, to find specific revenue figures, risk factors, or management commentary within one 10-K, 10-Q, 8-K, or earnings call transcript. The document ID comes from ListCompanyDocuments or from the '(ID: ...)' header of SearchDocuments/SearchCompanyDocuments results. Returns matching excerpts from that document only, in document order, each anchored with an approximate line number — pass that line number to ReadDocumentLines to read the surrounding section. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data."
     )]
@@ -222,7 +226,11 @@ public class RagSearchTools
         );
     }
 
-    [McpServerTool(Name = "ListCompanyDocuments")]
+    [McpServerTool(
+        Name = "ListCompanyDocuments",
+        Title = "Browse Company Filings",
+        ReadOnly = true
+    )]
     [Description(
         "Browse and discover available SEC filings and earnings call transcripts for a specific company in the Equibles database. Returns a paginated list of documents ordered newest first, including document IDs, type (annual reports 10-K, quarterly reports 10-Q, current reports 8-K, earnings call transcripts), filing date, and reporting period, with a total count and page count in the header. Supports filtering by date range and document type. Document types registered as hidden from filing lists (e.g. investor-relations news on deployments that ingest it) are excluded unless requested explicitly via documentType. Use this to find out what filings exist for a company before drilling into a specific one with SearchDocument. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data. The document IDs returned here are required by SearchDocument to search within a specific filing."
     )]

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -35,7 +35,7 @@ public class StockPriceTools
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
-    [McpServerTool(Name = "GetStockPrices")]
+    [McpServerTool(Name = "GetStockPrices", Title = "Daily Price History", ReadOnly = true)]
     [Description(
         "Get daily OHLCV (Open, High, Low, Close, Volume) price history for a stock. Useful for "
             + "technical analysis, charting, and price trend analysis. Prices are in USD and "
@@ -107,7 +107,7 @@ public class StockPriceTools
         );
     }
 
-    [McpServerTool(Name = "GetLatestPrices")]
+    [McpServerTool(Name = "GetLatestPrices", Title = "Latest Prices", ReadOnly = true)]
     [Description(
         "Get the most recent closing price (USD), daily change, and volume for one or more "
             + "stocks. Useful for quick price checks across a portfolio or watchlist."
@@ -191,7 +191,11 @@ public class StockPriceTools
         );
     }
 
-    [McpServerTool(Name = "GetStochasticOscillator")]
+    [McpServerTool(
+        Name = "GetStochasticOscillator",
+        Title = "Stochastic Oscillator",
+        ReadOnly = true
+    )]
     [Description(
         "Stochastic Oscillator (%K and %D) for a stock. %K measures the close relative to "
             + "the high/low range over the lookback window; %D is the smoothed signal line "
@@ -265,7 +269,11 @@ public class StockPriceTools
         );
     }
 
-    [McpServerTool(Name = "GetAverageTrueRange")]
+    [McpServerTool(
+        Name = "GetAverageTrueRange",
+        Title = "Average True Range (ATR)",
+        ReadOnly = true
+    )]
     [Description(
         "Average True Range (ATR) for a stock. Wilder's volatility measure built from "
             + "the True Range (max of high-low, |high-prev_close|, |low-prev_close|) and "
@@ -333,7 +341,7 @@ public class StockPriceTools
         );
     }
 
-    [McpServerTool(Name = "GetOnBalanceVolume")]
+    [McpServerTool(Name = "GetOnBalanceVolume", Title = "On-Balance Volume (OBV)", ReadOnly = true)]
     [Description(
         "On-Balance Volume (OBV) for a stock. Running cumulative volume that adds the "
             + "bar's volume on up-closes, subtracts on down-closes, and stays flat on "
@@ -394,7 +402,7 @@ public class StockPriceTools
         );
     }
 
-    [McpServerTool(Name = "GetBollingerBands")]
+    [McpServerTool(Name = "GetBollingerBands", Title = "Bollinger Bands", ReadOnly = true)]
     [Description(
         "Bollinger Bands for a stock. A middle band (simple moving average of close) with "
             + "upper and lower bands set a number of standard deviations above and below it. "

--- a/tests/Equibles.UnitTests/Mcp/McpToolAnnotationsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpToolAnnotationsTests.cs
@@ -1,0 +1,118 @@
+using System.Reflection;
+using Equibles.Cboe.Mcp.Tools;
+using Equibles.Cftc.Mcp.Tools;
+using Equibles.Congress.Mcp.Tools;
+using Equibles.FdaCatalysts.Mcp.Tools;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Fred.Mcp.Tools;
+using Equibles.GovernmentContracts.Mcp.Tools;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.InsiderTrading.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Yahoo.Mcp.Tools;
+using ModelContextProtocol.Server;
+
+namespace Equibles.UnitTests.Mcp;
+
+// Every tool the server exposes must carry a display title and a behavioural hint.
+// Clients surface the title in the connector consent screen — without one they fall
+// back to the raw method name — and without ReadOnly they must assume a tool may
+// mutate state, which turns a research-only server into a scary permission prompt.
+// Connector directories reject servers whose tools omit either.
+public class McpToolAnnotationsTests
+{
+    // One marker type per assembly that ships MCP tools.
+    private static readonly Type[] ToolAssemblyMarkers =
+    [
+        typeof(CboeTools),
+        typeof(CftcTools),
+        typeof(CongressTools),
+        typeof(FdaCatalystTools),
+        typeof(ShortDataTools),
+        typeof(FredTools),
+        typeof(GovernmentContractsTools),
+        typeof(InstitutionalHoldingsTools),
+        typeof(InsiderTradingTools),
+        typeof(FinancialFactsTools),
+        typeof(RagSearchTools),
+        typeof(StockPriceTools),
+    ];
+
+    [Fact]
+    public void EveryTool_DeclaresATitle()
+    {
+        var untitled = EnumerateTools()
+            .Where(t => string.IsNullOrWhiteSpace(t.Attribute.Title))
+            .Select(t => $"{t.Method.DeclaringType!.Name}.{t.Method.Name}")
+            .ToList();
+
+        untitled
+            .Should()
+            .BeEmpty("every MCP tool needs a human-readable Title for the consent screen");
+    }
+
+    [Fact]
+    public void EveryTool_DeclaresAReadOnlyHint()
+    {
+        // The server is research-only: it reads filings and market data and never writes.
+        // A tool that genuinely mutates state should set Destructive instead, and this
+        // assertion should then be narrowed rather than deleted.
+        var unhinted = EnumerateTools()
+            .Where(t => t.Attribute.ReadOnly != true)
+            .Select(t => $"{t.Method.DeclaringType!.Name}.{t.Method.Name}")
+            .ToList();
+
+        unhinted.Should().BeEmpty("every tool on this server is read-only and must say so");
+    }
+
+    [Fact]
+    public void ToolNames_StayWithinTheProtocolLengthLimit()
+    {
+        var overlong = EnumerateTools()
+            .Select(t => t.Attribute.Name ?? t.Method.Name)
+            .Where(name => name.Length > 64)
+            .ToList();
+
+        overlong.Should().BeEmpty("MCP tool names are capped at 64 characters");
+    }
+
+    [Fact]
+    public void ToolTitles_AreUniqueAcrossTheServer()
+    {
+        // Two tools sharing a title are indistinguishable in the consent screen.
+        var duplicates = EnumerateTools()
+            .GroupBy(t => t.Attribute.Title)
+            .Where(g => !string.IsNullOrWhiteSpace(g.Key) && g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        duplicates.Should().BeEmpty("each tool needs a distinguishable title");
+    }
+
+    [Fact]
+    public void EnumerateTools_FindsTheWholeToolSurface()
+    {
+        // Guards the reflection itself: if a marker type is dropped or an assembly stops
+        // being referenced, the assertions above would silently pass over nothing.
+        EnumerateTools().Should().HaveCountGreaterThan(50);
+    }
+
+    private static List<(McpServerToolAttribute Attribute, MethodInfo Method)> EnumerateTools()
+    {
+        return ToolAssemblyMarkers
+            .Select(marker => marker.Assembly)
+            .Distinct()
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => type.GetCustomAttribute<McpServerToolTypeAttribute>() != null)
+            .SelectMany(type =>
+                type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+            )
+            .Select(method =>
+                (Attribute: method.GetCustomAttribute<McpServerToolAttribute>(), Method: method)
+            )
+            .Where(t => t.Attribute != null)
+            .Select(t => (t.Attribute!, t.Method))
+            .ToList();
+    }
+}


### PR DESCRIPTION
## Summary

All 64 MCP tools declared only a `Name`. That left clients with nothing to display but the raw method name (`GetMarketWideCongressionalActivity`), and no way to distinguish a read-only lookup from something that mutates state — so a client must assume the worst and present a needlessly alarming consent screen for what is a research-only server.

Connector directories also treat both fields as a hard requirement, so the server would fail review as-is.

Every tool here reads SEC filings and market data and never writes, so each now carries a human-readable `Title` and `ReadOnly = true`.

Before:
```csharp
[McpServerTool(Name = "GetCongressionalTrades")]
```

After:
```csharp
[McpServerTool(Name = "GetCongressionalTrades", Title = "Congressional Trades by Stock", ReadOnly = true)]
```

## Code changes

- **23 tool files across 12 modules** (Cboe, Cftc, Congress, FdaCatalysts, Finra, Fred, GovernmentContracts, Holdings, InsiderTrading, Sec, Sec.FinancialFacts, Yahoo) — added `Title` and `ReadOnly = true` to all 64 `[McpServerTool]` declarations. No behavioural change; attribute metadata only.
- **`tests/Equibles.UnitTests/Mcp/McpToolAnnotationsTests.cs`** (new) — convention guard reflecting over all twelve tool assemblies. Asserts every tool declares a title, every tool declares a read-only hint, names stay within the 64-character protocol limit, and titles are unique so no two tools are indistinguishable in the consent screen. A fifth test guards the reflection itself, so a dropped marker type can't make the others silently pass over an empty set.

`Title`, `ReadOnly`, `Destructive` and `Idempotent` are already available on `McpServerToolAttribute` in the pinned `ModelContextProtocol` 1.4.0 — no dependency change.

## Verification

- `dotnet build -c Release` — 0 errors
- Unit suite — **3,659 passed, 0 failed** (3,654 existing + 5 new)
- Guard verified to actually fail: stripping the annotation from one tool fails 2 of the 5 tests, then reverted
- Formatted with the repo-pinned csharpier