### PR TITLE
ci: exempt Dependabot from the lowercase PR-title subject rule

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -31,7 +31,11 @@ jobs:
             ci
             revert
           # Subject must start lowercase to stay consistent with the rest of git log.
-          subjectPattern: ^[a-z].+$
+          # Dependabot is exempt: it titles its PRs "build: Bump X from 1 to 2"
+          # and the capitalisation isn't configurable, so enforcing lowercase
+          # there just means hand-editing every dependency PR before it can
+          # merge. The type prefix is still enforced for bot PRs.
+          subjectPattern: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && '^[A-Za-z].+$' || '^[a-z].+$' }}
           subjectPatternError: |
             The PR title subject must start with a lowercase letter.
             Got: "{subject}"


### PR DESCRIPTION
## Summary

Every weekly NuGet dependency PR fails the `PR title (Conventional Commits)` check. Dependabot titles them `build: Bump X from 1.0 to 1.1` — the `build` prefix is configured in `.github/dependabot.yml`, but Dependabot capitalises the word after the prefix and that isn't configurable. The workflow requires a lowercase subject, so the check goes red and the title has to be hand-edited before the PR can merge. Six open dependency PRs are blocked on exactly this today.

The lowercase rule stays in force for human PRs — it only relaxes for `dependabot[bot]`, which still has to produce a valid type prefix.

## Code changes

- `.github/workflows/lint-pr-title.yml` — `subjectPattern` is now chosen by PR author: `^[A-Za-z].+$` for `dependabot[bot]`, `^[a-z].+$` for everyone else. Expression form keeps the allowed-types list in one place.