### PR TITLE
fix(government-contracts): replace deep pagination with an amount-descending cursor

### DIFF
--- a/src/Equibles.GovernmentContracts.HostedService/GovernmentContractsScraperWorker.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/GovernmentContractsScraperWorker.cs
@@ -13,6 +13,13 @@ public class GovernmentContractsScraperWorker : BaseScraperWorker
     protected override TimeSpan SleepInterval { get; }
     protected override ErrorSource ErrorSource => ErrorSource.GovernmentContractsScraper;
 
+    // USAspending has documented bad spells lasting minutes (see UsaSpendingClient's
+    // retry rationale); a transport failure that survives the client's ~2min of
+    // retries usually clears within a backoff cycle or two. Only a streak of three
+    // faulted cycles (~1+2+4min of backoff) is worth an Errors-page row — the same
+    // brief-blip reasoning as DocumentProcessorWorker's threshold.
+    protected override int ErrorReportThreshold => 3;
+
     public GovernmentContractsScraperWorker(
         ILogger<GovernmentContractsScraperWorker> logger,
         IServiceScopeFactory scopeFactory,

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -105,26 +105,29 @@ public class GovernmentContractsImportService : IImporter
                     windowStart,
                     windowEnd
                 );
-                await _errorReporter.Report(
-                    ErrorSource.GovernmentContractsScraper,
-                    "GovernmentContractsImport.ImportWindow",
-                    ex,
-                    $"window: {windowStart}..{windowEnd}"
-                );
 
                 // A transport-level failure (the API is unreachable, even after the client's retries)
-                // is systemic: every remaining window would fail identically and record its own error,
-                // turning one outage into hundreds of duplicate rows. Stop the cycle after reporting
-                // once; the next run resumes from the same start date once the API is reachable again.
-                // Other (window-specific) failures fall through and the scan continues.
+                // is systemic: every remaining window would fail identically. Rethrow so the worker's
+                // consecutive-failure streak owns the reporting — it records ONE Error row per outage
+                // (once the streak reaches its threshold) and backs off, instead of this loop writing
+                // a fresh row every cycle for the same unreachable API. The next cycle resumes from
+                // the same start date. Window-specific failures are reported here and the scan
+                // continues to the remaining windows.
                 if (ex is HttpRequestException)
                 {
                     _logger.LogWarning(
                         "Government contracts import: aborting this cycle after a transport failure; "
                             + "remaining windows will be retried on the next run"
                     );
-                    break;
+                    throw;
                 }
+
+                await _errorReporter.Report(
+                    ErrorSource.GovernmentContractsScraper,
+                    "GovernmentContractsImport.ImportWindow",
+                    ex,
+                    $"window: {windowStart}..{windowEnd}"
+                );
             }
         }
 
@@ -144,7 +147,8 @@ public class GovernmentContractsImportService : IImporter
         var awards = await _client.GetContractAwards(
             windowStart,
             windowEnd,
-            _options.MinimumAwardAmount
+            _options.MinimumAwardAmount,
+            cancellationToken
         );
         if (awards.Count == 0)
             return 0;

--- a/src/Equibles.Integrations.GovernmentContracts/Contracts/IUsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Contracts/IUsaSpendingClient.cs
@@ -5,15 +5,18 @@ namespace Equibles.Integrations.GovernmentContracts.Contracts;
 public interface IUsaSpendingClient
 {
     /// <summary>
-    /// Fetches federal procurement contract awards (award types A/B/C/D) whose
+    /// Fetches every federal procurement contract award (award types A/B/C/D) whose
     /// action date falls within <paramref name="startDate"/>..<paramref name="endDate"/>
-    /// and whose award amount is at least <paramref name="minimumAmount"/>, following
-    /// pagination. The window must be narrow enough to stay under the API's
-    /// deep-pagination ceiling; truncation is logged rather than silently dropped.
+    /// and whose award amount is at least <paramref name="minimumAmount"/>. Dense
+    /// windows are handled internally with an amount-descending cursor (and, for
+    /// pathological same-amount tie runs, date bisection), so callers get the complete
+    /// set regardless of window density; only a single day with 10,000+ awards tied at
+    /// the exact same amount is truncated, and that is logged loudly.
     /// </summary>
     Task<List<UsaSpendingAwardRecord>> GetContractAwards(
         DateOnly startDate,
         DateOnly endDate,
-        decimal minimumAmount
+        decimal minimumAmount,
+        CancellationToken cancellationToken = default
     );
 }

--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -26,9 +26,24 @@ public class UsaSpendingClient : IUsaSpendingClient
     // outlast the spell while a genuine outage still fails the window promptly.
     private const int MaxRetries = 6;
 
-    // The API returns at most 100 rows/page and refuses to paginate past the
-    // 10,000th record, so 100 pages is the hard ceiling for a single window.
+    // The API returns at most 100 rows/page.
     private const int PageSize = 100;
+
+    // Offset pagination degrades sharply with depth (measured against the live API:
+    // page 1 ≈ 1.5s, page 25 ≈ 41s, page 50 ≈ 55s, page 90 drops the connection
+    // mid-body — a deterministic "response ended prematurely", not a blip). Results
+    // are sorted by award amount descending, so instead of paging deep the client
+    // pages at most this many pages, then tightens the band's upper amount bound to
+    // the smallest amount fetched and restarts from page 1 — every request stays
+    // shallow. A fresh band costs one slow query (~45–60s while the server builds
+    // its filter cache) and then ~1–2s per page, well inside the request timeout.
+    private const int MaxPagesPerBand = 10;
+
+    // Hard per-band ceiling — the API refuses to paginate past the 10,000th record.
+    // The cursor only pages past MaxPagesPerBand while stuck on a run of awards tied
+    // at the exact same amount (the upper bound can't tighten), so reaching this
+    // means 10,000+ same-amount awards in the window; FetchWindow then bisects the
+    // date range so the tie run lands in smaller windows.
     private const int MaxPages = 100;
 
     // Federal procurement contract award types (excludes grants/loans/other assistance).
@@ -69,58 +84,175 @@ public class UsaSpendingClient : IUsaSpendingClient
     public async Task<List<UsaSpendingAwardRecord>> GetContractAwards(
         DateOnly startDate,
         DateOnly endDate,
-        decimal minimumAmount
+        decimal minimumAmount,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var results = new List<UsaSpendingAwardRecord>();
+        // Amount-band resets re-fetch awards tied at the boundary amount (the upper
+        // bound is inclusive), so duplicates are dropped here by the award's
+        // globally-unique id rather than surfacing to callers.
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        await FetchWindow(
+            startDate,
+            endDate,
+            minimumAmount,
+            initialUpperBound: null,
+            results,
+            seenIds,
+            cancellationToken
+        );
+        return results;
+    }
+
+    /// <summary>
+    /// Fetches every award in the window with amount in [<paramref name="minimumAmount"/>,
+    /// <paramref name="initialUpperBound"/>] using an amount-descending cursor: page at most
+    /// <see cref="MaxPagesPerBand"/> shallow pages, then restart from page 1 with the upper
+    /// bound tightened to the smallest amount fetched. Completeness holds by induction —
+    /// results sort by amount descending, so everything above the new bound is already
+    /// fetched, and the inclusive bound re-covers ties at the boundary (deduplicated by id).
+    /// The cursor only pages deeper while stalled on a same-amount tie run; a run too long
+    /// even for that (<see cref="MaxPages"/>) bisects the date range instead.
+    /// </summary>
+    private async Task FetchWindow(
+        DateOnly startDate,
+        DateOnly endDate,
+        decimal minimumAmount,
+        decimal? initialUpperBound,
+        List<UsaSpendingAwardRecord> results,
+        HashSet<string> seenIds,
+        CancellationToken cancellationToken
     )
     {
         var startStr = FormatDate(startDate);
         var endStr = FormatDate(endDate);
-        var results = new List<UsaSpendingAwardRecord>();
+        var upperBound = initialUpperBound;
 
-        for (var page = 1; page <= MaxPages; page++)
+        for (var page = 1; ; page++)
         {
-            var body = BuildRequestBody(startStr, endStr, minimumAmount, page);
-            var response = await PostQuery(body);
-            if (response.Results.Count > 0)
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var body = BuildRequestBody(startStr, endStr, minimumAmount, upperBound, page);
+            var response = await PostQuery(body, cancellationToken);
+
+            foreach (var record in response.Results)
             {
-                results.AddRange(response.Results);
+                if (record.GeneratedInternalId == null || seenIds.Add(record.GeneratedInternalId))
+                {
+                    results.Add(record);
+                }
             }
 
             if (response.PageMetadata is not { HasNext: true })
             {
-                return results;
+                return;
             }
 
-            if (page == MaxPages)
+            if (response.Results.Count == 0)
             {
+                // hasNext on an empty page is a server contradiction; stop rather
+                // than loop on it forever.
                 _logger.LogWarning(
-                    "USAspending window {Start}..{End} (>= ${Min}) exceeded {MaxPages} pages "
-                        + "({Count} awards fetched) and has more results — narrow the window or raise the floor",
+                    "USAspending window {Start}..{End} returned an empty page {Page} with hasNext=true; stopping",
                     startStr,
                     endStr,
+                    page
+                );
+                return;
+            }
+
+            // Sorted by amount descending, so the last row carries the smallest
+            // amount fetched so far — the cursor's next inclusive upper bound.
+            var floor = response.Results[^1].Amount;
+
+            if (
+                page >= MaxPagesPerBand
+                && floor.HasValue
+                && floor.Value < (upperBound ?? decimal.MaxValue)
+            )
+            {
+                upperBound = floor.Value;
+                page = 0; // restart the band shallow; the for-loop increments to 1
+                continue;
+            }
+
+            if (page >= MaxPages)
+            {
+                if (startDate < endDate)
+                {
+                    // 10,000+ awards tied at one amount (or amount-less rows) in this
+                    // window — the cursor can't advance, so split the dates and let each
+                    // half re-cover the tie run; overlap is deduplicated by award id.
+                    var mid = startDate.AddDays((endDate.DayNumber - startDate.DayNumber) / 2);
+                    _logger.LogInformation(
+                        "USAspending window {Start}..{End} has an unpageable tie run at <= {Upper}; "
+                            + "bisecting at {Mid}",
+                        startStr,
+                        endStr,
+                        upperBound,
+                        FormatDate(mid)
+                    );
+                    await FetchWindow(
+                        startDate,
+                        mid,
+                        minimumAmount,
+                        upperBound,
+                        results,
+                        seenIds,
+                        cancellationToken
+                    );
+                    await FetchWindow(
+                        mid.AddDays(1),
+                        endDate,
+                        minimumAmount,
+                        upperBound,
+                        results,
+                        seenIds,
+                        cancellationToken
+                    );
+                    return;
+                }
+
+                // A single day with 10,000+ awards at the exact same amount cannot be
+                // enumerated through this endpoint at all; log the truncation loudly.
+                _logger.LogWarning(
+                    "USAspending single-day window {Start} (>= ${Min}) still has results after "
+                        + "{MaxPages} pages tied at <= {Upper} ({Count} awards fetched so far); "
+                        + "remaining ties are unreachable through this endpoint",
+                    startStr,
                     minimumAmount,
                     MaxPages,
+                    upperBound,
                     results.Count
                 );
+                return;
             }
         }
-
-        return results;
     }
 
     private static object BuildRequestBody(
         string startDate,
         string endDate,
         decimal minimumAmount,
+        decimal? maximumAmount,
         int page
     )
     {
+        // Both amount bounds are INCLUSIVE (verified against the live API: the counts of
+        // [a,b] and [b,∞) overlap by exactly the count of [b,b]) — the amount cursor
+        // relies on that to re-cover awards tied at the boundary instead of losing them.
+        object[] awardAmounts = maximumAmount.HasValue
+            ? [new { lower_bound = minimumAmount, upper_bound = maximumAmount.Value }]
+            : [new { lower_bound = minimumAmount }];
+
         return new
         {
             filters = new
             {
                 award_type_codes = ContractAwardTypeCodes,
                 time_period = new[] { new { start_date = startDate, end_date = endDate } },
-                award_amounts = new[] { new { lower_bound = minimumAmount } },
+                award_amounts = awardAmounts,
             },
             fields = RequestFields,
             page,
@@ -131,16 +263,22 @@ public class UsaSpendingClient : IUsaSpendingClient
         };
     }
 
-    private async Task<UsaSpendingAwardResponse> PostQuery(object body)
+    private async Task<UsaSpendingAwardResponse> PostQuery(
+        object body,
+        CancellationToken cancellationToken
+    )
     {
         var json = JsonConvert.SerializeObject(body);
-        var content = await SendWithRetry(async () =>
-        {
-            using var request = new HttpRequestMessage(HttpMethod.Post, SearchUrl);
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            return await _httpClient.SendAsync(request);
-        });
+        var content = await SendWithRetry(
+            async () =>
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, SearchUrl);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+                return await _httpClient.SendAsync(request, cancellationToken);
+            },
+            cancellationToken
+        );
 
         var response =
             JsonConvert.DeserializeObject<UsaSpendingAwardResponse>(content)
@@ -151,11 +289,14 @@ public class UsaSpendingClient : IUsaSpendingClient
         return response;
     }
 
-    private async Task<string> SendWithRetry(Func<Task<HttpResponseMessage>> sendRequest)
+    private async Task<string> SendWithRetry(
+        Func<Task<HttpResponseMessage>> sendRequest,
+        CancellationToken cancellationToken
+    )
     {
         for (var attempt = 0; attempt <= MaxRetries; attempt++)
         {
-            await RateLimiter.WaitAsync();
+            await RateLimiter.WaitAsync(cancellationToken);
 
             HttpResponseMessage response;
             try
@@ -163,7 +304,10 @@ public class UsaSpendingClient : IUsaSpendingClient
                 response = await sendRequest();
             }
             catch (Exception ex)
-                when (ex is HttpRequestException or TaskCanceledException && attempt < MaxRetries)
+                when (ex is HttpRequestException or TaskCanceledException
+                    && attempt < MaxRetries
+                    && !cancellationToken.IsCancellationRequested
+                )
             {
                 // A transport-level failure — connection reset, DNS blip, TLS error or a request
                 // timeout — throws here and never reaches the status-code checks below. Without this
@@ -178,7 +322,7 @@ public class UsaSpendingClient : IUsaSpendingClient
                     attempt + 1,
                     MaxRetries
                 );
-                await Task.Delay(delay);
+                await Task.Delay(delay, cancellationToken);
                 continue;
             }
 
@@ -193,7 +337,7 @@ public class UsaSpendingClient : IUsaSpendingClient
                         attempt + 1,
                         MaxRetries
                     );
-                    await Task.Delay(delay);
+                    await Task.Delay(delay, cancellationToken);
                     continue;
                 }
 
@@ -207,12 +351,12 @@ public class UsaSpendingClient : IUsaSpendingClient
                         attempt + 1,
                         MaxRetries
                     );
-                    await Task.Delay(delay);
+                    await Task.Delay(delay, cancellationToken);
                     continue;
                 }
 
                 response.EnsureSuccessStatusCode();
-                return await response.Content.ReadAsStringAsync();
+                return await response.Content.ReadAsStringAsync(cancellationToken);
             }
         }
 

--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -325,6 +325,19 @@ public class UsaSpendingClient : IUsaSpendingClient
                 await Task.Delay(delay, cancellationToken);
                 continue;
             }
+            catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Only reachable once the retry filter above stops matching, i.e. on the
+                // final attempt: an HttpClient timeout (not our token) surfaces as
+                // TaskCanceledException, which the import loop and the worker's report
+                // gate both treat as shutdown — a persistent-timeout outage would back
+                // off silently forever and never reach the Errors page. Map it to the
+                // transport failure it actually is.
+                throw new HttpRequestException(
+                    "USAspending request timed out after exhausting retries",
+                    ex
+                );
+            }
 
             using (response)
             {

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
@@ -30,10 +30,13 @@ public class GovernmentContractsImportServiceHttpAbortTests
         // Contract (from Import's window-loop comment): a transport-level failure —
         // HttpRequestException, the API unreachable even after the client's own retries —
         // is systemic, so every remaining window would fail identically. The cycle must
-        // STOP after reporting once rather than hammer the API once per window and record
-        // a duplicate error each time. With a multi-day scan split into one-day windows,
-        // the first window failing with HttpRequestException must therefore leave every
-        // later window un-fetched: the client is called exactly once, not once per window.
+        // STOP and RETHROW rather than hammer the API once per window: the worker's
+        // consecutive-failure streak owns reporting (one Error row per outage), so the
+        // service must not write its own row per cycle — that's exactly the flood that
+        // put 13 identical rows on the Errors page in one day. With a multi-day scan
+        // split into one-day windows, the first window failing with HttpRequestException
+        // must propagate and leave every later window un-fetched: the client is called
+        // exactly once, not once per window.
         var options = NewDbOptions();
         using (var seed = NewContext(options))
         {
@@ -53,7 +56,12 @@ public class GovernmentContractsImportServiceHttpAbortTests
 
         var client = Substitute.For<IUsaSpendingClient>();
         client
-            .GetContractAwards(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<decimal>())
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
             .ThrowsAsync(new HttpRequestException("USAspending unreachable"));
 
         // Empty GovernmentContract table -> DetermineStartDate falls back to MinSyncDate.
@@ -80,11 +88,19 @@ public class GovernmentContractsImportServiceHttpAbortTests
             new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
         );
 
-        await service.Import(CancellationToken.None);
+        var act = () => service.Import(CancellationToken.None);
 
+        // The transport failure must propagate (the worker's streak reporting depends on
+        // seeing the throw) after exactly one client call — no later window is scanned.
+        await act.Should().ThrowAsync<HttpRequestException>();
         await client
             .Received(1)
-            .GetContractAwards(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<decimal>());
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
@@ -52,7 +52,12 @@ public class GovernmentContractsImportServiceWindowContinueTests
 
         var client = Substitute.For<IUsaSpendingClient>();
         client
-            .GetContractAwards(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<decimal>())
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
             .ThrowsAsync(new InvalidOperationException("window-specific parse failure"));
 
         // Empty GovernmentContract table -> DetermineStartDate falls back to MinSyncDate.

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientAmountCursorTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientAmountCursorTests.cs
@@ -1,0 +1,257 @@
+using System.Net;
+using Equibles.Integrations.GovernmentContracts;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+/// <summary>
+/// Pins the amount-descending cursor that replaced deep offset pagination in
+/// <see cref="UsaSpendingClient.GetContractAwards"/>. USAspending's search endpoint
+/// degrades sharply with page depth and drops the connection outright around page 90
+/// ("The response ended prematurely" — the failure that froze the production backfill
+/// on a 118k-record week), so the client must never page deep: after its shallow page
+/// budget it restarts from page 1 with the band's upper amount bound tightened to the
+/// smallest amount fetched. These tests drive the client against a fake handler that
+/// honors the amount band and page number of each request, so they verify completeness
+/// (every award fetched exactly once) as well as the shallow-page invariant.
+/// </summary>
+public class UsaSpendingClientAmountCursorTests
+{
+    // Mirrors the client's constants: the shallow budget is 10 pages, the hard
+    // per-band ceiling (the API's own 10k-record limit) is 100 pages.
+    private const int MaxPagesPerBand = 10;
+    private const int MaxPages = 100;
+
+    [Fact]
+    public async Task GetContractAwards_WindowDenserThanPageBudget_TightensUpperBoundInsteadOfPagingDeep()
+    {
+        // 130 awards with strictly-descending amounts, served 5 per page: 10 pages cover
+        // 50 awards, so a naive pager would need 26 pages. The cursor must instead reset
+        // the band (upper bound = smallest amount seen, back to page 1) and still return
+        // every award exactly once, with no request ever exceeding the shallow budget.
+        var awards = Enumerable
+            .Range(0, 130)
+            .Select(i => new FakeAward($"CONT_AWD_{i}", 1_000_000m + (130 - i) * 1000m))
+            .ToList();
+        var handler = new BandAwareHandler(awards, pageSize: 5);
+        var sut = new UsaSpendingClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<UsaSpendingClient>>()
+        );
+
+        var result = await sut.GetContractAwards(
+            new DateOnly(2022, 1, 16),
+            new DateOnly(2022, 1, 22),
+            minimumAmount: 1_000_000m
+        );
+
+        result
+            .Select(r => r.GeneratedInternalId)
+            .Should()
+            .BeEquivalentTo(
+                awards.Select(a => a.Id),
+                "the cursor must return every award exactly once — no page skipped by a band reset, no boundary tie duplicated"
+            );
+        handler.MaxPageRequested.Should().BeLessThanOrEqualTo(MaxPagesPerBand);
+        handler
+            .UpperBoundsSeen.Should()
+            .BeInDescendingOrder("each band reset must tighten the upper bound monotonically");
+    }
+
+    [Fact]
+    public async Task GetContractAwards_TieRunLongerThanPageBudget_PagesThroughTheTiesThenResetsTheBand()
+    {
+        // Awards 20..89 all share one amount — a 70-row tie run at 6 rows/page. The first
+        // band reset lands the cursor on a band whose top 10 pages (60 rows) are ALL that
+        // tie amount: the smallest amount on the page equals the band's upper bound, so
+        // the cursor CANNOT tighten (an equal bound would refetch the same pages forever).
+        // It must page on through the ties — the one sanctioned use of deeper pages — and
+        // reset only once the amount drops.
+        var awards = new List<FakeAward>();
+        for (var i = 0; i < 20; i++)
+            awards.Add(new FakeAward($"HIGH_{i}", 9_000_000m - i * 1000m));
+        for (var i = 0; i < 70; i++)
+            awards.Add(new FakeAward($"TIE_{i}", 5_000_000m));
+        for (var i = 0; i < 20; i++)
+            awards.Add(new FakeAward($"LOW_{i}", 4_000_000m - i * 1000m));
+
+        var handler = new BandAwareHandler(awards, pageSize: 6);
+        var sut = new UsaSpendingClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<UsaSpendingClient>>()
+        );
+
+        var result = await sut.GetContractAwards(
+            new DateOnly(2022, 1, 16),
+            new DateOnly(2022, 1, 22),
+            minimumAmount: 1_000_000m
+        );
+
+        result
+            .Select(r => r.GeneratedInternalId)
+            .Should()
+            .BeEquivalentTo(
+                awards.Select(a => a.Id),
+                "ties at the band boundary must be re-covered by the inclusive upper bound and deduplicated, never lost"
+            );
+        handler
+            .MaxPageRequested.Should()
+            .BeGreaterThan(
+                MaxPagesPerBand,
+                "the tie run can only be crossed by paging past the shallow budget"
+            );
+        handler
+            .MaxPageRequested.Should()
+            .BeLessThanOrEqualTo(MaxPages, "the API refuses pages past the 10,000th record");
+    }
+
+    [Fact]
+    public async Task GetContractAwards_TieRunExceedingTheApiCeiling_BisectsTheDateWindow()
+    {
+        // Every page carries the same amount and hasNext stays true for the full window —
+        // a tie run past the API's 100-page ceiling. The client can't advance the amount
+        // cursor, so it must split the date range and rescan the halves (which the handler
+        // reports as completed) instead of looping forever or silently giving up.
+        var handler = new EndlessTieHandler(
+            fullWindowStart: "2022-01-16",
+            fullWindowEnd: "2022-01-22"
+        );
+        var sut = new UsaSpendingClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<UsaSpendingClient>>()
+        );
+
+        await sut.GetContractAwards(
+            new DateOnly(2022, 1, 16),
+            new DateOnly(2022, 1, 22),
+            minimumAmount: 1_000_000m
+        );
+
+        handler
+            .WindowsSeen.Should()
+            .Contain(
+                new[] { ("2022-01-16", "2022-01-19"), ("2022-01-20", "2022-01-22") },
+                "an unpageable tie run must bisect the window so the ties land in smaller date ranges"
+            );
+    }
+
+    private sealed record FakeAward(string Id, decimal Amount);
+
+    /// <summary>
+    /// Serves a fixed amount-descending dataset the way the real endpoint does: honors the
+    /// request's award_amounts band (both bounds inclusive, as verified against the live
+    /// API) and its page number, and records the deepest page and the bands requested.
+    /// </summary>
+    private sealed class BandAwareHandler : HttpMessageHandler
+    {
+        private readonly List<FakeAward> _sorted;
+        private readonly int _pageSize;
+
+        public int MaxPageRequested { get; private set; }
+        public List<decimal> UpperBoundsSeen { get; } = [];
+
+        public BandAwareHandler(IEnumerable<FakeAward> awards, int pageSize)
+        {
+            _sorted = awards.OrderByDescending(a => a.Amount).ToList();
+            _pageSize = pageSize;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var body = JObject.Parse(request.Content!.ReadAsStringAsync(cancellationToken).Result);
+            var page = body["page"]!.Value<int>();
+            var amounts = (JObject)body["filters"]!["award_amounts"]![0]!;
+            var lower = amounts["lower_bound"]!.Value<decimal>();
+            var upper = amounts["upper_bound"]?.Value<decimal>();
+
+            MaxPageRequested = Math.Max(MaxPageRequested, page);
+            if (upper.HasValue)
+                UpperBoundsSeen.Add(upper.Value);
+
+            var band = _sorted
+                .Where(a => a.Amount >= lower && (!upper.HasValue || a.Amount <= upper.Value))
+                .ToList();
+            var rows = band.Skip((page - 1) * _pageSize).Take(_pageSize).ToList();
+            var hasNext = page * _pageSize < band.Count;
+
+            var payload = new
+            {
+                results = rows.Select(a => new Dictionary<string, object>
+                {
+                    ["generated_internal_id"] = a.Id,
+                    ["Award ID"] = a.Id,
+                    ["Award Amount"] = a.Amount,
+                }),
+                page_metadata = new { page, hasNext },
+            };
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(payload)),
+                }
+            );
+        }
+    }
+
+    /// <summary>
+    /// Simulates a tie run past the API ceiling: for the full window every page returns
+    /// rows at one identical amount with hasNext always true; any narrower date range
+    /// completes immediately. Records the (start, end) of every window requested.
+    /// </summary>
+    private sealed class EndlessTieHandler : HttpMessageHandler
+    {
+        private readonly string _fullWindowStart;
+        private readonly string _fullWindowEnd;
+
+        public List<(string Start, string End)> WindowsSeen { get; } = [];
+
+        public EndlessTieHandler(string fullWindowStart, string fullWindowEnd)
+        {
+            _fullWindowStart = fullWindowStart;
+            _fullWindowEnd = fullWindowEnd;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var body = JObject.Parse(request.Content!.ReadAsStringAsync(cancellationToken).Result);
+            var page = body["page"]!.Value<int>();
+            var period = (JObject)body["filters"]!["time_period"]![0]!;
+            var window = (
+                Start: period["start_date"]!.Value<string>()!,
+                End: period["end_date"]!.Value<string>()!
+            );
+            if (!WindowsSeen.Contains(window))
+                WindowsSeen.Add(window);
+
+            var isFullWindow = window.Start == _fullWindowStart && window.End == _fullWindowEnd;
+            var payload = new
+            {
+                results = new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["generated_internal_id"] = $"TIE_{window.Start}_{window.End}_{page}",
+                        ["Award ID"] = $"PIID_{page}",
+                        ["Award Amount"] = 5_000_000m,
+                    },
+                },
+                page_metadata = new { page, hasNext = isFullWindow },
+            };
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(payload)),
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The government-contracts import was frozen on the 2022-01-16..2022-01-22 window: USAspending's `spending_by_award` endpoint degrades sharply with offset depth (measured: page 1 ≈ 1.5s, page 25 ≈ 41s, page 50 ≈ 55s, page 90 drops the connection mid-body — a deterministic "The response ended prematurely") and that week holds ~118k contract awards ≥ $1M, far past both the reachable page depth and the API's own 10,000-record pagination ceiling. Every cycle re-hit the wall, the cursor never advanced, and an identical error row landed on the Errors page each time (13 in one day).

Results are sorted by award amount descending, so the client now uses an amount-descending cursor instead of deep offsets: fetch at most 10 shallow pages, then restart from page 1 with the band's inclusive upper amount bound tightened to the smallest amount fetched. Amount bounds were verified inclusive against the live API (the counts of [a,b] and [b,∞) overlap by exactly the count of [b,b]), so boundary ties are re-covered and deduplicated by `generated_internal_id`. Same-amount tie runs page on past the shallow budget; a run past the API's 100-page ceiling bisects the date window. Dense windows now complete with every award above the floor captured — a fresh band costs one ~45-60s cache-building query and then ~1-2s per page, well inside the request timeout.

## Code changes

- `UsaSpendingClient` — amount-cursor `FetchWindow` (shallow bands, tie-run continuation, date bisection), inclusive-upper-bound request body, `CancellationToken` support so multi-hour dense-window fetches stop promptly on shutdown.
- `IUsaSpendingClient` — cancellation token parameter + updated contract docs (callers no longer need to pre-narrow windows).
- `GovernmentContractsImportService` — transport failures now rethrow instead of writing an Error row per cycle; the worker's consecutive-failure streak owns reporting. Window-specific failures still report and continue.
- `GovernmentContractsScraperWorker` — `ErrorReportThreshold = 3` so a brief USAspending bad spell backs off quietly and only a persistent outage records one row.
- Tests — three new cursor tests (band-reset completeness + shallow-page invariant, tie-run continuation, date bisection) against a band-aware fake handler; the transport-abort test updated to the rethrow contract.

All 3,662 unit tests pass.