### PR TITLE
fix(mcp): stop GetLatestPrices reporting a multi-session move as the day change

### DIFF
--- a/src/Equibles.Core/Calendars/UsMarketCalendar.cs
+++ b/src/Equibles.Core/Calendars/UsMarketCalendar.cs
@@ -49,6 +49,14 @@ public static class UsMarketCalendar
     }
 
     /// <summary>
+    /// The nearest trading day strictly before <paramref name="date"/> — the session a day
+    /// change is measured from. Distinct from <see cref="PreviousOrSameTradingDay"/>, which
+    /// returns the date itself when it already is a trading day.
+    /// </summary>
+    public static DateOnly PreviousTradingDay(DateOnly date) =>
+        PreviousOrSameTradingDay(date.AddDays(-1));
+
+    /// <summary>
     /// The date <paramref name="count"/> trading days after <paramref name="date"/>, skipping
     /// weekends and NYSE holidays. <paramref name="date"/> itself is not counted, so
     /// <c>AddTradingDays(friday, 1)</c> is the following Monday.

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -184,10 +184,8 @@ public class StockPriceTools
                     }
 
                     var price = latestTwo[0];
-                    var previousClose = DayChangeBasis(
-                        price,
-                        latestTwo.Count > 1 ? latestTwo[1] : null
-                    );
+                    var previous = latestTwo.Count > 1 ? latestTwo[1] : null;
+                    var previousClose = DayChangeBasis(price, previous);
                     var changeCell = "—";
                     var changePctCell = "—";
                     if (previousClose != null)
@@ -200,8 +198,11 @@ public class StockPriceTools
                                 "+0.00;-0.00;0.00"
                             ) + "%";
                     }
-                    else if (latestTwo.Count > 1)
+                    else if (previous != null && !IsPriorSession(price, previous))
                     {
+                        // Only a skipped session earns the footnote. A prior row with a
+                        // non-positive close is blanked too, and saying "no row for the session
+                        // before" about it would be wrong.
                         gapped = true;
                     }
 
@@ -753,14 +754,14 @@ public class StockPriceTools
     // So the basis is chosen by DATE, never by position: only the row dated the trading day
     // immediately before the latest one qualifies. Otherwise there is no day change to state,
     // and an absent percentage is honest where a wrong one is not.
-    private static decimal? DayChangeBasis(DailyStockPrice latest, DailyStockPrice previous)
-    {
-        if (previous == null || previous.Close <= 0)
-            return null;
-        return previous.Date == UsMarketCalendar.PreviousTradingDay(latest.Date)
-            ? previous.Close
-            : null;
-    }
+    private static decimal? DayChangeBasis(DailyStockPrice latest, DailyStockPrice previous) =>
+        IsPriorSession(latest, previous) && previous.Close > 0 ? previous.Close : null;
+
+    // Whether the second-newest stored row is the session immediately before the newest one.
+    // Shared with the caller so the "series skips a session" footnote and the decision to blank
+    // the columns can never disagree.
+    private static bool IsPriorSession(DailyStockPrice latest, DailyStockPrice previous) =>
+        previous != null && previous.Date == UsMarketCalendar.PreviousTradingDay(latest.Date);
 
     // Placeholder row for a ticker with no price to show (unknown symbol or no data),
     // keeping the em-dash columns identical across the per-ticker fallback branches.

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Core.Calendars;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -111,7 +112,10 @@ public class StockPriceTools
     [McpServerTool(Name = "GetLatestPrices", Title = "Latest Prices", ReadOnly = true)]
     [Description(
         "Get the most recent closing price (USD), daily change, and volume for one or more "
-            + "stocks. Useful for quick price checks across a portfolio or watchlist."
+            + "stocks. Useful for quick price checks across a portfolio or watchlist. The "
+            + "change columns are a ONE-SESSION move: they are shown only when the stored "
+            + "series holds the trading day immediately before the date on the row, and are "
+            + "\"—\" otherwise, so a change is never a multi-session move in disguise."
     )]
     public Task<string> GetLatestPrices(
         [Description(
@@ -142,6 +146,11 @@ public class StockPriceTools
                     "| Ticker | Date | Close | Change | Change % | Volume |",
                     "|--------|------|-------|--------|----------|--------|"
                 );
+
+                // Set when at least one ticker's change columns were withheld because its
+                // stored series skips the prior session, so the footnote explains the em-dash
+                // rather than leaving the caller to read it as missing coverage.
+                var gapped = false;
 
                 foreach (var ticker in tickerList)
                 {
@@ -175,10 +184,13 @@ public class StockPriceTools
                     }
 
                     var price = latestTwo[0];
-                    var previousClose = latestTwo.Count > 1 ? latestTwo[1].Close : (decimal?)null;
+                    var previousClose = DayChangeBasis(
+                        price,
+                        latestTwo.Count > 1 ? latestTwo[1] : null
+                    );
                     var changeCell = "—";
                     var changePctCell = "—";
-                    if (previousClose != null && previousClose.Value > 0)
+                    if (previousClose != null)
                     {
                         var change = price.Close - previousClose.Value;
                         changeCell = McpFormat.Invariant(change, "+0.00;-0.00;0.00");
@@ -188,9 +200,24 @@ public class StockPriceTools
                                 "+0.00;-0.00;0.00"
                             ) + "%";
                     }
+                    else if (latestTwo.Count > 1)
+                    {
+                        gapped = true;
+                    }
 
                     result.AppendLine(
                         $"| {ticker} | {price.Date:yyyy-MM-dd} | {McpFormat.Invariant(price.Close, "F2")} | {changeCell} | {changePctCell} | {McpFormat.WholeNumber(price.Volume)} |"
+                    );
+                }
+
+                if (gapped)
+                {
+                    result.AppendLine();
+                    result.AppendLine(
+                        "Note: a Change of \"—\" means the stored series has no row for the session "
+                            + "before the date shown, so no one-day move can be stated. The close and "
+                            + "volume on that row are still correct. Use GetStockPrices to see which "
+                            + "sessions are present."
                     );
                 }
 
@@ -711,6 +738,28 @@ public class StockPriceTools
             result.AppendLine(formatRow(i));
             emitted++;
         }
+    }
+
+    // The close a day change is measured FROM, or null when there is none.
+    //
+    // "The second-newest stored row" is NOT that close. The end-of-day price lane crawls the
+    // whole common-stock universe and can finish a session or more behind, so on any given day
+    // a slice of the universe is missing its most recent bar and the row below it is two or
+    // more sessions back. Differencing that states a multi-session move as the day's move —
+    // the close is right, the percentage is inflated, and nothing says so. Thinly traded
+    // symbols make it extreme: a row 25 sessions apart from its predecessor reported a
+    // five-figure percentage as a day change.
+    //
+    // So the basis is chosen by DATE, never by position: only the row dated the trading day
+    // immediately before the latest one qualifies. Otherwise there is no day change to state,
+    // and an absent percentage is honest where a wrong one is not.
+    private static decimal? DayChangeBasis(DailyStockPrice latest, DailyStockPrice previous)
+    {
+        if (previous == null || previous.Close <= 0)
+            return null;
+        return previous.Date == UsMarketCalendar.PreviousTradingDay(latest.Date)
+            ? previous.Close
+            : null;
     }
 
     // Placeholder row for a ticker with no price to show (unknown symbol or no data),

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesDayChangeGapTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesDayChangeGapTests.cs
@@ -1,0 +1,121 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Mcp.Tools;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Contract: the Change / Change % columns state a ONE-SESSION move, so they are rendered only
+/// when the stored series holds the trading day immediately before the row's date.
+///
+/// The end-of-day price lane crawls the whole common-stock universe and can finish a session or
+/// more behind, so the second-newest stored row is routinely two or more sessions back. Reading
+/// it as "yesterday" turns a multi-session move into a day change — measured in production, a
+/// symbol whose two newest rows sat 25 sessions apart reported +11,630.77% as its day change.
+///
+/// Pins the rendered output rather than the guard alone: the columns must blank AND the footnote
+/// must appear, so a caller cannot read the em-dash as missing coverage.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class StockPriceToolsGetLatestPricesDayChangeGapTests : ParadeDbMcpTestBase
+{
+    public StockPriceToolsGetLatestPricesDayChangeGapTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private StockPriceTools Sut() =>
+        new(
+            new DailyStockPriceRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<StockPriceTools>()
+        );
+
+    private async Task Seed(string ticker, params (DateOnly Date, decimal Close)[] bars)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Inc",
+            Cik = ticker.PadLeft(10, '0'),
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+
+        foreach (var (date, close) in bars)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = date,
+                        Open = close,
+                        High = close,
+                        Low = close,
+                        Close = close,
+                        AdjustedClose = close,
+                        Volume = 1_000_000,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetLatestPrices_ConsecutiveSessions_RendersTheChange()
+    {
+        // Thu 2026-07-30 -> Fri 2026-07-31, adjacent sessions: a real +10% day.
+        await Seed("ADJ", (new DateOnly(2026, 7, 30), 100m), (new DateOnly(2026, 7, 31), 110m));
+
+        var result = await Sut().GetLatestPrices("ADJ");
+
+        result.Should().Contain("+10.00").And.Contain("+10.00%");
+        result.Should().NotContain("no row for the session before");
+    }
+
+    [Fact]
+    public async Task GetLatestPrices_SessionSkipped_BlanksTheChangeAndExplains()
+    {
+        // Mon 2026-07-27 over Thu 2026-07-23 with Friday missing — the reported failure. Four
+        // calendar days apart, so no day-count tolerance can tell it from the holiday case below.
+        await Seed("GAP", (new DateOnly(2026, 7, 23), 100m), (new DateOnly(2026, 7, 27), 110m));
+
+        var result = await Sut().GetLatestPrices("GAP");
+
+        result.Should().Contain("| GAP | 2026-07-27 | 110.00 | — | — |");
+        result.Should().NotContain("+10.00%");
+        result.Should().Contain("no row for the session before");
+    }
+
+    [Fact]
+    public async Task GetLatestPrices_GapOverAMarketHoliday_StillRendersTheChange()
+    {
+        // Thu 2026-07-02 -> Mon 2026-07-06: also four calendar days, but adjacent sessions
+        // because Jul 4 2026 falls on a Saturday and the NYSE observes it on Fri Jul 3. The
+        // trading calendar is the only thing that separates this from the case above.
+        await Seed("HOL", (new DateOnly(2026, 7, 2), 100m), (new DateOnly(2026, 7, 6), 110m));
+
+        var result = await Sut().GetLatestPrices("HOL");
+
+        result.Should().Contain("+10.00%");
+        result.Should().NotContain("no row for the session before");
+    }
+
+    [Fact]
+    public async Task GetLatestPrices_SingleRow_BlanksTheChangeWithoutTheFootnote()
+    {
+        // One stored bar is not a gap — there is no prior row to have skipped a session, so the
+        // footnote would misdescribe it.
+        await Seed("ONE", (new DateOnly(2026, 7, 31), 110m));
+
+        var result = await Sut().GetLatestPrices("ONE");
+
+        result.Should().Contain("| ONE | 2026-07-31 | 110.00 | — | — |");
+        result.Should().NotContain("no row for the session before");
+    }
+}

--- a/tests/Equibles.UnitTests/Core/Calendars/UsMarketCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Core/Calendars/UsMarketCalendarTests.cs
@@ -123,6 +123,47 @@ public class UsMarketCalendarTests
         AssertNextWindow(from: Et(2025, 3, 15, 12, 0), expected: new DateOnly(2025, 3, 17));
     }
 
+    [Theory]
+    // Mid-week: the day before.
+    [InlineData(2025, 3, 12, 2025, 3, 11)] // Wed -> Tue
+    // Monday steps back over the weekend, not one calendar day.
+    [InlineData(2025, 3, 17, 2025, 3, 14)] // Mon -> Fri
+    // A trading day after a holiday steps over the holiday too. These are the cases a
+    // "within N calendar days" guard cannot express: the gap is 4 days and still adjacent.
+    [InlineData(2025, 1, 21, 2025, 1, 17)] // Tue after MLK Mon -> prior Fri
+    [InlineData(2025, 5, 27, 2025, 5, 23)] // Tue after Memorial Mon -> prior Fri
+    [InlineData(2026, 7, 6, 2026, 7, 2)] // Mon after the observed Jul 3 close -> prior Thu
+    // Good Friday and Thanksgiving: the weekday before is closed, so it is skipped.
+    [InlineData(2024, 4, 1, 2024, 3, 28)] // Easter Mon -> Thu (Good Friday closed)
+    [InlineData(2025, 11, 28, 2025, 11, 26)] // Fri after Thanksgiving -> Wed
+    // A weekend date still resolves to the last session before it.
+    [InlineData(2025, 3, 16, 2025, 3, 14)] // Sun -> Fri
+    public void PreviousTradingDay_StepsBackOverWeekendsAndHolidays(
+        int year,
+        int month,
+        int day,
+        int expectedYear,
+        int expectedMonth,
+        int expectedDay
+    )
+    {
+        UsMarketCalendar
+            .PreviousTradingDay(new DateOnly(year, month, day))
+            .Should()
+            .Be(new DateOnly(expectedYear, expectedMonth, expectedDay));
+    }
+
+    [Fact]
+    public void PreviousTradingDay_OnATradingDay_NeverReturnsTheDateItself()
+    {
+        // The distinction from PreviousOrSameTradingDay: a day change measured from the date
+        // being reported would always be zero.
+        var tradingDay = new DateOnly(2025, 3, 12);
+
+        UsMarketCalendar.PreviousOrSameTradingDay(tradingDay).Should().Be(tradingDay);
+        UsMarketCalendar.PreviousTradingDay(tradingDay).Should().BeBefore(tradingDay);
+    }
+
     private static void AssertNextWindow(DateTimeOffset from, DateOnly expected)
     {
         var windowStart = TimeSpan.FromHours(16);

--- a/tests/Equibles.UnitTests/Mcp/StockPriceToolsDayChangeBasisTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/StockPriceToolsDayChangeBasisTests.cs
@@ -1,0 +1,110 @@
+using System.Reflection;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Mcp.Tools;
+
+namespace Equibles.UnitTests.Mcp;
+
+// Pins the date guard on GetLatestPrices' Change / Change % columns.
+//
+// The defect this defends against: the tool takes the two newest DailyStockPrice rows and
+// differences them. The end-of-day lane crawls the whole common-stock universe and can finish
+// a session or more behind, so the second-newest row is frequently NOT the previous trading
+// session — and the difference is then a multi-session move presented as a one-day change.
+// Measured in production: SWDR's two newest rows sat 25 sessions apart and the tool reported
+// +11,630.77% as its day change.
+//
+// The guard is by DATE, not by row position or by a calendar-day tolerance. A tolerance cannot
+// work: Mon 2026-07-27 vs Thu 2026-07-23 (Friday skipped, a real reported case) is four
+// calendar days apart, and so is Mon 2026-07-06 vs Thu 2026-07-02, which IS adjacent because
+// Jul 3 was an observed market close. Only the trading calendar separates those two.
+public class StockPriceToolsDayChangeBasisTests
+{
+    private static MethodInfo Method() =>
+        typeof(StockPriceTools).GetMethod(
+            "DayChangeBasis",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static decimal? Basis(
+        DateOnly latestDate,
+        DateOnly? previousDate,
+        decimal previousClose = 100m
+    )
+    {
+        var latest = new DailyStockPrice { Date = latestDate, Close = 110m };
+        var previous =
+            previousDate == null
+                ? null
+                : new DailyStockPrice { Date = previousDate.Value, Close = previousClose };
+        return (decimal?)Method().Invoke(null, [latest, previous]);
+    }
+
+    [Fact]
+    public void ExposesThePrivateStaticHelper()
+    {
+        // Guards the reflection lookup itself: a rename would otherwise NRE rather than
+        // reporting that the pinned helper is gone.
+        Method().Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData(2025, 3, 12, 2025, 3, 11)] // Wed measured from Tue
+    [InlineData(2025, 3, 17, 2025, 3, 14)] // Mon measured from Fri
+    [InlineData(2025, 1, 21, 2025, 1, 17)] // Tue after MLK Monday — 4 calendar days, adjacent
+    [InlineData(2026, 7, 6, 2026, 7, 2)] // Mon after the observed Jul 3 close — also 4 days
+    [InlineData(2024, 4, 1, 2024, 3, 28)] // Easter Monday, over Good Friday
+    public void AdjacentSessions_YieldTheBasis(
+        int year,
+        int month,
+        int day,
+        int prevYear,
+        int prevMonth,
+        int prevDay
+    )
+    {
+        Basis(new DateOnly(year, month, day), new DateOnly(prevYear, prevMonth, prevDay))
+            .Should()
+            .Be(100m);
+    }
+
+    [Fact]
+    public void SkippedSession_YieldsNoBasis()
+    {
+        // The ADBE case: Friday missing, so Monday's row sits above Thursday's. Four calendar
+        // days apart — indistinguishable from the MLK case above without the calendar.
+        Basis(new DateOnly(2026, 7, 27), new DateOnly(2026, 7, 23)).Should().BeNull();
+    }
+
+    [Fact]
+    public void ManySkippedSessions_YieldNoBasis()
+    {
+        // The SWDR case, the one that produced a five-figure percentage.
+        Basis(new DateOnly(2026, 2, 6), new DateOnly(2025, 12, 30)).Should().BeNull();
+    }
+
+    [Fact]
+    public void SinglePriceRow_YieldsNoBasis()
+    {
+        Basis(new DateOnly(2025, 3, 12), null).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void NonPositivePreviousClose_YieldsNoBasis(decimal previousClose)
+    {
+        // A zero or negative close cannot be a denominator; the old code guarded this and the
+        // guard must survive the date check being added in front of it.
+        Basis(new DateOnly(2025, 3, 12), new DateOnly(2025, 3, 11), previousClose)
+            .Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void PreviousRowDatedAfterTheLatest_YieldsNoBasis()
+    {
+        // Defensive: the caller orders by date descending, but a basis must never come from a
+        // row that is not strictly the prior session.
+        Basis(new DateOnly(2025, 3, 12), new DateOnly(2025, 3, 13)).Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/Web/CsvExportServiceFormulaInjectionTests.cs
+++ b/tests/Equibles.UnitTests/Web/CsvExportServiceFormulaInjectionTests.cs
@@ -58,7 +58,9 @@ public class CsvExportServiceFormulaInjectionTests
     {
         // The two rules compose: FormatText prefixes, EscapeField then quotes for the comma. The
         // apostrophe must still be the first character inside the quotes.
-        var cell = CsvExportService.EscapeField(CsvExportService.FormatText("=cmd|'/c calc'!A1, Inc"));
+        var cell = CsvExportService.EscapeField(
+            CsvExportService.FormatText("=cmd|'/c calc'!A1, Inc")
+        );
 
         cell.Should().StartWith("\"'=cmd");
     }


### PR DESCRIPTION
## Summary

`GetLatestPrices` built its `Change` / `Change %` columns by differencing the two newest `DailyStockPrice` rows, guarded only by `previousClose > 0`. Nothing checked that the second row actually *is* the previous trading session.

The end-of-day price lane crawls the whole common-stock universe and can finish a session or more behind, so that row is frequently two or more sessions back — and the tool then states a multi-session move as a one-day change. The close is right, the percentage is wrong, and nothing says so.

Currently reproducing on the hosted MCP server (69 of 8,008 stocks are in this state right now; during a lane-lag window on 2026-07-28 it was roughly 5,000 of 7,800):

```
| Ticker | Date       | Close | Change | Change %    | Volume |
| SWDR   | 2026-02-06 | 15.25 | +15.12 | +11630.77%  | 20,353 |
| EXCBF  | 2026-05-26 |  0.67 |  +0.41 |   +152.91%  |    100 |
| RLNDF  | 2026-06-25 |  2.50 | -20.00 |    -88.89%  |    100 |
```

SWDR's two rows sit **25 sessions** apart. The reported figure is a five-figure percentage presented as a day change.

## Code changes

- **`Equibles.Core/Calendars/UsMarketCalendar`** — added `PreviousTradingDay(date)`, the nearest trading day *strictly* before a date. `PreviousOrSameTradingDay` returns the date itself when it is already a session, which would make any day change zero.
- **`Equibles.Yahoo.Mcp/Tools/StockPriceTools`** — new `DayChangeBasis(latest, previous)` helper returns the prior close only when its date is the trading day immediately before the row being shown. The change columns render `—` otherwise, and a footnote explains that the series is missing the prior session (so `—` is not read as missing coverage). The tool description now states that the change is a one-session move.
- **`Equibles.UnitTests`** — `StockPriceToolsDayChangeBasisTests` (12) pins the guard; `UsMarketCalendarTests` gains `PreviousTradingDay` coverage. Mutation-verified: dropping the date check fails 3 of the new tests.

### Why the calendar, and not a day tolerance

A "prior row within N calendar days" guard cannot express this. The reported ADBE case (Mon 2026-07-27 over Thu 2026-07-23, Friday skipped) is **4 calendar days** — and so is Mon 2026-07-06 over Thu 2026-07-02, which is genuinely adjacent because Jul 3 was an observed market close. Only the trading calendar separates them, and `UsMarketCalendar` already models NYSE holidays. `Equibles.Yahoo.Mcp` already references `Equibles.Core`, so this adds no dependency.

### Not in scope

`MarketController` differences the two newest VIX rows the same way. It is a different lane — one index series rather than an 8,400-ticker crawl, so a gap there means the Cboe lane is down rather than lagging. Left alone deliberately; happy to open a separate issue.

The second commit is a formatting-only fix to `CsvExportServiceFormulaInjectionTests`, which landed unformatted in #4269 and fails the tree-wide `csharpier check`.

Closes #4234