### PR TITLE
fix(mcp): stop the day-change guard blanking securities that trade through NYSE closures

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -760,8 +760,17 @@ public class StockPriceTools
     // Whether the second-newest stored row is the session immediately before the newest one.
     // Shared with the caller so the "series skips a session" footnote and the decision to blank
     // the columns can never disagree.
+    //
+    // The test is "no NYSE session was skipped", NOT "the prior row is exactly the NYSE previous
+    // session". Every date strictly between the previous NYSE session and the latest one is a
+    // weekend or an NYSE holiday, so a bar there belongs to a security trading on some other
+    // calendar — foreign ordinaries quoted here keep trading through Juneteenth, Good Friday and
+    // Memorial Day, and 121-297 of them carry a bar on each. Demanding an exact match blanked a
+    // correct one-session move for every one of them on the day after an NYSE holiday.
     private static bool IsPriorSession(DailyStockPrice latest, DailyStockPrice previous) =>
-        previous != null && previous.Date == UsMarketCalendar.PreviousTradingDay(latest.Date);
+        previous != null
+        && previous.Date < latest.Date
+        && previous.Date >= UsMarketCalendar.PreviousTradingDay(latest.Date);
 
     // Placeholder row for a ticker with no price to show (unknown symbol or no data),
     // keeping the em-dash columns identical across the per-ticker fallback branches.

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesDayChangeGapTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesDayChangeGapTests.cs
@@ -107,6 +107,20 @@ public class StockPriceToolsGetLatestPricesDayChangeGapTests : ParadeDbMcpTestBa
     }
 
     [Fact]
+    public async Task GetLatestPrices_PriorBarOnAnNyseClosure_StillRendersTheChange()
+    {
+        // Fri 2026-07-03 is the observed Independence Day close, yet 297 securities in production
+        // carry a bar for it — foreign ordinaries quoted here trade on their home calendar. No
+        // NYSE session sits between the two bars, so this is a real one-session move.
+        await Seed("FGN", (new DateOnly(2026, 7, 3), 100m), (new DateOnly(2026, 7, 6), 110m));
+
+        var result = await Sut().GetLatestPrices("FGN");
+
+        result.Should().Contain("+10.00%");
+        result.Should().NotContain("no row for the session before");
+    }
+
+    [Fact]
     public async Task GetLatestPrices_SingleRow_BlanksTheChangeWithoutTheFootnote()
     {
         // One stored bar is not a gap — there is no prior row to have skipped a session, so the

--- a/tests/Equibles.UnitTests/Mcp/StockPriceToolsDayChangeBasisTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/StockPriceToolsDayChangeBasisTests.cs
@@ -107,4 +107,45 @@ public class StockPriceToolsDayChangeBasisTests
         // row that is not strictly the prior session.
         Basis(new DateOnly(2025, 3, 12), new DateOnly(2025, 3, 13)).Should().BeNull();
     }
+
+    [Fact]
+    public void PreviousRowSameDateAsTheLatest_YieldsNoBasis()
+    {
+        // A duplicate bar is not a prior session; differencing it would state 0.00% as a day
+        // change that was never measured.
+        Basis(new DateOnly(2025, 3, 12), new DateOnly(2025, 3, 12)).Should().BeNull();
+    }
+
+    [Theory]
+    // Bars dated on days the NYSE is shut. Every date strictly between the previous NYSE session
+    // and the latest one is a weekend or a holiday, so a bar there belongs to a security trading
+    // on another calendar — foreign ordinaries quoted here keep trading through these closures,
+    // and production carries 121-297 such bars per holiday. No NYSE session is skipped, so the
+    // move is a genuine one-session change and must render.
+    [InlineData(2026, 7, 6, 2026, 7, 3)] // observed Independence Day (Jul 4 fell on a Saturday)
+    [InlineData(2026, 6, 22, 2026, 6, 19)] // Juneteenth, a Friday in 2026
+    [InlineData(2026, 5, 26, 2026, 5, 25)] // Memorial Day
+    [InlineData(2026, 4, 6, 2026, 4, 3)] // Good Friday
+    public void PriorRowOnAnNyseClosure_StillYieldsTheBasis(
+        int year,
+        int month,
+        int day,
+        int prevYear,
+        int prevMonth,
+        int prevDay
+    )
+    {
+        Basis(new DateOnly(year, month, day), new DateOnly(prevYear, prevMonth, prevDay))
+            .Should()
+            .Be(100m);
+    }
+
+    [Fact]
+    public void PriorRowOneSessionBeforeAClosure_StillYieldsTheBasis()
+    {
+        // The security has no bar on the closure itself, so the pre-closure session IS its prior
+        // one. Both this and the case above must pass: the rule is "no NYSE session was skipped",
+        // not "the prior row is exactly the NYSE previous session".
+        Basis(new DateOnly(2026, 7, 6), new DateOnly(2026, 7, 2)).Should().Be(100m);
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #4270, found by grading that fix against the whole production price corpus rather than a sample.

#4270 required the prior row to be **exactly** the previous NYSE session. That is stricter than the invariant it defends, which is only that **no NYSE session was skipped**.

Every date strictly between the previous NYSE session and the latest one is a weekend or an NYSE holiday. A bar there belongs to a security trading on some other calendar — foreign ordinaries quoted here keep trading through Juneteenth, Good Friday, Memorial Day and the observed Independence Day close. Production carries a bar on each closure for a large slice of them:

| Session | Prior bar | Securities | #4270 | This PR |
|---|---|---|---|---|
| 2026-04-06 | 2026-04-03 (Good Friday) | 297 | blank | renders |
| 2026-05-26 | 2026-05-25 (Memorial Day) | 121 | blank | renders |
| 2026-06-22 | 2026-06-19 (Juneteenth) | 242 | blank | renders |
| 2026-07-06 | 2026-07-03 (observed Jul 4) | 297 | blank | renders |

957 security-days across the four NYSE closures of 2026 so far, each showing no change on the following session despite a correct one-session move being available. It happens to bite nobody today — no security's two newest rows currently straddle a closure — but it would have fired on the session after Labor Day.

## Code changes

- **`StockPriceTools.IsPriorSession`** — now `PreviousTradingDay(latest) <= previous < latest` instead of `previous == PreviousTradingDay(latest)`. Nothing #4270 rejected becomes accepted: a skipped session still places the prior row strictly before that boundary, so the 25-session SWDR case and the skipped-Friday ADBE case are rejected exactly as before.
- **Tests** — four NYSE closures pinned as rendering, alongside the existing skipped-session rejections, so the two cannot be collapsed again. Added a duplicate-date rejection (a repeated bar is not a prior session). Plus an integration test seeding a bar on the observed Independence Day close.

Verified against every distinct (newest, second-newest) date pair in production — 137 pairs covering 8,012 securities. Both rules blank the same 69 gapped securities; the difference is entirely the closure-adjacent case above. 3,914 unit and 19 GetLatestPrices integration tests green.