### PR TITLE
fix(sec): degrade a timed-out BM25 pass instead of failing the whole hybrid search

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using Equibles.Core.AutoWiring;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.Data.Models;
@@ -16,6 +17,9 @@ namespace Equibles.Sec.BusinessLogic.Search;
 /// with Reciprocal Rank Fusion. The semantic arm is strictly additive: if embeddings are disabled,
 /// the query can't be embedded, or the vector lookup fails, the result is the plain BM25 ranking —
 /// the searcher never throws on the vector path and never returns fewer hits than BM25 alone.
+/// A BM25 pass that blows its statement budget (<see cref="ChunkSearchTimeoutException"/>) degrades
+/// the same way — the other pass and the vector arm still run; the timeout only resurfaces when the
+/// search would otherwise return a false "no matches".
 /// </summary>
 [Service(ServiceLifetime.Scoped)]
 public class HybridChunkSearcher
@@ -96,26 +100,11 @@ public class HybridChunkSearcher
         if (maxResultsPerCompany > 0)
             bm25Limit = Math.Max(bm25Limit, maxResults * PerCompanyOverFetchFactor);
 
-        var bm25 = await _chunkRepository.HybridSearch(
-            query,
-            bm25Limit,
-            ticker,
-            excludeTickers,
-            documentId,
-            documentTypes,
-            startDate,
-            endDate,
-            cancellationToken: cancellationToken
-        );
-
-        // Opt-in recall fallback: BM25 ANDs every query token, so a wordy natural-language
-        // query where a single token has no match ("drivers" vs the filing's "driven")
-        // excludes every on-point chunk. When the conjunctive pass can't fill the request,
-        // top up from a disjunctive (any-token) pass — conjunctive hits keep their rank and
-        // the broader hits only append after them, so precise matches never lose position.
-        if (disjunctiveFallback && bm25.Count < maxResults)
+        List<Chunk> bm25;
+        ChunkSearchTimeoutException bm25Timeout = null;
+        try
         {
-            var disjunctive = await _chunkRepository.HybridSearch(
+            bm25 = await _chunkRepository.HybridSearch(
                 query,
                 bm25Limit,
                 ticker,
@@ -124,20 +113,79 @@ public class HybridChunkSearcher
                 documentTypes,
                 startDate,
                 endDate,
-                conjunctive: false,
                 cancellationToken: cancellationToken
             );
-            var seen = bm25.Select(chunk => chunk.Id).ToHashSet();
-            bm25 = bm25.Concat(disjunctive.Where(chunk => !seen.Contains(chunk.Id))).ToList();
+        }
+        catch (ChunkSearchTimeoutException exception)
+        {
+            // A cold BM25 index (first touch after a Postgres restart) can push a long
+            // conjunctive query past its statement budget. Degrade to an empty pool
+            // instead of failing the whole search: the disjunctive fallback and the
+            // corpus vector arm below can still answer — and the timed-out statement
+            // itself warmed the index pages, so they usually do. The timeout is kept so
+            // an empty final result surfaces it rather than reading as "no matches".
+            _logger.LogWarning(exception, "Conjunctive BM25 pass timed out; degrading");
+            bm25 = [];
+            bm25Timeout = exception;
+        }
+
+        // An empty result after a timed-out BM25 pass is NOT a proven "no matches" —
+        // returning it would read as "the filings say nothing about this". Surface the
+        // timeout instead; a retry hits the index pages the failed pass just warmed.
+        List<Chunk> ThrowIfEmptyAfterTimeout(List<Chunk> results)
+        {
+            if (results.Count == 0 && bm25Timeout != null)
+                ExceptionDispatchInfo.Capture(bm25Timeout).Throw();
+            return results;
+        }
+
+        // Opt-in recall fallback: BM25 ANDs every query token, so a wordy natural-language
+        // query where a single token has no match ("drivers" vs the filing's "driven")
+        // excludes every on-point chunk. When the conjunctive pass can't fill the request,
+        // top up from a disjunctive (any-token) pass — conjunctive hits keep their rank and
+        // the broader hits only append after them, so precise matches never lose position.
+        if (disjunctiveFallback && bm25.Count < maxResults)
+        {
+            try
+            {
+                var disjunctive = await _chunkRepository.HybridSearch(
+                    query,
+                    bm25Limit,
+                    ticker,
+                    excludeTickers,
+                    documentId,
+                    documentTypes,
+                    startDate,
+                    endDate,
+                    conjunctive: false,
+                    cancellationToken: cancellationToken
+                );
+                var seen = bm25.Select(chunk => chunk.Id).ToHashSet();
+                bm25 = bm25.Concat(disjunctive.Where(chunk => !seen.Contains(chunk.Id))).ToList();
+                // The disjunctive pass matches a superset of the conjunctive pass, so its
+                // completed result also answers for a timed-out conjunctive pass — an
+                // empty pool now genuinely means "no matches", not "ran out of budget".
+                bm25Timeout = null;
+            }
+            catch (ChunkSearchTimeoutException exception)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "Disjunctive BM25 fallback timed out; keeping the conjunctive results"
+                );
+                bm25Timeout ??= exception;
+            }
         }
 
         // With only the pool re-rank available, an empty BM25 pool leaves the semantic arm
         // nothing to work on; with the corpus arm safe (Table mode, any document scope, or
         // Auto + ticker scope) the vector ranking can carry the result alone.
         if (!semanticActive || (bm25.Count == 0 && !corpusArmSafe))
-            return ApplyPoolControls(bm25, excludeTickers, documentTypes, maxResultsPerCompany)
-                .Take(maxResults)
-                .ToList();
+            return ThrowIfEmptyAfterTimeout(
+                ApplyPoolControls(bm25, excludeTickers, documentTypes, maxResultsPerCompany)
+                    .Take(maxResults)
+                    .ToList()
+            );
 
         // Bound the whole semantic arm: the global search aggregator abandons a slow provider but
         // doesn't cancel it, and the embedding server is shared with the backfill — so cap the
@@ -159,9 +207,11 @@ public class HybridChunkSearcher
             semanticCts.Token
         );
         if (vectorIds.Count == 0)
-            return ApplyPoolControls(bm25, excludeTickers, documentTypes, maxResultsPerCompany)
-                .Take(maxResults)
-                .ToList();
+            return ThrowIfEmptyAfterTimeout(
+                ApplyPoolControls(bm25, excludeTickers, documentTypes, maxResultsPerCompany)
+                    .Take(maxResults)
+                    .ToList()
+            );
 
         var bm25Ids = bm25.Select(chunk => chunk.Id).ToList();
         // Fuse the full pool (not just maxResults): the pool controls below discard
@@ -169,9 +219,11 @@ public class HybridChunkSearcher
         var fusedIds = RrfFusion.Fuse([bm25Ids, vectorIds], _options.RrfK).ToList();
 
         var fused = await MaterializeInOrder(fusedIds, bm25, cancellationToken);
-        return ApplyPoolControls(fused, excludeTickers, documentTypes, maxResultsPerCompany)
-            .Take(maxResults)
-            .ToList();
+        return ThrowIfEmptyAfterTimeout(
+            ApplyPoolControls(fused, excludeTickers, documentTypes, maxResultsPerCompany)
+                .Take(maxResults)
+                .ToList()
+        );
     }
 
     // The pool controls, re-applied AFTER fusion: the BM25 arm already resolves

--- a/src/Equibles.Sec.Repositories/ChunkRepository.cs
+++ b/src/Equibles.Sec.Repositories/ChunkRepository.cs
@@ -3,6 +3,7 @@ using Equibles.ParadeDB.EntityFrameworkCore;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Data.Models.Chunks;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace Equibles.Sec.Repositories;
 
@@ -134,9 +135,40 @@ public class ChunkRepository : BaseRepository<Chunk>
                 .Take(maxResults)
                 .ToListAsync(cancellationToken);
         }
+        catch (Exception exception)
+            when (exception is not OperationCanceledException && IsStatementTimeout(exception))
+        {
+            // The hard CommandTimeout above fired (a cold BM25 index after a Postgres
+            // restart can push a long multi-term query past the budget). Surface it as a
+            // typed timeout so callers can degrade — run another pass, let the vector arm
+            // answer — instead of failing the whole search, and so an empty result is
+            // never conflated with "no matches".
+            throw new ChunkSearchTimeoutException(
+                $"BM25 chunk search exceeded its {HybridSearchCommandTimeoutSeconds}s statement budget.",
+                exception
+            );
+        }
         finally
         {
             DbContext.Database.SetCommandTimeout(originalTimeout);
         }
+    }
+
+    // Npgsql surfaces its CommandTimeout-triggered cancellation either as the raw backend
+    // error (PostgresException 57014 "canceling statement due to user request") or wrapped
+    // in an NpgsqlException with a TimeoutException inside, depending on where in the read
+    // loop the cancel lands — walk the chain and match both shapes. A caller-requested
+    // cancellation surfaces as OperationCanceledException and is excluded at the catch site.
+    private static bool IsStatementTimeout(Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is PostgresException { SqlState: PostgresErrorCodes.QueryCanceled })
+                return true;
+            if (current is TimeoutException)
+                return true;
+        }
+
+        return false;
     }
 }

--- a/src/Equibles.Sec.Repositories/ChunkSearchTimeoutException.cs
+++ b/src/Equibles.Sec.Repositories/ChunkSearchTimeoutException.cs
@@ -1,0 +1,13 @@
+namespace Equibles.Sec.Repositories;
+
+/// <summary>
+/// The BM25 chunk search hit its per-statement command timeout (Postgres cancelled the
+/// statement). Distinct from an unknown fault so callers can degrade — run another pass, let
+/// the vector arm answer — and distinct from an empty result, which would read as "the
+/// filings say nothing about this" when the search in fact never finished.
+/// </summary>
+public class ChunkSearchTimeoutException : Exception
+{
+    public ChunkSearchTimeoutException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherBm25TimeoutTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherBm25TimeoutTests.cs
@@ -1,0 +1,139 @@
+using Equibles.Sec.BusinessLogic.Embeddings;
+using Equibles.Sec.BusinessLogic.Search;
+using Equibles.Sec.Data.Models.Chunks;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+// A BM25 pass that blows its statement budget (ChunkSearchTimeoutException — a cold index
+// after a Postgres restart) must DEGRADE, not fail the whole search: the disjunctive
+// fallback and the corpus vector arm still run. The timeout only resurfaces when the search
+// would otherwise return empty — an unproven empty would read as "the filings say nothing
+// about this", the exact lie the searcher exists to avoid.
+public class HybridChunkSearcherBm25TimeoutTests
+{
+    [Fact]
+    public async Task ConjunctiveTimeout_DisjunctiveFallbackCarriesTheResult()
+    {
+        var chunk = new Chunk { Id = Guid.NewGuid(), Content = "broadened match" };
+        var chunkRepository = new TimeoutChunkRepository(
+            conjunctiveTimesOut: true,
+            disjunctiveResults: [chunk],
+            allChunks: [chunk]
+        );
+        var searcher = NewSearcher(chunkRepository, new StubEmbeddingRepository([]));
+
+        var results = await searcher.Search(
+            "long natural language query",
+            5,
+            disjunctiveFallback: true
+        );
+
+        Assert.Single(results);
+        Assert.Equal(chunk.Id, results[0].Id);
+    }
+
+    [Fact]
+    public async Task ConjunctiveTimeout_TickerScoped_CorpusVectorArmCarriesTheResult()
+    {
+        var chunk = new Chunk
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Content = "semantic match",
+        };
+        var chunkRepository = new TimeoutChunkRepository(
+            conjunctiveTimesOut: true,
+            allChunks: [chunk]
+        );
+        var embeddingRepository = new StubEmbeddingRepository(similarChunkIds: [chunk.Id]);
+        var searcher = NewSearcher(chunkRepository, embeddingRepository);
+
+        var results = await searcher.Search("purely semantic question", 5, ticker: "AAPL");
+
+        Assert.Single(results);
+        Assert.Equal(chunk.Id, results[0].Id);
+        Assert.True(embeddingRepository.SearchSimilarChunksCalled);
+    }
+
+    [Fact]
+    public async Task ConjunctiveSucceeds_DisjunctiveTimeout_KeepsTheConjunctiveResults()
+    {
+        var chunk = new Chunk { Id = Guid.NewGuid(), Content = "precise match" };
+        var chunkRepository = new TimeoutChunkRepository(
+            disjunctiveTimesOut: true,
+            conjunctiveResults: [chunk],
+            allChunks: [chunk]
+        );
+        var searcher = NewSearcher(chunkRepository, new StubEmbeddingRepository([]));
+
+        var results = await searcher.Search("query", 5, disjunctiveFallback: true);
+
+        Assert.Single(results);
+        Assert.Equal(chunk.Id, results[0].Id);
+    }
+
+    [Fact]
+    public async Task ConjunctiveTimeout_DisjunctiveCompletesEmpty_ReturnsProvenEmptyWithoutThrowing()
+    {
+        // The disjunctive pass matches a SUPERSET of the conjunctive pass — when it
+        // completes with nothing, "no matches" is proven and the earlier timeout is moot.
+        var chunkRepository = new TimeoutChunkRepository(conjunctiveTimesOut: true);
+        var searcher = NewSearcher(chunkRepository, new StubEmbeddingRepository([]));
+
+        var results = await searcher.Search("query matching nothing", 5, disjunctiveFallback: true);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task AllPassesTimeout_Unscoped_SurfacesTheTimeoutInsteadOfAFalseEmpty()
+    {
+        var chunkRepository = new TimeoutChunkRepository(
+            conjunctiveTimesOut: true,
+            disjunctiveTimesOut: true
+        );
+        var searcher = NewSearcher(chunkRepository, new StubEmbeddingRepository([]));
+
+        await Assert.ThrowsAsync<ChunkSearchTimeoutException>(() =>
+            searcher.Search("long query", 5, disjunctiveFallback: true)
+        );
+    }
+
+    [Fact]
+    public async Task ConjunctiveTimeout_TickerScoped_CorpusArmEmpty_SurfacesTheTimeout()
+    {
+        // The vector arm ran but produced nothing to rank — the empty result is still
+        // unproven, so the timeout must surface rather than read as "no matches".
+        var chunkRepository = new TimeoutChunkRepository(conjunctiveTimesOut: true);
+        var searcher = NewSearcher(chunkRepository, new StubEmbeddingRepository([]));
+
+        await Assert.ThrowsAsync<ChunkSearchTimeoutException>(() =>
+            searcher.Search("semantic question", 5, ticker: "AAPL")
+        );
+    }
+
+    private static HybridChunkSearcher NewSearcher(
+        ChunkRepository chunkRepository,
+        EmbeddingRepository embeddingRepository
+    )
+    {
+        var embeddingClient = Substitute.For<IEmbeddingClient>();
+        embeddingClient.IsEnabled.Returns(true);
+        embeddingClient
+            .GenerateEmbedding(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new float[] { 0.1f, 0.2f }));
+
+        return new HybridChunkSearcher(
+            chunkRepository,
+            embeddingRepository,
+            embeddingClient,
+            Options.Create(new HybridSearchOptions()),
+            Options.Create(new EmbeddingConfig { ModelName = "test-model" }),
+            NullLogger<HybridChunkSearcher>.Instance
+        );
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherTestHarness.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherTestHarness.cs
@@ -41,6 +41,56 @@ internal sealed class StubChunkRepository : ChunkRepository
     public override IQueryable<Chunk> GetAll() => new TestAsyncEnumerable<Chunk>(_allChunks);
 }
 
+// BM25 stub whose passes can individually time out — models the cold-index case where the
+// per-statement budget fires. A pass that doesn't time out serves its canned results.
+internal sealed class TimeoutChunkRepository : ChunkRepository
+{
+    private readonly bool _conjunctiveTimesOut;
+    private readonly bool _disjunctiveTimesOut;
+    private readonly List<Chunk> _conjunctiveResults;
+    private readonly List<Chunk> _disjunctiveResults;
+    private readonly List<Chunk> _allChunks;
+
+    public TimeoutChunkRepository(
+        bool conjunctiveTimesOut = false,
+        bool disjunctiveTimesOut = false,
+        List<Chunk> conjunctiveResults = null,
+        List<Chunk> disjunctiveResults = null,
+        List<Chunk> allChunks = null
+    )
+        : base(null)
+    {
+        _conjunctiveTimesOut = conjunctiveTimesOut;
+        _disjunctiveTimesOut = disjunctiveTimesOut;
+        _conjunctiveResults = conjunctiveResults ?? [];
+        _disjunctiveResults = disjunctiveResults ?? [];
+        _allChunks = allChunks ?? [];
+    }
+
+    public override Task<List<Chunk>> HybridSearch(
+        string searchText,
+        int maxResults,
+        string ticker = null,
+        IReadOnlyCollection<string> excludeTickers = null,
+        Guid? documentId = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
+        DateOnly? startDate = null,
+        DateOnly? endDate = null,
+        bool conjunctive = true,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (conjunctive ? _conjunctiveTimesOut : _disjunctiveTimesOut)
+            throw new ChunkSearchTimeoutException(
+                "statement budget elapsed",
+                new TimeoutException()
+            );
+        return Task.FromResult(conjunctive ? _conjunctiveResults : _disjunctiveResults);
+    }
+
+    public override IQueryable<Chunk> GetAll() => new TestAsyncEnumerable<Chunk>(_allChunks);
+}
+
 internal sealed class StubEmbeddingRepository : EmbeddingRepository
 {
     private readonly List<Guid> _similarChunkIds;


### PR DESCRIPTION
## Summary

Production MCP calls (`SearchCompanyDocuments`) started failing with `Npgsql.PostgresException 57014: canceling statement due to user request` after a Postgres restart. The 57014 is our own doing: `ChunkRepository.HybridSearch` pins a deliberate 5s `CommandTimeout` on the BM25 statement (pdb.parse/pdb.score ignore the cancellation token), and on a cold BM25 index a long multi-term conjunctive query blows that budget — measured 6.2s cold vs 96ms warm for the identical query on the production corpus. The exception escaped unhandled, so one slow pass hard-failed the whole search even though the disjunctive fallback (1.25s) and the corpus vector arm could still have answered.

## Code changes

- **`ChunkSearchTimeoutException`** (new, `Equibles.Sec.Repositories`) — typed signal that the BM25 statement budget fired, distinct from an unknown fault and from a genuine empty result.
- **`ChunkRepository.HybridSearch`** — catches the CommandTimeout shapes (`PostgresException` 57014 or a `TimeoutException` anywhere in the chain; `OperationCanceledException` excluded so caller cancellation still propagates as cancellation) and rethrows the typed exception.
- **`HybridChunkSearcher.Search`** — a timed-out conjunctive pass degrades to an empty pool and the search continues (disjunctive fallback + vector arm); a timed-out disjunctive fallback keeps the conjunctive results. A completed disjunctive pass clears the timeout (it matches a superset, so its result proves the conjunctive answer too). The timeout only resurfaces when the final result would be empty — returning an unproven empty would read as "the filings say nothing about this".
- **Tests** — `HybridChunkSearcherBm25TimeoutTests` (6 cases: fallback carries the result, vector arm carries the result, disjunctive timeout keeps conjunctive results, proven empty returns without throwing, all-passes-timeout surfaces the timeout, empty-vector-arm surfaces the timeout) + a `TimeoutChunkRepository` stub in the shared harness.

No behavior change for searches that stay inside the budget. The 5s per-statement budget itself is unchanged — worst case is still 2×5s per call, and the failed statement warms the index pages so the surviving passes usually succeed.