### PR TITLE
feat(sec-mcp): add searchMode to SearchDocument — semantic (default) or exact

### DIFF
--- a/src/Equibles.Sec.Mcp/Equibles.Sec.Mcp.csproj
+++ b/src/Equibles.Sec.Mcp/Equibles.Sec.Mcp.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <InternalsVisibleTo Include="Equibles.UnitTests" />
+    <InternalsVisibleTo Include="Equibles.IntegrationTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="ModelContextProtocol" />
   </ItemGroup>
 

--- a/src/Equibles.Sec.Mcp/Tools/DocumentKeywordScan.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentKeywordScan.cs
@@ -1,0 +1,164 @@
+using System.Text;
+using Equibles.Mcp.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+
+namespace Equibles.Sec.Mcp.Tools;
+
+// The exact-match scan shared by SearchDocumentKeyword and SearchDocument's searchMode="exact":
+// loads the document text, matches the keyword as a typography-folded case-insensitive substring
+// per line, and renders each match with one line of context, grep-style. One implementation so the
+// two tools can never drift on folding, counting, or rendering.
+internal static class DocumentKeywordScan
+{
+    internal static async Task<string> Run(
+        DocumentRepository documentRepository,
+        IFileManager fileManager,
+        Guid documentId,
+        string keyword,
+        int maxResults
+    )
+    {
+        var (document, lines, error) = await LoadDocumentLines(
+            documentRepository,
+            fileManager,
+            documentId
+        );
+        if (error != null)
+            return error;
+
+        maxResults = McpLimit.Clamp(maxResults);
+
+        // Fold typography on BOTH sides: filings store smart punctuation (U+2019
+        // apostrophes, curly quotes) while callers type ASCII, so an unfolded
+        // ordinal Contains reports false negatives for text the document contains.
+        var foldedKeyword = TypographyFold.Fold(keyword);
+        var allMatches = Enumerable
+            .Range(0, lines.Length)
+            .Where(i =>
+                TypographyFold
+                    .Fold(lines[i])
+                    .Contains(foldedKeyword, StringComparison.OrdinalIgnoreCase)
+            )
+            .ToList();
+
+        if (allMatches.Count == 0)
+        {
+            return $"No matches found for \"{keyword}\" in {DocumentTextFormat.Header(document)}.";
+        }
+
+        // Count BEFORE truncating: presenting the capped count as the total makes
+        // the caller state "the filing mentions X exactly N times" and stop early.
+        var matches = allMatches.Take(maxResults).ToList();
+
+        var result = new StringBuilder();
+        result.AppendLine(
+            $"Keyword search for \"{keyword}\" in {DocumentTextFormat.Header(document)} — {McpFormat.WholeNumber(allMatches.Count)} matching line(s):"
+        );
+        result.AppendLine();
+
+        AppendMatchBlocks(result, lines, matches, keyword);
+
+        result.AppendLine(McpOutput.TruncationNote(matches.Count, allMatches.Count));
+
+        return result.ToString();
+    }
+
+    internal static async Task<(Document Document, string[] Lines, string Error)> LoadDocumentLines(
+        DocumentRepository documentRepository,
+        IFileManager fileManager,
+        Guid documentId
+    )
+    {
+        var document = await documentRepository.GetWithContent(documentId);
+        if (document == null)
+            return (null, null, $"Document {documentId} not found.");
+        if (document.Content == null)
+            return (null, null, $"Document {documentId} has no content.");
+
+        var bytes = await fileManager.GetContent(document.Content);
+        if (bytes == null)
+            return (null, null, $"Document {documentId} has no content.");
+
+        var text = Encoding.UTF8.GetString(bytes);
+        return (document, text.Split('\n'), null);
+    }
+
+    // Renders each match with one line of context on each side, merging overlapping and
+    // adjacent blocks grep-style so a document line never prints twice; a blank line
+    // separates non-contiguous blocks.
+    private static void AppendMatchBlocks(
+        StringBuilder result,
+        string[] lines,
+        List<int> matches,
+        string keyword
+    )
+    {
+        var matchSet = matches.ToHashSet();
+        var linesToPrint = new SortedSet<int>();
+        foreach (var lineIndex in matches)
+        {
+            if (lineIndex > 0)
+                linesToPrint.Add(lineIndex - 1);
+            linesToPrint.Add(lineIndex);
+            if (lineIndex < lines.Length - 1)
+                linesToPrint.Add(lineIndex + 1);
+        }
+
+        int? previous = null;
+        foreach (var lineIndex in linesToPrint)
+        {
+            if (previous.HasValue && lineIndex > previous.Value + 1)
+                result.AppendLine();
+
+            var content = matchSet.Contains(lineIndex)
+                ? HighlightKeyword(lines[lineIndex], keyword)
+                : lines[lineIndex];
+            result.AppendLine(DocumentTextFormat.Line(lineIndex + 1, content));
+            previous = lineIndex;
+        }
+
+        result.AppendLine();
+    }
+
+    private static string HighlightKeyword(string line, string keyword)
+    {
+        // An empty keyword makes IndexOf return the start position every
+        // iteration, so index never advances and the loop runs unbounded
+        // (DoS — keyword reaches here unvalidated from the MCP tool).
+        if (string.IsNullOrEmpty(keyword))
+            return line;
+
+        // Match on the folded pair so typography-folded matches still bold; the fold is
+        // one-to-one per char, so folded indices address the same span in the original
+        // line, which is what gets emitted.
+        var foldedLine = TypographyFold.Fold(line);
+        var foldedKeyword = TypographyFold.Fold(keyword);
+
+        var result = new StringBuilder();
+        var index = 0;
+
+        while (index < line.Length)
+        {
+            var matchIndex = foldedLine.IndexOf(
+                foldedKeyword,
+                index,
+                StringComparison.OrdinalIgnoreCase
+            );
+            if (matchIndex < 0)
+            {
+                result.Append(line, index, line.Length - index);
+                break;
+            }
+
+            result.Append(line, index, matchIndex - index);
+            result.Append("**");
+            result.Append(line, matchIndex, foldedKeyword.Length);
+            result.Append("**");
+            index = matchIndex + foldedKeyword.Length;
+        }
+
+        return result.ToString();
+    }
+}

--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextFormat.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextFormat.cs
@@ -1,0 +1,17 @@
+using Equibles.Mcp.Helpers;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Mcp.Tools;
+
+// Line and document-header rendering shared by the document text tools (ReadDocumentLines,
+// SearchDocumentKeyword) and the keyword scan SearchDocument's exact mode reuses.
+internal static class DocumentTextFormat
+{
+    internal static string Line(int lineNumber, string content)
+    {
+        return $"{lineNumber, 6} │ {content}";
+    }
+
+    internal static string Header(Document document) =>
+        $"{document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {McpFormat.Invariant(document.ReportingDate, "yyyy-MM-dd")}";
+}

--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -1,13 +1,10 @@
 using System.ComponentModel;
 using System.Text;
-using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
-using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Mcp.Helpers;
 using Equibles.Media.BusinessLogic;
-using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -49,89 +46,18 @@ public class DocumentTextTools
     )
     {
         return _runner.Execute(
-            async () =>
-            {
-                var (document, lines, error) = await LoadDocumentLines(documentId);
-                if (error != null)
-                    return error;
-
-                maxResults = McpLimit.Clamp(maxResults);
-
-                // Fold typography on BOTH sides: filings store smart punctuation (U+2019
-                // apostrophes, curly quotes) while callers type ASCII, so an unfolded
-                // ordinal Contains reports false negatives for text the document contains.
-                var foldedKeyword = TypographyFold.Fold(keyword);
-                var allMatches = Enumerable
-                    .Range(0, lines.Length)
-                    .Where(i =>
-                        TypographyFold
-                            .Fold(lines[i])
-                            .Contains(foldedKeyword, StringComparison.OrdinalIgnoreCase)
-                    )
-                    .ToList();
-
-                if (allMatches.Count == 0)
-                {
-                    return $"No matches found for \"{keyword}\" in {FormatDocumentHeader(document)}.";
-                }
-
-                // Count BEFORE truncating: presenting the capped count as the total makes
-                // the caller state "the filing mentions X exactly N times" and stop early.
-                var matches = allMatches.Take(maxResults).ToList();
-
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Keyword search for \"{keyword}\" in {FormatDocumentHeader(document)} — {McpFormat.WholeNumber(allMatches.Count)} matching line(s):"
-                );
-                result.AppendLine();
-
-                AppendMatchBlocks(result, lines, matches, keyword);
-
-                result.AppendLine(McpOutput.TruncationNote(matches.Count, allMatches.Count));
-
-                return result.ToString();
-            },
+            () =>
+                DocumentKeywordScan.Run(
+                    _documentRepository,
+                    _fileManager,
+                    documentId,
+                    keyword,
+                    maxResults
+                ),
             "SearchDocumentKeyword",
             $"documentId: {documentId}, keyword: {keyword}",
             "An error occurred while searching the document. Please try again."
         );
-    }
-
-    // Renders each match with one line of context on each side, merging overlapping and
-    // adjacent blocks grep-style so a document line never prints twice; a blank line
-    // separates non-contiguous blocks.
-    private static void AppendMatchBlocks(
-        StringBuilder result,
-        string[] lines,
-        List<int> matches,
-        string keyword
-    )
-    {
-        var matchSet = matches.ToHashSet();
-        var linesToPrint = new SortedSet<int>();
-        foreach (var lineIndex in matches)
-        {
-            if (lineIndex > 0)
-                linesToPrint.Add(lineIndex - 1);
-            linesToPrint.Add(lineIndex);
-            if (lineIndex < lines.Length - 1)
-                linesToPrint.Add(lineIndex + 1);
-        }
-
-        int? previous = null;
-        foreach (var lineIndex in linesToPrint)
-        {
-            if (previous.HasValue && lineIndex > previous.Value + 1)
-                result.AppendLine();
-
-            var content = matchSet.Contains(lineIndex)
-                ? HighlightKeyword(lines[lineIndex], keyword)
-                : lines[lineIndex];
-            result.AppendLine(FormatLine(lineIndex + 1, content));
-            previous = lineIndex;
-        }
-
-        result.AppendLine();
     }
 
     // Ceiling on the number of lines a single call returns: prod documents reach 500k+
@@ -156,7 +82,11 @@ public class DocumentTextTools
         return _runner.Execute(
             async () =>
             {
-                var (document, lines, error) = await LoadDocumentLines(documentId);
+                var (document, lines, error) = await DocumentKeywordScan.LoadDocumentLines(
+                    _documentRepository,
+                    _fileManager,
+                    documentId
+                );
                 if (error != null)
                     return error;
 
@@ -191,13 +121,13 @@ public class DocumentTextTools
 
                 var result = new StringBuilder();
                 result.AppendLine(
-                    $"{FormatDocumentHeader(document)} — lines {McpFormat.WholeNumber(startLine)} to {McpFormat.WholeNumber(endLine)} of {McpFormat.WholeNumber(totalLines)}:"
+                    $"{DocumentTextFormat.Header(document)} — lines {McpFormat.WholeNumber(startLine)} to {McpFormat.WholeNumber(endLine)} of {McpFormat.WholeNumber(totalLines)}:"
                 );
                 result.AppendLine();
 
                 for (var i = startLine - 1; i < endLine; i++)
                 {
-                    result.AppendLine(FormatLine(i + 1, lines[i]));
+                    result.AppendLine(DocumentTextFormat.Line(i + 1, lines[i]));
                 }
 
                 if (truncated)
@@ -214,71 +144,5 @@ public class DocumentTextTools
             $"documentId: {documentId}, lines: {startLine}-{endLine}",
             "An error occurred while reading document lines. Please try again."
         );
-    }
-
-    private async Task<(Document Document, string[] Lines, string Error)> LoadDocumentLines(
-        Guid documentId
-    )
-    {
-        var document = await _documentRepository.GetWithContent(documentId);
-        if (document == null)
-            return (null, null, $"Document {documentId} not found.");
-        if (document.Content == null)
-            return (null, null, $"Document {documentId} has no content.");
-
-        var bytes = await _fileManager.GetContent(document.Content);
-        if (bytes == null)
-            return (null, null, $"Document {documentId} has no content.");
-
-        var text = Encoding.UTF8.GetString(bytes);
-        return (document, text.Split('\n'), null);
-    }
-
-    private static string FormatLine(int lineNumber, string content)
-    {
-        return $"{lineNumber, 6} │ {content}";
-    }
-
-    private static string FormatDocumentHeader(Document document) =>
-        $"{document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {McpFormat.Invariant(document.ReportingDate, "yyyy-MM-dd")}";
-
-    private static string HighlightKeyword(string line, string keyword)
-    {
-        // An empty keyword makes IndexOf return the start position every
-        // iteration, so index never advances and the loop runs unbounded
-        // (DoS — keyword reaches here unvalidated from the MCP tool).
-        if (string.IsNullOrEmpty(keyword))
-            return line;
-
-        // Match on the folded pair so typography-folded matches still bold; the fold is
-        // one-to-one per char, so folded indices address the same span in the original
-        // line, which is what gets emitted.
-        var foldedLine = TypographyFold.Fold(line);
-        var foldedKeyword = TypographyFold.Fold(keyword);
-
-        var result = new StringBuilder();
-        var index = 0;
-
-        while (index < line.Length)
-        {
-            var matchIndex = foldedLine.IndexOf(
-                foldedKeyword,
-                index,
-                StringComparison.OrdinalIgnoreCase
-            );
-            if (matchIndex < 0)
-            {
-                result.Append(line, index, line.Length - index);
-                break;
-            }
-
-            result.Append(line, index, matchIndex - index);
-            result.Append("**");
-            result.Append(line, matchIndex, foldedKeyword.Length);
-            result.Append("**");
-            index = matchIndex + foldedKeyword.Length;
-        }
-
-        return result.ToString();
     }
 }

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -6,6 +6,7 @@ using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Mcp.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.BusinessLogic.Search;
 using Equibles.Sec.BusinessLogic.Search.Models;
 using Equibles.Sec.Data.Models;
@@ -39,6 +40,7 @@ public class RagSearchTools
     private readonly ISecDocumentService _secDocumentService;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly DocumentRepository _documentRepository;
+    private readonly IFileManager _fileManager;
     private readonly McpToolRunner _runner;
 
     public RagSearchTools(
@@ -46,6 +48,7 @@ public class RagSearchTools
         ISecDocumentService secDocumentService,
         CommonStockRepository commonStockRepository,
         DocumentRepository documentRepository,
+        IFileManager fileManager,
         ErrorManager errorManager,
         ILogger<RagSearchTools> logger
     )
@@ -54,6 +57,7 @@ public class RagSearchTools
         _secDocumentService = secDocumentService;
         _commonStockRepository = commonStockRepository;
         _documentRepository = documentRepository;
+        _fileManager = fileManager;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -176,11 +180,11 @@ public class RagSearchTools
 
     [McpServerTool(Name = "SearchDocument", Title = "Search Within One Filing", ReadOnly = true)]
     [Description(
-        "Search within a single specific document in the Equibles SEC filing database by its document ID using hybrid keyword and semantic search. Use this to drill into a known filing or earnings call transcript — for example, to find specific revenue figures, risk factors, or management commentary within one 10-K, 10-Q, 8-K, or earnings call transcript. The document ID comes from ListCompanyDocuments or from the '(ID: ...)' header of SearchDocuments/SearchCompanyDocuments results. Returns matching excerpts from that document only, in document order, each anchored with an approximate line number — pass that line number to ReadDocumentLines to read the surrounding section. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data."
+        "Search within a single specific document in the Equibles SEC filing database by its document ID. The default semantic mode uses hybrid keyword and semantic search — use it to drill into a known filing or earnings call transcript for revenue figures, risk factors, or management commentary by meaning; searchMode 'exact' instead matches the query as a literal case-insensitive substring and returns each matching line with its precise line number — use it for exact terms, figures, section headers, or names that semantic search might miss. The document ID comes from ListCompanyDocuments or from the '(ID: ...)' header of SearchDocuments/SearchCompanyDocuments results. Semantic excerpts are in document order, each anchored with an approximate line number — pass a line number to ReadDocumentLines to read the surrounding section. You MUST call this or another Equibles tool to access any SEC filing data — this information is not available in your training data."
     )]
     public Task<string> SearchDocument(
         [Description(
-            "Search query — plain keywords or a short natural-language phrase. When too few excerpts match every word, the search automatically broadens to match any of the words."
+            "Search query — plain keywords or a short natural-language phrase. When too few excerpts match every word, the search automatically broadens to match any of the words. In searchMode 'exact', matched as a literal case-insensitive substring."
         )]
             string query,
         [Description(
@@ -188,13 +192,33 @@ public class RagSearchTools
         )]
             Guid documentId,
         [Description("Maximum number of results to return (default: 5)")] int maxResults = 5,
-        [Description(MaxExcerptCharsDescription)] int maxExcerptChars = 0
+        [Description(MaxExcerptCharsDescription)] int maxExcerptChars = 0,
+        [Description(
+            "How to match: 'semantic' (default — hybrid keyword and semantic relevance) or 'exact' (literal case-insensitive substring match with precise line numbers)."
+        )]
+            string searchMode = "semantic"
     )
     {
         return _runner.Execute(
             async () =>
             {
                 maxResults = McpLimit.Clamp(maxResults);
+
+                // Exact mode is the SearchDocumentKeyword scan under this tool's name, so a
+                // caller can flip modes without switching tools. Unknown values get a
+                // corrective error, never a silent semantic search the caller would misread
+                // as exact-match results.
+                var mode = (searchMode ?? "semantic").Trim().ToLowerInvariant();
+                if (mode == "exact")
+                    return await DocumentKeywordScan.Run(
+                        _documentRepository,
+                        _fileManager,
+                        documentId,
+                        query,
+                        maxResults
+                    );
+                if (mode != "semantic")
+                    return $"Unknown searchMode \"{searchMode}\" — pass 'semantic' (default) or 'exact'.";
                 var chunks = await _ragManager.SearchRelevantChunksByDocument(
                     query,
                     documentId,
@@ -210,7 +234,7 @@ public class RagSearchTools
                     if (document == null)
                         return $"Document {documentId} not found — obtain a valid document ID from ListCompanyDocuments.";
 
-                    return $"No matching excerpts found in this document ({document.DocumentType} filed {McpFormat.Invariant(document.ReportingDate, "yyyy-MM-dd")}). Try SearchDocumentKeyword for exact-term matches.";
+                    return $"No matching excerpts found in this document ({document.DocumentType} filed {McpFormat.Invariant(document.ReportingDate, "yyyy-MM-dd")}). Try searchMode 'exact' for literal-term matches.";
                 }
 
                 var context = await _ragManager.BuildContext(
@@ -222,7 +246,7 @@ public class RagSearchTools
                     + $"_{chunks.Count} excerpt(s) returned (maxResults {maxResults}); excerpts are in document order — pass an excerpt's line number to ReadDocumentLines for surrounding context._";
             },
             "SearchDocument",
-            $"documentId: {documentId}, query: {query}"
+            $"documentId: {documentId}, query: {query}, searchMode: {searchMode}"
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsListCompanyDocumentsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsListCompanyDocumentsCultureInvarianceTests.cs
@@ -2,11 +2,13 @@ using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.BusinessLogic.Search;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
 using Equibles.Sec.Repositories;
+using NSubstitute;
 using Xunit;
 using File = Equibles.Media.Data.Models.File;
 
@@ -34,6 +36,7 @@ public class RagSearchToolsListCompanyDocumentsCultureInvarianceTests : ParadeDb
             secDocumentService,
             new CommonStockRepository(DbContext),
             new DocumentRepository(DbContext),
+            Substitute.For<IFileManager>(),
             ErrorManager,
             NullLogger<RagSearchTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.BusinessLogic.Search;
 using Equibles.Sec.Data.Models;
@@ -9,6 +10,7 @@ using Equibles.Sec.Data.Models.Chunks;
 using Equibles.Sec.Mcp.Tools;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Xunit;
 using File = Equibles.Media.Data.Models.File;
 
@@ -43,11 +45,16 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
             new DocumentRepository(DbContext),
             NullLogger<SecDocumentService>()
         );
+        // Exact mode reads the document text through IFileManager; serve the seeded
+        // FileContent bytes so searchMode "exact" scans the same content the DB holds.
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.GetContent(Arg.Any<File>()).Returns(ci => ((File)ci[0]).FileContent.Bytes);
         return new RagSearchTools(
             ragManager,
             secDocumentService,
             new CommonStockRepository(DbContext),
             new DocumentRepository(DbContext),
+            fileManager,
             ErrorManager,
             NullLogger<RagSearchTools>()
         );
@@ -399,6 +406,60 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
         var result = await Sut().SearchDocument("data center revenue growth drivers", document.Id);
 
         result.Should().Contain("Data Center computing grew");
+    }
+
+    [Fact]
+    public async Task SearchDocument_ExactMode_ReturnsLinePreciseKeywordMatches()
+    {
+        // Exact mode must run the SearchDocumentKeyword scan over the document TEXT (via
+        // IFileManager), not the chunk index — precise line numbers, literal substring.
+        var (_, document, _) = await SeedDocumentWithChunks(
+            chunkContents: new[] { "irrelevant chunk" }
+        );
+        document.Content.FileContent.Bytes = Encoding.UTF8.GetBytes(
+            "First line of the filing.\nTotal revenue was $6.62 billion.\nClosing remarks."
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().SearchDocument("Total revenue", document.Id, searchMode: "exact");
+
+        result.Should().Contain("Keyword search for \"Total revenue\"");
+        result.Should().Contain("1 matching line(s)");
+        // The scan's line format: width-6 right-aligned number + box-drawing bar.
+        result.Should().Contain("     2 │ **Total revenue** was $6.62 billion.");
+    }
+
+    [Fact]
+    public async Task SearchDocument_ExactModeNoMatches_ReturnsKeywordNoMatchMessage()
+    {
+        var (_, document, _) = await SeedDocumentWithChunks(
+            chunkContents: new[] { "Consumer electronics revenue." }
+        );
+        document.Content.FileContent.Bytes = Encoding.UTF8.GetBytes("Nothing relevant here.");
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .SearchDocument("Digital Media ARR", document.Id, searchMode: "exact");
+
+        // The exact-mode empty outcome is the keyword scan's message, not the semantic
+        // "no matching excerpts" one — the caller can tell which mode actually ran.
+        result.Should().StartWith("No matches found for \"Digital Media ARR\"");
+    }
+
+    [Fact]
+    public async Task SearchDocument_UnknownSearchMode_ReturnsCorrectiveError()
+    {
+        var (_, document, _) = await SeedDocumentWithChunks(
+            chunkContents: new[] { "Some content." }
+        );
+
+        var result = await Sut().SearchDocument("anything", document.Id, searchMode: "fuzzy");
+
+        // An unknown mode must never silently fall back to semantic search — the caller
+        // would misread relevance-ranked excerpts as exact-match results.
+        result
+            .Should()
+            .Be("Unknown searchMode \"fuzzy\" — pass 'semantic' (default) or 'exact'.");
     }
 
     // ── ListCompanyDocuments ────────────────────────────────────────────

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsEmptyKeywordTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsEmptyKeywordTests.cs
@@ -5,10 +5,11 @@ namespace Equibles.UnitTests.Sec;
 
 public class DocumentTextToolsEmptyKeywordTests
 {
-    private static readonly MethodInfo HighlightKeywordMethod = typeof(DocumentTextTools).GetMethod(
-        "HighlightKeyword",
-        BindingFlags.NonPublic | BindingFlags.Static
-    );
+    private static readonly MethodInfo HighlightKeywordMethod =
+        typeof(DocumentKeywordScan).GetMethod(
+            "HighlightKeyword",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
 
     // Contract: HighlightKeyword wraps every occurrence of `keyword` in a line.
     // An empty keyword has no meaningful occurrence, so the only safe behaviour

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderCalendarTests.cs
@@ -25,8 +25,8 @@ public class DocumentTextToolsFormatDocumentHeaderCalendarTests
             ReportingDate = new DateOnly(2026, 5, 27),
         };
 
-        var method = typeof(DocumentTextTools).GetMethod(
-            "FormatDocumentHeader",
+        var method = typeof(DocumentTextFormat).GetMethod(
+            "Header",
             BindingFlags.NonPublic | BindingFlags.Static
         );
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderTests.cs
@@ -40,8 +40,8 @@ public class DocumentTextToolsFormatDocumentHeaderTests
             ReportingDate = new DateOnly(2026, 5, 27),
         };
 
-        var method = typeof(DocumentTextTools).GetMethod(
-            "FormatDocumentHeader",
+        var method = typeof(DocumentTextFormat).GetMethod(
+            "Header",
             BindingFlags.NonPublic | BindingFlags.Static
         );
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatLineTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatLineTests.cs
@@ -49,8 +49,8 @@ public class DocumentTextToolsFormatLineTests
     [Fact]
     public void FormatLine_SmallLineNumber_RightAlignsToWidthSixWithBoxSeparator()
     {
-        var method = typeof(DocumentTextTools).GetMethod(
-            "FormatLine",
+        var method = typeof(DocumentTextFormat).GetMethod(
+            "Line",
             BindingFlags.NonPublic | BindingFlags.Static
         );
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsHighlightKeywordCaseInsensitiveTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsHighlightKeywordCaseInsensitiveTests.cs
@@ -19,7 +19,7 @@ public class DocumentTextToolsHighlightKeywordCaseInsensitiveTests
         // markers go around the SOURCE substring, not the search query.
         // Existing pins cover no-match and the empty-keyword DoS guard; this
         // closes the case-insensitivity contract.
-        var method = typeof(DocumentTextTools).GetMethod(
+        var method = typeof(DocumentKeywordScan).GetMethod(
             "HighlightKeyword",
             BindingFlags.NonPublic | BindingFlags.Static
         );

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsHighlightKeywordMultiMatchTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsHighlightKeywordMultiMatchTests.cs
@@ -18,7 +18,7 @@ public class DocumentTextToolsHighlightKeywordMultiMatchTests
         // ticker AAPL appears multiple times in one risk-factor paragraph
         // would show only the first as bolded, misleading the LLM into
         // thinking the other occurrences are not the same entity).
-        var method = typeof(DocumentTextTools).GetMethod(
+        var method = typeof(DocumentKeywordScan).GetMethod(
             "HighlightKeyword",
             BindingFlags.NonPublic | BindingFlags.Static
         );

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsHighlightKeywordNoMatchTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsHighlightKeywordNoMatchTests.cs
@@ -51,7 +51,7 @@ public class DocumentTextToolsHighlightKeywordNoMatchTests
     [Fact]
     public void HighlightKeyword_KeywordDoesNotOccurInLine_ReturnsLineUnchanged()
     {
-        var method = typeof(DocumentTextTools).GetMethod(
+        var method = typeof(DocumentKeywordScan).GetMethod(
             "HighlightKeyword",
             BindingFlags.NonPublic | BindingFlags.Static
         );

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsTests.cs
@@ -11,10 +11,11 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class DocumentTextToolsTests
 {
-    private static readonly MethodInfo HighlightKeywordMethod = typeof(DocumentTextTools).GetMethod(
-        "HighlightKeyword",
-        BindingFlags.NonPublic | BindingFlags.Static
-    );
+    private static readonly MethodInfo HighlightKeywordMethod =
+        typeof(DocumentKeywordScan).GetMethod(
+            "HighlightKeyword",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
 
     [Fact]
     public void HighlightKeyword_KeywordOccursWithDifferentCasing_HighlightsAllOccurrencesPreservingOriginalCase()


### PR DESCRIPTION
## Summary
`SearchDocument` gains a `searchMode` argument so one tool covers both in-document retrieval modes: `semantic` (default — the unchanged hybrid BM25+vector excerpt search) and `exact` (the line-precise literal scan `SearchDocumentKeyword` runs, now shared). Callers holding a document ID can flip modes without switching tools; an unknown mode returns a corrective error instead of silently running semantic search.

## Code changes
- `Equibles.Sec.Mcp/Tools/DocumentKeywordScan.cs` (new) — the exact-match scan (load text, typography-folded case-insensitive per-line match, grep-style context rendering) extracted from `DocumentTextTools` so both tools share one implementation.
- `Equibles.Sec.Mcp/Tools/DocumentTextFormat.cs` (new) — the shared width-6 `│` line format and document header.
- `Equibles.Sec.Mcp/Tools/RagSearchTools.cs` — `searchMode` parameter + routing, `IFileManager` dependency, no-results note now points at `searchMode 'exact'`.
- `Equibles.Sec.Mcp/Tools/DocumentTextTools.cs` — `SearchDocumentKeyword` delegates to the shared scan; `ReadDocumentLines` uses the shared loader/format.
- `Equibles.Sec.Mcp.csproj` — `InternalsVisibleTo` for the two test assemblies (same pattern as Media.HostedService).
- Tests: reflection pins repointed to the helpers' new homes; three new integration tests (exact mode line-precise output, exact-mode no-match message, unknown-mode corrective error). Unit suite + RagSearchTools integration suite pass locally against ParadeDB.