### PR TITLE
fix(sec-mcp): broaden sparse results in the corpus-wide document searches

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/IRagManager.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/IRagManager.cs
@@ -12,7 +12,8 @@ public interface IRagManager
         DateOnly? startDate = null,
         DateOnly? endDate = null,
         IReadOnlyCollection<string> excludeTickers = null,
-        int maxResultsPerCompany = 0
+        int maxResultsPerCompany = 0,
+        bool broadenSparseResults = false
     );
     public Task<List<Chunk>> SearchRelevantChunksByCompany(
         string query,
@@ -20,7 +21,8 @@ public interface IRagManager
         int maxResults = 5,
         IReadOnlyCollection<DocumentType> documentTypes = null,
         DateOnly? startDate = null,
-        DateOnly? endDate = null
+        DateOnly? endDate = null,
+        bool broadenSparseResults = false
     );
     public Task<List<Chunk>> SearchRelevantChunksByDocumentType(
         string query,

--- a/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
@@ -36,7 +36,8 @@ public class RagManager : IRagManager
         DateOnly? startDate = null,
         DateOnly? endDate = null,
         IReadOnlyCollection<string> excludeTickers = null,
-        int maxResultsPerCompany = 0
+        int maxResultsPerCompany = 0,
+        bool broadenSparseResults = false
     )
     {
         var chunks = await _hybridChunkSearcher.Search(
@@ -46,7 +47,8 @@ public class RagManager : IRagManager
             documentTypes: documentTypes,
             maxResultsPerCompany: maxResultsPerCompany,
             startDate: startDate,
-            endDate: endDate
+            endDate: endDate,
+            disjunctiveFallback: broadenSparseResults
         );
 
         _logger.LogInformation("Found {Count} relevant chunks for query", chunks.Count);
@@ -59,7 +61,8 @@ public class RagManager : IRagManager
         int maxResults = 5,
         IReadOnlyCollection<DocumentType> documentTypes = null,
         DateOnly? startDate = null,
-        DateOnly? endDate = null
+        DateOnly? endDate = null,
+        bool broadenSparseResults = false
     )
     {
         ticker = await ResolvePrimaryTicker(ticker);
@@ -69,7 +72,8 @@ public class RagManager : IRagManager
             ticker,
             documentTypes: documentTypes,
             startDate: startDate,
-            endDate: endDate
+            endDate: endDate,
+            disjunctiveFallback: broadenSparseResults
         );
 
         _logger.LogInformation(

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -103,7 +103,11 @@ public class RagSearchTools
                     ToDateOnly(startDate),
                     ToDateOnly(endDate),
                     ParseTickers(excludeTickers),
-                    Math.Max(maxResultsPerCompany, 0)
+                    Math.Max(maxResultsPerCompany, 0),
+                    // BM25 ANDs every query token, so one non-matching word in a wordy
+                    // natural-language query hides fully indexed filings; top up with
+                    // any-token matches (conjunctive hits keep their rank).
+                    broadenSparseResults: true
                 );
                 var context = await _ragManager.BuildContext(
                     chunks,
@@ -164,7 +168,9 @@ public class RagSearchTools
                     maxResults,
                     parsedTypes,
                     ToDateOnly(startDate),
-                    ToDateOnly(endDate)
+                    ToDateOnly(endDate),
+                    // Same recall top-up as SearchDocuments — see the note there.
+                    broadenSparseResults: true
                 );
                 var context = await _ragManager.BuildContext(
                     chunks,


### PR DESCRIPTION
## Summary

BM25 (the ParadeDB arm of `HybridChunkSearcher`) ANDs every query token, so one non-matching word in a wordy natural-language query ("FY2026" against a filing that says "fiscal 2026") empties the conjunctive pass — and under the default pool vector source the semantic arm only re-ranks the BM25 pool, so an empty pass returns nothing even when the documents are fully chunked and embedded. The searcher's `disjunctiveFallback` opt-in exists for exactly this (#4163 wired it into the single-document search), but the corpus-wide `SearchDocuments` and per-company `SearchCompanyDocuments` MCP tools never got it. Verified live: narrowly worded queries against indexed 8-Ks returned zero passages while broad phrasings matched.

The fallback is purely additive: conjunctive hits keep their rank, any-token matches only append after them, and it only fires when the conjunctive pass can't fill the request.

## Code changes

- `IRagManager` / `RagManager` — `SearchRelevantChunks` and `SearchRelevantChunksByCompany` gain `broadenSparseResults = false`, passed through as the searcher's `disjunctiveFallback` (mirrors the existing `SearchRelevantChunksByDocument` parameter).
- `RagSearchTools` — `SearchDocuments` and `SearchCompanyDocuments` pass `broadenSparseResults: true`.