### PR TITLE
chore: format HoldingsImportService with the pinned csharpier

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1058,7 +1058,8 @@ public class HoldingsImportService
         // underlying ordinary shares), and multiplying them together states a holding worth many
         // times the company. Keep the filer's share count, withhold the valuation, and stop the
         // repricing lane from re-deriving the same wrong figure later.
-        var issuerSize = context.IssuerSizes != null
+        var issuerSize =
+            context.IssuerSizes != null
             && context.IssuerSizes.TryGetValue(commonStockId, out var size)
                 ? size
                 : null;


### PR DESCRIPTION
The file landed unformatted, so the CSharpier lint check has been red on every branch since — unrelated PRs had to be merged over a failing required check. Formatting only (`dotnet tool run csharpier format`), no behavior change.