### PR TITLE
fix(financial-facts): rank total-net-revenue above the contract tags in the revenue family

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -38,6 +38,15 @@ public static class FinancialConceptAliases
         ["revenue"] =
         [
             G("Revenues"),
+            // Financial-sector headline top line ("Total net revenue"): banks and
+            // fintechs report interest income OUTSIDE the ASC 606 contract tags,
+            // so for a filer without Revenues the contract tag is only the FEE
+            // slice (SoFi FY2025: contract revenue $0.62B vs total net revenue
+            // $3.61B — the chart understated revenue ~6x). Placed after Revenues
+            // (filers tagging both keep their current series) and before the
+            // contract tags (fee revenue must never outrank the headline).
+            // Nonfinancial filers never tag it, so they are unaffected.
+            G("RevenuesNetOfInterestExpense"),
             G("RevenueFromContractWithCustomerExcludingAssessedTax"),
             // Some filers (REITs like ARE) tag their total-revenue line with the
             // assessed-tax-inclusive ASC 606 variant and never file the excluding


### PR DESCRIPTION
## Summary

For banks and fintechs the ASC-606 contract tags carry only the fee slice of revenue — interest income lives outside them — so a filer without `Revenues` charted its fee revenue as the top line. Verified on SoFi's FY2025 10-K: `RevenueFromContractWithCustomerExcludingAssessedTax` = $0.62B was shown as Revenue while the filer's headline "Total net revenue" (`RevenuesNetOfInterestExpense`) = $3.61B — a ~6x understatement.

## Code changes

- `FinancialConceptAliases`: insert `RevenuesNetOfInterestExpense` into the `revenue` family, after `Revenues` (filers tagging both keep their current series) and before the contract tags (fee revenue can never outrank the headline). Nonfinancial filers never tag it — unaffected.

Unit suite green locally; the downstream consumer's ordered-union contract test was updated in its own repo alongside the pin bump.