### PR TITLE
fix(congress): stop re-downloading already-ingested filings

### DIFF
--- a/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
+++ b/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
@@ -21,5 +21,6 @@ public class CongressModuleConfiguration : Equibles.Data.IFinancialModule
             .ValueGeneratedNever();
         builder.Entity<CongressionalAnnualDisclosure>();
         builder.Entity<CongressionalDisclosureLine>();
+        builder.Entity<CongressionalFilingRecord>();
     }
 }

--- a/src/Equibles.Congress.Data/Models/CongressionalFilingKind.cs
+++ b/src/Equibles.Congress.Data/Models/CongressionalFilingKind.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Congress.Data.Models;
+
+public enum CongressionalFilingKind
+{
+    [Display(Name = "House Periodic Transaction Report")]
+    HousePeriodicTransactionReport = 0,
+
+    [Display(Name = "House Annual Report")]
+    HouseAnnualReport = 1,
+
+    [Display(Name = "Senate Periodic Transaction Report")]
+    SenatePeriodicTransactionReport = 2,
+
+    [Display(Name = "Senate Annual Report")]
+    SenateAnnualReport = 3,
+}

--- a/src/Equibles.Congress.Data/Models/CongressionalFilingRecord.cs
+++ b/src/Equibles.Congress.Data/Models/CongressionalFilingRecord.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Congress.Data.Models;
+
+/// <summary>
+/// Marks one source filing as fully ingested so sync cycles never re-download
+/// it. A row is written only after the filing was fetched, parsed and its data
+/// committed (or it was skipped by a deterministic policy, e.g. a scanned
+/// paper filing) — fetch and parse failures are never recorded, so those
+/// filings keep retrying until they succeed. Deleting rows forces a re-ingest
+/// of the matching filings on the next cycle.
+/// </summary>
+[Index(nameof(Kind), nameof(SourceId), IsUnique = true)]
+public class CongressionalFilingRecord
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public CongressionalFilingKind Kind { get; set; }
+
+    // House: the DocID from the yearly FD index; Senate: the eFD report GUID.
+    [Required]
+    [MaxLength(128)]
+    public string SourceId { get; set; }
+
+    public DateOnly FilingDate { get; set; }
+
+    // Transactions or schedule lines the filing yielded; 0 also covers
+    // policy-skipped filings (scanned paper reports, candidate reports).
+    public int ItemCount { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Congress.HostedService/Models/AnnualReportFetchResult.cs
+++ b/src/Equibles.Congress.HostedService/Models/AnnualReportFetchResult.cs
@@ -1,0 +1,13 @@
+namespace Equibles.Congress.HostedService.Models;
+
+/// <summary>
+/// An annual-report fetch pass: the parsed reports plus the filings that were
+/// fully handled (including deterministic policy skips such as scanned paper
+/// or candidate reports) and may be marked as ingested once the reports are
+/// committed.
+/// </summary>
+public class AnnualReportFetchResult
+{
+    public List<AnnualDisclosureReport> Reports { get; set; } = [];
+    public List<ProcessedFiling> ProcessedFilings { get; set; } = [];
+}

--- a/src/Equibles.Congress.HostedService/Models/DisclosureFetchResult.cs
+++ b/src/Equibles.Congress.HostedService/Models/DisclosureFetchResult.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Congress.HostedService.Models;
+
+/// <summary>
+/// A trade-disclosure fetch pass: the parsed transactions plus the filings
+/// that were fully handled and may be marked as ingested once the
+/// transactions are committed.
+/// </summary>
+public class DisclosureFetchResult
+{
+    public List<DisclosureTransaction> Transactions { get; set; } = [];
+    public List<ProcessedFiling> ProcessedFilings { get; set; } = [];
+}

--- a/src/Equibles.Congress.HostedService/Models/DisclosureTransaction.cs
+++ b/src/Equibles.Congress.HostedService/Models/DisclosureTransaction.cs
@@ -4,6 +4,11 @@ namespace Equibles.Congress.HostedService.Models;
 
 public class DisclosureTransaction
 {
+    // The filing this transaction came from (House DocID / Senate report
+    // GUID) — lets the sync tie persistence outcomes back to the filing when
+    // deciding whether to mark it as ingested.
+    public string SourceId { get; set; }
+
     public required string MemberName { get; init; }
     public CongressPosition Position { get; init; }
     public string Ticker { get; init; }

--- a/src/Equibles.Congress.HostedService/Models/ProcessedFiling.cs
+++ b/src/Equibles.Congress.HostedService/Models/ProcessedFiling.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Congress.HostedService.Models;
+
+/// <summary>
+/// A source filing a client fully handled this cycle: fetched, parsed and
+/// either yielded items or was skipped by a deterministic policy. The sync
+/// services persist these as <c>CongressionalFilingRecord</c> rows — but only
+/// after the cycle's data has been committed, so a failed persist re-fetches
+/// the filing instead of losing it.
+/// </summary>
+public sealed record ProcessedFiling(string SourceId, DateOnly FilingDate, int ItemCount);

--- a/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
@@ -28,6 +28,7 @@ public class CongressionalAnnualDisclosureSyncService
     private readonly ILogger<CongressionalAnnualDisclosureSyncService> _logger;
     private readonly WorkerOptions _workerOptions;
     private readonly ErrorReporter _errorReporter;
+    private readonly CongressionalFilingLedger _filingLedger;
 
     // Electronic filing of congressional disclosures dates to the STOCK Act.
     private const int EarliestCoverageYear = 2012;
@@ -41,13 +42,15 @@ public class CongressionalAnnualDisclosureSyncService
         IServiceScopeFactory scopeFactory,
         IOptions<WorkerOptions> workerOptions,
         ILogger<CongressionalAnnualDisclosureSyncService> logger,
-        ErrorReporter errorReporter
+        ErrorReporter errorReporter,
+        CongressionalFilingLedger filingLedger
     )
     {
         _scopeFactory = scopeFactory;
         _workerOptions = workerOptions.Value;
         _logger = logger;
         _errorReporter = errorReporter;
+        _filingLedger = filingLedger;
     }
 
     public async Task SyncAll(CancellationToken ct)
@@ -64,18 +67,28 @@ public class CongressionalAnnualDisclosureSyncService
             currentYear
         );
 
-        var reports = new List<AnnualDisclosureReport>();
+        var houseProcessedIds = await _filingLedger.GetProcessedSourceIds(
+            CongressionalFilingKind.HouseAnnualReport,
+            ct
+        );
+        var senateProcessedIds = await _filingLedger.GetProcessedSourceIds(
+            CongressionalFilingKind.SenateAnnualReport,
+            ct
+        );
 
-        await FetchReports(
-            reports,
+        var houseResult = await FetchReports(
             "House",
             "CongressAnnual.SyncHouse",
             async sp =>
             {
                 var client = sp.GetRequiredService<HouseAnnualReportClient>();
-                var fetched = new List<AnnualDisclosureReport>();
+                var fetched = new AnnualReportFetchResult();
                 for (var year = fromYear; year <= currentYear; year++)
-                    fetched.AddRange(await client.GetAnnualReports(year, ct));
+                {
+                    var yearResult = await client.GetAnnualReports(year, houseProcessedIds, ct);
+                    fetched.Reports.AddRange(yearResult.Reports);
+                    fetched.ProcessedFilings.AddRange(yearResult.ProcessedFilings);
+                }
                 return fetched;
             },
             ct
@@ -84,8 +97,7 @@ public class CongressionalAnnualDisclosureSyncService
         // Senate reports are searched by submitted date; reports covering year
         // Y are filed from Y+1 onwards, and any late amendment of an older
         // year inside the window still updates that year.
-        await FetchReports(
-            reports,
+        var senateResult = await FetchReports(
             "Senate",
             "CongressAnnual.SyncSenate",
             sp =>
@@ -93,33 +105,51 @@ public class CongressionalAnnualDisclosureSyncService
                     .GetAnnualReports(
                         new DateOnly(fromYear + 1, 1, 1),
                         DateOnly.FromDateTime(DateTime.UtcNow),
+                        senateProcessedIds,
                         ct
                     ),
             ct
         );
 
-        if (reports.Count == 0)
-        {
-            _logger.LogInformation("No congressional annual disclosure reports found");
-            return;
-        }
+        var reports = houseResult.Reports.Concat(senateResult.Reports).ToList();
 
-        await ProcessReports(reports, ct);
+        IReadOnlySet<string> unpersistedReportIds = new HashSet<string>();
+        if (reports.Count == 0)
+            _logger.LogInformation("No congressional annual disclosure reports found");
+        else
+            unpersistedReportIds = await ProcessReports(reports, ct);
+
+        // Only after the reports are committed: a failed persist above throws
+        // before this point, so unrecorded filings re-fetch next cycle instead
+        // of being lost. Reports that were parsed but not stored (the
+        // member-not-found guard) stay unrecorded so they keep retrying.
+        await _filingLedger.RecordProcessed(
+            CongressionalFilingKind.HouseAnnualReport,
+            houseResult
+                .ProcessedFilings.Where(f => !unpersistedReportIds.Contains(f.SourceId))
+                .ToList(),
+            ct
+        );
+        await _filingLedger.RecordProcessed(
+            CongressionalFilingKind.SenateAnnualReport,
+            senateResult
+                .ProcessedFilings.Where(f => !unpersistedReportIds.Contains(f.SourceId))
+                .ToList(),
+            ct
+        );
     }
 
-    private async Task FetchReports(
-        List<AnnualDisclosureReport> target,
+    private async Task<AnnualReportFetchResult> FetchReports(
         string sourceLabel,
         string errorContext,
-        Func<IServiceProvider, Task<List<AnnualDisclosureReport>>> fetch,
+        Func<IServiceProvider, Task<AnnualReportFetchResult>> fetch,
         CancellationToken ct
     )
     {
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
-            var reports = await fetch(scope.ServiceProvider);
-            target.AddRange(reports);
+            return await fetch(scope.ServiceProvider);
         }
         catch (OperationCanceledException)
         {
@@ -129,10 +159,16 @@ public class CongressionalAnnualDisclosureSyncService
         {
             _logger.LogWarning(ex, "Failed to fetch {Source} annual disclosure data", sourceLabel);
             await _errorReporter.Report(ErrorSource.CongressScraper, errorContext, ex);
+            return new AnnualReportFetchResult();
         }
     }
 
-    private async Task ProcessReports(List<AnnualDisclosureReport> reports, CancellationToken ct)
+    // Returns the source report ids that were parsed but not stored (the
+    // member-not-found guard) so the caller leaves their filings unrecorded.
+    private async Task<IReadOnlySet<string>> ProcessReports(
+        List<AnnualDisclosureReport> reports,
+        CancellationToken ct
+    )
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
@@ -143,6 +179,7 @@ public class CongressionalAnnualDisclosureSyncService
         var latest = SelectLatestReports(reports);
         var members = await UpsertCongressMembers(latest, dbContext, memberRepository, ct);
 
+        var unpersistedReportIds = new HashSet<string>();
         int added = 0,
             replaced = 0,
             unchanged = 0;
@@ -155,6 +192,8 @@ public class CongressionalAnnualDisclosureSyncService
             if (!members.TryGetValue(memberName, out var member))
             {
                 _logger.LogWarning("Congress member not found after upsert: {Name}", memberName);
+                if (report.ReportId != null)
+                    unpersistedReportIds.Add(report.ReportId);
                 continue;
             }
 
@@ -189,6 +228,8 @@ public class CongressionalAnnualDisclosureSyncService
             replaced,
             unchanged
         );
+
+        return unpersistedReportIds;
     }
 
     private async Task<Dictionary<string, CongressMember>> UpsertCongressMembers(

--- a/src/Equibles.Congress.HostedService/Services/CongressionalFilingLedger.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalFilingLedger.cs
@@ -1,0 +1,72 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.Repositories;
+using Equibles.Core.AutoWiring;
+using FlexLabs.EntityFrameworkCore.Upsert;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Congress.HostedService.Services;
+
+/// <summary>
+/// The ingested-filing ledger behind the congressional sync services. Every
+/// cycle loads the already-ingested source ids per filing kind so the clients
+/// skip re-downloading those filings, and records the newly handled ones only
+/// after the cycle's data has been committed — a failed cycle therefore
+/// re-fetches its filings instead of losing them.
+/// </summary>
+[Service]
+public class CongressionalFilingLedger
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public CongressionalFilingLedger(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public virtual async Task<IReadOnlySet<string>> GetProcessedSourceIds(
+        CongressionalFilingKind kind,
+        CancellationToken ct
+    )
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var repository =
+            scope.ServiceProvider.GetRequiredService<CongressionalFilingRecordRepository>();
+        var sourceIds = await repository.GetByKind(kind).Select(r => r.SourceId).ToListAsync(ct);
+        return sourceIds.ToHashSet();
+    }
+
+    public virtual async Task RecordProcessed(
+        CongressionalFilingKind kind,
+        IReadOnlyCollection<ProcessedFiling> filings,
+        CancellationToken ct
+    )
+    {
+        if (filings.Count == 0)
+            return;
+
+        // Dedupe by source id: an id repeated in one batch (e.g. a listing
+        // page boundary shifting mid-search) would make the upsert's ON
+        // CONFLICT hit the same row twice and abort the whole statement.
+        var records = filings
+            .GroupBy(f => f.SourceId)
+            .Select(g => g.First())
+            .Select(f => new CongressionalFilingRecord
+            {
+                Kind = kind,
+                SourceId = f.SourceId,
+                FilingDate = f.FilingDate,
+                ItemCount = f.ItemCount,
+            })
+            .ToList();
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        await dbContext
+            .Set<CongressionalFilingRecord>()
+            .UpsertRange(records)
+            .On(r => new { r.Kind, r.SourceId })
+            .NoUpdate()
+            .RunAsync(ct);
+    }
+}

--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -20,22 +20,32 @@ public class CongressionalTradeSyncService
     private readonly ILogger<CongressionalTradeSyncService> _logger;
     private readonly WorkerOptions _workerOptions;
     private readonly ErrorReporter _errorReporter;
+    private readonly CongressionalFilingLedger _filingLedger;
 
     public CongressionalTradeSyncService(
         IServiceScopeFactory scopeFactory,
         IOptions<WorkerOptions> workerOptions,
         ILogger<CongressionalTradeSyncService> logger,
-        ErrorReporter errorReporter
+        ErrorReporter errorReporter,
+        CongressionalFilingLedger filingLedger
     )
     {
         _scopeFactory = scopeFactory;
         _workerOptions = workerOptions.Value;
         _logger = logger;
         _errorReporter = errorReporter;
+        _filingLedger = filingLedger;
     }
 
     // Congressional trade disclosures are available from 2012 (STOCK Act).
     private static readonly DateOnly EarliestAvailableDate = new(2012, 4, 1);
+
+    // A filing with a transaction whose ticker is not (yet) a tracked stock
+    // keeps re-fetching until the filing is this old, so a listing-lag gap
+    // (e.g. an IPO disclosed before the stock enters CommonStock) is
+    // back-matched on a later cycle. Older than this, the ticker is a
+    // genuinely untracked asset and the filing is retired.
+    private const int UnmatchedTickerRetryWindowDays = 30;
 
     public async Task SyncAll(CancellationToken ct)
     {
@@ -53,54 +63,110 @@ public class CongressionalTradeSyncService
             toDate
         );
 
-        var allTransactions = new List<DisclosureTransaction>();
+        var senateProcessedIds = await _filingLedger.GetProcessedSourceIds(
+            CongressionalFilingKind.SenatePeriodicTransactionReport,
+            ct
+        );
+        var houseProcessedIds = await _filingLedger.GetProcessedSourceIds(
+            CongressionalFilingKind.HousePeriodicTransactionReport,
+            ct
+        );
 
-        await FetchDisclosureTransactions(
-            allTransactions,
+        var senateResult = await FetchDisclosureTransactions(
             "Senate",
             "CongressTrades.SyncSenate",
             sp =>
                 sp.GetRequiredService<SenateDisclosureClient>()
-                    .GetRecentTransactions(fromDate, toDate, ct),
+                    .GetRecentTransactions(fromDate, toDate, senateProcessedIds, ct),
             ct
         );
-        await FetchDisclosureTransactions(
-            allTransactions,
+        var houseResult = await FetchDisclosureTransactions(
             "House",
             "CongressTrades.SyncHouse",
             sp =>
                 sp.GetRequiredService<HouseDisclosureClient>()
-                    .GetRecentTransactions(fromDate, toDate, ct),
+                    .GetRecentTransactions(fromDate, toDate, houseProcessedIds, ct),
             ct
         );
 
+        var allTransactions = senateResult.Transactions.Concat(houseResult.Transactions).ToList();
+
+        var outcome = TradePersistOutcome.Empty;
         if (allTransactions.Count == 0)
         {
             _logger.LogInformation("No congressional transactions found");
-            return;
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Fetched {Count} total congressional transactions, matching to tracked stocks",
+                allTransactions.Count
+            );
+
+            outcome = await ProcessTransactions(allTransactions, ct);
         }
 
-        _logger.LogInformation(
-            "Fetched {Count} total congressional transactions, matching to tracked stocks",
-            allTransactions.Count
+        // Only after the transactions are committed: a failed persist above
+        // throws before this point, so unrecorded filings re-fetch next cycle
+        // instead of being lost.
+        var unmatchedRetryCutoff = toDate.AddDays(-UnmatchedTickerRetryWindowDays);
+        await _filingLedger.RecordProcessed(
+            CongressionalFilingKind.SenatePeriodicTransactionReport,
+            FilterRecordable(senateResult.ProcessedFilings, outcome, unmatchedRetryCutoff),
+            ct
         );
-
-        await ProcessTransactions(allTransactions, ct);
+        await _filingLedger.RecordProcessed(
+            CongressionalFilingKind.HousePeriodicTransactionReport,
+            FilterRecordable(houseResult.ProcessedFilings, outcome, unmatchedRetryCutoff),
+            ct
+        );
     }
 
-    private async Task FetchDisclosureTransactions(
-        List<DisclosureTransaction> target,
+    // A filing is only retired once everything it disclosed is accounted for:
+    // rows that hit the member-not-found guard were parsed but never stored,
+    // so their filing must keep retrying; a filing with an unmatched ticker
+    // retries until it ages past the listing-lag window (see
+    // UnmatchedTickerRetryWindowDays).
+    internal static List<ProcessedFiling> FilterRecordable(
+        List<ProcessedFiling> filings,
+        TradePersistOutcome outcome,
+        DateOnly unmatchedRetryCutoff
+    ) =>
+        filings
+            .Where(f => !outcome.UnpersistedSourceIds.Contains(f.SourceId))
+            .Where(f =>
+                !outcome.UnmatchedTickerSourceIds.Contains(f.SourceId)
+                || f.FilingDate <= unmatchedRetryCutoff
+            )
+            .ToList();
+
+    /// <summary>
+    /// The persistence outcome of one sync cycle: filings named here had
+    /// transactions that were parsed but not stored, so they must not (yet)
+    /// be recorded as ingested.
+    /// </summary>
+    internal sealed record TradePersistOutcome(
+        IReadOnlySet<string> UnmatchedTickerSourceIds,
+        IReadOnlySet<string> UnpersistedSourceIds
+    )
+    {
+        public static readonly TradePersistOutcome Empty = new(
+            new HashSet<string>(),
+            new HashSet<string>()
+        );
+    }
+
+    private async Task<DisclosureFetchResult> FetchDisclosureTransactions(
         string sourceLabel,
         string errorContext,
-        Func<IServiceProvider, Task<List<DisclosureTransaction>>> fetch,
+        Func<IServiceProvider, Task<DisclosureFetchResult>> fetch,
         CancellationToken ct
     )
     {
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
-            var txns = await fetch(scope.ServiceProvider);
-            target.AddRange(txns);
+            return await fetch(scope.ServiceProvider);
         }
         catch (OperationCanceledException)
         {
@@ -110,10 +176,11 @@ public class CongressionalTradeSyncService
         {
             _logger.LogWarning(ex, "Failed to fetch {Source} disclosure data", sourceLabel);
             await _errorReporter.Report(ErrorSource.CongressScraper, errorContext, ex);
+            return new DisclosureFetchResult();
         }
     }
 
-    private async Task ProcessTransactions(
+    private async Task<TradePersistOutcome> ProcessTransactions(
         List<DisclosureTransaction> transactions,
         CancellationToken ct
     )
@@ -133,6 +200,17 @@ public class CongressionalTradeSyncService
             .AsNoTracking()
             .ToDictionaryAsync(s => s.Ticker, s => s, StringComparer.OrdinalIgnoreCase, ct);
 
+        // Tickered transactions whose stock is not tracked (yet): their
+        // filings stay retryable inside the listing-lag window.
+        var unmatchedTickerSourceIds = transactions
+            .Where(t =>
+                t.SourceId != null
+                && !string.IsNullOrEmpty(t.Ticker)
+                && !stocks.ContainsKey(t.Ticker)
+            )
+            .Select(t => t.SourceId)
+            .ToHashSet();
+
         var matched = transactions
             .Where(t => !string.IsNullOrEmpty(t.Ticker) && stocks.ContainsKey(t.Ticker))
             .ToList();
@@ -144,11 +222,24 @@ public class CongressionalTradeSyncService
         );
 
         if (matched.Count == 0)
-            return;
+            return new TradePersistOutcome(unmatchedTickerSourceIds, new HashSet<string>());
 
         var members = await UpsertCongressMembers(matched, dbContext, memberRepository, ct);
+
+        // Mirrors BuildTrades' member-not-found guard: those rows are parsed
+        // but never stored, so their filings must not be recorded as ingested.
+        var unpersistedSourceIds = matched
+            .Where(t =>
+                t.SourceId != null
+                && !members.ContainsKey(DisclosureParsingHelper.NormalizeMemberName(t.MemberName))
+            )
+            .Select(t => t.SourceId)
+            .ToHashSet();
+
         var trades = BuildTrades(matched, members, stocks);
         await PersistTrades(trades, dbContext, ct);
+
+        return new TradePersistOutcome(unmatchedTickerSourceIds, unpersistedSourceIds);
     }
 
     private async Task<Dictionary<string, CongressMember>> UpsertCongressMembers(

--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -273,6 +273,10 @@ public static partial class DisclosureParsingHelper
     public static string GetCell(List<string> cells, int index) =>
         index >= 0 && index < cells.Count ? cells[index] : null;
 
+    // The eFD report id is the GUID path segment of the report URL:
+    // /search/view/{ptr|annual}/{id}/.
+    public static string ExtractReportId(string reportUrl) => reportUrl.TrimEnd('/').Split('/')[^1];
+
     public static string CleanSentinel(string value) =>
         string.IsNullOrEmpty(value) || value == EmptySentinel ? null : value;
 

--- a/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
@@ -57,9 +57,13 @@ public partial class HouseAnnualReportClient
         _logger = logger;
     }
 
-    public async Task<List<AnnualDisclosureReport>> GetAnnualReports(int year, CancellationToken ct)
+    public async Task<AnnualReportFetchResult> GetAnnualReports(
+        int year,
+        IReadOnlySet<string> processedSourceIds,
+        CancellationToken ct
+    )
     {
-        var reports = new List<AnnualDisclosureReport>();
+        var result = new AnnualReportFetchResult();
 
         List<AnnualFiling> filings;
         try
@@ -73,23 +77,33 @@ public partial class HouseAnnualReportClient
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to download House FD index for year {Year}", year);
-            return reports;
+            return result;
         }
 
+        var newFilings = filings.Where(f => !processedSourceIds.Contains(f.DocId)).ToList();
         _logger.LogInformation(
-            "Found {Count} House annual report filings for year {Year}",
+            "Found {Count} House annual report filings for year {Year} ({New} not yet ingested)",
             filings.Count,
-            year
+            year,
+            newFilings.Count
         );
 
-        foreach (var filing in filings)
+        foreach (var filing in newFilings)
         {
             ct.ThrowIfCancellationRequested();
             try
             {
-                var report = await DownloadAndParseAnnualPdf(filing, year, ct);
+                var (report, handled) = await DownloadAndParseAnnualPdf(filing, year, ct);
                 if (report != null)
-                    reports.Add(report);
+                    result.Reports.Add(report);
+                if (handled)
+                    result.ProcessedFilings.Add(
+                        new ProcessedFiling(
+                            filing.DocId,
+                            filing.FilingDate,
+                            report?.Lines.Count ?? 0
+                        )
+                    );
             }
             catch (OperationCanceledException)
             {
@@ -97,6 +111,7 @@ public partial class HouseAnnualReportClient
             }
             catch (Exception ex)
             {
+                // Not recorded as processed — the filing retries next cycle.
                 _logger.LogWarning(
                     ex,
                     "Failed to parse House annual report PDF for {Member} (DocID {DocId})",
@@ -107,12 +122,12 @@ public partial class HouseAnnualReportClient
         }
 
         _logger.LogInformation(
-            "Parsed {Parsed} electronic House annual reports out of {Total} filings for year {Year}",
-            reports.Count,
-            filings.Count,
+            "Parsed {Parsed} electronic House annual reports out of {Total} new filings for year {Year}",
+            result.Reports.Count,
+            newFilings.Count,
             year
         );
-        return reports;
+        return result;
     }
 
     private async Task<List<AnnualFiling>> DownloadAndParseFilingIndex(
@@ -177,7 +192,11 @@ public partial class HouseAnnualReportClient
             .ToList();
     }
 
-    private async Task<AnnualDisclosureReport> DownloadAndParseAnnualPdf(
+    // Handled=true marks the filing as fully ingested (parsed, or skipped by a
+    // deterministic policy: scanned paper filing, non-member report). A
+    // missing PDF or a parse failure returns Handled=false so the filing is
+    // retried on a later cycle.
+    private async Task<(AnnualDisclosureReport Report, bool Handled)> DownloadAndParseAnnualPdf(
         AnnualFiling filing,
         int year,
         CancellationToken ct
@@ -189,7 +208,7 @@ public partial class HouseAnnualReportClient
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
             _logger.LogDebug("House annual report PDF not found: {Url}", pdfUrl);
-            return null;
+            return (null, false);
         }
 
         response.EnsureSuccessStatusCode();
@@ -209,7 +228,7 @@ public partial class HouseAnnualReportClient
                 filing.MemberName,
                 filing.DocId
             );
-            return null;
+            return (null, false);
         }
 
         if (content == null)
@@ -221,7 +240,7 @@ public partial class HouseAnnualReportClient
                 filing.DocId,
                 filing.MemberName
             );
-            return null;
+            return (null, true);
         }
 
         if (!IsMemberFilerStatus(content.FilerStatus))
@@ -235,20 +254,23 @@ public partial class HouseAnnualReportClient
                 filing.MemberName,
                 content.FilerStatus
             );
-            return null;
+            return (null, true);
         }
 
-        return new AnnualDisclosureReport
-        {
-            MemberName = filing.MemberName,
-            Position = CongressPosition.Representative,
-            StateDistrict = filing.StateDistrict,
-            Year = year,
-            FiledDate = filing.FilingDate,
-            ReportId = filing.DocId,
-            IsAmendment = filing.IsAmendment,
-            Lines = content.Lines,
-        };
+        return (
+            new AnnualDisclosureReport
+            {
+                MemberName = filing.MemberName,
+                Position = CongressPosition.Representative,
+                StateDistrict = filing.StateDistrict,
+                Year = year,
+                FiledDate = filing.FilingDate,
+                ReportId = filing.DocId,
+                IsAmendment = filing.IsAmendment,
+                Lines = content.Lines,
+            },
+            true
+        );
     }
 
     // Member and member-elect reports stay; anything else ("Congressional

--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -39,13 +39,14 @@ public partial class HouseDisclosureClient
         _logger = logger;
     }
 
-    public async Task<List<DisclosureTransaction>> GetRecentTransactions(
+    public async Task<DisclosureFetchResult> GetRecentTransactions(
         DateOnly fromDate,
         DateOnly toDate,
+        IReadOnlySet<string> processedSourceIds,
         CancellationToken ct
     )
     {
-        var transactions = new List<DisclosureTransaction>();
+        var result = new DisclosureFetchResult();
         var years = Enumerable.Range(fromDate.Year, toDate.Year - fromDate.Year + 1);
 
         foreach (var year in years)
@@ -54,19 +55,33 @@ public partial class HouseDisclosureClient
             try
             {
                 var filings = await DownloadAndParseFilingIndex(year, fromDate, toDate, ct);
+                var newFilings = filings.Where(f => !processedSourceIds.Contains(f.DocId)).ToList();
                 _logger.LogInformation(
-                    "Found {Count} House PTR filings for year {Year}",
+                    "Found {Count} House PTR filings for year {Year} ({New} not yet ingested)",
                     filings.Count,
-                    year
+                    year,
+                    newFilings.Count
                 );
 
-                foreach (var filing in filings)
+                foreach (var filing in newFilings)
                 {
                     try
                     {
                         ct.ThrowIfCancellationRequested();
                         var txns = await DownloadAndParsePtrPdf(filing, year, ct);
-                        transactions.AddRange(txns);
+
+                        // A missing PDF is not handled: leave the filing
+                        // unrecorded so it retries once the file appears.
+                        if (txns == null)
+                            continue;
+
+                        foreach (var txn in txns)
+                            txn.SourceId = filing.DocId;
+
+                        result.Transactions.AddRange(txns);
+                        result.ProcessedFilings.Add(
+                            new ProcessedFiling(filing.DocId, filing.FilingDate, txns.Count)
+                        );
                     }
                     catch (OperationCanceledException)
                     {
@@ -74,6 +89,7 @@ public partial class HouseDisclosureClient
                     }
                     catch (Exception ex)
                     {
+                        // Not recorded as processed — the filing retries next cycle.
                         _logger.LogWarning(
                             ex,
                             "Failed to parse House PTR PDF for {Member} (DocID {DocId})",
@@ -99,9 +115,9 @@ public partial class HouseDisclosureClient
 
         _logger.LogInformation(
             "Parsed {Count} transactions from House PTR filings",
-            transactions.Count
+            result.Transactions.Count
         );
-        return transactions;
+        return result;
     }
 
     private async Task<List<HouseFiling>> DownloadAndParseFilingIndex(
@@ -167,6 +183,10 @@ public partial class HouseDisclosureClient
             .ToList();
     }
 
+    // Returns null when the PDF is missing (404) so the caller can tell "not
+    // yet available" apart from "parsed with zero transactions"; a parse
+    // failure throws to the caller's per-filing handler. Both leave the filing
+    // unrecorded so it is retried on a later cycle.
     private async Task<List<DisclosureTransaction>> DownloadAndParsePtrPdf(
         HouseFiling filing,
         int year,
@@ -181,31 +201,13 @@ public partial class HouseDisclosureClient
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
             _logger.LogDebug("House PTR PDF not found: {Url}", pdfUrl);
-            return [];
+            return null;
         }
 
         response.EnsureSuccessStatusCode();
 
         var pdfBytes = await response.Content.ReadAsByteArrayAsync(ct);
-        return ParsePtrPdf(pdfBytes, filing);
-    }
-
-    private List<DisclosureTransaction> ParsePtrPdf(byte[] pdfBytes, HouseFiling filing)
-    {
-        try
-        {
-            return ParsePtrPdf(pdfBytes, filing.MemberName, filing.FilingDate);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to read House PTR PDF for {Member} (DocID {DocId})",
-                filing.MemberName,
-                filing.DocId
-            );
-            return [];
-        }
+        return ParsePtrPdf(pdfBytes, filing.MemberName, filing.FilingDate);
     }
 
     // PdfPig's page.Text concatenates glyphs with no line breaks, so the PTR

--- a/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
@@ -50,32 +50,45 @@ public partial class SenateAnnualReportClient
     /// the window. Originals and amendments both appear; the caller keeps the
     /// latest filed report per member-year.
     /// </summary>
-    public async Task<List<AnnualDisclosureReport>> GetAnnualReports(
+    public async Task<AnnualReportFetchResult> GetAnnualReports(
         DateOnly submittedFrom,
         DateOnly submittedTo,
+        IReadOnlySet<string> processedSourceIds,
         CancellationToken ct
     )
     {
         await _session.EnsureAuthenticated(ct);
 
         var filings = await SearchAnnualReports(submittedFrom, submittedTo, ct);
+        var newFilings = filings
+            .Where(f => !processedSourceIds.Contains(ExtractReportId(f.ReportUrl)))
+            .ToList();
         _logger.LogInformation(
-            "Found {Count} Senate annual report filings submitted between {From} and {To}",
+            "Found {Count} Senate annual report filings submitted between {From} and {To} ({New} not yet ingested)",
             filings.Count,
             submittedFrom,
-            submittedTo
+            submittedTo,
+            newFilings.Count
         );
 
-        var reports = new List<AnnualDisclosureReport>();
+        var result = new AnnualReportFetchResult();
 
-        foreach (var filing in filings)
+        foreach (var filing in newFilings)
         {
             ct.ThrowIfCancellationRequested();
             try
             {
                 var report = await FetchAndParseReport(filing, ct);
-                if (report != null)
-                    reports.Add(report);
+
+                // A null report is an unrecognized page layout: leave the
+                // filing unrecorded so it retries once the parser handles it.
+                if (report == null)
+                    continue;
+
+                result.Reports.Add(report);
+                result.ProcessedFilings.Add(
+                    new ProcessedFiling(report.ReportId, filing.DateSubmitted, report.Lines.Count)
+                );
             }
             catch (OperationCanceledException)
             {
@@ -83,6 +96,7 @@ public partial class SenateAnnualReportClient
             }
             catch (Exception ex)
             {
+                // Not recorded as processed — the filing retries next cycle.
                 _logger.LogWarning(
                     ex,
                     "Failed to parse Senate annual report for {Member} at {Url}",
@@ -93,11 +107,11 @@ public partial class SenateAnnualReportClient
         }
 
         _logger.LogInformation(
-            "Parsed {Parsed} electronic Senate annual reports out of {Total} filings",
-            reports.Count,
-            filings.Count
+            "Parsed {Parsed} electronic Senate annual reports out of {Total} new filings",
+            result.Reports.Count,
+            newFilings.Count
         );
-        return reports;
+        return result;
     }
 
     private async Task<List<SenateAnnualFiling>> SearchAnnualReports(
@@ -237,10 +251,6 @@ public partial class SenateAnnualReportClient
             Lines = lines,
         };
     }
-
-    // The eFD report id is the GUID path segment: /search/view/annual/{id}/.
-    internal static string ExtractReportId(string reportUrl) =>
-        reportUrl.TrimEnd('/').Split('/')[^1];
 
     /// <summary>
     /// Parses the Part 3 (assets) and Part 7 (liabilities) tables out of an

--- a/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
@@ -34,31 +34,42 @@ public class SenateDisclosureClient : IAsyncDisposable
         _logger = logger;
     }
 
-    public async Task<List<DisclosureTransaction>> GetRecentTransactions(
+    public async Task<DisclosureFetchResult> GetRecentTransactions(
         DateOnly fromDate,
         DateOnly toDate,
+        IReadOnlySet<string> processedSourceIds,
         CancellationToken ct
     )
     {
         await _session.EnsureAuthenticated(ct);
 
         var reports = await SearchPtrReports(fromDate, toDate, ct);
+        var newReports = reports
+            .Where(r => !processedSourceIds.Contains(ExtractReportId(r.ReportUrl)))
+            .ToList();
         _logger.LogInformation(
-            "Found {Count} Senate PTR reports between {From} and {To}",
+            "Found {Count} Senate PTR reports between {From} and {To} ({New} not yet ingested)",
             reports.Count,
             fromDate,
-            toDate
+            toDate,
+            newReports.Count
         );
 
-        var transactions = new List<DisclosureTransaction>();
+        var result = new DisclosureFetchResult();
 
-        foreach (var report in reports)
+        foreach (var report in newReports)
         {
             try
             {
                 ct.ThrowIfCancellationRequested();
+                var reportId = ExtractReportId(report.ReportUrl);
                 var reportTxns = await FetchAndParseReport(report, ct);
-                transactions.AddRange(reportTxns);
+                foreach (var txn in reportTxns)
+                    txn.SourceId = reportId;
+                result.Transactions.AddRange(reportTxns);
+                result.ProcessedFilings.Add(
+                    new ProcessedFiling(reportId, report.DateSubmitted, reportTxns.Count)
+                );
             }
             catch (OperationCanceledException)
             {
@@ -66,6 +77,7 @@ public class SenateDisclosureClient : IAsyncDisposable
             }
             catch (Exception ex)
             {
+                // Not recorded as processed — the report retries next cycle.
                 _logger.LogWarning(
                     ex,
                     "Failed to parse Senate report for {Member} at {Url}",
@@ -76,11 +88,11 @@ public class SenateDisclosureClient : IAsyncDisposable
         }
 
         _logger.LogInformation(
-            "Parsed {Count} transactions from {ReportCount} Senate PTR reports",
-            transactions.Count,
-            reports.Count
+            "Parsed {Count} transactions from {ReportCount} new Senate PTR reports",
+            result.Transactions.Count,
+            newReports.Count
         );
-        return transactions;
+        return result;
     }
 
     private async Task<List<SenateReport>> SearchPtrReports(

--- a/src/Equibles.Congress.Repositories/CongressionalFilingRecordRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressionalFilingRecordRepository.cs
@@ -1,0 +1,15 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Data;
+
+namespace Equibles.Congress.Repositories;
+
+public class CongressionalFilingRecordRepository : BaseRepository<CongressionalFilingRecord>
+{
+    public CongressionalFilingRecordRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<CongressionalFilingRecord> GetByKind(CongressionalFilingKind kind)
+    {
+        return GetAll().Where(r => r.Kind == kind);
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260721162641_AddCongressionalFilingRecord.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260721162641_AddCongressionalFilingRecord.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260721162641_AddCongressionalFilingRecord")]
+    partial class AddCongressionalFilingRecord
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260721162641_AddCongressionalFilingRecord.cs
+++ b/src/Equibles.Migrations/Migrations/20260721162641_AddCongressionalFilingRecord.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCongressionalFilingRecord : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CongressionalFilingRecord",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Kind = table.Column<int>(type: "integer", nullable: false),
+                    SourceId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    FilingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    ItemCount = table.Column<int>(type: "integer", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CongressionalFilingRecord", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CongressionalFilingRecord_Kind_SourceId",
+                table: "CongressionalFilingRecord",
+                columns: new[] { "Kind", "SourceId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CongressionalFilingRecord");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceProcessTests.cs
@@ -57,7 +57,8 @@ public class CongressionalAnnualDisclosureSyncServiceProcessTests : ParadeDbMcpT
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeScraperWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeScraperWorkerDoWorkTests.cs
@@ -70,7 +70,8 @@ public class CongressionalTradeScraperWorkerDoWorkTests
             innerScope,
             Options.Create(new WorkerOptions()),
             Substitute.For<ILogger<CongressionalTradeSyncService>>(),
-            errorReporter
+            errorReporter,
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
 
         var workerScope = ServiceScopeSubstitute.Create(

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceBothFailTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceBothFailTests.cs
@@ -41,7 +41,8 @@ public class CongressionalTradeSyncServiceBothFailTests
                 }
             ),
             Substitute.For<ILogger<CongressionalTradeSyncService>>(),
-            errorReporter
+            errorReporter,
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
 
         // Must not throw — both fetches fail, allTransactions stays empty,

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceFetchTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceFetchTests.cs
@@ -65,7 +65,8 @@ public class CongressionalTradeSyncServiceFetchTests
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
 
         // Both fetch helpers run their success path; with no transactions the

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
@@ -52,7 +52,8 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientGetRecentCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientGetRecentCatchTests.cs
@@ -49,10 +49,13 @@ public class HouseDisclosureClientGetRecentCatchTests
         ).GetRecentTransactions(
             new DateOnly(2024, 1, 1),
             new DateOnly(2024, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
-        transactions.Should().BeEmpty("the corrupt index is caught and the run completes");
+        transactions
+            .Transactions.Should()
+            .BeEmpty("the corrupt index is caught and the run completes");
     }
 
     [Fact]
@@ -81,10 +84,11 @@ public class HouseDisclosureClientGetRecentCatchTests
         ).GetRecentTransactions(
             new DateOnly(2024, 1, 1),
             new DateOnly(2024, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
-        transactions.Should().BeEmpty("the forbidden PTR fetch is caught per-filing");
+        transactions.Transactions.Should().BeEmpty("the forbidden PTR fetch is caught per-filing");
         handler.PtrRequested.Should().BeTrue("the inner loop must have attempted the PTR fetch");
     }
 

--- a/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientIndexNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientIndexNotFoundTests.cs
@@ -28,10 +28,11 @@ public class HouseDisclosureClientIndexNotFoundTests
         var transactions = await sut.GetRecentTransactions(
             new DateOnly(2024, 1, 1),
             new DateOnly(2024, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
-        transactions.Should().BeEmpty();
+        transactions.Transactions.Should().BeEmpty();
         handler.RequestCount.Should().Be(1);
         // PDF fetches must never start when the index ZIP itself is 404 — a regression
         // that fell through to DownloadAndParsePtrPdf with an empty filings list would

--- a/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientIndexParsedTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientIndexParsedTests.cs
@@ -42,13 +42,14 @@ public class HouseDisclosureClientIndexParsedTests
         var transactions = await sut.GetRecentTransactions(
             new DateOnly(2024, 1, 1),
             new DateOnly(2024, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
         // The PTR PDF 404s, so no transactions are produced — but the index
         // ZIP must have been read and the PTR filing's PDF must have been
         // requested (proving the parse + per-filing loop ran).
-        transactions.Should().BeEmpty();
+        transactions.Transactions.Should().BeEmpty();
         handler.IndexRequested.Should().BeTrue("the {year}FD.zip index must be fetched");
         handler
             .PdfRequestedDocId.Should()

--- a/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientLedgerSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientLedgerSkipTests.cs
@@ -1,0 +1,174 @@
+using System.IO.Compression;
+using System.Net;
+using System.Text;
+using Equibles.Congress.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using UglyToad.PdfPig.Writer;
+
+namespace Equibles.IntegrationTests.Congress;
+
+/// <summary>
+/// Pins the ingested-filing ledger contract on the House PTR client: filings
+/// whose DocID is already recorded are never re-downloaded, a successfully
+/// parsed filing is reported back as processed (even with zero transactions),
+/// and a missing or unreadable PDF is NOT reported — so it retries on a later
+/// cycle instead of being lost.
+/// </summary>
+public class HouseDisclosureClientLedgerSkipTests
+{
+    private const string IngestedDocId = "20011111";
+    private const string NewDocId = "20022222";
+
+    private static string IndexXml() =>
+        "<?xml version=\"1.0\"?><FinancialDisclosure>"
+        + "<Member><First>Jane</First><Last>Smith</Last>"
+        + $"<FilingType>P</FilingType><DocID>{IngestedDocId}</DocID>"
+        + "<FilingDate>2024-01-15</FilingDate><StateDst>CA01</StateDst></Member>"
+        + "<Member><First>Bob</First><Last>Jones</Last>"
+        + $"<FilingType>P</FilingType><DocID>{NewDocId}</DocID>"
+        + "<FilingDate>2024-02-01</FilingDate><StateDst>NY02</StateDst></Member>"
+        + "</FinancialDisclosure>";
+
+    // A structurally valid one-page PDF with no text: parses to zero
+    // transactions, proving "handled with no items" is still recorded.
+    private static byte[] BlankPdf()
+    {
+        var builder = new PdfDocumentBuilder();
+        builder.AddPage(612, 792);
+        return builder.Build();
+    }
+
+    private static HouseDisclosureClient CreateClient(HttpMessageHandler handler) =>
+        new(new HttpClient(handler), Substitute.For<ILogger<HouseDisclosureClient>>());
+
+    [Fact]
+    public async Task GetRecentTransactions_IngestedDocId_IsNeverDownloadedAgain()
+    {
+        var handler = new HouseHandler(
+            IndexXml(),
+            docId => new HttpResponseMessage(HttpStatusCode.NotFound)
+        );
+        var sut = CreateClient(handler);
+
+        await sut.GetRecentTransactions(
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            new HashSet<string> { IngestedDocId },
+            CancellationToken.None
+        );
+
+        handler.RequestedPdfDocIds.Should().NotContain(IngestedDocId);
+        handler.RequestedPdfDocIds.Should().Contain(NewDocId);
+    }
+
+    [Fact]
+    public async Task GetRecentTransactions_ParsedPdf_IsReportedProcessedEvenWithZeroTransactions()
+    {
+        var pdf = BlankPdf();
+        var handler = new HouseHandler(
+            IndexXml(),
+            docId => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(pdf),
+            }
+        );
+        var sut = CreateClient(handler);
+
+        var result = await sut.GetRecentTransactions(
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            new HashSet<string> { IngestedDocId },
+            CancellationToken.None
+        );
+
+        result.Transactions.Should().BeEmpty();
+        result.ProcessedFilings.Should().ContainSingle();
+        result.ProcessedFilings[0].SourceId.Should().Be(NewDocId);
+        result.ProcessedFilings[0].ItemCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetRecentTransactions_MissingPdf_IsNotReportedProcessed()
+    {
+        var handler = new HouseHandler(
+            IndexXml(),
+            docId => new HttpResponseMessage(HttpStatusCode.NotFound)
+        );
+        var sut = CreateClient(handler);
+
+        var result = await sut.GetRecentTransactions(
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            new HashSet<string>(),
+            CancellationToken.None
+        );
+
+        result.Transactions.Should().BeEmpty();
+        result.ProcessedFilings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetRecentTransactions_UnreadablePdf_IsNotReportedProcessed()
+    {
+        var handler = new HouseHandler(
+            IndexXml(),
+            docId => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("not a pdf")),
+            }
+        );
+        var sut = CreateClient(handler);
+
+        var result = await sut.GetRecentTransactions(
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            new HashSet<string>(),
+            CancellationToken.None
+        );
+
+        result.Transactions.Should().BeEmpty();
+        result.ProcessedFilings.Should().BeEmpty();
+    }
+
+    private sealed class HouseHandler : HttpMessageHandler
+    {
+        private readonly byte[] _zip;
+        private readonly Func<string, HttpResponseMessage> _pdfResponse;
+
+        public List<string> RequestedPdfDocIds { get; } = [];
+
+        public HouseHandler(string indexXml, Func<string, HttpResponseMessage> pdfResponse)
+        {
+            _pdfResponse = pdfResponse;
+            using var buffer = new MemoryStream();
+            using (var zip = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                var entry = zip.CreateEntry("2024FD.xml");
+                using var s = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(indexXml);
+                s.Write(bytes, 0, bytes.Length);
+            }
+            _zip = buffer.ToArray();
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.EndsWith("FD.zip"))
+                return Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(_zip),
+                    }
+                );
+
+            var docId = url.Split('/')[^1].Replace(".pdf", "");
+            RequestedPdfDocIds.Add(docId);
+            return Task.FromResult(_pdfResponse(docId));
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientPtrPdfParseTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/HouseDisclosureClientPtrPdfParseTests.cs
@@ -37,12 +37,13 @@ public class HouseDisclosureClientPtrPdfParseTests
         var transactions = await sut.GetRecentTransactions(
             new DateOnly(2024, 1, 1),
             new DateOnly(2024, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
         // The PDF is unparseable, so no transactions — but the year completed
         // (the corrupt-PDF catch swallowed it) and the PDF was actually fetched.
-        transactions.Should().BeEmpty();
+        transactions.Transactions.Should().BeEmpty();
         handler.PdfFetched.Should().BeTrue("the post-NotFound parse path must have run");
     }
 

--- a/tests/Equibles.UnitTests/Congress/CongressSyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressSyncServiceTests.cs
@@ -40,7 +40,15 @@ public class CongressSyncServiceTests
             Substitute.For<ILogger<ErrorReporter>>()
         );
 
-        return new CongressionalTradeSyncService(scopeFactory, options, logger, errorReporter);
+        var filingLedger = Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null);
+
+        return new CongressionalTradeSyncService(
+            scopeFactory,
+            options,
+            logger,
+            errorReporter,
+            filingLedger
+        );
     }
 
     private static List<CongressionalTrade> InvokeBuildTrades(

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
@@ -118,7 +118,8 @@ public class CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests
             scopeFactory,
             Options.Create(new WorkerOptions()),
             Substitute.For<ILogger<CongressionalTradeSyncService>>(),
-            errorReporter
+            errorReporter,
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
     }
 }

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesFutureDateTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesFutureDateTests.cs
@@ -23,7 +23,8 @@ public class CongressionalTradeSyncServiceBuildTradesFutureDateTests
             Substitute.For<ErrorReporter>(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
 
     private static List<CongressionalTrade> InvokeBuildTrades(

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesMemberNotFoundTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesMemberNotFoundTests.cs
@@ -28,7 +28,8 @@ public class CongressionalTradeSyncServiceBuildTradesMemberNotFoundTests
             Substitute.For<ErrorReporter>(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
 
         var stock = new CommonStock

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesMissingMemberTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesMissingMemberTests.cs
@@ -23,7 +23,8 @@ public class CongressionalTradeSyncServiceBuildTradesMissingMemberTests
             Substitute.For<ErrorReporter>(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
 
     private static List<CongressionalTrade> InvokeBuildTrades(

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesSameDayTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesSameDayTests.cs
@@ -32,7 +32,8 @@ public class CongressionalTradeSyncServiceBuildTradesSameDayTests
             Substitute.For<ErrorReporter>(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
         var stock = new CommonStock
         {

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesTests.cs
@@ -31,7 +31,8 @@ public class CongressionalTradeSyncServiceBuildTradesTests
             Substitute.For<ErrorReporter>(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
         );
 
         var member = new CongressMember { Id = Guid.NewGuid(), Name = "Jane Smith" };

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceFilterRecordableTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceFilterRecordableTests.cs
@@ -1,0 +1,96 @@
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Pins the retirement rules for trade filings: a filing whose rows hit the
+/// member-not-found guard is never recorded; a filing with an unmatched
+/// ticker is only recorded once it has aged past the listing-lag retry
+/// cutoff; everything else records immediately.
+/// </summary>
+public class CongressionalTradeSyncServiceFilterRecordableTests
+{
+    private static readonly DateOnly Cutoff = new(2026, 6, 21);
+
+    private static ProcessedFiling Filing(string sourceId, DateOnly filingDate) =>
+        new(sourceId, filingDate, ItemCount: 1);
+
+    private static CongressionalTradeSyncService.TradePersistOutcome Outcome(
+        IEnumerable<string> unmatched = null,
+        IEnumerable<string> unpersisted = null
+    ) => new((unmatched ?? []).ToHashSet(), (unpersisted ?? []).ToHashSet());
+
+    [Fact]
+    public void FilterRecordable_CleanFiling_IsRecorded()
+    {
+        var filings = new List<ProcessedFiling> { Filing("A", Cutoff.AddDays(10)) };
+
+        var recordable = CongressionalTradeSyncService.FilterRecordable(filings, Outcome(), Cutoff);
+
+        recordable.Should().ContainSingle(f => f.SourceId == "A");
+    }
+
+    [Fact]
+    public void FilterRecordable_UnpersistedFiling_IsNeverRecorded()
+    {
+        // Even an old filing stays unrecorded when its rows were not stored.
+        var filings = new List<ProcessedFiling> { Filing("A", Cutoff.AddYears(-1)) };
+
+        var recordable = CongressionalTradeSyncService.FilterRecordable(
+            filings,
+            Outcome(unpersisted: ["A"]),
+            Cutoff
+        );
+
+        recordable.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FilterRecordable_UnmatchedTickerInsideRetryWindow_IsNotRecorded()
+    {
+        var filings = new List<ProcessedFiling> { Filing("A", Cutoff.AddDays(1)) };
+
+        var recordable = CongressionalTradeSyncService.FilterRecordable(
+            filings,
+            Outcome(unmatched: ["A"]),
+            Cutoff
+        );
+
+        recordable.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FilterRecordable_UnmatchedTickerPastRetryWindow_IsRetired()
+    {
+        var filings = new List<ProcessedFiling> { Filing("A", Cutoff) };
+
+        var recordable = CongressionalTradeSyncService.FilterRecordable(
+            filings,
+            Outcome(unmatched: ["A"]),
+            Cutoff
+        );
+
+        recordable.Should().ContainSingle(f => f.SourceId == "A");
+    }
+
+    [Fact]
+    public void FilterRecordable_MixedBatch_KeepsOnlyRecordableFilings()
+    {
+        var filings = new List<ProcessedFiling>
+        {
+            Filing("clean", Cutoff.AddDays(5)),
+            Filing("unmatched-recent", Cutoff.AddDays(5)),
+            Filing("unmatched-old", Cutoff.AddDays(-5)),
+            Filing("unpersisted", Cutoff.AddDays(-5)),
+        };
+
+        var recordable = CongressionalTradeSyncService.FilterRecordable(
+            filings,
+            Outcome(unmatched: ["unmatched-recent", "unmatched-old"], unpersisted: ["unpersisted"]),
+            Cutoff
+        );
+
+        recordable.Select(f => f.SourceId).Should().BeEquivalentTo("clean", "unmatched-old");
+    }
+}

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceTests.cs
@@ -42,12 +42,14 @@ public class CongressionalTradeSyncServiceTests
         var workerOptions = Options.Create(
             new WorkerOptions { MinSyncDate = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
         );
+        var filingLedger = Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null);
 
         var sut = new CongressionalTradeSyncService(
             scopeFactory,
             workerOptions,
             logger,
-            errorReporter
+            errorReporter,
+            filingLedger
         );
 
         await sut.SyncAll(CancellationToken.None);
@@ -108,6 +110,7 @@ public class CongressionalTradeSyncServiceTests
             Substitute.For<ILogger<ErrorReporter>>()
         );
         var workerOptions = Options.Create(new WorkerOptions { MinSyncDate = null });
+        var filingLedger = Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null);
 
         var expectedFromUpper = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-90));
         var expectedFromLower = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-91));
@@ -116,7 +119,8 @@ public class CongressionalTradeSyncServiceTests
             scopeFactory,
             workerOptions,
             logger,
-            errorReporter
+            errorReporter,
+            filingLedger
         );
 
         await sut.SyncAll(CancellationToken.None);

--- a/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientTests.cs
@@ -257,9 +257,13 @@ public class HouseAnnualReportClientTests
             Substitute.For<ILogger<HouseAnnualReportClient>>()
         );
 
-        var result = await sut.GetAnnualReports(2024, CancellationToken.None);
+        var result = await sut.GetAnnualReports(
+            2024,
+            new HashSet<string>(),
+            CancellationToken.None
+        );
 
-        result.Should().BeEmpty();
+        result.Reports.Should().BeEmpty();
         handler
             .Requests.Should()
             .ContainSingle("a 404 FD ZIP must not cascade into per-filing PDF downloads");
@@ -288,9 +292,13 @@ public class HouseAnnualReportClientTests
             Substitute.For<ILogger<HouseAnnualReportClient>>()
         );
 
-        var result = await sut.GetAnnualReports(year, CancellationToken.None);
+        var result = await sut.GetAnnualReports(
+            year,
+            new HashSet<string>(),
+            CancellationToken.None
+        );
 
-        result.Should().BeEmpty("every annual PDF request 404s in this setup");
+        result.Reports.Should().BeEmpty("every annual PDF request 404s in this setup");
         var pdfRequests = handler.Requests.Where(r => r.EndsWith(".pdf")).ToList();
         pdfRequests
             .Should()
@@ -320,9 +328,13 @@ public class HouseAnnualReportClientTests
             Substitute.For<ILogger<HouseAnnualReportClient>>()
         );
 
-        var result = await sut.GetAnnualReports(year, CancellationToken.None);
+        var result = await sut.GetAnnualReports(
+            year,
+            new HashSet<string>(),
+            CancellationToken.None
+        );
 
-        var report = result.Should().ContainSingle().Subject;
+        var report = result.Reports.Should().ContainSingle().Subject;
         report.MemberName.Should().Be("Jane Q. Doe", "the honorific prefix is stripped");
         report.Position.Should().Be(CongressPosition.Representative);
         report.StateDistrict.Should().Be("NY14");
@@ -352,10 +364,14 @@ public class HouseAnnualReportClientTests
             Substitute.For<ILogger<HouseAnnualReportClient>>()
         );
 
-        var result = await sut.GetAnnualReports(year, CancellationToken.None);
+        var result = await sut.GetAnnualReports(
+            year,
+            new HashSet<string>(),
+            CancellationToken.None
+        );
 
         result
-            .Should()
+            .Reports.Should()
             .BeEmpty("an image-only PDF has no schedules and is not an electronic filing");
         handler.Requests.Should().HaveCount(2, "the ZIP and the single PDF");
     }

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
@@ -1,7 +1,6 @@
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Reflection;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.HostedService.Models;
 using Equibles.Congress.HostedService.Services;
@@ -196,10 +195,11 @@ public class HouseDisclosureClientTests
         var result = await sut.GetRecentTransactions(
             new DateOnly(2025, 1, 1),
             new DateOnly(2025, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
-        result.Should().BeEmpty();
+        result.Transactions.Should().BeEmpty();
         handler
             .Requests.Should()
             .ContainSingle(
@@ -224,10 +224,11 @@ public class HouseDisclosureClientTests
         var result = await sut.GetRecentTransactions(
             new DateOnly(2025, 1, 1),
             new DateOnly(2025, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
-        result.Should().BeEmpty();
+        result.Transactions.Should().BeEmpty();
         handler
             .Requests.Should()
             .ContainSingle(
@@ -237,34 +238,50 @@ public class HouseDisclosureClientTests
     }
 
     [Fact]
-    public void ParsePtrPdf_MalformedPdfBytes_ReturnsEmptyListWithoutThrowing()
+    public async Task GetRecentTransactions_MalformedPtrPdfBytes_SkipsFilingWithoutThrowing()
     {
-        // The per-filing ParsePtrPdf(byte[], HouseFiling) wrapper scopes a bad
-        // PDF (truncated CDN response, corrupt upload) to a single skipped
-        // filing instead of letting PdfDocument.Open's exception abort the
-        // remaining year of filings in GetRecentTransactions.
-        var parsePtrPdfMethod = typeof(HouseDisclosureClient).GetMethod(
-            "ParsePtrPdf",
-            BindingFlags.NonPublic | BindingFlags.Instance
-        );
-        var houseFilingType = typeof(HouseDisclosureClient).GetNestedType(
-            "HouseFiling",
-            BindingFlags.NonPublic
-        );
-        var filing = houseFilingType
-            .GetConstructors()[0]
-            .Invoke(["Jane Doe", "20251234", new DateOnly(2025, 2, 1), "CA01"]);
-        using var httpClient = new HttpClient();
-        var client = new HouseDisclosureClient(
+        // The per-filing catch in GetRecentTransactions scopes a bad PDF
+        // (truncated CDN response, corrupt upload) to a single skipped filing
+        // instead of letting PdfDocument.Open's exception abort the remaining
+        // year of filings.
+        const int year = 2025;
+        const string docId = "20251234";
+        var xml = $"""
+            <FinancialDisclosures>
+              <Member>
+                <Prefix>Hon.</Prefix>
+                <First>Jane</First>
+                <Last>Doe</Last>
+                <FilingType>P</FilingType>
+                <StateDst>CA01</StateDst>
+                <Year>{year}</Year>
+                <FilingDate>2/1/{year}</FilingDate>
+                <DocID>{docId}</DocID>
+              </Member>
+            </FinancialDisclosures>
+            """;
+        var zipBytes = BuildZipWithSingleEntry($"{year}FD.xml", xml);
+        var handler = new UrlRoutingHandler(zipBytes, pdfBytes: [0x00, 0x01, 0x02, 0x03, 0x04]);
+        using var httpClient = new HttpClient(handler);
+        var sut = new HouseDisclosureClient(
             httpClient,
             Substitute.For<ILogger<HouseDisclosureClient>>()
         );
-        var malformedBytes = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
 
-        var result =
-            (List<DisclosureTransaction>)parsePtrPdfMethod.Invoke(client, [malformedBytes, filing]);
+        var result = await sut.GetRecentTransactions(
+            new DateOnly(year, 1, 1),
+            new DateOnly(year, 12, 31),
+            new HashSet<string>(),
+            CancellationToken.None
+        );
 
-        result.Should().BeEmpty();
+        result.Transactions.Should().BeEmpty();
+        handler
+            .Requests.Should()
+            .Contain(
+                r => r.Contains($"ptr-pdfs/{year}/{docId}.pdf"),
+                "the corrupt PDF must have been fetched before its parse failure was scoped"
+            );
     }
 
     [Fact]
@@ -297,10 +314,11 @@ public class HouseDisclosureClientTests
         var result = await sut.GetRecentTransactions(
             new DateOnly(year, 1, 1),
             new DateOnly(year, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
-        result.Should().BeEmpty();
+        result.Transactions.Should().BeEmpty();
         handler
             .Requests.Should()
             .HaveCount(
@@ -370,9 +388,14 @@ public class HouseDisclosureClientTests
     private sealed class UrlRoutingHandler : HttpMessageHandler
     {
         private readonly byte[] _zipBytes;
+        private readonly byte[] _pdfBytes;
         public List<string> Requests { get; } = new();
 
-        public UrlRoutingHandler(byte[] zipBytes) => _zipBytes = zipBytes;
+        public UrlRoutingHandler(byte[] zipBytes, byte[] pdfBytes = null)
+        {
+            _zipBytes = zipBytes;
+            _pdfBytes = pdfBytes;
+        }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -393,7 +416,19 @@ public class HouseDisclosureClientTests
             }
 
             if (url.Contains("/ptr-pdfs/"))
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            {
+                if (_pdfBytes == null)
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+                var pdfResponse = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(_pdfBytes),
+                };
+                pdfResponse.Content.Headers.ContentType = new MediaTypeHeaderValue(
+                    "application/pdf"
+                );
+                return Task.FromResult(pdfResponse);
+            }
 
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
         }

--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientRetryTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientRetryTests.cs
@@ -59,10 +59,11 @@ public class SenateAnnualReportClientRetryTests
         var result = await sut.GetAnnualReports(
             new DateOnly(2025, 1, 1),
             new DateOnly(2025, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
-        result.Should().ContainSingle().Which.MemberName.Should().Be("Jane Doe");
+        result.Reports.Should().ContainSingle().Which.MemberName.Should().Be("Jane Doe");
         await session
             .Received(2)
             .Fetch(

--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientSearchDateCultureTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientSearchDateCultureTests.cs
@@ -41,6 +41,7 @@ public class SenateAnnualReportClientSearchDateCultureTests
             await sut.GetAnnualReports(
                 new DateOnly(2025, 1, 1),
                 new DateOnly(2025, 12, 31),
+                new HashSet<string>(),
                 CancellationToken.None
             );
 

--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientTests.cs
@@ -123,7 +123,7 @@ public class SenateAnnualReportClientTests
             .Be(
                 "https://efdsearch.senate.gov/search/view/annual/8c41ca4c-ccda-483e-99ed-d7f27f8a5c8f/"
             );
-        SenateAnnualReportClient
+        DisclosureParsingHelper
             .ExtractReportId(filing.ReportUrl)
             .Should()
             .Be("8c41ca4c-ccda-483e-99ed-d7f27f8a5c8f");
@@ -201,10 +201,11 @@ public class SenateAnnualReportClientTests
         var result = await sut.GetAnnualReports(
             new DateOnly(2025, 1, 1),
             new DateOnly(2025, 12, 31),
+            new HashSet<string>(),
             CancellationToken.None
         );
 
-        var report = result.Should().ContainSingle().Subject;
+        var report = result.Reports.Should().ContainSingle().Subject;
         report.MemberName.Should().Be("Jane Doe");
         report.Position.Should().Be(CongressPosition.Senator);
         report.Year.Should().Be(2024);

--- a/tests/Equibles.UnitTests/Congress/SenateDisclosureClientFetchTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateDisclosureClientFetchTests.cs
@@ -73,6 +73,7 @@ public class SenateDisclosureClientFetchTests
             .GetRecentTransactions(
                 new DateOnly(2024, 1, 1),
                 new DateOnly(2024, 1, 31),
+                new HashSet<string>(),
                 CancellationToken.None
             );
 
@@ -107,6 +108,7 @@ public class SenateDisclosureClientFetchTests
             .GetRecentTransactions(
                 new DateOnly(2024, 1, 1),
                 new DateOnly(2024, 1, 31),
+                new HashSet<string>(),
                 CancellationToken.None
             );
 
@@ -127,6 +129,7 @@ public class SenateDisclosureClientFetchTests
             .GetRecentTransactions(
                 new DateOnly(2024, 1, 1),
                 new DateOnly(2024, 1, 31),
+                new HashSet<string>(),
                 CancellationToken.None
             );
 
@@ -151,6 +154,7 @@ public class SenateDisclosureClientFetchTests
             .GetRecentTransactions(
                 new DateOnly(2024, 1, 1),
                 new DateOnly(2024, 1, 31),
+                new HashSet<string>(),
                 CancellationToken.None
             );
 
@@ -170,6 +174,7 @@ public class SenateDisclosureClientFetchTests
                 .GetRecentTransactions(
                     new DateOnly(2024, 1, 1),
                     new DateOnly(2024, 1, 31),
+                    new HashSet<string>(),
                     CancellationToken.None
                 );
 
@@ -206,6 +211,7 @@ public class SenateDisclosureClientFetchTests
                 .GetRecentTransactions(
                     new DateOnly(2024, 1, 1),
                     new DateOnly(2024, 1, 31),
+                    new HashSet<string>(),
                     CancellationToken.None
                 );
 
@@ -227,10 +233,13 @@ public class SenateDisclosureClientFetchTests
             .GetRecentTransactions(
                 new DateOnly(2024, 1, 1),
                 new DateOnly(2024, 1, 31),
+                new HashSet<string>(),
                 CancellationToken.None
             );
 
-        result.Should().BeEmpty("the only report failed to fetch, but the run completed");
+        result
+            .Transactions.Should()
+            .BeEmpty("the only report failed to fetch, but the run completed");
         session.FetchedUrls.Should().Contain(ReportUrl);
     }
 
@@ -249,6 +258,7 @@ public class SenateDisclosureClientFetchTests
                 .GetRecentTransactions(
                     new DateOnly(2024, 1, 1),
                     new DateOnly(2024, 1, 31),
+                    new HashSet<string>(),
                     CancellationToken.None
                 );
 


### PR DESCRIPTION
## Summary

The congressional scrapers re-fetched every filing in their sync window on every cycle — dedup only happened at the DB upsert *after* download. With a 2020 backfill floor configured, that meant ~6,800 House PDFs re-downloaded per cycle (and every Senate eFD report re-fetched through the browser), multiplied by every worker restart since cycles keep no checkpoint. Production was pushing ~167k GETs/day at disclosures-clerk.house.gov for essentially zero new data.

This adds a persistent ingested-filing ledger so each filing is downloaded once, ever — cutting steady-state traffic to the yearly index ZIPs / search pages plus genuinely new filings (~99.5% reduction).

## Code changes

- **Equibles.Congress.Data**: new `CongressionalFilingRecord` entity (unique index on `Kind` + `SourceId`) + `CongressionalFilingKind` enum (House PTR / House annual / Senate PTR / Senate annual); registered in the module configuration.
- **Equibles.Congress.Repositories**: `CongressionalFilingRecordRepository` with `GetByKind`.
- **Equibles.Congress.HostedService**:
  - `CongressionalFilingLedger` loads ingested source-ids per lane and records new ones (FlexLabs upsert, batch-deduped, ON CONFLICT no-op).
  - All four clients take an `IReadOnlySet<string>` of ingested ids, skip those filings, and return which filings they fully handled (`ProcessedFiling`) alongside the parsed data.
  - Both sync services record handled filings **only after** the cycle's data is committed.
- **Equibles.Migrations**: `AddCongressionalFilingRecord`.
- **Tests**: existing Congress suites updated to the new signatures; new coverage pins the ledger contract (skip ingested DocIDs, record parsed-but-empty filings, never record 404/unreadable PDFs) and the retirement filter rules.

## No data can be lost

- A filing is recorded only after parse success **and** the cycle's DB commit — a failed persist throws before recording, so everything re-fetches next cycle.
- 404s, unreadable PDFs, and unrecognized Senate layouts are never recorded → they retry until they succeed.
- Deterministic policy skips (scanned paper filings, candidate reports) are recorded with `ItemCount = 0` — same outcome as today, minus the re-downloads.
- A filing containing a ticker not (yet) in `CommonStock` keeps retrying for 30 days (covers IPO listing lag) before being retired as a genuinely untracked asset.
- Amendments carry their own DocID / report GUID, so the amendment-replace flow still sees and applies them.
- Deleting ledger rows force-reingests the matching filings (operator escape hatch).

First cycle after deploy performs one last full sweep (empty ledger) and then goes quiet.

## Verification

- `dotnet build Equibles.sln -c Release`: clean; `dotnet csharpier check .`: clean.
- Unit suite: 3,664 passed. Congress integration tests (incl. ParadeDB-backed): 92 passed.