### PR TITLE
fix(sec): harden the BM25 timeout degrade — precise classification, bounded fallback budget

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
@@ -19,7 +19,11 @@ namespace Equibles.Sec.BusinessLogic.Search;
 /// the searcher never throws on the vector path and never returns fewer hits than BM25 alone.
 /// A BM25 pass that blows its statement budget (<see cref="ChunkSearchTimeoutException"/>) degrades
 /// the same way — the other pass and the vector arm still run; the timeout only resurfaces when the
-/// search would otherwise return a false "no matches".
+/// search would otherwise return a false "no matches". A non-empty degraded result may therefore be
+/// semantic-only (the keyword passes timed out while the vector arm answered) — that trade is
+/// accepted deliberately: a somewhat weaker ranking beats an error, and the warning log is the
+/// trace. The pass after a timed-out pass runs on a tighter statement budget, so one search can
+/// never hold a connection for much more than a single full budget plus that reduced one.
 /// </summary>
 [Service(ServiceLifetime.Scoped)]
 public class HybridChunkSearcher
@@ -52,6 +56,13 @@ public class HybridChunkSearcher
     // discards a dominant filer's surplus hits, so the pool must hold enough distinct
     // companies to refill the requested result count.
     private const int PerCompanyOverFetchFactor = 5;
+
+    // Statement budget for a BM25 pass that runs AFTER another pass already timed out.
+    // The timed-out pass warmed the index pages it died on (measured on the production
+    // corpus: 6.2s cold vs 1.25s for the warm disjunctive pass), so a tighter budget
+    // still lets the degrade succeed while bounding what one search can pin a database
+    // connection for — the pair can never burn more than one full budget plus this.
+    private const int DegradedPassTimeoutSeconds = 3;
 
     public async Task<List<Chunk>> Search(
         string query,
@@ -129,16 +140,6 @@ public class HybridChunkSearcher
             bm25Timeout = exception;
         }
 
-        // An empty result after a timed-out BM25 pass is NOT a proven "no matches" —
-        // returning it would read as "the filings say nothing about this". Surface the
-        // timeout instead; a retry hits the index pages the failed pass just warmed.
-        List<Chunk> ThrowIfEmptyAfterTimeout(List<Chunk> results)
-        {
-            if (results.Count == 0 && bm25Timeout != null)
-                ExceptionDispatchInfo.Capture(bm25Timeout).Throw();
-            return results;
-        }
-
         // Opt-in recall fallback: BM25 ANDs every query token, so a wordy natural-language
         // query where a single token has no match ("drivers" vs the filing's "driven")
         // excludes every on-point chunk. When the conjunctive pass can't fill the request,
@@ -158,6 +159,10 @@ public class HybridChunkSearcher
                     startDate,
                     endDate,
                     conjunctive: false,
+                    // After a timed-out conjunctive pass the fallback runs on the pages
+                    // that pass just warmed — tighten its budget so the pair stays
+                    // bounded (see DegradedPassTimeoutSeconds).
+                    commandTimeoutSeconds: bm25Timeout != null ? DegradedPassTimeoutSeconds : null,
                     cancellationToken: cancellationToken
                 );
                 var seen = bm25.Select(chunk => chunk.Id).ToHashSet();
@@ -175,6 +180,18 @@ public class HybridChunkSearcher
                 );
                 bm25Timeout ??= exception;
             }
+        }
+
+        // An empty result after a timed-out BM25 pass is NOT a proven "no matches" —
+        // returning it would read as "the filings say nothing about this". Surface the
+        // timeout instead; a retry hits the index pages the failed passes just warmed.
+        // Declared below the fallback block on purpose: it reads bm25Timeout at call
+        // time, and every mutation of that variable happens above this line.
+        List<Chunk> ThrowIfEmptyAfterTimeout(List<Chunk> results)
+        {
+            if (results.Count == 0 && bm25Timeout != null)
+                ExceptionDispatchInfo.Capture(bm25Timeout).Throw();
+            return results;
         }
 
         // With only the pool re-rank available, an empty BM25 pool leaves the semantic arm

--- a/src/Equibles.Sec.Repositories/ChunkRepository.cs
+++ b/src/Equibles.Sec.Repositories/ChunkRepository.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Equibles.Data;
 using Equibles.ParadeDB.EntityFrameworkCore;
 using Equibles.Sec.Data.Models;
@@ -20,6 +21,8 @@ public class ChunkRepository : BaseRepository<Chunk>
         : base(dbContext) { }
 
     // virtual: unit tests stub the search seam by subclassing (no BM25 index in a unit run).
+    // commandTimeoutSeconds overrides the default statement budget for this one call — the
+    // searcher tightens it on a degrade pass that follows an already timed-out pass.
     public virtual async Task<List<Chunk>> HybridSearch(
         string searchText,
         int maxResults,
@@ -30,6 +33,7 @@ public class ChunkRepository : BaseRepository<Chunk>
         DateOnly? startDate = null,
         DateOnly? endDate = null,
         bool conjunctive = true,
+        int? commandTimeoutSeconds = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -126,8 +130,10 @@ public class ChunkRepository : BaseRepository<Chunk>
         // statement independently of pdb.parse / pdb.score honouring the
         // cancellation token, then restore the prior value so other queries
         // sharing this DbContext are not affected.
+        var timeoutSeconds = commandTimeoutSeconds ?? HybridSearchCommandTimeoutSeconds;
         var originalTimeout = DbContext.Database.GetCommandTimeout();
-        DbContext.Database.SetCommandTimeout(HybridSearchCommandTimeoutSeconds);
+        DbContext.Database.SetCommandTimeout(timeoutSeconds);
+        var stopwatch = Stopwatch.StartNew();
         try
         {
             return await query
@@ -136,7 +142,10 @@ public class ChunkRepository : BaseRepository<Chunk>
                 .ToListAsync(cancellationToken);
         }
         catch (Exception exception)
-            when (exception is not OperationCanceledException && IsStatementTimeout(exception))
+            when (exception is not OperationCanceledException
+                && !cancellationToken.IsCancellationRequested
+                && IsStatementTimeout(exception, stopwatch.Elapsed, timeoutSeconds)
+            )
         {
             // The hard CommandTimeout above fired (a cold BM25 index after a Postgres
             // restart can push a long multi-term query past the budget). Surface it as a
@@ -144,7 +153,7 @@ public class ChunkRepository : BaseRepository<Chunk>
             // answer — instead of failing the whole search, and so an empty result is
             // never conflated with "no matches".
             throw new ChunkSearchTimeoutException(
-                $"BM25 chunk search exceeded its {HybridSearchCommandTimeoutSeconds}s statement budget.",
+                $"BM25 chunk search exceeded its {timeoutSeconds}s statement budget.",
                 exception
             );
         }
@@ -154,18 +163,34 @@ public class ChunkRepository : BaseRepository<Chunk>
         }
     }
 
+    // How far past the statement budget an elapsed run may land and still be attributed to
+    // it (the cancel round-trip adds a moment). Anything slower is some other wait.
+    private const int StatementTimeoutSlackSeconds = 2;
+
     // Npgsql surfaces its CommandTimeout-triggered cancellation either as the raw backend
     // error (PostgresException 57014 "canceling statement due to user request") or wrapped
     // in an NpgsqlException with a TimeoutException inside, depending on where in the read
-    // loop the cancel lands — walk the chain and match both shapes. A caller-requested
-    // cancellation surfaces as OperationCanceledException and is excluded at the catch site.
-    private static bool IsStatementTimeout(Exception exception)
+    // loop the cancel lands — walk the chain and match both shapes. The bare-TimeoutException
+    // shape is only trusted when the run actually lasted about the statement budget: a pool
+    // exhaustion or connect timeout carries the same TimeoutException but elapses on the
+    // connection-string timeout (15s default), and relabelling THAT as the statement budget
+    // would send the caller into a doomed degrade pass against a database it cannot reach.
+    // A caller-requested cancellation surfaces as OperationCanceledException (or trips the
+    // token) and is excluded at the catch site.
+    // internal: the classification rules are pinned by unit tests.
+    internal static bool IsStatementTimeout(
+        Exception exception,
+        TimeSpan elapsed,
+        int budgetSeconds
+    )
     {
+        var withinBudgetWindow =
+            elapsed <= TimeSpan.FromSeconds(budgetSeconds + StatementTimeoutSlackSeconds);
         for (var current = exception; current != null; current = current.InnerException)
         {
             if (current is PostgresException { SqlState: PostgresErrorCodes.QueryCanceled })
                 return true;
-            if (current is TimeoutException)
+            if (current is TimeoutException && withinBudgetWindow)
                 return true;
         }
 

--- a/src/Equibles.Sec.Repositories/Equibles.Sec.Repositories.csproj
+++ b/src/Equibles.Sec.Repositories/Equibles.Sec.Repositories.csproj
@@ -3,4 +3,8 @@
     <ProjectReference Include="..\Equibles.Sec.Data\Equibles.Sec.Data.csproj" />
     <ProjectReference Include="..\Equibles.Search.Abstractions\Equibles.Search.Abstractions.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- The statement-timeout classification rules are pinned by unit tests. -->
+    <InternalsVisibleTo Include="Equibles.UnitTests" />
+  </ItemGroup>
 </Project>

--- a/tests/Equibles.UnitTests/Sec/ChunkRepositoryStatementTimeoutClassificationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ChunkRepositoryStatementTimeoutClassificationTests.cs
@@ -1,0 +1,92 @@
+using Equibles.Sec.Repositories;
+using Npgsql;
+
+namespace Equibles.UnitTests.Sec;
+
+// Pins ChunkRepository's statement-timeout classification: the backend 57014 is definitive,
+// a bare TimeoutException only counts when the run actually elapsed about the statement
+// budget (a pool-exhaustion or connect timeout carries the same TimeoutException but waits
+// on the 15s connection-string timeout — relabelling THAT as the statement budget would
+// send callers into a doomed degrade pass), and other Postgres faults never classify.
+public class ChunkRepositoryStatementTimeoutClassificationTests
+{
+    private const int BudgetSeconds = 5;
+
+    [Fact]
+    public void QueryCanceled_Classifies_RegardlessOfElapsed()
+    {
+        var canceled = NewPostgresException(PostgresErrorCodes.QueryCanceled);
+
+        Assert.True(
+            ChunkRepository.IsStatementTimeout(canceled, TimeSpan.FromSeconds(30), BudgetSeconds)
+        );
+    }
+
+    [Fact]
+    public void QueryCanceled_WrappedInAProviderException_Classifies()
+    {
+        var wrapped = new InvalidOperationException(
+            "An exception occurred while reading",
+            NewPostgresException(PostgresErrorCodes.QueryCanceled)
+        );
+
+        Assert.True(
+            ChunkRepository.IsStatementTimeout(wrapped, TimeSpan.FromSeconds(5), BudgetSeconds)
+        );
+    }
+
+    [Fact]
+    public void TimeoutException_AtTheBudget_Classifies()
+    {
+        // Npgsql's own CommandTimeout shape: NpgsqlException wrapping a TimeoutException,
+        // thrown right around the statement budget.
+        var commandTimeout = new NpgsqlException(
+            "Exception while reading from stream",
+            new TimeoutException("Timeout during reading attempt")
+        );
+
+        Assert.True(
+            ChunkRepository.IsStatementTimeout(
+                commandTimeout,
+                TimeSpan.FromSeconds(BudgetSeconds + 1),
+                BudgetSeconds
+            )
+        );
+    }
+
+    [Fact]
+    public void TimeoutException_LongAfterTheBudget_DoesNotClassify()
+    {
+        // The pool-exhaustion / connect-timeout shape: same TimeoutException inside, but
+        // it elapses on the 15s connection-string timeout, far past the statement budget.
+        var poolExhausted = new NpgsqlException(
+            "The connection pool has been exhausted",
+            new TimeoutException()
+        );
+
+        Assert.False(
+            ChunkRepository.IsStatementTimeout(
+                poolExhausted,
+                TimeSpan.FromSeconds(15),
+                BudgetSeconds
+            )
+        );
+    }
+
+    [Fact]
+    public void OtherPostgresFault_DoesNotClassify()
+    {
+        var undefinedTable = NewPostgresException(PostgresErrorCodes.UndefinedTable);
+
+        Assert.False(
+            ChunkRepository.IsStatementTimeout(
+                undefinedTable,
+                TimeSpan.FromSeconds(1),
+                BudgetSeconds
+            )
+        );
+    }
+
+    private static PostgresException NewPostgresException(string sqlState) =>
+        new("message", "ERROR", "ERROR", sqlState);
+}

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherBm25TimeoutTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherBm25TimeoutTests.cs
@@ -104,6 +104,58 @@ public class HybridChunkSearcherBm25TimeoutTests
     }
 
     [Fact]
+    public async Task ConjunctiveCompletesEmpty_DisjunctiveTimeout_SurfacesTheTimeout()
+    {
+        // The conjunctive pass proved nothing (its empty is a SUBSET question — the
+        // disjunctive superset might still have matched), so a timed-out fallback leaves
+        // the empty unproven and the timeout must surface.
+        var chunkRepository = new TimeoutChunkRepository(disjunctiveTimesOut: true);
+        var searcher = NewSearcher(chunkRepository, new StubEmbeddingRepository([]));
+
+        await Assert.ThrowsAsync<ChunkSearchTimeoutException>(() =>
+            searcher.Search("query", 5, disjunctiveFallback: true)
+        );
+    }
+
+    [Fact]
+    public async Task NonTimeoutFault_EscapesUntouched()
+    {
+        // The degrade is strictly for timeouts — a real fault must not be swallowed
+        // into an empty pool.
+        var chunkRepository = new TimeoutChunkRepository(
+            conjunctiveError: new InvalidOperationException("index corrupt")
+        );
+        var searcher = NewSearcher(chunkRepository, new StubEmbeddingRepository([]));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            searcher.Search("query", 5, disjunctiveFallback: true)
+        );
+        Assert.Empty(chunkRepository.DisjunctiveBudgets);
+    }
+
+    [Fact]
+    public async Task ConjunctiveTimeout_FallbackRunsOnTheTightenedBudget()
+    {
+        // The pass after a timed-out pass gets a reduced statement budget so the pair
+        // stays bounded; a fallback after a HEALTHY short pass keeps the default.
+        var chunk = new Chunk { Id = Guid.NewGuid(), Content = "broadened match" };
+        var timedOut = new TimeoutChunkRepository(
+            conjunctiveTimesOut: true,
+            disjunctiveResults: [chunk],
+            allChunks: [chunk]
+        );
+        await NewSearcher(timedOut, new StubEmbeddingRepository([]))
+            .Search("query", 5, disjunctiveFallback: true);
+
+        var healthy = new TimeoutChunkRepository(disjunctiveResults: [chunk], allChunks: [chunk]);
+        await NewSearcher(healthy, new StubEmbeddingRepository([]))
+            .Search("query", 5, disjunctiveFallback: true);
+
+        Assert.NotNull(Assert.Single(timedOut.DisjunctiveBudgets));
+        Assert.Null(Assert.Single(healthy.DisjunctiveBudgets));
+    }
+
+    [Fact]
     public async Task ConjunctiveTimeout_TickerScoped_CorpusArmEmpty_SurfacesTheTimeout()
     {
         // The vector arm ran but produced nothing to rank — the empty result is still

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherTestHarness.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherTestHarness.cs
@@ -32,6 +32,7 @@ internal sealed class StubChunkRepository : ChunkRepository
         DateOnly? startDate = null,
         DateOnly? endDate = null,
         bool conjunctive = true,
+        int? commandTimeoutSeconds = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -41,19 +42,27 @@ internal sealed class StubChunkRepository : ChunkRepository
     public override IQueryable<Chunk> GetAll() => new TestAsyncEnumerable<Chunk>(_allChunks);
 }
 
-// BM25 stub whose passes can individually time out — models the cold-index case where the
-// per-statement budget fires. A pass that doesn't time out serves its canned results.
+// BM25 stub whose passes can individually time out (or fault with an arbitrary exception) —
+// models the cold-index case where the per-statement budget fires. A pass that doesn't fail
+// serves its canned results, and every pass records the statement budget it was handed so
+// tests can pin the tightened degrade budget.
 internal sealed class TimeoutChunkRepository : ChunkRepository
 {
     private readonly bool _conjunctiveTimesOut;
     private readonly bool _disjunctiveTimesOut;
+    private readonly Exception _conjunctiveError;
     private readonly List<Chunk> _conjunctiveResults;
     private readonly List<Chunk> _disjunctiveResults;
     private readonly List<Chunk> _allChunks;
 
+    public List<int?> ConjunctiveBudgets { get; } = [];
+
+    public List<int?> DisjunctiveBudgets { get; } = [];
+
     public TimeoutChunkRepository(
         bool conjunctiveTimesOut = false,
         bool disjunctiveTimesOut = false,
+        Exception conjunctiveError = null,
         List<Chunk> conjunctiveResults = null,
         List<Chunk> disjunctiveResults = null,
         List<Chunk> allChunks = null
@@ -62,6 +71,7 @@ internal sealed class TimeoutChunkRepository : ChunkRepository
     {
         _conjunctiveTimesOut = conjunctiveTimesOut;
         _disjunctiveTimesOut = disjunctiveTimesOut;
+        _conjunctiveError = conjunctiveError;
         _conjunctiveResults = conjunctiveResults ?? [];
         _disjunctiveResults = disjunctiveResults ?? [];
         _allChunks = allChunks ?? [];
@@ -77,9 +87,13 @@ internal sealed class TimeoutChunkRepository : ChunkRepository
         DateOnly? startDate = null,
         DateOnly? endDate = null,
         bool conjunctive = true,
+        int? commandTimeoutSeconds = null,
         CancellationToken cancellationToken = default
     )
     {
+        (conjunctive ? ConjunctiveBudgets : DisjunctiveBudgets).Add(commandTimeoutSeconds);
+        if (conjunctive && _conjunctiveError != null)
+            throw _conjunctiveError;
         if (conjunctive ? _conjunctiveTimesOut : _disjunctiveTimesOut)
             throw new ChunkSearchTimeoutException(
                 "statement budget elapsed",


### PR DESCRIPTION
## Summary

Review follow-up to #4261. Two behavioural tightenings: (1) the statement-timeout classifier no longer swallows connection-level faults — a bare `TimeoutException` in the chain only classifies when the run actually elapsed about the statement budget, so pool exhaustion / connect timeouts (which wait on the 15s connection-string timeout) propagate untouched instead of triggering a doomed degrade pass; (2) the degrade pass that follows an already timed-out pass runs on a tightened 3s budget, bounding what one search can pin a DB connection for at ~8s instead of 2×5s (the failed pass warmed the index pages — measured 1.25s warm vs 6.2s cold on the production corpus — so the degrade still succeeds).

## Code changes

- `ChunkRepository` — `HybridSearch` gains an optional `commandTimeoutSeconds` override; the catch filter also excludes a tripped cancellation token; `IsStatementTimeout(exception, elapsed, budget)` is elapsed-gated for the TimeoutException shape and internal (pinned by tests via `InternalsVisibleTo`).
- `HybridChunkSearcher` — passes the tightened budget to a fallback that follows a timeout; the empty-after-timeout guard moved below the fallback block it depends on; the class doc states the partial-degrade contract (a non-empty degraded result may be semantic-only).
- Tests — `ChunkRepositoryStatementTimeoutClassificationTests` (5 rules), plus three searcher cases: conjunctive-empty + disjunctive-timeout throws (the unproven empty), a non-timeout fault escapes untouched, and the fallback budget is tightened only after a timeout.