### PR TITLE
fix(yahoo): correct daily volumes captured before the feed settled them

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Configuration/YahooPriceScraperOptions.cs
+++ b/src/Equibles.Yahoo.HostedService/Configuration/YahooPriceScraperOptions.cs
@@ -12,4 +12,17 @@ public class YahooPriceScraperOptions : ScraperOptions
     /// can be short (fresh daily closes) without multiplying the per-stock enrichment traffic.
     /// </summary>
     public int EnrichmentIntervalHours { get; set; } = 24;
+
+    /// <summary>
+    /// How many days back a stored bar's volume is still re-read from the feed and corrected
+    /// upward. A bar is stored as soon as its date rolls over in UTC — four hours after the US
+    /// close — but the feed is still serving an unsettled volume then, and revises it upward
+    /// overnight as the closing cross and late-reported off-exchange prints land. Without a
+    /// re-read the first, short figure is permanent (the importer is otherwise insert-only).
+    /// The default covers the previous session across a weekend, which is all steady-state
+    /// operation needs. Raise it temporarily to repair a longer stretch of stored volumes: the
+    /// window only ever widens a fetch that was already going to happen, so a wider setting costs
+    /// no extra upstream calls, only a larger response and more rows compared per stock.
+    /// </summary>
+    public int VolumeResettleWindowDays { get; set; } = 5;
 }

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -12,6 +12,7 @@ using Equibles.Integrations.Yahoo.Models;
 using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Worker;
 using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.HostedService.Configuration;
 using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,6 +33,7 @@ public class YahooPriceImportService
     private readonly TickerMapService _tickerMapService;
     private readonly ErrorReporter _errorReporter;
     private readonly WorkerOptions _workerOptions;
+    private readonly YahooPriceScraperOptions _scraperOptions;
 
     public YahooPriceImportService(
         IServiceScopeFactory scopeFactory,
@@ -39,7 +41,8 @@ public class YahooPriceImportService
         IYahooFinanceClient yahooClient,
         TickerMapService tickerMapService,
         ErrorReporter errorReporter,
-        IOptions<WorkerOptions> workerOptions
+        IOptions<WorkerOptions> workerOptions,
+        IOptions<YahooPriceScraperOptions> scraperOptions
     )
     {
         _scopeFactory = scopeFactory;
@@ -48,6 +51,7 @@ public class YahooPriceImportService
         _tickerMapService = tickerMapService;
         _errorReporter = errorReporter;
         _workerOptions = workerOptions.Value;
+        _scraperOptions = scraperOptions.Value;
     }
 
     public Task Import(CancellationToken cancellationToken) =>
@@ -660,9 +664,14 @@ public class YahooPriceImportService
             cancellationToken
         );
 
-        var newPrices = MapFreshRows(commonStockId, prices, ticker, today)
-            .Where(p => !existingDates.Contains(p.Date))
-            .ToList();
+        var freshRows = MapFreshRows(commonStockId, prices, ticker, today);
+
+        // Runs before the insert path's early return: a stock whose only unsettled bar is one it
+        // ALREADY stored has nothing new to insert, and that is exactly the stock whose volume
+        // still needs correcting.
+        await ResettleVolumes(ticker, commonStockId, freshRows, today, cancellationToken);
+
+        var newPrices = freshRows.Where(p => !existingDates.Contains(p.Date)).ToList();
 
         if (newPrices.Count == 0)
             return 0;
@@ -672,6 +681,80 @@ public class YahooPriceImportService
         _logger.LogDebug("Inserted {Count} prices for {Ticker}", inserted, ticker);
         return inserted;
     }
+
+    // Corrects stored volumes that were captured before the feed settled them.
+    //
+    // A bar becomes storable the moment its date rolls over in UTC, which is only four hours after
+    // the 20:00 UTC close. The feed serves a daily bar that early with an unsettled volume — the
+    // closing cross and late-reported off-exchange prints are still landing — and revises it upward
+    // overnight. OHLC is right from the start; only volume moves, and for names whose volume
+    // settles late it moves a lot (a quarter of the day's shares is routine). PersistPrices is
+    // insert-only, so that first short figure used to be permanent.
+    //
+    // Re-reading the window off the SAME chart response the stock was already fetching costs no
+    // extra upstream call — ResolveStartDate only widens a request that was going to happen anyway.
+    // Steady state therefore corrects each session's volume when the next session syncs.
+    private async Task<int> ResettleVolumes(
+        string ticker,
+        Guid commonStockId,
+        List<DailyStockPrice> freshRows,
+        DateOnly today,
+        CancellationToken cancellationToken
+    )
+    {
+        var windowStart = ResettleWindowStart(today, _scraperOptions.VolumeResettleWindowDays);
+
+        // Last-wins rather than ToDictionary: a feed that repeats a date must not throw here, and
+        // the insert path already assumes the response holds one bar per date.
+        var fetched = new Dictionary<DateOnly, long>();
+        foreach (var row in freshRows)
+        {
+            if (row.Date >= windowStart)
+                fetched[row.Date] = row.Volume;
+        }
+
+        if (fetched.Count == 0)
+            return 0;
+
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+        var stored = await repo.GetAll()
+            .Where(p => p.CommonStockId == commonStockId && p.Date >= windowStart && p.Date < today)
+            .ToListAsync(cancellationToken);
+
+        var corrected = 0;
+        foreach (var row in stored)
+        {
+            if (
+                !fetched.TryGetValue(row.Date, out var volume)
+                || !IsVolumeUpgrade(row.Volume, volume)
+            )
+                continue;
+
+            row.Volume = volume;
+            corrected++;
+        }
+
+        if (corrected == 0)
+            return 0;
+
+        // The rows are tracked, so saving the mutated Volume is enough — no repo.Update, which
+        // would mark every column dirty and clobber a concurrent split reconcile's price basis.
+        await repo.SaveChanges();
+        _logger.LogDebug("Corrected {Count} stored volumes for {Ticker}", corrected, ticker);
+        return corrected;
+    }
+
+    // Settled volume only ever accrues, so a fetched figure below the stored one is a degraded
+    // response (a partial re-serve, a venue dropping out), never a correction. Accepting only
+    // upgrades makes the repair monotone: a flaky feed can never walk a good figure back down.
+    private static bool IsVolumeUpgrade(long stored, long fetched) => fetched > stored;
+
+    // The oldest date whose stored volume is still re-read. Pure so the boundary is pinnable, and
+    // clamped so a zero or negative setting degrades to "today only" — which the settled-bar guard
+    // then empties — rather than reaching back over the whole series.
+    private static DateOnly ResettleWindowStart(DateOnly today, int windowDays) =>
+        today.AddDays(-Math.Max(windowDays, 0));
 
     // Upserts the split events Yahoo returned for this ticker into StockSplit via
     // the CorporateActions capture manager. Resolved in its own scope (mirrors
@@ -1092,11 +1175,21 @@ public class YahooPriceImportService
         if (!HasSettledTradingDay(forwardOnly, today))
             return forwardOnly;
 
+        // Past the same gate, pull the start back over the volume-resettle window so the response
+        // carries the recently-stored bars whose volume may not have settled yet (see
+        // ResettleVolumes). Same ride-along rule as the heal below: it widens a request that was
+        // already being made, never triggers one, so an up-to-date stock still costs zero calls.
+        var startDate = Min(
+            forwardOnly,
+            ResettleWindowStart(today, _scraperOptions.VolumeResettleWindowDays)
+        );
+
         var windowStart = today.AddDays(-GapHealWindowDays);
-        // Already reaching back past the window (a never-synced stock, or one mid-backfill) — it is
-        // going to re-request those sessions anyway, so there is nothing to widen.
-        if (forwardOnly <= windowStart)
-            return forwardOnly;
+        // Already reaching back past the window (a never-synced stock, one mid-backfill, or a
+        // resettle window widened past the heal window) — it is going to re-request those sessions
+        // anyway, so there is nothing to widen.
+        if (startDate <= windowStart)
+            return startDate;
 
         List<DateOnly> storedDates;
         DateOnly? earliestStored;
@@ -1123,8 +1216,10 @@ public class YahooPriceImportService
             today,
             hasHistoryBeforeWindow: earliestStored < windowStart
         );
-        return earliestGap is { } gap && gap < forwardOnly ? gap : forwardOnly;
+        return earliestGap is { } gap && gap < startDate ? gap : startDate;
     }
+
+    private static DateOnly Min(DateOnly left, DateOnly right) => left < right ? left : right;
 
     // The earliest settled trading day in [windowStart, today) with no stored bar, or null when the
     // window is complete. Pure so the rule is pinnable without a database.

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileBlankSectorTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileBlankSectorTests.cs
@@ -12,6 +12,7 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
+using Equibles.Yahoo.HostedService.Configuration;
 using Equibles.Yahoo.HostedService.Services;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -72,7 +73,8 @@ public class YahooPriceImportServiceCompanyProfileBlankSectorTests : IDisposable
             _yahooClient,
             new TickerMapService(scopeFactory),
             errorReporter,
-            Options.Create(new WorkerOptions())
+            Options.Create(new WorkerOptions()),
+            Options.Create(new YahooPriceScraperOptions())
         );
 
         _yahooClient

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfilePreservesSectorTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfilePreservesSectorTests.cs
@@ -12,6 +12,7 @@ using Equibles.Integrations.Yahoo.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
+using Equibles.Yahoo.HostedService.Configuration;
 using Equibles.Yahoo.HostedService.Services;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -68,7 +69,8 @@ public class YahooPriceImportServiceCompanyProfilePreservesSectorTests : IDispos
             _yahooClient,
             new TickerMapService(scopeFactory),
             errorReporter,
-            Options.Create(new WorkerOptions())
+            Options.Create(new WorkerOptions()),
+            Options.Create(new YahooPriceScraperOptions())
         );
 
         _yahooClient

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
@@ -13,6 +13,7 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
+using Equibles.Yahoo.HostedService.Configuration;
 using Equibles.Yahoo.HostedService.Services;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -80,7 +81,8 @@ public class YahooPriceImportServiceCompanyProfileTests : IDisposable
             _yahooClient,
             new TickerMapService(scopeFactory),
             errorReporter,
-            Options.Create(new WorkerOptions())
+            Options.Create(new WorkerOptions()),
+            Options.Create(new YahooPriceScraperOptions())
         );
 
         _yahooClient

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceKeepExistingSectorTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceKeepExistingSectorTests.cs
@@ -12,6 +12,7 @@ using Equibles.Integrations.Yahoo.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
+using Equibles.Yahoo.HostedService.Configuration;
 using Equibles.Yahoo.HostedService.Services;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -81,7 +82,8 @@ public class YahooPriceImportServiceKeepExistingSectorTests : IDisposable
             _yahooClient,
             new TickerMapService(scopeFactory),
             errorReporter,
-            Options.Create(new WorkerOptions())
+            Options.Create(new WorkerOptions()),
+            Options.Create(new YahooPriceScraperOptions())
         );
 
         _yahooClient

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceMissingCommonStockTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceMissingCommonStockTests.cs
@@ -12,6 +12,7 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.HostedService.Configuration;
 using Equibles.Yahoo.HostedService.Services;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -71,7 +72,8 @@ public class YahooPriceImportServiceMissingCommonStockTests : IDisposable
             _yahooClient,
             new TickerMapService(scopeFactory),
             errorReporter,
-            Options.Create(new WorkerOptions())
+            Options.Create(new WorkerOptions()),
+            Options.Create(new YahooPriceScraperOptions())
         );
 
         _yahooClient.GetKeyStatistics(Arg.Any<string>()).Returns((KeyStatistics)null);

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -15,6 +15,7 @@ using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.HostedService.Configuration;
 using Equibles.Yahoo.HostedService.Services;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -79,7 +80,8 @@ public class YahooPriceImportServiceTests : IDisposable
             _yahooClient,
             tickerMapService,
             _errorReporter,
-            Options.Create(_workerOptions)
+            Options.Create(_workerOptions),
+            Options.Create(new YahooPriceScraperOptions())
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
@@ -1,0 +1,236 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Calendars;
+using Equibles.Core.Configuration;
+using Equibles.CorporateActions.BusinessLogic;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Yahoo.Contracts;
+using Equibles.Integrations.Yahoo.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Worker;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.HostedService.Configuration;
+using Equibles.Yahoo.HostedService.Services;
+using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Yahoo;
+
+/// <summary>
+/// End-to-end cover for the volume resettle. The pure rules are pinned in the unit suite; what
+/// these need to prove is the WIRING, which is where the bug actually lived: the fetch window has
+/// to reach back far enough to re-request an already-stored bar, and the correction has to run
+/// before the insert path's "nothing new to insert" early return.
+///
+/// Every case is set up the way steady-state operation actually reaches the correction: the stock
+/// is one settled session behind, so the new bar is what drives the fetch and the older stored bar
+/// is corrected by riding it. A stock that is FULLY current is deliberately not covered, because
+/// it deliberately does not fetch at all — re-reading it would cost a call per stock per cycle to
+/// buy less than a day of freshness (see the settled-trading-day gate in ResolveStartDate).
+///
+/// Real numbers from the defect: KRC's 2026-07-27 bar was stored with 1,183,039 shares hours after
+/// the close, while the settled figure was 1,573,891.
+/// </summary>
+public class YahooPriceImportServiceVolumeResettleTests : IDisposable
+{
+    private const long UnsettledVolume = 1_183_039;
+    private const long SettledVolume = 1_573_891;
+
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly DailyStockPriceRepository _priceRepo;
+    private readonly CommonStockRepository _stockRepo;
+    private readonly IYahooFinanceClient _yahooClient;
+    private readonly YahooPriceImportService _service;
+
+    // Wide enough that the two most recent trading days are inside it whatever weekday the suite
+    // runs on, so the cases exercise the wiring rather than the calendar. The default window's own
+    // boundary is pinned in the unit suite.
+    private const int WindowDays = 30;
+
+    public YahooPriceImportServiceVolumeResettleTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+        _priceRepo = new DailyStockPriceRepository(_dbContext);
+        _stockRepo = new CommonStockRepository(_dbContext);
+        var splitRepo = new StockSplitRepository(_dbContext);
+
+        _yahooClient = Substitute.For<IYahooFinanceClient>();
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(DailyStockPriceRepository), _priceRepo),
+            (typeof(CommonStockRepository), _stockRepo),
+            (typeof(ISharesOutstandingProvider), Substitute.For<ISharesOutstandingProvider>()),
+            (
+                typeof(SplitPriceReconciliationManager),
+                new SplitPriceReconciliationManager(splitRepo)
+            ),
+            (typeof(StockSplitCaptureManager), new StockSplitCaptureManager(splitRepo))
+        );
+
+        _service = new YahooPriceImportService(
+            scopeFactory,
+            Substitute.For<ILogger<YahooPriceImportService>>(),
+            _yahooClient,
+            new TickerMapService(scopeFactory),
+            errorReporter,
+            Options.Create(new WorkerOptions()),
+            Options.Create(new YahooPriceScraperOptions { VolumeResettleWindowDays = WindowDays })
+        );
+
+        _yahooClient.GetKeyStatistics(Arg.Any<string>()).Returns((KeyStatistics)null);
+        _yahooClient.GetCompanyProfile(Arg.Any<string>()).Returns((CompanyProfile)null);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task Import_StoredBarVolumeSettledUpward_IsCorrected()
+    {
+        // The exact shape of an ordinary daily cycle: the stock holds the previous session and the
+        // newest settled one is missing, so the fetch is driven by that new bar. The stored bar's
+        // correction has to ride it — nothing else requests that date.
+        var stock = SeedStock("KRC");
+        var (newest, previous) = TwoMostRecentSettledSessions();
+        SeedPrice(stock, previous, UnsettledVolume);
+
+        var requestedStart = default(DateOnly);
+        _yahooClient
+            .GetChart("KRC", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(call =>
+            {
+                requestedStart = (DateOnly)call[1];
+                return Chart((previous, SettledVolume), (newest, SettledVolume));
+            });
+
+        await _service.Import(CancellationToken.None);
+
+        // The window must actually reach the stored bar — the forward-only start date alone would
+        // begin after it, and the feed would never be asked to re-serve it.
+        requestedStart.Should().BeOnOrBefore(previous);
+
+        _priceRepo.GetAll().Single(p => p.Date == previous).Volume.Should().Be(SettledVolume);
+        // The new session still lands: the correction must not displace the insert path.
+        _priceRepo.GetAll().Single(p => p.Date == newest).Volume.Should().Be(SettledVolume);
+    }
+
+    [Fact]
+    public async Task Import_FeedServesLowerVolume_KeepsTheStoredFigure()
+    {
+        // A degraded re-serve (a partial response, a venue dropping out) must never walk a settled
+        // figure back down. Without the upgrade-only rule the repair would oscillate with the feed.
+        var stock = SeedStock("KRC");
+        var (newest, previous) = TwoMostRecentSettledSessions();
+        SeedPrice(stock, previous, SettledVolume);
+
+        _yahooClient
+            .GetChart("KRC", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(Chart((previous, UnsettledVolume), (newest, SettledVolume)));
+
+        await _service.Import(CancellationToken.None);
+
+        _priceRepo.GetAll().Single(p => p.Date == previous).Volume.Should().Be(SettledVolume);
+    }
+
+    [Fact]
+    public async Task Import_BarOlderThanTheWindow_IsLeftAlone()
+    {
+        // The window bounds the repair. A bar from before it keeps its stored volume even when the
+        // response carries a different figure for that date, so a cycle can never rewrite
+        // arbitrarily deep history off one chart call — only the widened window may.
+        var stock = SeedStock("KRC");
+        var (newest, previous) = TwoMostRecentSettledSessions();
+        var beyondWindow = previous.AddDays(-(WindowDays + 30));
+        SeedPrice(stock, beyondWindow, UnsettledVolume);
+        SeedPrice(stock, previous, UnsettledVolume);
+
+        _yahooClient
+            .GetChart("KRC", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(
+                Chart(
+                    (beyondWindow, SettledVolume),
+                    (previous, SettledVolume),
+                    (newest, SettledVolume)
+                )
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        _priceRepo.GetAll().Single(p => p.Date == beyondWindow).Volume.Should().Be(UnsettledVolume);
+        _priceRepo.GetAll().Single(p => p.Date == previous).Volume.Should().Be(SettledVolume);
+    }
+
+    // The two most recent settled sessions, resolved off the real calendar so the cases behave the
+    // same whatever weekday the suite runs on. The service derives "today" from the clock and never
+    // stores the in-progress bar, so the newest settled session is the last trading day before it.
+    private static (DateOnly Newest, DateOnly Previous) TwoMostRecentSettledSessions()
+    {
+        var newest = UsMarketCalendar.PreviousOrSameTradingDay(
+            DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1)
+        );
+        var previous = UsMarketCalendar.PreviousOrSameTradingDay(newest.AddDays(-1));
+        return (newest, previous);
+    }
+
+    private static YahooChartData Chart(params (DateOnly Date, long Volume)[] bars) =>
+        new()
+        {
+            Prices = bars.Select(b => new HistoricalPrice
+                {
+                    Date = b.Date,
+                    Open = 39.57m,
+                    High = 39.70m,
+                    Low = 39.03m,
+                    Close = 39.41m,
+                    AdjustedClose = 39.41m,
+                    Volume = b.Volume,
+                })
+                .ToList(),
+        };
+
+    private CommonStock SeedStock(string ticker)
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = $"{ticker} Inc.",
+            Cik = $"CIK-{ticker}",
+        };
+        _stockRepo.Add(stock);
+        _stockRepo.SaveChanges().GetAwaiter().GetResult();
+        return stock;
+    }
+
+    private void SeedPrice(CommonStock stock, DateOnly date, long volume)
+    {
+        _priceRepo.Add(
+            new DailyStockPrice
+            {
+                CommonStockId = stock.Id,
+                Date = date,
+                Open = 39.57m,
+                High = 39.70m,
+                Low = 39.03m,
+                Close = 39.41m,
+                AdjustedClose = 39.41m,
+                Volume = volume,
+            }
+        );
+        _priceRepo.SaveChanges().GetAwaiter().GetResult();
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Pins the two pure rules behind the volume resettle: which stored bars are still re-read
+/// (<c>ResettleWindowStart</c>) and which fetched figure is allowed to replace a stored one
+/// (<c>IsVolumeUpgrade</c>).
+///
+/// The bug they guard: a daily bar becomes storable four hours after the US close, when the feed
+/// is still serving an unsettled volume that it revises upward overnight. OHLC is correct from the
+/// start; volume is routinely a quarter short for names whose shares settle late. The importer is
+/// otherwise insert-only, so without the resettle that first short figure is permanent.
+/// </summary>
+public class YahooPriceImportServiceVolumeResettleTests
+{
+    private static readonly MethodInfo IsVolumeUpgradeMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "IsVolumeUpgrade",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static readonly MethodInfo ResettleWindowStartMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "ResettleWindowStart",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static bool IsVolumeUpgrade(long stored, long fetched) =>
+        (bool)IsVolumeUpgradeMethod.Invoke(null, [stored, fetched]);
+
+    private static DateOnly ResettleWindowStart(DateOnly today, int windowDays) =>
+        (DateOnly)ResettleWindowStartMethod.Invoke(null, [today, windowDays]);
+
+    private static readonly DateOnly Today = new(2026, 7, 29);
+
+    [Fact]
+    public void IsVolumeUpgrade_SettledFigureAboveStored_IsAccepted()
+    {
+        // The case that motivated the fix: KRC's 2026-07-27 bar stored 1,183,039 shares hours
+        // after the close, while the settled figure was 1,573,891 — a 24.8% shortfall that the
+        // insert-only importer would otherwise have kept forever.
+        IsVolumeUpgrade(1_183_039, 1_573_891).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsVolumeUpgrade_FigureBelowStored_IsRejected()
+    {
+        // Settled volume only accrues, so a lower reading is a degraded response — a partial
+        // re-serve or a venue dropping out — never a correction. Accepting it would let a flaky
+        // feed walk a good figure back down, which is worse than the shortfall being fixed.
+        IsVolumeUpgrade(1_573_891, 1_183_039).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsVolumeUpgrade_UnchangedFigure_IsRejected()
+    {
+        // The steady-state case: an already-settled bar re-read on the next sync must not mark the
+        // row dirty, or every stock would write every session's row back on every cycle.
+        IsVolumeUpgrade(1_573_891, 1_573_891).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResettleWindowStart_DefaultWindow_ReachesBackOverAWeekend()
+    {
+        // The default of 5 days must cover the previous session even across a weekend: syncing on
+        // a Wednesday has to still reach the preceding Friday's bar, which is the oldest one whose
+        // volume could have been captured unsettled.
+        ResettleWindowStart(Today, 5).Should().Be(new DateOnly(2026, 7, 24));
+    }
+
+    [Fact]
+    public void ResettleWindowStart_WidenedWindow_ReachesBackFurther()
+    {
+        // Raising the setting is how a longer stretch of stored volumes gets repaired: the window
+        // only widens a fetch that was already happening, so a wider setting buys a longer repair
+        // at no extra upstream calls.
+        ResettleWindowStart(Today, 120).Should().Be(new DateOnly(2026, 3, 31));
+    }
+
+    [Fact]
+    public void ResettleWindowStart_ZeroOrNegativeWindow_ClampsToToday()
+    {
+        // A misconfigured zero or negative window must degrade to "today only" — which the
+        // settled-bar guard then empties — rather than flipping the sign and reaching FORWARD, or
+        // being read as "no clamp" and dragging the fetch back over the stock's whole series.
+        ResettleWindowStart(Today, 0).Should().Be(Today);
+        ResettleWindowStart(Today, -30).Should().Be(Today);
+    }
+}


### PR DESCRIPTION
## Summary

Stored daily volumes are systematically short, by up to ~29% on recent sessions.

A daily bar becomes storable the moment its date rolls over in UTC — only four hours after the 20:00 UTC close. The feed is still serving an **unsettled** volume then, and revises it upward overnight as the closing cross and late-reported off-exchange prints land. OHLC is correct from the start; only volume moves, and for names whose shares settle late it moves a lot. `PersistPrices` is insert-only, so that first short figure was permanent.

Measured against the settled figures for 2026-07-27:

| Ticker | Stored | Settled | Short by |
|---|---|---|---|
| PFE | 27,955,647 | 38,355,200 | −27.1% |
| KRC | 1,183,039 | 1,573,891 | −24.8% |
| F | 54,600,033 | 58,748,400 | −7.1% |
| INTC | 132,032,608 | 133,247,300 | −0.9% |
| NVDA | 153,410,785 | 154,353,700 | −0.6% |
| AAPL | 49,556,300 | 49,604,300 | −0.1% |

The shortfall scales with how much of a name's volume settles late, so it is worst exactly where daily volume is least liquid and most load-bearing.

## Code changes

**`YahooPriceImportService`**

- `ResolveStartDate` pulls the fetch start back over a volume-resettle window. This sits **past** the existing settled-trading-day gate, so it follows the same ride-along rule as the gap heal: it widens a request that was already being made, never triggers one. An up-to-date stock still costs zero upstream calls.
- New `ResettleVolumes` re-reads the window off the same chart response and corrects stored volumes. It runs **before** the insert path's "nothing new to insert" early return — the stock whose only unsettled bar is one it already stored is exactly the stock that returns there.
- `IsVolumeUpgrade` accepts a fetched figure only when it is higher than the stored one. Settled volume only accrues, so a lower reading is a degraded response (a partial re-serve, a venue dropping out), never a correction. This keeps the repair monotone — a flaky feed can never walk a good figure back down.
- Rows are mutated in place and saved, not pushed through `repo.Update`, which would mark every column dirty and clobber a concurrent split reconcile's price basis. Only `Volume` is touched; `AdjustedClose` stays owned by the split-reconcile path, which rewrites the whole series at once to keep one basis.

**`YahooPriceScraperOptions`**

- `VolumeResettleWindowDays`, default 5 — enough to cover the previous session across a weekend, which is all steady state needs. Raising it temporarily repairs a longer stretch of stored volumes at no extra upstream calls, only a larger response per stock.

Steady state therefore corrects each session's volume when the next session syncs. A fully-current stock is deliberately left alone: re-reading it would cost a call per stock per cycle to buy less than a day of freshness.

## Tests

- `tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs` — pins the two pure rules: the upgrade-only comparison (accepts higher, rejects lower and equal) and the window boundary (default reaches back over a weekend, a widened setting reaches further, zero/negative clamps to today instead of flipping sign).
- `tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs` — end-to-end cover for the wiring, which is where the bug lived: the request start actually reaches the stored bar, the correction lands without displacing the insert, a lower re-serve is ignored, and a bar beyond the window is left alone. All three fail with the window disabled.
- The six existing integration tests that construct the service directly take the new options argument.

Full suites green: 3,818 unit, 2,277 integration. csharpier clean.