### PR TITLE
fix(common-stocks): record the ticker alias mid-rename and reclaim re-adopted symbols

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -112,23 +112,63 @@ public class CommonStockManager
 
         if (
             string.IsNullOrWhiteSpace(retiredTicker)
-            || string.Equals(retiredTicker, commonStock.Ticker, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(
+                retiredTicker.Trim(),
+                commonStock.Ticker,
+                StringComparison.OrdinalIgnoreCase
+            )
         )
         {
             return null;
         }
 
-        var normalized = retiredTicker.ToUpperInvariant();
+        var normalized = retiredTicker.Trim().ToUpperInvariant();
 
-        // Never shadow a live symbol: if any stock currently lists it (primary or
+        // The stock keeping the symbol as a secondary listing isn't a retirement — the live
+        // lookup still resolves it, so an alias would never fire (and would turn into a wrong
+        // redirect the day the secondary is dropped without a rename).
+        if (
+            commonStock.SecondaryTickers != null
+            && commonStock.SecondaryTickers.Any(t =>
+                string.Equals(t, normalized, StringComparison.OrdinalIgnoreCase)
+            )
+        )
+        {
+            return null;
+        }
+
+        // Never shadow a live symbol: if any OTHER stock currently lists it (primary or
         // secondary), the live resolution wins on every lookup and the alias would only
-        // linger as a wrong redirect after that holder eventually renames.
+        // linger as a wrong redirect after that holder eventually renames. The caller is the
+        // sync MID-RENAME — this stock's own row still holds the retired symbol in the
+        // database (the new ticker is staged in memory, unflushed, and EF never flushes
+        // before a query) — so the check must exclude the stock itself or it matches its own
+        // stale row and no alias is ever recorded on the one path that matters.
         var liveHolder = await _commonStockRepository
             .GetAll()
-            .AnyAsync(cs => cs.Ticker == normalized || cs.SecondaryTickers.Contains(normalized));
+            .AnyAsync(cs =>
+                cs.Id != commonStock.Id
+                && (cs.Ticker == normalized || cs.SecondaryTickers.Contains(normalized))
+            );
         if (liveHolder)
         {
             return null;
+        }
+
+        // Re-adoption cleanup — the deletion half of last-writer-wins the redirect design
+        // depends on: the symbol this stock is renaming TO may sit in the alias map from an
+        // earlier retirement (its own A→B→A round trip, or another issuer's). Once it is live
+        // again the alias is at best shadowed and at worst a wrong redirect, so it goes.
+        var adopted = commonStock.Ticker?.ToUpperInvariant();
+        if (adopted != null)
+        {
+            var staleAdopted = await _commonStockRepository
+                .GetTickerAliases()
+                .FirstOrDefaultAsync(a => a.Ticker == adopted);
+            if (staleAdopted != null)
+            {
+                _commonStockRepository.DeleteTickerAlias(staleAdopted);
+            }
         }
 
         // Last-writer-wins: a symbol another stock retired earlier now belongs to this

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerRecordTickerAliasTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerRecordTickerAliasTests.cs
@@ -62,6 +62,59 @@ public class CommonStockManagerRecordTickerAliasTests
         alias.CommonStockId.Should().Be(stock.Id);
     }
 
+    // THE PRODUCTION ORDERING — the sync calls this MID-RENAME: the stock's row in the
+    // database still holds the retired symbol, the new ticker exists only on the in-memory
+    // entity, unflushed. The live-holder guard queries the database, so without excluding
+    // the stock itself it matches this very row and stages nothing — which shipped the
+    // feature as a silent no-op on the only path that ever calls it. The test above seeds
+    // the stock already saved under the NEW symbol, which is exactly how that was missed.
+    [Fact]
+    public async Task RecordTickerAlias_RenameStagedInMemoryOnly_StillStagesTheAlias()
+    {
+        var stock = await SeedStock("LC", "1409970");
+        stock.Ticker = "HAPN"; // in-memory only — the database row still says LC
+
+        var staged = await _sut.RecordTickerAlias(stock, "LC");
+        await _repository.SaveChanges();
+
+        staged.Should().NotBeNull();
+        var alias = await _repository.GetTickerAliases().SingleAsync();
+        alias.Ticker.Should().Be("LC");
+        alias.CommonStockId.Should().Be(stock.Id);
+    }
+
+    // Re-adoption cleanup (the deletion half of last-writer-wins): renaming BACK to a symbol
+    // that sits in the alias map deletes that alias — once the symbol is live again the row
+    // is at best shadowed, at worst a wrong redirect after the next rename.
+    [Fact]
+    public async Task RecordTickerAlias_RenamingOntoAnAliasedSymbol_DeletesTheStaleAlias()
+    {
+        var stock = await SeedStock("HAPN", "1409970");
+        await _sut.RecordTickerAlias(stock, "LC");
+        await _repository.SaveChanges();
+
+        // The round trip: HAPN → LC again (rename staged in memory, mid-sync).
+        stock.Ticker = "LC";
+        await _sut.RecordTickerAlias(stock, "HAPN");
+        await _repository.SaveChanges();
+
+        var aliases = await _repository.GetTickerAliases().ToListAsync();
+        aliases.Should().ContainSingle().Which.Ticker.Should().Be("HAPN");
+    }
+
+    // A symbol the stock keeps as a SECONDARY listing after the primary moves is not a
+    // retirement — the live lookup still resolves it, so no alias is staged.
+    [Fact]
+    public async Task RecordTickerAlias_SymbolKeptAsOwnSecondary_StagesNothing()
+    {
+        var stock = await SeedStock("ABLZF", "1091587", ["ABBNY"]);
+
+        var staged = await _sut.RecordTickerAlias(stock, "ABBNY");
+
+        staged.Should().BeNull();
+        (await _repository.GetTickerAliases().AnyAsync()).Should().BeFalse();
+    }
+
     // Lowercase input normalizes to the stored uppercase form — the unique index must never
     // hold two case-variants of one symbol.
     [Fact]


### PR DESCRIPTION
## Summary

Review of #4240 caught the write path **dead on arrival**: the live-holder guard runs as a database query, but the only caller is the SEC sync **mid-rename** — the stock's own row still holds the retired symbol (the new ticker is staged in memory, unflushed, and EF never flushes before a query). The guard matched the renaming stock's own stale row and returned null, so **no alias was ever recorded** on the one path that matters. The tests missed it because every case seeded the stock already saved under the *new* symbol — the inverse of the production ordering.

## Code changes

- **Self-exclusion in the live-holder guard** (`cs.Id != commonStock.Id`), with the mid-rename reasoning documented at the check.
- **Regression test in the production ordering**: seed under the OLD symbol, mutate `Ticker` in memory without saving, then record — stages the alias. (Empirically null before this fix.)
- **Re-adoption reclaim** — the deletion half of last-writer-wins that the model's doc-comment promised but nothing implemented: renaming *onto* a symbol that sits in the alias map deletes that stale alias. Without it, an A→B→A round trip left alias `A` pointing at a stock whose live ticker is `A` again — shadowed today, a wrong redirect after the next rename, and the feeder for a self-redirect loop in the downstream portal.
- **Own-secondary guard**: a symbol the stock keeps as its own secondary listing is not a retirement; stages nothing.
- **Trim before normalize**, matching the read side.

## Verification

Build clean; the RecordTickerAlias suite is now 10 tests including the production-ordering case, the A→B→A reclaim round trip, and the own-secondary guard — all passing. Formatted with the pinned csharpier.