### PR TITLE
fix(government-contracts): lighter 2-day windows + 3h poll cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- Government contracts — the backfill no longer freezes when USAspending has one of its intermittent bad spells. The import now persists a resumable scan checkpoint (the last fully-completed action-date window) instead of resuming from `MAX(ActionDate)`, so a transport failure that aborts a cycle resumes where it left off rather than restarting the whole range and re-flooding the error log; once caught up it re-scans a trailing lookback window each cycle so late-published awards are not permanently skipped. PR #4213.
+- Government contracts — the backfill no longer freezes when USAspending has one of its intermittent bad spells. The import now persists a resumable scan checkpoint (the last fully-completed action-date window) instead of resuming from `MAX(ActionDate)`, so a transport failure that aborts a cycle resumes where it left off rather than restarting the whole range and re-flooding the error log; once caught up it re-scans a trailing lookback window each cycle so late-published awards are not permanently skipped. PR #4213. The scan window was also narrowed from 7 days to 2 (each window fires far fewer API requests, so it completes through the API's flakiness rather than aborting) and the poll interval tightened from 24h to 3h, so new awards surface within hours once the backfill catches up. PR #4214.
 
 ## [1.4.0] — 2026-07-03
 

--- a/src/Equibles.GovernmentContracts.HostedService/Configuration/GovernmentContractsScraperOptions.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Configuration/GovernmentContractsScraperOptions.cs
@@ -4,6 +4,15 @@ namespace Equibles.GovernmentContracts.HostedService.Configuration;
 
 public class GovernmentContractsScraperOptions : ScraperOptions
 {
+    public GovernmentContractsScraperOptions()
+    {
+        // Federal contract awards publish gradually through the day; poll several times a day
+        // (the base default is 24h) so new awards surface within hours of USAspending
+        // publishing them instead of once daily. The source still lags the real award date by
+        // days, so this is about as fresh as this dataset meaningfully gets — tune if needed.
+        SleepIntervalHours = 3;
+    }
+
     /// <summary>
     /// Awards below this dollar value are ignored — federal procurement is dominated by
     /// a long tail of small actions, and only material awards move a public company.
@@ -11,10 +20,15 @@ public class GovernmentContractsScraperOptions : ScraperOptions
     public decimal MinimumAwardAmount { get; set; } = 1_000_000m;
 
     /// <summary>
-    /// Width (in days) of each action-date window fetched per API call. Narrow enough to
-    /// stay under USAspending's 10,000-record deep-pagination ceiling for a window.
+    /// Width (in days) of each action-date window fetched per API call. Kept small on purpose:
+    /// a single 7-day window fired ~250 requests (deep amount-cursor paging at the $1M floor),
+    /// so during one of USAspending's intermittent bad spells the odds every one of those
+    /// requests survives is near zero and the whole window — the whole cycle — aborts. A 2-day
+    /// window is roughly a third of the requests, far likelier to complete in a brief healthy
+    /// stretch; the scan checkpoint makes the extra window count free (each completed window is
+    /// durable). The amount-cursor still handles the per-window deep-pagination ceiling.
     /// </summary>
-    public int WindowDays { get; set; } = 7;
+    public int WindowDays { get; set; } = 2;
 
     /// <summary>
     /// Once the scan has caught up to today, how many trailing days it re-covers each cycle.


### PR DESCRIPTION
## Summary

Follow-up to #4213. The scan checkpoint made progress durable, but the backfill still couldn't climb out of its 2022 freeze: the first 7-day window fires ~250 API requests (deep amount-cursor paging at the $1M floor), so during one of USAspending's intermittent bad spells at least one request exhausts its retries and the whole window — the whole cycle — aborts before any window completes. No completed window means no checkpoint, so it never advances.

## Code changes

- `GovernmentContractsScraperOptions.WindowDays` 7 → **2**. A 2-day window is ~1/3 the requests, far likelier to finish in a brief healthy stretch; the checkpoint from #4213 makes the extra window count free (every completed window is durable). The amount-cursor still handles per-window depth.
- `SleepIntervalHours` 24 → **3** (via the options constructor, overriding the shared base default only for this scraper). Once caught up, new awards surface within ~3h of USAspending publishing them instead of once a day. The source's own multi-day publish lag remains the real floor — this is about as fresh as the dataset meaningfully gets.

## Verification

- [x] `dotnet build` clean; government-contracts + configuration unit tests pass (107).
- No schema change. No other scraper's cadence is affected (the base `ScraperOptions` default stays 24h).

## Notes for reviewers

- Both are one-line tunables. If catch-up still struggles through a bad spell, `WindowDays` can drop to 1; `SleepIntervalHours` can go tighter, though it won't beat USAspending's publish lag.