### PR TITLE
Drop a named data provider from a source comment

### DIFF
--- a/src/Equibles.CorporateActions.Data/Models/CapturedSplit.cs
+++ b/src/Equibles.CorporateActions.Data/Models/CapturedSplit.cs
@@ -1,7 +1,7 @@
 namespace Equibles.CorporateActions.Data.Models;
 
 // A source-neutral split observation handed to StockSplitCaptureManager for
-// upsert. Each capturing source (Yahoo, massive.com, SEC filings) maps its own
+// upsert. Each capturing source maps its own
 // payload to this DTO at its worker boundary, so the manager stays decoupled
 // from any one integration. The ratio is Numerator:Denominator.
 public class CapturedSplit

--- a/src/Equibles.CorporateActions.Data/Models/CapturedSplit.cs
+++ b/src/Equibles.CorporateActions.Data/Models/CapturedSplit.cs
@@ -1,9 +1,9 @@
 namespace Equibles.CorporateActions.Data.Models;
 
 // A source-neutral split observation handed to StockSplitCaptureManager for
-// upsert. Each capturing source maps its own
-// payload to this DTO at its worker boundary, so the manager stays decoupled
-// from any one integration. The ratio is Numerator:Denominator.
+// upsert. Each capturing source maps its own payload to this DTO at its worker
+// boundary, so the manager stays decoupled from any one integration. The ratio
+// is Numerator:Denominator.
 public class CapturedSplit
 {
     public DateOnly EffectiveDate { get; set; }


### PR DESCRIPTION
A code comment listed the split-capture sources by name, including a commercial data provider. Which vendors the hosted service buys from is not public information, and this repository is public.

The sentence carries the same meaning without it — the point is that each source maps its own payload at the worker boundary, not who the sources are. Comment-only change.