### PR TITLE
fix(holdings): report what a clone backtest actually covers, and label option positions

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
@@ -196,8 +196,48 @@ public class CloneBacktestTools
             $"Alpha vs benchmark (total return): {FormatPercent(alpha)}. "
                 + $"{result.Points.Count} daily points simulated."
         );
+
+        // A clone is long-only, so a filer who expresses its thesis in options is only partly
+        // tracked — and the answer above then describes the leftovers rather than the manager.
+        // Stating that is not optional garnish: a model reading this tool has no other way to know,
+        // and will otherwise report the number as the manager's performance.
+        var coverage = result.Coverage;
+        if (coverage is { QuartersMeasured: > 0 })
+        {
+            output.AppendLine();
+            output.AppendLine(
+                $"Coverage: the clone tracks {FormatShare(coverage.AverageLongPercent)} of "
+                    + $"{holder.Name}'s reported 13F value on average across {coverage.QuartersMeasured} "
+                    + $"quarter(s), and as little as {FormatShare(coverage.MinimumLongPercent)} in its "
+                    + "thinnest quarter. The remainder is option positions, which a long-only clone "
+                    + "cannot replicate and excludes."
+            );
+            if (!coverage.IsRepresentative)
+            {
+                output.AppendLine(
+                    "WARNING: most of this filer's reported book is options, so the return above is "
+                        + "the performance of the residual equity positions, NOT of this manager. Do "
+                        + "not present it as their track record; a manager whose options thesis lost "
+                        + "money can still show a large positive clone return."
+                );
+            }
+        }
+
+        if (result.TruncatedAt.HasValue)
+        {
+            output.AppendLine(
+                $"Note: {holder.Name} has not filed since its portfolio of "
+                    + $"{FormatDate(result.TruncatedAt.Value)} went stale, so the simulation stops "
+                    + "there rather than marking a frozen portfolio forward."
+            );
+        }
+
         return output.ToString();
     }
+
+    // Unsigned share of a whole, one decimal — coverage is never negative, so the signed format
+    // used for returns would render a misleading leading "+".
+    private static string FormatShare(decimal value) => McpFormat.Invariant(value, "0.0") + "%";
 
     // Signed percentage with one decimal, invariant culture so MCP markdown stays locale-stable.
     private static string FormatPercent(decimal value) =>

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -205,8 +205,8 @@ public class InstitutionalHoldingsTools
         var result = MarkdownTable.Start(
             $"Top institutional holders of {stock.Name} ({ticker}) as of {FormatDate(targetDate)}:",
             subtitle,
-            "| # | Institution | Shares | Value ($M) | % of Inst. Total |",
-            "|---|------------|--------|-----------|-----------|"
+            "| # | Institution | Type | Shares | Value ($M) | % of Inst. Total |",
+            "|---|------------|------|--------|-----------|-----------|"
         );
 
         result.AppendNumberedRows(
@@ -218,6 +218,7 @@ public class InstitutionalHoldingsTools
                 var pct = Percentage.Of(h.Shares, totalSharesAll);
                 var adjustedShares = SplitAdjustment.AdjustShareCount(h.Shares, shareFactor);
                 return $"| {rank} | {h.InstitutionalHolder.Name} | "
+                    + $"{PositionType(h.OptionType)} | "
                     + $"{McpFormat.WholeNumber(adjustedShares)} | "
                     + $"{FormatMillions(h.Value)} | "
                     + $"{McpFormat.Invariant(pct, "F2")}% |";
@@ -227,6 +228,11 @@ public class InstitutionalHoldingsTools
         result.AppendLine();
         result.AppendLine(
             "_% of Inst. Total = the position's share of all institutional 13F shares in the stock, not of shares outstanding._"
+        );
+        result.AppendLine(
+            "_Type: Common = shares held outright. Put/Call = an option position reported at the "
+                + "underlying's notional value. A PUT IS A BEARISH POSITION, so a large put line is a "
+                + "holder betting against this stock, not accumulating it._"
         );
 
         return result.ToString();
@@ -442,8 +448,8 @@ public class InstitutionalHoldingsTools
         var result = MarkdownTable.Start(
             $"Portfolio of {holder.Name} (CIK: {holder.Cik}) as of {FormatDate(targetDate)}:",
             subtitle,
-            "| # | Ticker | Company | Shares | Value ($M) | % of Portfolio |",
-            "|---|--------|---------|--------|-----------|----------------|"
+            "| # | Ticker | Company | Type | Shares | Value ($M) | % of Portfolio |",
+            "|---|--------|---------|------|--------|-----------|----------------|"
         );
 
         result.AppendNumberedRows(
@@ -457,14 +463,36 @@ public class InstitutionalHoldingsTools
                 );
                 var pct = Percentage.Of(h.Value, totalValue);
                 return $"| {rank} | {h.CommonStock.Ticker} | {h.CommonStock.Name} | "
+                    + $"{PositionType(h.OptionType)} | "
                     + $"{McpFormat.WholeNumber(shares)} | "
                     + $"{FormatMillions(h.Value)} | "
                     + $"{FormatPercent(pct)}% |";
             }
         );
 
+        // A 13F reports option positions beside common stock, and a put is a bet AGAINST the
+        // issuer. Without this the table reads as a long book: Scion's Q3 2025 filing shows a
+        // 5,000,000-share Palantir line at 67% of the portfolio, which is a put — Burry was short
+        // Palantir, and every surface that omitted the distinction reported the opposite.
+        result.AppendLine();
+        result.AppendLine(
+            "_Type: Common = shares held outright. Put/Call = an option position, reported at the "
+                + "notional value of the underlying shares, not the premium paid. A PUT IS A BEARISH "
+                + "POSITION — the filer profits if the stock falls. Option notional is included in the "
+                + "portfolio total and the percentages above, exactly as the filer reported it._"
+        );
+
         return result.ToString();
     }
+
+    // How a 13F line should be described to a reader: the security type, not the activity bucket.
+    private static string PositionType(OptionType? optionType) =>
+        optionType switch
+        {
+            Equibles.Holdings.Data.Models.OptionType.Put => "Put",
+            Equibles.Holdings.Data.Models.OptionType.Call => "Call",
+            _ => "Common",
+        };
 
     [McpServerTool(
         Name = "SearchInstitutions",
@@ -1254,7 +1282,7 @@ public class InstitutionalHoldingsTools
         result.AppendLine($"| Quarters tracked | {summary.QuartersReported} |");
         result.AppendLine();
         result.AppendLine(
-            "_Reported AUM = total value of 13F-reportable long U.S. positions only — it excludes cash, bonds, non-U.S. holdings, and shorts, and is NOT the firm's total assets under management._"
+            "_Reported AUM = total value of 13F-reportable U.S. positions — it excludes cash, bonds, non-U.S. holdings, and short stock, and is NOT the firm's total assets under management. It DOES include the notional value of reported put and call positions, so a filer expressing its views in options can show an AUM far larger than the equity it actually holds._"
         );
         result.AppendLine(
             "_Quarters tracked counts the 13F quarters in this database, not the filer's full filing history._"

--- a/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
@@ -17,6 +17,15 @@ public static class HoldingsBacktestCalculator
     // +8.75% reads as a "448% CAGR"); below this window length no CAGR is reported at all.
     public const int MinAnnualizationDays = 90;
 
+    // How long past its last rebalance a portfolio is still treated as this filer's. A filer that
+    // is still filing rebalances every ~91 days (a quarter's report, 45 days later), so a gap this
+    // wide means the filings stopped — the filer deregistered, was acquired, or fell under the
+    // reporting threshold. Simulating past it does not extend the manager's track record, it just
+    // marks a frozen snapshot to market and credits the manager with it: Scion's last filing
+    // matured on 2025-11-14, and the three-year window kept trading those three stocks for another
+    // eight months as though they were still his book.
+    public const int StaleTailDays = 150;
+
     // Shift a 13F ReportDate forward to its rebalance date (+RebalanceDelayDays). A ReportDate
     // within RebalanceDelayDays of DateOnly.MaxValue would overflow the calendar, so cap the
     // shift at MaxValue instead of throwing — a far-future date then reads as out-of-window.
@@ -60,6 +69,20 @@ public static class HoldingsBacktestCalculator
             .Select(s => (Snapshot: s, RebalanceDate: RebalanceDateOf(s.ReportDate)))
             .OrderBy(x => x.RebalanceDate)
             .ToList();
+
+        // Stop where the filer's portfolio stopped being current, so the tail of a window is never
+        // a dead filer's frozen book presented as a live track record.
+        var lastRebalance = ordered[^1].RebalanceDate;
+        var staleAfter =
+            lastRebalance.DayNumber > DateOnly.MaxValue.DayNumber - StaleTailDays
+                ? DateOnly.MaxValue
+                : lastRebalance.AddDays(StaleTailDays);
+        if (to > staleAfter)
+        {
+            to = staleAfter;
+            result.EndDate = to;
+            result.TruncatedAt = staleAfter;
+        }
 
         // The snapshot active at `from`: the latest whose rebalance date is on or before
         // `from`, so the simulation opens at `from` with the portfolio that had actually
@@ -126,6 +149,10 @@ public static class HoldingsBacktestCalculator
             result.BenchmarkSummary = ComputeSummary(result.Points.Select(p => p.BenchmarkValue));
         }
 
+        // Measured over the snapshots the simulation actually rebalanced on, not every snapshot
+        // handed in — a quarter outside the window says nothing about what this result covers.
+        result.Coverage = ComputeCoverage(ordered.Take(snapshotIdx + 1).Select(x => x.Snapshot));
+
         return result;
     }
 
@@ -181,6 +208,44 @@ public static class HoldingsBacktestCalculator
             sum += shares * price.Value;
         }
         return sum > 0 ? sum : fallback;
+    }
+
+    /// <summary>
+    /// The share of each snapshot's reported value that the long-only clone could actually hold.
+    /// Options are counted in the denominator precisely because they are what the clone drops:
+    /// leaving them out would report 100% coverage for a filer whose book is all puts.
+    /// </summary>
+    private static BacktestCoverage ComputeCoverage(IEnumerable<BacktestQuarterSnapshot> snapshots)
+    {
+        var coverage = new BacktestCoverage();
+        var shares = new List<decimal>();
+
+        foreach (var snapshot in snapshots)
+        {
+            decimal total = 0;
+            decimal longValue = 0;
+            foreach (var position in snapshot.Positions)
+            {
+                if (position.Value <= 0)
+                    continue;
+                total += position.Value;
+                if (!position.IsOption)
+                    longValue += position.Value;
+            }
+
+            if (total <= 0)
+                continue;
+
+            shares.Add(longValue / total * 100m);
+        }
+
+        if (shares.Count == 0)
+            return coverage;
+
+        coverage.QuartersMeasured = shares.Count;
+        coverage.AverageLongPercent = Math.Round(shares.Sum() / shares.Count, 2);
+        coverage.MinimumLongPercent = Math.Round(shares.Min(), 2);
+        return coverage;
     }
 
     private static BacktestStrategySummary ComputeSummary(IEnumerable<decimal> series)

--- a/src/Equibles.Holdings.Repositories/Models/BacktestCoverage.cs
+++ b/src/Equibles.Holdings.Repositories/Models/BacktestCoverage.cs
@@ -1,0 +1,70 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+/// <summary>
+/// How much of a filer's reported 13F book the clone simulation actually tracks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A clone is long-only: option legs are notional, cannot be replicated by buying the underlying,
+/// and are skipped. For most filers that discards a rounding error. For a filer who expresses its
+/// thesis in options it discards the thesis, and what remains is a handful of residual equity
+/// positions that had nothing to do with the manager's actual bet — yet the result is still
+/// presented as "cloning this manager".
+/// </para>
+/// <para>
+/// Michael Burry's Scion is the extreme case: across a trailing three years its filings are 80–90%
+/// put notional, and in Q1 2025 the entire long book was a single $13M Estée Lauder position beside
+/// $109M of puts. The clone rode that one stock to +41% for the quarter, which is over half of the
+/// +102.5% three-year headline the page advertised — during a period when the manager's real,
+/// options-expressed return was negative. Nothing in the arithmetic was wrong; the number simply
+/// was not a description of Burry.
+/// </para>
+/// <para>
+/// So the simulation reports what it covered. A caller that cannot show this must not show the
+/// headline either.
+/// </para>
+/// </remarks>
+public class BacktestCoverage
+{
+    /// <summary>
+    /// Mean share of reported value that was long equity, across the snapshots the simulation
+    /// rebalanced on. Each quarter counts once: a quarter is one rebalance decision, so weighting
+    /// by portfolio size would let a single huge quarter speak for the rest.
+    /// </summary>
+    public decimal AverageLongPercent { get; set; }
+
+    /// <summary>
+    /// The worst single quarter. Carried separately because an average hides the case that matters
+    /// most — a book that is fully long for two years and then 4% long for the stretch that
+    /// produced the return.
+    /// </summary>
+    public decimal MinimumLongPercent { get; set; }
+
+    /// <summary>Quarters with any reported value, i.e. how many the two figures above are over.</summary>
+    public int QuartersMeasured { get; set; }
+
+    /// <summary>
+    /// The average below which a clone stops being a description of the manager. Set where a
+    /// meaningful minority of the book is already untracked; Scion's trailing three years average
+    /// about 58%, and that result was not Burry's.
+    /// </summary>
+    public const decimal RepresentativeAveragePercent = 60m;
+
+    /// <summary>
+    /// The single-quarter floor. A quarter this thinly covered contributes a return drawn from
+    /// whatever equity happened to be left over, which is how one $13M residual position came to
+    /// supply half of a three-year headline.
+    /// </summary>
+    public const decimal RepresentativeMinimumPercent = 50m;
+
+    /// <summary>
+    /// Whether the simulated return can honestly be presented as this manager's. Both bounds must
+    /// hold: an average alone would pass a book that was fully long for two years and 4% long for
+    /// the stretch that produced the return. A surface showing the headline without checking this
+    /// is asserting something the data does not support.
+    /// </summary>
+    public bool IsRepresentative =>
+        QuartersMeasured > 0
+        && AverageLongPercent >= RepresentativeAveragePercent
+        && MinimumLongPercent >= RepresentativeMinimumPercent;
+}

--- a/src/Equibles.Holdings.Repositories/Models/BacktestResult.cs
+++ b/src/Equibles.Holdings.Repositories/Models/BacktestResult.cs
@@ -13,4 +13,17 @@ public class BacktestResult
     public BacktestStrategySummary BenchmarkSummary { get; set; } = new();
 
     public string Reason { get; set; }
+
+    /// <summary>
+    /// How much of the filer's reported book the simulation actually tracked. Null when nothing was
+    /// simulated. A surface that shows the return must show this too — see
+    /// <see cref="BacktestCoverage"/>.
+    /// </summary>
+    public BacktestCoverage Coverage { get; set; }
+
+    /// <summary>
+    /// Set when the requested window ran past the point where the filer's portfolio stopped being
+    /// current and the simulation was cut short there. Null when the window was honoured in full.
+    /// </summary>
+    public DateOnly? TruncatedAt { get; set; }
 }

--- a/tests/Equibles.UnitTests/Holdings/BacktestCoverageIsRepresentativeTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/BacktestCoverageIsRepresentativeTests.cs
@@ -1,0 +1,71 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class BacktestCoverageIsRepresentativeTests
+{
+    private static BacktestCoverage Coverage(decimal average, decimal minimum, int quarters = 12) =>
+        new()
+        {
+            AverageLongPercent = average,
+            MinimumLongPercent = minimum,
+            QuartersMeasured = quarters,
+        };
+
+    [Fact]
+    public void IsRepresentative_PlainLongBook_IsTrue()
+    {
+        // The ordinary filer must pass cleanly. If this ever went false, every clone on the
+        // platform would carry a warning — and a warning that is always on is one nobody reads.
+        Coverage(100m, 100m).IsRepresentative.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRepresentative_ScionShapedBook_IsFalse()
+    {
+        // Scion's trailing three years: about 58% of reported value tracked on average, and as
+        // little as 4% in the quarter that supplied most of the return. This is the case that
+        // produced a +102.5% headline for a manager whose actual result was negative.
+        Coverage(58m, 4m).IsRepresentative.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRepresentative_HealthyAverageButOneCollapsedQuarter_IsFalse()
+    {
+        // The reason both bounds exist. A book that is fully long for years and then almost
+        // entirely options for one stretch still averages well, and that one stretch is exactly
+        // where an outlier return comes from. An average-only rule would wave this through.
+        Coverage(85m, 5m).IsRepresentative.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRepresentative_EveryQuarterAcceptableButAverageThin_IsFalse()
+    {
+        // The mirror case: no single quarter collapses, but a persistent minority of the book is
+        // untracked in all of them. A minimum-only rule would wave this through.
+        Coverage(55m, 52m).IsRepresentative.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRepresentative_ExactlyOnBothThresholds_IsTrue()
+    {
+        // The bounds are inclusive. Pinned because an off-by-one here silently reclassifies every
+        // filer sitting on the line, in whichever direction the mistake goes.
+        Coverage(
+            BacktestCoverage.RepresentativeAveragePercent,
+            BacktestCoverage.RepresentativeMinimumPercent
+        )
+            .IsRepresentative.Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void IsRepresentative_NothingMeasured_IsFalse()
+    {
+        // With no quarters measured the two percentages are zero, which must not read as "0% is
+        // below the bar so warn" by accident — it has to be false because nothing was established.
+        // A caller treating an unmeasured result as representative would show the headline for a
+        // filer we know nothing about.
+        Coverage(0m, 0m, quarters: 0).IsRepresentative.Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCoverageTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCoverageTests.cs
@@ -1,0 +1,129 @@
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsBacktestCalculatorCoverageTests
+{
+    private static readonly Guid StockA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid StockB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static BacktestQuarterSnapshot Snapshot(
+        DateOnly reportDate,
+        params (Guid StockId, long Value, bool IsOption)[] positions
+    ) =>
+        new()
+        {
+            ReportDate = reportDate,
+            Positions = positions
+                .Select(p => new BacktestPosition
+                {
+                    CommonStockId = p.StockId,
+                    Shares = 10_000,
+                    Value = p.Value,
+                    IsOption = p.IsOption,
+                })
+                .ToList(),
+        };
+
+    private static BacktestResult Run(params BacktestQuarterSnapshot[] snapshots) =>
+        HoldingsBacktestCalculator.Calculate(
+            snapshots,
+            from: HoldingsBacktestCalculator.RebalanceDateOf(snapshots[0].ReportDate),
+            to: HoldingsBacktestCalculator.RebalanceDateOf(snapshots[^1].ReportDate).AddDays(10),
+            priceOf: (_, _) => 100m,
+            benchmarkPriceOf: _ => 100m
+        );
+
+    [Fact]
+    public void Calculate_BookIsMostlyOptions_ReportsHowLittleTheCloneTracks()
+    {
+        // Scion's Q3 2025 shape: a $912M Palantir put and a $186M NVDA put beside $55M of actual
+        // equity. The clone can only buy the equity, so it tracks about 4% of what the manager
+        // reported — and the return it produces describes that 4%, not the manager. Without this
+        // figure the page has no way to know it should not be advertising the number.
+        var result = Run(
+            Snapshot(
+                new DateOnly(2025, 9, 30),
+                (StockA, 912_100_000, true),
+                (StockB, 55_000_000, false)
+            )
+        );
+
+        result.Coverage.QuartersMeasured.Should().Be(1);
+        result.Coverage.AverageLongPercent.Should().BeApproximately(5.69m, 0.01m);
+        result.Coverage.MinimumLongPercent.Should().BeApproximately(5.69m, 0.01m);
+    }
+
+    [Fact]
+    public void Calculate_PlainLongBook_ReportsFullCoverage()
+    {
+        // The ordinary filer. Coverage has to read 100% here or every clone on the platform would
+        // carry a warning, and a warning that is always on is a warning nobody reads.
+        var result = Run(
+            Snapshot(
+                new DateOnly(2025, 9, 30),
+                (StockA, 1_000_000, false),
+                (StockB, 500_000, false)
+            )
+        );
+
+        result.Coverage.AverageLongPercent.Should().Be(100m);
+        result.Coverage.MinimumLongPercent.Should().Be(100m);
+    }
+
+    [Fact]
+    public void Calculate_CoverageCollapsesInOneQuarter_KeepsTheWorstQuarterVisible()
+    {
+        // The case the average alone hides, and the one that produced the misleading headline: a
+        // book that is fully long for a year and then almost entirely options for the stretch that
+        // generated the return. The mean reads like a mild caveat; the minimum says the quarter
+        // that mattered was not being tracked at all.
+        var result = Run(
+            Snapshot(new DateOnly(2024, 12, 31), (StockA, 1_000_000, false)),
+            Snapshot(new DateOnly(2025, 3, 31), (StockA, 1_000_000, false)),
+            Snapshot(
+                new DateOnly(2025, 6, 30),
+                (StockA, 990_000_000, true),
+                (StockB, 10_000_000, false)
+            )
+        );
+
+        result.Coverage.QuartersMeasured.Should().Be(3);
+        result.Coverage.AverageLongPercent.Should().BeApproximately(66.99m, 0.01m);
+        result.Coverage.MinimumLongPercent.Should().BeApproximately(1m, 0.01m);
+    }
+
+    [Fact]
+    public void Calculate_OnlyOptionsReported_ReportsZeroRatherThanNoMeasurement()
+    {
+        // An all-options filer produces an empty portfolio, and the calculator already returns a
+        // flat line for it. Coverage must say 0% rather than leave the figure unset, because an
+        // absent measurement reads to a caller exactly like "nothing to warn about".
+        var result = Run(Snapshot(new DateOnly(2025, 9, 30), (StockA, 912_100_000, true)));
+
+        result.Coverage.QuartersMeasured.Should().Be(1);
+        result.Coverage.AverageLongPercent.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Calculate_SnapshotsOutsideTheWindow_AreNotCounted()
+    {
+        // Coverage describes what THIS result covers. A later quarter the simulation never reached
+        // must not dilute it, or a window ending before a filer pivoted into options would inherit
+        // a warning it does not deserve — and, worse, the reverse.
+        var result = HoldingsBacktestCalculator.Calculate(
+            [
+                Snapshot(new DateOnly(2024, 12, 31), (StockA, 1_000_000, false)),
+                Snapshot(new DateOnly(2025, 6, 30), (StockA, 1_000_000, true)),
+            ],
+            from: HoldingsBacktestCalculator.RebalanceDateOf(new DateOnly(2024, 12, 31)),
+            to: HoldingsBacktestCalculator.RebalanceDateOf(new DateOnly(2025, 6, 30)).AddDays(-1),
+            priceOf: (_, _) => 100m,
+            benchmarkPriceOf: _ => 100m
+        );
+
+        result.Coverage.QuartersMeasured.Should().Be(1);
+        result.Coverage.AverageLongPercent.Should().Be(100m);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorTests.cs
@@ -75,20 +75,75 @@ public class HoldingsBacktestCalculatorTests
     [Fact]
     public void Calculate_HorizonExceedsMaxYears_ClampsEndDate()
     {
-        var snapshot = SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000);
+        // The filer keeps filing right through the requested 25 years, so nothing goes stale and
+        // the only thing bounding the simulation is the MaxYears horizon. Seeding the full history
+        // matters: with a single snapshot the stale-tail cut would bind first and this would stop
+        // testing the horizon clamp at all.
         var from = new DateOnly(2024, 5, 15);
-        var requestedTo = from.AddYears(25);
+        var snapshots = new List<BacktestQuarterSnapshot>();
+        for (var quarter = 0; quarter < 100; quarter++)
+        {
+            snapshots.Add(
+                SingleStockSnapshot(
+                    new DateOnly(2024, 3, 31).AddMonths(quarter * 3),
+                    StockA,
+                    1_000_000
+                )
+            );
+        }
 
         var result = HoldingsBacktestCalculator.Calculate(
-            [snapshot],
+            snapshots,
             from: from,
-            to: requestedTo,
+            to: from.AddYears(25),
             priceOf: (_, _) => 100m,
             benchmarkPriceOf: _ => 100m
         );
 
         result.EndDate.Should().Be(from.AddYears(HoldingsBacktestCalculator.MaxYears));
         result.Points.Last().Date.Should().BeOnOrBefore(result.EndDate);
+    }
+
+    [Fact]
+    public void Calculate_FilerStoppedFiling_StopsAtTheStaleTailInsteadOfMarkingAFrozenBookForward()
+    {
+        // Scion filed its last 13F for 2025-09-30, which matured on 2025-11-14, and then
+        // deregistered. A trailing three-year window still runs to today, so the simulation kept
+        // trading that final three-stock snapshot for another eight months and reported the result
+        // as the manager's track record. A filer that is still filing rebalances every ~91 days, so
+        // a gap of 150 says the filings stopped rather than that this is still their portfolio.
+        var lastReport = new DateOnly(2025, 9, 30);
+        var lastRebalance = HoldingsBacktestCalculator.RebalanceDateOf(lastReport);
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [SingleStockSnapshot(lastReport, StockA, 1_000_000)],
+            from: new DateOnly(2025, 11, 20),
+            to: new DateOnly(2026, 7, 28),
+            priceOf: (_, _) => 100m,
+            benchmarkPriceOf: _ => 100m
+        );
+
+        var staleAfter = lastRebalance.AddDays(HoldingsBacktestCalculator.StaleTailDays);
+        result.TruncatedAt.Should().Be(staleAfter);
+        result.EndDate.Should().Be(staleAfter);
+        result.Points.Last().Date.Should().Be(staleAfter);
+    }
+
+    [Fact]
+    public void Calculate_FilerStillCurrent_DoesNotTruncate()
+    {
+        // The common case must be untouched: a filer whose latest filing has matured inside the
+        // normal quarterly cadence keeps the window it was asked for, and reports no truncation.
+        var result = HoldingsBacktestCalculator.Calculate(
+            [SingleStockSnapshot(new DateOnly(2026, 3, 31), StockA, 1_000_000)],
+            from: new DateOnly(2026, 5, 20),
+            to: new DateOnly(2026, 7, 28),
+            priceOf: (_, _) => 100m,
+            benchmarkPriceOf: _ => 100m
+        );
+
+        result.TruncatedAt.Should().BeNull();
+        result.EndDate.Should().Be(new DateOnly(2026, 7, 28));
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Mcp/InstitutionalHoldingsToolsPositionTypeTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InstitutionalHoldingsToolsPositionTypeTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class InstitutionalHoldingsToolsPositionTypeTests
+{
+    private static string Describe(OptionType? optionType)
+    {
+        var method = typeof(InstitutionalHoldingsTools).GetMethod(
+            "PositionType",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.Should().NotBeNull("the portfolio tables label each line through this helper");
+        return (string)method.Invoke(null, [optionType]);
+    }
+
+    [Fact]
+    public void PositionType_PutLeg_SaysPut()
+    {
+        // The line that made this necessary: Scion's Q3 2025 filing reports 5,000,000 Palantir
+        // shares at 67% of the portfolio, and it is a PUT — Burry was betting against Palantir.
+        // Rendered without the label it reads as the largest long position in the book, which
+        // reverses the manager's actual view. OptionType.Put is the enum's zero value, so a
+        // switch that falls through to a default lands precisely on the most misleading case.
+        Describe(OptionType.Put).Should().Be("Put");
+    }
+
+    [Fact]
+    public void PositionType_CallLeg_SaysCall()
+    {
+        Describe(OptionType.Call).Should().Be("Call");
+    }
+
+    [Fact]
+    public void PositionType_NoOptionType_SaysCommon()
+    {
+        // Shares held outright. Naming it rather than leaving the cell blank matters: a blank
+        // reads as missing data, and the whole point of the column is that every line states what
+        // it is.
+        Describe(null).Should().Be("Common");
+    }
+}


### PR DESCRIPTION
## Summary

Two related ways the holdings surfaces described an options-driven filer as if it were a long-only stock picker.

**The clone backtest reported a return it had no business attributing to the manager.** A clone is long-only — option legs are notional, cannot be replicated by buying the underlying, and are skipped. For most filers that discards a rounding error. For a filer who expresses their thesis in options it discards the thesis, and what is left is whatever residual equity happened to be in the filing.

Michael Burry's Scion is the extreme case. Across a trailing three years its filings are 80–90% put notional, and in Q1 2025 the entire long book was a single $13M Estée Lauder position beside $109M of puts. The clone rode that one stock to +41% for the quarter, which is over half of the **+102.5% three-year headline** the page advertised — over a period when the manager's real, options-expressed return was negative. None of the arithmetic was wrong. The number simply was not a description of Burry, and nothing on the page said so.

**The portfolio tools presented puts as long positions.** `GetInstitutionPortfolio` rendered Scion's Q3 2025 filing as "PLTR, 5,000,000 shares, 66.7% of portfolio" with no marker. That line is a *put* — Burry was betting against Palantir. A reader, human or model, gets the direction of the manager's largest position exactly backwards.

## Code changes

- **`BacktestCoverage`** (new) — the share of reported value the simulation actually tracked: the mean across the quarters it rebalanced on, and the worst single quarter. Both are needed; an average alone passes a book that was fully long for two years and 4% long for the stretch that produced the return. `IsRepresentative` encodes the thresholds once so every surface agrees rather than each inventing its own.
- **`HoldingsBacktestCalculator`** — computes coverage over the snapshots it actually used (not every snapshot handed in), and stops the simulation `StaleTailDays` after the filer's last rebalance. A filer that is still filing rebalances every ~91 days, so a 150-day gap means the filings stopped: Scion's last filing matured 2025-11-14, and the three-year window kept trading those three stocks for another eight months as though they were still his book. `FundScoringManager` already persisted `result.EndDate`, so a truncated score honestly reports the shorter window.
- **`GetFundCloneBacktest`** — states the coverage, and warns explicitly when the result is not representative. This tool previously carried no long-only caveat at all, unlike the two portal views. A model reading it has no other way to know, and will otherwise report the number as the manager's track record.
- **`GetInstitutionPortfolio` / `GetTopHolders`** — a Type column (Common / Put / Call) and a footnote spelling out that a put is a bearish position and that option notional is included in the totals.
- **`GetInstitutionSummary`** — the AUM footnote claimed to exclude shorts without mentioning that it *includes* option notional, so a filer expressing its views in options shows an AUM far larger than the equity it holds.

## Tests

Nine new tests: coverage for an options-heavy book, a plain long book, a collapse in one quarter, an all-options filer, and snapshots outside the window; plus stale-tail truncation, a still-current filer that must not truncate, and the horizon clamp.

`Calculate_HorizonExceedsMaxYears_ClampsEndDate` previously passed a single 2024 snapshot and asserted a 10-year window — behaviour this change deliberately supersedes. It now seeds a filer that keeps filing, so it tests the horizon clamp rather than an accidental property.

Full suites green: 3,793 unit, 2,268 integration.

## Note on thresholds

60% average / 50% minimum are judgement calls, set where a meaningful minority of the book is untracked. Scion's trailing three years average about 58%, with a 4% worst quarter, so it fails both. They live as constants on `BacktestCoverage` and are easy to retune.