### PR TITLE
feat(common-stocks): remember retired tickers so renamed symbols can redirect

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -87,6 +87,71 @@ public class CommonStockManager
     }
 
     /// <summary>
+    /// Stages a <see cref="CommonStockTickerAlias"/> for a primary ticker the stock is
+    /// abandoning, so URLs published under the old symbol can 301 to the current one.
+    /// Stages only — no SaveChanges: the caller is the SEC sync mid-rename, and the alias
+    /// must commit (or roll back) atomically with the rename itself.
+    /// <para>
+    /// Semantics differ from the CUSIP alias on purpose. A CUSIP identifies one security
+    /// forever, so the first owner keeps a retired CUSIP; tickers are recycled across
+    /// unrelated issuers, so redirects are last-writer-wins:
+    /// an alias equal to any LIVE primary or secondary ticker is never recorded (the live
+    /// symbol would shadow it anyway — recording it would only seed a stale row for the
+    /// day the live holder renames); and recording a symbol another stock retired earlier
+    /// deletes that stale alias first — the most recent holder owns the redirect.
+    /// </para>
+    /// Returns the staged entity, or null when nothing was staged, so the caller can
+    /// detach it if the surrounding update is rolled back.
+    /// </summary>
+    public async Task<CommonStockTickerAlias> RecordTickerAlias(
+        CommonStock commonStock,
+        string retiredTicker
+    )
+    {
+        ArgumentNullException.ThrowIfNull(commonStock);
+
+        if (
+            string.IsNullOrWhiteSpace(retiredTicker)
+            || string.Equals(retiredTicker, commonStock.Ticker, StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            return null;
+        }
+
+        var normalized = retiredTicker.ToUpperInvariant();
+
+        // Never shadow a live symbol: if any stock currently lists it (primary or
+        // secondary), the live resolution wins on every lookup and the alias would only
+        // linger as a wrong redirect after that holder eventually renames.
+        var liveHolder = await _commonStockRepository
+            .GetAll()
+            .AnyAsync(cs => cs.Ticker == normalized || cs.SecondaryTickers.Contains(normalized));
+        if (liveHolder)
+        {
+            return null;
+        }
+
+        // Last-writer-wins: a symbol another stock retired earlier now belongs to this
+        // stock's history — delete the stale alias so the unique index accepts the new
+        // row (also covers this stock re-retiring a symbol it held twice).
+        var existing = await _commonStockRepository
+            .GetTickerAliases()
+            .FirstOrDefaultAsync(a => a.Ticker == normalized);
+        if (existing != null)
+        {
+            if (existing.CommonStockId == commonStock.Id)
+            {
+                return null;
+            }
+            _commonStockRepository.DeleteTickerAlias(existing);
+        }
+
+        return _commonStockRepository.AddTickerAlias(
+            new CommonStockTickerAlias { CommonStockId = commonStock.Id, Ticker = normalized }
+        );
+    }
+
+    /// <summary>
     /// Sets the company's fiscal year-end (month 1-12, optional day 1-31),
     /// sourced from SEC EDGAR's submissions <c>fiscalYearEnd</c> field. A
     /// no-op change persists nothing. Saves directly via the repository — like

--- a/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
+++ b/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
@@ -10,6 +10,7 @@ public class CommonStocksModuleConfiguration : Equibles.Data.IFinancialModule
     {
         builder.Entity<CommonStock>();
         builder.Entity<CommonStockCusipAlias>();
+        builder.Entity<CommonStockTickerAlias>();
         builder.Entity<Industry>();
         builder.Entity<Sector>();
     }

--- a/src/Equibles.CommonStocks.Data/Models/CommonStockTickerAlias.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStockTickerAlias.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// A primary ticker the stock previously traded under. The SEC sync renames
+/// <c>CommonStock.Ticker</c> in place when an issuer changes its symbol
+/// (LendingClub's LC → HAPN), which orphans every URL, bookmark and search
+/// result published under the old symbol — the row's other identifiers survive
+/// the rename, but the old ticker itself is gone from the table. Rows are
+/// recorded by <c>CommonStockManager.RecordTickerAlias</c> whenever the sync
+/// changes a primary ticker, so a miss-path lookup can 301 the old symbol to
+/// the current one.
+///
+/// This is deliberately a separate map rather than a history column on the
+/// stock: it is consulted only on the miss path, so no ticker query — screener,
+/// sitemap, importer maps, uniqueness validation — can accidentally see a
+/// retired symbol. Unlike the CUSIP alias (first owner keeps a retired CUSIP
+/// forever), ticker aliases are last-writer-wins: exchanges recycle symbols
+/// across unrelated issuers, so the most recent holder of a symbol owns its
+/// redirect, and an alias is deleted outright when a company adopts that
+/// symbol as a live ticker again.
+/// </summary>
+[Index(nameof(Ticker), IsUnique = true)]
+[Index(nameof(CommonStockId))]
+public class CommonStockTickerAlias
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+
+    public virtual CommonStock CommonStock { get; set; }
+
+    [Required]
+    [MaxLength(16)]
+    public string Ticker { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -144,4 +144,26 @@ public class CommonStockRepository : BaseRepository<CommonStock>
         DbContext.Set<CommonStockCusipAlias>().Add(alias);
         return alias;
     }
+
+    /// <summary>
+    /// Retired primary tickers recorded when the SEC sync renamed a stock's symbol.
+    /// Same aggregate reasoning as the CUSIP aliases: no independent lifecycle, so
+    /// access lives here rather than in a dedicated repository. Consulted only on
+    /// the miss path — a live ticker always resolves before any alias is looked at.
+    /// </summary>
+    public IQueryable<CommonStockTickerAlias> GetTickerAliases()
+    {
+        return DbContext.Set<CommonStockTickerAlias>().AsQueryable();
+    }
+
+    public CommonStockTickerAlias AddTickerAlias(CommonStockTickerAlias alias)
+    {
+        DbContext.Set<CommonStockTickerAlias>().Add(alias);
+        return alias;
+    }
+
+    public void DeleteTickerAlias(CommonStockTickerAlias alias)
+    {
+        DbContext.Set<CommonStockTickerAlias>().Remove(alias);
+    }
 }

--- a/src/Equibles.Migrations/Migrations/20260728204000_AddCommonStockTickerAlias.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260728204000_AddCommonStockTickerAlias.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728204000_AddCommonStockTickerAlias")]
+    partial class AddCommonStockTickerAlias
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260728204000_AddCommonStockTickerAlias.cs
+++ b/src/Equibles.Migrations/Migrations/20260728204000_AddCommonStockTickerAlias.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommonStockTickerAlias : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CommonStockTickerAlias",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Ticker = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CommonStockTickerAlias", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CommonStockTickerAlias_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStockTickerAlias_CommonStockId",
+                table: "CommonStockTickerAlias",
+                column: "CommonStockId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStockTickerAlias_Ticker",
+                table: "CommonStockTickerAlias",
+                column: "Ticker",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CommonStockTickerAlias");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -235,6 +235,12 @@ public class CompanySyncService : ICompanySyncService
             )
                 return;
 
+            // A ticker change orphans every URL published under the old symbol — record it
+            // as a redirect alias BEFORE the manager's save so alias and rename commit in
+            // the same unit of work. Staged only; the catch below unwinds it on rollback.
+            if (oldTicker != primaryTicker)
+                await state.CommonStockManager.RecordTickerAlias(existingStock, oldTicker);
+
             await state.CommonStockManager.Update(existingStock);
 
             if (oldTicker != primaryTicker)
@@ -259,6 +265,24 @@ public class CompanySyncService : ICompanySyncService
             existingStock.SecondaryTickers = oldSecondaryTickers;
             existingStock.Website = oldWebsite;
             state.DbContext.Entry(existingStock).State = EntityState.Unchanged;
+            // Unwind any alias changes RecordTickerAlias staged for this failed rename — a
+            // pending insert (the new alias) or delete (the last-writer-wins reclaim of a
+            // stale one) would otherwise ride along on the NEXT SaveChanges of this
+            // long-lived sync context, recording a redirect for a rename that never landed.
+            // Earlier stocks in the batch already committed theirs (Update saves per stock),
+            // so only this rename's pending entries can be in these states.
+            foreach (
+                var aliasEntry in state
+                    .DbContext.ChangeTracker.Entries<CommonStockTickerAlias>()
+                    .Where(e => e.State is EntityState.Added or EntityState.Deleted)
+                    .ToList()
+            )
+            {
+                aliasEntry.State =
+                    aliasEntry.State == EntityState.Added
+                        ? EntityState.Detached
+                        : EntityState.Unchanged;
+            }
             _logger.LogError(
                 ex,
                 "Error updating company {Ticker} - {Name} (CIK: {Cik})",

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerRecordTickerAliasTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerRecordTickerAliasTests.cs
@@ -1,0 +1,149 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.CommonStocks;
+
+/// <summary>
+/// Contract for the ticker-rename redirect map: a retired primary ticker is recorded so the
+/// old symbol can 301 to the current one; an alias never shadows a live primary or secondary
+/// ticker; and — unlike the CUSIP alias's first-owner-keeps rule — a recycled symbol belongs
+/// to its most recent holder (last-writer-wins), because exchanges reassign tickers across
+/// unrelated issuers. RecordTickerAlias only STAGES: the caller (the SEC sync mid-rename)
+/// owns the SaveChanges so alias and rename commit atomically.
+/// </summary>
+public class CommonStockManagerRecordTickerAliasTests
+{
+    private readonly CommonStockManager _sut;
+    private readonly CommonStockRepository _repository;
+
+    public CommonStockManagerRecordTickerAliasTests()
+    {
+        var context = TestDbContextFactory.Create(new CommonStocksModuleConfiguration());
+        _repository = new CommonStockRepository(context);
+        _sut = new CommonStockManager(_repository, Substitute.For<IBus>());
+    }
+
+    private async Task<CommonStock> SeedStock(
+        string ticker,
+        string cik,
+        List<string> secondaryTickers = null
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Test Co",
+            Cik = cik,
+            SecondaryTickers = secondaryTickers ?? [],
+        };
+        _repository.Add(stock);
+        await _repository.SaveChanges();
+        return stock;
+    }
+
+    // The LendingClub shape: LC → HAPN records LC as this stock's alias.
+    [Fact]
+    public async Task RecordTickerAlias_RetiredTicker_StagesAliasForTheStock()
+    {
+        var stock = await SeedStock("HAPN", "1409970");
+
+        var staged = await _sut.RecordTickerAlias(stock, "LC");
+        await _repository.SaveChanges();
+
+        staged.Should().NotBeNull();
+        var alias = await _repository.GetTickerAliases().SingleAsync();
+        alias.Ticker.Should().Be("LC");
+        alias.CommonStockId.Should().Be(stock.Id);
+    }
+
+    // Lowercase input normalizes to the stored uppercase form — the unique index must never
+    // hold two case-variants of one symbol.
+    [Fact]
+    public async Task RecordTickerAlias_LowercaseInput_StoresUppercase()
+    {
+        var stock = await SeedStock("HAPN", "1409970");
+
+        await _sut.RecordTickerAlias(stock, "lc");
+        await _repository.SaveChanges();
+
+        (await _repository.GetTickerAliases().SingleAsync()).Ticker.Should().Be("LC");
+    }
+
+    // A symbol some OTHER stock currently trades under (primary) is live — recording it
+    // would seed a redirect that only ever fires wrongly, after that holder renames.
+    [Fact]
+    public async Task RecordTickerAlias_SymbolIsAnotherStocksLivePrimary_StagesNothing()
+    {
+        var renamed = await SeedStock("HAPN", "1409970");
+        await SeedStock("LC", "9999999");
+
+        var staged = await _sut.RecordTickerAlias(renamed, "LC");
+
+        staged.Should().BeNull();
+        (await _repository.GetTickerAliases().AnyAsync()).Should().BeFalse();
+    }
+
+    // Same for a live SECONDARY ticker — those resolve on every stock route too.
+    [Fact]
+    public async Task RecordTickerAlias_SymbolIsAnotherStocksLiveSecondary_StagesNothing()
+    {
+        var renamed = await SeedStock("HAPN", "1409970");
+        await SeedStock("ABLZF", "1091587", ["LC"]);
+
+        var staged = await _sut.RecordTickerAlias(renamed, "LC");
+
+        staged.Should().BeNull();
+        (await _repository.GetTickerAliases().AnyAsync()).Should().BeFalse();
+    }
+
+    // Last-writer-wins: the symbol was already an alias of a DIFFERENT stock (an earlier
+    // holder retired it). The most recent holder owns the redirect, so the stale row is
+    // replaced — the opposite of SetCusip's first-owner-keeps rule, deliberately.
+    [Fact]
+    public async Task RecordTickerAlias_SymbolAliasedToAnotherStock_ReassignsToTheNewHolder()
+    {
+        var earlierHolder = await SeedStock("NEWCO", "1111111");
+        await _sut.RecordTickerAlias(earlierHolder, "XYZ");
+        await _repository.SaveChanges();
+
+        var laterHolder = await SeedStock("LATER", "2222222");
+        await _sut.RecordTickerAlias(laterHolder, "XYZ");
+        await _repository.SaveChanges();
+
+        var alias = await _repository.GetTickerAliases().SingleAsync(a => a.Ticker == "XYZ");
+        alias.CommonStockId.Should().Be(laterHolder.Id);
+    }
+
+    // Re-retiring a symbol the stock already has an alias for is a no-op, not a duplicate.
+    [Fact]
+    public async Task RecordTickerAlias_AlreadyAliasedToSameStock_StagesNothing()
+    {
+        var stock = await SeedStock("HAPN", "1409970");
+        await _sut.RecordTickerAlias(stock, "LC");
+        await _repository.SaveChanges();
+
+        var staged = await _sut.RecordTickerAlias(stock, "LC");
+        await _repository.SaveChanges();
+
+        staged.Should().BeNull();
+        (await _repository.GetTickerAliases().CountAsync()).Should().Be(1);
+    }
+
+    // Guard rails: blank input and "retiring" the stock's own current ticker stage nothing.
+    [Fact]
+    public async Task RecordTickerAlias_BlankOrCurrentTicker_StagesNothing()
+    {
+        var stock = await SeedStock("HAPN", "1409970");
+
+        (await _sut.RecordTickerAlias(stock, null)).Should().BeNull();
+        (await _sut.RecordTickerAlias(stock, "  ")).Should().BeNull();
+        (await _sut.RecordTickerAlias(stock, "hapn")).Should().BeNull();
+        (await _repository.GetTickerAliases().AnyAsync()).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

When an issuer changes its ticker, `CompanySyncService` renames `CommonStock.Ticker` in place and the old symbol vanishes from the table — every URL, bookmark, and search result published under it starts failing, with no way to recover the mapping. LendingClub's LC → HAPN orphaned the whole `/stocks/lc` tree in the downstream deployment (its Search Console shows the old URLs 404ing sitewide).

`CommonStockTickerAlias` records the retired symbol at the moment of the rename. It is deliberately a **separate map consulted only on the miss path** — same reasoning as `CongressMemberRedirect` — so no ticker query (screener, sitemap, importer maps, uniqueness validation) can accidentally see a retired symbol.

**Semantics differ from the CUSIP alias on purpose.** A CUSIP identifies one security forever, so `SetCusip`'s first-owner-keeps rule is right there. Exchanges *recycle* tickers across unrelated issuers, so redirects are last-writer-wins:

- an alias equal to any **live** primary or secondary ticker is never recorded (live resolution shadows it anyway; recording would only seed a wrong redirect for the day that holder renames);
- recording a symbol an earlier holder retired **deletes the stale alias first** — the most recent holder owns the redirect;
- a stale alias shadowed by a live adoption self-heals at that holder's next rename.

## Code changes

- **`CommonStockTickerAlias`** — model (unique `Ticker` index, `CommonStockId` index, FK cascade so the alias dies with the stock), registered in `CommonStocksModuleConfiguration`.
- **`CommonStockRepository`** — `GetTickerAliases` / `AddTickerAlias` / `DeleteTickerAlias`, mirroring the CUSIP accessors (aggregate-owned, no dedicated repository).
- **`CommonStockManager.RecordTickerAlias`** — stages only, no `SaveChanges`: the caller is the SEC sync mid-rename and alias + rename must commit atomically. Returns the staged entity (or null) so callers can unwind.
- **`CompanySyncService.UpdateExistingStock`** — records the alias before `CommonStockManager.Update` (one save); the existing rollback path now also unwinds pending alias inserts *and* the last-writer-wins deletes, so a failed rename can't leak a redirect onto the long-lived sync context's next save.
- **Migration** `AddCommonStockTickerAlias` — plain table creation, same shape as `AddCommonStockCusipAlias`.
- **Tests** — 7 integration tests: record + normalization, live-primary refusal, live-secondary refusal, last-writer-wins reassignment, same-stock idempotence, blank/current-ticker guards.

The consuming 301 redirect lands in the downstream portal (it resolves the alias on the miss path and redirects to the current symbol, gated on the target still being listed).

## Verification

`dotnet build -c Release` clean; the 7 new tests pass (`vstest`, 542 ms); all touched files formatted with the pinned csharpier.