### PR TITLE
fix(government-contracts): scan windows by action date so they are finishable

### DIFF
--- a/src/Equibles.GovernmentContracts.HostedService/Configuration/GovernmentContractsScraperOptions.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Configuration/GovernmentContractsScraperOptions.cs
@@ -20,15 +20,16 @@ public class GovernmentContractsScraperOptions : ScraperOptions
     public decimal MinimumAwardAmount { get; set; } = 1_000_000m;
 
     /// <summary>
-    /// Width (in days) of each action-date window fetched per API call. Kept as small as is
-    /// practical (1 day): a 7-day window fired ~250 requests (deep amount-cursor paging at the
-    /// $1M floor), and during one of USAspending's intermittent bad spells the odds every one
-    /// of those survives is near zero, so the whole window — the whole cycle — aborts. A 1-day
-    /// window is a fraction of the requests, so it can finish inside a brief healthy stretch;
-    /// paired with the client's raised retry patience, a flaky page usually rides out the spell
-    /// rather than failing the window. The scan checkpoint makes the extra window count free
-    /// (each completed window is durable). The amount-cursor still handles the per-window
-    /// deep-pagination ceiling.
+    /// Width (in days) of each action-date window fetched per API call. A day of federal
+    /// contract actions at the $1M floor is only a few hundred awards (~2–5 pages), so a
+    /// 1-day window is the cheapest useful unit of work and stays small enough to finish
+    /// inside a brief healthy stretch of a flaky API. Windows are not free to lose — a
+    /// window aborts as a whole — so narrow beats wide: the scan checkpoint banks every
+    /// completed window, making the higher window count essentially free.
+    ///
+    /// The earlier "a 7-day window fires ~250 requests" tuning note measured a broken
+    /// query, not real volume: the client was omitting the window's date_type, so
+    /// USAspending was returning every contract in force rather than those actioned.
     /// </summary>
     public int WindowDays { get; set; } = 1;
 

--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -268,7 +268,22 @@ public class UsaSpendingClient : IUsaSpendingClient
             filters = new
             {
                 award_type_codes = ContractAwardTypeCodes,
-                time_period = new[] { new { start_date = startDate, end_date = endDate } },
+                // date_type is NOT optional. Omit it and USAspending defaults the window to
+                // period-of-performance OVERLAP — every contract merely IN FORCE on those dates —
+                // which is neither what the scan means nor a size it can enumerate: measured
+                // against the live API, a single day at the $1M floor returned 118,159 awards
+                // (~1,180 pages, and near-identical for every date tried, the tell that the
+                // window wasn't filtering at all) versus 169 with action_date. The scan's cursor
+                // and checkpoint are both keyed on the award ACTION date, so say so explicitly.
+                time_period = new[]
+                {
+                    new
+                    {
+                        start_date = startDate,
+                        end_date = endDate,
+                        date_type = "action_date",
+                    },
+                },
                 award_amounts = awardAmounts,
             },
             fields = RequestFields,

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientWindowDateTypeTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientWindowDateTypeTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using Equibles.Integrations.GovernmentContracts;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+/// <summary>
+/// Pins the <c>date_type</c> on every window filter <see cref="UsaSpendingClient"/> sends.
+///
+/// USAspending's <c>time_period</c> filter defaults to period-of-performance OVERLAP when
+/// <c>date_type</c> is omitted, so the window silently selects every contract merely IN FORCE
+/// on those dates instead of those actioned in them. That is wrong twice over: the scan's
+/// cursor and checkpoint are both keyed on the award action date, and the result set is far
+/// too large to enumerate — measured against the live API, one day at the $1M floor returned
+/// 118,159 awards (~1,180 pages) omitting it versus 169 with <c>action_date</c>. In production
+/// that made a 1-day window unfinishable: the import burned ~256 requests per cycle, never
+/// completed a window, never advanced the checkpoint, and refilled the error log every cycle.
+/// It is a silent failure — the request still returns 200 with plausible awards — so it needs
+/// a test rather than a code comment.
+/// </summary>
+public class UsaSpendingClientWindowDateTypeTests
+{
+    [Fact]
+    public async Task GetContractAwards_SendsActionDateWindows()
+    {
+        var handler = new BodyCapturingHandler();
+        var sut = new UsaSpendingClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<UsaSpendingClient>>()
+        );
+
+        await sut.GetContractAwards(
+            new DateOnly(2022, 1, 20),
+            new DateOnly(2022, 1, 20),
+            minimumAmount: 1_000_000m
+        );
+
+        handler.Bodies.Should().NotBeEmpty("the client must have queried the window");
+        foreach (var body in handler.Bodies)
+        {
+            var period = (JObject)body["filters"]!["time_period"]![0]!;
+            // Bind first: `period["date_type"]?.Value<string>().Should()...` would short-circuit
+            // the whole assertion chain on the null this test exists to catch, and pass silently.
+            var dateType = period["date_type"]?.Value<string>();
+            dateType
+                .Should()
+                .Be(
+                    "action_date",
+                    "omitting date_type makes USAspending match contracts in force over the "
+                        + "window rather than those actioned in it — a 700x larger, wrongly-keyed "
+                        + "result set that no window can page through"
+                );
+            period["start_date"]!.Value<string>().Should().Be("2022-01-20");
+            period["end_date"]!.Value<string>().Should().Be("2022-01-20");
+        }
+    }
+
+    /// <summary>
+    /// Records every request body and answers with a single terminal page, so the client
+    /// issues exactly the one query the assertions inspect.
+    /// </summary>
+    private sealed class BodyCapturingHandler : HttpMessageHandler
+    {
+        public List<JObject> Bodies { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Bodies.Add(JObject.Parse(request.Content!.ReadAsStringAsync(cancellationToken).Result));
+
+            var payload = new
+            {
+                results = Array.Empty<Dictionary<string, object>>(),
+                page_metadata = new { page = 1, hasNext = false },
+            };
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(payload)),
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The USAspending window filter omitted `date_type`. That filter **defaults to period-of-performance overlap**, so every window was selecting every contract merely *in force* across those dates instead of the ones *actioned* in them.

That is wrong twice over:

1. **Wrong key.** The scan's cursor and checkpoint are both keyed on the award action date, so the window was never selecting what the scan means.
2. **Unfinishable.** The result set is far too large to enumerate.

Measured against the live API for a single day at the $1M floor:

| `date_type` | awards | pages |
|---|---|---|
| omitted (period-of-performance overlap) | **118,159** | ~1,180 |
| `action_date` | **169** | 2 |

The count barely moved across unrelated dates — 118,111 / 118,200 / 118,159 / 115,489 / 116,432 for five different days — which is the tell that the window was not filtering at all.

### Production impact

The 1-day window could never finish. Each cycle burned ~256 requests over 6.5 minutes, died mid-window on a transport failure, never advanced the checkpoint, and refilled the error log:

```
20:04:56 Government contracts import: scanning 01/20/2022..07/24/2026
20:11:31 Government contracts import failed for window 01/20/2022..01/20/2022
20:11:31 aborting this cycle after a transport failure
```

...repeating on the identical window every cycle. The backfill had not moved past `2022-01-20`, and the rows it did ingest carry action dates from **1962 onward** — they are old contracts still running, not new awards:

```
 2000-01-01 |    13
 2001-01-01 |    10
 ...
 2021-01-01 |  1575
```

With the fix a window is a few hundred awards (~2-5 pages), so it completes in seconds and the whole 2022 to today backfill becomes tractable.

## Code changes

- **`UsaSpendingClient.BuildRequestBody`** — send `date_type: "action_date"` on every window filter.
- **`UsaSpendingClientWindowDateTypeTests`** (new) — assert every outgoing request carries it. This is a silent failure (the request still returns `200` with plausible awards when `date_type` is missing), so a comment would not have held it; verified the test fails without the fix.
- **`GovernmentContractsScraperOptions`** — correct the `WindowDays` tuning note, which recorded request volumes measured off the broken query.

## Testing

- Full OSS unit suite: **3,681 passed, 0 failed**.
- Fix validated against the live API before and after, including that no award returned for a window is dated after it (so the cursor cannot be pushed forward past unscanned days).
- `csharpier check .` clean across 3,149 files.
