### PR TITLE
fix(government-contracts): resumable scan checkpoint so API blips can't freeze the backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- Government contracts — the backfill no longer freezes when USAspending has one of its intermittent bad spells. The import now persists a resumable scan checkpoint (the last fully-completed action-date window) instead of resuming from `MAX(ActionDate)`, so a transport failure that aborts a cycle resumes where it left off rather than restarting the whole range and re-flooding the error log; once caught up it re-scans a trailing lookback window each cycle so late-published awards are not permanently skipped. PR #4213.
+
 ## [1.4.0] — 2026-07-03
 
 ### Added

--- a/src/Equibles.GovernmentContracts.Data/GovernmentContractsModuleConfiguration.cs
+++ b/src/Equibles.GovernmentContracts.Data/GovernmentContractsModuleConfiguration.cs
@@ -8,5 +8,6 @@ public class GovernmentContractsModuleConfiguration : Equibles.Data.IFinancialMo
     public void ConfigureEntities(ModelBuilder builder)
     {
         builder.Entity<GovernmentContract>();
+        builder.Entity<GovernmentContractsScanState>();
     }
 }

--- a/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractsScanState.cs
+++ b/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractsScanState.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.GovernmentContracts.Data.Models;
+
+/// <summary>
+/// Resumable scan checkpoint for the government-contracts backfill, keyed by a
+/// worker-assigned cursor name. Persists the end date of the last action-date window the
+/// import fully completed, so a cycle aborted mid-scan by a transport failure resumes there
+/// instead of restarting the whole range.
+///
+/// Decoupled from <c>MAX(GovernmentContract.ActionDate)</c> on purpose: that watermark only
+/// advances when a window inserts rows, so an empty window (or one whose awards match no
+/// public company) leaves it unchanged — and a window that keeps failing during one of
+/// USAspending's intermittent bad spells then freezes the cursor and replays the same range
+/// every cycle, flooding the error log. The checkpoint advances per fully-completed window
+/// regardless of whether that window inserted anything.
+/// </summary>
+public class GovernmentContractsScanState
+{
+    [Key]
+    [MaxLength(100)]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Inclusive end date of the newest window the import fully completed; null until the
+    /// first window lands.
+    /// </summary>
+    public DateOnly? LastCompletedWindowEnd { get; set; }
+
+    /// <summary>When the checkpoint last advanced (UTC); null until the first advance.</summary>
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/src/Equibles.GovernmentContracts.HostedService/Configuration/GovernmentContractsScraperOptions.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Configuration/GovernmentContractsScraperOptions.cs
@@ -15,4 +15,14 @@ public class GovernmentContractsScraperOptions : ScraperOptions
     /// stay under USAspending's 10,000-record deep-pagination ceiling for a window.
     /// </summary>
     public int WindowDays { get; set; } = 7;
+
+    /// <summary>
+    /// Once the scan has caught up to today, how many trailing days it re-covers each cycle.
+    /// USAspending publishes awards days-to-weeks after their action date, so a strict
+    /// resume-after-the-frontier cursor would permanently skip any award that lands inside a
+    /// window already passed. Re-scanning a trailing window each cycle picks those up; the
+    /// rescan is cheap and idempotent (deduplicated by AwardUniqueKey on insert). Defaults to
+    /// one window's width.
+    /// </summary>
+    public int RescanLookbackDays { get; set; } = 7;
 }

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -19,6 +19,9 @@ public class GovernmentContractsImportService : IImporter
 {
     private const int InsertBatchSize = 1000;
 
+    // Single well-known row that persists the forward award scan's resume point.
+    private const string ScanStateName = "award-scan";
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<GovernmentContractsImportService> _logger;
     private readonly IUsaSpendingClient _client;
@@ -96,6 +99,12 @@ public class GovernmentContractsImportService : IImporter
                     recipientLookup,
                     cancellationToken
                 );
+
+                // The window completed — advance the resumable checkpoint even when it
+                // inserted nothing, so an empty or all-non-public window (and, above all, a
+                // later transport abort in this same cycle) can't rewind the scan to here.
+                // This is decoupled from MAX(ActionDate), which only moves on an insert.
+                await AdvanceCheckpoint(windowEnd);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -211,8 +220,10 @@ public class GovernmentContractsImportService : IImporter
     {
         using var scope = _scopeFactory.CreateScope();
         var repository = scope.ServiceProvider.GetRequiredService<GovernmentContractRepository>();
+        var scanStateRepository =
+            scope.ServiceProvider.GetRequiredService<GovernmentContractsScanStateRepository>();
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
-        // Future action dates are excluded from the cursor: a single mis-dated row would
+        // Future action dates are excluded from the watermark: a single mis-dated row would
         // otherwise push the resume point past today and freeze the import forever (this
         // happened in prod when period-of-performance starts were stored as ActionDate).
         var latest = await repository
@@ -220,23 +231,98 @@ public class GovernmentContractsImportService : IImporter
             .Where(c => c.ActionDate != null && c.ActionDate <= today)
             .MaxAsync(c => c.ActionDate, cancellationToken);
 
-        return ResolveStartDate(latest, today, _workerOptions);
+        var checkpoint = await scanStateRepository.GetByName(ScanStateName);
+
+        return ResolveStartDate(
+            latest,
+            checkpoint?.LastCompletedWindowEnd,
+            today,
+            _options.RescanLookbackDays,
+            _workerOptions
+        );
     }
 
     /// <summary>
-    /// Resume the day after the newest credible action date, clamped to today so an
-    /// outlier can never push the incremental cursor into the future. Pure so the
-    /// cursor policy is unit-testable.
+    /// Resolve the date the next scan cycle starts from. Pure so the cursor policy is
+    /// unit-testable.
+    ///
+    /// With no persisted checkpoint (the first run after this ships, or a fresh install) the
+    /// cursor falls back to the data-derived watermark exactly as before: the day after the
+    /// newest credible action date, or the configured floor when the table is empty.
+    ///
+    /// Once a checkpoint exists it owns the cursor. The scan resumes the day after the
+    /// furthest window it has fully completed — never behind data already ingested — but
+    /// never later than a trailing <paramref name="rescanLookbackDays"/> window, so awards
+    /// USAspending publishes late (dated inside a window already passed) are still re-covered
+    /// and deduplicated by AwardUniqueKey on insert. A consequence is that once caught up the
+    /// scan no longer reports "already up to date"; it re-scans the trailing window each cycle.
     /// </summary>
     public static DateOnly ResolveStartDate(
         DateOnly? latestActionDate,
+        DateOnly? checkpointEnd,
         DateOnly today,
+        int rescanLookbackDays,
         WorkerOptions workerOptions
     )
     {
         if (latestActionDate > today)
             latestActionDate = today;
 
-        return SyncDateResolver.Resolve(latestActionDate ?? default, workerOptions);
+        if (checkpointEnd == null)
+            return SyncDateResolver.Resolve(latestActionDate ?? default, workerOptions);
+
+        // Resume after the furthest point we have fully scanned, but never behind data
+        // already ingested (defensive — the checkpoint should always lead the watermark).
+        var frontier = checkpointEnd.Value;
+        if (latestActionDate.HasValue && latestActionDate.Value > frontier)
+            frontier = latestActionDate.Value;
+
+        var afterFrontier = frontier.AddDays(1);
+        var lookbackFloor = today.AddDays(-(Math.Max(1, rescanLookbackDays) - 1));
+        return afterFrontier < lookbackFloor ? afterFrontier : lookbackFloor;
+    }
+
+    /// <summary>
+    /// Advance the persisted scan checkpoint to <paramref name="windowEnd"/>. Best-effort by
+    /// design — a persist failure must never fail the scan; the window is simply re-scanned
+    /// next cycle and deduplicated by AwardUniqueKey. The write is monotonic so a trailing
+    /// lookback rescan (which re-completes earlier windows) can never rewind the frontier.
+    /// </summary>
+    private async Task AdvanceCheckpoint(DateOnly windowEnd)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var repository =
+                scope.ServiceProvider.GetRequiredService<GovernmentContractsScanStateRepository>();
+
+            var state = await repository.GetByName(ScanStateName);
+            var isNew = state == null;
+            if (isNew)
+            {
+                state = new GovernmentContractsScanState { Name = ScanStateName };
+            }
+            else if (state.LastCompletedWindowEnd >= windowEnd)
+            {
+                return;
+            }
+
+            state.LastCompletedWindowEnd = windowEnd;
+            state.UpdatedAt = DateTime.UtcNow;
+            if (isNew)
+                repository.Add(state);
+            else
+                repository.Update(state);
+            await repository.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Government contracts import: failed to persist scan checkpoint at {WindowEnd}; "
+                    + "the window will be re-scanned next cycle",
+                windowEnd
+            );
+        }
     }
 }

--- a/src/Equibles.GovernmentContracts.Repositories/GovernmentContractsScanStateRepository.cs
+++ b/src/Equibles.GovernmentContracts.Repositories/GovernmentContractsScanStateRepository.cs
@@ -1,0 +1,16 @@
+using Equibles.Data;
+using Equibles.GovernmentContracts.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.GovernmentContracts.Repositories;
+
+public class GovernmentContractsScanStateRepository : BaseRepository<GovernmentContractsScanState>
+{
+    public GovernmentContractsScanStateRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public virtual async Task<GovernmentContractsScanState> GetByName(string name)
+    {
+        return await GetAll().FirstOrDefaultAsync(s => s.Name == name);
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260723212852_AddGovernmentContractsScanState.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260723212852_AddGovernmentContractsScanState.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260723212852_AddGovernmentContractsScanState")]
+    partial class AddGovernmentContractsScanState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260723212852_AddGovernmentContractsScanState.cs
+++ b/src/Equibles.Migrations/Migrations/20260723212852_AddGovernmentContractsScanState.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGovernmentContractsScanState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GovernmentContractsScanState",
+                columns: table => new
+                {
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    LastCompletedWindowEnd = table.Column<DateOnly>(type: "date", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GovernmentContractsScanState", x => x.Name);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GovernmentContractsScanState");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCheckpointTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCheckpointTests.cs
@@ -1,0 +1,287 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.GovernmentContracts.Data;
+using Equibles.GovernmentContracts.Data.Models;
+using Equibles.GovernmentContracts.HostedService.Configuration;
+using Equibles.GovernmentContracts.HostedService.Services;
+using Equibles.GovernmentContracts.Repositories;
+using Equibles.Integrations.GovernmentContracts.Contracts;
+using Equibles.Integrations.GovernmentContracts.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// Contract: the persisted scan checkpoint advances per fully-completed window (independently
+// of whether that window inserted rows) and is monotonic, so a transport abort mid-scan can
+// no longer rewind the cursor to the start of the range and replay it every cycle — the
+// freeze that kept the government-contracts backfill stuck at 2022-01-13 and re-flooded the
+// Errors page.
+public class GovernmentContractsImportServiceCheckpointTests
+{
+    // Must match GovernmentContractsImportService.ScanStateName — pins the persisted row key.
+    private const string ScanStateName = "award-scan";
+
+    [Fact]
+    public async Task Import_TransportAbortMidScan_CheckpointHoldsAtLastCompletedWindow_ResumesThereNextCycle()
+    {
+        // A five-day scan in one-day windows where the third window's fetch throws
+        // HttpRequestException. The first two windows complete (advancing the checkpoint), the
+        // third aborts the cycle. The checkpoint must hold at the second window's end, and the
+        // NEXT cycle must resume at the third window — not restart the whole range.
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SeedCompany(options);
+
+        var scopeFactory = ScopeFactory(options);
+        var workerOptions = Options.Create(
+            new WorkerOptions { MinSyncDate = today.AddDays(-4).ToDateTime(TimeOnly.MinValue) }
+        );
+        // Lookback of 1 keeps the trailing-rescan pull-back out of this backfill assertion, so
+        // the resume point is exactly the aborted window.
+        var scraperOptions = Options.Create(
+            new GovernmentContractsScraperOptions
+            {
+                WindowDays = 1,
+                RescanLookbackDays = 1,
+                MinimumAwardAmount = 1_000_000m,
+            }
+        );
+
+        var failingClient = Substitute.For<IUsaSpendingClient>();
+        ReturnsEmptyForAllWindows(failingClient);
+        failingClient
+            .GetContractAwards(
+                today.AddDays(-2),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new HttpRequestException("USAspending bad spell"));
+
+        var act = () =>
+            NewService(scopeFactory, failingClient, scraperOptions, workerOptions)
+                .Import(CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        ReadCheckpoint(options)
+            .Should()
+            .Be(
+                today.AddDays(-3),
+                "the checkpoint holds at the last completed window when the cycle aborts"
+            );
+
+        // Next cycle, the spell has cleared: resume at the aborted window, don't restart.
+        var healthyClient = Substitute.For<IUsaSpendingClient>();
+        ReturnsEmptyForAllWindows(healthyClient);
+
+        await NewService(scopeFactory, healthyClient, scraperOptions, workerOptions)
+            .Import(CancellationToken.None);
+
+        await healthyClient
+            .DidNotReceive()
+            .GetContractAwards(
+                today.AddDays(-4),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
+        await healthyClient
+            .DidNotReceive()
+            .GetContractAwards(
+                today.AddDays(-3),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
+        await healthyClient
+            .Received()
+            .GetContractAwards(
+                today.AddDays(-2),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
+        ReadCheckpoint(options)
+            .Should()
+            .Be(today, "the resumed cycle scans through to today and advances the checkpoint");
+    }
+
+    [Fact]
+    public async Task Import_EmptyWindows_StillAdvanceTheCheckpoint()
+    {
+        // Every window returns zero awards (nothing inserted, so max(ActionDate) never moves).
+        // The checkpoint must still advance to the final window — otherwise a long run of
+        // empty-for-us windows would re-scan from the same start forever.
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SeedCompany(options);
+
+        var scopeFactory = ScopeFactory(options);
+        var workerOptions = Options.Create(
+            new WorkerOptions { MinSyncDate = today.AddDays(-2).ToDateTime(TimeOnly.MinValue) }
+        );
+        var scraperOptions = Options.Create(
+            new GovernmentContractsScraperOptions
+            {
+                WindowDays = 1,
+                RescanLookbackDays = 1,
+                MinimumAwardAmount = 1_000_000m,
+            }
+        );
+
+        var client = Substitute.For<IUsaSpendingClient>();
+        ReturnsEmptyForAllWindows(client);
+
+        await NewService(scopeFactory, client, scraperOptions, workerOptions)
+            .Import(CancellationToken.None);
+
+        ReadCheckpoint(options).Should().Be(today);
+    }
+
+    [Fact]
+    public async Task Import_TrailingRescan_DoesNotRewindTheCheckpoint()
+    {
+        // A caught-up checkpoint (at today) with a 7-day lookback re-scans today-6..today each
+        // cycle. Re-completing those earlier windows must not rewind the checkpoint — the
+        // monotonic guard keeps it at today.
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SeedCompany(options);
+        using (var seed = NewContext(options))
+        {
+            seed.Add(
+                new GovernmentContractsScanState
+                {
+                    Name = ScanStateName,
+                    LastCompletedWindowEnd = today,
+                    UpdatedAt = DateTime.UtcNow,
+                }
+            );
+            seed.SaveChanges();
+        }
+
+        var scopeFactory = ScopeFactory(options);
+        var workerOptions = Options.Create(new WorkerOptions());
+        var scraperOptions = Options.Create(
+            new GovernmentContractsScraperOptions
+            {
+                WindowDays = 1,
+                RescanLookbackDays = 7,
+                MinimumAwardAmount = 1_000_000m,
+            }
+        );
+
+        var client = Substitute.For<IUsaSpendingClient>();
+        ReturnsEmptyForAllWindows(client);
+
+        await NewService(scopeFactory, client, scraperOptions, workerOptions)
+            .Import(CancellationToken.None);
+
+        // Proves the trailing rescan actually ran (earlier window fetched) yet did not rewind.
+        await client
+            .Received()
+            .GetContractAwards(
+                today.AddDays(-(7 - 1)),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
+        ReadCheckpoint(options).Should().Be(today);
+    }
+
+    private static void ReturnsEmptyForAllWindows(IUsaSpendingClient client) =>
+        client
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(new List<UsaSpendingAwardRecord>()));
+
+    private static GovernmentContractsImportService NewService(
+        IServiceScopeFactory scopeFactory,
+        IUsaSpendingClient client,
+        IOptions<GovernmentContractsScraperOptions> scraperOptions,
+        IOptions<WorkerOptions> workerOptions
+    ) =>
+        new(
+            scopeFactory,
+            NullLogger<GovernmentContractsImportService>.Instance,
+            client,
+            new RecipientResolver(scopeFactory),
+            scraperOptions,
+            workerOptions,
+            new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
+        );
+
+    private static void SeedCompany(DbContextOptions<EquiblesFinancialDbContext> options)
+    {
+        using var seed = NewContext(options);
+        // One named company so BuildLookup is non-empty and the empty-universe guard passes.
+        seed.Add(
+            new CommonStock
+            {
+                Ticker = "LMT",
+                Name = "Lockheed Martin Corporation",
+                Cik = "1",
+            }
+        );
+        seed.SaveChanges();
+    }
+
+    private static DateOnly? ReadCheckpoint(DbContextOptions<EquiblesFinancialDbContext> options)
+    {
+        using var ctx = NewContext(options);
+        return ctx.Set<GovernmentContractsScanState>()
+            .AsNoTracking()
+            .FirstOrDefault(s => s.Name == ScanStateName)
+            ?.LastCompletedWindowEnd;
+    }
+
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new GovernmentContractsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static IServiceScopeFactory ScopeFactory(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => NewContext(options));
+        services.AddScoped<CommonStockRepository>();
+        services.AddScoped<GovernmentContractRepository>();
+        services.AddScoped<GovernmentContractsScanStateRepository>();
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCursorTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCursorTests.cs
@@ -5,19 +5,29 @@ using Xunit;
 
 namespace Equibles.UnitTests.GovernmentContracts;
 
-// Contract: the incremental import cursor resumes the day after the newest credible
-// action date and can never point past today — a single mis-dated future row froze
+// Contract: with no persisted checkpoint the import cursor resumes the day after the newest
+// credible action date and can never point past today — a single mis-dated future row froze
 // prod ingestion for over two years when the cursor keyed on raw max(ActionDate).
+//
+// Once a scan checkpoint exists it OWNS the cursor: the scan resumes after the last
+// fully-completed window (so a transport abort no longer restarts the whole range and
+// re-floods the Errors page), never behind data already ingested, and re-covers a trailing
+// lookback window so awards USAspending publishes late are not permanently skipped.
 public class GovernmentContractsImportServiceCursorTests
 {
     private static readonly DateOnly Today = new(2026, 7, 17);
+    private const int Lookback = 7;
+
+    // --- No checkpoint yet: unchanged data-derived watermark behavior ---
 
     [Fact]
     public void Resumes_the_day_after_the_latest_action_date()
     {
         var start = GovernmentContractsImportService.ResolveStartDate(
             new DateOnly(2026, 6, 1),
+            checkpointEnd: null,
             Today,
+            Lookback,
             new WorkerOptions()
         );
 
@@ -31,7 +41,9 @@ public class GovernmentContractsImportServiceCursorTests
         // worst allowed effect is "synced through today" (resume tomorrow).
         var start = GovernmentContractsImportService.ResolveStartDate(
             new DateOnly(2028, 12, 31),
+            checkpointEnd: null,
             Today,
+            Lookback,
             new WorkerOptions()
         );
 
@@ -43,7 +55,9 @@ public class GovernmentContractsImportServiceCursorTests
     {
         var start = GovernmentContractsImportService.ResolveStartDate(
             DateOnly.MaxValue,
+            checkpointEnd: null,
             Today,
+            Lookback,
             new WorkerOptions()
         );
 
@@ -55,7 +69,9 @@ public class GovernmentContractsImportServiceCursorTests
     {
         var start = GovernmentContractsImportService.ResolveStartDate(
             null,
+            checkpointEnd: null,
             Today,
+            Lookback,
             new WorkerOptions { MinSyncDate = new DateTime(2021, 3, 1) }
         );
 
@@ -67,7 +83,9 @@ public class GovernmentContractsImportServiceCursorTests
     {
         var start = GovernmentContractsImportService.ResolveStartDate(
             null,
+            checkpointEnd: null,
             Today,
+            Lookback,
             new WorkerOptions()
         );
 
@@ -79,10 +97,109 @@ public class GovernmentContractsImportServiceCursorTests
     {
         var start = GovernmentContractsImportService.ResolveStartDate(
             Today,
+            checkpointEnd: null,
             Today,
+            Lookback,
             new WorkerOptions()
         );
 
         start.Should().Be(Today.AddDays(1));
+    }
+
+    // --- Checkpoint present: it owns the cursor ---
+
+    [Fact]
+    public void A_backfill_checkpoint_resumes_the_day_after_the_completed_window()
+    {
+        // The freeze fix: mid-backfill (checkpoint far behind today) the scan resumes right
+        // after the last completed window, NOT at the stale max(ActionDate) that a transport
+        // abort left unchanged.
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            latestActionDate: new DateOnly(2022, 1, 13),
+            checkpointEnd: new DateOnly(2022, 1, 20),
+            Today,
+            Lookback,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(new DateOnly(2022, 1, 21));
+    }
+
+    [Fact]
+    public void A_checkpoint_carries_the_scan_forward_past_a_lagging_watermark()
+    {
+        // Even with no rows inserted past 2022-01-13 (every window since was empty or matched
+        // no public company), the checkpoint carries the scan forward on its own.
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            latestActionDate: new DateOnly(2022, 1, 13),
+            checkpointEnd: new DateOnly(2023, 6, 30),
+            Today,
+            Lookback,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(new DateOnly(2023, 7, 1));
+    }
+
+    [Fact]
+    public void A_checkpoint_behind_ingested_data_never_resumes_behind_the_watermark()
+    {
+        // Defensive: the checkpoint should always lead the watermark, but if it somehow lags,
+        // resume after the newer ingested data rather than re-scanning already-stored rows.
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            latestActionDate: new DateOnly(2022, 1, 20),
+            checkpointEnd: new DateOnly(2022, 1, 10),
+            Today,
+            Lookback,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(new DateOnly(2022, 1, 21));
+    }
+
+    [Fact]
+    public void A_caught_up_checkpoint_re_scans_the_trailing_lookback_window()
+    {
+        // Once the checkpoint reaches today, each cycle re-covers the trailing lookback window
+        // so late-published awards inside it are still picked up (deduplicated on insert).
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            latestActionDate: Today,
+            checkpointEnd: Today,
+            Today,
+            Lookback,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(Today.AddDays(-(Lookback - 1)));
+    }
+
+    [Fact]
+    public void A_checkpoint_inside_the_lookback_window_pulls_back_to_the_floor()
+    {
+        // Checkpoint three days behind today with a 7-day lookback: start pulls back to the
+        // lookback floor (today-6), re-covering the already-scanned tail and closing the gap.
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            latestActionDate: Today.AddDays(-3),
+            checkpointEnd: Today.AddDays(-3),
+            Today,
+            Lookback,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(Today.AddDays(-(Lookback - 1)));
+    }
+
+    [Fact]
+    public void The_lookback_window_width_is_configurable()
+    {
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            latestActionDate: Today,
+            checkpointEnd: Today,
+            Today,
+            rescanLookbackDays: 3,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(Today.AddDays(-2));
     }
 }

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
@@ -133,6 +133,7 @@ public class GovernmentContractsImportServiceHttpAbortTests
         services.AddScoped(_ => NewContext(options));
         services.AddScoped<CommonStockRepository>();
         services.AddScoped<GovernmentContractRepository>();
+        services.AddScoped<GovernmentContractsScanStateRepository>();
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
 }

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
@@ -126,6 +126,7 @@ public class GovernmentContractsImportServiceWindowContinueTests
         services.AddScoped(_ => NewContext(options));
         services.AddScoped<CommonStockRepository>();
         services.AddScoped<GovernmentContractRepository>();
+        services.AddScoped<GovernmentContractsScanStateRepository>();
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
 }

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherDocumentScopedSemanticTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherDocumentScopedSemanticTests.cs
@@ -143,7 +143,10 @@ public class HybridChunkSearcherDocumentScopedSemanticTests
 
     // Minimal in-memory IQueryable implementing EF Core's async query surface, so the
     // fused-id materialization runs over a plain list.
-    private sealed class TestAsyncEnumerable<T> : EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
+    private sealed class TestAsyncEnumerable<T>
+        : EnumerableQuery<T>,
+            IAsyncEnumerable<T>,
+            IQueryable<T>
     {
         public TestAsyncEnumerable(IEnumerable<T> enumerable)
             : base(enumerable) { }
@@ -172,7 +175,8 @@ public class HybridChunkSearcherDocumentScopedSemanticTests
 
         public object Execute(Expression expression) => _inner.Execute(expression);
 
-        public TResult Execute<TResult>(Expression expression) => _inner.Execute<TResult>(expression);
+        public TResult Execute<TResult>(Expression expression) =>
+            _inner.Execute<TResult>(expression);
 
         public TResult ExecuteAsync<TResult>(
             Expression expression,


### PR DESCRIPTION
## Summary

The government-contracts backfill froze at 2022-01-13 and hadn't advanced in two days, while the error log filled with "response ended prematurely" rows. The import cursor resumed from `MAX(ActionDate)`, which only advances when a window inserts rows; a transport failure aborts the whole cycle, so during one of USAspending's intermittent multi-minute bad spells the scan restarted the same first window every cycle and never climbed out. This adds a resumable scan checkpoint so a blip can no longer freeze ingestion or re-flood the Errors page.

## Code changes

- **New `GovernmentContractsScanState` entity + repository + module registration + migration** — a single-row checkpoint (`award-scan`) persisting the end date of the last action-date window the import fully completed.
- **`GovernmentContractsImportService`** — advance the checkpoint after every completed window, including empty ones and windows that matched no public company (decoupled from `MAX(ActionDate)`, which only moves on an insert). `ResolveStartDate` now resumes the day after the checkpoint (never behind the ingested watermark) and, once caught up, re-covers a trailing lookback window each cycle so late-published awards aren't permanently skipped (deduplicated by `AwardUniqueKey`). Checkpoint writes are best-effort and monotonic.
- **New `RescanLookbackDays` option** (default 7, one window's width).
- **Tests** — checkpoint resume-after-transport-abort, empty-window-advances, monotonic-no-rewind on the trailing rescan, plus the existing `ResolveStartDate` cursor tests updated for the new signature and extended with the checkpoint cases.

## Verification

- [x] `dotnet build Equibles.sln -c Release` is clean locally
- [x] `Equibles.UnitTests` passes locally (3679 tests, incl. 81 government-contracts)
- [x] `dotnet csharpier check` is clean on the changed files
- [x] CHANGELOG.md updated under `## [Unreleased]`

## Notes for reviewers

- Behavior change once caught up: the scan no longer logs "already up to date"; it re-scans the trailing `RescanLookbackDays` window each cycle. This is cheap (one window, deduped on insert) and also closes a latent late-arrival gap the old `MAX(ActionDate)+1` cursor already had — USAspending publishes awards days-to-weeks after their action date, so a strict resume-after-the-frontier cursor would permanently skip any that land inside a window already passed.
- The deliberate abort-on-transport-failure + worker streak reporting (one Error row per outage) is unchanged; this PR only adds the ability to resume, so a genuine outage still reports once but no longer replays the same window forever.
