### PR TITLE
feat(congress): add a redirect map for merged member ids

### DIFF
--- a/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
+++ b/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
@@ -22,5 +22,6 @@ public class CongressModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<CongressionalAnnualDisclosure>();
         builder.Entity<CongressionalDisclosureLine>();
         builder.Entity<CongressionalFilingRecord>();
+        builder.Entity<CongressMemberRedirect>();
     }
 }

--- a/src/Equibles.Congress.Data/Models/CongressMemberRedirect.cs
+++ b/src/Equibles.Congress.Data/Models/CongressMemberRedirect.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Equibles.Congress.Data.Models;
+
+/// <summary>
+/// A retired <see cref="CongressMember"/> id and the member it was merged into.
+///
+/// Filings spell one person several ways, so the same member could be created more than once
+/// before <c>NormalizeMemberName</c> canonicalised the upsert key. Collapsing those duplicates
+/// deletes rows whose ids are live, indexed URLs (<c>/congress/members/{id}/{slug}</c>), so the
+/// portal keeps this map to 301 a retired id to the survivor instead of 404ing it.
+///
+/// This is deliberately a separate map rather than a "merged into" column on the member itself:
+/// a tombstone column would oblige every member query — leaderboard, rankings, sitemap, ingest
+/// resolution — to filter merged rows, and a single missed call site puts a ghost member back on
+/// a public page. A map is consulted only on the miss path, so no read can accidentally see it.
+/// Same shape and reasoning as the article slug alias on the content side.
+/// </summary>
+public class CongressMemberRedirect
+{
+    /// <summary>
+    /// The RETIRED member's id. The redirect IS that old identity, so the key is always supplied
+    /// by the caller and never generated.
+    /// </summary>
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; }
+
+    /// <summary>The surviving member this id now resolves to.</summary>
+    public Guid MergedIntoId { get; set; }
+
+    public virtual CongressMember MergedInto { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Congress.Repositories/CongressMemberRedirectRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressMemberRedirectRepository.cs
@@ -1,0 +1,20 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Data;
+
+namespace Equibles.Congress.Repositories;
+
+public class CongressMemberRedirectRepository : BaseRepository<CongressMemberRedirect>
+{
+    public CongressMemberRedirectRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    /// <summary>
+    /// The redirect for a retired member id, if that id was merged away. Returns
+    /// <see cref="IQueryable{T}"/> so the caller projects only what it needs — the portal wants
+    /// the survivor's id and name to build the canonical URL, never the redirect row itself.
+    /// </summary>
+    public IQueryable<CongressMemberRedirect> GetByRetiredId(Guid retiredId)
+    {
+        return GetAll().Where(r => r.Id == retiredId);
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260727191631_AddCongressMemberRedirect.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260727191631_AddCongressMemberRedirect.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727191631_AddCongressMemberRedirect")]
+    partial class AddCongressMemberRedirect
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260727191631_AddCongressMemberRedirect.cs
+++ b/src/Equibles.Migrations/Migrations/20260727191631_AddCongressMemberRedirect.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCongressMemberRedirect : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CongressMemberRedirect",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    MergedIntoId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CongressMemberRedirect", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CongressMemberRedirect_CongressMember_MergedIntoId",
+                        column: x => x.MergedIntoId,
+                        principalTable: "CongressMember",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CongressMemberRedirect_MergedIntoId",
+                table: "CongressMemberRedirect",
+                column: "MergedIntoId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CongressMemberRedirect");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Filings spell one person several ways, so the same member could be created more than once before `NormalizeMemberName` canonicalised the upsert key (#3374). Collapsing those duplicates means **deleting rows whose ids are live, indexed URLs** — `/congress/members/{id}/{slug}` is in `sitemap-congress.xml` — so a retired id needs somewhere to point.

`CongressMemberRedirect` maps a retired member id to its survivor. The consumer (commercial portal) consults it only when a member lookup misses, and 301s instead of 404ing.

## Design note

This is deliberately a **separate map**, not a `MergedIntoId` tombstone column on `CongressMember`.

A tombstone would oblige *every* member query — leaderboard, rankings, sitemap, ingest resolution — to filter merged rows, and a single missed call site puts a ghost member back on a public page. A map is simply unreachable from the read paths: nothing can accidentally select it. It mirrors the article slug alias on the content side, which solves the same problem for renamed slugs.

## Code changes

- `Equibles.Congress.Data/Models/CongressMemberRedirect.cs` — `Id` is the **retired** member's id (`DatabaseGenerated.None`; the redirect *is* that old identity, so the key is always supplied), `MergedIntoId` FK → `CongressMember` with cascade delete, `CreationTime`.
- `CongressModuleConfiguration` — registers the entity.
- `Equibles.Congress.Repositories/CongressMemberRedirectRepository.cs` — `GetByRetiredId` returns `IQueryable` so callers project only the survivor fields they need.
- Migration `20260727191631_AddCongressMemberRedirect` — **purely additive** (one `CreateTable` + the FK index), so it is invisible to running code until something writes to it.

## Verification

Builds clean; `csharpier` applied. No behaviour changes on its own — this ships the storage ahead of the consumer, which is what makes the deploy safe (additive migration first, then the portal that reads it).