### PR TITLE
Stop valuing positions larger than the issuer they are in

### DIFF
--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
@@ -64,6 +64,20 @@ public class InstitutionalHolding
     public int ValueRetryCount { get; set; }
     public DateTime? ValueLastRetryAt { get; set; }
 
+    /// <summary>
+    /// The position's dollar value could not be derived honestly, so <see cref="Value"/> is zero
+    /// and means "unknown" rather than "nothing". Set when the reported share count is larger than
+    /// the issuer itself — the tell of a count in different units from our price series, such as a
+    /// depositary-share issuer whose filer reports the underlying ordinary shares. The share count
+    /// is still what the filer reported; only the valuation is withheld.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="ValuePending"/>, which means "no price yet, retry later". This one
+    /// never resolves on its own: re-deriving from the same count would reproduce the same wrong
+    /// figure, so the repricing lane must leave these rows alone.
+    /// </remarks>
+    public bool ValueUnavailable { get; set; }
+
     public List<HoldingManagerEntry> ManagerEntries { get; set; } = [];
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -129,6 +129,27 @@ public class HoldingsScraperWorker : BaseScraperWorker
 
         // Recalculate holdings that were imported without a Yahoo price available
         await RecalculatePendingValues(stoppingToken);
+
+        // Withdraw the derived value from stored positions bigger than their issuer. Self-
+        // terminating once the back catalogue is clean, so it costs one query per cycle after that.
+        await RepairImpossiblePositions(stoppingToken);
+    }
+
+    private async Task RepairImpossiblePositions(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var scope = ScopeFactory.CreateAsyncScope();
+            var repairer =
+                scope.ServiceProvider.GetRequiredService<ImpossiblePositionRepairService>();
+            await repairer.Repair(cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            // A repair pass is maintenance, not ingestion: its failure must not fail the cycle
+            // that just imported this quarter's filings.
+            Logger.LogWarning(exception, "Impossible-position repair pass failed");
+        }
     }
 
     /// <summary>

--- a/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
+++ b/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
@@ -27,4 +27,9 @@ public class ImportContext
 
     // Yahoo stock prices: (CommonStockId, ReportDate) → closing price
     public Dictionary<(Guid, DateOnly), decimal> StockPrices { get; set; } = [];
+
+    // Issuer size: CommonStockId → (shares outstanding, market capitalization). Used only to
+    // reject a position larger than the company it is in (ImpossiblePositionGuard); a stock
+    // missing here is simply not judged.
+    public Dictionary<Guid, IssuerSize> IssuerSizes { get; set; } = [];
 }

--- a/src/Equibles.Holdings.HostedService/Models/IssuerSize.cs
+++ b/src/Equibles.Holdings.HostedService/Models/IssuerSize.cs
@@ -1,0 +1,9 @@
+namespace Equibles.Holdings.HostedService.Models;
+
+/// <summary>
+/// How big the issuer is, as the two figures stored side by side on the stock. Carried through an
+/// import so a position can be checked against the company it claims to be a piece of. Both are
+/// needed: the share count is the yardstick, and the market cap is the only independent way to
+/// tell whether that count is trustworthy (see <c>ImpossiblePositionGuard</c>).
+/// </summary>
+public record IssuerSize(long SharesOutstanding, double MarketCapitalization);

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -409,6 +409,11 @@ public class HoldingsImportService
         }
 
         context.CusipMapping = cusipMapping;
+        context.IssuerSizes = await LoadIssuerSizes(
+            stockRepo,
+            cusipMapping.Values.Distinct().ToList(),
+            cancellationToken
+        );
 
         foreach (var (accession, cusips) in scheduleCusipsByAccession)
         {
@@ -422,6 +427,34 @@ public class HoldingsImportService
         }
 
         return CusipMappingOutcome.Mapped;
+    }
+
+    /// <summary>
+    /// Loads how big each mapped issuer is, so a position can be checked against the company it
+    /// claims to be part of (see <see cref="ImpossiblePositionGuard"/>). One query over the stocks
+    /// this data set actually references.
+    /// </summary>
+    private static async Task<Dictionary<Guid, IssuerSize>> LoadIssuerSizes(
+        CommonStockRepository stockRepo,
+        List<Guid> stockIds,
+        CancellationToken cancellationToken
+    )
+    {
+        var sizes = await stockRepo
+            .GetAll()
+            .Where(cs => stockIds.Contains(cs.Id))
+            .Select(cs => new
+            {
+                cs.Id,
+                cs.SharesOutStanding,
+                cs.MarketCapitalization,
+            })
+            .ToListAsync(cancellationToken);
+
+        return sizes.ToDictionary(
+            s => s.Id,
+            s => new IssuerSize(s.SharesOutStanding, s.MarketCapitalization)
+        );
     }
 
     /// <summary>
@@ -962,6 +995,9 @@ public class HoldingsImportService
             existing.VotingAuthSole += holding.VotingAuthSole;
             existing.VotingAuthShared += holding.VotingAuthShared;
             existing.VotingAuthNone += holding.VotingAuthNone;
+            // One unpriceable leg makes the merged position unpriceable: the surviving legs would
+            // otherwise sum to a value that silently omits part of the holding.
+            existing.ValueUnavailable |= holding.ValueUnavailable;
             existing.ManagerEntries.Add(managerEntry);
             return false;
         }
@@ -1017,6 +1053,28 @@ public class HoldingsImportService
             hasPrice && product >= long.MinValue && product <= long.MaxValue ? (long)product : 0L;
         var valuePending = !hasPrice;
 
+        // A count bigger than the whole issuer is not a position we can price: the shares are in
+        // different units from the price (a depositary-share issuer whose filer reports the
+        // underlying ordinary shares), and multiplying them together states a holding worth many
+        // times the company. Keep the filer's share count, withhold the valuation, and stop the
+        // repricing lane from re-deriving the same wrong figure later.
+        var issuerSize = context.IssuerSizes != null
+            && context.IssuerSizes.TryGetValue(commonStockId, out var size)
+                ? size
+                : null;
+        var valueUnavailable =
+            issuerSize != null
+            && ImpossiblePositionGuard.ExceedsTheIssuer(
+                shares,
+                issuerSize.SharesOutstanding,
+                issuerSize.MarketCapitalization
+            );
+        if (valueUnavailable)
+        {
+            value = 0L;
+            valuePending = false;
+        }
+
         var otherManagerNumber = ParseNullableInt(GetValue(row, "OTHERMANAGER"));
         var discretion = ParseInvestmentDiscretion(GetValue(row, "INVESTMENTDISCRETION"));
 
@@ -1060,6 +1118,7 @@ public class HoldingsImportService
             Cusip = cusip,
             AccessionNumber = accession,
             IsAmendment = isAmendment,
+            ValueUnavailable = valueUnavailable,
             ValuePending = valuePending,
         };
 
@@ -1110,6 +1169,7 @@ public class HoldingsImportService
                         Cusip = incoming.Cusip,
                         IsAmendment = incoming.IsAmendment,
                         ValuePending = incoming.ValuePending,
+                        ValueUnavailable = incoming.ValueUnavailable,
                     }
             )
             .RunAsync(cancellationToken);

--- a/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionGuard.cs
+++ b/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionGuard.cs
@@ -1,0 +1,89 @@
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Rejects the dollar value of a position that cannot exist: one holder reporting more shares
+/// than the issuer has.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A holding's <c>Value</c> is always DERIVED as shares × the closing price, never taken from the
+/// filing, so a share count in the wrong units is silently multiplied into a wrong dollar figure
+/// that every AUM ranking then treats as real. The live case: a Schedule 13D/A reported
+/// 32,098,694,296 Class A ordinary shares of NaaS — accurately, at 55.9% of the class — but NaaS
+/// lists in the US as an American Depositary Share worth 3,200 ordinary shares, so pricing an
+/// ordinary-share count at the ADS price produced a $100.8B position in a $38M company.
+/// </para>
+/// <para>
+/// The test is arithmetic rather than a judgment: a single holder cannot own several times the
+/// company. It deliberately does NOT try to recover the true value — the depositary ratio is not
+/// modelled, and inventing one would replace a wrong number with a different wrong number. The
+/// position keeps its reported share count (which is what the filer actually said) and loses only
+/// the derived dollar figure, on the same principle as the day-change basis: a missing value is
+/// honest, a wrong one is not.
+/// </para>
+/// </remarks>
+internal static class ImpossiblePositionGuard
+{
+    /// <summary>
+    /// How far past the issuer's shares outstanding a position may sit before it is impossible.
+    /// Not 1×, because the two figures come from different dates: the share count is today's while
+    /// the holding is a quarter-end position, and a buyback or a reverse split between them is
+    /// ordinary. Nothing legitimate reaches 2× — the rows this catches are 100× to 11,000×.
+    /// </summary>
+    internal const long SharesOutstandingMultiple = 2;
+
+    /// <summary>
+    /// The widest and narrowest per-share price treated as a real listing when sanity-checking the
+    /// anchor below. Deliberately generous: it exists to reject a nonsense share count, not to
+    /// judge a share price.
+    /// </summary>
+    internal const double MinimumPlausibleSharePrice = 0.01;
+    internal const double MaximumPlausibleSharePrice = 10_000;
+
+    /// <summary>
+    /// True when the position reports more shares than the issuer plausibly has, so its derived
+    /// value must not be published.
+    /// </summary>
+    internal static bool ExceedsTheIssuer(
+        long shares,
+        long sharesOutstanding,
+        double marketCapitalization
+    )
+    {
+        if (shares <= 0)
+        {
+            return false;
+        }
+
+        if (!AnchorIsTrustworthy(sharesOutstanding, marketCapitalization))
+        {
+            return false;
+        }
+
+        return shares > sharesOutstanding * SharesOutstandingMultiple;
+    }
+
+    /// <summary>
+    /// Whether the issuer's share count can be used to judge a position at all.
+    /// </summary>
+    /// <remarks>
+    /// <c>CommonStock.SharesOutStanding</c> is itself wrong for a handful of stocks — Air Lease
+    /// carries 200 shares beside a correct $7.28B market cap — and a guard anchored on a corrupt
+    /// count deletes real data: that one stock accounts for 7,309 of the 7,749 rows a naive
+    /// shares-outstanding rule matches, every one of them a legitimate holding. So the count has
+    /// to agree with the market cap stored next to it before it is trusted: the implied per-share
+    /// price must look like a share price. When it doesn't, the issuer is simply not judged — the
+    /// guard stays silent rather than guessing which of the two figures is the broken one.
+    /// </remarks>
+    internal static bool AnchorIsTrustworthy(long sharesOutstanding, double marketCapitalization)
+    {
+        if (sharesOutstanding <= 0 || marketCapitalization <= 0)
+        {
+            return false;
+        }
+
+        var impliedSharePrice = marketCapitalization / sharesOutstanding;
+        return impliedSharePrice >= MinimumPlausibleSharePrice
+            && impliedSharePrice <= MaximumPlausibleSharePrice;
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
@@ -1,0 +1,112 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Withdraws the derived value from stored positions that are larger than the issuer they are in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ImpossiblePositionGuard"/> stops these at import, but a quarterly data set is
+/// processed once and never revisited, so every row ingested before the guard existed keeps its
+/// wrong figure forever. This pass applies the same rule to what is already stored.
+/// </para>
+/// <para>
+/// It runs every cycle and is self-terminating: once a row is marked it no longer matches, so the
+/// second pass over a repaired database does one cheap query and stops. That also makes it the
+/// heal path for any row a future import writes before its issuer's size is known.
+/// </para>
+/// </remarks>
+[Service]
+public class ImpossiblePositionRepairService
+{
+    // The database narrows to positions above the multiple; the guard then makes the real decision
+    // in memory, so the rule lives in exactly one place and the two paths cannot drift.
+    private const int BatchSize = 500;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ImpossiblePositionRepairService> _logger;
+
+    public ImpossiblePositionRepairService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<ImpossiblePositionRepairService> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task<int> Repair(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+
+        // Candidates only — the coarse "more shares than the issuer has" filter, which SQL can
+        // serve from the existing indexes. Whether the issuer's own figures are trustworthy enough
+        // to act on is decided by the guard below, not here.
+        var candidates = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => !h.ValueUnavailable && h.Shares > 0)
+            .Join(
+                dbContext.Set<CommonStock>(),
+                h => h.CommonStockId,
+                cs => cs.Id,
+                (h, cs) =>
+                    new
+                    {
+                        Holding = h,
+                        cs.SharesOutStanding,
+                        cs.MarketCapitalization,
+                    }
+            )
+            .Where(x =>
+                x.SharesOutStanding > 0
+                && x.MarketCapitalization > 0
+                && x.Holding.Shares
+                    > x.SharesOutStanding * ImpossiblePositionGuard.SharesOutstandingMultiple
+            )
+            .ToListAsync(cancellationToken);
+
+        var repaired = 0;
+        foreach (var candidate in candidates)
+        {
+            if (
+                !ImpossiblePositionGuard.ExceedsTheIssuer(
+                    candidate.Holding.Shares,
+                    candidate.SharesOutStanding,
+                    candidate.MarketCapitalization
+                )
+            )
+            {
+                continue;
+            }
+
+            candidate.Holding.Value = 0L;
+            candidate.Holding.ValuePending = false;
+            candidate.Holding.ValueUnavailable = true;
+            repaired++;
+
+            if (repaired % BatchSize == 0)
+            {
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        if (repaired > 0)
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+            _logger.LogWarning(
+                "Withdrew the derived value from {Repaired} position(s) reporting more shares than "
+                    + "the issuer has, out of {Candidates} candidate(s); the rest sit on a share "
+                    + "count the issuer's own figures cannot vouch for",
+                repaired,
+                candidates.Count
+            );
+        }
+
+        return repaired;
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260728000837_AddInstitutionalHoldingValueUnavailable.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260728000837_AddInstitutionalHoldingValueUnavailable.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728000837_AddInstitutionalHoldingValueUnavailable")]
+    partial class AddInstitutionalHoldingValueUnavailable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260728000837_AddInstitutionalHoldingValueUnavailable.cs
+++ b/src/Equibles.Migrations/Migrations/20260728000837_AddInstitutionalHoldingValueUnavailable.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstitutionalHoldingValueUnavailable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ValueUnavailable",
+                table: "InstitutionalHolding",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ValueUnavailable",
+                table: "InstitutionalHolding");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/ImpossiblePositionGuardTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/ImpossiblePositionGuardTests.cs
@@ -1,0 +1,119 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// A holding's value is always derived as shares × price, so a share count in the wrong units is
+/// multiplied straight into a dollar figure every AUM ranking then treats as real. The live case:
+/// a Schedule 13D/A accurately reporting 32,098,694,296 Class A ordinary shares of NaaS — 55.9% of
+/// the class — priced at the ADS quote, which is worth 3,200 ordinary shares, giving a $100.8B
+/// position in a $38M company.
+///
+/// The guard's second job is knowing when NOT to fire. <c>SharesOutStanding</c> is itself corrupt
+/// for a few stocks, and anchoring on it blindly deletes real data: Air Lease stores 200 shares
+/// beside a correct $7.28B market cap, and a naive rule would have dropped its 7,309 legitimate
+/// holdings — 94% of everything such a rule matches.
+/// </summary>
+public class ImpossiblePositionGuardTests
+{
+    // NaaS as stored: 12,055,201 ADS outstanding, $37.6M market cap ($3.12 implied per share).
+    private const long NaasSharesOutstanding = 12_055_201;
+    private const double NaasMarketCap = 37_600_000d;
+
+    [Fact]
+    public void APositionLargerThanTheIssuer_CannotBeValued()
+    {
+        ImpossiblePositionGuard
+            .ExceedsTheIssuer(32_098_694_296L, NaasSharesOutstanding, NaasMarketCap)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void AnOrdinaryMajorityStake_IsLeftAlone()
+    {
+        ImpossiblePositionGuard
+            .ExceedsTheIssuer(6_700_000L, NaasSharesOutstanding, NaasMarketCap)
+            .Should()
+            .BeFalse("a 55% holder owns a legitimate slice of the company");
+    }
+
+    [Theory]
+    // The multiple is deliberately loose: the share count is today's while the holding is a
+    // quarter-end position, so a buyback or reverse split between them is ordinary.
+    [InlineData(12_055_202L, false)] // barely above the count
+    [InlineData(24_110_402L, false)] // exactly 2×, the boundary
+    [InlineData(24_110_403L, true)] // past 2×
+    public void TheToleranceAbsorbsAShareCountFromADifferentDate(long shares, bool expected)
+    {
+        ImpossiblePositionGuard
+            .ExceedsTheIssuer(shares, NaasSharesOutstanding, NaasMarketCap)
+            .Should()
+            .Be(expected);
+    }
+
+    [Fact]
+    public void ACorruptShareCount_DisablesTheGuardRatherThanDeletingRealHoldings()
+    {
+        // Air Lease as stored: 200 shares against a correct $7.28B market cap, implying $36M a
+        // share. One of the two figures is broken and the guard cannot tell which, so it declines
+        // to judge — every Air Lease holding keeps its value.
+        ImpossiblePositionGuard
+            .ExceedsTheIssuer(13_862_881L, 200L, 7_282_301_440d)
+            .Should()
+            .BeFalse();
+
+        ImpossiblePositionGuard.AnchorIsTrustworthy(200L, 7_282_301_440d).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AnIssuerWhoseFiguresAgree_IsJudged()
+    {
+        ImpossiblePositionGuard
+            .AnchorIsTrustworthy(NaasSharesOutstanding, NaasMarketCap)
+            .Should()
+            .BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0L, 1_000_000d)] // no share count
+    [InlineData(1_000_000L, 0d)] // no market cap
+    [InlineData(-5L, 1_000_000d)]
+    public void AMissingFigure_LeavesTheIssuerUnjudged(
+        long sharesOutstanding,
+        double marketCapitalization
+    )
+    {
+        ImpossiblePositionGuard
+            .AnchorIsTrustworthy(sharesOutstanding, marketCapitalization)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void AnEmptyPosition_IsNotImpossible()
+    {
+        ImpossiblePositionGuard
+            .ExceedsTheIssuer(0L, NaasSharesOutstanding, NaasMarketCap)
+            .Should()
+            .BeFalse();
+    }
+
+    [Theory]
+    // The plausibility band only has to reject a nonsense share count, so it is wide on purpose:
+    // a sub-cent implied price and a five-figure one both still describe a real listing badly.
+    [InlineData(1_000_000L, 5_000d, false)] // $0.005 a share — implied price below the floor
+    [InlineData(1_000_000L, 20_000_000_000d, false)] // $20,000 a share — above the ceiling
+    [InlineData(1_000_000L, 50_000_000d, true)] // $50 a share
+    public void TheBandAcceptsRealListingsAndRejectsNonsense(
+        long sharesOutstanding,
+        double marketCapitalization,
+        bool expected
+    )
+    {
+        ImpossiblePositionGuard
+            .AnchorIsTrustworthy(sharesOutstanding, marketCapitalization)
+            .Should()
+            .Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

A holding's `Value` is always **derived** as shares × closing price, never taken from the filing, so a share count in the wrong units is multiplied straight into a dollar figure that every AUM ranking then treats as real.

The case that surfaced it is **not a filer error**. Accession `0001185185-26-003123` is a Schedule 13D/A that accurately reports:

```
<aggregateAmountOwned>32098694296.00</aggregateAmountOwned>
<percentOfClass>55.9</percentOfClass>
<securitiesClassTitle>Class A ordinary shares, par value $0.000001 per share</securitiesClassTitle>
```

32.1 billion **Class A ordinary shares** = 55.9% of the class, filed correctly. NaaS lists in the US as an **American Depositary Share worth 3,200 ordinary shares**, so pricing an ordinary-share count at the ADS quote produced a **$100.8B position in a $38M company**. On production **420 positions across 165 filers and 109 issuers** are wrong this way — LTM (ADS = 2,000 shares) tops it at a $5.27 **trillion** holding — and most of them are depositary-share listings.

## What it does

The depositary ratio isn't modelled, and inventing one would swap a wrong number for a different wrong number. So a position that cannot exist keeps the share count the filer reported and loses only the **derived value**:

- `InstitutionalHolding.ValueUnavailable` marks it, so `Value = 0` reads as *unknown* rather than *nothing*, and the repricing lane (which only picks up `ValuePending`) can't re-derive the same figure later.
- Value-summing aggregates need no change — an unavailable position contributes zero, so a filer's reported total drops instead of being inflated by the ratio.

## Knowing when not to fire

`SharesOutStanding` is itself wrong for a few stocks, and anchoring on it blindly deletes real data: **Air Lease stores 200 shares outstanding beside a correct $7.28B market cap**, and a naive `Shares > 2 × SharesOutStanding` rule matches 7,749 rows of which **7,309 are Air Lease alone**, every one a legitimate holding.

So the count is trusted only when the market cap stored beside it implies a plausible share price (Air Lease's implies $36M a share). When the two disagree, the issuer simply isn't judged — the guard declines rather than guessing which figure is broken. That takes the match down to the 420 real ones.

The tolerance is 2× rather than 1×, because the share count is today's while the holding is a quarter-end position and a buyback or reverse split between them is ordinary. Nothing legitimate reaches 2×; the rows this catches run 100× to 11,000×.

## Code changes

- `ImpossiblePositionGuard` — the rule and its anchor sanity check, pure and unit-tested.
- `InstitutionalHolding.ValueUnavailable` + additive migration.
- `HoldingsImportService` — issuer sizes loaded once per data set, guard applied at `ParseHoldingRow` (the single choke point both 13F and 13D/G rows pass through), flag carried through the upsert and OR'd when legs of one position merge.
- `ImpossiblePositionRepairService` — applies the same rule to stored rows, since a quarterly data set is processed once and never revisited. Runs each cycle, self-terminating once the back catalogue is clean; SQL narrows to candidates and the guard makes the decision, so the rule exists in one place.
- 14 unit tests, incl. the Air Lease non-deletion case and the 2× boundary. Full OSS unit suite green (3,762).