### PR TITLE
fix(holdings): the filed value must accumulate with the value it audits

### DIFF
--- a/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
+++ b/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
@@ -49,4 +49,11 @@ public class ImportContext
         (string Cusip, DateOnly ReportDate),
         UnmappedCusipTally
     > UnmappedCusips { get; } = [];
+
+    // The filing whose unmapped CUSIPs are currently being collected, and the CUSIPs already
+    // counted for it, so a position split across otherManager legs counts once (see
+    // HoldingsImportService.RecordUnmappedCusip). Reset at each accession boundary.
+    public string UnmappedCusipAccession { get; set; }
+
+    public HashSet<string> UnmappedCusipsSeenInAccession { get; } = [];
 }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -560,10 +560,26 @@ public class HoldingsImportService
         ImportContext context,
         Dictionary<string, string> row,
         string cusip,
+        string accession,
         SubmissionRow submission
     )
     {
         if (string.IsNullOrWhiteSpace(cusip))
+            return;
+
+        // One filing reporting a security across several otherManager legs is ONE position we
+        // failed to map, not several. Counting raw rows inflates both the position count and the
+        // dollars the queue ranks on — the tracked lane collapses those legs in AddOrMergeHolding,
+        // so the untracked lane has to collapse them too or the two are not comparable. Rows for
+        // an accession arrive contiguously, so remembering only the current filing's CUSIPs is
+        // enough and keeps this bounded.
+        if (!string.Equals(context.UnmappedCusipAccession, accession, StringComparison.Ordinal))
+        {
+            context.UnmappedCusipAccession = accession;
+            context.UnmappedCusipsSeenInAccession.Clear();
+        }
+
+        if (!context.UnmappedCusipsSeenInAccession.Add(cusip))
             return;
 
         if (!TryParseDateOnly(submission.PeriodOfReport, out var reportDate))
@@ -1032,7 +1048,7 @@ public class HoldingsImportService
             if (!context.CusipMapping.TryGetValue(cusip, out var commonStockId))
             {
                 totalSkipped++;
-                RecordUnmappedCusip(context, row, cusip, submission);
+                RecordUnmappedCusip(context, row, cusip, accession, submission);
                 continue;
             }
 
@@ -1154,6 +1170,15 @@ public class HoldingsImportService
         {
             existing.Shares += holding.Shares;
             existing.Value += holding.Value;
+            // The filed value has to accumulate with the value it is there to audit. A filer that
+            // splits one position across otherManager codes files a value per leg, so keeping only
+            // the first leg's figure leaves the merged row claiming a fraction of what was filed —
+            // and every such position then reads as a gross derived-vs-filed disagreement that is
+            // really an artefact of this merge.
+            existing.FiledValue =
+                existing.FiledValue is null && holding.FiledValue is null
+                    ? null
+                    : (existing.FiledValue ?? 0) + (holding.FiledValue ?? 0);
             existing.VotingAuthSole += holding.VotingAuthSole;
             existing.VotingAuthShared += holding.VotingAuthShared;
             existing.VotingAuthNone += holding.VotingAuthNone;

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceFiledValueMergeTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceFiledValueMergeTests.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceFiledValueMergeTests
+{
+    private static readonly Guid StockId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid HolderId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static InstitutionalHolding Leg(long shares, long value, long? filedValue) =>
+        new()
+        {
+            CommonStockId = StockId,
+            InstitutionalHolderId = HolderId,
+            ReportDate = new DateOnly(2020, 3, 31),
+            ShareType = ShareType.Shares,
+            FilingType = FilingType.Form13F,
+            Shares = shares,
+            Value = value,
+            FiledValue = filedValue,
+        };
+
+    private static bool AddOrMerge(
+        Dictionary<string, InstitutionalHolding> map,
+        InstitutionalHolding holding
+    )
+    {
+        var method = typeof(HoldingsImportService).GetMethod(
+            "AddOrMergeHolding",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.Should().NotBeNull();
+        return (bool)method.Invoke(null, [map, holding, new HoldingManagerEntry()]);
+    }
+
+    [Fact]
+    public void AddOrMergeHolding_PositionSplitAcrossManagerLegs_AccumulatesTheFiledValueToo()
+    {
+        // A filer that discloses one security across several otherManager codes files a value per
+        // leg, and the merge sums Shares and Value across them. FiledValue exists to audit that
+        // sum, so it has to accumulate with it: keeping only the first leg's figure leaves the row
+        // claiming a fraction of what was filed, and every multi-leg position then reads as a gross
+        // derived-vs-filed disagreement that is an artefact of this merge rather than a real basis
+        // problem. On the first production re-import that was 147,182 positions in one quarter,
+        // which is enough noise to bury the genuine signals the check exists to surface.
+        var map = new Dictionary<string, InstitutionalHolding>();
+
+        AddOrMerge(map, Leg(shares: 100, value: 1_000, filedValue: 900)).Should().BeTrue();
+        AddOrMerge(map, Leg(shares: 50, value: 500, filedValue: 450)).Should().BeFalse();
+
+        var merged = map.Values.Should().ContainSingle().Subject;
+        merged.Shares.Should().Be(150);
+        merged.Value.Should().Be(1_500);
+        merged.FiledValue.Should().Be(1_350);
+    }
+
+    [Fact]
+    public void AddOrMergeHolding_NoLegFiledAValue_LeavesItNull()
+    {
+        // Schedule 13D/G reports no value at all. Summing nulls into 0 would turn "the filing does
+        // not carry this figure" into "the filer said zero", and the audit would then compare
+        // against a number nobody filed.
+        var map = new Dictionary<string, InstitutionalHolding>();
+
+        AddOrMerge(map, Leg(shares: 100, value: 1_000, filedValue: null));
+        AddOrMerge(map, Leg(shares: 50, value: 500, filedValue: null));
+
+        map.Values.Single().FiledValue.Should().BeNull();
+    }
+
+    [Fact]
+    public void AddOrMergeHolding_OnlyOneLegFiledAValue_KeepsWhatWasFiled()
+    {
+        // A partially-populated position must report the figure that exists rather than collapsing
+        // to null, so the audit still has something to compare and the row is not silently dropped
+        // from the check.
+        var map = new Dictionary<string, InstitutionalHolding>();
+
+        AddOrMerge(map, Leg(shares: 100, value: 1_000, filedValue: null));
+        AddOrMerge(map, Leg(shares: 50, value: 500, filedValue: 450));
+
+        map.Values.Single().FiledValue.Should().Be(450);
+    }
+}


### PR DESCRIPTION
Two defects in the audit surfaces added by #4242, both found by reading their first production output during the #4245 re-import. Neither affects the published `Value` — that is derived, and the re-import verified it (Apple's 2020-03-31 positions now imply \$254.29, the true unadjusted close, where they previously implied the split-adjusted \$63.57).

## `FiledValue` was not summed across a filer's legs

`AddOrMergeHolding` sums `Shares` and `Value` when a filer discloses one security across several `otherManager` codes, but `FiledValue` kept only the first leg's figure. The merged row then claimed a fraction of what was filed, so every multi-leg position read as a gross derived-vs-filed disagreement that was an artefact of the merge rather than a real basis problem.

That was **147,182 positions in a single quarter** on the first re-imported data set — enough noise to bury the genuine signals the check exists to surface. Null handling is preserved: a position where no leg filed a value stays null rather than becoming a zero nobody reported.

## The unmapped-CUSIP queue counted legs, not positions

`RecordUnmappedCusip` ran per raw row, so the same multi-leg split inflated both the position count and the dollars the queue ranks on. The tracked lane collapses those legs, so the untracked lane has to as well or the two are not comparable. Rows for an accession arrive contiguously, so this remembers only the current filing's CUSIPs.

## Note on the queue's first real output

It works — the first data set parked 28,340 identifiers, and the top entry is `02079K107`, **Alphabet Class C**, which is absent from `CommonStock` entirely (only Class A, `02079K305`, is tracked). Every Alphabet Class C position across 4,100 filings is being dropped. That is a pre-existing coverage gap this queue was built to expose, not a regression; filing separately.

Suites green: 3,805 unit, 2,268 integration.