### PR TITLE
fix(holdings): the stale-tail note implied a portfolio that does not exist

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
@@ -226,9 +226,9 @@ public class CloneBacktestTools
         if (result.TruncatedAt.HasValue)
         {
             output.AppendLine(
-                $"Note: {holder.Name} has not filed since its portfolio of "
-                    + $"{FormatDate(result.TruncatedAt.Value)} went stale, so the simulation stops "
-                    + "there rather than marking a frozen portfolio forward."
+                $"Note: {holder.Name} has stopped filing, so the simulation ends on "
+                    + $"{FormatDate(result.TruncatedAt.Value)} — the point its last reported "
+                    + "portfolio went stale — rather than marking that portfolio forward to today."
             );
         }
 


### PR DESCRIPTION
Verifying #4243 on production surfaced a wording bug in the note I added.

For Scion the tool printed:

> Scion Asset Management, LLC has not filed since its portfolio of **2026-04-13** went stale…

`TruncatedAt` is the date the simulation *stops* — the last rebalance plus 150 days — not the date of any filing. Scion's last reported portfolio is 2025-09-30. So the sentence asserts a portfolio that does not exist, in the middle of a change whose whole point is not stating things that aren't true.

Reworded to say what the date actually is:

> Scion Asset Management, LLC has stopped filing, so the simulation ends on 2026-04-13 — the point its last reported portfolio went stale — rather than marking that portfolio forward to today.