### PR TITLE
feat(sec): exhaustive in-document semantic ranking for document-scoped searches

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
@@ -70,6 +70,16 @@ public class HybridChunkSearcher
             _options.Enabled
             && _options.VectorSource != VectorSource.Off
             && _embeddingClient.IsEnabled;
+
+        // The corpus vector arm ranks stored vectors directly, so it can surface chunks BM25
+        // never retrieved — but corpus-WIDE it needs an ANN index to stay inside the query
+        // budget, so it only runs when configured (VectorSource.Table). A DOCUMENT-scoped
+        // search is the exception: one document's chunks are a bounded set served by the
+        // existing btree indexes, so the exhaustive in-document ranking is always safe — and
+        // it is what makes a purely semantic question (zero token overlap with the filing's
+        // wording) findable at all.
+        var corpusArmSafe =
+            semanticActive && (_options.VectorSource == VectorSource.Table || documentId.HasValue);
         var bm25Limit = maxResults;
         if (semanticActive)
             bm25Limit = Math.Max(bm25Limit, _options.CandidatePoolSize);
@@ -111,7 +121,10 @@ public class HybridChunkSearcher
             bm25 = bm25.Concat(disjunctive.Where(chunk => !seen.Contains(chunk.Id))).ToList();
         }
 
-        if (!semanticActive || bm25.Count == 0)
+        // With only the pool re-rank available, an empty BM25 pool leaves the semantic arm
+        // nothing to work on; with the corpus arm safe (Table mode, or any document-scoped
+        // search) the vector ranking can carry the result alone.
+        if (!semanticActive || (bm25.Count == 0 && !corpusArmSafe))
             return ApplyPoolControls(bm25, excludeTickers, documentTypes, maxResultsPerCompany)
                 .Take(maxResults)
                 .ToList();
@@ -127,6 +140,7 @@ public class HybridChunkSearcher
         var vectorIds = await RankSemantically(
             query,
             bm25,
+            corpusArmSafe,
             ticker,
             documentId,
             documentTypes is { Count: 1 } ? documentTypes.First() : null,
@@ -195,10 +209,13 @@ public class HybridChunkSearcher
     }
 
     // Produces a semantic ranking of chunk ids, swallowing any embedding-server failure into an
-    // empty list so retrieval degrades to BM25 rather than erroring.
+    // empty list so retrieval degrades to BM25 rather than erroring. The corpus arm wins over
+    // the pool re-rank whenever it is safe (Table mode, or a document-scoped search) — it can
+    // surface chunks BM25 never retrieved, which the pool re-rank by construction cannot.
     private async Task<List<Guid>> RankSemantically(
         string query,
         IReadOnlyList<Chunk> bm25Pool,
+        bool corpusArmSafe,
         string ticker,
         Guid? documentId,
         DocumentType documentType,
@@ -209,10 +226,8 @@ public class HybridChunkSearcher
     {
         try
         {
-            return _options.VectorSource switch
-            {
-                VectorSource.Pool => await RankPool(query, bm25Pool, cancellationToken),
-                VectorSource.Table => await RankCorpus(
+            return corpusArmSafe
+                ? await RankCorpus(
                     query,
                     ticker,
                     documentId,
@@ -220,9 +235,8 @@ public class HybridChunkSearcher
                     startDate,
                     endDate,
                     cancellationToken
-                ),
-                _ => [],
-            };
+                )
+                : await RankPool(query, bm25Pool, cancellationToken);
         }
         catch (Exception exception)
         {

--- a/src/Equibles.Sec.BusinessLogic/Search/VectorSource.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/VectorSource.cs
@@ -15,6 +15,9 @@ public enum VectorSource
     /// surface a chunk BM25 never retrieved). Fast — one query embed plus an indexed by-id vector
     /// lookup, no ANN index — and scales with backfill coverage: pooled chunks without a vector yet
     /// just keep their BM25 rank. This is the production form of the bake-off's validated re-rank.
+    /// Exception: a DOCUMENT-scoped search always uses the exhaustive in-document vector ranking
+    /// instead — one document's chunks are a bounded set served by btree indexes, no ANN index
+    /// needed — so a purely semantic query can find passages BM25 missed within that document.
     /// </summary>
     Pool,
 

--- a/src/Equibles.Sec.Repositories/ChunkRepository.cs
+++ b/src/Equibles.Sec.Repositories/ChunkRepository.cs
@@ -18,7 +18,8 @@ public class ChunkRepository : BaseRepository<Chunk>
     public ChunkRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
 
-    public async Task<List<Chunk>> HybridSearch(
+    // virtual: unit tests stub the search seam by subclassing (no BM25 index in a unit run).
+    public virtual async Task<List<Chunk>> HybridSearch(
         string searchText,
         int maxResults,
         string ticker = null,

--- a/src/Equibles.Sec.Repositories/EmbeddingRepository.cs
+++ b/src/Equibles.Sec.Repositories/EmbeddingRepository.cs
@@ -54,7 +54,8 @@ public class EmbeddingRepository : BaseRepository<Embedding>
     /// arm, scoped through the Chunk navigation to the same ticker/document/type/date filters BM25
     /// applies so the two arms rank over the same universe. Returns chunk ids in similarity order.
     /// </summary>
-    public async Task<List<Guid>> SearchSimilarChunks(
+    // virtual: unit tests stub the vector seam by subclassing (no pgvector in a unit run).
+    public virtual async Task<List<Guid>> SearchSimilarChunks(
         float[] queryEmbedding,
         string model,
         int maxResults,

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherDocumentScopedSemanticTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherDocumentScopedSemanticTests.cs
@@ -1,0 +1,208 @@
+using System.Linq.Expressions;
+using Equibles.Data;
+using Equibles.Sec.BusinessLogic.Embeddings;
+using Equibles.Sec.BusinessLogic.Search;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+// Document-scoped searches must use the exhaustive in-document vector ranking regardless of
+// the configured VectorSource: one document's chunks are a bounded set served by btree
+// indexes, so no ANN index is needed, and it is the only way a purely semantic query (zero
+// token overlap with the filing's wording) can find its passage — the pool re-rank can, by
+// construction, never surface a chunk BM25 didn't retrieve. Corpus-WIDE searches without an
+// ANN index must NOT take that path: an unscoped nearest-neighbour query sequential-scans the
+// whole Embedding table (122 GB in production), so under Pool mode an empty BM25 pool stays
+// an empty result until the corpus index exists.
+public class HybridChunkSearcherDocumentScopedSemanticTests
+{
+    [Fact]
+    public async Task DocumentScoped_PoolMode_EmptyBm25_ReturnsSemanticallyRankedChunks()
+    {
+        var documentId = Guid.NewGuid();
+        var chunk = new Chunk
+        {
+            Id = Guid.NewGuid(),
+            DocumentId = documentId,
+            Content = "management discussed operational headwinds",
+        };
+        var chunkRepository = new StubChunkRepository(bm25Results: [], allChunks: [chunk]);
+        var embeddingRepository = new StubEmbeddingRepository(similarChunkIds: [chunk.Id]);
+        var searcher = NewSearcher(chunkRepository, embeddingRepository);
+
+        var results = await searcher.Search(
+            "what challenges did leadership acknowledge",
+            5,
+            documentId: documentId
+        );
+
+        Assert.Single(results);
+        Assert.Equal(chunk.Id, results[0].Id);
+        Assert.True(embeddingRepository.SearchSimilarChunksCalled);
+    }
+
+    [Fact]
+    public async Task CorpusWide_PoolMode_EmptyBm25_ReturnsEmptyWithoutTheVectorArm()
+    {
+        var chunkRepository = new StubChunkRepository(bm25Results: [], allChunks: []);
+        var embeddingRepository = new StubEmbeddingRepository(similarChunkIds: []);
+        var searcher = NewSearcher(chunkRepository, embeddingRepository);
+
+        var results = await searcher.Search("some query no token matches", 5);
+
+        Assert.Empty(results);
+        Assert.False(embeddingRepository.SearchSimilarChunksCalled);
+    }
+
+    private static HybridChunkSearcher NewSearcher(
+        ChunkRepository chunkRepository,
+        EmbeddingRepository embeddingRepository
+    )
+    {
+        var embeddingClient = Substitute.For<IEmbeddingClient>();
+        embeddingClient.IsEnabled.Returns(true);
+        embeddingClient
+            .GenerateEmbedding(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[] { 0.1f, 0.2f }));
+
+        return new HybridChunkSearcher(
+            chunkRepository,
+            embeddingRepository,
+            embeddingClient,
+            Options.Create(new HybridSearchOptions()),
+            Options.Create(new EmbeddingConfig { ModelName = "test-model" }),
+            NullLogger<HybridChunkSearcher>.Instance
+        );
+    }
+
+    private sealed class StubChunkRepository : ChunkRepository
+    {
+        private readonly List<Chunk> _bm25Results;
+        private readonly List<Chunk> _allChunks;
+
+        public StubChunkRepository(List<Chunk> bm25Results, List<Chunk> allChunks)
+            : base(null)
+        {
+            _bm25Results = bm25Results;
+            _allChunks = allChunks;
+        }
+
+        public override Task<List<Chunk>> HybridSearch(
+            string searchText,
+            int maxResults,
+            string ticker = null,
+            IReadOnlyCollection<string> excludeTickers = null,
+            Guid? documentId = null,
+            IReadOnlyCollection<DocumentType> documentTypes = null,
+            DateOnly? startDate = null,
+            DateOnly? endDate = null,
+            bool conjunctive = true,
+            CancellationToken cancellationToken = default
+        )
+        {
+            return Task.FromResult(_bm25Results);
+        }
+
+        public override IQueryable<Chunk> GetAll() => new TestAsyncEnumerable<Chunk>(_allChunks);
+    }
+
+    private sealed class StubEmbeddingRepository : EmbeddingRepository
+    {
+        private readonly List<Guid> _similarChunkIds;
+
+        public bool SearchSimilarChunksCalled { get; private set; }
+
+        public StubEmbeddingRepository(List<Guid> similarChunkIds)
+            : base(null)
+        {
+            _similarChunkIds = similarChunkIds;
+        }
+
+        public override Task<List<Guid>> SearchSimilarChunks(
+            float[] queryEmbedding,
+            string model,
+            int maxResults,
+            string ticker = null,
+            Guid? documentId = null,
+            DocumentType documentType = null,
+            DateTime? startUtc = null,
+            DateTime? endUtc = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            SearchSimilarChunksCalled = true;
+            return Task.FromResult(_similarChunkIds);
+        }
+    }
+
+    // Minimal in-memory IQueryable implementing EF Core's async query surface, so the
+    // fused-id materialization runs over a plain list.
+    private sealed class TestAsyncEnumerable<T> : EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
+    {
+        public TestAsyncEnumerable(IEnumerable<T> enumerable)
+            : base(enumerable) { }
+
+        public TestAsyncEnumerable(Expression expression)
+            : base(expression) { }
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(
+            CancellationToken cancellationToken = default
+        ) => new TestAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+
+        IQueryProvider IQueryable.Provider => new TestAsyncQueryProvider<T>(this);
+    }
+
+    private sealed class TestAsyncQueryProvider<TEntity> : IAsyncQueryProvider
+    {
+        private readonly IQueryProvider _inner;
+
+        internal TestAsyncQueryProvider(IQueryProvider inner) => _inner = inner;
+
+        public IQueryable CreateQuery(Expression expression) =>
+            new TestAsyncEnumerable<TEntity>(expression);
+
+        public IQueryable<TElement> CreateQuery<TElement>(Expression expression) =>
+            new TestAsyncEnumerable<TElement>(expression);
+
+        public object Execute(Expression expression) => _inner.Execute(expression);
+
+        public TResult Execute<TResult>(Expression expression) => _inner.Execute<TResult>(expression);
+
+        public TResult ExecuteAsync<TResult>(
+            Expression expression,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var expectedResultType = typeof(TResult).GetGenericArguments()[0];
+            var executionResult = _inner.Execute(expression);
+            return (TResult)
+                typeof(Task)
+                    .GetMethod(nameof(Task.FromResult))!
+                    .MakeGenericMethod(expectedResultType)
+                    .Invoke(null, [executionResult])!;
+        }
+    }
+
+    private sealed class TestAsyncEnumerator<T> : IAsyncEnumerator<T>
+    {
+        private readonly IEnumerator<T> _inner;
+
+        public TestAsyncEnumerator(IEnumerator<T> inner) => _inner = inner;
+
+        public T Current => _inner.Current;
+
+        public ValueTask<bool> MoveNextAsync() => ValueTask.FromResult(_inner.MoveNext());
+
+        public ValueTask DisposeAsync()
+        {
+            _inner.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Inside one document the vector search can skip the ANN index entirely: a document's chunks are a bounded set (tens to a few hundred rows served by the existing btree indexes), so ranking ALL of them by cosine similarity is cheap. This PR makes every document-scoped search use that exhaustive in-document ranking regardless of the configured `VectorSource` — and lets it return semantic-only results when the keyword pass finds nothing. Previously, under the production pool source, the semantic arm could only re-rank the BM25 pool, so a purely semantic question (zero token overlap with the filing's wording) returned nothing even though the answer's chunk was embedded.

Corpus-wide behavior is deliberately unchanged: without an ANN index an unscoped nearest-neighbour query sequential-scans the whole Embedding table (122 GB in production), so market-wide semantic retrieval stays gated on `VectorSource=Table` + the index. A regression test pins that guard.

## Code changes

- `HybridChunkSearcher` — new `corpusArmSafe` gate (Table mode, or any `documentId`-scoped call); the semantic arm picks the corpus ranking whenever safe, and an empty BM25 pool no longer short-circuits when the corpus arm can carry the result; `RankSemantically` takes the gate instead of switching on `VectorSource`.
- `VectorSource` — Pool doc comment records the document-scoped exception.
- `ChunkRepository.HybridSearch` / `EmbeddingRepository.SearchSimilarChunks` — now `virtual` so unit tests can stub the search seams.
- `HybridChunkSearcherDocumentScopedSemanticTests` — document-scoped + empty BM25 returns semantically ranked chunks; corpus-wide + empty BM25 stays empty without touching the vector arm.