### PR TITLE
fix(prices): never answer a secondary ticker with the primary's price series

### DIFF
--- a/src/Equibles.CommonStocks.Data/Helpers/SecondaryTickerPolicy.cs
+++ b/src/Equibles.CommonStocks.Data/Helpers/SecondaryTickerPolicy.cs
@@ -1,0 +1,58 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.CommonStocks.Data.Helpers;
+
+/// <summary>
+/// One <see cref="CommonStock"/> row is one SEC FILER, and the filer's other listed
+/// symbols ride along in <see cref="CommonStock.SecondaryTickers"/>: share classes
+/// (BRK-A beside BRK-B, GOOG beside GOOGL), warrants, units, preferreds, and separate
+/// fund series of one trust (BWET beside BDRY). Those are DIFFERENT securities and they
+/// trade at their own prices.
+/// <para>
+/// Price data is stored once per row and fetched under the PRIMARY symbol only, so a
+/// secondary symbol has no series of its own — and a lookup that accepts either
+/// spelling answers it with the primary's bars. That reported BRK-A at BRK-B's close,
+/// off by the 1500:1 the charter fixes between the two classes.
+/// </para>
+/// <para>
+/// Price surfaces therefore resolve through <see cref="IsSecondarySymbol"/> and decline
+/// rather than substitute. Surfaces reading FILER-level data (filings, 13F holdings,
+/// insider transactions) are unaffected: those genuinely belong to the whole company,
+/// which is why the permissive lookup exists.
+/// </para>
+/// </summary>
+public static class SecondaryTickerPolicy
+{
+    /// <summary>
+    /// Whether <paramref name="requestedTicker"/> named a symbol other than
+    /// <paramref name="stock"/>'s primary one. Accepts the dot class-share notation for
+    /// the dash form the data stores (BRK.B is BRK-B, not a secondary symbol) so the
+    /// spelling a caller happens to use cannot change the answer.
+    /// </summary>
+    public static bool IsSecondarySymbol(CommonStock stock, string requestedTicker)
+    {
+        if (stock?.Ticker == null || requestedTicker == null)
+            return false;
+
+        var requested = TickerNormalizer.Normalize(requestedTicker);
+        var primary = TickerNormalizer.Normalize(stock.Ticker);
+        if (requested == primary)
+            return false;
+
+        return !requested.Contains('.') || requested.Replace('.', '-') != primary;
+    }
+
+    /// <summary>
+    /// Why the requested symbol has no prices, naming the primary so the caller can
+    /// retry. Says which company owns the series rather than only that the symbol
+    /// failed — a bare "not found" reads as missing coverage.
+    /// </summary>
+    public static string NoPriceSeriesMessage(CommonStock stock, string requestedTicker)
+    {
+        return $"No price series for '{requestedTicker}'. It is a secondary symbol on "
+            + $"{stock.Ticker} ({stock.Name}) — a different security from the same SEC filer "
+            + "(share class, warrant, unit, preferred or fund series). Prices are stored per "
+            + $"filer under the primary symbol, so request {stock.Ticker} for that company's "
+            + "own prices.";
+    }
+}

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -518,11 +518,9 @@ public class StockPriceTools
     // (SecondaryTickerPolicy): it is a different security sharing one filer's row, and
     // the row's bars belong to the primary symbol alone. SecondaryOf carries that
     // primary so the batch tool can say so in a table cell.
-    private async Task<(
-        CommonStock Stock,
-        CommonStock SecondaryOf,
-        string Error
-    )> ResolveTicker(string ticker)
+    private async Task<(CommonStock Stock, CommonStock SecondaryOf, string Error)> ResolveTicker(
+        string ticker
+    )
     {
         var resolved = await ResolvePricedSpelling(ticker);
         if (resolved.Stock == null && ticker != null && ticker.Contains('.'))

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
@@ -59,7 +60,7 @@ public class StockPriceTools
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await ResolveTicker(ticker);
+                var (stock, _, stockError) = await ResolveTicker(ticker);
                 if (stockError != null)
                     return stockError;
 
@@ -144,10 +145,19 @@ public class StockPriceTools
 
                 foreach (var ticker in tickerList)
                 {
-                    var (stock, _) = await ResolveTicker(ticker);
+                    var (stock, secondaryOf, _) = await ResolveTicker(ticker);
                     if (stock == null)
                     {
-                        result.AppendLine(PlaceholderRow(ticker, "Not found"));
+                        // A secondary symbol says which primary owns the series, so the
+                        // caller can re-ask instead of reading the row as no coverage.
+                        result.AppendLine(
+                            PlaceholderRow(
+                                ticker,
+                                secondaryOf == null
+                                    ? "Not found"
+                                    : $"No series — secondary symbol on {secondaryOf.Ticker}"
+                            )
+                        );
                         continue;
                     }
 
@@ -499,21 +509,45 @@ public class StockPriceTools
         return Math.Round((upper.Value - lower.Value) / middle.Value, 4);
     }
 
-    // Resolves a ticker to a stock, additionally accepting the dot class-share notation
-    // (BRK.B) for the dash form the price data stores (BRK-B). This is a mechanical
-    // format conversion between two spellings of the same symbol, not a heuristic.
-    private async Task<(CommonStock Stock, string Error)> ResolveTicker(string ticker)
+    // Resolves a ticker to the stock whose price series it names, additionally accepting
+    // the dot class-share notation (BRK.B) for the dash form the price data stores
+    // (BRK-B). This is a mechanical format conversion between two spellings of the same
+    // symbol, not a heuristic.
+    //
+    // A symbol that resolves only as a SECONDARY ticker is declined rather than served
+    // (SecondaryTickerPolicy): it is a different security sharing one filer's row, and
+    // the row's bars belong to the primary symbol alone. SecondaryOf carries that
+    // primary so the batch tool can say so in a table cell.
+    private async Task<(
+        CommonStock Stock,
+        CommonStock SecondaryOf,
+        string Error
+    )> ResolveTicker(string ticker)
+    {
+        var resolved = await ResolvePricedSpelling(ticker);
+        if (resolved.Stock == null && ticker != null && ticker.Contains('.'))
+        {
+            // The dashed spelling either resolves or explains itself; either beats
+            // "not found" against a symbol stored only in the dashed form.
+            var dashed = await ResolvePricedSpelling(ticker.Replace('.', '-'));
+            if (dashed.Stock != null || dashed.SecondaryOf != null)
+                return dashed;
+        }
+        return resolved;
+    }
+
+    private async Task<(
+        CommonStock Stock,
+        CommonStock SecondaryOf,
+        string Error
+    )> ResolvePricedSpelling(string ticker)
     {
         var (stock, error) = await _commonStockRepository.ResolveByTicker(ticker);
-        if (stock == null && ticker != null && ticker.Contains('.'))
-        {
-            var (dashed, _) = await _commonStockRepository.ResolveByTicker(
-                ticker.Replace('.', '-')
-            );
-            if (dashed != null)
-                return (dashed, null);
-        }
-        return (stock, error);
+        if (stock == null)
+            return (null, null, error);
+        if (SecondaryTickerPolicy.IsSecondarySymbol(stock, ticker))
+            return (null, stock, SecondaryTickerPolicy.NoPriceSeriesMessage(stock, ticker));
+        return (stock, null, null);
     }
 
     // Strict argument parsing shared by the date-ranged price tools: a non-empty date must
@@ -569,7 +603,7 @@ public class StockPriceTools
         string Error
     )> LoadAscendingPriceWindow(string ticker, string startDate, string endDate, int warmupBars)
     {
-        var (stock, stockError) = await ResolveTicker(ticker);
+        var (stock, _, stockError) = await ResolveTicker(ticker);
         if (stockError != null)
             return (null, null, 0, stockError);
 

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -522,12 +522,13 @@ public class StockPriceTools
         string ticker
     )
     {
-        var resolved = await ResolvePricedSpelling(ticker);
+        var resolved = await ResolvePricedSpelling(ticker, ticker);
         if (resolved.Stock == null && ticker != null && ticker.Contains('.'))
         {
             // The dashed spelling either resolves or explains itself; either beats
-            // "not found" against a symbol stored only in the dashed form.
-            var dashed = await ResolvePricedSpelling(ticker.Replace('.', '-'));
+            // "not found" against a symbol stored only in the dashed form. It stays the
+            // LOOKUP spelling only — the message keeps echoing what the caller wrote.
+            var dashed = await ResolvePricedSpelling(ticker.Replace('.', '-'), ticker);
             if (dashed.Stock != null || dashed.SecondaryOf != null)
                 return dashed;
         }
@@ -538,13 +539,17 @@ public class StockPriceTools
         CommonStock Stock,
         CommonStock SecondaryOf,
         string Error
-    )> ResolvePricedSpelling(string ticker)
+    )> ResolvePricedSpelling(string lookupTicker, string requestedTicker)
     {
-        var (stock, error) = await _commonStockRepository.ResolveByTicker(ticker);
+        var (stock, error) = await _commonStockRepository.ResolveByTicker(lookupTicker);
         if (stock == null)
             return (null, null, error);
-        if (SecondaryTickerPolicy.IsSecondarySymbol(stock, ticker))
-            return (null, stock, SecondaryTickerPolicy.NoPriceSeriesMessage(stock, ticker));
+        if (SecondaryTickerPolicy.IsSecondarySymbol(stock, lookupTicker))
+            return (
+                null,
+                stock,
+                SecondaryTickerPolicy.NoPriceSeriesMessage(stock, requestedTicker)
+            );
         return (stock, null, null);
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsSecondaryTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsSecondaryTickerTests.cs
@@ -1,0 +1,134 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Mcp.Tools;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// One CommonStock row is one SEC filer, and the filer's other listed symbols ride along
+/// in SecondaryTickers — sibling share classes, warrants, units, separate fund series.
+/// The row holds ONE price series, fetched under the primary symbol, so a lookup that
+/// accepts either spelling answered a secondary symbol with the primary's bars.
+///
+/// In production that made BRK-A report BRK-B's close (the two are fixed at 1500:1 by
+/// charter) and BWET, the Breakwave Tanker fund, report BDRY's — identical close, change
+/// and volume. These pin the refusal end-to-end through the real repository.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class StockPriceToolsSecondaryTickerTests : ParadeDbMcpTestBase
+{
+    public StockPriceToolsSecondaryTickerTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private StockPriceTools Sut() =>
+        new(
+            new DailyStockPriceRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<StockPriceTools>()
+        );
+
+    private async Task<CommonStock> SeedBerkshire()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "BRK-B",
+            Name = "Berkshire Hathaway Inc",
+            Cik = "0001067983",
+            SecondaryTickers = ["BRK-A"],
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+
+        DbContext
+            .Set<DailyStockPrice>()
+            .Add(
+                new DailyStockPrice
+                {
+                    CommonStockId = stock.Id,
+                    Date = new DateOnly(2026, 7, 31),
+                    Open = 510m,
+                    High = 512m,
+                    Low = 509m,
+                    Close = 511.54m,
+                    AdjustedClose = 511.54m,
+                    Volume = 3_934_400,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+        return stock;
+    }
+
+    [Fact]
+    public async Task GetLatestPrices_ASecondarySymbol_DoesNotReportThePrimarysPrice()
+    {
+        await SeedBerkshire();
+
+        var result = await Sut().GetLatestPrices("BRK-A,BRK-B");
+
+        result.Should().Contain("| BRK-B | 2026-07-31 | 511.54 |", "the primary still answers");
+        result
+            .Should()
+            .Contain(
+                "No series — secondary symbol on BRK-B",
+                "the row must say which symbol owns the series, not carry a price"
+            );
+        result
+            .Should()
+            .NotContain(
+                "| BRK-A | 2026-07-31 | 511.54 |",
+                "Class A must never be served Class B's close"
+            );
+    }
+
+    [Fact]
+    public async Task GetStockPrices_ASecondarySymbol_ExplainsInsteadOfServingTheSeries()
+    {
+        await SeedBerkshire();
+
+        var result = await Sut().GetStockPrices("BRK-A");
+
+        result.Should().Contain("No price series for 'BRK-A'");
+        result.Should().Contain("BRK-B", "the caller needs the symbol that does carry it");
+        result.Should().NotContain("511.54");
+    }
+
+    [Fact]
+    public async Task GetStockPrices_ThePrimaryInDotNotation_StillResolves()
+    {
+        await SeedBerkshire();
+
+        // The dot form is a spelling of the SAME symbol, so the refusal must not catch it.
+        var result = await Sut().GetStockPrices("BRK.B");
+
+        result.Should().Contain("511.54");
+        result.Should().NotContain("No price series");
+    }
+
+    [Fact]
+    public async Task GetStockPrices_ASecondarySymbolInDotNotation_IsStillRefused()
+    {
+        await SeedBerkshire();
+
+        var result = await Sut().GetStockPrices("BRK.A");
+
+        result.Should().Contain("No price series for 'BRK.A'");
+        result.Should().NotContain("511.54");
+    }
+
+    [Fact]
+    public async Task GetBollingerBands_ASecondarySymbol_IsRefusedLikeTheOtherPriceReads()
+    {
+        await SeedBerkshire();
+
+        // Every indicator shares one resolution path, so none of them can drift back to
+        // serving the primary's bars.
+        var result = await Sut().GetBollingerBands("BRK-A");
+
+        result.Should().Contain("No price series for 'BRK-A'");
+    }
+}


### PR DESCRIPTION
## Summary

A `CommonStock` row is one **SEC filer**, and the filer's other listed symbols ride along in `SecondaryTickers` — sibling share classes, warrants, units, preferreds, and separate fund series of one trust. Those are different securities trading at their own prices.

Daily bars are fetched under the **primary** symbol only (`YahooPriceImportService.ResolveTickers` selects `s.Ticker`) and stored per stock row, so a secondary symbol has no series of its own. `GetByTicker` matches primary *or* secondary, so every price tool served the primary's bars under whichever symbol was requested — silently, with no warning.

Observed in production:

| Requested | Returned | Reality |
|---|---|---|
| `BRK-A` | BRK-B's close, `$511.54` | Class A is fixed at 1500× Class B by charter |
| `BWET` (Breakwave Tanker) | BDRY's bar — same close, change **and** volume | different fund series of one trust |
| `GOOG`, `FOX`, `UHAL-B` | GOOGL / FOXA / UHAL's bars | different classes |

2,428 secondary tickers across 1,467 stocks are affected.

## Code changes

- **`Equibles.CommonStocks.Data/Helpers/SecondaryTickerPolicy.cs`** (new) — states the rule once. `IsSecondarySymbol` folds the dot class-share notation before comparing, so `BRK.B` still resolves to `BRK-B` and the spelling a caller happens to use cannot change the answer. `NoPriceSeriesMessage` names the primary so the caller can re-ask instead of reading the refusal as missing coverage.
- **`Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs`** — every tool already funnelled through one private `ResolveTicker`; it now applies the policy and declines. `GetLatestPrices` keeps its table shape, printing `No series — secondary symbol on BRK-B` in the row rather than a price.
- **`tests/Equibles.IntegrationTests/Mcp/StockPriceToolsSecondaryTickerTests.cs`** (new) — end-to-end through the real repository: the primary still answers, the sibling class is refused, both dot spellings behave correctly, and an indicator is refused too (all indicators share the one resolution path).

Filer-level lookups are deliberately untouched — filings, 13F holdings and insider transactions genuinely belong to the whole company, which is why the permissive lookup exists.

## Verification

`dotnet build Equibles.sln -c Release` clean. The new tests are integration tests on the ParadeDB fixture and need Docker, which is unavailable on the machine this was written on — they run in this repo's pipeline.