### PR TITLE
feat(mcp): expose the government contracts tools on the self-hosted server

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See [`docs/`](docs/README.md) for the user guide and technical documentation.
 
 ## What's Included
 
-Everything marked **Self-hosted** is scraped, stored, and served by this repo — **62 MCP tools**, no account, no key. [Equibles Cloud](https://equibles.com) runs this exact core over the same protocol with the same tool names, and adds 35 more tools, 97 in total.
+Everything marked **Self-hosted** is scraped, stored, and served by this repo — **64 MCP tools**, no account, no key. [Equibles Cloud](https://equibles.com) runs this exact core over the same protocol with the same tool names, and adds 33 more tools, 97 in total.
 
 | Domain | Data Source | Self-hosted | [Equibles Cloud](https://equibles.com) | Description |
 |--------|------------|:---:|:---:|-------------|
@@ -35,7 +35,7 @@ Everything marked **Self-hosted** is scraped, stored, and served by this repo �
 | **Stock Prices** | Yahoo Finance | ✅ | ✅ | Daily OHLCV prices with technical indicators (SMA, RSI, MACD) |
 | **Futures Positioning** | CFTC | ✅ | ✅ | Commitments of Traders (COT) data for 30+ futures contracts |
 | **Market Indicators** | CBOE | ✅ | ✅ | VIX volatility index (1990+) and put/call ratios by category |
-| **Government Contracts** | USAspending.gov | Scraped ¹ | ✅ | Federal contract awards to public companies — amounts, awarding agencies, dates, and NAICS/PSC codes |
+| **Government Contracts** | USAspending.gov | ✅ | ✅ | Federal contract awards to public companies — amounts, awarding agencies, dates, and NAICS/PSC codes |
 | **FDA Catalysts** | FDA.gov | ✅ | ✅ | Advisory-committee (AdComm) meeting calendar — scheduled FDA panel dates, center, and title that act as regulatory catalysts for biotech/pharma stocks |
 | **Earnings Call Transcripts** | Company webcasts | — | ✅ | Full quarterly-call transcripts with speaker attribution, searchable alongside filings |
 | **Earnings Call Audio** | Company webcasts | — | ✅ | The recorded call itself, playable and aligned to the transcript |
@@ -52,8 +52,6 @@ Everything marked **Self-hosted** is scraped, stored, and served by this repo �
 | **Smart Money** | Derived | — | ✅ | Insider sentiment scores, super-investor portfolios, and market-wide congressional activity |
 | **Risk Flags** | SEC filings | — | ✅ | Going-concern language and customer-concentration disclosures |
 | **Market Context** | Derived | — | ✅ | Correlated stocks, plus market calendar and open/closed status |
-
-¹ Collected by the worker, but not yet exposed as MCP tools in the self-hosted build.
 
 ## Why Some Data Is Cloud-Only
 
@@ -279,7 +277,7 @@ Any MCP-compatible client can connect to `http://localhost:8081/mcp` (HTTP trans
 
 ## Tools
 
-This self-hosted build exposes 62 tools over MCP. The hosted server at `https://mcp.equibles.com/mcp` exposes 97 — the same 62 plus [35 more](#whats-included). Full catalog and client setup: [daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server).
+This self-hosted build exposes 64 tools over MCP. The hosted server at `https://mcp.equibles.com/mcp` exposes 97 — the same 64 plus [33 more](#whats-included). Full catalog and client setup: [daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server).
 
 **13F institutional holdings**
 
@@ -378,6 +376,11 @@ This self-hosted build exposes 62 tools over MCP. The hosted server at `https://
 - GetAverageTrueRange — average true range (ATR)
 - GetOnBalanceVolume — on-balance volume (OBV)
 - GetBollingerBands — Bollinger Bands
+
+**Government contracts (USAspending)**
+
+- GetGovernmentContracts — federal contract awards for a company
+- GetTopGovernmentContractors — largest public-company contractors
 
 ## Vector Embeddings (advanced, opt-in)
 

--- a/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
+++ b/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Equibles.Congress.Mcp\Equibles.Congress.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Finra.Mcp\Equibles.Finra.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.Mcp\Equibles.Yahoo.Mcp.csproj" />
+    <ProjectReference Include="..\Equibles.GovernmentContracts.Mcp\Equibles.GovernmentContracts.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Plugins\Equibles.Plugins.csproj" />
     <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -14,6 +14,7 @@ using Equibles.Finra.Data.Extensions;
 using Equibles.Finra.Mcp.Extensions;
 using Equibles.Fred.Data.Extensions;
 using Equibles.Fred.Mcp.Extensions;
+using Equibles.GovernmentContracts.Mcp.Extensions;
 using Equibles.Holdings.Data.Extensions;
 using Equibles.Holdings.Mcp.Extensions;
 using Equibles.InsiderTrading.Data.Extensions;
@@ -100,6 +101,7 @@ public partial class Program
             mcp.AddCongress();
             mcp.AddShortData();
             mcp.AddStockPrices();
+            mcp.AddGovernmentContracts();
         });
 
         builder.Services.AddSingleton<IApiKeyValidator, SimpleApiKeyValidator>();

--- a/tests/Equibles.IntegrationTests/Mcp/Server/McpServerEndpointTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Server/McpServerEndpointTests.cs
@@ -84,5 +84,11 @@ public class McpServerEndpointTests : IAsyncLifetime
         toolNames.Should().Contain("SearchCompanyDocuments");
         toolNames.Should().Contain("GetCongressionalTrades");
         toolNames.Should().Contain("GetStockPrices");
+        // Government contracts shipped as a module for a long time while the server never
+        // called AddGovernmentContracts(), so the worker scraped USAspending awards that no
+        // MCP client could ever read. Pin it here — this test hosts the real server, so a
+        // dropped Add*() call or a missing project reference (the assembly has to be in the
+        // output folder for PluginLoader to find its module and repositories) fails here.
+        toolNames.Should().Contain("GetGovernmentContracts");
     }
 }

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsMcpBuilderExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsMcpBuilderExtensionsTests.cs
@@ -1,0 +1,31 @@
+using Equibles.GovernmentContracts.Mcp.Extensions;
+using Equibles.GovernmentContracts.Mcp.Tools;
+using Equibles.Mcp;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class GovernmentContractsMcpBuilderExtensionsTests
+{
+    [Fact]
+    public void AddGovernmentContracts_RegistersAssemblyMcpModuleForGovernmentContractsTools()
+    {
+        // AddGovernmentContracts wires the USAspending award MCP tools into the
+        // EquiblesMcpBuilder via AssemblyMcpModule<GovernmentContractsTools>. The
+        // marker type drives the AutoWiring assembly scan; a regression that swaps
+        // it for a non-GovernmentContracts type would silently miss every award
+        // tool at runtime. Pin the marker so the regression surfaces here.
+        var services = new ServiceCollection();
+        var mcpServerBuilder = Substitute.For<IMcpServerBuilder>();
+        var builder = new EquiblesMcpBuilder(services, mcpServerBuilder);
+
+        builder.AddGovernmentContracts();
+
+        builder
+            .Modules.Should()
+            .ContainSingle()
+            .Which.Should()
+            .BeOfType<AssemblyMcpModule<GovernmentContractsTools>>();
+    }
+}


### PR DESCRIPTION
## Summary

`Equibles.GovernmentContracts.Mcp` has existed with two working tools, and the worker has been scraping USAspending contract awards into the database — but `Equibles.Mcp.Server` never called `AddGovernmentContracts()`. The self-hosted build was collecting federal award data that no MCP client could read. The hosted server has always registered it, so this closes a gap between the two.

The project reference is the load-bearing half, not just a compile fix: `PluginLoader.LoadAll()` scans `AppContext.BaseDirectory` for `Equibles.*.dll`, and `AddAllModulesOfType<IFinancialModule>()` / `AddAllRepositories()` then scan loaded assemblies. Without the reference the assembly never reaches the output folder, so the module's entities and repositories would not register even if the `Add` call were there.

Self-hosted goes from **62 tools to 64**: `GetGovernmentContracts` and `GetTopGovernmentContractors`.

## Code changes

- `src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj` — project reference to `Equibles.GovernmentContracts.Mcp`.
- `src/Equibles.Mcp.Server/Program.cs` — `mcp.AddGovernmentContracts()` in the `AddEquiblesMcp` block, plus the using.
- `tests/Equibles.IntegrationTests/Mcp/Server/McpServerEndpointTests.cs` — asserts `GetGovernmentContracts` in `tools/list`. This test hosts the real server over HTTP, so it covers the registration *and* the project reference.
- `tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsMcpBuilderExtensionsTests.cs` — new, pins the `AssemblyMcpModule<GovernmentContractsTools>` marker, matching the existing per-module builder tests.
- `README.md` — government contracts row goes from `Scraped ¹` to ✅ and the footnote is gone; counts updated to 64 self-hosted / 33 added by the cloud; the `## Tools` catalog gains a "Government contracts (USAspending)" group so it stays at exactly 64 bullets.

## Verification

- `dotnet build Equibles.sln -c Release` — 0 warnings, 0 errors.
- Full unit suite: 3812 passed.
- Integration tests matching `Mcp`: 517 passed.
- Repo-pinned csharpier: clean.
- **Guard proven non-vacuous** — commenting out `mcp.AddGovernmentContracts()` and rebuilding makes the integration test fail on the missing tool name; restoring it passes.