### PR TITLE
fix(congress): treat the unabbreviated "Honorable" as an honorific

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -22,6 +22,10 @@ public static partial class DisclosureParsingHelper
         "Ms",
         "Dr",
         "Hon",
+        // "Hon" is also filed unabbreviated. Without this entry "Donald Sternoff Honorable
+        // Beyer" survives normalisation and stands as a second record beside "Donald Sternoff
+        // Beyer" — the exact fragmentation the abbreviated token already prevents.
+        "Honorable",
     };
 
     /// <summary>

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperNormalizeMemberNameTests.cs
@@ -25,6 +25,12 @@ public class DisclosureParsingHelperNormalizeMemberNameTests
     [InlineData("Matt Mr Rosendale", "Matt Rosendale")]
     [InlineData("Mr Matt Rosendale", "Matt Rosendale")]
     [InlineData("Hon. Mr. Smith", "Smith")]
+    // "Hon" is also filed unabbreviated; without it this stood as a second record beside
+    // "Donald Sternoff Beyer" in production.
+    [InlineData("Donald Sternoff Honorable Beyer", "Donald Sternoff Beyer")]
+    [InlineData("Honorable Donald Beyer", "Donald Beyer")]
+    // A surname that merely begins with the same letters is whole-token matched, so it stays.
+    [InlineData("Grace Honorables", "Grace Honorables")]
     // Doubled first name emitted by the parser.
     [InlineData("Scott Scott Franklin", "Scott Franklin")]
     // Stray whitespace collapses.


### PR DESCRIPTION
## Summary

`NormalizeMemberName` drops honorific tokens so one member resolves to one `CongressMember` record (#3374), but the token set only carried the abbreviated `Hon`. Filings also use the full word.

Without it, `Donald Sternoff Honorable Beyer` survives normalisation and stands in production as a **second record** beside `Donald Sternoff Beyer` — the exact fragmentation the abbreviated token already prevents. Two records for one member split his trades and annual disclosures across both, so neither page shows his full history.

## Code changes

- `DisclosureParsingHelper.HonorificTokens` — add `"Honorable"`.
- Tests — pin the mid-name and leading cases, plus a negative (`Grace Honorables` stays intact, since matching is whole-token).

## Verification

`Equibles.UnitTests` normaliser suite: **19 passed, 0 failed.**

Measured against the live member table (676 rows), this is the difference between 14 and 15 name-variant groups that the normaliser resolves. The remaining variants are initial/punctuation differences (`Adam B Schiff` vs `Adam B. Schiff`, `John Curtis` vs `John R Curtis`) which this method deliberately does **not** reconcile — as its own doc comment says, that needs a stable filer id and risks merging two distinct people.