### PR TITLE
fix(yahoo): gap-heal rides existing fetches only; outage warning sized to the universe

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -154,35 +154,49 @@ public class YahooPriceImportService
             }
         }
 
-        WarnIfUpstreamServedNothing(fetched, fetchedWithNothingNew);
+        WarnIfUpstreamServedNothing(crawlOrder.Count, fetched, fetchedWithNothingNew);
         return totalInserted;
     }
 
-    // A stock is only fetched when a settled session is genuinely missing for it, so a fetch that
-    // returns nothing new is the upstream feed failing to serve a bar it should have. One or two of
-    // those is ordinary (a stock that did not trade); the whole crawl doing it is an outage.
+    // A barren fetch — one that called the provider and inserted nothing — is only evidence of an
+    // upstream outage in AGGREGATE, and the aggregate that matters is the universe, not the cycle's
+    // fetches. A quiet cycle legitimately looks close to 100% barren: once the active set is
+    // current, the only stocks still fetched are the dormant tail and the thin lines that did not
+    // trade the session (~600 of ~8,400 on a normal day), and every one of them returns nothing by
+    // design. The outage signature differs in SIZE, not ratio — the whole universe fetching and
+    // inserting nothing — so the warning requires the barren set to be a large share of the
+    // universe, which a quiet cycle's tail (~7%) never reaches.
     //
     // This exists because that outage is otherwise INVISIBLE. On 2026-07-24 Yahoo served the entire
     // session's daily bars with null OHLC; the importer correctly refused to store them, so the lane
     // ran flat out — thousands of successful HTTP 200s — and wrote nothing, with every log line at
     // Information saying the cycle had started and completed normally. The per-fetch detail that
     // would have shown it is at Debug, which production does not emit.
-    private void WarnIfUpstreamServedNothing(int fetched, int fetchedWithNothingNew)
+    private void WarnIfUpstreamServedNothing(
+        int universeSize,
+        int fetched,
+        int fetchedWithNothingNew
+    )
     {
-        if (fetched < MinFetchesForUpstreamWarning)
+        if (universeSize <= 0 || fetched < MinFetchesForUpstreamWarning)
             return;
 
         var barrenRatio = (double)fetchedWithNothingNew / fetched;
         if (barrenRatio < BarrenFetchWarningRatio)
             return;
 
+        if ((double)fetchedWithNothingNew / universeSize < BarrenUniverseShareForWarning)
+            return;
+
         _logger.LogWarning(
             "Yahoo served no new settled bars for {Barren} of {Fetched} stocks that needed one "
-                + "({Percent:P0}). The price feed is likely publishing incomplete bars upstream; "
-                + "stored prices will stay stale until it recovers.",
+                + "({Percent:P0} of the {Universe}-stock universe). The price feed is likely "
+                + "publishing incomplete bars upstream; stored prices will stay stale until it "
+                + "recovers.",
             fetchedWithNothingNew,
             fetched,
-            barrenRatio
+            (double)fetchedWithNothingNew / universeSize,
+            universeSize
         );
     }
 
@@ -192,6 +206,11 @@ public class YahooPriceImportService
     // Deliberately high: a normal catch-up cycle inserts for nearly every stock it fetches, so this
     // only trips when the feed is broadly refusing to serve usable bars.
     private const double BarrenFetchWarningRatio = 0.9;
+
+    // The size half of the signature. The real 2026-07-24 outage put ~73% of the universe in the
+    // barren set; a healthy quiet cycle's dormant-plus-thin tail sits near 7%. Anything above a
+    // quarter of the universe returning nothing is not a tail.
+    private const double BarrenUniverseShareForWarning = 0.25;
 
     // Pass 2 — key statistics + company profile. Two extra Yahoo calls per stock and the bulk of a
     // cycle's traffic, which is why it runs on its own slower cadence AND strictly after prices.
@@ -1058,6 +1077,21 @@ public class YahooPriceImportService
     {
         var forwardOnly = await GetSyncStartDate(commonStockId, cancellationToken);
 
+        // The heal only ever RIDES a fetch the forward-only date already demands — it must never
+        // trigger one of its own. A stock that is fully current returns here untouched, so the
+        // "current stocks cost zero Yahoo calls" property the whole cheap-cycle design rests on
+        // survives, and so does its DB twin (no extra window query on quiet cycles). Without this
+        // gate a holed-but-otherwise-current stock re-fetched on EVERY cycle for the life of the
+        // window: for the 2026-07-24 upstream outage that is ~5,500 stocks × ~11 quiet cycles a
+        // day against the shared request budget — a ten-day self-inflicted fetch storm. The same
+        // gate bounds two structural cases to one attempt per settled session, riding a fetch that
+        // was happening anyway: a thin stock that simply does not trade every session (whose
+        // rolling window always contains "holes"), and an unmodeled market-wide closure (a
+        // mourning day / weather closure UsMarketCalendar does not list), which holes the entire
+        // universe at once.
+        if (!HasSettledTradingDay(forwardOnly, today))
+            return forwardOnly;
+
         var windowStart = today.AddDays(-GapHealWindowDays);
         // Already reaching back past the window (a never-synced stock, or one mid-backfill) — it is
         // going to re-request those sessions anyway, so there is nothing to widen.
@@ -1065,6 +1099,7 @@ public class YahooPriceImportService
             return forwardOnly;
 
         List<DateOnly> storedDates;
+        DateOnly? earliestStored;
         using (var scope = _scopeFactory.CreateScope())
         {
             var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
@@ -1074,32 +1109,45 @@ public class YahooPriceImportService
                 )
                 .Select(p => p.Date)
                 .ToListAsync(cancellationToken);
+            // The stock's first bar EVER, not first-in-window: the discriminator between "listed
+            // mid-window" and "the feed failed to serve the window's leading edge" (see
+            // FindEarliestGap). An aggregate on the (CommonStockId, Date) index.
+            earliestStored = await repo.GetAll()
+                .Where(p => p.CommonStockId == commonStockId)
+                .MinAsync(p => (DateOnly?)p.Date, cancellationToken);
         }
 
-        var earliestGap = FindEarliestGap(storedDates, windowStart, today);
+        var earliestGap = FindEarliestGap(
+            storedDates,
+            windowStart,
+            today,
+            hasHistoryBeforeWindow: earliestStored < windowStart
+        );
         return earliestGap is { } gap && gap < forwardOnly ? gap : forwardOnly;
     }
 
     // The earliest settled trading day in [windowStart, today) with no stored bar, or null when the
     // window is complete. Pure so the rule is pinnable without a database.
     //
-    // A stock whose history simply starts inside the window (a new listing) must not read as a hole
-    // for every day before its first bar, so the scan begins at the earliest stored date rather than
-    // at windowStart. A stock with nothing stored in the window at all has no gap to speak of — it
-    // is plain staleness, which the forward-only start date already covers.
+    // The scan's starting point decides two opposite cases. A stock with bars OLDER than the window
+    // has provably existed for all of it, so a missing session at the window's leading edge is a
+    // real hole — scanning from the earliest IN-WINDOW bar instead would silently shorten the heal
+    // window as an outage day slides toward its edge. A stock whose entire history STARTS inside
+    // the window (a new listing) scans from its first bar, because the days before a listing
+    // existed are not holes. A stock with nothing stored in the window at all has no gap to speak
+    // of — that is plain staleness, which the forward-only start date already covers.
     private static DateOnly? FindEarliestGap(
         List<DateOnly> storedDates,
         DateOnly windowStart,
-        DateOnly today
+        DateOnly today,
+        bool hasHistoryBeforeWindow
     )
     {
         if (storedDates.Count == 0)
             return null;
 
         var stored = storedDates.ToHashSet();
-        var scanFrom = storedDates.Min();
-        if (scanFrom < windowStart)
-            scanFrom = windowStart;
+        var scanFrom = hasHistoryBeforeWindow ? windowStart : storedDates.Min();
 
         for (var date = scanFrom; date < today; date = date.AddDays(1))
         {

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceGapHealTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceGapHealTests.cs
@@ -29,8 +29,16 @@ public class YahooPriceImportServiceGapHealTests
     private static readonly DateOnly Today = new(2026, 7, 27);
     private static readonly DateOnly WindowStart = new(2026, 7, 17);
 
+    // hasHistoryBeforeWindow = true models the common case: an established stock whose bars
+    // predate the window, so a missing session anywhere in it — including the leading edge — is a
+    // real hole. The new-listing case passes false explicitly.
     private static DateOnly? FindGap(params DateOnly[] storedDates) =>
-        (DateOnly?)FindEarliestGapMethod.Invoke(null, [storedDates.ToList(), WindowStart, Today]);
+        (DateOnly?)
+            FindEarliestGapMethod.Invoke(null, [storedDates.ToList(), WindowStart, Today, true]);
+
+    private static DateOnly? FindGapForNewListing(params DateOnly[] storedDates) =>
+        (DateOnly?)
+            FindEarliestGapMethod.Invoke(null, [storedDates.ToList(), WindowStart, Today, false]);
 
     private static DateOnly D(int day) => new(2026, 7, day);
 
@@ -70,7 +78,18 @@ public class YahooPriceImportServiceGapHealTests
     {
         // A stock whose history starts inside the window has no bars before its listing date; those
         // are not holes, and scanning from windowStart would re-request them every cycle.
-        FindGap(D(23), D(24)).Should().BeNull();
+        FindGapForNewListing(D(23), D(24)).Should().BeNull();
+    }
+
+    [Fact]
+    public void AnEstablishedStock_MissingTheWindowsLeadingEdge_IsAGap()
+    {
+        // The opposite of the new-listing case, and indistinguishable from it by the in-window
+        // dates alone: bars stored for every session EXCEPT the window's first. For a stock with
+        // history before the window that first session is a real hole — scanning from the earliest
+        // in-window bar would silently shorten the heal window as an outage day slid toward its
+        // edge, making the 10-day promise quietly non-uniform.
+        FindGap(D(20), D(21), D(22), D(23), D(24)).Should().Be(D(17));
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceOutageWarningTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceOutageWarningTests.cs
@@ -1,0 +1,78 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Equibles.Yahoo.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Tests for the upstream-outage warning in <see cref="YahooPriceImportService"/>, exercised via
+/// reflection on the private <c>WarnIfUpstreamServedNothing</c>.
+///
+/// The warning's first version compared barren fetches against the cycle's fetches alone, which is
+/// a ratio a HEALTHY quiet cycle maxes out: once the active set is current, the only stocks still
+/// fetched are the dormant tail and the thin lines that did not trade (~600 of ~8,400), and every
+/// one returns nothing by design — so it would have fired on most cycles of every normal day and
+/// been filtered as noise within a week. The signature that separates a real outage is SIZE: on
+/// 2026-07-24 ~73% of the universe fetched and inserted nothing. These pin the size condition.
+/// </summary>
+public class YahooPriceImportServiceOutageWarningTests
+{
+    private static readonly MethodInfo WarnMethod = typeof(YahooPriceImportService).GetMethod(
+        "WarnIfUpstreamServedNothing",
+        BindingFlags.NonPublic | BindingFlags.Instance
+    );
+
+    private static int Warn(int universeSize, int fetched, int fetchedWithNothingNew)
+    {
+        var logger = Substitute.For<ILogger<YahooPriceImportService>>();
+        var service = (YahooPriceImportService)
+            RuntimeHelpers.GetUninitializedObject(typeof(YahooPriceImportService));
+        typeof(YahooPriceImportService)
+            .GetField("_logger", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(service, logger);
+
+        WarnMethod.Invoke(service, [universeSize, fetched, fetchedWithNothingNew]);
+
+        return logger
+            .ReceivedCalls()
+            .Count(call => call.GetMethodInfo().Name == nameof(ILogger.Log));
+    }
+
+    [Fact]
+    public void TheRealOutageSignature_Fires()
+    {
+        // 2026-07-24 as measured: ~6,100 fetched, ~6,100 barren, of an 8,402-stock universe (73%).
+        Warn(8402, 6100, 6100).Should().Be(1);
+    }
+
+    [Fact]
+    public void AHealthyQuietCycle_DoesNotFire()
+    {
+        // The dormant-plus-thin tail: every fetch barren (ratio 1.0), but only ~7% of the universe.
+        // The ratio test alone fired here ~9 times a day — the exact false positive being pinned.
+        Warn(8402, 620, 620).Should().Be(0);
+    }
+
+    [Fact]
+    public void TheFirstCycleOfANormalDay_DoesNotFire()
+    {
+        // Post-rollover, the whole universe fetches and ~92% inserts; barren ratio is far below
+        // the threshold even though the fetch count is huge.
+        Warn(8402, 8000, 620).Should().Be(0);
+    }
+
+    [Fact]
+    public void ASmallCrawl_IsNeverEvidence()
+    {
+        // A tiny configured universe or a weekend no-op can be 100% barren without meaning anything.
+        Warn(150, 150, 150).Should().Be(0);
+    }
+
+    [Fact]
+    public void AnEmptyUniverse_NeverDividesByZero()
+    {
+        Warn(0, 0, 0).Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

Adversarial review of #4224 found four real defects, all sharing one root: the gap-heal was reasoned per stock instead of priced across the universe and the cycle cadence. This PR fixes all four.

**1. The heal could trigger fetches of its own — a ten-day fetch storm.** A stock fully current except one holed session re-fetched on *every* cycle for the window's life: for the 2026-07-24 outage, ~5,500 stocks × ~11 quiet cycles/day against the shared 40-req/min budget, starting the moment the next session's bars landed. The heal now only rides a fetch the forward-only date already demands (`HasSettledTradingDay(forwardOnly, today)` gates the whole path). Holes are re-asked at most once per settled session, on a fetch that was happening anyway — which also makes the original "costs nothing extra" claim actually true, and restores zero DB cost for current stocks on quiet cycles.

**2. The same gate bounds two structural cases.** A thin stock that doesn't trade every session always has "holes" in its rolling window — ungated, it became permanent every-cycle work, the exact pathology #4223 removed. And an unmodeled market-wide closure (mourning day, weather) holes the entire universe at once — ungated, that was ~8.4k stocks re-fetching every cycle for 10 days.

**3. The outage warning would have fired on most healthy cycles.** A quiet cycle is legitimately near-100% barren: once the active set is current, only the dormant tail and the ~600 thin lines that didn't trade are fetched, all returning nothing by design. The ratio test alone fires ~9×/day and gets filtered as noise within a week. The signature that separates the real outage is **size**: ~73% of the universe barren vs ~7% for a healthy tail. The warning now also requires the barren set to exceed a quarter of the universe.

**4. A hole at the window's leading edge was invisible.** Scanning from the earliest *in-window* bar cannot distinguish "listed mid-window" from "the feed failed the window's first session" — so the heal window silently shortened as an outage day slid toward its edge. `FindEarliestGap` now takes the discriminator (does the stock have bars older than the window, from a cheap MIN aggregate on the same index) and scans from `windowStart` for established stocks.

## Not addressed here (acknowledged)

- Cancellation mid-pass drops the cycle's counters (no warning on a deploy during an outage) — accepted: partial-cycle counters would themselves false-positive; the next completed cycle recovers the signal.
- Enrichment tail starvation (in-memory stamp + restart-from-head + a sweep longer than the deploy cadence) predates this work and needs a progress marker — tracked separately.

## Tests

Updated `YahooPriceImportServiceGapHealTests` for the new contract and added the leading-edge case: an established stock missing the window's first session **is** a gap; a new listing still is not. Full suite green: **3,740 passed, 0 failed**; csharpier clean.