### PR TITLE
Survive a repeated cover-page share-count artifact and correct it from the balance sheet

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -35,14 +35,22 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         "ifrs-full:ClassesOfOrdinarySharesAxis",
     ];
 
-    // A cover-page count this many times smaller than BOTH the issuer's previous cover-page count
+    // A cover-page count this many times smaller than BOTH the issuer's recent cover-page history
     // and the same filing's balance-sheet count is treated as a filing artifact (see
-    // IsCollapsedCoverPageCount). Observed artifacts are 10x-1000x off (a dropped digit or a
+    // TryResolveCollapseCorrection). Observed artifacts are 10x-1000x off (a dropped digit or a
     // thousands-scaled entry). A genuine reduction this large in one filing window (a reverse
     // split, going private) resolves safely either way: a balance sheet stated on the new share
     // basis agrees with the reduced cover page and the count is kept, while a contradicted one
-    // abstains and the price feed's listed-security count stands.
+    // is replaced by the balance-sheet count that contradicted it.
     private const decimal CoverPageCollapseFactor = 5m;
+
+    // How far back the collapse check's history anchor looks. The anchor asks whether the issuer
+    // was RECENTLY much bigger, and it must survive the artifact being repeated (Air Lease filed
+    // 200 on two consecutive cover pages, so "the previous fact" was the artifact itself) — hence
+    // the maximum over a window rather than the single most recent fact. Two years spans an
+    // annual filer with a missed year while keeping some ancient mis-scaled fact from posing as
+    // recent history.
+    private const int CollapseHistoryWindowDays = 730;
 
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
@@ -112,9 +120,10 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     // most recent filing wins; a same-filing tie keeps the consolidated total, which is the entity
     // figure directly (#5158).
     //
-    // Null when nothing is on record, or when the latest cover-page count is a filing artifact
-    // (see IsCollapsedCoverPageCount): EDGAR abstains rather than propagate a count its own filing
-    // contradicts, and the caller's fallback source (the price feed's listed-security count) stands.
+    // When the latest cover-page count is a filing artifact (see TryResolveCollapseCorrection),
+    // the same filing's balance-sheet count — the figure that proved the artifact — is returned in
+    // its place, so a repeated artifact cannot pin the stored count to garbage while every other
+    // statement in the filing carries the real figure. Null when nothing is on record.
     public async Task<long?> GetCurrentSharesOutstanding(
         CommonStock stock,
         CancellationToken cancellationToken = default
@@ -179,13 +188,13 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
 
         if (consolidated != null)
         {
-            var collapsed = await IsCollapsedCoverPageCount(
+            var correction = await TryResolveCollapseCorrection(
                 stock,
                 consolidated,
                 coverPageConceptIds,
                 cancellationToken
             );
-            return collapsed ? null : consolidated;
+            return correction ?? consolidated;
         }
 
         // No dei cover-page fact on record — fall back to the balance-sheet consolidated count,
@@ -194,17 +203,29 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         return await GetLatestConsolidated(stock, fallbackConceptIds, cancellationToken);
     }
 
-    // True when the latest consolidated cover-page count is contradicted as a collapse artifact by
-    // BOTH of the filer's own other statements of the same measure: the previous cover-page count
-    // (an earlier filing) and the same filing's us-gaap balance-sheet count, each at least
-    // CoverPageCollapseFactor times larger. Real filings show this exact shape when the filer drops
-    // a digit or types the count in thousands (observed: 36,710 vs 36.4M; 161,489 vs 17.0M;
-    // 8,294,933 vs 82.9M) — the artifact then poisons every downstream ratio until the next filing.
+    // The corrected share count when the latest consolidated cover-page count is contradicted as
+    // a collapse artifact by BOTH of the filer's own other statements of the same measure: the
+    // issuer's recent cover-page history and the same filing's us-gaap balance-sheet count, each
+    // at least CoverPageCollapseFactor times larger. Real filings show this exact shape when the
+    // filer drops a digit or types the count in thousands (observed: 36,710 vs 36.4M; 161,489 vs
+    // 17.0M; 8,294,933 vs 82.9M; Air Lease's flat 200 vs 112.4M) — the artifact then poisons every
+    // downstream ratio until the filer corrects it. Null when the cover-page count stands.
+    //
     // Requiring both anchors keeps the check one-sided and conservative: a garbage-LARGE
     // balance-sheet figure alone (the mis-scaled inverse artifact) does not fire because history
     // still confirms the cover-page count, and a genuinely tiny issuer (e.g. a wholly-owned
-    // subsidiary with 1 share) has a tiny prior count, so it does not fire either.
-    private async Task<bool> IsCollapsedCoverPageCount(
+    // subsidiary with 1 share) has a tiny history, so it does not fire either. Two subtleties,
+    // both paid for in production by Air Lease sticking at 200 shares against a $7.28B market cap:
+    //
+    //   - the history anchor is the MAXIMUM over a recent window, not the single previous fact —
+    //     AL filed the artifact on two consecutive cover pages (a 10-K/A then a 10-Q), so "the
+    //     previous fact" was the artifact itself and the old check could never fire again;
+    //   - when the two anchors prove the artifact, the balance-sheet count that proved it is
+    //     RETURNED rather than abstained from. Abstention hands the decision to the price feed's
+    //     listed-security count, and an issuer the feed carries no share base for then keeps the
+    //     garbage forever. Believing the filer's two agreeing statements over its one contradicted
+    //     one is the same judgment the detection already makes.
+    private async Task<SharesFact> TryResolveCollapseCorrection(
         CommonStock stock,
         SharesFact latest,
         IReadOnlyCollection<Guid> coverPageConceptIds,
@@ -212,44 +233,106 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     )
     {
         var collapseThreshold = latest.Shares * CoverPageCollapseFactor;
+        var historyWindowStart = latest.Filed.AddDays(-CollapseHistoryWindowDays);
 
-        var priorCoverPage = await _financialFactRepository
+        var priorCoverPageMax = await _financialFactRepository
             .GetConsolidatedByStock(stock)
             .Where(f =>
                 coverPageConceptIds.Contains(f.FinancialConceptId)
                 && f.Unit == SharesUnit
                 && f.FiledDate < latest.Filed
+                && f.FiledDate >= historyWindowStart
                 && f.Value > 0
             )
-            .OrderByDescending(f => f.FiledDate)
-            .ThenByDescending(f => f.PeriodEnd)
-            .Select(f => (decimal?)f.Value)
-            .FirstOrDefaultAsync(cancellationToken);
-        if (priorCoverPage == null || priorCoverPage < collapseThreshold)
-            return false;
+            .MaxAsync(f => (decimal?)f.Value, cancellationToken);
+        if (priorCoverPageMax == null || priorCoverPageMax < collapseThreshold)
+            return null;
 
-        // The same filing's balance-sheet count at its most recent as-of date. Same-accession so a
-        // later filing can never masquerade as the corroborating anchor.
+        var sameFilingBalanceSheet = await GetSameFilingBalanceSheetCount(
+            stock,
+            latest.AccessionNumber,
+            cancellationToken
+        );
+        if (sameFilingBalanceSheet == null || sameFilingBalanceSheet < collapseThreshold)
+            return null;
+
+        // The corroborating figure becomes the answer. Same range-check as every other
+        // decimal->long cast here; an unrepresentable count degrades to "cover page stands".
+        return sameFilingBalanceSheet <= long.MaxValue
+            ? new SharesFact(
+                (long)sameFilingBalanceSheet.Value,
+                latest.Filed,
+                latest.Form,
+                latest.AccessionNumber
+            )
+            : null;
+    }
+
+    // The filing's own balance-sheet share count at its most recent as-of date: the consolidated
+    // (classless) fact when the filer states one, otherwise the sum of its single-dimension
+    // per-class facts on a class-of-stock axis — mirroring the consolidated-then-per-class shape
+    // of the cover-page resolution, because filers split the balance-sheet count the same way (Air
+    // Lease states it only on us-gaap:StatementClassOfStockAxis, so a consolidated-only read is
+    // blind to its real figure). Same-accession so a later filing can never masquerade as the
+    // corroborating anchor. Null when the filing states no balance-sheet count at all.
+    private async Task<decimal?> GetSameFilingBalanceSheetCount(
+        CommonStock stock,
+        string accessionNumber,
+        CancellationToken cancellationToken
+    )
+    {
         var balanceSheetConceptIds = await ResolveConceptIds(
             cancellationToken,
             FactTaxonomy.UsGaap
         );
         if (balanceSheetConceptIds.Count == 0)
-            return false;
+            return null;
 
-        var sameFilingBalanceSheet = await _financialFactRepository
+        var consolidated = await _financialFactRepository
             .GetConsolidatedByStock(stock)
             .Where(f =>
                 balanceSheetConceptIds.Contains(f.FinancialConceptId)
                 && f.Unit == SharesUnit
-                && f.AccessionNumber == latest.AccessionNumber
+                && f.AccessionNumber == accessionNumber
                 && f.Value > 0
             )
             .OrderByDescending(f => f.PeriodEnd)
             .Select(f => (decimal?)f.Value)
             .FirstOrDefaultAsync(cancellationToken);
+        if (consolidated != null)
+            return consolidated;
 
-        return sameFilingBalanceSheet != null && sameFilingBalanceSheet >= collapseThreshold;
+        // Per-class facts, pinned the way GetLatestPerClass pins the cover-page sum: one axis and
+        // one as-of date within the accession, grouped by class member so a restated row never
+        // double-counts a class. Zero-valued members (a class with nothing outstanding) are kept —
+        // they simply add nothing.
+        var perClassFacts = await _financialFactRepository
+            .GetByStock(stock)
+            .Where(f =>
+                balanceSheetConceptIds.Contains(f.FinancialConceptId)
+                && f.Unit == SharesUnit
+                && f.AccessionNumber == accessionNumber
+                && f.Dimensions.Count == 1
+                && f.Dimensions.Any(d => ClassOfStockAxes.Contains(d.Axis))
+            )
+            .Include(f => f.Dimensions)
+            .ToListAsync(cancellationToken);
+        if (perClassFacts.Count == 0)
+            return null;
+
+        var latest = perClassFacts
+            .OrderByDescending(f => f.PeriodEnd)
+            .ThenBy(f => Array.IndexOf(ClassOfStockAxes, f.Dimensions[0].Axis))
+            .First();
+
+        var total = perClassFacts
+            .Where(f =>
+                f.PeriodEnd == latest.PeriodEnd && f.Dimensions[0].Axis == latest.Dimensions[0].Axis
+            )
+            .GroupBy(f => f.Dimensions[0].Member)
+            .Sum(g => g.First().Value);
+
+        return total > 0 ? total : null;
     }
 
     // The latest-filed consolidated (classless) cover-page count and the filing it came from, or

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderCoverPageIntegrityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderCoverPageIntegrityTests.cs
@@ -20,11 +20,14 @@ namespace Equibles.UnitTests.Sec;
 //   because its per-class facts were invisible and a stale consolidated fact won);
 // - IsForeignPrivateIssuer keys off the SAME fact GetCurrentSharesOutstanding picks, so a
 //   multi-class 20-F filer with no current consolidated fact is still recognized;
-// - a cover-page count contradicted as a collapse by BOTH the issuer's previous cover-page count
+// - a cover-page count contradicted as a collapse by BOTH the issuer's recent cover-page history
 //   and the same filing's balance-sheet count is a filing artifact (a dropped digit or a
 //   thousands-scaled entry: Armata 36,710 vs 36.4M; FB Bancorp 161,489 vs 17.0M; PTC Therapeutics
-//   8,294,933 vs 82.9M) — the provider abstains (null) so the price feed's listed-security count
-//   stands, instead of poisoning market cap and short-interest ratios until the next filing.
+//   8,294,933 vs 82.9M; Air Lease a flat 200 vs 112.4M) — the provider returns the balance-sheet
+//   count that proved the artifact, instead of poisoning market cap and short-interest ratios
+//   until the filer corrects itself. The history anchor is the maximum over a recent window, not
+//   the single previous fact: Air Lease filed the artifact on two consecutive cover pages, so the
+//   previous fact WAS the artifact and a most-recent-prior check could never fire again.
 public class SharesOutstandingProviderCoverPageIntegrityTests
 {
     private const string IfrsClassAxis = "ifrs-full:ClassesOfShareCapitalAxis";
@@ -206,12 +209,13 @@ public class SharesOutstandingProviderCoverPageIntegrityTests
     }
 
     [Fact]
-    public async Task GetCurrentSharesOutstanding_ThousandsScaledCoverPage_ReturnsNull()
+    public async Task GetCurrentSharesOutstanding_ThousandsScaledCoverPage_ReturnsTheBalanceSheetCount()
     {
         await using var db = NewDb();
         // Armata: the latest 10-Q cover page says 36,710 — the count typed in thousands — while
         // the previous cover-page fact says 36,632,775 and the SAME filing's balance sheet says
-        // 36,431,444. Both anchors contradict the collapse, so the provider must abstain.
+        // 36,431,444. Both anchors contradict the collapse, so the provider returns the
+        // balance-sheet count that proved it.
         var stock = Stock("ARMP");
         var coverPage = CoverPageConcept();
         var balanceSheet = BalanceSheetConcept();
@@ -234,11 +238,13 @@ public class SharesOutstandingProviderCoverPageIntegrityTests
 
         var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
 
-        shares.Should().BeNull("a cover-page count both anchors contradict is a filing artifact");
+        shares
+            .Should()
+            .Be(36_431_444, "a cover-page count both anchors contradict is a filing artifact");
     }
 
     [Fact]
-    public async Task GetCurrentSharesOutstanding_DroppedDigitJustUnderTenfold_ReturnsNull()
+    public async Task GetCurrentSharesOutstanding_DroppedDigitJustUnderTenfold_IsCorrected()
     {
         await using var db = NewDb();
         // PTC Therapeutics: the filer dropped a digit — 8,294,933 against 82,882,024 on the same
@@ -266,7 +272,109 @@ public class SharesOutstandingProviderCoverPageIntegrityTests
 
         var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
 
-        shares.Should().BeNull();
+        shares.Should().Be(82_882_024);
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_ArtifactRepeatedAcrossFilings_IsStillCorrected()
+    {
+        await using var db = NewDb();
+        // Air Lease: the cover page says 200 on TWO consecutive filings (a 10-K/A, then the 10-Q),
+        // so the immediately-prior cover-page fact is the artifact itself and a most-recent-prior
+        // anchor can never fire. The window's maximum still sees the real 112.0M from February.
+        // The filing states no consolidated balance-sheet count — only a per-class fact on the
+        // class-of-stock axis (Class A 112,415,671, an empty preferred class at 0) — so the
+        // corroboration must sum the classes, and their sum is the corrected answer.
+        var stock = Stock("AL");
+        var coverPage = CoverPageConcept();
+        var balanceSheet = BalanceSheetConcept();
+        db.AddRange(stock, coverPage, balanceSheet);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                112_035_408m,
+                new(2026, 2, 12),
+                new(2026, 2, 10),
+                "0000950170-26-000001",
+                DocumentType.TenK
+            )
+        );
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                200m,
+                new(2026, 4, 30),
+                new(2026, 4, 30),
+                "0000950170-26-000002",
+                DocumentType.TenK
+            )
+        );
+        const string acc = "0000950170-26-000003";
+        db.Add(Fact(stock, coverPage, 200m, new(2026, 5, 7), new(2026, 5, 5), acc));
+        db.Add(
+            ClassFact(
+                stock,
+                balanceSheet,
+                112_415_671m,
+                new(2026, 5, 7),
+                new(2026, 3, 31),
+                acc,
+                "us-gaap:CommonClassAMember",
+                "us-gaap:StatementClassOfStockAxis"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                balanceSheet,
+                0m,
+                new(2026, 5, 7),
+                new(2026, 3, 31),
+                acc,
+                "us-gaap:SeriesAPreferredStockMember",
+                "us-gaap:StatementClassOfStockAxis"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(112_415_671);
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_LargeHistoryOutsideTheWindow_KeepsTheCoverPageCount()
+    {
+        await using var db = NewDb();
+        // The history anchor asks whether the issuer was RECENTLY much bigger. A count from years
+        // before the window opened is not recent history — an issuer that genuinely shrank long
+        // ago must not have its current cover page second-guessed by its distant past, even when
+        // a same-filing balance-sheet figure happens to be mis-scaled large.
+        var stock = Stock("TINY");
+        var coverPage = CoverPageConcept();
+        var balanceSheet = BalanceSheetConcept();
+        db.AddRange(stock, coverPage, balanceSheet);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                50_000_000m,
+                new(2022, 3, 1),
+                new(2022, 2, 25),
+                "0000950170-22-000001",
+                DocumentType.TenK
+            )
+        );
+        const string acc = "0000950170-26-000009";
+        db.Add(Fact(stock, coverPage, 40_000m, new(2026, 5, 7), new(2026, 5, 5), acc));
+        db.Add(Fact(stock, balanceSheet, 40_000_000m, new(2026, 5, 7), new(2026, 3, 31), acc));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(40_000);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Air Lease's stored share count has been **200** since early May — against a correct $7.28B market cap (implying $36M per share). The source is genuine: AL filed `EntityCommonStockSharesOutstanding = 200` on **two consecutive cover pages** (10-K/A 2026-04-30, 10-Q 2026-05-07), confirmed in the SEC's own companyfacts, while the same 10-Q's balance sheet states **112,415,671** shares.

The existing collapse check could not fire, for two independent reasons:

1. its **history anchor read the single previous cover-page fact** — which was the artifact itself (the 10-K/A), so once a filer repeats the mistake the check is disarmed forever;
2. its **balance-sheet corroboration read only the consolidated (dimensionless) fact** — AL states the count only on `us-gaap:StatementClassOfStockAxis` (Class A member), so the corroborating figure was invisible.

And even had it fired, abstention (returning null) would not have healed the stored row: the price feed carries no share base for AL, so the fallback writer had nothing to write. The row was permanently stuck — the anchor corruption in #6658's terms.

## The fix

One judgment, applied consistently: **believe the filer's two agreeing statements over its one contradicted one.**

- **History anchor = max over a two-year window**, not the most recent prior fact. A repeated artifact can't poison the maximum; a large count from before the window is not "recent history", so a genuinely-shrunk issuer isn't second-guessed by its distant past.
- **Balance-sheet corroboration falls back to the per-class class-axis sum** when no consolidated fact exists — pinned to one accession, one as-of date, one axis, grouped by member, mirroring the cover-page per-class resolution exactly.
- **A proven collapse is corrected, not abstained from**: the provider returns the balance-sheet count that proved it. The correction reaches the stored row through the existing importer path — `UpdateSharesOutstanding` runs every facts cycle, and the stored 200 fails `ImpliesPlausibleSharePrice` so the write guard rightly lets the repair through.

The conservative structure is unchanged: both anchors must exceed 5× (a real reverse split's balance sheet sits on the new basis, so it never fires), a garbage-large balance sheet alone never fires (Regeneron case, still pinned), and a genuinely tiny issuer (QVC's 1 share) has tiny history (still pinned).

## Verification against production data

AL's exact fact shape (repeated 200, per-class-only balance sheet with a zero preferred class, real prior at 112.0M) is reproduced as a test and resolves to 112,415,671. All 3,764 OSS unit tests pass.

## Code changes

- `SharesOutstandingProvider` — `IsCollapsedCoverPageCount` → `TryResolveCollapseCorrection` (returns the correction); windowed max history anchor; `GetSameFilingBalanceSheetCount` with consolidated-then-per-class resolution.
- Tests — Armata/PTC collapse cases now pin the corrected value; new AL repeated-artifact + per-class case; new outside-the-window case pinning that distant history cannot fire the check.