### PR TITLE
docs: name and link the cloud column in the capability table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ See [`docs/`](docs/README.md) for the user guide and technical documentation.
 
 ## What's Included
 
-Everything marked **Self-hosted** is scraped, stored, and served by this repo — **62 MCP tools**, no account, no key. The **Cloud** column is [Equibles Cloud](https://equibles.com/mcp), which runs this exact core over the same protocol with the same tool names and adds 35 more tools, 97 in total.
+Everything marked **Self-hosted** is scraped, stored, and served by this repo — **62 MCP tools**, no account, no key. [Equibles Cloud](https://equibles.com) runs this exact core over the same protocol with the same tool names, and adds 35 more tools, 97 in total.
 
-| Domain | Data Source | Self-hosted | Cloud | Description |
+| Domain | Data Source | Self-hosted | [Equibles Cloud](https://equibles.com) | Description |
 |--------|------------|:---:|:---:|-------------|
 | **SEC Filings** | SEC EDGAR | ✅ | ✅ | 10-K, 10-Q, 8-K annual/quarterly/current reports with full-text search |
 | **Financial Statements** | SEC XBRL | ✅ | ✅ | Parsed income statement, balance sheet, and cash flow facts per fiscal period |


### PR DESCRIPTION
## Summary

The capability table's right-hand column was headed just `Cloud`. Every tick in it refers to Equibles Cloud, but a reader scanning the table had no way to reach it without scrolling back up to the prose above.

Head the column `Equibles Cloud` and link it to equibles.com, and point the sentence above the table at the same place.

## Code changes

- `README.md` — column header is now `[Equibles Cloud](https://equibles.com)`; the intro sentence links the product name rather than describing "the Cloud column".

Verified: table still 29 rows and 5 columns throughout, `## Tools` still has exactly 62 bullets.