### PR TITLE
fix(yahoo): stop the price lane starving behind dead tickers and enrichment

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -78,14 +78,37 @@ public class YahooPriceImportService
         // those stocks' full, fully-adjusted history and overwrite the stored rows (#2879).
         await ReconcilePendingSplits(DateOnly.FromDateTime(DateTime.UtcNow), cancellationToken);
 
-        var totalInserted = 0;
+        // Crawl the recently-active stocks first, stalest-first within them, and the long-dormant
+        // tail afterwards (see OrderByCrawlPriority for why the plain stalest-first order starved
+        // the daily lane).
+        var crawlOrder = await OrderByCrawlPriority(tickerMap, cancellationToken);
 
-        // Crawl stalest-first: the ticker map's DB order is stable across cycles, so with a
-        // multi-hour crawl any interruption (deploy, crash, rate-limit stall) starves the same
-        // tail stocks for days while head stocks re-sync every cycle. Ordering by each stock's
-        // last stored price date spends every partial cycle on the most out-of-date stocks;
-        // never-synced stocks lead.
-        var crawlOrder = await OrderByStalestPrice(tickerMap, cancellationToken);
+        // Prices for the WHOLE universe first, enrichment only afterwards. The two used to be
+        // interleaved per ticker, which made every stock cost three Yahoo calls instead of one and
+        // stretched a full pass to hours — and since an interrupted cycle simply restarts from the
+        // top, a worker that restarts more often than a pass takes (a deploy, say) would keep
+        // re-walking the head and never reach the stocks missing yesterday's bar. Prices are the
+        // time-critical half and are nearly free once a stock is current (the settled-trading-day
+        // gate makes an up-to-date stock cost zero calls), so they must never queue behind
+        // enrichment traffic for the stock in front.
+        var totalInserted = await ImportPrices(crawlOrder, cancellationToken);
+
+        _logger.LogInformation(
+            "Yahoo price sync complete. Inserted {Count} new price records",
+            totalInserted
+        );
+
+        if (includeEnrichment)
+            await ImportEnrichment(crawlOrder, cancellationToken);
+    }
+
+    // Pass 1 — the settled daily bars. One Yahoo call per stock that actually needs one.
+    private async Task<int> ImportPrices(
+        List<KeyValuePair<string, Guid>> crawlOrder,
+        CancellationToken cancellationToken
+    )
+    {
+        var totalInserted = 0;
 
         foreach (var (ticker, commonStockId) in crawlOrder)
         {
@@ -99,17 +122,16 @@ public class YahooPriceImportService
 
             try
             {
-                var inserted = await ImportTicker(ticker, commonStockId, today, cancellationToken);
-                totalInserted += inserted;
-                if (includeEnrichment)
-                {
-                    await SyncKeyStatistics(ticker, commonStockId, cancellationToken);
-                    await SyncCompanyProfile(ticker, commonStockId, cancellationToken);
-                }
+                totalInserted += await ImportTicker(
+                    ticker,
+                    commonStockId,
+                    today,
+                    cancellationToken
+                );
             }
             catch (HttpRequestException ex)
             {
-                _logger.LogWarning(ex, "Failed to fetch data for {Ticker}, skipping", ticker);
+                _logger.LogWarning(ex, "Failed to fetch prices for {Ticker}, skipping", ticker);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -119,7 +141,7 @@ public class YahooPriceImportService
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error importing data for {Ticker}", ticker);
+                _logger.LogError(ex, "Error importing prices for {Ticker}", ticker);
                 await _errorReporter.Report(
                     ErrorSource.YahooPriceScraper,
                     $"ImportTicker({ticker})",
@@ -128,15 +150,63 @@ public class YahooPriceImportService
             }
         }
 
-        _logger.LogInformation(
-            "Yahoo price sync complete. Inserted {Count} new price records",
-            totalInserted
-        );
+        return totalInserted;
     }
 
-    // Orders the ticker map by each stock's most recent stored price date, oldest first (stocks
-    // with no prices at all lead). One grouped MAX(Date) query over the price table per cycle.
-    private async Task<List<KeyValuePair<string, Guid>>> OrderByStalestPrice(
+    // Pass 2 — key statistics + company profile. Two extra Yahoo calls per stock and the bulk of a
+    // cycle's traffic, which is why it runs on its own slower cadence AND strictly after prices.
+    private async Task ImportEnrichment(
+        List<KeyValuePair<string, Guid>> crawlOrder,
+        CancellationToken cancellationToken
+    )
+    {
+        foreach (var (ticker, commonStockId) in crawlOrder)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                await SyncKeyStatistics(ticker, commonStockId, cancellationToken);
+                await SyncCompanyProfile(ticker, commonStockId, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(ex, "Failed to fetch enrichment for {Ticker}, skipping", ticker);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error enriching {Ticker}", ticker);
+                await _errorReporter.Report(ErrorSource.YahooPriceScraper, $"Enrich({ticker})", ex);
+            }
+        }
+    }
+
+    // A stock whose newest stored bar is within this many calendar days is treated as actively
+    // trading and belongs to the daily working set. Comfortably clears a long weekend plus a
+    // holiday, so a healthy stock can never fall out of the set just because the market was shut.
+    private const int ActivelyTradedWindowDays = 10;
+
+    // Orders the crawl: actively-traded stocks first (stalest of them leading), long-dormant and
+    // never-synced stocks after them, stalest-first within each group. One grouped MAX(Date) query
+    // over the price table per cycle.
+    //
+    // Plain stalest-first is the obvious order and it was actively harmful. Sorting the whole
+    // universe by last stored date puts the stocks that will never return data — delisted tickers,
+    // bankruptcy-suffixed symbols, expired warrants, foreign OTC lines Yahoo does not serve — at
+    // the front of EVERY cycle, because "no data for months" sorts as "stalest". They cost a call
+    // each, yield nothing, and are re-paid on the next cycle: in production 617 such stocks sat
+    // ahead of the 5,484 that were merely missing the previous session's bar, so the lane spent its
+    // first ~23 minutes on hopeless work while the whole site showed a stale close.
+    //
+    // Splitting on recency fixes that without reintroducing starvation, which is what stalest-first
+    // was guarding against. The dormant tail still runs every cycle, just second — and once the
+    // working set is current it costs nearly nothing to walk (the settled-trading-day gate skips an
+    // up-to-date stock without any Yahoo call), so the tail gets almost the entire cycle anyway.
+    private async Task<List<KeyValuePair<string, Guid>>> OrderByCrawlPriority(
         Dictionary<string, Guid> tickerMap,
         CancellationToken cancellationToken
     )
@@ -149,10 +219,30 @@ public class YahooPriceImportService
             .Select(g => new { StockId = g.Key, LastDate = g.Max(p => p.Date) })
             .ToDictionaryAsync(x => x.StockId, x => x.LastDate, cancellationToken);
 
+        return BuildCrawlOrder(tickerMap, lastDates, DateOnly.FromDateTime(DateTime.UtcNow));
+    }
+
+    // Pure so the priority rule is pinnable in tests without a database.
+    private static List<KeyValuePair<string, Guid>> BuildCrawlOrder(
+        Dictionary<string, Guid> tickerMap,
+        IReadOnlyDictionary<Guid, DateOnly> lastDates,
+        DateOnly today
+    )
+    {
+        var activeSince = today.AddDays(-ActivelyTradedWindowDays);
+
         return tickerMap
-            .OrderBy(kv =>
-                lastDates.TryGetValue(kv.Value, out var lastDate) ? lastDate : DateOnly.MinValue
-            )
+            .Select(kv => new
+            {
+                Entry = kv,
+                LastDate = lastDates.TryGetValue(kv.Value, out var lastDate)
+                    ? lastDate
+                    : DateOnly.MinValue,
+            })
+            // false (0) sorts before true (1), so the actively-traded group leads.
+            .OrderBy(x => x.LastDate < activeSince)
+            .ThenBy(x => x.LastDate)
+            .Select(x => x.Entry)
             .ToList();
     }
 

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceCrawlOrderTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceCrawlOrderTests.cs
@@ -1,0 +1,133 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Tests for the crawl priority rule in <see cref="YahooPriceImportService"/>, exercised through
+/// the pure private static <c>BuildCrawlOrder</c> via reflection.
+///
+/// The lane used to sort the whole universe stalest-first, which reads as obviously correct and was
+/// the reason the daily price lane fell days behind. Stocks that will never return data again —
+/// delisted tickers, bankruptcy-suffixed symbols, expired warrants, foreign OTC lines Yahoo does not
+/// serve — sort as "stalest" precisely because they have no recent data, so they led every single
+/// cycle. In production 617 of them sat ahead of the 5,484 stocks that were merely missing the
+/// previous session's bar, and a worker restarting more often than a full pass takes never got past
+/// them: the site showed a close from two sessions earlier while the lane worked flat out.
+/// </summary>
+public class YahooPriceImportServiceCrawlOrderTests
+{
+    private static readonly MethodInfo BuildCrawlOrderMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "BuildCrawlOrder",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static readonly DateOnly Today = new(2026, 7, 27);
+
+    private static List<string> Order(
+        Dictionary<string, Guid> tickerMap,
+        Dictionary<Guid, DateOnly> lastDates
+    )
+    {
+        var result =
+            (List<KeyValuePair<string, Guid>>)
+                BuildCrawlOrderMethod.Invoke(null, [tickerMap, lastDates, Today]);
+        return result.Select(kv => kv.Key).ToList();
+    }
+
+    [Fact]
+    public void ActivelyTradedStocks_LeadLongDormantOnes()
+    {
+        // The defect in one assertion: DEAD is "stalest" and would lead under the old rule, pushing
+        // the stock that is merely one session behind to the back of an hours-long crawl.
+        var live = Guid.NewGuid();
+        var dead = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid> { ["DEAD"] = dead, ["LIVE"] = live };
+        var lastDates = new Dictionary<Guid, DateOnly>
+        {
+            [dead] = new DateOnly(2026, 5, 11),
+            [live] = new DateOnly(2026, 7, 23),
+        };
+
+        Order(tickerMap, lastDates).Should().Equal("LIVE", "DEAD");
+    }
+
+    [Fact]
+    public void NeverSyncedStocks_GoToTheTail_NotTheHead()
+    {
+        // A stock with no rows at all has no date to sort on, so it used to lead the crawl. Its
+        // backfill matters, but never at the cost of the whole universe's daily freshness — and it
+        // still runs every cycle, just after the working set.
+        var fresh = Guid.NewGuid();
+        var neverSynced = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid> { ["NEW"] = neverSynced, ["CUR"] = fresh };
+        var lastDates = new Dictionary<Guid, DateOnly> { [fresh] = new DateOnly(2026, 7, 24) };
+
+        Order(tickerMap, lastDates).Should().Equal("CUR", "NEW");
+    }
+
+    [Fact]
+    public void WithinTheActiveGroup_TheStalestStillLeads()
+    {
+        // The original ordering intent is preserved where it actually helps: among stocks that are
+        // genuinely trading, the one furthest behind is caught up first, so a partial cycle spends
+        // itself on the biggest gaps rather than re-syncing already-current stocks.
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var c = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>
+        {
+            ["CUR"] = c,
+            ["MID"] = b,
+            ["OLD"] = a,
+        };
+        var lastDates = new Dictionary<Guid, DateOnly>
+        {
+            [a] = new DateOnly(2026, 7, 21),
+            [b] = new DateOnly(2026, 7, 23),
+            [c] = new DateOnly(2026, 7, 24),
+        };
+
+        Order(tickerMap, lastDates).Should().Equal("OLD", "MID", "CUR");
+    }
+
+    [Fact]
+    public void TheActiveWindow_ClearsALongWeekendPlusAHoliday()
+    {
+        // A healthy stock must not drop out of the working set just because the market was shut for
+        // several days — that would demote it exactly when it is about to need a fresh bar. Four
+        // calendar days back is still comfortably active.
+        var holidayGap = Guid.NewGuid();
+        var dormant = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>
+        {
+            ["DORMANT"] = dormant,
+            ["HOLIDAY"] = holidayGap,
+        };
+        var lastDates = new Dictionary<Guid, DateOnly>
+        {
+            [dormant] = new DateOnly(2026, 6, 15),
+            [holidayGap] = Today.AddDays(-4),
+        };
+
+        Order(tickerMap, lastDates).Should().Equal("HOLIDAY", "DORMANT");
+    }
+
+    [Fact]
+    public void EveryStockStillAppearsExactlyOnce()
+    {
+        // Partitioning must reorder the crawl, never shrink it — dropping a stock would silently
+        // freeze its price series with nothing in the logs to show for it.
+        var ids = Enumerable.Range(0, 6).Select(_ => Guid.NewGuid()).ToList();
+        var tickerMap = ids.Select((id, i) => (id, i)).ToDictionary(x => $"T{x.i}", x => x.id);
+        var lastDates = new Dictionary<Guid, DateOnly>
+        {
+            [ids[0]] = new DateOnly(2026, 7, 24),
+            [ids[1]] = new DateOnly(2026, 1, 2),
+            [ids[3]] = new DateOnly(2026, 7, 20),
+        };
+
+        Order(tickerMap, lastDates).Should().BeEquivalentTo(tickerMap.Keys);
+    }
+}


### PR DESCRIPTION
## Summary

The daily price lane was falling days behind. Measured on a Monday, two sessions after Friday's close: only **2,301 of 8,402** stocks had Friday's `DailyStockPrice` bar — **5,484 still held Thursday's**. Everything downstream of the settled series (charts, technical indicators, the 52-week range, valuation history, screeners) was reading stale data, and a day change computed against it reported a two-session move as today's.

Two causes, both of which look correct at a glance.

### Stalest-first put the hopeless stocks at the front of every cycle

Sorting the whole universe by last stored date means a stock that will *never* return data leads forever, precisely because it has no recent data. Delisted tickers, bankruptcy-suffixed symbols (`DYNTQ`), expired warrants (`OABIW`), foreign OTC lines Yahoo doesn't serve (`IBERF`, `LINMF`, `MGSD`).

In production **617** such stocks sat ahead of the 5,484 that were merely missing one session. They cost a call each, returned nothing, and were re-paid on the next cycle — roughly the first 23 minutes of every pass spent on work that could never succeed.

### Interleaving enrichment with prices tripled the cost per stock

`SyncKeyStatistics` + `SyncCompanyProfile` add two calls per stock, so each stock cost three calls instead of one and a full pass took ~5 hours at the observed ~27 stocks/min. Since an interrupted cycle restarts from the top, a worker restarting more often than a pass takes — i.e. a deploy — kept re-walking the same head and never reached the stocks missing yesterday's bar.

## What changed

- **Prices run as their own pass over the whole universe, before any enrichment.** Prices are the time-critical half and are nearly free once a stock is current: the settled-trading-day gate skips an up-to-date stock with no Yahoo call at all. They must never queue behind enrichment traffic for the stock in front.
- **The crawl puts actively-traded stocks first** (newest bar within 10 calendar days — comfortably clears a long weekend plus a holiday), stalest-first within that group, with the dormant and never-synced tail after.

The tail is **not** starved, which is what the original stalest-first ordering was guarding against: once the working set is current, walking it costs almost nothing, so the tail gets nearly the entire cycle.

## What it was not

Rate limiting, which was my first hypothesis. The worker logged **zero** 429s and **zero** session expiries across the whole period. Yahoo does 429 a crumbless request, which is misleading if you test with a bare `curl` — the client uses an authenticated session. The failure log was also misread easily: 5,192 failure lines over one day, but only **609 distinct tickers**, i.e. the same dead set retried, not broad throttling.

## Tests

`YahooPriceImportServiceCrawlOrderTests` pins the priority rule through the pure `BuildCrawlOrder`: actively-traded leads dormant, never-synced goes to the tail rather than the head, stalest-first still holds *within* the active group, the window clears a long weekend, and the partition reorders without dropping any stock.

Full unit suite green locally: **3,732 passed, 0 failed**. Solution builds clean in Release; csharpier check passes.