### PR TITLE
fix(holdings): recover CUSIPs retired before the FTD lane first ran

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -21,6 +21,81 @@ public class CommonStockManager
     }
 
     /// <summary>
+    /// Records CUSIPs a stock USED to trade under, without touching its current one.
+    /// <para>
+    /// <see cref="SetCusip"/> only ever captures a retirement it witnesses live, so a
+    /// CUSIP change that happened before this pipeline first ran leaves no alias — and
+    /// every 13F line filed under the retired value stays unmappable forever. AMC's
+    /// pre-2023-reverse-split 00165C104 is the shape: `GetTopHolders(AMC, 2022-12-31)`
+    /// answered with 4 institutions holding 845 shares, against 274 holding 102M a year
+    /// later. The cliff is the CUSIP change, not an ownership event.
+    /// </para>
+    /// <para>
+    /// Callers must have established that the CUSIP belongs to this issuer. Aliases the
+    /// table has already claimed are left with their first owner (one CUSIP identifies
+    /// one security, ever), so a re-run records nothing and publishes nothing.
+    /// </para>
+    /// <para>
+    /// Recording one publishes <see cref="StockCusipChanged"/> for the same reason
+    /// <see cref="SetCusip"/> does: quarterly 13F data sets already marked processed hold
+    /// no holdings for lines filed under the newly-mapped CUSIP, and the consumer clears
+    /// that ledger so the Holdings worker re-imports them. A burst collapses to a no-op
+    /// once cleared, so a sweep recording many aliases costs one invalidation.
+    /// </para>
+    /// </summary>
+    public async Task<int> RecordRetiredCusipAliases(
+        CommonStock commonStock,
+        IEnumerable<string> retiredCusips
+    )
+    {
+        ArgumentNullException.ThrowIfNull(commonStock);
+        ArgumentNullException.ThrowIfNull(retiredCusips);
+
+        var candidates = retiredCusips
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .Select(c => c.Trim().ToUpperInvariant())
+            .Where(c => !string.Equals(c, commonStock.Cusip, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (candidates.Count == 0)
+        {
+            return 0;
+        }
+
+        var alreadyRecorded = await _commonStockRepository
+            .GetCusipAliases()
+            .Where(a => candidates.Contains(a.Cusip.ToUpper()))
+            .Select(a => a.Cusip)
+            .ToListAsync();
+        var taken = new HashSet<string>(alreadyRecorded, StringComparer.OrdinalIgnoreCase);
+
+        var recorded = 0;
+        foreach (var cusip in candidates.Where(c => !taken.Contains(c)))
+        {
+            _commonStockRepository.AddCusipAlias(
+                new CommonStockCusipAlias { CommonStockId = commonStock.Id, Cusip = cusip }
+            );
+            recorded++;
+        }
+
+        if (recorded == 0)
+        {
+            return 0;
+        }
+
+        await _commonStockRepository.SaveChanges();
+
+        // Root bus, after the write commits — same reasoning as SetCusip: this flow only
+        // saves the financial context, so a bus outbox on another context would capture
+        // the publish and never deliver it.
+        await _bus.Publish(
+            new StockCusipChanged(commonStock.Id, commonStock.Ticker, null, commonStock.Cusip)
+        );
+
+        return recorded;
+    }
+
+    /// <summary>
     /// Sets a stock's CUSIP. When the value actually changes, publishes
     /// <see cref="StockCusipChanged"/> after SaveChanges so the Holdings module can
     /// backfill quarterly 13F data sets that were processed while this stock

--- a/src/Equibles.CommonStocks.Data/Helpers/CusipIdentity.cs
+++ b/src/Equibles.CommonStocks.Data/Helpers/CusipIdentity.cs
@@ -1,0 +1,39 @@
+namespace Equibles.CommonStocks.Data.Helpers;
+
+/// <summary>
+/// Structural facts about a CUSIP. The first 6 characters identify the ISSUER and the
+/// next 2 the specific issue, so two CUSIPs sharing a prefix are two securities of one
+/// issuer (AMC's 00165C104 and 00165C302 across its 2023 reverse split) while a differing
+/// prefix means different issuers.
+/// <para>
+/// This is the check that makes a retired-CUSIP backfill safe against TICKER RECYCLING:
+/// a symbol freed by a delisted issuer and reassigned years later would otherwise carry
+/// the dead issuer's CUSIP onto whichever company holds the symbol now, and its 13F
+/// positions with it.
+/// </para>
+/// </summary>
+public static class CusipIdentity
+{
+    private const int IssuerLength = 6;
+
+    /// <summary>
+    /// The 6-character issuer prefix, or null when the value is too short to carry one.
+    /// </summary>
+    public static string Issuer(string cusip)
+    {
+        var trimmed = cusip?.Trim();
+        return trimmed == null || trimmed.Length < IssuerLength
+            ? null
+            : trimmed[..IssuerLength].ToUpperInvariant();
+    }
+
+    /// <summary>
+    /// Whether both CUSIPs name the same issuer. False when either is missing or
+    /// malformed — an unknown issuer is never assumed to match.
+    /// </summary>
+    public static bool SameIssuer(string cusip, string other)
+    {
+        var issuer = Issuer(cusip);
+        return issuer != null && issuer == Issuer(other);
+    }
+}

--- a/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
@@ -61,5 +61,10 @@ public class FtdScraperWorker : BaseScraperWorker
 
         var ftdService = scope.ServiceProvider.GetRequiredService<FtdImportService>();
         await ftdService.Import(stoppingToken);
+
+        // Then a bounded slice of the archive sweep that recovers CUSIPs retired before
+        // this pipeline first ran — the live import above can only witness retirements
+        // that happen while it is running.
+        await ftdService.BackfillRetiredCusips(stoppingToken);
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
 using System.IO.Compression;
 using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
@@ -130,6 +132,207 @@ public class FtdImportService
             _logger.LogInformation("Seeded or updated {Count} CUSIPs from FTD data", cusipsSeeded);
         }
     }
+
+    /// <summary>
+    /// Walks the FTD archive backwards in time recording the CUSIPs each tracked symbol
+    /// USED to trade under, as <see cref="CommonStockCusipAlias"/> rows.
+    /// <para>
+    /// <see cref="SeedCusips"/> only captures a retirement it witnesses live, so every
+    /// CUSIP change that predates this pipeline left no alias — and the 13F lines filed
+    /// under those values never map. AMC's holders for 2022-12-31 read 4 institutions /
+    /// 845 shares because its pre-reverse-split 00165C104 was unmapped; a year later the
+    /// same stock shows 274 / 102M.
+    /// </para>
+    /// <para>
+    /// The CNS fails file is the authority: the SEC itself publishes SYMBOL and CUSIP on
+    /// one row, so no name matching or guessing is involved. Two guards keep it honest —
+    /// the symbol must be a tracked stock's PRIMARY ticker (sibling securities file under
+    /// their own symbols, so AMC's preferred units at 00165C203 land on APE, not AMC),
+    /// and the CUSIP must share the stock's current ISSUER prefix, which is what stops a
+    /// recycled ticker from importing a dead issuer's identity. A merger that changes the
+    /// issuer prefix (Merck's 589331107 → 58933Y105) is deliberately NOT recovered:
+    /// coverage loss over a wrong link.
+    /// </para>
+    /// <para>
+    /// Bounded per cycle (<see cref="AliasSweepFilesPerCycle"/>) with the frontier in
+    /// <see cref="BackfillState"/>, so it never blocks the daily import; one
+    /// <see cref="StockCusipChanged"/> per cycle that recorded anything invalidates the
+    /// processed-data-set ledger, and the Holdings worker re-imports the history that can
+    /// now resolve.
+    /// </para>
+    /// </summary>
+    public async Task BackfillRetiredCusips(CancellationToken cancellationToken)
+    {
+        var fileNames = await NextAliasSweepFiles();
+        if (fileNames.Count == 0)
+        {
+            return;
+        }
+
+        var tickerMap = await BuildTickerMap(cancellationToken);
+        if (tickerMap.Count == 0)
+        {
+            return;
+        }
+
+        var strippedAliases = BuildStrippedTickerAliases(tickerMap);
+        var cusipsByTicker = new Dictionary<string, HashSet<string>>(
+            StringComparer.OrdinalIgnoreCase
+        );
+
+        foreach (var fileName in fileNames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var records = await DownloadAndParse(fileName, cancellationToken);
+                foreach (var record in records)
+                {
+                    if (string.IsNullOrEmpty(record.Cusip) || string.IsNullOrEmpty(record.Symbol))
+                        continue;
+                    if (
+                        !TryResolveSymbol(record.Symbol, tickerMap, strippedAliases, out var ticker)
+                    )
+                        continue;
+
+                    if (!cusipsByTicker.TryGetValue(ticker, out var cusips))
+                    {
+                        cusips = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        cusipsByTicker[ticker] = cusips;
+                    }
+                    cusips.Add(record.Cusip);
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                // A missing archive file costs coverage for that fortnight only; the
+                // frontier still advances so the sweep cannot wedge on one bad file.
+                _logger.LogWarning(
+                    ex,
+                    "Retired-CUSIP sweep: failed to download {File}, skipping",
+                    fileName
+                );
+            }
+        }
+
+        var recorded = await RecordRetiredCusips(cusipsByTicker, cancellationToken);
+        await AdvanceAliasSweepFrontier(fileNames[^1]);
+
+        if (recorded > 0)
+        {
+            _logger.LogInformation(
+                "Retired-CUSIP sweep: recorded {Count} alias(es) across {Files} FTD file(s)",
+                recorded,
+                fileNames.Count
+            );
+        }
+    }
+
+    private async Task<int> RecordRetiredCusips(
+        Dictionary<string, HashSet<string>> cusipsByTicker,
+        CancellationToken cancellationToken
+    )
+    {
+        if (cusipsByTicker.Count == 0)
+        {
+            return 0;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var stockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
+
+        var stocks = await stockRepo
+            .GetByTickers(cusipsByTicker.Keys.ToList())
+            .ToListAsync(cancellationToken);
+
+        var recorded = 0;
+        foreach (var stock in stocks)
+        {
+            // Only the stock's OWN symbol may contribute: a secondary ticker names a
+            // different security sharing this filer's row, and its CUSIP is not this
+            // security's retired identity.
+            if (stock.Cusip == null || !cusipsByTicker.TryGetValue(stock.Ticker, out var seen))
+                continue;
+
+            var retired = seen.Where(c => CusipIdentity.SameIssuer(c, stock.Cusip)).ToList();
+            if (retired.Count == 0)
+                continue;
+
+            recorded += await stockManager.RecordRetiredCusipAliases(stock, retired);
+        }
+
+        return recorded;
+    }
+
+    // The sweep runs oldest-first from the start of the archive and stops once the
+    // frontier passes the newest file — the live import owns everything from there.
+    private async Task<List<string>> NextAliasSweepFiles()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stateRepo = scope.ServiceProvider.GetRequiredService<BackfillStateRepository>();
+        var state = await stateRepo.GetByName(AliasSweepCursorName);
+
+        var all = GetFileNames(OldestAvailableDate);
+        var startIndex = 0;
+        if (state?.Floor != null)
+        {
+            // A frontier no current file name matches means the archive naming moved on;
+            // sweeping from the start again would re-download years for nothing.
+            var index = all.IndexOf(FileNameOf(state.Floor.Value));
+            if (index < 0)
+            {
+                return [];
+            }
+            startIndex = index + 1;
+        }
+
+        return all.Skip(startIndex).Take(AliasSweepFilesPerCycle).ToList();
+    }
+
+    private async Task AdvanceAliasSweepFrontier(string lastFileName)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stateRepo = scope.ServiceProvider.GetRequiredService<BackfillStateRepository>();
+        var state = await stateRepo.GetByName(AliasSweepCursorName);
+        if (state == null)
+        {
+            state = new BackfillState { Name = AliasSweepCursorName };
+            stateRepo.Add(state);
+        }
+
+        state.Floor = FrontierOf(lastFileName);
+        await stateRepo.SaveChanges();
+    }
+
+    // The frontier is stored as the swept file's own timestamp so the cursor round-trips
+    // through BackfillState's DateTime column: the month at midnight, plus a day for the
+    // second-half ("b") file so the two halves of one month stay ordered.
+    internal static DateTime FrontierOf(string fileName)
+    {
+        var yearMonth = fileName["cnsfails".Length..];
+        var month = DateTime.ParseExact(
+            yearMonth[..6],
+            "yyyyMM",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal
+        );
+        return yearMonth[6] == 'b' ? month.AddDays(1) : month;
+    }
+
+    internal static string FileNameOf(DateTime frontier)
+    {
+        var half = frontier.Day > 1 ? "b" : "a";
+        return $"cnsfails{frontier:yyyyMM}{half}.zip";
+    }
+
+    private const string AliasSweepCursorName = "Ftd.RetiredCusipSweep";
+
+    // Twelve fortnightly files ≈ six months of archive per daily cycle, so the whole
+    // 2017→today range is swept in about a fortnight of cycles without ever making the
+    // FTD worker's run long.
+    private const int AliasSweepFilesPerCycle = 12;
 
     /// <summary>
     /// Seeds and updates CUSIP values on CommonStock records by matching FTD

--- a/tests/Equibles.UnitTests/CommonStocks/CusipIdentityTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CusipIdentityTests.cs
@@ -1,0 +1,58 @@
+using Equibles.CommonStocks.Data.Helpers;
+using Xunit;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// A CUSIP's first 6 characters identify the ISSUER and the next 2 the specific issue.
+/// The retired-CUSIP sweep leans on that to stay safe against ticker recycling: a symbol
+/// freed by a delisted issuer and reassigned years later would otherwise pull the dead
+/// issuer's CUSIP — and its 13F positions — onto whichever company holds the symbol now.
+/// </summary>
+public class CusipIdentityTests
+{
+    [Fact]
+    public void AmcAcrossItsReverseSplitIsOneIssuer()
+    {
+        // 00165C104 (pre-2023) and 00165C302 (current) differ only in the issue digits.
+        CusipIdentity.SameIssuer("00165C104", "00165C302").Should().BeTrue();
+    }
+
+    [Fact]
+    public void MerckAcrossItsMergerIsNotOneIssuer()
+    {
+        // 589331107 → 58933Y105 moved the issuer prefix itself, so the sweep declines to
+        // link them. Coverage loss over a wrong link — deliberate.
+        CusipIdentity.SameIssuer("589331107", "58933Y105").Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnrelatedIssuersDoNotMatch()
+    {
+        CusipIdentity.SameIssuer("037833100", "594918104").Should().BeFalse();
+    }
+
+    [Fact]
+    public void CasingAndSurroundingWhitespaceDoNotChangeTheAnswer()
+    {
+        CusipIdentity.SameIssuer(" 00165c104 ", "00165C302").Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("0016")]
+    public void AValueTooShortToCarryAnIssuerNeverMatches(string cusip)
+    {
+        // An unknown issuer must never be assumed to match — that is the whole guard.
+        CusipIdentity.SameIssuer(cusip, "00165C302").Should().BeFalse();
+        CusipIdentity.SameIssuer("00165C302", cusip).Should().BeFalse();
+        CusipIdentity.Issuer(cusip).Should().BeNull();
+    }
+
+    [Fact]
+    public void TheIssuerIsTheFirstSixCharactersUpperCased()
+    {
+        CusipIdentity.Issuer("00165c104").Should().Be("00165C");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceAliasSweepCursorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceAliasSweepCursorTests.cs
@@ -1,0 +1,56 @@
+using Equibles.Sec.HostedService.Services;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// The retired-CUSIP sweep resumes from a frontier stored in BackfillState's DateTime
+/// column, so a fortnightly archive file name has to survive the round trip through a
+/// timestamp. If it does not, the sweep either re-downloads years of archive every cycle
+/// or silently stops advancing.
+/// </summary>
+public class FtdImportServiceAliasSweepCursorTests
+{
+    [Theory]
+    [InlineData("cnsfails201706b.zip")]
+    [InlineData("cnsfails202212a.zip")]
+    [InlineData("cnsfails202212b.zip")]
+    [InlineData("cnsfails202601a.zip")]
+    public void AFileNameSurvivesTheFrontierRoundTrip(string fileName)
+    {
+        var frontier = FtdImportService.FrontierOf(fileName);
+
+        FtdImportService.FileNameOf(frontier).Should().Be(fileName);
+    }
+
+    [Fact]
+    public void TheTwoHalvesOfOneMonthStayOrdered()
+    {
+        // Both halves share a month, so the frontier must separate them or the sweep
+        // cannot tell which of the two it already read.
+        var first = FtdImportService.FrontierOf("cnsfails202212a.zip");
+        var second = FtdImportService.FrontierOf("cnsfails202212b.zip");
+
+        first.Should().BeBefore(second);
+    }
+
+    [Fact]
+    public void TheFrontierAdvancesAcrossMonths()
+    {
+        var december = FtdImportService.FrontierOf("cnsfails202212b.zip");
+        var january = FtdImportService.FrontierOf("cnsfails202301a.zip");
+
+        december.Should().BeBefore(january);
+    }
+
+    [Fact]
+    public void EveryGeneratedFileNameRoundTrips()
+    {
+        // The cursor is looked up by IndexOf against this very list, so a spelling the
+        // round trip cannot reproduce would strand the sweep.
+        var all = FtdImportService.GetFileNames(new DateOnly(2017, 6, 1));
+
+        all.Should()
+            .OnlyContain(f => FtdImportService.FileNameOf(FtdImportService.FrontierOf(f)) == f);
+    }
+}


### PR DESCRIPTION
## Summary

`SetCusip` records a retired CUSIP only when it **witnesses the change live**, so every CUSIP change that predates this pipeline left no `CommonStockCusipAlias` — and the 13F lines filed under those values never map to anything.

AMC is the shape. Its pre-reverse-split `00165C104` has no alias, so:

| Report date | Institutions | Shares |
|---|---:|---:|
| 2022-12-31 | 4 | 845 |
| 2023-09-30 | 274 | 102,262,657 |

The cliff is the August-2023 CUSIP change, not an ownership event. `UnmappedCusip` already logs the misses — 93,765 distinct CUSIPs across 2.47M positions. Same class: Merck `589331107` (25 quarters), FireEye, WPX Energy, Veradigm.

## Code changes

- **`FtdImportService.BackfillRetiredCusips`** — walks the CNS fails archive recording what each tracked symbol used to trade under. The SEC publishes SYMBOL and CUSIP on one row, so nothing is inferred from issuer names. Verified against the real December-2022 file: `20221215|00165C104|AMC|237531|AMC ENTMT HLDGS INC CL A COM S|5.75`.
- **Two guards.** The symbol must be a tracked stock's **primary** ticker, so sibling securities filing under their own symbols stay separate — AMC's preferred units at `00165C203` appear under `APE` and can never land on `AMC` (confirmed in the same file). And the CUSIP must share the stock's current **issuer prefix** (`CusipIdentity`, new), which is what stops a recycled ticker from importing a delisted issuer's identity along with its positions. A merger that moves the prefix itself (Merck `589331107` → `58933Y105`) is deliberately not recovered — coverage loss over a wrong link.
- **`CommonStockManager.RecordRetiredCusipAliases`** — records aliases without touching the stock's current CUSIP, leaves already-claimed aliases with their first owner, and publishes `StockCusipChanged` exactly as `SetCusip` does. That is the healing step: the existing consumer clears the processed-data-set ledger and signals the Holdings worker to re-import the history that can now resolve. No parser-version bump needed.
- **Bounded and resumable** — 12 files per cycle with the frontier in `BackfillState` (`Ftd.RetiredCusipSweep`), so the FTD worker's run never lengthens; the whole 2017→today archive is swept in about a fortnight of daily cycles, then the sweep goes quiet.

## Verification

- `dotnet build Equibles.sln -c Release` clean; `csharpier check` clean.
- Full unit suite green: **3,873 passed, 0 failed** (15 new: CUSIP issuer identity across AMC's split and Merck's merger, plus the frontier round-trip that keeps the sweep resumable).
- The premise was checked against the live SEC archive rather than assumed — see the two file excerpts above.
- Not yet observable end-to-end: the holder counts only heal after the sweep runs on a deployed worker and the Holdings re-import completes.