### PR TITLE
perf(financial-facts): index FinancialFact by concept and period

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260728170230_AddFinancialFactConceptPeriodIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260728170230_AddFinancialFactConceptPeriodIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728170230_AddFinancialFactConceptPeriodIndex")]
+    partial class AddFinancialFactConceptPeriodIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260728170230_AddFinancialFactConceptPeriodIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260728170230_AddFinancialFactConceptPeriodIndex.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <summary>
+    /// Btree on FinancialFact(FinancialConceptId, PeriodEnd) for the queries that ask about a
+    /// concept across ALL companies ("has this concept any fact since &lt;date&gt;?"). The existing
+    /// company-first index cannot serve those: with CommonStockId unconstrained Postgres restarts
+    /// the index search once per distinct stock, measured at 42.6M index searches / 173M buffer
+    /// hits / 32s for a single 4,038-concept batch of the concept curation lane.
+    ///
+    /// Raw SQL with CREATE INDEX CONCURRENTLY (suppressTransaction) so the build takes no write
+    /// lock on the live FinancialFact table — the SEC fact ingest writes continuously — and
+    /// IF NOT EXISTS keeps it idempotent for deployments that pre-built the index by hand.
+    /// Pre-building is the expectation on a large installation: the table is ~156M rows / 84 GB,
+    /// and a build running inside the deploy's 900s schema gate would risk aborting the release.
+    ///
+    /// The new index leads with FinancialConceptId, so it fully covers everything the
+    /// single-column FK index served; that one is dropped afterwards rather than before, so no
+    /// window exists in which neither index is available.
+    /// </summary>
+    public partial class AddFinancialFactConceptPeriodIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // A failed CONCURRENTLY build leaves an INVALID index behind, which IF NOT EXISTS
+            // would then treat as "exists" forever — drop such a leftover first (an invalid
+            // index serves no queries, so the plain drop's brief lock is free), then build.
+            migrationBuilder.Sql(
+                "DO $$ BEGIN "
+                    + "IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                    + "WHERE c.relname = 'IX_FinancialFact_FinancialConceptId_PeriodEnd' AND NOT i.indisvalid) THEN "
+                    + "EXECUTE 'DROP INDEX \"IX_FinancialFact_FinancialConceptId_PeriodEnd\"'; END IF; END $$;",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_FinancialFact_FinancialConceptId_PeriodEnd\" "
+                    + "ON \"FinancialFact\" (\"FinancialConceptId\", \"PeriodEnd\");",
+                suppressTransaction: true
+            );
+
+            // Redundant once the composite above exists: same leading column, so it serves the
+            // FK lookups and cascade deletes the single-column index served.
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_FinancialFact_FinancialConceptId\";",
+                suppressTransaction: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_FinancialFact_FinancialConceptId\" "
+                    + "ON \"FinancialFact\" (\"FinancialConceptId\");",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_FinancialFact_FinancialConceptId_PeriodEnd\";",
+                suppressTransaction: true
+            );
+        }
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs
@@ -15,6 +15,12 @@ namespace Equibles.Sec.FinancialFacts.Data.Models;
 /// <see cref="FiledDate"/>.
 /// </summary>
 [Index(nameof(CommonStockId), nameof(FinancialConceptId), nameof(PeriodEnd))]
+// Concept-first twin of the index above, for the queries that ask about a concept across ALL
+// companies ("has this concept any fact since <date>?"). The company-first index cannot serve
+// those: with CommonStockId unconstrained Postgres restarts the search once per distinct stock,
+// which measured 42.6M index searches and 32s for a single 4,038-concept batch of the concept
+// curation lane. Leading with FinancialConceptId makes each probe one range scan.
+[Index(nameof(FinancialConceptId), nameof(PeriodEnd))]
 [Index(nameof(CommonStockId), nameof(FiscalYear), nameof(FiscalPeriod))]
 [Index(nameof(DocumentId))]
 [Index(


### PR DESCRIPTION
## Summary

Queries that ask about a concept across **all** companies — *"has this concept any fact since `<date>`?"* — have no index that fits. The existing composite is `(CommonStockId, FinancialConceptId, PeriodEnd)`, and with the leading column unconstrained Postgres cannot scan one range: it restarts the index search once per distinct stock.

Measured with `EXPLAIN (ANALYZE, BUFFERS)` on a 156M-row / 84 GB table, for a single 4,038-concept batch of the concept-name curation lane:

```
->  Nested Loop Anti Join  (actual rows=405.00 loops=5)
      ->  Index Only Scan using "IX_FinancialFact_CommonStockId_FinancialConceptId_PeriodEnd"
            Index Cond: (("FinancialConceptId" = f."Id") AND ("PeriodEnd" >= '2024-07-28'))
            Index Searches: 42631376          <-- one per (concept, stock), not per concept
            Buffers: shared hit=173903668 read=909754
Execution Time: 32178.437 ms
```

42.6M index searches and 173M buffer hits for 4k concepts. In production that lane refills roughly every 16 minutes with four parallel workers, so it competes continuously with everything else on the box.

Leading with `FinancialConceptId` makes each probe one range scan.

## Code changes

- **`FinancialFact`** — new `[Index(nameof(FinancialConceptId), nameof(PeriodEnd))]`, documented with the measurement so the next reader doesn't assume the company-first index already covers it.
- **`AddFinancialFactConceptPeriodIndex`** — hand-written raw SQL rather than the scaffolded `CreateIndex`:
  - `CREATE INDEX CONCURRENTLY` (`suppressTransaction: true`) so the build takes no write lock on the live table — the SEC fact ingest writes to it continuously.
  - `IF NOT EXISTS`, plus an upfront cleanup of an `indisvalid = false` leftover from a previously failed concurrent build (which `IF NOT EXISTS` would otherwise treat as "exists" forever). This makes the migration a no-op for an installation that pre-built the index by hand — the expectation at this table size, since a build inside a deployment's schema gate would risk aborting the release.
  - The redundant single-column FK index `IX_FinancialFact_FinancialConceptId` is dropped **after** the composite is built, never before: the new index has the same leading column and serves everything the old one did (FK lookups, cascade deletes), and ordering the drop last leaves no window in which neither index is present.

Same pattern as the existing `AddChunkTickerIndex` migration.

## Verification

`dotnet build -c Release` clean. The model snapshot picks up the new index and drops the old FK index entry, so the schema and the model agree.