### PR TITLE
fix(holdings): re-import 13F history so stored values leave the split-basis error behind

### DIFF
--- a/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
@@ -23,8 +23,15 @@ public class ProcessedDataSet
     /// Version 2: scope restatement-amendment deletes to the amendment's own
     /// filing type (#3738) — re-import all 13F history so a Schedule 13D/G
     /// amendment that previously wiped a same-quarter 13F-HR portfolio is healed.
+    /// Version 3: restate as-filed share counts onto the price series' basis
+    /// before deriving Value (#4242). Every position on a stock that split after
+    /// its report date was multiplied across two share bases and is wrong by the
+    /// split ratio — 1.87M rows carrying $39.3T that should read $90.2T, mostly
+    /// understated by forward splits and a smaller set inflated up to 200x by
+    /// reverse ones. Nothing recomputes a stored value, so only a re-import
+    /// heals them.
     /// </summary>
-    public const int CurrentParserVersion = 2;
+    public const int CurrentParserVersion = 3;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 


### PR DESCRIPTION
#4242 corrected how a position's `Value` is derived, but only for filings imported *after* it. Nothing recomputes a stored value — `HoldingsValueRecalculator` only touches rows flagged `ValuePending`, and these are not — so the existing rows keep the units error indefinitely.

## What is still wrong in the data

Measured on production:

- **1,872,970 rows** are affected — every position on a stock that split *after* its report date. That is 5.8% of the 32.3M-row table, not all of it.
- Those rows currently total **$39.3T** and should total **$90.2T**.
- **1,739,998** are understated (forward splits) and **132,972** overstated (reverse splits).

The two directions fail very differently. Forward splits make positions look *small*, which is why this went unreported for so long — Amazon reads $461B against a true $9.2T, NVIDIA $689B against $8.0T. Reverse splits produce the visibly impossible: EPIQ Capital Group currently shows a **$72.5B** position in Quince Therapeutics, a microcap, where the real figure is about $356M.

Everything that sums `Value` inherits this: AUM rankings, top-holders tables, most-held stocks, sector allocation, superinvestor pages, the screener, the REST API and the clone backtests.

## The change

One line: `ProcessedDataSet.CurrentParserVersion` 2 → 3, plus the comment recording why.

`HoldingsScraperWorker.IsAlreadyProcessed` treats any data set stamped below the current version as unprocessed, so the next cycle re-imports all 27 quarterly data sets oldest-first (so amendments re-apply after their originals) through the corrected derivation. This is the mechanism the constant exists for; versions 1 and 2 were bumped for the same reason.

## Operational notes

- **Not capped.** `DoWork` walks every stale data set in a single cycle, so this is one long run rather than a drip. It is resumable — each data set is stamped on success, so a restart picks up where it stopped.
- **Resource shape**: re-downloads 27 zips from SEC and rewrites ~32M rows via upsert. It also republishes `Filings13FImported` per affected quarter, so the aggregate-snapshot rebuild runs behind it.
- **Blocks its own worker's maintenance tasks** (`RecalculatePendingValues`, `RepairImpossiblePositions`) until it finishes. The other scraper workers are separate `BackgroundService`s and are unaffected.
- **Values are inconsistent while it runs** — earlier quarters corrected, later ones not yet. They are wrong today regardless, so this is not a regression.
- No schema change.

The realtime lane's `ProcessedFiling` ledger has no parser version, so current-quarter filings ingested there are not re-derived directly — but the bulk data set for that quarter upserts over them once SEC publishes it, and current-quarter rows are the least affected (a split has to land after the report date to corrupt one).

Suites green: 3,802 unit, 2,268 integration.