### PR TITLE
fix(yahoo): never resettle a volume across a split basis

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -723,6 +723,7 @@ public class YahooPriceImportService
             .ToListAsync(cancellationToken);
 
         var corrected = 0;
+        var skippedOnBasis = 0;
         foreach (var row in stored)
         {
             if (!fetched.TryGetValue(row.Date, out var bar))
@@ -731,13 +732,28 @@ public class YahooPriceImportService
             // Both records must describe the session on the SAME split basis before their volumes
             // can be compared at all — see IsSameSplitBasis.
             if (!IsSameSplitBasis(row.Close, bar.Close))
+            {
+                skippedOnBasis++;
                 continue;
+            }
 
             if (!IsVolumeUpgrade(row.Volume, bar.Volume))
                 continue;
 
             row.Volume = bar.Volume;
             corrected++;
+        }
+
+        // A basis mismatch is the only place the store's divergence from the feed's served basis
+        // is ever visible — the reconcile has already stamped the split as applied and will not
+        // revisit the stock — so surface it rather than dropping the signal silently.
+        if (skippedOnBasis > 0)
+        {
+            _logger.LogInformation(
+                "Skipped {Count} stored volumes for {Ticker}: stored close disagrees with the feed's split basis",
+                skippedOnBasis,
+                ticker
+            );
         }
 
         if (corrected == 0)
@@ -755,34 +771,50 @@ public class YahooPriceImportService
     // upgrades makes the repair monotone: a flaky feed can never walk a good figure back down.
     private static bool IsVolumeUpgrade(long stored, long fetched) => fetched > stored;
 
-    // Two records of the same session are only comparable when they are on the same split basis,
-    // and the close is what proves it: a split moves price and volume by the SAME ratio in opposite
-    // directions, so a basis mismatch shows up as a close that differs by that ratio.
-    //
-    // The stored series and the feed genuinely disagree here. ReconcilePendingSplits rewrites a
-    // split stock's whole history onto the post-split basis, while the feed keeps serving that same
-    // window as-traded for a while (observed on WLFC's 3:1: stored close 72.3267 / volume 168,879
-    // against a served 216.98 / 56,300 — the same session on two bases).
-    //
-    // Without this guard the upgrade-only rule turns into a corruption rule on REVERSE splits.
-    // A 1:25 reverse leaves the stored volume 25x SMALLER than the as-traded figure, so the served
-    // number always looks like an upgrade and gets written over a correctly-adjusted row — silently
-    // inflating that stock's volume history by the split ratio. (A forward split is accidentally
-    // safe, since the adjusted figure is already the larger one.) Volume basis belongs to the split
-    // reconcile, so a mismatch means skip, never rewrite.
+    // Relative half-width of the same-basis close comparison; full rationale on IsSameSplitBasis.
     private const decimal SameBasisCloseTolerance = 0.01m;
 
+    // One last-digit tick of absolute headroom on top of the relative tolerance. Both closes are
+    // rounded to 4 decimals at ingest, so a genuine minor revision of a sub-cent close moves it by
+    // a full 0.0001 — more than 1% of the price — and a purely relative tolerance would freeze the
+    // resettle out of the OTC tail. One tick stays orders of magnitude below any split ratio.
+    private const decimal SameBasisCloseTickHeadroom = 0.0001m;
+
+    // Two records of the same session are only comparable when they are on the same split basis,
+    // and the close is what proves it: a split moves price and volume by the SAME ratio in
+    // opposite directions, so a basis mismatch shows up as a close that differs by that ratio.
+    //
+    // The stored series and the feed genuinely disagree here, in BOTH orderings — the guard must
+    // stay direction-agnostic:
+    //  - Pre-reconcile (the window EVERY split passes through): CaptureSplits records a split at
+    //    the end of the same cycle whose ReconcilePendingSplits pass already ran, so until the
+    //    next cycle the stored pre-split rows are still as-traded while the feed already serves
+    //    them adjusted. On a forward split the adjusted volume is ratio-times LARGER, so it reads
+    //    as a settlement upgrade and would leave a row whose volume is adjusted under an as-traded
+    //    close.
+    //  - Post-reconcile (observed on WLFC's 3:1): the reconcile stored the adjusted basis and the
+    //    feed later went back to serving the window as-traded. On a reverse split the as-traded
+    //    volume is ratio-times larger than the stored adjusted one, so it reads as an upgrade and
+    //    would inflate the stock's volume history by the split ratio.
+    // Which basis each side holds varies by stock and over time (PRPL's reconciled series is
+    // as-traded while WLFC's is adjusted, minutes apart), so only this value comparison is safe —
+    // a split-table lookup would guess wrong on real data. A mismatch means skip, never rewrite:
+    // volume basis belongs to the split reconcile, which rewrites the series as a whole.
+    //
+    // Tolerance: both closes are rounded to 4 decimals at ingest, so same-basis values differ only
+    // by a genuine minor revision — well inside 1% — while the split ratios Yahoo emits for real
+    // splits (5:4 = 25%, 21:20 = 4.76%) sit far outside it. The one family inside the tolerance is
+    // a tiny stock dividend recorded as a split (101:100 = 0.99%); accepting it bounds the volume
+    // error at ~1%, negligible against the 10-29% unsettled shortfall the resettle exists to fix.
     private static bool IsSameSplitBasis(decimal storedClose, decimal fetchedClose)
     {
-        // A guard on a non-positive close would divide meaning out of the tolerance; nothing to
-        // compare, so treat it as unproven rather than same-basis.
+        // Nothing to compare against, so the basis is unproven rather than matching — and a zero
+        // stored close would collapse the relative tolerance to exact equality.
         if (storedClose <= 0m || fetchedClose <= 0m)
             return false;
 
-        // 1% is far tighter than the smallest real split ratio (5:4 moves the close 25%) and far
-        // looser than the rounding gap between a stored numeric(18,4) and the feed's own value, so
-        // it separates the two cases without ever needing the split table.
-        return Math.Abs(fetchedClose - storedClose) <= storedClose * SameBasisCloseTolerance;
+        return Math.Abs(fetchedClose - storedClose)
+            <= storedClose * SameBasisCloseTolerance + SameBasisCloseTickHeadroom;
     }
 
     // The oldest date whose stored volume is still re-read. Pure so the boundary is pinnable, and

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -706,11 +706,11 @@ public class YahooPriceImportService
 
         // Last-wins rather than ToDictionary: a feed that repeats a date must not throw here, and
         // the insert path already assumes the response holds one bar per date.
-        var fetched = new Dictionary<DateOnly, long>();
+        var fetched = new Dictionary<DateOnly, DailyStockPrice>();
         foreach (var row in freshRows)
         {
             if (row.Date >= windowStart)
-                fetched[row.Date] = row.Volume;
+                fetched[row.Date] = row;
         }
 
         if (fetched.Count == 0)
@@ -725,13 +725,18 @@ public class YahooPriceImportService
         var corrected = 0;
         foreach (var row in stored)
         {
-            if (
-                !fetched.TryGetValue(row.Date, out var volume)
-                || !IsVolumeUpgrade(row.Volume, volume)
-            )
+            if (!fetched.TryGetValue(row.Date, out var bar))
                 continue;
 
-            row.Volume = volume;
+            // Both records must describe the session on the SAME split basis before their volumes
+            // can be compared at all — see IsSameSplitBasis.
+            if (!IsSameSplitBasis(row.Close, bar.Close))
+                continue;
+
+            if (!IsVolumeUpgrade(row.Volume, bar.Volume))
+                continue;
+
+            row.Volume = bar.Volume;
             corrected++;
         }
 
@@ -749,6 +754,36 @@ public class YahooPriceImportService
     // response (a partial re-serve, a venue dropping out), never a correction. Accepting only
     // upgrades makes the repair monotone: a flaky feed can never walk a good figure back down.
     private static bool IsVolumeUpgrade(long stored, long fetched) => fetched > stored;
+
+    // Two records of the same session are only comparable when they are on the same split basis,
+    // and the close is what proves it: a split moves price and volume by the SAME ratio in opposite
+    // directions, so a basis mismatch shows up as a close that differs by that ratio.
+    //
+    // The stored series and the feed genuinely disagree here. ReconcilePendingSplits rewrites a
+    // split stock's whole history onto the post-split basis, while the feed keeps serving that same
+    // window as-traded for a while (observed on WLFC's 3:1: stored close 72.3267 / volume 168,879
+    // against a served 216.98 / 56,300 — the same session on two bases).
+    //
+    // Without this guard the upgrade-only rule turns into a corruption rule on REVERSE splits.
+    // A 1:25 reverse leaves the stored volume 25x SMALLER than the as-traded figure, so the served
+    // number always looks like an upgrade and gets written over a correctly-adjusted row — silently
+    // inflating that stock's volume history by the split ratio. (A forward split is accidentally
+    // safe, since the adjusted figure is already the larger one.) Volume basis belongs to the split
+    // reconcile, so a mismatch means skip, never rewrite.
+    private const decimal SameBasisCloseTolerance = 0.01m;
+
+    private static bool IsSameSplitBasis(decimal storedClose, decimal fetchedClose)
+    {
+        // A guard on a non-positive close would divide meaning out of the tolerance; nothing to
+        // compare, so treat it as unproven rather than same-basis.
+        if (storedClose <= 0m || fetchedClose <= 0m)
+            return false;
+
+        // 1% is far tighter than the smallest real split ratio (5:4 moves the close 25%) and far
+        // looser than the rounding gap between a stored numeric(18,4) and the feed's own value, so
+        // it separates the two cases without ever needing the split table.
+        return Math.Abs(fetchedClose - storedClose) <= storedClose * SameBasisCloseTolerance;
+    }
 
     // The oldest date whose stored volume is still re-read. Pure so the boundary is pinnable, and
     // clamped so a zero or negative setting degrades to "today only" — which the settled-bar guard

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
@@ -174,6 +174,31 @@ public class YahooPriceImportServiceVolumeResettleTests : IDisposable
         _priceRepo.GetAll().Single(p => p.Date == previous).Volume.Should().Be(SettledVolume);
     }
 
+    [Fact]
+    public async Task Import_StoredRowOnAPostReverseSplitBasis_IsNotOverwrittenByAsTradedVolume()
+    {
+        // The corruption case. A reconciled 1:25 reverse-split row holds an adjusted close 25x
+        // larger and an adjusted volume 25x smaller than the as-traded session the feed is still
+        // serving for that date. The as-traded volume therefore always looks like a settlement
+        // upgrade, and writing it would inflate the stock's volume history by the split ratio.
+        var stock = SeedStock("PRPL");
+        var (newest, previous) = TwoMostRecentSettledSessions();
+        const decimal adjustedClose = 8.05m;
+        const long adjustedVolume = 23_560;
+        SeedPrice(stock, previous, adjustedVolume, adjustedClose);
+
+        // The feed serves that same session as-traded: close 25x smaller, volume 25x larger.
+        _yahooClient
+            .GetChart("PRPL", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(Chart(close: 0.322m, bars: [(previous, 589_000), (newest, 22_247)]));
+
+        await _service.Import(CancellationToken.None);
+
+        var stored = _priceRepo.GetAll().Single(p => p.Date == previous);
+        stored.Volume.Should().Be(adjustedVolume);
+        stored.Close.Should().Be(adjustedClose);
+    }
+
     // The two most recent settled sessions, resolved off the real calendar so the cases behave the
     // same whatever weekday the suite runs on. The service derives "today" from the clock and never
     // stores the in-progress bar, so the newest settled session is the last trading day before it.
@@ -187,16 +212,20 @@ public class YahooPriceImportServiceVolumeResettleTests : IDisposable
     }
 
     private static YahooChartData Chart(params (DateOnly Date, long Volume)[] bars) =>
+        Chart(close: 39.41m, bars);
+
+    // The close is what proves the split basis, so a case about basis has to be able to set it.
+    private static YahooChartData Chart(decimal close, (DateOnly Date, long Volume)[] bars) =>
         new()
         {
             Prices = bars.Select(b => new HistoricalPrice
                 {
                     Date = b.Date,
-                    Open = 39.57m,
-                    High = 39.70m,
-                    Low = 39.03m,
-                    Close = 39.41m,
-                    AdjustedClose = 39.41m,
+                    Open = close,
+                    High = close,
+                    Low = close,
+                    Close = close,
+                    AdjustedClose = close,
                     Volume = b.Volume,
                 })
                 .ToList(),
@@ -216,18 +245,18 @@ public class YahooPriceImportServiceVolumeResettleTests : IDisposable
         return stock;
     }
 
-    private void SeedPrice(CommonStock stock, DateOnly date, long volume)
+    private void SeedPrice(CommonStock stock, DateOnly date, long volume, decimal close = 39.41m)
     {
         _priceRepo.Add(
             new DailyStockPrice
             {
                 CommonStockId = stock.Id,
                 Date = date,
-                Open = 39.57m,
-                High = 39.70m,
-                Low = 39.03m,
-                Close = 39.41m,
-                AdjustedClose = 39.41m,
+                Open = close,
+                High = close,
+                Low = close,
+                Close = close,
+                AdjustedClose = close,
                 Volume = volume,
             }
         );

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
@@ -199,6 +199,32 @@ public class YahooPriceImportServiceVolumeResettleTests : IDisposable
         stored.Close.Should().Be(adjustedClose);
     }
 
+    [Fact]
+    public async Task Import_StoredAsTradedRowServedAdjusted_IsNotOverwrittenByAdjustedVolume()
+    {
+        // The PRE-reconcile ordering every split passes through: the split is captured at the end
+        // of the cycle whose reconcile pass already ran, so for one full cycle the stored
+        // pre-split rows are still as-traded while the feed already serves them adjusted. On a
+        // forward split the adjusted volume is ratio-times larger, so without the basis guard it
+        // would read as a settlement upgrade and leave a row with an adjusted volume under an
+        // as-traded close. Real WLFC 3:1 numbers.
+        var stock = SeedStock("WLFC");
+        var (newest, previous) = TwoMostRecentSettledSessions();
+        const decimal asTradedClose = 216.98m;
+        const long asTradedVolume = 56_300;
+        SeedPrice(stock, previous, asTradedVolume, asTradedClose);
+
+        _yahooClient
+            .GetChart("WLFC", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(Chart(close: 72.3267m, bars: [(previous, 168_879), (newest, 60_000)]));
+
+        await _service.Import(CancellationToken.None);
+
+        var storedRow = _priceRepo.GetAll().Single(p => p.Date == previous);
+        storedRow.Volume.Should().Be(asTradedVolume);
+        storedRow.Close.Should().Be(asTradedClose);
+    }
+
     // The two most recent settled sessions, resolved off the real calendar so the cases behave the
     // same whatever weekday the suite runs on. The service derives "today" from the clock and never
     // stores the in-progress bar, so the newest settled session is the last trading day before it.

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBasisGuardTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBasisGuardTests.cs
@@ -1,0 +1,82 @@
+using System.Reflection;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Pins <c>YahooPriceImportService.IsSameSplitBasis</c>, the guard that stops the volume resettle
+/// from comparing two records of the same session that sit on different split bases.
+///
+/// The stored series and the feed really do disagree. ReconcilePendingSplits rewrites a split
+/// stock's whole history onto the post-split basis while the feed keeps serving that window
+/// as-traded, so the same session exists twice on two bases — observed on WLFC's 3:1 split.
+///
+/// The failure mode this prevents is specific to REVERSE splits: they leave the stored volume
+/// SMALLER than the as-traded figure by the split ratio, so the served number always looks like a
+/// settlement upgrade and would overwrite a correctly-adjusted row, inflating that stock's volume
+/// history. Forward splits are only accidentally safe.
+/// </summary>
+public class YahooPriceImportServiceSplitBasisGuardTests
+{
+    private static readonly MethodInfo IsSameSplitBasisMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "IsSameSplitBasis",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static bool IsSameSplitBasis(decimal storedClose, decimal fetchedClose) =>
+        (bool)IsSameSplitBasisMethod.Invoke(null, [storedClose, fetchedClose]);
+
+    [Fact]
+    public void IsSameSplitBasis_ForwardSplitBases_AreRejected()
+    {
+        // Real WLFC 2026-07-14 across its 3:1 split: the stored row had been reconciled onto the
+        // post-split basis (72.3267) while the feed was still serving that session as-traded
+        // (216.98). Comparing their volumes is meaningless.
+        IsSameSplitBasis(72.3267m, 216.98m).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSameSplitBasis_ReverseSplitBases_AreRejected()
+    {
+        // The dangerous direction. A 1:25 reverse leaves the stored close 25x LARGER and the stored
+        // volume 25x SMALLER than as-traded, so without this guard the served volume always reads
+        // as an upgrade and overwrites a correct row.
+        IsSameSplitBasis(8.05m, 0.322m).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSameSplitBasis_SameBasis_IsAccepted()
+    {
+        // The ordinary case the resettle exists for: an unsplit session, same close on both sides,
+        // so the volumes describe the same thing and the higher one is a genuine settlement.
+        IsSameSplitBasis(39.41m, 39.41m).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSameSplitBasis_RoundingGap_IsStillSameBasis()
+    {
+        // The stored close is a rounded numeric(18,4) while the feed carries full precision. That
+        // gap must not read as a basis mismatch, or the resettle would silently stop correcting
+        // anything — the guard would turn into an off switch.
+        IsSameSplitBasis(39.41m, 39.409999847412109375m).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSameSplitBasis_SmallestRealSplitRatio_IsRejected()
+    {
+        // A 5:4 split moves the close 25% — the tightest real ratio, and still far outside the
+        // tolerance. Pins that the tolerance cannot be widened into admitting a split.
+        IsSameSplitBasis(80m, 100m).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSameSplitBasis_NonPositiveClose_IsRejected()
+    {
+        // Nothing to compare against, so the basis is unproven rather than matching. A zero stored
+        // close would also collapse the relative tolerance to an exact-equality test.
+        IsSameSplitBasis(0m, 39.41m).Should().BeFalse();
+        IsSameSplitBasis(39.41m, 0m).Should().BeFalse();
+        IsSameSplitBasis(-39.41m, -39.41m).Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBasisGuardTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBasisGuardTests.cs
@@ -7,14 +7,14 @@ namespace Equibles.UnitTests.Yahoo;
 /// Pins <c>YahooPriceImportService.IsSameSplitBasis</c>, the guard that stops the volume resettle
 /// from comparing two records of the same session that sit on different split bases.
 ///
-/// The stored series and the feed really do disagree. ReconcilePendingSplits rewrites a split
-/// stock's whole history onto the post-split basis while the feed keeps serving that window
-/// as-traded, so the same session exists twice on two bases — observed on WLFC's 3:1 split.
-///
-/// The failure mode this prevents is specific to REVERSE splits: they leave the stored volume
-/// SMALLER than the as-traded figure by the split ratio, so the served number always looks like a
-/// settlement upgrade and would overwrite a correctly-adjusted row, inflating that stock's volume
-/// history. Forward splits are only accidentally safe.
+/// The stored series and the feed disagree in BOTH orderings, so the guard must be
+/// direction-agnostic. Pre-reconcile — the window every split passes through, because the split is
+/// captured at the end of the same cycle whose reconcile pass already ran — the stored rows are
+/// as-traded while the feed serves them adjusted; on a forward split the adjusted volume is
+/// ratio-times larger and reads as a settlement upgrade. Post-reconcile the stored rows are
+/// adjusted while the feed can go back to serving as-traded (observed on WLFC); on a reverse split
+/// the as-traded volume is ratio-times larger and reads as an upgrade. Either way the "upgrade"
+/// would put a wrong-basis volume under the stored close, inflating history by the split ratio.
 /// </summary>
 public class YahooPriceImportServiceSplitBasisGuardTests
 {
@@ -28,21 +28,31 @@ public class YahooPriceImportServiceSplitBasisGuardTests
         (bool)IsSameSplitBasisMethod.Invoke(null, [storedClose, fetchedClose]);
 
     [Fact]
-    public void IsSameSplitBasis_ForwardSplitBases_AreRejected()
+    public void IsSameSplitBasis_StoredAdjustedServedAsTraded_IsRejected()
     {
-        // Real WLFC 2026-07-14 across its 3:1 split: the stored row had been reconciled onto the
-        // post-split basis (72.3267) while the feed was still serving that session as-traded
-        // (216.98). Comparing their volumes is meaningless.
+        // Real WLFC 2026-07-14 across its 3:1 split, post-reconcile: the stored row had been
+        // reconciled onto the adjusted basis (72.3267) while the feed went back to serving the
+        // session as-traded (216.98). Comparing their volumes is meaningless.
         IsSameSplitBasis(72.3267m, 216.98m).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSameSplitBasis_StoredAsTradedServedAdjusted_IsRejected()
+    {
+        // The same WLFC session in the PRE-reconcile ordering — the window every split passes
+        // through. The stored row is still as-traded (216.98) while the feed already serves it
+        // adjusted (72.3267), whose volume is 3x larger and would read as a settlement upgrade.
+        // This ordering is why the guard cannot be narrowed to reverse splits only.
+        IsSameSplitBasis(216.98m, 72.3267m).Should().BeFalse();
     }
 
     [Fact]
     public void IsSameSplitBasis_ReverseSplitBases_AreRejected()
     {
-        // The dangerous direction. A 1:25 reverse leaves the stored close 25x LARGER and the stored
-        // volume 25x SMALLER than as-traded, so without this guard the served volume always reads
-        // as an upgrade and overwrites a correct row.
+        // A 1:25 reverse in both orderings. Whichever side holds the as-traded close, its volume
+        // is 25x the adjusted figure — an automatic "upgrade" without the guard.
         IsSameSplitBasis(8.05m, 0.322m).Should().BeFalse();
+        IsSameSplitBasis(0.322m, 8.05m).Should().BeFalse();
     }
 
     [Fact]
@@ -54,20 +64,51 @@ public class YahooPriceImportServiceSplitBasisGuardTests
     }
 
     [Fact]
-    public void IsSameSplitBasis_RoundingGap_IsStillSameBasis()
+    public void IsSameSplitBasis_MinorRevision_IsStillSameBasis()
     {
-        // The stored close is a rounded numeric(18,4) while the feed carries full precision. That
-        // gap must not read as a basis mismatch, or the resettle would silently stop correcting
-        // anything — the guard would turn into an off switch.
-        IsSameSplitBasis(39.41m, 39.409999847412109375m).Should().BeTrue();
+        // Both closes are rounded to 4 decimals at ingest, so a same-basis pair differs only when
+        // the feed genuinely revised the close a little. A one-tick revision must not read as a
+        // basis mismatch, or the guard would silently turn the resettle into an off switch.
+        IsSameSplitBasis(39.4100m, 39.4101m).Should().BeTrue();
     }
 
     [Fact]
-    public void IsSameSplitBasis_SmallestRealSplitRatio_IsRejected()
+    public void IsSameSplitBasis_ToleranceBoundary_IsPinned()
     {
-        // A 5:4 split moves the close 25% — the tightest real ratio, and still far outside the
-        // tolerance. Pins that the tolerance cannot be widened into admitting a split.
+        // 1% relative plus one tick of absolute headroom: at a stored close of 100 the cut sits
+        // at 1.0001. Pins the boundary from both sides so the tolerance can neither silently
+        // widen toward the split ratios nor collapse into exact equality.
+        IsSameSplitBasis(100m, 101m).Should().BeTrue();
+        IsSameSplitBasis(100m, 101.01m).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSameSplitBasis_SubCentOneTickRevision_IsStillSameBasis()
+    {
+        // The tick headroom's reason to exist: below $0.005 a single last-digit tick exceeds 1%
+        // of the price, so a purely relative tolerance would freeze the resettle out of the OTC
+        // tail forever. One tick must pass; the smallest split ratio at any price still fails.
+        IsSameSplitBasis(0.0050m, 0.0051m).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSameSplitBasis_RealSplitRatios_AreRejected()
+    {
+        // The split ratios Yahoo emits for real splits sit far outside the tolerance: 5:4 moves
+        // the close 25%, 21:20 (a 5% stock dividend) 4.76%. Pinned so the tolerance can never be
+        // widened into admitting a split.
         IsSameSplitBasis(80m, 100m).Should().BeFalse();
+        IsSameSplitBasis(100m, 95.2381m).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSameSplitBasis_TinyStockDividendRatio_IsInsideTheBound()
+    {
+        // Deliberate, documented bound: a 1% stock dividend recorded as a 101:100 split moves the
+        // close 0.99% — inside the tolerance — so its volume comparison proceeds and the error is
+        // bounded at ~1%, negligible against the 10-29% unsettled shortfall being repaired. If
+        // this pin breaks because the tolerance tightened, sub-cent stocks likely broke too.
+        IsSameSplitBasis(100m, 99.0099m).Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Follow-up to #4259. The volume resettle compares a stored row against the feed's bar for the same date and takes the higher figure — but those two are not always on the same split basis, and on a **reverse split** that turns the upgrade-only rule into a corruption rule.

`ReconcilePendingSplits` rewrites a split stock's whole history onto the post-split basis, while the feed keeps serving that same window as-traded for a while. Observed live on WLFC's 3:1 split of 2026-07-20, same session on two bases:

| | Close | Volume |
|---|---|---|
| stored (adjusted) | 72.3267 | 168,879 |
| served (as-traded) | 216.98 | 56,300 |

- **Forward split** — the adjusted volume is the *larger* one, so the served figure fails the upgrade test. Safe, but only accidentally.
- **Reverse split** — a 1:25 leaves the stored volume 25× *smaller* than as-traded, so the served figure always reads as a settlement upgrade and gets written over a correctly-adjusted row, **inflating that stock's volume history by the split ratio**.

The 2026-07-20 split batch alone carries plenty of reverse splits (CCG 1:35, DFNS 1:125, PRPL 1:25, BANL 1:13, NIKI 1:10, CIIT 1:10, CDT 1:10), so this is not hypothetical — and it would have been hit hard by a widened repair window.

## Code changes

**`YahooPriceImportService`**

- `IsSameSplitBasis` proves the basis off the close before any volume comparison. A split moves price and volume by the same ratio in opposite directions, so a mismatched basis shows up as a close differing by that ratio.
- The tolerance (1%) sits far below the smallest real split ratio — a 5:4 split moves the close 25% — and far above the rounding gap between a stored `numeric(18,4)` and the feed's own full-precision value. So it separates the two cases **without needing a split-table lookup or any extra query**.
- A mismatch means *skip*, never rewrite: volume basis belongs to the split reconcile, which rewrites the series as a whole precisely so it stays on one basis.
- `ResettleVolumes` now keys the fetched bars by the whole row rather than just the volume, since the close is what proves the basis.

## Tests

- `YahooPriceImportServiceSplitBasisGuardTests` — pins both split directions with the real WLFC and PRPL numbers, the same-basis accept, the rounding-gap accept (a regression here would silently turn the resettle into an off switch), the tightest real split ratio, and non-positive closes.
- `Import_StoredRowOnAPostReverseSplitBasis_IsNotOverwrittenByAsTradedVolume` — end-to-end proof that a reconciled reverse-split row keeps its adjusted volume. Verified to fail when the guard is removed.

Full suites green: 3,824 unit, 2,278 integration. csharpier clean.