### PR TITLE
fix(government-contracts): round the amount cursor's upper bound up to a whole dollar

### DIFF
--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -163,16 +163,24 @@ public class UsaSpendingClient : IUsaSpendingClient
             }
 
             // Sorted by amount descending, so the last row carries the smallest
-            // amount fetched so far — the cursor's next inclusive upper bound.
+            // amount fetched so far. The API's award_amounts validator only accepts
+            // whole-dollar values — any fractional bound is a 422 ("'x.51' is not a
+            // valid type (dictionary)") — so the cursor's next inclusive upper bound
+            // is the floor rounded UP to a whole dollar: everything between the floor
+            // and its ceiling is re-covered by the next band and deduplicated, so
+            // nothing is lost. The reset requires the CEILED value to strictly
+            // decrease — a run of awards within the same dollar rides the tie-run
+            // continuation below instead of looping on an unchanged bound.
             var floor = response.Results[^1].Amount;
+            var nextUpperBound = floor.HasValue ? decimal.Ceiling(floor.Value) : (decimal?)null;
 
             if (
                 page >= MaxPagesPerBand
-                && floor.HasValue
-                && floor.Value < (upperBound ?? decimal.MaxValue)
+                && nextUpperBound.HasValue
+                && nextUpperBound.Value < (upperBound ?? decimal.MaxValue)
             )
             {
-                upperBound = floor.Value;
+                upperBound = nextUpperBound.Value;
                 page = 0; // restart the band shallow; the for-loop increments to 1
                 continue;
             }

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientAmountCursorTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientAmountCursorTests.cs
@@ -138,6 +138,46 @@ public class UsaSpendingClientAmountCursorTests
             );
     }
 
+    [Fact]
+    public async Task GetContractAwards_CentValuedAmounts_SendsWholeDollarBoundsAndLosesNothing()
+    {
+        // Real award amounts carry cents (the first production cycle died on
+        // upper_bound=532543287.51 — the API 422s any fractional bound). The cursor
+        // must round its bound UP to a whole dollar; the inclusive band then
+        // re-covers everything between the true floor and the ceiling, deduplicated
+        // by id, so completeness still holds.
+        var awards = Enumerable
+            .Range(0, 130)
+            .Select(i => new FakeAward($"CENTS_{i}", 1_000_000m + (130 - i) * 997.13m))
+            .ToList();
+        var handler = new BandAwareHandler(awards, pageSize: 5);
+        var sut = new UsaSpendingClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<UsaSpendingClient>>()
+        );
+
+        var result = await sut.GetContractAwards(
+            new DateOnly(2022, 1, 2),
+            new DateOnly(2022, 1, 8),
+            minimumAmount: 1_000_000m
+        );
+
+        result
+            .Select(r => r.GeneratedInternalId)
+            .Should()
+            .BeEquivalentTo(
+                awards.Select(a => a.Id),
+                "rounding the bound up must widen the band, never narrow it — no award may be lost"
+            );
+        handler
+            .UpperBoundsSeen.Should()
+            .OnlyContain(
+                u => decimal.Ceiling(u) == u,
+                "the API rejects fractional amount bounds with a 422"
+            );
+        handler.MaxPageRequested.Should().BeLessThanOrEqualTo(MaxPagesPerBand);
+    }
+
     private sealed record FakeAward(string Id, decimal Amount);
 
     /// <summary>
@@ -172,7 +212,25 @@ public class UsaSpendingClientAmountCursorTests
 
             MaxPageRequested = Math.Max(MaxPageRequested, page);
             if (upper.HasValue)
+            {
                 UpperBoundsSeen.Add(upper.Value);
+                // The real API's award_amounts validator only accepts whole-dollar
+                // values; a fractional bound is a 422. Mirror that so the cursor can
+                // never regress to sending cents (the bug that froze the first
+                // production cycle of the cursor rollout).
+                if (decimal.Ceiling(upper.Value) != upper.Value)
+                {
+                    return Task.FromResult(
+                        new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
+                        {
+                            Content = new StringContent(
+                                $"{{\"detail\": \"Invalid value in 'filters|award_amounts'. "
+                                    + $"'{upper.Value}' is not a valid type (dictionary).\"}}"
+                            ),
+                        }
+                    );
+                }
+            }
 
             var band = _sorted
                 .Where(a => a.Amount >= lower && (!upper.HasValue || a.Amount <= upper.Value))


### PR DESCRIPTION
## Summary

The amount cursor shipped in #4205 died on its first production cycle: USAspending's `award_amounts` validator only accepts whole-dollar values, and the cursor's tightened upper bound carries the cents of a real award amount (`upper_bound=532543287.51` → 422 "'532543287.51' is not a valid type (dictionary)"). Verified against the live API: `x` and `x.0` pass, `x.5`/`x.51` fail, for both bounds.

The cursor now rounds its upper bound UP to a whole dollar. The inclusive band re-covers everything between the true floor and the ceiling and dedupe by award id drops the overlap, so completeness holds. The band reset requires the ceiled bound to strictly decrease — a run of awards within one dollar rides the existing tie-run continuation instead of looping on an unchanged bound.

## Code changes

- `UsaSpendingClient.FetchWindow` — `decimal.Ceiling` on the cursor bound + strict-decrease guard on the ceiled value.
- `UsaSpendingClientAmountCursorTests` — the band-aware fake now 422s fractional bounds exactly like the real API (so every cursor test enforces the contract), plus a cent-valued dataset test asserting whole-dollar bounds and zero loss.

All 3,663 unit tests pass.