### PR TITLE
Correct a collapsed cover page only when the evidence is overdetermined

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -44,6 +44,18 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     // is replaced by the balance-sheet count that contradicted it.
     private const decimal CoverPageCollapseFactor = 5m;
 
+    // Members observed on the class-of-stock axes that are not share classes by taxonomy
+    // definition, excluded from any per-class sum: the consolidated roll-up (summing it with the
+    // classes it totals double-counts the company), treasury shares (issued but not outstanding),
+    // and the ADS listing (a different unit from the ordinary-share classes beside it).
+    private static readonly string[] NonClassMembers =
+    [
+        "us-gaap:CommonStockMember",
+        "us-gaap:TreasuryStockMember",
+        "us-gaap:TreasuryStockCommonMember",
+        "dei:AdrMember",
+    ];
+
     // How far back the collapse check's history anchor looks. The anchor asks whether the issuer
     // was RECENTLY much bigger, and it must survive the artifact being repeated (Air Lease filed
     // 200 on two consecutive cover pages, so "the previous fact" was the artifact itself) — hence
@@ -188,13 +200,16 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
 
         if (consolidated != null)
         {
-            var correction = await TryResolveCollapseCorrection(
+            var collapse = await EvaluateCoverPageCollapse(
                 stock,
                 consolidated,
                 coverPageConceptIds,
                 cancellationToken
             );
-            return correction ?? consolidated;
+            // Not collapsed → the cover page stands. Collapsed with a grounded correction → the
+            // correction. Collapsed without one → abstain, so the caller's fallback source (the
+            // price feed's listed-security count) stands and nothing propagates a contested figure.
+            return collapse.Collapsed ? collapse.Correction : consolidated;
         }
 
         // No dei cover-page fact on record — fall back to the balance-sheet consolidated count,
@@ -203,29 +218,48 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         return await GetLatestConsolidated(stock, fallbackConceptIds, cancellationToken);
     }
 
-    // The corrected share count when the latest consolidated cover-page count is contradicted as
-    // a collapse artifact by BOTH of the filer's own other statements of the same measure: the
-    // issuer's recent cover-page history and the same filing's us-gaap balance-sheet count, each
-    // at least CoverPageCollapseFactor times larger. Real filings show this exact shape when the
-    // filer drops a digit or types the count in thousands (observed: 36,710 vs 36.4M; 161,489 vs
-    // 17.0M; 8,294,933 vs 82.9M; Air Lease's flat 200 vs 112.4M) — the artifact then poisons every
-    // downstream ratio until the filer corrects it. Null when the cover-page count stands.
+    // Whether the latest consolidated cover-page count is a collapse artifact, and — separately —
+    // whether the evidence is strong enough to state the corrected figure. NotCollapsed keeps the
+    // cover page; Collapsed with a null Correction abstains (the pre-existing behavior, so the
+    // price feed's listed-security count stands); Collapsed with a Correction returns it.
+    private sealed record CollapseOutcome(bool Collapsed, SharesFact Correction)
+    {
+        public static readonly CollapseOutcome NotCollapsed = new(false, null);
+        public static readonly CollapseOutcome Abstain = new(true, null);
+    }
+
+    // A cover-page count is COLLAPSED when contradicted by BOTH of the filer's own other
+    // statements of the same measure: the issuer's recent cover-page history and the same filing's
+    // us-gaap balance-sheet count, each at least CoverPageCollapseFactor times larger. Real
+    // filings show this shape when the filer drops a digit or types the count in thousands
+    // (observed: 36,710 vs 36.4M; 161,489 vs 17.0M; 8,294,933 vs 82.9M; Air Lease's flat 200 vs
+    // 112.4M). Requiring both anchors keeps the check conservative: a genuinely tiny issuer (a
+    // wholly-owned subsidiary with 1 share) has a tiny history, so it never fires. The history
+    // anchor is the MAXIMUM over a recent window, not the single previous fact — AL filed the
+    // artifact on two consecutive cover pages, so "the previous fact" was the artifact itself and
+    // a most-recent-prior check could never fire again.
     //
-    // Requiring both anchors keeps the check one-sided and conservative: a garbage-LARGE
-    // balance-sheet figure alone (the mis-scaled inverse artifact) does not fire because history
-    // still confirms the cover-page count, and a genuinely tiny issuer (e.g. a wholly-owned
-    // subsidiary with 1 share) has a tiny history, so it does not fire either. Two subtleties,
-    // both paid for in production by Air Lease sticking at 200 shares against a $7.28B market cap:
+    // A collapse is CORRECTED — the balance-sheet count returned as the answer instead of
+    // abstaining — only when the evidence is overdetermined, because a wrong correction is a write
+    // where abstention wrote nothing:
     //
-    //   - the history anchor is the MAXIMUM over a recent window, not the single previous fact —
-    //     AL filed the artifact on two consecutive cover pages (a 10-K/A then a 10-Q), so "the
-    //     previous fact" was the artifact itself and the old check could never fire again;
-    //   - when the two anchors prove the artifact, the balance-sheet count that proved it is
-    //     RETURNED rather than abstained from. Abstention hands the decision to the price feed's
-    //     listed-security count, and an issuer the feed carries no share base for then keeps the
-    //     garbage forever. Believing the filer's two agreeing statements over its one contradicted
-    //     one is the same judgment the detection already makes.
-    private async Task<SharesFact> TryResolveCollapseCorrection(
+    //   - the two corroborators must AGREE with each other as same-unit statements (within the
+    //     collapse factor). That grounds the correction in two independent agreeing figures — and
+    //     kills the trap where a nominal balance-sheet placeholder (1/100/1000 shares) happens to
+    //     clear a threshold computed from a count that is itself garbage-small;
+    //   - the cover page must sit beyond MaxPlausibleSameUnitRatio of the correction — too far off
+    //     to be a statement of the same unit at all (a flat placeholder, a thousands-scaled
+    //     entry). Inside that ratio the cover page could be the one honest figure in the filing —
+    //     Reliability Inc's cover page says a correct 46.7M while its history AND classless
+    //     balance-sheet fact both carry the same 300M mis-tag (the authorized count): 6.4x apart,
+    //     two agreeing statements, and both wrong. In that band the collapse stands but the
+    //     correction abstains, exactly as the check behaved before corrections existed.
+    //
+    // Abstention is not free — an issuer the price feed carries no share base for keeps its
+    // garbage until the filer corrects itself — which is why the overdetermined cases correct
+    // rather than abstain. AL clears both bars (history 112.0M vs balance sheet 112.4M, cover page
+    // 562,000x away); RLBY clears neither.
+    private async Task<CollapseOutcome> EvaluateCoverPageCollapse(
         CommonStock stock,
         SharesFact latest,
         IReadOnlyCollection<Guid> coverPageConceptIds,
@@ -246,7 +280,7 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
             )
             .MaxAsync(f => (decimal?)f.Value, cancellationToken);
         if (priorCoverPageMax == null || priorCoverPageMax < collapseThreshold)
-            return null;
+            return CollapseOutcome.NotCollapsed;
 
         var sameFilingBalanceSheet = await GetSameFilingBalanceSheetCount(
             stock,
@@ -254,18 +288,38 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
             cancellationToken
         );
         if (sameFilingBalanceSheet == null || sameFilingBalanceSheet < collapseThreshold)
-            return null;
+            return CollapseOutcome.NotCollapsed;
 
-        // The corroborating figure becomes the answer. Same range-check as every other
-        // decimal->long cast here; an unrepresentable count degrades to "cover page stands".
+        // Corroborator agreement: history and balance sheet must be same-unit statements of the
+        // same figure, or the correction has no ground to stand on.
+        var larger = Math.Max(priorCoverPageMax.Value, sameFilingBalanceSheet.Value);
+        var smaller = Math.Min(priorCoverPageMax.Value, sameFilingBalanceSheet.Value);
+        if (larger > smaller * CoverPageCollapseFactor)
+            return CollapseOutcome.Abstain;
+
+        // The cover page must be beyond any same-unit reading of the correction. A zero-valued
+        // cover-page fact (no count at all) is trivially beyond it — without the explicit branch
+        // the threshold arithmetic above degenerates to zero and admits anything.
+        var beyondSameUnit =
+            latest.Shares <= 0
+            || sameFilingBalanceSheet
+                >= latest.Shares * (decimal)ShareBasisPlausibility.MaxPlausibleSameUnitRatio;
+        if (!beyondSameUnit)
+            return CollapseOutcome.Abstain;
+
+        // Same range-check as every other decimal->long cast here; an unrepresentable count
+        // degrades to abstention rather than a throw.
         return sameFilingBalanceSheet <= long.MaxValue
-            ? new SharesFact(
-                (long)sameFilingBalanceSheet.Value,
-                latest.Filed,
-                latest.Form,
-                latest.AccessionNumber
+            ? new CollapseOutcome(
+                true,
+                new SharesFact(
+                    (long)sameFilingBalanceSheet.Value,
+                    latest.Filed,
+                    latest.Form,
+                    latest.AccessionNumber
+                )
             )
-            : null;
+            : CollapseOutcome.Abstain;
     }
 
     // The filing's own balance-sheet share count at its most recent as-of date: the consolidated
@@ -305,15 +359,21 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         // Per-class facts, pinned the way GetLatestPerClass pins the cover-page sum: one axis and
         // one as-of date within the accession, grouped by class member so a restated row never
         // double-counts a class. Zero-valued members (a class with nothing outstanding) are kept —
-        // they simply add nothing.
+        // they simply add nothing — while a negative row is excluded rather than silently
+        // subtracted. Members that are not a share class by taxonomy definition are excluded too:
+        // filers put the consolidated roll-up, treasury shares, and the ADS listing on the same
+        // axis, and summing any of those with the real classes double-counts or mixes units.
         var perClassFacts = await _financialFactRepository
             .GetByStock(stock)
             .Where(f =>
                 balanceSheetConceptIds.Contains(f.FinancialConceptId)
                 && f.Unit == SharesUnit
                 && f.AccessionNumber == accessionNumber
+                && f.Value >= 0
                 && f.Dimensions.Count == 1
-                && f.Dimensions.Any(d => ClassOfStockAxes.Contains(d.Axis))
+                && f.Dimensions.Any(d =>
+                    ClassOfStockAxes.Contains(d.Axis) && !NonClassMembers.Contains(d.Member)
+                )
             )
             .Include(f => f.Dimensions)
             .ToListAsync(cancellationToken);

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderCoverPageIntegrityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderCoverPageIntegrityTests.cs
@@ -23,11 +23,17 @@ namespace Equibles.UnitTests.Sec;
 // - a cover-page count contradicted as a collapse by BOTH the issuer's recent cover-page history
 //   and the same filing's balance-sheet count is a filing artifact (a dropped digit or a
 //   thousands-scaled entry: Armata 36,710 vs 36.4M; FB Bancorp 161,489 vs 17.0M; PTC Therapeutics
-//   8,294,933 vs 82.9M; Air Lease a flat 200 vs 112.4M) — the provider returns the balance-sheet
-//   count that proved the artifact, instead of poisoning market cap and short-interest ratios
-//   until the filer corrects itself. The history anchor is the maximum over a recent window, not
-//   the single previous fact: Air Lease filed the artifact on two consecutive cover pages, so the
-//   previous fact WAS the artifact and a most-recent-prior check could never fire again.
+//   8,294,933 vs 82.9M; Air Lease a flat 200 vs 112.4M). The history anchor is the maximum over a
+//   recent window, not the single previous fact: Air Lease filed the artifact on two consecutive
+//   cover pages, so the previous fact WAS the artifact and a most-recent-prior check could never
+//   fire again;
+// - a proven collapse is CORRECTED to the balance-sheet count only when the evidence is
+//   overdetermined — the two corroborators agree with each other AND the cover page is too far
+//   off to be a same-unit statement at all. Otherwise the provider abstains (null): Reliability
+//   Inc's cover page says a correct 46.7M while its history and classless balance-sheet fact both
+//   carry the same 300M mis-tag — 6.4x apart, two agreeing statements, both wrong. A correction
+//   is a write where abstention wrote nothing, so it has to clear a far higher bar than the
+//   detection itself.
 public class SharesOutstandingProviderCoverPageIntegrityTests
 {
     private const string IfrsClassAxis = "ifrs-full:ClassesOfShareCapitalAxis";
@@ -244,12 +250,14 @@ public class SharesOutstandingProviderCoverPageIntegrityTests
     }
 
     [Fact]
-    public async Task GetCurrentSharesOutstanding_DroppedDigitJustUnderTenfold_IsCorrected()
+    public async Task GetCurrentSharesOutstanding_DroppedDigitJustUnderTenfold_Abstains()
     {
         await using var db = NewDb();
         // PTC Therapeutics: the filer dropped a digit — 8,294,933 against 82,882,024 on the same
         // filing's balance sheet and 82,774,730 on the previous cover page. The discrepancy is
-        // 9.99x, so a threshold of 10 would miss it; the collapse factor must catch it.
+        // 9.99x, so a threshold of 10 would miss it; the collapse factor must catch it. But 9.99x
+        // is INSIDE the same-unit ratio, where a cover page can still be the one honest figure
+        // (the RLBY shape), so the provider abstains rather than writing the balance-sheet count.
         var stock = Stock("PTCT");
         var coverPage = CoverPageConcept();
         var balanceSheet = BalanceSheetConcept();
@@ -272,7 +280,104 @@ public class SharesOutstandingProviderCoverPageIntegrityTests
 
         var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
 
-        shares.Should().Be(82_882_024);
+        shares.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_MistagAgreeingAcrossStatements_AbstainsRatherThanCorrects()
+    {
+        await using var db = NewDb();
+        // Reliability Inc: the cover page says a CORRECT 46,707,790 while earlier cover pages and
+        // the same filing's classless balance-sheet fact both carry the same 300,000,000 mis-tag
+        // (the authorized count). The two corroborators agree — and both are wrong. At 6.4x the
+        // cover page is well inside a same-unit reading, so writing the "correction" would replace
+        // the one honest figure in the filing with the mistake. The provider must abstain.
+        var stock = Stock("RLBY");
+        var coverPage = CoverPageConcept();
+        var balanceSheet = BalanceSheetConcept();
+        db.AddRange(stock, coverPage, balanceSheet);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                300_000_000m,
+                new(2025, 11, 14),
+                new(2025, 11, 10),
+                "0001493152-25-000001"
+            )
+        );
+        const string acc = "0001493152-26-024677";
+        db.Add(Fact(stock, coverPage, 46_707_790m, new(2026, 5, 20), new(2026, 5, 11), acc));
+        db.Add(Fact(stock, balanceSheet, 300_000_000m, new(2026, 5, 20), new(2026, 3, 31), acc));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().BeNull("two agreeing corroborators can still both carry the same mistake");
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_PlaceholderBalanceSheetDisagreeingWithHistory_Abstains()
+    {
+        await using var db = NewDb();
+        // A garbage-small cover page (200) makes the collapse threshold trivially clearable — a
+        // nominal 1,000-share balance-sheet placeholder is five times it. The placeholder disagrees
+        // with the issuer's real history by orders of magnitude, so it must never be promoted to
+        // the corrected count; the provider abstains.
+        var stock = Stock("SHEL");
+        var coverPage = CoverPageConcept();
+        var balanceSheet = BalanceSheetConcept();
+        db.AddRange(stock, coverPage, balanceSheet);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                112_000_000m,
+                new(2026, 2, 12),
+                new(2026, 2, 10),
+                "0000950170-26-000021"
+            )
+        );
+        const string acc = "0000950170-26-000022";
+        db.Add(Fact(stock, coverPage, 200m, new(2026, 5, 7), new(2026, 5, 5), acc));
+        db.Add(Fact(stock, balanceSheet, 1_000m, new(2026, 5, 7), new(2026, 3, 31), acc));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCurrentSharesOutstanding_ZeroCoverPageCount_IsCorrectedOnlyByAgreeingCorroborators()
+    {
+        await using var db = NewDb();
+        // A zero-valued cover-page fact carries no count at all, and every threshold computed from
+        // it degenerates to zero — the shape that once admitted any same-accession balance-sheet
+        // figure unchecked. With history and the balance sheet agreeing on the real figure, the
+        // correction is grounded in two independent statements and proceeds.
+        var stock = Stock("ZERO");
+        var coverPage = CoverPageConcept();
+        var balanceSheet = BalanceSheetConcept();
+        db.AddRange(stock, coverPage, balanceSheet);
+        db.Add(
+            Fact(
+                stock,
+                coverPage,
+                50_000_000m,
+                new(2026, 2, 12),
+                new(2026, 2, 10),
+                "0000950170-26-000031"
+            )
+        );
+        const string acc = "0000950170-26-000032";
+        db.Add(Fact(stock, coverPage, 0m, new(2026, 5, 7), new(2026, 5, 5), acc));
+        db.Add(Fact(stock, balanceSheet, 50_100_000m, new(2026, 5, 7), new(2026, 3, 31), acc));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(50_100_000);
     }
 
     [Fact]
@@ -282,9 +387,9 @@ public class SharesOutstandingProviderCoverPageIntegrityTests
         // Air Lease: the cover page says 200 on TWO consecutive filings (a 10-K/A, then the 10-Q),
         // so the immediately-prior cover-page fact is the artifact itself and a most-recent-prior
         // anchor can never fire. The window's maximum still sees the real 112.0M from February.
-        // The filing states no consolidated balance-sheet count — only a per-class fact on the
-        // class-of-stock axis (Class A 112,415,671, an empty preferred class at 0) — so the
-        // corroboration must sum the classes, and their sum is the corrected answer.
+        // The filing states no consolidated balance-sheet count — only per-class facts on the
+        // class-of-stock axis (Class A 112,415,671, an empty Class B at 0) — so the corroboration
+        // must sum the classes, and their sum is the corrected answer.
         var stock = Stock("AL");
         var coverPage = CoverPageConcept();
         var balanceSheet = BalanceSheetConcept();
@@ -333,7 +438,34 @@ public class SharesOutstandingProviderCoverPageIntegrityTests
                 new(2026, 5, 7),
                 new(2026, 3, 31),
                 acc,
-                "us-gaap:SeriesAPreferredStockMember",
+                "us-gaap:CommonClassBMember",
+                "us-gaap:StatementClassOfStockAxis"
+            )
+        );
+        // Filers put non-class members on the same axis: the consolidated roll-up (which would
+        // double-count the classes it totals) and treasury shares (issued but not outstanding).
+        // Both must be excluded from the sum.
+        db.Add(
+            ClassFact(
+                stock,
+                balanceSheet,
+                112_415_671m,
+                new(2026, 5, 7),
+                new(2026, 3, 31),
+                acc,
+                "us-gaap:CommonStockMember",
+                "us-gaap:StatementClassOfStockAxis"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                balanceSheet,
+                9_000_000m,
+                new(2026, 5, 7),
+                new(2026, 3, 31),
+                acc,
+                "us-gaap:TreasuryStockCommonMember",
                 "us-gaap:StatementClassOfStockAxis"
             )
         );


### PR DESCRIPTION
Hardening of #4232, from an adversarial review of that diff replayed against the production database before the correction path had done any damage.

## What the review found

**The correction could return a worse value than the abstention it replaced.** Reliability Inc (RLBY): the cover page states a **correct 46,707,790** while earlier cover pages and the same filing's classless balance-sheet fact both carry the **same 300,000,000 mis-tag** (the authorized count). Both anchors pass at 6.4×, so #4232 would have written 300M over the correct figure — 1 wrong write among the 7 corrections firing on prod data that day.

**A zero-valued cover-page fact made both anchors vacuous.** `GetLatestConsolidated` doesn't filter `Value > 0`, so `latest.Shares = 0` collapses every threshold to zero and any same-accession balance-sheet figure was returned unchecked — 28 stocks in prod have a zero-valued winning cover-page fact.

**The 5×–300× band had no downstream net.** Both writers' guards trip at ≥300× (`MaxPlausibleSameUnitRatio`), so any wrong correction between 5× and 300× is written by both.

## The rule now

A correction is a write where abstention wrote nothing, so it must clear a far higher bar than the detection:

1. **Corroborators must agree with each other** as same-unit statements (within the collapse factor). Also kills the nominal-placeholder trap — a 1,000-share balance-sheet placeholder clearing a threshold computed from a garbage-small count now fails on disagreement with real history.
2. **The cover page must sit beyond `MaxPlausibleSameUnitRatio` (300×) of the correction** — too far off to be a statement of the same unit at all. Inside that band the collapse is still detected but the provider **abstains**, exactly the pre-#4232 behavior: RLBY (6.4×), PTC's dropped digit (9.99×) and FB Bancorp (105×) all revert to abstention; **Air Lease (562,000×, corroborators agreeing to 0.3%) still heals**.
3. **Zero-valued cover pages** take an explicit branch and correct only on agreeing corroborators.
4. The per-class balance-sheet sum **excludes non-class members by taxonomy definition** — `us-gaap:CommonStockMember` (the roll-up; summing it with the classes it totals double-counts), treasury members (issued, not outstanding), `dei:AdrMember` (different unit) — and drops negative rows rather than silently subtracting.

Structurally, `TryResolveCollapseCorrection` became `EvaluateCoverPageCollapse` returning a three-way outcome (not collapsed / collapsed-abstain / collapsed-corrected), so abstention is again expressible.

## Tests

New pins: the RLBY shape (abstains), the placeholder shape (abstains), the zero-cover-page shape (corrects only on agreement), the roll-up/treasury exclusion inside the AL case; PTC reverts to pinning abstention. All 3,767 OSS unit tests pass.

## Known remaining gaps (accepted, follow-up material)

- `DocumentType` has no `TwentyFa`/`FortyFa`, so an FPI's amended annual filing resolves `Form = Other` and `IsForeignPrivateIssuer` misses it — pre-existing, now much less exposed since corrections need the overdetermined bar.
- The classless balance-sheet fact is still preferred over a fresher dimensional one within the same filing; harmless now that a disagreeing classless figure can only cause abstention.