### PR TITLE
feat(finra): poll for the short-interest file on FINRA's publication evenings

### DIFF
--- a/src/Equibles.Core/Calendars/UsMarketCalendar.cs
+++ b/src/Equibles.Core/Calendars/UsMarketCalendar.cs
@@ -20,6 +20,14 @@ public static class UsMarketCalendar
     public static DateTimeOffset ToEastern(DateTimeOffset instant) =>
         TimeZoneInfo.ConvertTime(instant, EasternTimeZone);
 
+    /// <summary>
+    /// The calendar date <paramref name="instant"/> falls on in US Eastern time — the market
+    /// calendar's own time zone. Callers must not use the UTC date: from 20:00 ET onwards it
+    /// has already rolled over to tomorrow.
+    /// </summary>
+    public static DateOnly EasternDate(DateTimeOffset instant) =>
+        DateOnly.FromDateTime(ToEastern(instant).DateTime);
+
     /// <summary>True for any weekday that is not an observed NYSE holiday.</summary>
     public static bool IsTradingDay(DateOnly date)
     {

--- a/src/Equibles.Core/Calendars/UsMarketCalendar.cs
+++ b/src/Equibles.Core/Calendars/UsMarketCalendar.cs
@@ -1,4 +1,4 @@
-namespace Equibles.Worker;
+namespace Equibles.Core.Calendars;
 
 /// <summary>
 /// NYSE trading-day calendar plus US Eastern time helpers. Pure and deterministic so the
@@ -26,6 +26,37 @@ public static class UsMarketCalendar
         if (date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
             return false;
         return !IsNyseHoliday(date);
+    }
+
+    /// <summary>
+    /// <paramref name="date"/> itself when it is a trading day, otherwise the nearest
+    /// trading day before it. Models the "roll back to the prior business day" convention
+    /// regulatory calendars use for a fixed date that lands on a weekend or holiday.
+    /// </summary>
+    public static DateOnly PreviousOrSameTradingDay(DateOnly date)
+    {
+        while (!IsTradingDay(date))
+            date = date.AddDays(-1);
+        return date;
+    }
+
+    /// <summary>
+    /// The date <paramref name="count"/> trading days after <paramref name="date"/>, skipping
+    /// weekends and NYSE holidays. <paramref name="date"/> itself is not counted, so
+    /// <c>AddTradingDays(friday, 1)</c> is the following Monday.
+    /// </summary>
+    public static DateOnly AddTradingDays(DateOnly date, int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        for (var remaining = count; remaining > 0; remaining--)
+        {
+            do
+            {
+                date = date.AddDays(1);
+            } while (!IsTradingDay(date));
+        }
+        return date;
     }
 
     public static bool IsNyseHoliday(DateOnly date)

--- a/src/Equibles.Finra.Data/Calendars/ShortInterestCalendar.cs
+++ b/src/Equibles.Finra.Data/Calendars/ShortInterestCalendar.cs
@@ -1,0 +1,129 @@
+using Equibles.Core.Calendars;
+
+namespace Equibles.Finra.Data.Calendars;
+
+/// <summary>
+/// FINRA's semi-monthly short interest reporting calendar, derived from the rule FINRA
+/// publishes at
+/// https://www.finra.org/filing-reporting/regulatory-filing-systems/short-interest.
+///
+/// Three rules generate every row of that page's table:
+///   settlement  — the 15th and the last day of each month, rolled BACK to the prior
+///                 trading day when it lands on a weekend or NYSE holiday;
+///   due         — <see cref="DueTradingDaysAfterSettlement"/> trading days after settlement
+///                 ("by 6 p.m. Eastern Time on the second business day after the reporting
+///                 settlement date", per FINRA Rule 4560);
+///   publication — <see cref="PublicationTradingDaysAfterDue"/> trading days after the due
+///                 date, when FINRA disseminates the file.
+///
+/// Deriving beats scraping here on both accuracy and reach: FINRA's page is behind a
+/// bot-blocker (a plain HTTP GET is answered 403), it only ever lists the current and next
+/// year, and the derivation reproduces every published row of both those years exactly —
+/// <c>ShortInterestCalendarTests</c> pins the output against FINRA's tables verbatim, so a
+/// rule change on FINRA's side fails the build rather than silently skewing the dates.
+/// </summary>
+public static class ShortInterestCalendar
+{
+    /// <summary>FINRA Rule 4560: reports are due the second business day after settlement.</summary>
+    private const int DueTradingDaysAfterSettlement = 2;
+
+    /// <summary>FINRA disseminates the file five business days after the filing deadline.</summary>
+    private const int PublicationTradingDaysAfterDue = 5;
+
+    /// <summary>Positions are also measured mid-month, as of the 15th.</summary>
+    private const int MidMonthDay = 15;
+
+    /// <summary>
+    /// The reporting cycle for <paramref name="settlementDate"/>. The caller is expected to pass
+    /// a real FINRA settlement date (see <see cref="CyclesInYear"/>); any date is accepted so a
+    /// stored settlement date can be dated without first being matched against the calendar.
+    /// </summary>
+    public static ShortInterestReportingCycle ForSettlementDate(DateOnly settlementDate)
+    {
+        var dueDate = UsMarketCalendar.AddTradingDays(
+            settlementDate,
+            DueTradingDaysAfterSettlement
+        );
+        var publicationDate = UsMarketCalendar.AddTradingDays(
+            dueDate,
+            PublicationTradingDaysAfterDue
+        );
+        return new ShortInterestReportingCycle(settlementDate, dueDate, publicationDate);
+    }
+
+    /// <summary>The 24 cycles whose settlement date falls in <paramref name="year"/>, oldest first.</summary>
+    public static IEnumerable<ShortInterestReportingCycle> CyclesInYear(int year)
+    {
+        foreach (var settlementDate in SettlementDatesInYear(year))
+            yield return ForSettlementDate(settlementDate);
+    }
+
+    /// <summary>
+    /// The next <paramref name="count"/> cycles whose data has not been published yet as of
+    /// <paramref name="asOf"/> — a cycle publishing today still counts, since the file lands
+    /// in the evening. Oldest first.
+    /// </summary>
+    /// <param name="asOf">Today's date in US Eastern time (the calendar's own time zone).</param>
+    /// <param name="count">How many cycles to return.</param>
+    /// <param name="afterSettlementDate">
+    /// When set, only cycles settling strictly after this date are returned. Pass the newest
+    /// settlement date already stored so a cycle whose file has just landed drops off the list
+    /// instead of being listed as still upcoming.
+    /// </param>
+    public static List<ShortInterestReportingCycle> Upcoming(
+        DateOnly asOf,
+        int count,
+        DateOnly? afterSettlementDate = null
+    )
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        var upcoming = new List<ShortInterestReportingCycle>(count);
+        // A cycle publishes at most ~4 weeks after it settles, so the pending window never
+        // reaches back further than the previous month; start there and walk forward. The
+        // horizon is bounded by count, and a year yields 24 cycles, so this is a short scan.
+        for (var year = asOf.AddMonths(-1).Year; upcoming.Count < count; year++)
+        {
+            foreach (var cycle in CyclesInYear(year))
+            {
+                if (cycle.PublicationDate < asOf)
+                    continue;
+                if (afterSettlementDate is { } floor && cycle.SettlementDate <= floor)
+                    continue;
+
+                upcoming.Add(cycle);
+                if (upcoming.Count == count)
+                    break;
+            }
+        }
+        return upcoming;
+    }
+
+    /// <summary>
+    /// The cycle FINRA publishes on <paramref name="date"/>, or null when nothing is scheduled
+    /// to publish that day. Drives the worker's publication-evening poll.
+    /// </summary>
+    public static ShortInterestReportingCycle PublishingOn(DateOnly date)
+    {
+        // A publication date is at most a few weeks after its settlement date, so a cycle
+        // publishing today settled either this year or — for the early-January dates that
+        // carry the December 31 settlement — the previous one.
+        return CyclesInYear(date.Year - 1)
+            .Concat(CyclesInYear(date.Year))
+            .FirstOrDefault(cycle => cycle.PublicationDate == date);
+    }
+
+    // The 15th and the last day of each month, each rolled back to the prior trading day.
+    private static IEnumerable<DateOnly> SettlementDatesInYear(int year)
+    {
+        for (var month = 1; month <= 12; month++)
+        {
+            yield return UsMarketCalendar.PreviousOrSameTradingDay(
+                new DateOnly(year, month, MidMonthDay)
+            );
+            yield return UsMarketCalendar.PreviousOrSameTradingDay(
+                new DateOnly(year, month, DateTime.DaysInMonth(year, month))
+            );
+        }
+    }
+}

--- a/src/Equibles.Finra.Data/Calendars/ShortInterestCalendar.cs
+++ b/src/Equibles.Finra.Data/Calendars/ShortInterestCalendar.cs
@@ -84,17 +84,14 @@ public static class ShortInterestCalendar
         // horizon is bounded by count, and a year yields 24 cycles, so this is a short scan.
         for (var year = asOf.AddMonths(-1).Year; upcoming.Count < count; year++)
         {
-            foreach (var cycle in CyclesInYear(year))
-            {
-                if (cycle.PublicationDate < asOf)
-                    continue;
-                if (afterSettlementDate is { } floor && cycle.SettlementDate <= floor)
-                    continue;
-
-                upcoming.Add(cycle);
-                if (upcoming.Count == count)
-                    break;
-            }
+            upcoming.AddRange(
+                CyclesInYear(year)
+                    .Where(cycle =>
+                        cycle.PublicationDate >= asOf
+                        && (afterSettlementDate is not { } floor || cycle.SettlementDate > floor)
+                    )
+                    .Take(count - upcoming.Count)
+            );
         }
         return upcoming;
     }

--- a/src/Equibles.Finra.Data/Calendars/ShortInterestReportingCycle.cs
+++ b/src/Equibles.Finra.Data/Calendars/ShortInterestReportingCycle.cs
@@ -1,0 +1,15 @@
+namespace Equibles.Finra.Data.Calendars;
+
+/// <summary>
+/// One row of FINRA's short interest reporting calendar: the settlement date positions are
+/// measured as of, the deadline broker-dealers must file by, and the date FINRA disseminates
+/// the file publicly. See <see cref="ShortInterestCalendar"/> for how these are derived.
+/// </summary>
+/// <param name="SettlementDate">The date short positions are measured as of.</param>
+/// <param name="DueDate">Broker-dealer filing deadline, 6:00 p.m. ET on this date.</param>
+/// <param name="PublicationDate">The date FINRA publishes the file (data becomes fetchable).</param>
+public sealed record ShortInterestReportingCycle(
+    DateOnly SettlementDate,
+    DateOnly DueDate,
+    DateOnly PublicationDate
+);

--- a/src/Equibles.Finra.Data/Equibles.Finra.Data.csproj
+++ b/src/Equibles.Finra.Data/Equibles.Finra.Data.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
+    <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Finra.HostedService/Configuration/FinraScraperOptions.cs
+++ b/src/Equibles.Finra.HostedService/Configuration/FinraScraperOptions.cs
@@ -12,7 +12,18 @@ public class FinraScraperOptions : ScraperOptions
     /// </summary>
     public bool EveningPollEnabled { get; set; } = true;
 
-    /// <summary>How often to re-check for the file while inside the post-close poll window.</summary>
+    /// <summary>
+    /// When true (default), the worker also minute-polls for the semi-monthly short INTEREST
+    /// file during the same post-close window, on the ~24 days a year FINRA's reporting
+    /// calendar publishes one (see <c>ShortInterestCalendar</c>). Polling stops as soon as that
+    /// cycle's settlement date is stored. Requires <see cref="EveningPollEnabled"/>.
+    /// </summary>
+    public bool ShortInterestPublicationPollEnabled { get; set; } = true;
+
+    /// <summary>
+    /// How often to re-check for a file while inside the post-close poll window. Governs both
+    /// the daily short-volume poll and the publication-day short-interest poll.
+    /// </summary>
     public int ShortVolumePollIntervalMinutes { get; set; } = 1;
 
     /// <summary>Poll-window start, ET hour (16 = 16:00, regular market close).</summary>

--- a/src/Equibles.Finra.HostedService/FinraScraperWorker.cs
+++ b/src/Equibles.Finra.HostedService/FinraScraperWorker.cs
@@ -1,5 +1,7 @@
+using Equibles.Core.Calendars;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.Finra.Data.Calendars;
 using Equibles.Finra.HostedService.Configuration;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Finra.Repositories;
@@ -14,7 +16,7 @@ public class FinraScraperWorker : BaseScraperWorker
 {
     private readonly FinraScraperOptions _options;
 
-    // True when the cycle just polled for an unpublished short-volume file, so the next
+    // True when the cycle just polled for a file FINRA hasn't published yet, so the next
     // wait uses the short poll interval rather than the idle wait-until-next-window. Reset
     // at the top of every DoWork, mirroring the base class resetting its own retry flag.
     private bool _pollWaitRequested;
@@ -59,23 +61,61 @@ public class FinraScraperWorker : BaseScraperWorker
 
         // Short volume is always attempted first — its importer scans [floor, today] and
         // stores nothing for a day FINRA hasn't published, so an unpublished day leaves the
-        // DB short of today's session and ShouldPollForToday stays true.
+        // DB short of today's session and ShortVolumeOutstanding stays true.
         await RunShortVolumeImport(stoppingToken);
+        var shortVolumeOutstanding = await ShortVolumeOutstanding(stoppingToken);
 
-        if (await ShouldPollForToday(stoppingToken))
+        // On one of the ~24 publication evenings a year, the short-interest file is the thing
+        // we are waiting for, so its import runs even while short volume is still outstanding —
+        // otherwise a late daily file would starve the very import being polled for. On every
+        // other cycle short interest keeps its slow cadence and yields to the short-volume poll.
+        var publishingCycle = PublishingCycleInWindow();
+        var shortInterestOutstanding = false;
+        if (publishingCycle != null)
+        {
+            await RunShortInterestImport(stoppingToken);
+            shortInterestOutstanding = !await SettlementDateStored(
+                publishingCycle.SettlementDate,
+                stoppingToken
+            );
+        }
+        else if (!shortVolumeOutstanding)
+        {
+            await RunShortInterestImport(stoppingToken);
+        }
+
+        if (shortVolumeOutstanding || shortInterestOutstanding)
         {
             Logger.LogInformation(
-                "Short volume for today's session is not published yet; polling again in {Minutes} min",
+                "FINRA has not published {Pending} yet; polling again in {Minutes} min",
+                PendingDescription(
+                    shortVolumeOutstanding,
+                    publishingCycle,
+                    shortInterestOutstanding
+                ),
                 _options.ShortVolumePollIntervalMinutes
             );
             _pollWaitRequested = true;
             RequestRetrySoon();
-            // Skip the slow-cadence imports while minute-polling so we don't hammer them.
+            // Skip the slow-cadence import while minute-polling so we don't hammer it.
             return;
         }
 
-        await RunShortInterestImport(stoppingToken);
         await RunOffExchangeVolumeImport(stoppingToken);
+    }
+
+    private static string PendingDescription(
+        bool shortVolumeOutstanding,
+        ShortInterestReportingCycle publishingCycle,
+        bool shortInterestOutstanding
+    )
+    {
+        var pending = new List<string>(2);
+        if (shortVolumeOutstanding)
+            pending.Add("today's short-volume file");
+        if (shortInterestOutstanding)
+            pending.Add($"short interest settling {publishingCycle.SettlementDate:yyyy-MM-dd}");
+        return string.Join(" and ", pending);
     }
 
     private async Task RunShortVolumeImport(CancellationToken stoppingToken)
@@ -102,31 +142,61 @@ public class FinraScraperWorker : BaseScraperWorker
         await service.Import(stoppingToken);
     }
 
-    // True while we should keep minute-polling for today's file: evening polling enabled,
-    // ET-now is on an NYSE trading day inside the post-close window, and today's session row
-    // is not yet stored.
-    private async Task<bool> ShouldPollForToday(CancellationToken stoppingToken)
+    // True while we should keep minute-polling for today's short-volume file: ET-now is inside
+    // the post-close window on an NYSE trading day and today's session row is not yet stored.
+    private async Task<bool> ShortVolumeOutstanding(CancellationToken stoppingToken)
+    {
+        var etDate = EveningWindowDate();
+        if (etDate == null || !UsMarketCalendar.IsTradingDay(etDate.Value))
+            return false;
+
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
+        var alreadyStored = await repo.GetByDate(etDate.Value).AnyAsync(stoppingToken);
+        return !alreadyStored;
+    }
+
+    // The short-interest cycle FINRA publishes today, when ET-now is inside the post-close
+    // window and the publication poll is enabled; null on any other cycle. Publication dates
+    // are derived as trading-day arithmetic, so they are always trading days.
+    private ShortInterestReportingCycle PublishingCycleInWindow()
+    {
+        if (!_options.ShortInterestPublicationPollEnabled)
+            return null;
+
+        var etDate = EveningWindowDate();
+        return etDate == null ? null : ShortInterestCalendar.PublishingOn(etDate.Value);
+    }
+
+    // Today's ET date when evening polling is enabled and ET-now is inside the post-close
+    // window; null otherwise. The window opens at the regular market close so a file that
+    // lands minutes later is picked up the same evening.
+    private DateOnly? EveningWindowDate()
     {
         if (!_options.EveningPollEnabled)
-            return false;
+            return null;
 
         var nowEt = UsMarketCalendar.ToEastern(UtcNow());
-        var etDate = DateOnly.FromDateTime(nowEt.DateTime);
-
-        if (!UsMarketCalendar.IsTradingDay(etDate))
-            return false;
-
         var timeOfDay = nowEt.TimeOfDay;
         if (
             timeOfDay < TimeSpan.FromHours(_options.WindowStartHourEt)
             || timeOfDay >= TimeSpan.FromHours(_options.WindowEndHourEt)
         )
-            return false;
+            return null;
 
+        return DateOnly.FromDateTime(nowEt.DateTime);
+    }
+
+    // True once any row for this settlement date has landed — the importer stores nothing for
+    // a date FINRA has not published, so the first stored row means the file is out.
+    private async Task<bool> SettlementDateStored(
+        DateOnly settlementDate,
+        CancellationToken stoppingToken
+    )
+    {
         await using var scope = ScopeFactory.CreateAsyncScope();
-        var repo = scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
-        var alreadyStored = await repo.GetByDate(etDate).AnyAsync(stoppingToken);
-        return !alreadyStored;
+        var repo = scope.ServiceProvider.GetRequiredService<ShortInterestRepository>();
+        return await repo.GetBySettlementDate(settlementDate).AnyAsync(stoppingToken);
     }
 
     protected override Task WaitForNextCycle(TimeSpan interval, CancellationToken stoppingToken) =>

--- a/src/Equibles.Finra.HostedService/FinraScraperWorker.cs
+++ b/src/Equibles.Finra.HostedService/FinraScraperWorker.cs
@@ -65,24 +65,23 @@ public class FinraScraperWorker : BaseScraperWorker
         await RunShortVolumeImport(stoppingToken);
         var shortVolumeOutstanding = await ShortVolumeOutstanding(stoppingToken);
 
-        // On one of the ~24 publication evenings a year, the short-interest file is the thing
-        // we are waiting for, so its import runs even while short volume is still outstanding —
-        // otherwise a late daily file would starve the very import being polled for. On every
-        // other cycle short interest keeps its slow cadence and yields to the short-volume poll.
+        // On one of the ~24 publication evenings a year, the semi-monthly short-interest file is
+        // what we are waiting for, so it is imported even while today's short-volume file is
+        // still outstanding — otherwise a late daily file would starve the very import being
+        // polled for. Checking the store BEFORE importing matters: once the settlement date has
+        // landed the poll is satisfied, and short interest must drop back to its slow cadence
+        // instead of re-running every minute until short volume catches up.
         var publishingCycle = PublishingCycleInWindow();
-        var shortInterestOutstanding = false;
-        if (publishingCycle != null)
-        {
+        var awaitingPublication =
+            publishingCycle != null
+            && !await SettlementDateStored(publishingCycle.SettlementDate, stoppingToken);
+
+        if (awaitingPublication || !shortVolumeOutstanding)
             await RunShortInterestImport(stoppingToken);
-            shortInterestOutstanding = !await SettlementDateStored(
-                publishingCycle.SettlementDate,
-                stoppingToken
-            );
-        }
-        else if (!shortVolumeOutstanding)
-        {
-            await RunShortInterestImport(stoppingToken);
-        }
+
+        var shortInterestOutstanding =
+            awaitingPublication
+            && !await SettlementDateStored(publishingCycle.SettlementDate, stoppingToken);
 
         if (shortVolumeOutstanding || shortInterestOutstanding)
         {
@@ -90,8 +89,8 @@ public class FinraScraperWorker : BaseScraperWorker
                 "FINRA has not published {Pending} yet; polling again in {Minutes} min",
                 PendingDescription(
                     shortVolumeOutstanding,
-                    publishingCycle,
-                    shortInterestOutstanding
+                    shortInterestOutstanding,
+                    publishingCycle
                 ),
                 _options.ShortVolumePollIntervalMinutes
             );
@@ -104,10 +103,12 @@ public class FinraScraperWorker : BaseScraperWorker
         await RunOffExchangeVolumeImport(stoppingToken);
     }
 
+    // What the poll is still waiting on, for the log line. shortInterestOutstanding implies a
+    // non-null cycle — it is only ever set from one.
     private static string PendingDescription(
         bool shortVolumeOutstanding,
-        ShortInterestReportingCycle publishingCycle,
-        bool shortInterestOutstanding
+        bool shortInterestOutstanding,
+        ShortInterestReportingCycle publishingCycle
     )
     {
         var pending = new List<string>(2);

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
+using Equibles.Core.Calendars;
 using Equibles.Core.Configuration;
 using Equibles.CorporateActions.BusinessLogic;
 using Equibles.CorporateActions.Data.Models;

--- a/tests/Equibles.IntegrationTests/Finra/FinraScraperWorkerPollingTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraScraperWorkerPollingTests.cs
@@ -311,6 +311,11 @@ public class FinraScraperWorkerPollingTests : IDisposable
         // Short interest has landed but today's short-volume file has not, so the poll stays
         // armed and off-exchange is still deferred.
         await _finraClient.DidNotReceive().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+        // ...and short interest must NOT re-import on every one of those minute-polls: its file
+        // is already in, so it drops back to the slow cadence while short volume catches up.
+        await _finraClient
+            .DidNotReceive()
+            .GetShortInterestSettlementDatesAfter(Arg.Any<DateOnly>());
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Finra/FinraScraperWorkerPollingTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraScraperWorkerPollingTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Calendars;
 using Equibles.Core.Configuration;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
@@ -26,7 +27,13 @@ namespace Equibles.IntegrationTests.Finra;
 /// post-close ET window on a trading day, while today's short-volume file is still
 /// unpublished, the worker re-runs only the short-volume import (and requests a fast retry)
 /// while skipping the slow-cadence short-interest and off-exchange imports. Outside that
-/// condition all three run. Which imports ran is observed through the shared FINRA client.
+/// condition all three run.
+///
+/// The exception is one of the ~24 short-interest publication evenings a year, where the
+/// semi-monthly file is the thing being polled for: there short interest runs alongside the
+/// short-volume poll and keeps the poll armed until its settlement date lands.
+///
+/// Which imports ran is observed through the shared FINRA client.
 /// </summary>
 public class FinraScraperWorkerPollingTests : IDisposable
 {
@@ -45,7 +52,16 @@ public class FinraScraperWorkerPollingTests : IDisposable
         _finraClient
             .GetDailyShortVolume(Arg.Any<DateOnly>())
             .Returns(new List<ShortVolumeRecord>());
+        // Discovery has three entry points — empty store, forward-from-newest, and backfill —
+        // and the importer picks between them by what is already stored, so all three are
+        // stubbed and the tests observe whichever one their seed data selects.
         _finraClient.GetShortInterestSettlementDates().Returns(new List<DateOnly>());
+        _finraClient
+            .GetShortInterestSettlementDatesAfter(Arg.Any<DateOnly>())
+            .Returns(new List<DateOnly>());
+        _finraClient
+            .GetShortInterestSettlementDatesBetween(Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new List<DateOnly>());
         _finraClient
             .GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>())
             .Returns(new List<OffExchangeWeeklyRecord>());
@@ -142,12 +158,13 @@ public class FinraScraperWorkerPollingTests : IDisposable
             workerOptions
         );
 
-        // The worker resolves the three import services + the repo used by ShouldPollForToday.
+        // The worker resolves the three import services + the two repos its poll gates read.
         var workerScopeFactory = ServiceScopeSubstitute.Create(
             (typeof(ShortVolumeImportService), shortVolume),
             (typeof(ShortInterestImportService), shortInterest),
             (typeof(OffExchangeVolumeImportService), offExchange),
-            (typeof(DailyShortVolumeRepository), new DailyShortVolumeRepository(_dbContext))
+            (typeof(DailyShortVolumeRepository), new DailyShortVolumeRepository(_dbContext)),
+            (typeof(ShortInterestRepository), new ShortInterestRepository(_dbContext))
         );
 
         return new TestableFinraScraperWorker(
@@ -229,6 +246,95 @@ public class FinraScraperWorkerPollingTests : IDisposable
 
         await _finraClient.Received().GetShortInterestSettlementDates();
         await _finraClient.Received().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    // Tuesday 2025-03-11 is a FINRA short-interest publication date (the 2025-02-28 settlement);
+    // 16:30 ET puts it inside the default post-close window.
+    private static DateTimeOffset PublicationEvening() => Et(2025, 3, 11, 16, 30);
+
+    private static readonly DateOnly PublishedSettlementDate = new(2025, 2, 28);
+
+    private async Task SeedShortInterest(DateOnly settlementDate)
+    {
+        var stockId = _stockRepo.GetAll().Select(s => s.Id).First();
+        _dbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStockId = stockId,
+                    SettlementDate = settlementDate,
+                    CurrentShortPosition = 1,
+                }
+            );
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+    }
+
+    [Fact]
+    public async Task DoWork_PublicationEveningWithFileMissing_RunsShortInterestAndKeepsPolling()
+    {
+        await SeedStock();
+
+        await BuildWorker(PublicationEvening()).RunCycle(CancellationToken.None);
+
+        // Short interest runs even though today's short-volume file is also still missing —
+        // otherwise a late daily file would starve the import we are actually polling for.
+        await _finraClient.Received().GetShortInterestSettlementDates();
+        // Still minute-polling, so the slow-cadence off-exchange import is skipped.
+        await _finraClient.DidNotReceive().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task DoWork_PublicationEveningWithFileLanded_StopsPolling()
+    {
+        await SeedStock();
+        await SeedShortVolume(new DateOnly(2025, 3, 11));
+        await SeedShortInterest(PublishedSettlementDate);
+
+        await BuildWorker(PublicationEvening()).RunCycle(CancellationToken.None);
+
+        // The settlement date is stored, so nothing is outstanding and the cycle completes
+        // through to the slow-cadence import instead of re-arming the poll.
+        await _finraClient.Received().GetShortInterestSettlementDatesAfter(Arg.Any<DateOnly>());
+        await _finraClient.Received().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task DoWork_PublicationEveningWithShortVolumeStillMissing_KeepsPolling()
+    {
+        await SeedStock();
+        await SeedShortInterest(PublishedSettlementDate);
+
+        await BuildWorker(PublicationEvening()).RunCycle(CancellationToken.None);
+
+        // Short interest has landed but today's short-volume file has not, so the poll stays
+        // armed and off-exchange is still deferred.
+        await _finraClient.DidNotReceive().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task DoWork_PublicationPollDisabled_LeavesShortInterestOnItsSlowCadence()
+    {
+        await SeedStock();
+
+        var options = new FinraScraperOptions { ShortInterestPublicationPollEnabled = false };
+        await BuildWorker(PublicationEvening(), options).RunCycle(CancellationToken.None);
+
+        // Back to the short-volume-only poll: short interest yields to it as before.
+        await _finraClient.DidNotReceive().GetShortInterestSettlementDates();
+        await _finraClient.DidNotReceive().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task DoWork_NonPublicationEvening_LeavesShortInterestOnItsSlowCadence()
+    {
+        await SeedStock();
+
+        // Wednesday 2025-03-12 publishes nothing, so the short-volume poll wins as before.
+        await BuildWorker(InWindowTradingDay()).RunCycle(CancellationToken.None);
+
+        await _finraClient.DidNotReceive().GetShortInterestSettlementDates();
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Core/Calendars/UsMarketCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Core/Calendars/UsMarketCalendarTests.cs
@@ -51,6 +51,27 @@ public class UsMarketCalendarTests
         UsMarketCalendar.IsTradingDay(new DateOnly(year, month, day)).Should().Be(expectedOpen);
     }
 
+    [Theory]
+    // 23:30 ET on New Year's Eve is already Jan 1 in UTC, so a caller reading the UTC date
+    // would be a day ahead of the market calendar.
+    [InlineData(2025, 12, 31, 23, 30, "2025-12-31")]
+    [InlineData(2026, 7, 15, 0, 30, "2026-07-15")]
+    [InlineData(2026, 7, 15, 16, 30, "2026-07-15")]
+    public void EasternDate_ReturnsTheEasternCalendarDate_NotTheUtcOne(
+        int year,
+        int month,
+        int day,
+        int hour,
+        int minute,
+        string expected
+    )
+    {
+        UsMarketCalendar
+            .EasternDate(Et(year, month, day, hour, minute))
+            .Should()
+            .Be(DateOnly.Parse(expected));
+    }
+
     [Fact]
     public void ToEastern_SummerInstant_IsEdtMinusFour()
     {

--- a/tests/Equibles.UnitTests/Core/Calendars/UsMarketCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Core/Calendars/UsMarketCalendarTests.cs
@@ -1,6 +1,6 @@
-using Equibles.Worker;
+using Equibles.Core.Calendars;
 
-namespace Equibles.UnitTests.Worker;
+namespace Equibles.UnitTests.Core.Calendars;
 
 public class UsMarketCalendarTests
 {

--- a/tests/Equibles.UnitTests/Finra/ShortInterestCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortInterestCalendarTests.cs
@@ -1,0 +1,182 @@
+using Equibles.Finra.Data.Calendars;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Pins <see cref="ShortInterestCalendar"/> against FINRA's own published reporting calendar
+/// at https://www.finra.org/filing-reporting/regulatory-filing-systems/short-interest.
+///
+/// Every settlement/due/publication triple below is transcribed verbatim from that page (the
+/// tail of the 2025 table it still lists, plus the whole of 2026). The calendar is derived
+/// rather than scraped — FINRA answers a plain HTTP GET with 403 and only ever publishes the
+/// current and next year — so this suite is what keeps the derivation honest: if FINRA ever
+/// changes the rule, these rows fail instead of the dates quietly skewing.
+/// </summary>
+public class ShortInterestCalendarTests
+{
+    // FINRA's published calendar, "settlement, due, publication". Adding the next year's table
+    // here as FINRA publishes it is the intended way to re-verify the derivation.
+    private static readonly string[][] PublishedRows =
+    [
+        // 2025
+        ["2025-11-14", "2025-11-18", "2025-11-25"],
+        ["2025-11-28", "2025-12-02", "2025-12-09"],
+        ["2025-12-15", "2025-12-17", "2025-12-24"],
+        ["2025-12-31", "2026-01-05", "2026-01-12"],
+        // 2026
+        ["2026-01-15", "2026-01-20", "2026-01-27"],
+        ["2026-01-30", "2026-02-03", "2026-02-10"],
+        ["2026-02-13", "2026-02-18", "2026-02-25"],
+        ["2026-02-27", "2026-03-03", "2026-03-10"],
+        ["2026-03-13", "2026-03-17", "2026-03-24"],
+        ["2026-03-31", "2026-04-02", "2026-04-10"],
+        ["2026-04-15", "2026-04-17", "2026-04-24"],
+        ["2026-04-30", "2026-05-04", "2026-05-11"],
+        ["2026-05-15", "2026-05-19", "2026-05-27"],
+        ["2026-05-29", "2026-06-02", "2026-06-09"],
+        ["2026-06-15", "2026-06-17", "2026-06-25"],
+        ["2026-06-30", "2026-07-02", "2026-07-10"],
+        ["2026-07-15", "2026-07-17", "2026-07-24"],
+        ["2026-07-31", "2026-08-04", "2026-08-11"],
+        ["2026-08-14", "2026-08-18", "2026-08-25"],
+        ["2026-08-31", "2026-09-02", "2026-09-10"],
+        ["2026-09-15", "2026-09-17", "2026-09-24"],
+        ["2026-09-30", "2026-10-02", "2026-10-09"],
+        ["2026-10-15", "2026-10-19", "2026-10-26"],
+        ["2026-10-30", "2026-11-03", "2026-11-10"],
+        ["2026-11-13", "2026-11-17", "2026-11-24"],
+        ["2026-11-30", "2026-12-02", "2026-12-09"],
+        ["2026-12-15", "2026-12-17", "2026-12-24"],
+        ["2026-12-31", "2027-01-05", "2027-01-12"],
+    ];
+
+    public static TheoryData<string, string, string> PublishedCalendar
+    {
+        get
+        {
+            var data = new TheoryData<string, string, string>();
+            foreach (var row in PublishedRows)
+                data.Add(row[0], row[1], row[2]);
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(PublishedCalendar))]
+    public void ForSettlementDate_MatchesFinrasPublishedCalendar(
+        string settlement,
+        string due,
+        string publication
+    )
+    {
+        var cycle = ShortInterestCalendar.ForSettlementDate(DateOnly.Parse(settlement));
+
+        cycle.DueDate.Should().Be(DateOnly.Parse(due));
+        cycle.PublicationDate.Should().Be(DateOnly.Parse(publication));
+    }
+
+    [Fact]
+    public void CyclesInYear_2026_YieldsFinrasTwentyFourSettlementDates()
+    {
+        // The settlement-date rule on its own: the 15th and the month end, each rolled back to
+        // the prior trading day. A missing or extra cycle would slip past the per-row theory.
+        var expected = PublishedRows
+            .Select(row => DateOnly.Parse(row[0]))
+            .Where(date => date.Year == 2026)
+            .ToList();
+
+        var settlementDates = ShortInterestCalendar
+            .CyclesInYear(2026)
+            .Select(cycle => cycle.SettlementDate)
+            .ToList();
+
+        settlementDates.Should().HaveCount(24);
+        settlementDates.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void PublishingOn_APublicationDate_ReturnsThatCycle()
+    {
+        var cycle = ShortInterestCalendar.PublishingOn(new DateOnly(2026, 7, 24));
+
+        cycle.Should().NotBeNull();
+        cycle.SettlementDate.Should().Be(new DateOnly(2026, 7, 15));
+    }
+
+    [Fact]
+    public void PublishingOn_ADateNothingPublishes_ReturnsNull()
+    {
+        ShortInterestCalendar.PublishingOn(new DateOnly(2026, 7, 23)).Should().BeNull();
+    }
+
+    [Fact]
+    public void PublishingOn_EarlyJanuary_ResolvesThePreviousYearsDecemberSettlement()
+    {
+        // The December 31 cycle publishes in January, so the lookup must reach back a year.
+        var cycle = ShortInterestCalendar.PublishingOn(new DateOnly(2026, 1, 12));
+
+        cycle.Should().NotBeNull();
+        cycle.SettlementDate.Should().Be(new DateOnly(2025, 12, 31));
+    }
+
+    [Fact]
+    public void Upcoming_ReturnsTheNextCyclesOldestFirst()
+    {
+        var upcoming = ShortInterestCalendar.Upcoming(new DateOnly(2026, 7, 20), count: 2);
+
+        upcoming
+            .Select(cycle => cycle.SettlementDate)
+            .Should()
+            .Equal(new DateOnly(2026, 7, 15), new DateOnly(2026, 7, 31));
+    }
+
+    [Fact]
+    public void Upcoming_OnAPublicationDate_StillListsThatDaysCycle()
+    {
+        // The file lands in the evening, so on its publication date the cycle is still pending.
+        var upcoming = ShortInterestCalendar.Upcoming(new DateOnly(2026, 7, 24), count: 1);
+
+        upcoming.Single().SettlementDate.Should().Be(new DateOnly(2026, 7, 15));
+        upcoming.Single().PublicationDate.Should().Be(new DateOnly(2026, 7, 24));
+    }
+
+    [Fact]
+    public void Upcoming_WithAStoredSettlementFloor_SkipsCyclesAlreadyCaptured()
+    {
+        // Once the July 15 file has landed it must drop off the "next reporting dates" list
+        // even though its publication date is still today.
+        var upcoming = ShortInterestCalendar.Upcoming(
+            new DateOnly(2026, 7, 24),
+            count: 2,
+            afterSettlementDate: new DateOnly(2026, 7, 15)
+        );
+
+        upcoming
+            .Select(cycle => cycle.SettlementDate)
+            .Should()
+            .Equal(new DateOnly(2026, 7, 31), new DateOnly(2026, 8, 14));
+    }
+
+    [Fact]
+    public void Upcoming_AcrossTheYearBoundary_ContinuesIntoTheNextYear()
+    {
+        // The December 15 cycle published on the 24th, so only the December 31 cycle is still
+        // pending in 2026 and the list has to roll into the next year to fill its count.
+        var upcoming = ShortInterestCalendar.Upcoming(new DateOnly(2026, 12, 28), count: 3);
+
+        upcoming
+            .Select(cycle => cycle.SettlementDate)
+            .Should()
+            .Equal(
+                new DateOnly(2026, 12, 31),
+                new DateOnly(2027, 1, 15),
+                new DateOnly(2027, 1, 29)
+            );
+    }
+
+    [Fact]
+    public void Upcoming_CountZero_ReturnsEmpty()
+    {
+        ShortInterestCalendar.Upcoming(new DateOnly(2026, 7, 24), count: 0).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Problem

Short interest is published twice a month. `FinraScraperWorker` already caps its idle wait to the next trading-day 16:00 ET window, so it *wakes* on time — but on that wake-up it imports short volume first, and while today's daily short-volume file is still unpublished it **skips short interest entirely** and minute-polls for short volume. Short interest therefore lands only once the unrelated daily file does.

Measured on prod (`MIN(CreationTime)` per settlement, server time +01):

| settlement | daily short-volume file landed | short interest landed |
|---|---|---|
| 2026-07-15 | 22:23:53 (17:23 ET) | 22:43:40 (17:43 ET) |

So the file sat ~1h43 past the 16:00 ET wake-up, waiting on a file it has nothing to do with — and if the daily file had not published at all that evening, short interest would have been skipped until the next day.

## What changed

**`ShortInterestCalendar` (new, `Equibles.Finra.Data`)** — derives FINRA's reporting calendar:

| | rule |
|---|---|
| settlement | the 15th and the last day of each month, rolled back to the prior trading day |
| due | settlement + 2 trading days (FINRA Rule 4560, "by 6 p.m. ET on the second business day after") |
| publication | due + 5 trading days (= exactly 7 trading days after settlement) |

Derived rather than scraped: FINRA answers a plain HTTP GET with **403**, and the page only ever lists the current and next year. `ShortInterestCalendarTests` pins the derivation against FINRA's published 2025 + 2026 tables **verbatim** — all 28 rows.

It also matches our own ingestion history exactly — every recent settlement landed on the derived publication date:

| settlement | derived publication | actually landed |
|---|---|---|
| 2026-05-15 | 2026-05-27 | 2026-05-27 |
| 2026-05-29 | 2026-06-09 | 2026-06-09 |
| 2026-06-15 | 2026-06-25 | 2026-06-25 |
| 2026-06-30 | 2026-07-10 | 2026-07-10 |
| 2026-07-15 | 2026-07-24 | 2026-07-24 |

**`FinraScraperWorker`** — on one of the ~24 publication evenings a year, short interest is imported from the 16:00 ET wake-up **regardless of whether the daily short-volume file has landed**, and the minute-poll stays armed until that cycle's settlement date is stored. Off the calendar, behaviour is unchanged.

The store is checked *before* importing, not after: otherwise, once short interest had landed but short volume had not, the poll would stay armed for short volume and re-run the short-interest import every minute for hours. Pinned by `DoWork_PublicationEveningWithShortVolumeStillMissing_KeepsPolling`.

Gated by `FinraScraper:ShortInterestPublicationPollEnabled` (default on).

**`UsMarketCalendar`** moves `Equibles.Worker` → `Equibles.Core` so the calendar can reach its trading-day arithmetic without a worker reference, and gains `PreviousOrSameTradingDay` / `AddTradingDays` / `EasternDate`.

## Tests

- `ShortInterestCalendarTests` — 28 published rows + the settlement-date set, `PublishingOn`, `Upcoming` (year boundary, stored-settlement floor)
- `FinraScraperWorkerPollingTests` — 5 new cases for the publication evening (file missing / landed / short-volume still missing / poll disabled / non-publication day)
- Full suites green locally: **3718** unit, **2249** integration