### PR TITLE
feat(holdings): keep the identifiers filed with every other-manager name

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -113,6 +113,7 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
             .IncludeProperties(h => new { h.Shares, h.Value });
 
         builder.Entity<UnmappedCusip>();
+        builder.Entity<FilingOtherManager>();
         builder.Entity<ProcessedDataSet>();
         builder.Entity<ProcessedFiling>();
         builder.Entity<InstitutionalFiling>();

--- a/src/Equibles.Holdings.Data/Models/FilingOtherManager.cs
+++ b/src/Equibles.Holdings.Data/Models/FilingOtherManager.cs
@@ -1,0 +1,82 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Data.Models;
+
+/// <summary>
+/// One manager a 13F filing names besides the filer itself, with the identifiers the SEC filed
+/// alongside the name. The filing-level half of the manager split: a position's per-manager legs
+/// live on <see cref="HoldingManagerEntry"/> and carry only a sequence number, and this table is
+/// what turns that number into an institution.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A large holding company does not file one 13F per subsidiary. It files a single combination
+/// report covering all of them and attributes each position to a numbered entry in its
+/// other-manager table — so Goldman Sachs Group's filing carries eight managers, and every
+/// position it reports points at one of them. Without the identifiers, that structure is invisible:
+/// a holder row is one opaque total, and the subsidiary that actually holds the shares cannot be
+/// linked to its own filings.
+/// </para>
+/// <para>
+/// The names alone are not enough to recover it. Matching institutions on name is guesswork that
+/// silently merges unrelated firms, so only the filed identifiers are stored and only they are
+/// joined on: CIK first, then the Form 13F file number, then the CRD. The SEC lets all three be
+/// blank, which is why a row can carry a name and nothing else — such a row is displayable but not
+/// linkable, and that is the intended outcome rather than a reason to fall back to name matching.
+/// </para>
+/// <para>
+/// Rows are replaced per accession on every import, so a re-import restates a filing's list rather
+/// than duplicating it. They are never swept for accessions outside the import: a "new holdings"
+/// amendment leaves a holder's quarter spanning several accessions, and the positions that kept the
+/// original's accession still need its manager list to resolve.
+/// </para>
+/// </remarks>
+[Index(nameof(AccessionNumber))]
+[Index(nameof(Cik))]
+public class FilingOtherManager
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>The filing that named this manager.</summary>
+    [Required]
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    /// <summary>Which page of the filing named it, and so which way the relationship points.</summary>
+    public OtherManagerDirection Direction { get; set; }
+
+    /// <summary>
+    /// For <see cref="OtherManagerDirection.IncludedInReport"/>, the filing's own sequence number —
+    /// the value a position's <see cref="HoldingManagerEntry.ManagerNumber"/> refers to. The cover
+    /// page's list is sequence-less, so those rows carry a 1-based ordinal in filed order instead,
+    /// which keeps the column non-null and the list stably ordered without inventing a filed value.
+    /// </summary>
+    public int SequenceNumber { get; set; }
+
+    /// <summary>
+    /// Central index key, leading zeros trimmed to match how filer CIKs are stored elsewhere.
+    /// Null when the filing did not carry one.
+    /// </summary>
+    [MaxLength(16)]
+    public string Cik { get; set; }
+
+    /// <summary>Form 13F file number ("028-…"). The fallback identity when no CIK was filed.</summary>
+    [MaxLength(32)]
+    public string Form13FFileNumber { get; set; }
+
+    /// <summary>CRD number, where the manager is a registered adviser.</summary>
+    [MaxLength(32)]
+    public string CrdNumber { get; set; }
+
+    /// <summary>SEC file number ("801-…"). Absent from the realtime filing XML, so null on rows
+    /// written before the quarterly data set restates them.</summary>
+    [MaxLength(32)]
+    public string SecFileNumber { get; set; }
+
+    /// <summary>The manager's name as filed. Display only — never matched on.</summary>
+    [MaxLength(256)]
+    public string Name { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.Data/Models/OtherManagerDirection.cs
+++ b/src/Equibles.Holdings.Data/Models/OtherManagerDirection.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Holdings.Data.Models;
+
+/// <summary>
+/// Which way a <see cref="FilingOtherManager"/> edge points between the filing manager and the
+/// other manager it names. A 13F cover page and its summary page each carry an other-manager
+/// list, and they mean opposite things.
+/// </summary>
+public enum OtherManagerDirection
+{
+    /// <summary>
+    /// The summary page's list (<c>otherManagers2Info</c> / <c>OTHERMANAGER2.tsv</c>): managers
+    /// whose positions this filing reports. Parent to subsidiary — the combination report a
+    /// holding company files on behalf of its asset-management arms.
+    /// </summary>
+    [Display(Name = "Included in this report")]
+    IncludedInReport = 0,
+
+    /// <summary>
+    /// The cover page's list (<c>otherManagersInfo</c> / <c>OTHERMANAGER.tsv</c>): managers who
+    /// report this filer's positions for it. Subsidiary to parent — the opposite edge, filed by
+    /// the child rather than the parent.
+    /// </summary>
+    [Display(Name = "Reports for this filer")]
+    ReportsForFiler = 1,
+}

--- a/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
@@ -35,8 +35,14 @@ public class ProcessedDataSet
     /// track 7 of the 8 positions this filing declares"; the same re-import also
     /// rebuilds the unmapped-CUSIP queue through the per-key flush (#4249),
     /// healing the under-counts the old slice-wipe left behind.
+    /// Version 5: keep the identifiers filed alongside every other-manager name
+    /// (#4263). Both of a 13F's other-manager lists carry a CIK, a Form 13F file
+    /// number and a CRD, and the import read only the name — so a combination
+    /// report's subsidiaries were stored as unmatched strings and the
+    /// parent/subsidiary structure they describe could not be recovered. The
+    /// re-import populates FilingOtherManager for all history.
     /// </summary>
-    public const int CurrentParserVersion = 4;
+    public const int CurrentParserVersion = 5;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 

--- a/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
+++ b/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
@@ -17,8 +17,17 @@ public class ImportContext
     public Dictionary<string, Guid> CusipMapping { get; set; }
     public Dictionary<string, Guid> CikToHolderId { get; set; }
 
-    // Other managers: AccessionNumber → (SequenceNumber → ManagerName)
-    public Dictionary<string, Dictionary<int, string>> OtherManagers { get; set; } = [];
+    // Summary-page other managers (the positions this filing reports on behalf of):
+    // AccessionNumber → (SequenceNumber → manager identity). The sequence number is what a
+    // position's OTHERMANAGER column points at.
+    public Dictionary<string, Dictionary<int, OtherManagerIdentity>> OtherManagers { get; set; } =
+        [];
+
+    // Cover-page other managers (the managers who report FOR this filer — the opposite edge):
+    // AccessionNumber → identities in filed order. The cover page carries no sequence numbers,
+    // so nothing references these; they are stored for the relationship alone.
+    public Dictionary<string, List<OtherManagerIdentity>> CoverPageOtherManagers { get; set; } =
+        [];
 
     // For Schedule 13D/13G submissions only: AccessionNumber → tracked stock ids
     // of the issuer(s) the filing reports. A 13D/G covers a single issuer, so its

--- a/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
+++ b/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
@@ -21,13 +21,12 @@ public class ImportContext
     // AccessionNumber → (SequenceNumber → manager identity). The sequence number is what a
     // position's OTHERMANAGER column points at.
     public Dictionary<string, Dictionary<int, OtherManagerIdentity>> OtherManagers { get; set; } =
-        [];
+    [];
 
     // Cover-page other managers (the managers who report FOR this filer — the opposite edge):
     // AccessionNumber → identities in filed order. The cover page carries no sequence numbers,
     // so nothing references these; they are stored for the relationship alone.
-    public Dictionary<string, List<OtherManagerIdentity>> CoverPageOtherManagers { get; set; } =
-        [];
+    public Dictionary<string, List<OtherManagerIdentity>> CoverPageOtherManagers { get; set; } = [];
 
     // For Schedule 13D/13G submissions only: AccessionNumber → tracked stock ids
     // of the issuer(s) the filing reports. A 13D/G covers a single issuer, so its

--- a/src/Equibles.Holdings.HostedService/Models/OtherManagerIdentity.cs
+++ b/src/Equibles.Holdings.HostedService/Models/OtherManagerIdentity.cs
@@ -1,0 +1,19 @@
+namespace Equibles.Holdings.HostedService.Models;
+
+/// <summary>
+/// One entry from a 13F's other-manager table, as filed. Carries the identifiers alongside the
+/// name so the import can persist a manager the rest of the platform can resolve to an
+/// institution, instead of a name string nothing can safely match on.
+/// </summary>
+/// <remarks>
+/// Every field except <see cref="Name"/> is optional at the source: the SEC accepts a manager
+/// entry with a name and nothing else. Callers must treat the identifiers as absent rather than
+/// falling back to matching on the name.
+/// </remarks>
+public record OtherManagerIdentity(
+    string Name,
+    string Cik,
+    string Form13FFileNumber,
+    string CrdNumber,
+    string SecFileNumber
+);

--- a/src/Equibles.Holdings.HostedService/Models/Parsed13FFiling.cs
+++ b/src/Equibles.Holdings.HostedService/Models/Parsed13FFiling.cs
@@ -31,8 +31,17 @@ public class Parsed13FFiling
     /// filing was made in (whole dollars post-2023). Null when absent.</summary>
     public long? TableValueTotal { get; set; }
 
-    /// <summary>Other-manager table: sequence number → manager name.</summary>
-    public Dictionary<int, string> OtherManagers { get; set; } = [];
+    /// <summary>
+    /// Summary-page other-manager table: sequence number → manager identity. The positions this
+    /// filing reports on behalf of; a holding's <c>otherManager</c> element points at the sequence.
+    /// </summary>
+    public Dictionary<int, OtherManagerIdentity> OtherManagers { get; set; } = [];
+
+    /// <summary>
+    /// Cover-page other-manager list, in filed order: the managers who report FOR this filer. The
+    /// opposite edge to <see cref="OtherManagers"/>, and sequence-less, so nothing points at it.
+    /// </summary>
+    public List<OtherManagerIdentity> CoverPageOtherManagers { get; set; } = [];
 
     public List<Parsed13FHolding> Holdings { get; set; } = [];
 }

--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -87,12 +87,54 @@ public class Filing13FXmlParser
                 continue;
 
             var inner = Child(otherManager2, "otherManager");
-            var name = Value(Child(inner, "name"));
-            if (!string.IsNullOrEmpty(name))
-                filing.OtherManagers[seq] = name;
+            var identity = ReadOtherManager(inner);
+            if (identity != null)
+                filing.OtherManagers[seq] = identity;
+        }
+
+        // The cover page's own list means the opposite of the summary page's: these are the
+        // managers who report FOR this filer, not the ones it reports for. Combination reports
+        // carry both. Scoped to coverPage because otherManager is also the local name of the
+        // element nested inside each summary-page otherManager2 — an unscoped scan would fold the
+        // two lists into one and invert half the relationships.
+        var otherManagersInfo = Descendant(coverPage, "otherManagersInfo");
+        if (otherManagersInfo != null)
+        {
+            foreach (var otherManager in Children(otherManagersInfo, "otherManager"))
+            {
+                var identity = ReadOtherManager(otherManager);
+                if (identity != null)
+                    filing.CoverPageOtherManagers.Add(identity);
+            }
         }
 
         return filing;
+    }
+
+    /// <summary>
+    /// Reads one <c>otherManager</c> block. Only the name is mandatory in the SEC schema, so every
+    /// identifier is optional and a block carrying nothing but a name is still a valid entry —
+    /// displayable, if not linkable. Returns null when even the name is missing.
+    /// </summary>
+    private static OtherManagerIdentity ReadOtherManager(XElement otherManager)
+    {
+        var name = Value(Child(otherManager, "name"));
+        if (string.IsNullOrEmpty(name))
+            return null;
+
+        // A present-but-empty element is an absent identifier, not a blank value — storing "" would
+        // make every identifier-less manager compare equal to every other one.
+        return new OtherManagerIdentity(
+            name,
+            HoldingsParsingHelper.NormalizeCik(Value(Child(otherManager, "cik"))),
+            HoldingsParsingHelper.NormalizeIdentifier(
+                Value(Child(otherManager, "form13FFileNumber"))
+            ),
+            HoldingsParsingHelper.NormalizeIdentifier(Value(Child(otherManager, "crdNumber"))),
+            // Absent from every filing seen so far, but declared by the schema; the quarterly
+            // data set does carry it, and restates these rows when it lands.
+            HoldingsParsingHelper.NormalizeIdentifier(Value(Child(otherManager, "secFileNumber")))
+        );
     }
 
     /// <summary>

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -89,9 +89,11 @@ public class HoldingsImportService
         await BuildPriceMap(context, cancellationToken);
         await BuildSplitMap(context, cancellationToken);
         await ParseOtherManagers(context, cancellationToken);
+        await ParseOtherManagerCoverList(context, cancellationToken);
         await UpsertInstitutionalHolders(context, cancellationToken);
         await HandleAmendments(context, cancellationToken);
         var insertedHoldings = await StreamAndInsertHoldings(context, cancellationToken);
+        await FlushFilingOtherManagers(context, cancellationToken);
         await SyncFilingSummaries(context, cancellationToken);
         await PublishAffectedQuartersAsync(context, cancellationToken);
         return new ImportResult(
@@ -912,7 +914,7 @@ public class HoldingsImportService
             return;
         }
 
-        var managers = new Dictionary<string, Dictionary<int, string>>(
+        var managers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(
             StringComparer.OrdinalIgnoreCase
         );
         await foreach (var row in context.TsvParser.ParseEntry(entry))
@@ -923,7 +925,7 @@ public class HoldingsImportService
                     context.Submissions,
                     out var accession,
                     out var seq,
-                    out var name
+                    out var identity
                 )
             )
                 continue;
@@ -934,11 +936,69 @@ public class HoldingsImportService
                 managers[accession] = seqMap;
             }
 
-            seqMap[seq] = name;
+            seqMap[seq] = identity;
         }
 
         context.OtherManagers = managers;
         _logger.LogInformation("Parsed other-manager mappings for {Count} filings", managers.Count);
+    }
+
+    /// <summary>
+    /// Parses OTHERMANAGER.tsv — the cover page's list of managers who report FOR the filer, the
+    /// opposite edge to the summary page's list. Absent from archives built before this lane
+    /// existed (and from the Schedule 13D/G synthetic archive), so a missing entry is normal.
+    /// </summary>
+    private async Task ParseOtherManagerCoverList(
+        ImportContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        var entry = FindEntry(context.Archive, "OTHERMANAGER.tsv");
+        if (entry == null)
+        {
+            _logger.LogInformation(
+                "OTHERMANAGER.tsv not found, skipping cover-page other-manager parsing"
+            );
+            return;
+        }
+
+        // Ordered by the SEC's surrogate key where present so the stored ordinal follows filed
+        // order rather than however the archive happened to stream. Rows without one keep their
+        // file position, which is the same order for every archive seen so far.
+        var ordered = new Dictionary<string, List<(long Sort, OtherManagerIdentity Identity)>>(
+            StringComparer.OrdinalIgnoreCase
+        );
+        var position = 0L;
+        await foreach (var row in context.TsvParser.ParseEntry(entry))
+        {
+            position++;
+            var accession = GetValue(row, AccessionNumberColumn);
+            if (string.IsNullOrEmpty(accession) || !context.Submissions.ContainsKey(accession))
+                continue;
+
+            var name = GetValue(row, "NAME");
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            var sort = ParseNullableLong(GetValue(row, "OTHERMANAGER_SK")) ?? position;
+            if (!ordered.TryGetValue(accession, out var list))
+            {
+                list = [];
+                ordered[accession] = list;
+            }
+
+            list.Add((sort, BuildOtherManagerIdentity(row, name)));
+        }
+
+        context.CoverPageOtherManagers = ordered.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.OrderBy(item => item.Sort).Select(item => item.Identity).ToList(),
+            StringComparer.OrdinalIgnoreCase
+        );
+        _logger.LogInformation(
+            "Parsed cover-page other-manager lists for {Count} filings",
+            context.CoverPageOtherManagers.Count
+        );
     }
 
     private bool TryParseOtherManagerRow(
@@ -946,11 +1006,11 @@ public class HoldingsImportService
         Dictionary<string, SubmissionRow> submissions,
         out string accession,
         out int seq,
-        out string name
+        out OtherManagerIdentity identity
     )
     {
         seq = 0;
-        name = null;
+        identity = null;
 
         accession = GetValue(row, AccessionNumberColumn);
         if (string.IsNullOrEmpty(accession) || !submissions.ContainsKey(accession))
@@ -966,11 +1026,146 @@ public class HoldingsImportService
             return false;
         }
 
-        name = GetValue(row, "NAME");
+        var name = GetValue(row, "NAME");
         if (string.IsNullOrWhiteSpace(name))
             return false;
 
+        identity = BuildOtherManagerIdentity(row, name);
         return true;
+    }
+
+    /// <summary>
+    /// Reads a manager's filed identifiers off an other-manager row. Every identifier column is
+    /// optional at the source and absent entirely from archives written before this lane existed,
+    /// so each read tolerates a missing column and yields null rather than failing the row — the
+    /// name alone still makes a usable, if unlinkable, entry.
+    /// </summary>
+    private static OtherManagerIdentity BuildOtherManagerIdentity(
+        Dictionary<string, string> row,
+        string name
+    )
+    {
+        return new OtherManagerIdentity(
+            ClampLength(name, 256),
+            NormalizeCik(GetValue(row, "CIK")),
+            ClampLength(NormalizeIdentifier(GetValue(row, "FORM13FFILENUMBER")), 32),
+            ClampLength(NormalizeIdentifier(GetValue(row, "CRDNUMBER")), 32),
+            ClampLength(NormalizeIdentifier(GetValue(row, "SECFILENUMBER")), 32)
+        );
+    }
+
+    /// <summary>
+    /// Persists both other-manager lists for every 13F accession this import covers, replacing
+    /// whatever those accessions held before.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The delete spans every 13F accession in the import, not only the ones that produced rows,
+    /// so a filing that no longer declares a manager has its stale list cleared rather than kept
+    /// forever. Accessions outside the import are left alone on purpose: a "new holdings"
+    /// amendment merges without deleting, so a holder's quarter can span several accessions and
+    /// the positions still carrying an older one need its list to resolve. Sweeping orphans the
+    /// way the filing summaries do would strand exactly those positions.
+    /// </para>
+    /// <para>
+    /// Restricted to Form 13F because the Schedule 13D/G lane shares this pipeline and ships a
+    /// header-only OTHERMANAGER2.tsv — without the filter a 13D/G import would delete a 13F
+    /// filing's managers and write nothing back.
+    /// </para>
+    /// <para>
+    /// No transaction wraps it, matching every other phase here: a data set is only marked
+    /// processed once the whole import returns, so a crash mid-write is healed by the re-import
+    /// rather than by a rollback.
+    /// </para>
+    /// </remarks>
+    private async Task FlushFilingOtherManagers(
+        ImportContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        var accessions = context
+            .Submissions.Values.Where(s => s.FormType.ToHoldingsFilingType() == FilingType.Form13F)
+            .Select(s => s.AccessionNumber)
+            .ToList();
+        if (accessions.Count == 0)
+            return;
+
+        var rows = new List<FilingOtherManager>();
+        foreach (var accession in accessions)
+        {
+            if (context.OtherManagers.TryGetValue(accession, out var seqMap))
+            {
+                foreach (var (sequence, identity) in seqMap)
+                {
+                    rows.Add(
+                        BuildFilingOtherManager(
+                            accession,
+                            OtherManagerDirection.IncludedInReport,
+                            sequence,
+                            identity
+                        )
+                    );
+                }
+            }
+
+            if (!context.CoverPageOtherManagers.TryGetValue(accession, out var coverList))
+                continue;
+
+            // The cover page files no sequence numbers, so the stored ordinal is positional. It
+            // orders the list and keeps the column non-null; nothing points at it.
+            for (var index = 0; index < coverList.Count; index++)
+            {
+                rows.Add(
+                    BuildFilingOtherManager(
+                        accession,
+                        OtherManagerDirection.ReportsForFiler,
+                        index + 1,
+                        coverList[index]
+                    )
+                );
+            }
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+
+        var replaced = await dbContext
+            .Set<FilingOtherManager>()
+            .Where(m => accessions.Contains(m.AccessionNumber))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        if (rows.Count > 0)
+        {
+            dbContext.Set<FilingOtherManager>().AddRange(rows);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        _logger.LogInformation(
+            "Stored {Count} other-manager row(s) across {Filings} filing(s), replacing {Replaced} existing row(s)",
+            rows.Count,
+            accessions.Count,
+            replaced
+        );
+    }
+
+    private static FilingOtherManager BuildFilingOtherManager(
+        string accession,
+        OtherManagerDirection direction,
+        int sequenceNumber,
+        OtherManagerIdentity identity
+    )
+    {
+        return new FilingOtherManager
+        {
+            AccessionNumber = ClampLength(accession, 32),
+            Direction = direction,
+            SequenceNumber = sequenceNumber,
+            Cik = ClampLength(identity.Cik, 16),
+            Form13FFileNumber = identity.Form13FFileNumber,
+            CrdNumber = identity.CrdNumber,
+            SecFileNumber = identity.SecFileNumber,
+            Name = identity.Name,
+        };
     }
 
     private async Task HandleAmendments(ImportContext context, CancellationToken cancellationToken)

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsParsingHelper.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsParsingHelper.cs
@@ -88,6 +88,15 @@ internal static class HoldingsParsingHelper
         return int.TryParse(value, out var result) ? result : null;
     }
 
+    /// <summary>
+    /// Parses a surrogate key. Widened past <see cref="int"/> because the SEC declares these
+    /// columns as NUMBER(38), so a value can legitimately outrun a 32-bit parse.
+    /// </summary>
+    internal static long? ParseNullableLong(string value)
+    {
+        return long.TryParse(value, out var result) ? result : null;
+    }
+
     internal static decimal? ParseNullableDecimal(string value)
     {
         return decimal.TryParse(
@@ -110,12 +119,34 @@ internal static class HoldingsParsingHelper
             return null;
         if (
             context.OtherManagers.TryGetValue(accession, out var seqMap)
-            && seqMap.TryGetValue(managerNumber.Value, out var name)
+            && seqMap.TryGetValue(managerNumber.Value, out var identity)
         )
         {
-            return name;
+            return identity.Name;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Strips the leading zeros EDGAR pads CIKs with, so a filed identifier compares equal to the
+    /// spelling filer CIKs are stored under. Blank stays null: an absent identifier must not
+    /// become an empty string that looks like a value.
+    /// </summary>
+    internal static string NormalizeCik(string cik)
+    {
+        var trimmed = NormalizeIdentifier(cik);
+        return trimmed == null ? null : NormalizeIdentifier(trimmed.TrimStart('0'));
+    }
+
+    /// <summary>
+    /// Normalizes a filed identifier to "value or absent". A blank is absent: the SEC keeps the
+    /// column present and empty rather than omitting it, and an empty string is not a missing
+    /// identifier — it is a value that compares equal to every other blank, so joining on it
+    /// would collide every identifier-less manager into one.
+    /// </summary>
+    internal static string NormalizeIdentifier(string value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
     }
 
     internal static InvestmentDiscretion ParseInvestmentDiscretion(string value)

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
@@ -32,7 +32,16 @@ public class Realtime13FArchiveBuilder
             "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMTTYPE\tPUTCALL\tVALUE\tSSHPRNAMT\tVOTING_AUTH_SOLE\t"
                 + "VOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\tINVESTMENTDISCRETION\n"
         );
-        var otherManager = new StringBuilder("ACCESSION_NUMBER\tSEQUENCENUMBER\tNAME\n");
+        // Both other-manager sections carry the SEC's identifier columns, in its column order, so
+        // the synthetic archive stays parseable by the same reader as the quarterly one.
+        var otherManager = new StringBuilder(
+            "ACCESSION_NUMBER\tSEQUENCENUMBER\tCIK\tFORM13FFILENUMBER\tCRDNUMBER\tSECFILENUMBER\t"
+                + "NAME\n"
+        );
+        var otherManagerCover = new StringBuilder(
+            "ACCESSION_NUMBER\tOTHERMANAGER_SK\tCIK\tFORM13FFILENUMBER\tCRDNUMBER\tSECFILENUMBER\t"
+                + "NAME\n"
+        );
         var summaryPage = new StringBuilder("ACCESSION_NUMBER\tTABLEENTRYTOTAL\tTABLEVALUETOTAL\n");
 
         foreach (var filing in filings)
@@ -61,9 +70,35 @@ public class Realtime13FArchiveBuilder
                 filing.ConfidentialTreatmentRequested ? "Y" : "N"
             );
 
-            foreach (var (seq, name) in filing.OtherManagers)
+            foreach (var (seq, identity) in filing.OtherManagers)
             {
-                AppendRow(otherManager, Clean(filing.AccessionNumber), seq, Clean(name));
+                AppendRow(
+                    otherManager,
+                    Clean(filing.AccessionNumber),
+                    seq,
+                    Clean(identity.Cik),
+                    Clean(identity.Form13FFileNumber),
+                    Clean(identity.CrdNumber),
+                    Clean(identity.SecFileNumber),
+                    Clean(identity.Name)
+                );
+            }
+
+            // The cover-page list files no sequence numbers, so the surrogate key is positional —
+            // it preserves filed order through the archive and nothing points at it.
+            for (var index = 0; index < filing.CoverPageOtherManagers.Count; index++)
+            {
+                var identity = filing.CoverPageOtherManagers[index];
+                AppendRow(
+                    otherManagerCover,
+                    Clean(filing.AccessionNumber),
+                    index + 1,
+                    Clean(identity.Cik),
+                    Clean(identity.Form13FFileNumber),
+                    Clean(identity.CrdNumber),
+                    Clean(identity.SecFileNumber),
+                    Clean(identity.Name)
+                );
             }
 
             // Emitted even when both totals are null (empty cells): the import parses the row
@@ -109,6 +144,7 @@ public class Realtime13FArchiveBuilder
                 WriteEntry(writer, "COVERPAGE.tsv", coverPage);
                 WriteEntry(writer, "INFOTABLE.tsv", infoTable);
                 WriteEntry(writer, "OTHERMANAGER2.tsv", otherManager);
+                WriteEntry(writer, "OTHERMANAGER.tsv", otherManagerCover);
                 WriteEntry(writer, "SUMMARYPAGE.tsv", summaryPage);
             }
             zipBytes = buffer.ToArray();

--- a/src/Equibles.Holdings.Repositories/FilingOtherManagerRepository.cs
+++ b/src/Equibles.Holdings.Repositories/FilingOtherManagerRepository.cs
@@ -1,0 +1,17 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+public class FilingOtherManagerRepository : BaseRepository<FilingOtherManager>
+{
+    public FilingOtherManagerRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<FilingOtherManager> GetByAccessionNumbers(
+        IEnumerable<string> accessionNumbers
+    )
+    {
+        return GetAll().Where(m => accessionNumbers.Contains(m.AccessionNumber));
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260731005632_AddFilingOtherManagers.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260731005632_AddFilingOtherManagers.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260731005632_AddFilingOtherManagers")]
+    partial class AddFilingOtherManagers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260731005632_AddFilingOtherManagers.cs
+++ b/src/Equibles.Migrations/Migrations/20260731005632_AddFilingOtherManagers.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFilingOtherManagers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FilingOtherManager",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Direction = table.Column<int>(type: "integer", nullable: false),
+                    SequenceNumber = table.Column<int>(type: "integer", nullable: false),
+                    Cik = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: true),
+                    Form13FFileNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    CrdNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    SecFileNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    Name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FilingOtherManager", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FilingOtherManager_AccessionNumber",
+                table: "FilingOtherManager",
+                column: "AccessionNumber");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FilingOtherManager_Cik",
+                table: "FilingOtherManager",
+                column: "Cik");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FilingOtherManager");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserOtherManagersNoCoverPageFallbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserOtherManagersNoCoverPageFallbackTests.cs
@@ -38,6 +38,13 @@ public class Filing13FXmlParserOtherManagersNoCoverPageFallbackTests
             filingDate: new DateOnly(2025, 11, 14)
         );
 
-        filing.OtherManagers.Should().ContainKey(1).WhoseValue.Should().Be("SOLE CO-MANAGER");
+        filing.OtherManagers.Should().ContainKey(1);
+        filing.OtherManagers[1].Name.Should().Be("SOLE CO-MANAGER");
+        filing.OtherManagers[1].Cik.Should().Be("9999999");
+
+        // The cover page is absent entirely, so there is no opposite edge to read. The
+        // summary-page block must not be mistaken for one just because its nested element shares
+        // the name — that would invent a parent pointing at the filer's own subsidiary.
+        filing.CoverPageOtherManagers.Should().BeEmpty();
     }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserOtherManagersSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserOtherManagersSkipTests.cs
@@ -49,8 +49,9 @@ public class Filing13FXmlParserOtherManagersSkipTests
         );
 
         filing.OtherManagers.Should().HaveCount(1);
-        filing.OtherManagers.Should().ContainKey(3).WhoseValue.Should().Be("GOOD ADVISORS");
+        filing.OtherManagers.Should().ContainKey(3);
+        filing.OtherManagers[3].Name.Should().Be("GOOD ADVISORS");
         filing.OtherManagers.Should().NotContainKey(0);
-        filing.OtherManagers.Values.Should().NotContain("BAD CO");
+        filing.OtherManagers.Values.Select(m => m.Name).Should().NotContain("BAD CO");
     }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
@@ -61,6 +61,13 @@ public class Filing13FXmlParserParseCoverPageTests
         filing.Cik.Should().Be("1067983");
         filing.FilingManagerName.Should().Be("BERKSHIRE HATHAWAY INC");
         filing.City.Should().Be("OMAHA");
-        filing.OtherManagers.Should().ContainKey(1).WhoseValue.Should().Be("DECOY ADVISORS LLC");
+        filing.OtherManagers.Should().ContainKey(1);
+        filing.OtherManagers[1].Name.Should().Be("DECOY ADVISORS LLC");
+
+        // The decoy's own CIK belongs to the co-manager entry, never to the filer — now that the
+        // parser reads it, the two must land in different places rather than one overwriting the
+        // other.
+        filing.OtherManagers[1].Cik.Should().Be("9999999");
+        filing.Cik.Should().Be("1067983");
     }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFilingOtherManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFilingOtherManagerTests.cs
@@ -1,0 +1,319 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins <c>FlushFilingOtherManagers</c> against a real database: the replace-per-accession
+/// contract, the two directions staying distinct, and the two ways the phase can silently destroy
+/// data it should not touch.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServiceFilingOtherManagerTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public HoldingsImportServiceFilingOtherManagerTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private HoldingsImportService CreateImporter()
+    {
+        var priceProvider = Substitute.For<IStockPriceProvider>();
+        priceProvider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(new Dictionary<(Guid, DateOnly), decimal>()));
+
+        return new HoldingsImportService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            priceProvider,
+            Substitute.For<MassTransit.IBus>()
+        );
+    }
+
+    private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)
+    {
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, body) in entries)
+            {
+                var entry = writer.CreateEntry(name);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(body);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    private const string Submission =
+        "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+        + "13F-HR\tACC-001\t2024-10-15\t2024-09-30\t0000886982\n";
+
+    private const string CoverPage =
+        "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\t"
+        + "FILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+        + "ACC-001\tN\tGOLDMAN SACHS GROUP INC\tNEW YORK\tNY\t028-04981\t\n";
+
+    // The import bails before the flush unless at least one position maps to a tracked stock, so
+    // the table carries a real row attributed to the first co-manager.
+    private const string InfoTable =
+        "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\t"
+        + "VOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+        + "ACC-001\t037833100\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t1\n";
+
+    private async Task SeedTrackedStock()
+    {
+        using var seed = FreshContext();
+        seed.Set<CommonStock>()
+            .Add(
+                new CommonStock
+                {
+                    Id = Guid.NewGuid(),
+                    Ticker = "AAPL",
+                    Name = "Apple Inc",
+                    Cik = "0000320193",
+                    Cusip = "037833100",
+                }
+            );
+        await seed.SaveChangesAsync();
+    }
+
+    private const string OtherManager2 =
+        "ACCESSION_NUMBER\tSEQUENCENUMBER\tCIK\tFORM13FFILENUMBER\tCRDNUMBER\tSECFILENUMBER\tNAME\n"
+        + "ACC-001\t1\t0000769993\t028-00687\t000000361\t\tGOLDMAN SACHS & CO. LLC\n"
+        + "ACC-001\t2\t0001229262\t028-10981\t000107738\t\tGOLDMAN SACHS ASSET MANAGEMENT, L.P.\n";
+
+    private const string OtherManagerCover =
+        "ACCESSION_NUMBER\tOTHERMANAGER_SK\tCIK\tFORM13FFILENUMBER\tCRDNUMBER\tSECFILENUMBER\tNAME\n"
+        + "ACC-001\t7\t0000895421\t028-24289\t\t\tMORGAN STANLEY\n";
+
+    private async Task Import(params (string Name, string Body)[] entries)
+    {
+        using var archive = BuildArchive(entries);
+        await CreateImporter()
+            .ImportDataSet(archive, new DateOnly(2024, 1, 1), CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ImportDataSet_BothManagerLists_PersistsEachUnderItsOwnDirection()
+    {
+        await SeedTrackedStock();
+        // The whole point of the table: a combination report's subsidiaries become rows carrying
+        // the identifiers that make them linkable, and the cover page's opposite edge is stored as
+        // a distinct direction rather than merged into the same list.
+        await Import(
+            ("SUBMISSION.tsv", Submission),
+            ("COVERPAGE.tsv", CoverPage),
+            ("INFOTABLE.tsv", InfoTable),
+            ("OTHERMANAGER2.tsv", OtherManager2),
+            ("OTHERMANAGER.tsv", OtherManagerCover)
+        );
+
+        using var verify = FreshContext();
+        var rows = await verify
+            .Set<FilingOtherManager>()
+            .OrderBy(m => m.Direction)
+            .ThenBy(m => m.SequenceNumber)
+            .ToListAsync();
+
+        rows.Should().HaveCount(3);
+
+        rows[0].Direction.Should().Be(OtherManagerDirection.IncludedInReport);
+        rows[0].SequenceNumber.Should().Be(1);
+        rows[0].Name.Should().Be("GOLDMAN SACHS & CO. LLC");
+        rows[0].Cik.Should().Be("769993", "the stored spelling has no leading zeros");
+        rows[0].Form13FFileNumber.Should().Be("028-00687");
+        rows[0].CrdNumber.Should().Be("000000361");
+        rows[0].SecFileNumber.Should().BeNull();
+
+        rows[1].Direction.Should().Be(OtherManagerDirection.IncludedInReport);
+        rows[1].SequenceNumber.Should().Be(2);
+        rows[1].Cik.Should().Be("1229262");
+
+        // The cover page files no sequence number, so the stored ordinal is positional — the SEC's
+        // surrogate key (7) orders the list but is not itself stored.
+        rows[2].Direction.Should().Be(OtherManagerDirection.ReportsForFiler);
+        rows[2].SequenceNumber.Should().Be(1);
+        rows[2].Name.Should().Be("MORGAN STANLEY");
+        rows[2].Cik.Should().Be("895421");
+    }
+
+    [Fact]
+    public async Task ImportDataSet_SameArchiveTwice_DoesNotDuplicateTheManagerRows()
+    {
+        await SeedTrackedStock();
+        // History is re-imported whenever the parser version moves, so the phase runs repeatedly
+        // over the same accessions. Appending instead of replacing would multiply every
+        // combination report's manager list by the number of re-imports.
+        var entries = new[]
+        {
+            ("SUBMISSION.tsv", Submission),
+            ("COVERPAGE.tsv", CoverPage),
+            ("INFOTABLE.tsv", InfoTable),
+            ("OTHERMANAGER2.tsv", OtherManager2),
+            ("OTHERMANAGER.tsv", OtherManagerCover),
+        };
+
+        await Import(entries);
+        await Import(entries);
+
+        using var verify = FreshContext();
+        (await verify.Set<FilingOtherManager>().CountAsync()).Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ImportDataSet_ArchiveNoLongerDeclaringManagers_ClearsTheStaleList()
+    {
+        await SeedTrackedStock();
+        // A restated filing can drop managers it previously named. Deleting only the accessions
+        // that produced rows would leave the old list behind for ever, so the delete spans every
+        // 13F accession the import covers.
+        await Import(
+            ("SUBMISSION.tsv", Submission),
+            ("COVERPAGE.tsv", CoverPage),
+            ("INFOTABLE.tsv", InfoTable),
+            ("OTHERMANAGER2.tsv", OtherManager2),
+            ("OTHERMANAGER.tsv", OtherManagerCover)
+        );
+
+        await Import(
+            ("SUBMISSION.tsv", Submission),
+            ("COVERPAGE.tsv", CoverPage),
+            ("INFOTABLE.tsv", InfoTable)
+        );
+
+        using var verify = FreshContext();
+        (await verify.Set<FilingOtherManager>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportDataSet_ScheduleFiling_LeavesAnotherFilingsManagersAlone()
+    {
+        await SeedTrackedStock();
+        // Schedule 13D/G shares this pipeline and its synthetic archive ships a header-only
+        // OTHERMANAGER2 section. Without the Form 13F filter the phase would treat those
+        // accessions as "covered", find no rows, and delete manager lists it never owned.
+        await Import(
+            ("SUBMISSION.tsv", Submission),
+            ("COVERPAGE.tsv", CoverPage),
+            ("INFOTABLE.tsv", InfoTable),
+            ("OTHERMANAGER2.tsv", OtherManager2)
+        );
+
+        var scheduleSubmission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "SC 13G\tACC-001\t2024-10-16\t2024-09-30\t0000886982\n";
+        var scheduleCover =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\t"
+            + "FILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-001\tN\tGOLDMAN SACHS GROUP INC\tNEW YORK\tNY\t\t\n";
+
+        await Import(
+            ("SUBMISSION.tsv", scheduleSubmission),
+            ("COVERPAGE.tsv", scheduleCover),
+            ("INFOTABLE.tsv", InfoTable),
+            (
+                "OTHERMANAGER2.tsv",
+                "ACCESSION_NUMBER\tSEQUENCENUMBER\tCIK\tFORM13FFILENUMBER\tCRDNUMBER\t"
+                    + "SECFILENUMBER\tNAME\n"
+            )
+        );
+
+        using var verify = FreshContext();
+        (await verify.Set<FilingOtherManager>().CountAsync())
+            .Should()
+            .Be(2, "a Schedule 13D/G import must not touch a 13F filing's manager list");
+    }
+
+    [Fact]
+    public async Task ImportDataSet_LegacyThreeColumnSection_StillStoresTheNames()
+    {
+        await SeedTrackedStock();
+        // Archives predating the identifier columns must keep parsing. The managers are stored
+        // with null identifiers — displayable, not linkable — rather than being dropped.
+        await Import(
+            ("SUBMISSION.tsv", Submission),
+            ("COVERPAGE.tsv", CoverPage),
+            ("INFOTABLE.tsv", InfoTable),
+            (
+                "OTHERMANAGER2.tsv",
+                "ACCESSION_NUMBER\tSEQUENCENUMBER\tNAME\n" + "ACC-001\t1\tLEGACY ADVISORS\n"
+            )
+        );
+
+        using var verify = FreshContext();
+        var row = await verify.Set<FilingOtherManager>().SingleAsync();
+        row.Name.Should().Be("LEGACY ADVISORS");
+        row.Cik.Should().BeNull();
+        row.Form13FFileNumber.Should().BeNull();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
@@ -78,14 +78,14 @@ public class HoldingsParsingHelperTests
         // exact sequence-number selection (not e.g. first-in-iteration order).
         var context = new ImportContext
         {
-            OtherManagers = new Dictionary<string, Dictionary<int, string>>(
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(
                 StringComparer.OrdinalIgnoreCase
             )
             {
                 ["ACC-001"] = new()
                 {
-                    [1] = "Capital Group Companies, Inc.",
-                    [2] = "Capital Research Global Investors",
+                    [1] = new OtherManagerIdentity("Capital Group Companies, Inc.", null, null, null, null),
+                    [2] = new OtherManagerIdentity("Capital Research Global Investors", null, null, null, null),
                 },
             },
         };

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
@@ -84,8 +84,20 @@ public class HoldingsParsingHelperTests
             {
                 ["ACC-001"] = new()
                 {
-                    [1] = new OtherManagerIdentity("Capital Group Companies, Inc.", null, null, null, null),
-                    [2] = new OtherManagerIdentity("Capital Research Global Investors", null, null, null, null),
+                    [1] = new OtherManagerIdentity(
+                        "Capital Group Companies, Inc.",
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    [2] = new OtherManagerIdentity(
+                        "Capital Research Global Investors",
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
                 },
             },
         };

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13FArchiveBuilderOtherManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13FArchiveBuilderOtherManagerTests.cs
@@ -27,7 +27,18 @@ public class Realtime13FArchiveBuilderOtherManagerTests
             StateOrCountry = "NE",
             Form13FFileNumber = "028-1",
             CrdNumber = "111",
-            OtherManagers = new Dictionary<int, string> { [1] = "EVIL\tADVISORS\nLLC" },
+            OtherManagers = new Dictionary<int, OtherManagerIdentity>
+            {
+                [1] = new OtherManagerIdentity(
+                    "EVIL\tADVISORS\nLLC",
+                    // The identifiers are free-text out of the same XML and go through the same
+                    // writer, so each is a row-corrupting field in its own right.
+                    "12\t345",
+                    "028-\n1",
+                    "999",
+                    null
+                ),
+            },
         };
 
         using var archive = new Realtime13FArchiveBuilder().Build([filing]);
@@ -42,6 +53,58 @@ public class Realtime13FArchiveBuilderOtherManagerTests
         var manager = rows[0];
         manager["ACCESSION_NUMBER"].Should().Be("0001067983-26-000401");
         manager["SEQUENCENUMBER"].Should().Be("1");
+        manager["CIK"].Should().Be("12 345");
+        manager["FORM13FFILENUMBER"].Should().Be("028- 1");
+        manager["CRDNUMBER"].Should().Be("999");
         manager["NAME"].Should().Be("EVIL ADVISORS LLC");
+    }
+
+    [Fact]
+    public async Task Build_CoverPageOtherManagers_WritesTheOppositeEdgeToItsOwnSection()
+    {
+        // The cover-page list is the child→parent edge and must land in OTHERMANAGER.tsv, not be
+        // folded into the summary page's OTHERMANAGER2.tsv — the two mean opposite things, so a
+        // writer that merged them would invert half the relationships the importer stores. The
+        // list files no sequence numbers, so the surrogate key is positional.
+        var filing = new Parsed13FFiling
+        {
+            AccessionNumber = "0000769993-26-000034",
+            Cik = "769993",
+            FilingDate = new DateOnly(2026, 5, 15),
+            PeriodOfReport = new DateOnly(2026, 3, 31),
+            FilingManagerName = "GOLDMAN SACHS & CO. LLC",
+            CoverPageOtherManagers =
+            [
+                new OtherManagerIdentity(
+                    "GOLDMAN SACHS GROUP INC",
+                    "886982",
+                    "028-04981",
+                    null,
+                    null
+                ),
+            ],
+        };
+
+        using var archive = new Realtime13FArchiveBuilder().Build([filing]);
+
+        var coverEntry = archive.GetEntry("OTHERMANAGER.tsv");
+        coverEntry.Should().NotBeNull();
+
+        var rows = new List<Dictionary<string, string>>();
+        await foreach (var row in new TsvParser().ParseEntry(coverEntry))
+            rows.Add(row);
+
+        rows.Should().HaveCount(1);
+        rows[0]["ACCESSION_NUMBER"].Should().Be("0000769993-26-000034");
+        rows[0]["OTHERMANAGER_SK"].Should().Be("1");
+        rows[0]["CIK"].Should().Be("886982");
+        rows[0]["FORM13FFILENUMBER"].Should().Be("028-04981");
+        rows[0]["NAME"].Should().Be("GOLDMAN SACHS GROUP INC");
+
+        // The summary-page section stays empty: this filing reports for nobody.
+        var summaryRows = new List<Dictionary<string, string>>();
+        await foreach (var row in new TsvParser().ParseEntry(archive.GetEntry("OTHERMANAGER2.tsv")))
+            summaryRows.Add(row);
+        summaryRows.Should().BeEmpty();
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserOtherManagerIdentityTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserOtherManagerIdentityTests.cs
@@ -1,0 +1,160 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Filing13FXmlParserOtherManagerIdentityTests
+{
+    [Fact]
+    public void ParseCoverPage_OtherManager2WithIdentifiers_KeepsAllOfThem()
+    {
+        // The identifiers are the only thing that can tie a co-manager to an institution: names
+        // are not safe to match on, so a parser that reads <name> and drops the siblings leaves
+        // every subsidiary in a combination report permanently unlinkable. The CIK is stored the
+        // way filer CIKs are stored — leading zeros gone — or the join silently never matches.
+        var xml =
+            "<edgarSubmission>"
+            + "  <headerData><cik>0000886982</cik></headerData>"
+            + "  <coverPage><reportCalendarOrQuarter>03-31-2026</reportCalendarOrQuarter></coverPage>"
+            + "  <summaryPage>"
+            + "    <otherManagers2Info>"
+            + "      <otherManager2>"
+            + "        <sequenceNumber>1</sequenceNumber>"
+            + "        <otherManager>"
+            + "          <cik>0000769993</cik>"
+            + "          <form13FFileNumber>028-00687</form13FFileNumber>"
+            + "          <crdNumber>000000361</crdNumber>"
+            + "          <name>GOLDMAN SACHS &amp; CO. LLC</name>"
+            + "        </otherManager>"
+            + "      </otherManager2>"
+            + "    </otherManagers2Info>"
+            + "  </summaryPage>"
+            + "</edgarSubmission>";
+
+        var result = new Filing13FXmlParser().ParseCoverPage(
+            xml,
+            accessionNumber: "0000886982-26-000274",
+            cik: "0000886982",
+            filingDate: new DateOnly(2026, 5, 15)
+        );
+
+        var manager = result.OtherManagers[1];
+        manager.Name.Should().Be("GOLDMAN SACHS & CO. LLC");
+        manager.Cik.Should().Be("769993");
+        manager.Form13FFileNumber.Should().Be("028-00687");
+        manager.CrdNumber.Should().Be("000000361");
+    }
+
+    [Fact]
+    public void ParseCoverPage_OtherManagerWithNameOnly_KeepsTheEntryWithNullIdentifiers()
+    {
+        // Every identifier is optional in the SEC schema, and secFileNumber is absent from every
+        // live filing seen so far. A parser that required one would drop real managers; one that
+        // substituted an empty string would make an absent identifier look like a filed value and
+        // let it be joined on. The entry survives, unlinkable, with nulls.
+        var xml =
+            "<edgarSubmission>"
+            + "  <headerData><cik>0001067983</cik></headerData>"
+            + "  <coverPage><reportCalendarOrQuarter>03-31-2026</reportCalendarOrQuarter></coverPage>"
+            + "  <summaryPage>"
+            + "    <otherManagers2Info>"
+            + "      <otherManager2>"
+            + "        <sequenceNumber>2</sequenceNumber>"
+            + "        <otherManager><name>NAMELESS ADVISORS</name></otherManager>"
+            + "      </otherManager2>"
+            + "    </otherManagers2Info>"
+            + "  </summaryPage>"
+            + "</edgarSubmission>";
+
+        var result = new Filing13FXmlParser().ParseCoverPage(
+            xml,
+            accessionNumber: "0001067983-26-000401",
+            cik: "0001067983",
+            filingDate: new DateOnly(2026, 5, 15)
+        );
+
+        var manager = result.OtherManagers[2];
+        manager.Name.Should().Be("NAMELESS ADVISORS");
+        manager.Cik.Should().BeNull();
+        manager.Form13FFileNumber.Should().BeNull();
+        manager.CrdNumber.Should().BeNull();
+        manager.SecFileNumber.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseCoverPage_BothManagerLists_KeepsThemApartAndDoesNotInvertEitherEdge()
+    {
+        // The two lists mean opposite things — the cover page names who reports FOR this filer,
+        // the summary page names who it reports for — and a combination report carries both. They
+        // also share the element name `otherManager`, so an unscoped scan folds them into one and
+        // silently inverts half the relationships. This pins that they stay separate.
+        var xml =
+            "<edgarSubmission>"
+            + "  <headerData><cik>0000895421</cik></headerData>"
+            + "  <coverPage>"
+            + "    <reportCalendarOrQuarter>03-31-2026</reportCalendarOrQuarter>"
+            + "    <reportType>13F COMBINATION REPORT</reportType>"
+            + "    <otherManagersInfo>"
+            + "      <otherManager>"
+            + "        <cik>0002026079</cik>"
+            + "        <form13FFileNumber>028-24289</form13FFileNumber>"
+            + "        <name>PARENT REPORTING FOR US</name>"
+            + "      </otherManager>"
+            + "    </otherManagersInfo>"
+            + "  </coverPage>"
+            + "  <summaryPage>"
+            + "    <otherManagers2Info>"
+            + "      <otherManager2>"
+            + "        <sequenceNumber>1</sequenceNumber>"
+            + "        <otherManager><name>SUBSIDIARY WE REPORT FOR</name></otherManager>"
+            + "      </otherManager2>"
+            + "    </otherManagers2Info>"
+            + "  </summaryPage>"
+            + "</edgarSubmission>";
+
+        var result = new Filing13FXmlParser().ParseCoverPage(
+            xml,
+            accessionNumber: "0000895421-26-000183",
+            cik: "0000895421",
+            filingDate: new DateOnly(2026, 5, 15)
+        );
+
+        result.OtherManagers.Should().HaveCount(1);
+        result.OtherManagers[1].Name.Should().Be("SUBSIDIARY WE REPORT FOR");
+
+        result.CoverPageOtherManagers.Should().HaveCount(1);
+        result.CoverPageOtherManagers[0].Name.Should().Be("PARENT REPORTING FOR US");
+        result.CoverPageOtherManagers[0].Cik.Should().Be("2026079");
+        result.CoverPageOtherManagers[0].Form13FFileNumber.Should().Be("028-24289");
+    }
+
+    [Fact]
+    public void ParseCoverPage_NoCoverPageList_LeavesTheOppositeEdgeEmpty()
+    {
+        // Most 13F-HR filings carry no cover-page list at all. The summary page's own nested
+        // <otherManager> elements must not be mistaken for one — that would invent a parent
+        // relationship pointing at the filer's own subsidiaries.
+        var xml =
+            "<edgarSubmission>"
+            + "  <headerData><cik>0000886982</cik></headerData>"
+            + "  <coverPage><reportCalendarOrQuarter>03-31-2026</reportCalendarOrQuarter></coverPage>"
+            + "  <summaryPage>"
+            + "    <otherManagers2Info>"
+            + "      <otherManager2>"
+            + "        <sequenceNumber>1</sequenceNumber>"
+            + "        <otherManager><name>A SUBSIDIARY</name></otherManager>"
+            + "      </otherManager2>"
+            + "    </otherManagers2Info>"
+            + "  </summaryPage>"
+            + "</edgarSubmission>";
+
+        var result = new Filing13FXmlParser().ParseCoverPage(
+            xml,
+            accessionNumber: "0000886982-26-000274",
+            cik: "0000886982",
+            filingDate: new DateOnly(2026, 5, 15)
+        );
+
+        result.OtherManagers.Should().HaveCount(1);
+        result.CoverPageOtherManagers.Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
@@ -65,7 +65,7 @@ public class Filing13FXmlParserParseCoverPageTests
         result.Form13FFileNumber.Should().Be("028-00338");
         result.CrdNumber.Should().Be("314159");
         result.OtherManagers.Should().HaveCount(2);
-        result.OtherManagers[1].Should().Be("General Re-New England Asset Mgmt");
-        result.OtherManagers[3].Should().Be("New England Asset Management");
+        result.OtherManagers[1].Name.Should().Be("General Re-New England Asset Mgmt");
+        result.OtherManagers[3].Name.Should().Be("New England Asset Management");
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildOtherManagerIdentityTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildOtherManagerIdentityTests.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceBuildOtherManagerIdentityTests
+{
+    private static OtherManagerIdentity Invoke(Dictionary<string, string> row, string name)
+    {
+        var method = typeof(HoldingsImportService).GetMethod(
+            "BuildOtherManagerIdentity",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        return (OtherManagerIdentity)method!.Invoke(null, [row, name]);
+    }
+
+    [Fact]
+    public void BuildOtherManagerIdentity_LegacyThreeColumnRow_YieldsNameWithNullIdentifiers()
+    {
+        // Every archive written before this lane existed — and the Schedule 13D/G synthetic one,
+        // which ships a header-only section — carries only ACCESSION_NUMBER/SEQUENCENUMBER/NAME.
+        // A reader that assumed the identifier columns were present would throw or, worse, store
+        // empty strings that later look like filed identifiers and get joined on. The row must
+        // still parse, identifiers absent.
+        var row = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ACCESSION_NUMBER"] = "0000950123-24-007578",
+            ["SEQUENCENUMBER"] = "1",
+            ["NAME"] = "LEGACY ADVISORS",
+        };
+
+        var identity = Invoke(row, "LEGACY ADVISORS");
+
+        identity.Name.Should().Be("LEGACY ADVISORS");
+        identity.Cik.Should().BeNull();
+        identity.Form13FFileNumber.Should().BeNull();
+        identity.CrdNumber.Should().BeNull();
+        identity.SecFileNumber.Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildOtherManagerIdentity_FullRow_TrimsTheCikToTheStoredSpelling()
+    {
+        // Filer CIKs are stored with leading zeros stripped. The data set pads them, so an
+        // untrimmed value compares unequal to the very holder it identifies and the manager stays
+        // unlinked despite carrying a perfectly good CIK.
+        var row = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["CIK"] = "0000769993",
+            ["FORM13FFILENUMBER"] = "028-00687",
+            ["CRDNUMBER"] = "000000361",
+            ["SECFILENUMBER"] = "801-16048",
+            ["NAME"] = "GOLDMAN SACHS & CO. LLC",
+        };
+
+        var identity = Invoke(row, "GOLDMAN SACHS & CO. LLC");
+
+        identity.Cik.Should().Be("769993");
+        identity.Form13FFileNumber.Should().Be("028-00687");
+        identity.CrdNumber.Should().Be("000000361");
+        identity.SecFileNumber.Should().Be("801-16048");
+    }
+
+    [Fact]
+    public void BuildOtherManagerIdentity_BlankIdentifierColumns_StayNullRatherThanBecomingEmpty()
+    {
+        // The SEC keeps these columns present and empty rather than omitting them, so every one of
+        // them arrives as "" instead of null. An empty string is not an absent identifier — it is a
+        // value that compares equal to every other blank, so joining on it would collide every
+        // identifier-less manager into a single institution.
+        var row = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["CIK"] = "   ",
+            ["FORM13FFILENUMBER"] = "",
+            ["CRDNUMBER"] = "",
+            ["SECFILENUMBER"] = "",
+            ["NAME"] = "BLANK IDENTIFIER ADVISORS",
+        };
+
+        var identity = Invoke(row, "BLANK IDENTIFIER ADVISORS");
+
+        identity.Cik.Should().BeNull();
+        identity.Form13FFileNumber.Should().BeNull();
+        identity.CrdNumber.Should().BeNull();
+        identity.SecFileNumber.Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildOtherManagerIdentity_OverlongValues_AreClampedToTheirColumnBounds()
+    {
+        // The other-manager table is free text out of a filer's own submission. A value past the
+        // destination column's bound aborts the whole insert with a 22001, losing every manager in
+        // the batch; keeping the prefix beats losing the batch.
+        var row = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["FORM13FFILENUMBER"] = new string('F', 80),
+            ["CRDNUMBER"] = new string('C', 80),
+            ["SECFILENUMBER"] = new string('S', 80),
+        };
+
+        var identity = Invoke(row, new string('N', 400));
+
+        identity.Name.Should().HaveLength(256);
+        identity.Form13FFileNumber.Should().HaveLength(32);
+        identity.CrdNumber.Should().HaveLength(32);
+        identity.SecFileNumber.Should().HaveLength(32);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowPricePresentTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowPricePresentTests.cs
@@ -56,7 +56,7 @@ public class HoldingsImportServiceParseHoldingRowPricePresentTests
             {
                 [(commonStockId, reportDate)] = 12.50m,
             },
-            OtherManagers = new Dictionary<string, Dictionary<int, string>>(),
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(),
         };
 
         var result = method.Invoke(

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValuePendingTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValuePendingTests.cs
@@ -50,7 +50,7 @@ public class HoldingsImportServiceParseHoldingRowValuePendingTests
         {
             CoverPages = new Dictionary<string, CoverPageRow>(),
             StockPrices = new Dictionary<(Guid, DateOnly), decimal>(),
-            OtherManagers = new Dictionary<string, Dictionary<int, string>>(),
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(),
         };
 
         var result = method.Invoke(

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTests.cs
@@ -253,7 +253,10 @@ public class HoldingsImportServiceTests
                 StringComparer.OrdinalIgnoreCase
             )
             {
-                ["ACC-001"] = new() { [1] = new OtherManagerIdentity("Goldman Sachs", null, null, null, null) },
+                ["ACC-001"] = new()
+                {
+                    [1] = new OtherManagerIdentity("Goldman Sachs", null, null, null, null),
+                },
             },
         };
 
@@ -283,7 +286,10 @@ public class HoldingsImportServiceTests
                 StringComparer.OrdinalIgnoreCase
             )
             {
-                ["ACC-001"] = new() { [1] = new OtherManagerIdentity("Goldman Sachs", null, null, null, null) },
+                ["ACC-001"] = new()
+                {
+                    [1] = new OtherManagerIdentity("Goldman Sachs", null, null, null, null),
+                },
             },
         };
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTests.cs
@@ -238,7 +238,7 @@ public class HoldingsImportServiceTests
     {
         var context = new ImportContext
         {
-            OtherManagers = new Dictionary<string, Dictionary<int, string>>(),
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(),
         };
 
         HoldingsParsingHelper.ResolveManagerName(context, "ACC-001", null).Should().BeNull();
@@ -249,11 +249,11 @@ public class HoldingsImportServiceTests
     {
         var context = new ImportContext
         {
-            OtherManagers = new Dictionary<string, Dictionary<int, string>>(
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(
                 StringComparer.OrdinalIgnoreCase
             )
             {
-                ["ACC-001"] = new() { [1] = "Goldman Sachs" },
+                ["ACC-001"] = new() { [1] = new OtherManagerIdentity("Goldman Sachs", null, null, null, null) },
             },
         };
 
@@ -268,7 +268,7 @@ public class HoldingsImportServiceTests
     {
         var context = new ImportContext
         {
-            OtherManagers = new Dictionary<string, Dictionary<int, string>>(),
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(),
         };
 
         HoldingsParsingHelper.ResolveManagerName(context, "ACC-999", 1).Should().BeNull();
@@ -279,11 +279,11 @@ public class HoldingsImportServiceTests
     {
         var context = new ImportContext
         {
-            OtherManagers = new Dictionary<string, Dictionary<int, string>>(
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(
                 StringComparer.OrdinalIgnoreCase
             )
             {
-                ["ACC-001"] = new() { [1] = "Goldman Sachs" },
+                ["ACC-001"] = new() { [1] = new OtherManagerIdentity("Goldman Sachs", null, null, null, null) },
             },
         };
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperResolveManagerNameHappyPathTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperResolveManagerNameHappyPathTests.cs
@@ -18,11 +18,11 @@ public class HoldingsParsingHelperResolveManagerNameHappyPathTests
         // name in every multi-manager 13F-HR filing.
         var context = new ImportContext
         {
-            OtherManagers = new Dictionary<string, Dictionary<int, string>>
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>
             {
-                ["0001234-25-000001"] = new Dictionary<int, string>
+                ["0001234-25-000001"] = new Dictionary<int, OtherManagerIdentity>
                 {
-                    [2] = "Acme Capital Advisors",
+                    [2] = new OtherManagerIdentity("Acme Capital Advisors", null, null, null, null),
                 },
             },
         };

--- a/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTests.cs
@@ -276,7 +276,7 @@ public class HoldingsParsingHelperTests
         // chain is the dangerous one.
         var context = new ImportContext
         {
-            OtherManagers = new Dictionary<string, Dictionary<int, string>>(),
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(),
         };
 
         var result = HoldingsParsingHelper.ResolveManagerName(

--- a/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderBuildTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderBuildTests.cs
@@ -43,7 +43,16 @@ public class Realtime13FArchiveBuilderBuildTests
                     OtherManagerNumber = 1,
                 },
             },
-            OtherManagers = { [1] = new OtherManagerIdentity("General Re-New England Asset Mgmt", null, null, null, null) },
+            OtherManagers =
+            {
+                [1] = new OtherManagerIdentity(
+                    "General Re-New England Asset Mgmt",
+                    null,
+                    null,
+                    null,
+                    null
+                ),
+            },
         };
 
         using var archive = _sut.Build([filing]);

--- a/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderBuildTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderBuildTests.cs
@@ -43,12 +43,12 @@ public class Realtime13FArchiveBuilderBuildTests
                     OtherManagerNumber = 1,
                 },
             },
-            OtherManagers = { [1] = "General Re-New England Asset Mgmt" },
+            OtherManagers = { [1] = new OtherManagerIdentity("General Re-New England Asset Mgmt", null, null, null, null) },
         };
 
         using var archive = _sut.Build([filing]);
 
-        archive.Entries.Should().HaveCount(5);
+        archive.Entries.Should().HaveCount(6);
         archive
             .Entries.Select(e => e.Name)
             .Should()
@@ -57,6 +57,7 @@ public class Realtime13FArchiveBuilderBuildTests
                 "COVERPAGE.tsv",
                 "INFOTABLE.tsv",
                 "OTHERMANAGER2.tsv",
+                "OTHERMANAGER.tsv",
                 "SUMMARYPAGE.tsv",
             ]);
 

--- a/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderTests.cs
@@ -13,7 +13,7 @@ public class Realtime13FArchiveBuilderTests
     {
         using var archive = _sut.Build([]);
 
-        archive.Entries.Should().HaveCount(5);
+        archive.Entries.Should().HaveCount(6);
         archive
             .Entries.Select(e => e.Name)
             .Should()
@@ -22,6 +22,7 @@ public class Realtime13FArchiveBuilderTests
                 "COVERPAGE.tsv",
                 "INFOTABLE.tsv",
                 "OTHERMANAGER2.tsv",
+                "OTHERMANAGER.tsv",
                 "SUMMARYPAGE.tsv",
             ]);
     }
@@ -39,6 +40,7 @@ public class Realtime13FArchiveBuilderTests
                 "COVERPAGE.tsv",
                 "INFOTABLE.tsv",
                 "OTHERMANAGER2.tsv",
+                "OTHERMANAGER.tsv",
                 "SUMMARYPAGE.tsv",
             ]);
     }
@@ -215,8 +217,8 @@ public class Realtime13FArchiveBuilderTests
     public void Build_WithOtherManagers_WritesManagerRows()
     {
         var filing = CreateFiling();
-        filing.OtherManagers[1] = "Manager Alpha";
-        filing.OtherManagers[2] = "Manager Beta";
+        filing.OtherManagers[1] = new OtherManagerIdentity("Manager Alpha", null, null, null, null);
+        filing.OtherManagers[2] = new OtherManagerIdentity("Manager Beta", null, null, null, null);
 
         using var archive = _sut.Build([filing]);
         var content = ReadEntry(archive, "OTHERMANAGER2.tsv");
@@ -337,7 +339,7 @@ public class Realtime13FArchiveBuilderTests
                 InvestmentDiscretion = "SOLE",
             }
         );
-        filing.OtherManagers[1] = "Test Manager";
+        filing.OtherManagers[1] = new OtherManagerIdentity("Test Manager", null, null, null, null);
 
         using var archive = _sut.Build([filing]);
 


### PR DESCRIPTION
## Summary

A 13F names other managers on two pages, and both lists carry a CIK, a Form 13F file number and a CRD alongside the name. The import read only the name.

That made the structure those lists describe unrecoverable. Goldman Sachs Group's latest 13F is a combination report covering eight subsidiaries, attributing every position to one of them — but with only the names kept, it collapsed into one opaque holder row whose subsidiaries were unmatched strings. Names are not safe to match institutions on, so the filed identifiers are the only way to link a co-manager back to its own filings.

Two directions exist and mean opposite things. The summary page's list (`otherManagers2Info` / `OTHERMANAGER2.tsv`) is the managers this filing reports *for* — parent to subsidiary. The cover page's list (`otherManagersInfo` / `OTHERMANAGER.tsv`) is the managers who report *for this filer* — the opposite edge. Combination reports carry both; Morgan Stanley's current filing is one.

## Code changes

**New entity** — `FilingOtherManager` records one named manager per filing, keyed by accession + sequence, with a `Direction` separating the two lists. A position's existing `HoldingManagerEntry.ManagerNumber` already points at the summary-page sequence, so the per-position table is untouched.

**Bulk reader** (`HoldingsImportService`) — `TryParseOtherManagerRow` now reads the identifier columns it was skipping; a new `ParseOtherManagerCoverList` reads `OTHERMANAGER.tsv`, which was not read at all. Both tolerate missing columns, so archives predating this still parse.

**Filing XML reader** (`Filing13FXmlParser`) — takes the identifiers off the `otherManager` element it was already reaching into for the name, and reads the cover-page list scoped to `coverPage`. The scoping matters: both pages nest an element named `otherManager`, so an unscoped scan would fold the lists together and invert half the relationships.

**Blank is absent** — missing columns and present-but-empty cells yield null, not `""`. An empty string is a value that compares equal to every other blank, so it would collide every identifier-less manager into one institution.

**Synthetic archive** (`Realtime13FArchiveBuilder`) — gains the same columns and the new section, so it stays parseable by the same reader as the SEC's quarterly one.

**Replace-per-accession** — the flush deletes across every 13F accession an import covers, not just those producing rows, so a filing that drops a manager has its stale list cleared. Accessions *outside* the import keep their rows on purpose: a "new holdings" amendment merges without deleting, so a holder's quarter can span accessions and the older ones are still referenced. Restricted to Form 13F — the Schedule 13D/G lane shares this pipeline and ships a header-only section, which would otherwise delete lists it never owned.

**Parser version 5** re-imports history to populate the table.

## Tests

New: XML identity extraction, the two lists staying separate in both directions, legacy three-column tolerance, blank-to-null, length clamping, and against a real database — both directions persisted, re-import idempotency, stale-list clearing, and a Schedule 13D/G import leaving a 13F filing's managers alone.

Existing pins updated for the widened type and the new archive section.

Full suites green locally: 3850 unit, 2285 integration.