### PR TITLE
build: drop the redundant Hosting.Abstractions version override

### DIFF
--- a/src/Equibles.Messaging/Equibles.Messaging.csproj
+++ b/src/Equibles.Messaging/Equibles.Messaging.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" VersionOverride="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

#4199 pinned `Microsoft.Extensions.Hosting.Abstractions` to `10.0.10` with a `VersionOverride` on the project reference while the central version was still `10.0.9`. That same PR moved the central version to `10.0.10`, so the override became a no-op — and the longer attribute line pushed the file past CSharpier's width, turning the lint job red on `main`.

Removing the override restores the central-package-management invariant (versions live in `Directory.Packages.props`, projects reference by name only) and fixes the format check.

## Code changes

- `src/Equibles.Messaging/Equibles.Messaging.csproj` — drop `VersionOverride="10.0.10"` from the `Microsoft.Extensions.Hosting.Abstractions` reference. The explicit reference itself stays; it's what keeps the transitive MassTransit dependency from tripping NU1605.

## Verification

- `dotnet csharpier check .` — clean, 3131 files
- `dotnet restore Equibles.sln` — 0 NU1605 downgrades
- `dotnet build Equibles.sln -c Release` — 0 errors
- `dotnet test --filter "Category!=Functional&Category!=Live"` — 3659 unit + 2237 integration passed, 0 failed