### PR TITLE
fix(holdings): the portfolio subtitle counts tracked positions, matching its own footnote

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -440,8 +440,8 @@ public class InstitutionalHoldingsTools
     )
     {
         var subtitle =
-            $"Showing top {holdings.Count} of {McpFormat.WholeNumber(totalPositions)} positions. "
-            + $"Total 13F value: ${FormatMillions(totalValue)}M";
+            $"Showing top {holdings.Count} of {McpFormat.WholeNumber(totalPositions)} tracked positions. "
+            + $"Tracked 13F value: ${FormatMillions(totalValue)}M";
         if (notes != null)
             subtitle = $"{subtitle}\n{notes}";
 


### PR DESCRIPTION
Follow-up to #4249: that PR added the coverage footnote to GetInstitutionPortfolio but the subtitle edit was lost to a formatting mismatch in the patch script, so the tool still leads with "7 positions. Total 13F value" and then footnotes that the total is only of tracked securities. The subtitle now says tracked positions / Tracked 13F value, so the headline and its footnote agree. Verified live against Scion (CIK 1649339), whose filing declares 8 positions of which we track 7.