### PR TITLE
fix(insider-trading): widen the TransactionDate covering index so sentiment scoring stops timing out

### DIFF
--- a/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
+++ b/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
@@ -25,20 +25,33 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
             .IsRequired()
             .HasDefaultValueSql("'{}'");
 
-        // Covering index for the insider-trading dashboard's "top by dollar
-        // volume" queries (run three times per page: buys, sells, biggest).
-        // Each filters a ~90-day TransactionDate window, drops invalid-price and
-        // derivative rows, then orders by Shares * PricePerShare. The date window
-        // is the only selective filter, but the planner was choosing a full seq
-        // scan over the plain [Index(TransactionDate)] btree; the INCLUDE columns
-        // let the window resolve as an index-only scan (no heap fetch for the
-        // filter/sort fields), turning an ~805ms scan into ~90ms. Postgres-specific
-        // INCLUDE isn't expressible via the [Index] attribute, so it lives here;
-        // EF merges it with the entity's [Index(TransactionDate)] attribute into a
-        // single btree with the INCLUDE list attached.
+        // Covering index for every ~90-day TransactionDate window scan. Two
+        // consumers share it:
+        //   - the insider-trading dashboard's "top by dollar volume" boards (run
+        //     three times per page: buys, sells, biggest), which drop invalid-price
+        //     and derivative rows then order by Shares * PricePerShare;
+        //   - the insider-sentiment scoring pass, which additionally groups by
+        //     CommonStockId, counts distinct InsiderOwnerId per direction, and
+        //     gates on TransactionCode / IsRule10b5One.
+        // The date window is the only selective filter, but the planner was
+        // choosing a full seq scan over the plain [Index(TransactionDate)] btree;
+        // the INCLUDE columns let the window resolve as an index-only scan (no heap
+        // fetch for the filter/sort/group fields). The sentiment gate's four
+        // columns were missing from the original five, so that query fell back to
+        // heap-fetching every candidate row: 124k fetches over a 90-day window,
+        // 66,497 buffers, ~84ms warm but 17-30s cold — which timed out the 30s
+        // CommandTimeout on a cold cache. With them included it is an index-only
+        // scan: 2,511 buffers, zero heap fetches.
+        // Postgres-specific INCLUDE isn't expressible via the [Index] attribute, so
+        // it lives here; EF merges it with the entity's [Index(TransactionDate)]
+        // attribute into a single btree with the INCLUDE list attached. The
+        // explicit name keeps the widened index distinct from the five-column one
+        // it supersedes, so the migration can build the replacement CONCURRENTLY
+        // before dropping the old one instead of rebuilding in place under lock.
         builder
             .Entity<InsiderTransaction>()
             .HasIndex(t => t.TransactionDate)
+            .HasDatabaseName("IX_InsiderTransaction_TransactionDate_Covering")
             .IncludeProperties(t => new
             {
                 t.Shares,
@@ -46,6 +59,10 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
                 t.IsPriceValid,
                 t.SecurityKind,
                 t.SecurityTitle,
+                t.CommonStockId,
+                t.InsiderOwnerId,
+                t.TransactionCode,
+                t.IsRule10b5One,
             });
     }
 }

--- a/src/Equibles.Migrations/Migrations/20260731145857_WidenInsiderTransactionCoveringIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260731145857_WidenInsiderTransactionCoveringIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260731145857_WidenInsiderTransactionCoveringIndex")]
+    partial class WidenInsiderTransactionCoveringIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260731145857_WidenInsiderTransactionCoveringIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260731145857_WidenInsiderTransactionCoveringIndex.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <summary>
+    /// Widens the TransactionDate covering index with the four columns the insider-sentiment
+    /// gate reads (CommonStockId, InsiderOwnerId, TransactionCode, IsRule10b5One) so its
+    /// 90-day window resolves as an index-only scan instead of heap-fetching every candidate
+    /// row. Measured on production: 66,497 buffers down to 2,511, zero heap fetches.
+    ///
+    /// Raw SQL rather than the scaffolded DropIndex/CreateIndex pair, for three reasons:
+    /// CONCURRENTLY (suppressTransaction) so neither build takes a write lock on the live
+    /// table — the Form 4 scraper writes continuously; IF NOT EXISTS so a deployment that
+    /// pre-built the index by hand is a no-op; and create-before-drop so no window exists in
+    /// which a TransactionDate scan has no covering index to use. The scaffolded version
+    /// dropped first and rebuilt 361 MB under ACCESS EXCLUSIVE inside the deploy's migrate
+    /// gate.
+    ///
+    /// An index-only scan is only reachable while the visibility map is fresh, and nothing was
+    /// keeping it so: at ~1k inserts/day against 3.16M rows, the server-wide
+    /// autovacuum_vacuum_insert_scale_factor of 0.2 puts the next insert-triggered vacuum
+    /// ~630 days out, and the update path's 0.2 left a bulk reprocess pass's 512k dead tuples
+    /// parked below the 633k trigger indefinitely. Production sat at 46.5% all-visible pages,
+    /// which is why the planner refused an index-only scan even once the index existed. The
+    /// table-level overrides below pin both paths to this table's actual churn; a full vacuum
+    /// pass costs 7.7s.
+    /// </summary>
+    public partial class WidenInsiderTransactionCoveringIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // A failed CONCURRENTLY build leaves an INVALID index behind, which IF NOT EXISTS
+            // would then treat as "exists" forever — drop such a leftover first (an invalid
+            // index serves no queries, so the plain drop's brief lock is free), then build.
+            migrationBuilder.Sql(
+                "DO $$ BEGIN "
+                    + "IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                    + "WHERE c.relname = 'IX_InsiderTransaction_TransactionDate_Covering' AND NOT i.indisvalid) THEN "
+                    + "EXECUTE 'DROP INDEX \"IX_InsiderTransaction_TransactionDate_Covering\"'; END IF; END $$;",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_InsiderTransaction_TransactionDate_Covering\" "
+                    + "ON \"InsiderTransaction\" (\"TransactionDate\") "
+                    + "INCLUDE (\"Shares\", \"PricePerShare\", \"IsPriceValid\", \"SecurityKind\", "
+                    + "\"SecurityTitle\", \"CommonStockId\", \"InsiderOwnerId\", \"TransactionCode\", "
+                    + "\"IsRule10b5One\");",
+                suppressTransaction: true
+            );
+            // Only now that the replacement is live and valid: the old five-column index is a
+            // strict subset (same key column, fewer INCLUDE columns), so every query it served
+            // is served by the new one.
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InsiderTransaction_TransactionDate\";",
+                suppressTransaction: true
+            );
+            // Insert-triggered vacuum on a fixed row count rather than a fraction of a
+            // 3.16M-row table — this is what keeps the visibility map fresh, and the newest
+            // rows are exactly the ones every 90-day window scan reads.
+            migrationBuilder.Sql(
+                "ALTER TABLE \"InsiderTransaction\" SET ("
+                    + "autovacuum_vacuum_insert_threshold = 5000, "
+                    + "autovacuum_vacuum_insert_scale_factor = 0, "
+                    + "autovacuum_vacuum_scale_factor = 0.02);"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "ALTER TABLE \"InsiderTransaction\" RESET ("
+                    + "autovacuum_vacuum_insert_threshold, "
+                    + "autovacuum_vacuum_insert_scale_factor, "
+                    + "autovacuum_vacuum_scale_factor);"
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_InsiderTransaction_TransactionDate\" "
+                    + "ON \"InsiderTransaction\" (\"TransactionDate\") "
+                    + "INCLUDE (\"Shares\", \"PricePerShare\", \"IsPriceValid\", \"SecurityKind\", "
+                    + "\"SecurityTitle\");",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InsiderTransaction_TransactionDate_Covering\";",
+                suppressTransaction: true
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`GetInsiderSentimentScores` failed in production with a 30s command timeout (`30,081ms` against a `CommandTimeout` of 30,000). The query behind it is `CountDistinctInsidersByDirection`, which `pg_stat_statements` shows at mean 1,502ms but **max 17,432ms** over 104 calls — enormous variance for a query that is 84ms warm.

The sentiment pass filters the same ~90-day `TransactionDate` window as the insider dashboard's dollar-volume boards, but additionally groups by `CommonStockId`, counts distinct `InsiderOwnerId` per direction, and gates on `TransactionCode` / `IsRule10b5One`. None of those four columns were in the covering index's `INCLUDE` list, so every candidate row had to be fetched from the heap — 124k fetches over the window, 66,497 buffers. Runtime is then purely a function of how much of that is in Postgres's buffer cache, which is exactly the 84ms → 17s → 30s spread.

Adding the four columns turns it into an index-only scan. Measured on production:

| | before | after |
|---|---|---|
| plan node | Index Scan | **Index Only Scan** |
| heap fetches | 124k | **0** |
| buffers | 66,497 | **2,511** |
| planner cost | 56,091 | **6,131** |
| warm execution | 84ms | 18ms |

The old five-column index is a strict subset of the new one (same key column, fewer `INCLUDE` columns), so every query it served is served by the replacement — verified for the dashboard's dollar-volume query, which also switches to a parallel index-only scan. It is dropped, net **-278 MB** (639 MB → 361 MB).

### The visibility map was the actual blocker

An index-only scan is only reachable while the visibility map is fresh, and nothing was keeping it so. Production sat at **46.5% all-visible pages**, so the planner refused the index-only scan even after the index existed — the first `EXPLAIN` with the new index in place still chose the old plan. A manual `VACUUM` (7.7s) took it to 100% and the plan flipped immediately.

Why it had degraded:

- **Insert path**: `autovacuum_vacuum_insert_scale_factor` is 0.2 server-wide, so on 3.16M rows the next insert-triggered vacuum needs 633k inserts. At ~1k inserts/day that is **~630 days**.
- **Update path**: the same 0.2 on the dead-tuple trigger left a bulk reprocess pass's 512,605 dead tuples parked just below the 633k threshold indefinitely.

The migration sets table-level overrides pinning both paths to this table's actual churn (`insert_threshold = 5000`, `insert_scale_factor = 0`, `vacuum_scale_factor = 0.02`). Without this the index-only scan silently rots back to a heap-fetching plan and the timeout returns.

## Code changes

- **`src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs`** — adds `CommonStockId`, `InsiderOwnerId`, `TransactionCode`, `IsRule10b5One` to the index's `IncludeProperties`, and names it explicitly (`IX_InsiderTransaction_TransactionDate_Covering`) so the replacement can be built alongside the index it supersedes rather than rebuilt in place under lock. Comment now records both consumers and the measured numbers.
- **`src/Equibles.Migrations/Migrations/20260731145857_WidenInsiderTransactionCoveringIndex.cs`** — hand-written raw SQL rather than the scaffolded `DropIndex`/`CreateIndex` pair, following the `AddChunkTickerIndex` precedent: `CONCURRENTLY` + `suppressTransaction` so neither build takes a write lock on the live table (the Form 4 scraper writes continuously), `IF NOT EXISTS` so a deployment that pre-built the index by hand is a no-op, invalid-leftover cleanup, and create-before-drop so no window exists in which a `TransactionDate` scan has no covering index. The scaffolded version dropped first and rebuilt 361 MB under `ACCESS EXCLUSIVE` inside the deploy's migrate gate.

## Testing

- `dotnet build Equibles.sln -c Release` — clean.
- `dotnet test Equibles.sln -c Release --filter "Category!=Functional&Category!=Live"` — **3,858 unit + 2,286 integration passed, 0 failed**.
- `dotnet csharpier check .` — clean across 3,200 files.
- Both `EXPLAIN (ANALYZE, BUFFERS)` results above captured against the live production database.