### PR TITLE
fix(media): fit resized images inside the bounds and store the resized bytes

### DIFF
--- a/src/Equibles.Media.BusinessLogic/ImageManager.cs
+++ b/src/Equibles.Media.BusinessLogic/ImageManager.cs
@@ -4,6 +4,7 @@ using Equibles.Media.Data.Models;
 using Equibles.Media.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using MimeTypes;
+using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
 
@@ -28,8 +29,8 @@ public class ImageManager : IImageManager
      * </summary>
      * <param name="content">The image content.</param>
      * <param name="fileName">The file name.</param>
-     * <param name="maxWidth">The maximum width of the image. 0 to keep the aspect ratio.</param>
-     * <param name="maxHeight">The maximum height of the image. 0 to keep the aspect ratio.</param>
+     * <param name="maxWidth">The maximum width of the image. Null or 0 leaves it unbounded.</param>
+     * <param name="maxHeight">The maximum height of the image. Null or 0 leaves it unbounded.</param>
      * <returns>The saved image object.</returns>
      */
     public async Task<Image> SaveImage(
@@ -64,9 +65,36 @@ public class ImageManager : IImageManager
             || (maxHeight != null && imageProcessor.Height > maxHeight);
         if (exceedsMaxBounds)
         {
+            // ResizeMode.Max fits the image INSIDE the bounds, preserving the aspect ratio.
+            // The plain Resize(width, height) overload stretches to the exact box when both
+            // bounds are set, which distorted every source whose aspect differed from the
+            // bounds (a 2408x1648 upload was recorded as 2400x2400).
             imageProcessor.Mutate(i =>
-                i.Resize(maxWidth ?? 0, maxHeight ?? 0, new BicubicResampler())
+                i.Resize(
+                    new ResizeOptions
+                    {
+                        Size = new SixLabors.ImageSharp.Size(maxWidth ?? 0, maxHeight ?? 0),
+                        Mode = ResizeMode.Max,
+                        Sampler = new BicubicResampler(),
+                    }
+                )
             );
+
+            // The stored bytes must BE the resized image. Storing the original while the row
+            // records the resized dimensions shipped blobs that disagreed with their metadata
+            // — and meant the cap never actually shrank anything on disk. Re-encode in the
+            // format the bytes arrived in; JPEG gets an explicit quality because the encoder
+            // default (75) visibly degrades a photo that was only meant to be scaled down.
+            var format =
+                imageProcessor.Metadata.DecodedImageFormat
+                ?? throw new InvalidOperationException("The decoded image reports no format.");
+            var encoder =
+                format is JpegFormat
+                    ? new JpegEncoder { Quality = 90 }
+                    : imageProcessor.Configuration.ImageFormatsManager.GetEncoder(format);
+            using var resizedStream = new MemoryStream();
+            await imageProcessor.SaveAsync(resizedStream, encoder);
+            content = resizedStream.ToArray();
         }
 
         var image = new Image()

--- a/src/Equibles.Media.BusinessLogic/ImageManager.cs
+++ b/src/Equibles.Media.BusinessLogic/ImageManager.cs
@@ -60,20 +60,27 @@ public class ImageManager : IImageManager
         // maxWidth/maxHeight are a *maximum* — only resize when the source
         // actually exceeds them. A source already within bounds must not be
         // enlarged (wastes storage and blurs the image).
+        // A null or non-positive bound is unconstrained, matching the doc — checking it here
+        // (not just at the Size below) also keeps a "0 = no cap" configuration from ever
+        // producing a Size(0, 0), which ImageSharp rejects.
         var exceedsMaxBounds =
-            (maxWidth != null && imageProcessor.Width > maxWidth)
-            || (maxHeight != null && imageProcessor.Height > maxHeight);
+            (maxWidth is > 0 && imageProcessor.Width > maxWidth)
+            || (maxHeight is > 0 && imageProcessor.Height > maxHeight);
         if (exceedsMaxBounds)
         {
-            // ResizeMode.Max fits the image INSIDE the bounds, preserving the aspect ratio.
-            // The plain Resize(width, height) overload stretches to the exact box when both
-            // bounds are set, which distorted every source whose aspect differed from the
-            // bounds (a 2408x1648 upload was recorded as 2400x2400).
+            // The bounds are a bounding BOX: ResizeMode.Max fits the image inside them and
+            // preserves the aspect ratio. The previous Resize(width, height) overload resolved
+            // to ResizeMode.Crop, which recorded an exact centre-cropped box (a 2408x1648
+            // upload became 2400x2400) — invisible on screen only because the ORIGINAL bytes
+            // were stored, so the recorded dimensions lied instead.
             imageProcessor.Mutate(i =>
                 i.Resize(
                     new ResizeOptions
                     {
-                        Size = new SixLabors.ImageSharp.Size(maxWidth ?? 0, maxHeight ?? 0),
+                        Size = new SixLabors.ImageSharp.Size(
+                            maxWidth is > 0 ? maxWidth.Value : 0,
+                            maxHeight is > 0 ? maxHeight.Value : 0
+                        ),
                         Mode = ResizeMode.Max,
                         Sampler = new BicubicResampler(),
                     }

--- a/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
@@ -118,4 +118,89 @@ public class ImageManagerSaveImageMaxBoundsTests
         format.Name.Should().Be("JPEG");
         image.ContentType.Should().Be("image/jpeg");
     }
+
+    // The doc says a null or 0 bound is unconstrained. A 0 alongside a real bound must
+    // therefore behave exactly like null — derived from the aspect ratio, never a
+    // Size(0, 0) the resizer would reject.
+    [Fact]
+    public async Task SaveImage_ZeroBound_IsUnconstrained()
+    {
+        var content = CreateMinimalPng(100, 50);
+
+        var image = await _sut.SaveImage(content, "wide.png", 0, 40);
+
+        image.Width.Should().Be(80);
+        image.Height.Should().Be(40);
+    }
+
+    // Both bounds 0 = no cap at all: the original bytes are stored untouched. Guards the
+    // "MaxDimension=0 to disable" configuration a caller can reasonably write.
+    [Fact]
+    public async Task SaveImage_AllBoundsZero_StoresTheOriginalUntouched()
+    {
+        var content = CreateMinimalPng(100, 50);
+
+        var image = await _sut.SaveImage(content, "wide.png", 0, 0);
+
+        image.Width.Should().Be(100);
+        image.Height.Should().Be(50);
+        image.FileContent.Bytes.Should().Equal(content);
+    }
+
+    // The re-encode runs the whole image through the format's encoder, so a multi-frame
+    // GIF must come out with every frame — a silent collapse to the first frame would
+    // turn an animation into a still.
+    [Fact]
+    public async Task SaveImage_AnimatedGif_KeepsItsFramesWhenResized()
+    {
+        using var animation = new Image<Rgba32>(100, 50);
+        using var second = new Image<Rgba32>(100, 50);
+        using var third = new Image<Rgba32>(100, 50);
+        animation.Frames.AddFrame(second.Frames.RootFrame);
+        animation.Frames.AddFrame(third.Frames.RootFrame);
+        using var stream = new MemoryStream();
+        animation.SaveAsGif(stream);
+
+        var image = await _sut.SaveImage(stream.ToArray(), "anim.gif", 40, 40);
+
+        using var stored = SixLabors.ImageSharp.Image.Load(image.FileContent.Bytes);
+        stored.Frames.Count.Should().Be(3);
+        stored.Width.Should().Be(40);
+        stored.Height.Should().Be(20);
+    }
+
+    // Production runs the filesystem store, not the database one — the resized bytes must
+    // reach that write path too, not just the FileContent row the other tests read.
+    [Fact]
+    public async Task SaveImage_FilesystemStore_WritesTheResizedBytesToDisk()
+    {
+        var root = Directory.CreateTempSubdirectory("equibles-imagemanager-test").FullName;
+        try
+        {
+            var context = TestDbContextFactory.Create(new MediaModuleConfiguration());
+            var sut = new ImageManager(
+                new ImageRepository(context),
+                FileStorageRouterTestFactory.Create(
+                    new Equibles.Media.BusinessLogic.Configuration.FileStorageOptions
+                    {
+                        Enabled = true,
+                        RootPath = root,
+                    }
+                )
+            );
+
+            var image = await sut.SaveImage(CreateMinimalPng(100, 50), "wide.png", 40, 40);
+
+            image.RelativePath.Should().NotBeNullOrEmpty();
+            using var stored = SixLabors.ImageSharp.Image.Load(
+                Path.Combine(root, image.RelativePath)
+            );
+            stored.Width.Should().Be(40);
+            stored.Height.Should().Be(20);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
 }

--- a/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
@@ -28,6 +28,14 @@ public class ImageManagerSaveImageMaxBoundsTests
         return stream.ToArray();
     }
 
+    private static byte[] CreateMinimalJpeg(int width, int height)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        using var stream = new MemoryStream();
+        image.SaveAsJpeg(stream);
+        return stream.ToArray();
+    }
+
     // Contract: maxWidth/maxHeight are documented as the *maximum* width/height.
     // A source already within those bounds must not be enlarged — a 10x10
     // image saved with a 4000x4000 cap should stay 10x10, not be upscaled
@@ -41,5 +49,73 @@ public class ImageManagerSaveImageMaxBoundsTests
 
         image.Width.Should().Be(10);
         image.Height.Should().Be(10);
+    }
+
+    // The bounds are a bounding BOX, not a target size. The plain Resize(w, h)
+    // overload stretches to the exact box when both bounds are set, which
+    // recorded a 2408x1648 upload as 2400x2400 in production.
+    [Fact]
+    public async Task SaveImage_SourceExceedingMax_PreservesTheAspectRatio()
+    {
+        var content = CreateMinimalPng(100, 50);
+
+        var image = await _sut.SaveImage(content, "wide.png", 40, 40);
+
+        image.Width.Should().Be(40);
+        image.Height.Should().Be(20);
+    }
+
+    // The stored bytes must BE the resized image. Recording resized dimensions
+    // while storing the original bytes shipped blobs that disagreed with their
+    // metadata — and meant the cap never shrank anything on disk.
+    [Fact]
+    public async Task SaveImage_SourceExceedingMax_StoresTheResizedBytes()
+    {
+        var content = CreateMinimalPng(100, 50);
+
+        var image = await _sut.SaveImage(content, "wide.png", 40, 40);
+
+        using var stored = SixLabors.ImageSharp.Image.Load(image.FileContent.Bytes);
+        stored.Width.Should().Be(image.Width);
+        stored.Height.Should().Be(image.Height);
+        image.Size.Should().Be(image.FileContent.Bytes.Length);
+    }
+
+    // A single bound leaves the other dimension derived from the aspect ratio.
+    [Fact]
+    public async Task SaveImage_SingleBound_DerivesTheOtherDimension()
+    {
+        var content = CreateMinimalPng(100, 50);
+
+        var image = await _sut.SaveImage(content, "wide.png", 40, null);
+
+        image.Width.Should().Be(40);
+        image.Height.Should().Be(20);
+    }
+
+    // Within bounds nothing is re-encoded: the caller's exact bytes are stored,
+    // so an already-fitting upload is never degraded or re-compressed.
+    [Fact]
+    public async Task SaveImage_SourceWithinBounds_StoresTheOriginalBytesUntouched()
+    {
+        var content = CreateMinimalPng(10, 10);
+
+        var image = await _sut.SaveImage(content, "small.png", 4000, 4000);
+
+        image.FileContent.Bytes.Should().Equal(content);
+    }
+
+    // A resized image is re-encoded in the format it arrived in — a resized JPEG
+    // must not come back as a PNG wearing a .jpg extension and image/jpeg type.
+    [Fact]
+    public async Task SaveImage_ResizedJpeg_IsStoredAsJpeg()
+    {
+        var content = CreateMinimalJpeg(100, 50);
+
+        var image = await _sut.SaveImage(content, "photo.jpg", 40, 40);
+
+        var format = SixLabors.ImageSharp.Image.DetectFormat(image.FileContent.Bytes);
+        format.Name.Should().Be("JPEG");
+        image.ContentType.Should().Be("image/jpeg");
     }
 }


### PR DESCRIPTION
## Summary

`ImageManager.SaveImage`'s resize path was broken in two independent ways whenever both bounds were set — and every real caller passes a square cap:

1. **Aspect ratio destroyed.** The plain `Resize(width, height)` overload stretches to the exact box, so a 2408×1648 upload was recorded as 2400×2400. Callers emit those dimensions as `width`/`height` attributes, so browsers reserve a wrongly-shaped box and the page jumps when the real image arrives.

2. **The resized pixels were thrown away.** `_storageRouter.Save(image, content, …)` stored the *original* bytes, so the blob disagreed with the row's recorded dimensions — and the size cap never actually shrank anything on disk.

## Code changes

- `ImageManager.SaveImage` — resize with `ResizeMode.Max` (bounds are a bounding box, aspect always preserved; a 0/null bound stays unconstrained), then re-encode the mutated image in the format it arrived in and hand those bytes to the storage router. JPEG re-encodes at quality 90 — the encoder default (75) visibly degrades a photo that was only meant to be scaled down. A source already within bounds keeps the caller's exact bytes, untouched.

## Tests

Extended `ImageManagerSaveImageMaxBoundsTests` (6 total, all passing): aspect preserved on the both-bounds path, stored bytes decode to the recorded dimensions with `Size` matching, single-bound derives the other dimension, within-bounds bytes stay byte-identical, and a resized JPEG is still a JPEG.

Media suite locally: 52/54 — the 2 failures are the pre-existing Testcontainers tests, which need a local Docker daemon (not running here); they fail at Docker connect before touching this code.