### PR TITLE
fix(holdings): stop later data sets wiping the unmapped-CUSIP queue, and say what the totals cover

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -599,10 +599,16 @@ public class HoldingsImportService
         tally.Add(GetValue(row, "NAMEOFISSUER"), filedDollars);
     }
 
-    // Replaces the parked-CUSIP rows for every quarter this data set covers. Replacing the whole
-    // slice rather than merging into it keeps the queue honest in both directions: re-importing a
-    // data set cannot inflate a count, and an identifier that has since been mapped simply stops
-    // being written instead of lingering as a gap that no longer exists.
+    // Writes this import's unmapped identifiers into the queue without destroying what other
+    // imports contributed. One report date's filings are spread across SEVERAL data sets — the
+    // filing windows straddle quarter boundaries, and amendments land months later — so deleting
+    // a whole report-date slice here let the last data set processed wipe every other one's rows:
+    // Scion's $13.1M Bruker preferred vanished behind a later data set's $3.3M sighting of the
+    // same identifier. Instead, each import replaces only the (CUSIP, quarter) keys it actually
+    // saw, and clears rows whose identifier it can now resolve — that is how a newly-added alias
+    // empties its backlog from the queue on the forced re-import, since a mapped CUSIP appears in
+    // no tally. A key seen by two data sets keeps the most recent import's figures (a floor, not a
+    // census); the queue ranks leads by materiality, so surviving with a floor beats vanishing.
     private async Task FlushUnmappedCusips(
         ImportContext context,
         CancellationToken cancellationToken
@@ -622,37 +628,80 @@ public class HoldingsImportService
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
 
         var dates = reportDates.ToList();
-        await dbContext
-            .Set<UnmappedCusip>()
-            .Where(u => dates.Contains(u.ReportDate))
-            .ExecuteDeleteAsync(cancellationToken);
+
+        // Identifiers this import resolved are no longer gaps anywhere in the covered window,
+        // whichever data set recorded them.
+        var mappedCusips = context.CusipMapping.Keys.ToList();
+        var cleared =
+            mappedCusips.Count == 0
+                ? 0
+                : await dbContext
+                    .Set<UnmappedCusip>()
+                    .Where(u => dates.Contains(u.ReportDate) && mappedCusips.Contains(u.Cusip))
+                    .ExecuteDeleteAsync(cancellationToken);
 
         if (context.UnmappedCusips.Count == 0)
-            return;
-
-        var rows = context
-            .UnmappedCusips.Select(pair => new UnmappedCusip
+        {
+            if (cleared > 0)
             {
-                Cusip = pair.Key.Cusip,
-                ReportDate = pair.Key.ReportDate,
-                IssuerName = Truncate(pair.Value.IssuerName, MaxIssuerNameLength),
-                Positions = pair.Value.Positions,
-                FiledValue = pair.Value.FiledValue,
-            })
-            .ToList();
+                _logger.LogInformation(
+                    "Cleared {Cleared} parked CUSIP row(s) whose identifier now resolves",
+                    cleared
+                );
+            }
+            return;
+        }
 
-        dbContext.Set<UnmappedCusip>().AddRange(rows);
+        // Update-or-insert per key the import saw; rows for keys only other data sets saw are
+        // untouched. The candidate load is bounded by this import's own distinct CUSIPs.
+        var tallyCusips = context.UnmappedCusips.Keys.Select(key => key.Cusip).Distinct().ToList();
+        var existingByKey = (
+            await dbContext
+                .Set<UnmappedCusip>()
+                .Where(u => dates.Contains(u.ReportDate) && tallyCusips.Contains(u.Cusip))
+                .ToListAsync(cancellationToken)
+        ).ToDictionary(u => (u.Cusip, u.ReportDate));
+
+        foreach (var ((cusip, reportDate), tally) in context.UnmappedCusips)
+        {
+            if (existingByKey.TryGetValue((cusip, reportDate), out var existing))
+            {
+                existing.IssuerName = Truncate(tally.IssuerName, MaxIssuerNameLength);
+                existing.Positions = tally.Positions;
+                existing.FiledValue = tally.FiledValue;
+                existing.CreationTime = DateTime.UtcNow;
+                continue;
+            }
+
+            dbContext
+                .Set<UnmappedCusip>()
+                .Add(
+                    new UnmappedCusip
+                    {
+                        Cusip = cusip,
+                        ReportDate = reportDate,
+                        IssuerName = Truncate(tally.IssuerName, MaxIssuerNameLength),
+                        Positions = tally.Positions,
+                        FiledValue = tally.FiledValue,
+                    }
+                );
+        }
+
         await dbContext.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation(
-            "Parked {Count} unmapped CUSIP(s) carrying {Total:N0} filed dollars. Largest: {Largest}",
-            rows.Count,
-            rows.Sum(r => (decimal)r.FiledValue),
+            "Parked {Count} unmapped CUSIP(s) carrying {Total:N0} filed dollars; cleared {Cleared} now-resolved row(s). Largest: {Largest}",
+            context.UnmappedCusips.Count,
+            context.UnmappedCusips.Values.Sum(t => (decimal)t.FiledValue),
+            cleared,
             string.Join(
                 ", ",
-                rows.OrderByDescending(r => r.FiledValue)
+                context
+                    .UnmappedCusips.OrderByDescending(pair => pair.Value.FiledValue)
                     .Take(5)
-                    .Select(r => $"{r.Cusip} ({r.IssuerName}) {r.FiledValue:N0}")
+                    .Select(pair =>
+                        $"{pair.Key.Cusip} ({pair.Value.IssuerName}) {pair.Value.FiledValue:N0}"
+                    )
             )
         );
     }

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -481,6 +481,12 @@ public class InstitutionalHoldingsTools
                 + "POSITION — the filer profits if the stock falls. Option notional is included in the "
                 + "portfolio total and the percentages above, exactly as the filer reported it._"
         );
+        result.AppendLine(
+            "_Coverage: totals span the U.S.-listed common stock (and its put/call positions) "
+                + "this platform tracks. A 13F can also report security types outside that "
+                + "coverage — preferred shares, bonds, warrants, untracked share classes — so the "
+                + "filing's own declared total can exceed the figure above._"
+        );
 
         return result.ToString();
     }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFlushUnmappedCusipsTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFlushUnmappedCusipsTests.cs
@@ -1,0 +1,186 @@
+using System.Reflection;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// The unmapped-CUSIP queue survives being written by several imports. One report date's filings
+/// are spread across SEVERAL data sets — filing windows straddle quarter boundaries and amendments
+/// land months later — so a flush that replaced the whole report-date slice let the last data set
+/// processed wipe every other one's rows: Scion's $13.1M Bruker preferred vanished behind a later
+/// data set's $3.3M sighting of the same identifier. Each import may only replace the keys it
+/// actually saw, and may clear rows whose identifier it can now resolve.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServiceFlushUnmappedCusipsTests : IAsyncLifetime
+{
+    private static readonly DateOnly Quarter = new(2025, 9, 30);
+
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public HoldingsImportServiceFlushUnmappedCusipsTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Flush_TwoImportsCoverTheSameQuarter_TheSecondKeepsTheFirstsRows()
+    {
+        // The Bruker regression. Import A (the filing window's own data set) parks Scion's
+        // preferred; import B (the next window, carrying stragglers and amendments for the same
+        // quarter) parks a different identifier. B must add to the queue, not restate it.
+        await Flush(Context(tally: [("116794207", "BRUKER CORP", 13_137_181m)]));
+        await Flush(Context(tally: [("999999999", "SOME OTHER CO", 3_261_600m)]));
+
+        var rows = await Rows();
+        rows.Should().HaveCount(2);
+        rows.Single(r => r.Cusip == "116794207").FiledValue.Should().Be(13_137_181L);
+        rows.Single(r => r.Cusip == "999999999").FiledValue.Should().Be(3_261_600L);
+    }
+
+    [Fact]
+    public async Task Flush_SameKeySeenByALaterImport_ReplacesRatherThanDuplicatesOrSums()
+    {
+        // Re-importing a data set (or an amendment restating a position) must not inflate the
+        // queue: the unique (Cusip, ReportDate) key is real, and the newer sighting's figures win.
+        await Flush(Context(tally: [("116794207", "BRUKER CORP", 13_137_181m)]));
+        await Flush(Context(tally: [("116794207", "BRUKER CORP", 14_000_000m)]));
+
+        var row = (await Rows()).Should().ContainSingle().Subject;
+        row.FiledValue.Should().Be(14_000_000L);
+    }
+
+    [Fact]
+    public async Task Flush_IdentifierNowResolves_ItsRowsAreClearedEvenWithNothingToPark()
+    {
+        // The healing path: an operator adds the missing alias, the forced re-import runs, and the
+        // once-unmapped identifier lands in CusipMapping instead of the tally. Its queue rows are
+        // stale gaps and must go — including when the import parks nothing else at all, which is
+        // exactly the shape of a re-import after the last gap is mapped.
+        await Flush(Context(tally: [("116794207", "BRUKER CORP", 13_137_181m)]));
+        await Flush(Context(tally: [], mapped: ["116794207"]));
+
+        (await Rows()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Flush_ResolvedClearIsScopedToTheImportsOwnQuarters_OtherQuartersWait()
+    {
+        // The clear rides each import and is bounded to the quarters that import covers, so one
+        // import cannot blast rows it knows nothing about; other quarters are healed when their
+        // own data sets re-run (the forced re-import covers all of them).
+        await Flush(
+            Context(
+                tally: [("116794207", "BRUKER CORP", 13_137_181m)],
+                quarter: new DateOnly(2025, 6, 30)
+            )
+        );
+        await Flush(Context(tally: [], mapped: ["116794207"], quarter: Quarter));
+
+        var row = (await Rows()).Should().ContainSingle().Subject;
+        row.ReportDate.Should().Be(new DateOnly(2025, 6, 30));
+    }
+
+    private async Task Flush(ImportContext context)
+    {
+        var service = new HoldingsImportService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<MassTransit.IBus>()
+        );
+
+        var method = typeof(HoldingsImportService).GetMethod(
+            "FlushUnmappedCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        method.Should().NotBeNull();
+        await (Task)method.Invoke(service, [context, CancellationToken.None]);
+    }
+
+    private static ImportContext Context(
+        (string Cusip, string Issuer, decimal Dollars)[] tally,
+        string[] mapped = null,
+        DateOnly? quarter = null
+    )
+    {
+        var reportDate = quarter ?? Quarter;
+        var context = new ImportContext
+        {
+            Submissions = new Dictionary<string, SubmissionRow>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["0000000000-25-000001"] = new()
+                {
+                    AccessionNumber = "0000000000-25-000001",
+                    PeriodOfReport = reportDate.ToString("yyyy-MM-dd"),
+                    FilingDate = "2025-11-03",
+                    FormType = "13F-HR",
+                    Cik = "1649339",
+                },
+            },
+            CusipMapping = (mapped ?? []).ToDictionary(c => c, _ => Guid.NewGuid()),
+        };
+
+        foreach (var (cusip, issuer, dollars) in tally)
+        {
+            var entry = new UnmappedCusipTally();
+            entry.Add(issuer, dollars);
+            context.UnmappedCusips[(cusip, reportDate)] = entry;
+        }
+
+        return context;
+    }
+
+    private async Task<List<UnmappedCusip>> Rows()
+    {
+        var ctx = FreshContext();
+        return await ctx.Set<UnmappedCusip>().AsNoTracking().ToListAsync();
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+}


### PR DESCRIPTION
Found by comparing the Scion portal page against the raw SEC filing. Two related problems.

## The queue wiped itself

One report date's filings are spread across **several** data sets — the filing windows straddle quarter boundaries, and amendments land months later. `FlushUnmappedCusips` deleted the whole report-date slice before writing what the current import saw, so the last data set processed erased every other one's rows.

Concrete case: Scion's Q3 2025 filing includes a **$13.1M Bruker 6.375% Preferred Series A** (`116794207`) — correctly unmapped, we track common stock only. The data set covering its filing window parked it; the next data set (stragglers and amendments for the same quarter) then wiped that row and left only its own $3.3M sighting of the identifier. The queue's whole job is ranking gaps by materiality, and it was systematically under-reporting them — visible in the uneven per-quarter row counts (1,276 for 2025-06-30 vs 3,502 for 2025-09-30).

Now each import:
- **replaces only the (CUSIP, quarter) keys it actually saw** — rows other data sets contributed survive;
- **clears rows whose identifier it can now resolve**, scoped to its own quarters — this is how a newly-added alias empties its backlog on the forced re-import, since a mapped CUSIP appears in no tally.

A key seen by two data sets keeps the most recent import's figures — a floor, not a census, and documented as such. Surviving with a floor beats vanishing.

## The totals claimed to be something they are not

`GetInstitutionPortfolio` labelled its sum "Total 13F value" and its count "positions". Both cover only the securities this platform tracks; Scion's actual filing totals $1,381M across 8 positions, of which we show $1,368M across 7 (the Bruker preferred is out of scope by design). Anyone cross-checking against the SEC filing or another tracker sees us as wrong with no way to learn why.

The subtitle now says **tracked** positions / **tracked** 13F value, and a coverage footnote states that a 13F can report security types outside our coverage, so the filing's own declared total can exceed ours.

## Tests

Four integration tests against real Postgres (the flush uses `ExecuteDelete`, which in-memory can't run): the Bruker two-import survival case, same-key replace without duplication or summing, resolved-identifier clearing (including the nothing-to-park shape), and the clear staying scoped to the import's own quarters.

Suites green: 3,805 unit, 2,272 integration.