### PR TITLE
fix(government-contracts): break the USAspending scan deadlock without opening a data hole

### DIFF
--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -149,7 +149,17 @@ public class GovernmentContractsImportService : IImporter
                     throw;
                 }
 
-                frontierIsContiguous = false;
+                if (frontierIsContiguous)
+                {
+                    // The first hole this cycle. Windows run oldest-first, so this is the
+                    // earliest unresolved day — pull the frontier back behind it and stop
+                    // advancing for the rest of the cycle. Freezing alone is not enough: once
+                    // the scan has caught up, the checkpoint LEADS the trailing-rescan window,
+                    // so a failure inside that window is already behind the frontier and the
+                    // next cycle would step straight over it as the lookback slid forward.
+                    frontierIsContiguous = false;
+                    await RetractCheckpoint(windowStart.AddDays(-1));
+                }
 
                 await _errorReporter.Report(
                     ErrorSource.GovernmentContractsScraper,
@@ -168,24 +178,22 @@ public class GovernmentContractsImportService : IImporter
 
     /// <summary>
     /// Does this HTTP failure condemn the whole cycle, or only the window that produced it?
-    /// Systemic on purpose (the client has already exhausted its own retry ladder by the time
-    /// any of these surface): a response-less failure or an exhausted timeout, any 5xx, an
-    /// exhausted 429/408 — continuing would restart the full backoff ladder against a source
-    /// that is rate-limiting or timing out — and the global 401/403/404 rejections, which are
-    /// about our credentials or the endpoint, not the dates we asked for. Everything else is a
-    /// request-level rejection of one window (422 out-of-range, 400 malformed).
+    ///
+    /// Systemic is the DEFAULT, and deliberately so. Stepping over a failure only makes sense
+    /// when we know it is about the dates we asked for; for anything else, continuing fans the
+    /// same failure out across every remaining window — up to ~6,900 of them from the 2007
+    /// epoch at the default one-day width — writing an Error row each time while the source is
+    /// telling us to stop. A systemic abort instead hands the outage to the worker's
+    /// consecutive-failure streak, which reports once and backs off.
+    ///
+    /// 422 is the sole request-level exit: it is USAspending's validation rejection of the
+    /// window's own filters, the failure this classifier exists for (an action-date range below
+    /// the 2007-10-01 epoch). 400 stays systemic even though it reads "malformed" — the fields
+    /// it most likely refers to (filter shape, award-type codes) are identical in every window,
+    /// so treating it as window-level would fan out a source-wide defect.
     /// </summary>
     private static bool IsSystemicHttpFailure(HttpRequestException exception) =>
-        exception.StatusCode switch
-        {
-            null => true,
-            HttpStatusCode.RequestTimeout => true,
-            HttpStatusCode.TooManyRequests => true,
-            HttpStatusCode.Unauthorized => true,
-            HttpStatusCode.Forbidden => true,
-            HttpStatusCode.NotFound => true,
-            var status => (int)status >= (int)HttpStatusCode.InternalServerError,
-        };
+        exception.StatusCode != HttpStatusCode.UnprocessableEntity;
 
     private async Task<int> ImportWindow(
         DateOnly windowStart,
@@ -379,6 +387,54 @@ public class GovernmentContractsImportService : IImporter
                 ex,
                 "Government contracts import: failed to persist scan checkpoint at {WindowEnd}; "
                     + "the window will be re-scanned next cycle",
+                windowEnd
+            );
+        }
+    }
+
+    /// <summary>
+    /// Pull the persisted checkpoint BACK to <paramref name="windowEnd"/> when it currently
+    /// leads that day, so the next cycle resumes at the window that just failed. The mirror of
+    /// <see cref="AdvanceCheckpoint"/>, and the only path allowed to lower the frontier.
+    ///
+    /// Needed because a caught-up scan re-covers a trailing lookback window that sits BEHIND
+    /// the checkpoint: a failure there is already inside the scanned region, so merely
+    /// declining to advance would leave the frontier untouched and the next cycle's lookback
+    /// would slide past the failed day, losing any award published for it late. Best-effort
+    /// like its counterpart — a persist failure only costs the retry, never the cycle.
+    /// </summary>
+    private async Task RetractCheckpoint(DateOnly windowEnd)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var repository =
+                scope.ServiceProvider.GetRequiredService<GovernmentContractsScanStateRepository>();
+
+            // No row yet means nothing has been banked, so there is no frontier to pull back:
+            // the cold-start cursor already resumes at or before this window.
+            var state = await repository.GetByName(ScanStateName);
+            if (state == null || state.LastCompletedWindowEnd <= windowEnd)
+                return;
+
+            _logger.LogWarning(
+                "Government contracts import: pulling the scan checkpoint back from {From} to "
+                    + "{To} so the failed window is re-covered next cycle",
+                state.LastCompletedWindowEnd,
+                windowEnd
+            );
+
+            state.LastCompletedWindowEnd = windowEnd;
+            state.UpdatedAt = DateTime.UtcNow;
+            repository.Update(state);
+            await repository.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Government contracts import: failed to retract the scan checkpoint to "
+                    + "{WindowEnd}; the failed window may not be re-covered",
                 windowEnd
             );
         }

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
@@ -18,6 +19,9 @@ namespace Equibles.GovernmentContracts.HostedService.Services;
 public class GovernmentContractsImportService : IImporter
 {
     private const int InsertBatchSize = 1000;
+
+    // USAspending rejects action-date searches earlier than its federal-award data epoch.
+    private static readonly DateOnly UsaSpendingMinimumActionDate = new(2007, 10, 1);
 
     // Single well-known row that persists the forward award scan's resume point.
     private const string ScanStateName = "award-scan";
@@ -79,6 +83,14 @@ public class GovernmentContractsImportService : IImporter
         var windowDays = Math.Max(1, _options.WindowDays);
         var totalInserted = 0;
 
+        // The checkpoint records the CONTIGUOUS fully-scanned frontier, so it may only advance
+        // while every window behind it has succeeded. Once a window fails this cycle the
+        // frontier freezes: later windows still run (their awards are ingested and deduplicated
+        // by AwardUniqueKey), but the resume point stays behind the hole so the next cycle
+        // re-covers it. Advancing past a failed window would silently lose its awards forever
+        // once it fell outside the trailing rescan lookback.
+        var frontierIsContiguous = true;
+
         for (
             var windowStart = startDate;
             windowStart <= today;
@@ -104,7 +116,8 @@ public class GovernmentContractsImportService : IImporter
                 // inserted nothing, so an empty or all-non-public window (and, above all, a
                 // later transport abort in this same cycle) can't rewind the scan to here.
                 // This is decoupled from MAX(ActionDate), which only moves on an insert.
-                await AdvanceCheckpoint(windowEnd);
+                if (frontierIsContiguous)
+                    await AdvanceCheckpoint(windowEnd);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -115,21 +128,28 @@ public class GovernmentContractsImportService : IImporter
                     windowEnd
                 );
 
-                // A transport-level failure (the API is unreachable, even after the client's retries)
-                // is systemic: every remaining window would fail identically. Rethrow so the worker's
-                // consecutive-failure streak owns the reporting — it records ONE Error row per outage
-                // (once the streak reaches its threshold) and backs off, instead of this loop writing
-                // a fresh row every cycle for the same unreachable API. The next cycle resumes from
-                // the same start date. Window-specific failures are reported here and the scan
-                // continues to the remaining windows.
-                if (ex is HttpRequestException)
+                // Systemic failures — a response-less transport error, an exhausted 5xx, an
+                // exhausted 429/408, or a global auth/endpoint rejection — say nothing about this
+                // window and everything about the source: every remaining window would fail
+                // identically, and re-entering the client's retry ladder for each of them only
+                // hammers an API that already told us to stop. Rethrow so the worker's
+                // consecutive-failure streak owns reporting and backoff. A request-level 4xx
+                // (422 on an out-of-range window, 400 on a malformed one) is a rejection of THIS
+                // window only; report it, freeze the frontier, and scan the rest.
+                if (
+                    ex is HttpRequestException httpException
+                    && IsSystemicHttpFailure(httpException)
+                )
                 {
                     _logger.LogWarning(
-                        "Government contracts import: aborting this cycle after a transport failure; "
-                            + "remaining windows will be retried on the next run"
+                        "Government contracts import: aborting this cycle after a systemic failure "
+                            + "({StatusCode}); remaining windows will be retried on the next run",
+                        httpException.StatusCode?.ToString() ?? "no response"
                     );
                     throw;
                 }
+
+                frontierIsContiguous = false;
 
                 await _errorReporter.Report(
                     ErrorSource.GovernmentContractsScraper,
@@ -145,6 +165,27 @@ public class GovernmentContractsImportService : IImporter
             totalInserted
         );
     }
+
+    /// <summary>
+    /// Does this HTTP failure condemn the whole cycle, or only the window that produced it?
+    /// Systemic on purpose (the client has already exhausted its own retry ladder by the time
+    /// any of these surface): a response-less failure or an exhausted timeout, any 5xx, an
+    /// exhausted 429/408 — continuing would restart the full backoff ladder against a source
+    /// that is rate-limiting or timing out — and the global 401/403/404 rejections, which are
+    /// about our credentials or the endpoint, not the dates we asked for. Everything else is a
+    /// request-level rejection of one window (422 out-of-range, 400 malformed).
+    /// </summary>
+    private static bool IsSystemicHttpFailure(HttpRequestException exception) =>
+        exception.StatusCode switch
+        {
+            null => true,
+            HttpStatusCode.RequestTimeout => true,
+            HttpStatusCode.TooManyRequests => true,
+            HttpStatusCode.Unauthorized => true,
+            HttpStatusCode.Forbidden => true,
+            HttpStatusCode.NotFound => true,
+            var status => (int)status >= (int)HttpStatusCode.InternalServerError,
+        };
 
     private async Task<int> ImportWindow(
         DateOnly windowStart,
@@ -250,12 +291,21 @@ public class GovernmentContractsImportService : IImporter
     /// cursor falls back to the data-derived watermark exactly as before: the day after the
     /// newest credible action date, or the configured floor when the table is empty.
     ///
-    /// Once a checkpoint exists it owns the cursor. The scan resumes the day after the
-    /// furthest window it has fully completed — never behind data already ingested — but
-    /// never later than a trailing <paramref name="rescanLookbackDays"/> window, so awards
-    /// USAspending publishes late (dated inside a window already passed) are still re-covered
-    /// and deduplicated by AwardUniqueKey on insert. A consequence is that once caught up the
-    /// scan no longer reports "already up to date"; it re-scans the trailing window each cycle.
+    /// Once a checkpoint exists it SOLELY owns the cursor. The scan resumes the day after the
+    /// furthest contiguous window it has fully completed, but never later than a trailing
+    /// <paramref name="rescanLookbackDays"/> window, so awards USAspending publishes late
+    /// (dated inside a window already passed) are still re-covered and deduplicated by
+    /// AwardUniqueKey on insert. A consequence is that once caught up the scan no longer
+    /// reports "already up to date"; it re-scans the trailing window each cycle.
+    ///
+    /// <paramref name="latestActionDate"/> deliberately does NOT pull the cursor forward here.
+    /// A cycle that fails one window keeps scanning the later ones, so ingested data routinely
+    /// leads the frontier — letting MAX(ActionDate) win would step straight over the failed
+    /// window and lose its awards for good. It still seeds the cold-start path below, where no
+    /// checkpoint exists to be trusted.
+    ///
+    /// Every resolution path is clamped to USAspending's 2007-10-01 action-date epoch without
+    /// lowering a later cursor.
     /// </summary>
     public static DateOnly ResolveStartDate(
         DateOnly? latestActionDate,
@@ -268,18 +318,26 @@ public class GovernmentContractsImportService : IImporter
         if (latestActionDate > today)
             latestActionDate = today;
 
+        DateOnly resolvedStartDate;
         if (checkpointEnd == null)
-            return SyncDateResolver.Resolve(latestActionDate ?? default, workerOptions);
+        {
+            resolvedStartDate = SyncDateResolver.Resolve(
+                latestActionDate ?? default,
+                workerOptions
+            );
+        }
+        else
+        {
+            // Resume after the furthest point we have CONTIGUOUSLY scanned. See the remarks
+            // above for why an ingested action date past this point must not drag it forward.
+            var afterFrontier = checkpointEnd.Value.AddDays(1);
+            var lookbackFloor = today.AddDays(-(Math.Max(1, rescanLookbackDays) - 1));
+            resolvedStartDate = afterFrontier < lookbackFloor ? afterFrontier : lookbackFloor;
+        }
 
-        // Resume after the furthest point we have fully scanned, but never behind data
-        // already ingested (defensive — the checkpoint should always lead the watermark).
-        var frontier = checkpointEnd.Value;
-        if (latestActionDate.HasValue && latestActionDate.Value > frontier)
-            frontier = latestActionDate.Value;
-
-        var afterFrontier = frontier.AddDays(1);
-        var lookbackFloor = today.AddDays(-(Math.Max(1, rescanLookbackDays) - 1));
-        return afterFrontier < lookbackFloor ? afterFrontier : lookbackFloor;
+        return resolvedStartDate < UsaSpendingMinimumActionDate
+            ? UsaSpendingMinimumActionDate
+            : resolvedStartDate;
     }
 
     /// <summary>

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -20,6 +20,11 @@ public class GovernmentContractsImportService : IImporter
 {
     private const int InsertBatchSize = 1000;
 
+    // How many windows in a row may fail before the scan treats the failure as source-wide and
+    // aborts the cycle. Low enough that a fan-out costs a handful of Error rows instead of
+    // thousands, high enough that a short run of genuinely bad days does not stop the scan.
+    private const int MaxConsecutiveWindowFailures = 5;
+
     // USAspending rejects action-date searches earlier than its federal-award data epoch.
     private static readonly DateOnly UsaSpendingMinimumActionDate = new(2007, 10, 1);
 
@@ -92,6 +97,16 @@ public class GovernmentContractsImportService : IImporter
         // rescan lookback.
         var frontierIsContiguous = true;
 
+        // Nothing stepped over may fan out across the range. 422 is USAspending's validation
+        // rejection for the WHOLE request, not just its dates, so a bad request-invariant field
+        // (a filter shape, an award-type code, an out-of-range amount bound) 422s on every
+        // window alike — and stepping over each of ~6,900 of them would write an Error row
+        // apiece while the worker still saw a successful cycle. Past this many consecutive
+        // window failures the pattern is the source, not the window: stop and let the worker's
+        // failure streak back off. Counted consecutively so a scan pockmarked with isolated bad
+        // days still completes.
+        var consecutiveWindowFailures = 0;
+
         for (
             var windowStart = startDate;
             windowStart <= today;
@@ -119,6 +134,8 @@ public class GovernmentContractsImportService : IImporter
                 // This is decoupled from MAX(ActionDate), which only moves on an insert.
                 if (frontierIsContiguous)
                     await AdvanceCheckpoint(windowEnd);
+
+                consecutiveWindowFailures = 0;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -167,6 +184,17 @@ public class GovernmentContractsImportService : IImporter
                     ex,
                     $"window: {windowStart}..{windowEnd}"
                 );
+
+                if (++consecutiveWindowFailures >= MaxConsecutiveWindowFailures)
+                {
+                    _logger.LogWarning(
+                        "Government contracts import: aborting this cycle after {Count} "
+                            + "consecutive window failures; the failure is source-wide, not "
+                            + "window-specific",
+                        consecutiveWindowFailures
+                    );
+                    throw;
+                }
             }
         }
 
@@ -411,10 +439,33 @@ public class GovernmentContractsImportService : IImporter
             var repository =
                 scope.ServiceProvider.GetRequiredService<GovernmentContractsScanStateRepository>();
 
-            // No row yet means nothing has been banked, so there is no frontier to pull back:
-            // the cold-start cursor already resumes at or before this window.
             var state = await repository.GetByName(ScanStateName);
-            if (state == null || state.LastCompletedWindowEnd <= windowEnd)
+
+            // No row yet is NOT "nothing to do". Without one the next cycle falls back to the
+            // cold-start cursor, which resolves off MAX(ActionDate) — and the later windows of
+            // this very cycle are still running and inserting rows past the failure. Leaving
+            // the row absent would let that watermark carry the scan straight over the failed
+            // window. Create it here so the hole survives to the next cycle.
+            if (state == null)
+            {
+                _logger.LogWarning(
+                    "Government contracts import: opening the scan checkpoint at {To} so the "
+                        + "failed first window is re-covered next cycle",
+                    windowEnd
+                );
+                repository.Add(
+                    new GovernmentContractsScanState
+                    {
+                        Name = ScanStateName,
+                        LastCompletedWindowEnd = windowEnd,
+                        UpdatedAt = DateTime.UtcNow,
+                    }
+                );
+                await repository.SaveChanges();
+                return;
+            }
+
+            if (state.LastCompletedWindowEnd <= windowEnd)
                 return;
 
             _logger.LogWarning(

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -84,11 +84,12 @@ public class GovernmentContractsImportService : IImporter
         var totalInserted = 0;
 
         // The checkpoint records the CONTIGUOUS fully-scanned frontier, so it may only advance
-        // while every window behind it has succeeded. Once a window fails this cycle the
-        // frontier freezes: later windows still run (their awards are ingested and deduplicated
-        // by AwardUniqueKey), but the resume point stays behind the hole so the next cycle
-        // re-covers it. Advancing past a failed window would silently lose its awards forever
-        // once it fell outside the trailing rescan lookback.
+        // while every window behind it has succeeded. On the first failure of a cycle the
+        // frontier is pulled back behind that window and stops advancing: later windows still
+        // run (their awards are ingested and deduplicated by AwardUniqueKey), but the resume
+        // point stays behind the hole so the next cycle re-covers it. Leaving the frontier past
+        // a failed window would silently lose its awards once it fell outside the trailing
+        // rescan lookback.
         var frontierIsContiguous = true;
 
         for (
@@ -128,14 +129,13 @@ public class GovernmentContractsImportService : IImporter
                     windowEnd
                 );
 
-                // Systemic failures — a response-less transport error, an exhausted 5xx, an
-                // exhausted 429/408, or a global auth/endpoint rejection — say nothing about this
-                // window and everything about the source: every remaining window would fail
-                // identically, and re-entering the client's retry ladder for each of them only
-                // hammers an API that already told us to stop. Rethrow so the worker's
-                // consecutive-failure streak owns reporting and backoff. A request-level 4xx
-                // (422 on an out-of-range window, 400 on a malformed one) is a rejection of THIS
-                // window only; report it, freeze the frontier, and scan the rest.
+                // Anything the classifier calls systemic says nothing about this window and
+                // everything about the source: the remaining windows would fail identically,
+                // and re-entering the client's retry ladder for each of them only hammers an
+                // API that already told us to stop. Rethrow so the worker's consecutive-failure
+                // streak owns reporting and backoff. Only a 422 — USAspending rejecting THIS
+                // window's own date filters — is stepped over: report it, pull the frontier
+                // back behind it, and scan the rest.
                 if (
                     ex is HttpRequestException httpException
                     && IsSystemicHttpFailure(httpException)

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCursorTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCursorTests.cs
@@ -9,10 +9,11 @@ namespace Equibles.UnitTests.GovernmentContracts;
 // credible action date and can never point past today — a single mis-dated future row froze
 // prod ingestion for over two years when the cursor keyed on raw max(ActionDate).
 //
-// Once a scan checkpoint exists it OWNS the cursor: the scan resumes after the last
-// fully-completed window (so a transport abort no longer restarts the whole range and
-// re-floods the Errors page), never behind data already ingested, and re-covers a trailing
-// lookback window so awards USAspending publishes late are not permanently skipped.
+// Once a scan checkpoint exists it SOLELY owns the cursor: the scan resumes after the last
+// contiguously-completed window (so a transport abort no longer restarts the whole range and
+// re-floods the Errors page) and re-covers a trailing lookback window so awards USAspending
+// publishes late are not permanently skipped. max(ActionDate) deliberately cannot drag the
+// cursor past the checkpoint — that is what keeps a failed window from being skipped for good.
 public class GovernmentContractsImportServiceCursorTests
 {
     private static readonly DateOnly Today = new(2026, 7, 17);
@@ -79,6 +80,34 @@ public class GovernmentContractsImportServiceCursorTests
     }
 
     [Fact]
+    public void Clamps_a_configured_min_sync_date_before_the_usa_spending_epoch()
+    {
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            null,
+            checkpointEnd: null,
+            Today,
+            Lookback,
+            new WorkerOptions { MinSyncDate = new DateTime(2000, 1, 1) }
+        );
+
+        start.Should().Be(new DateOnly(2007, 10, 1));
+    }
+
+    [Fact]
+    public void Leaves_the_exact_usa_spending_epoch_unchanged()
+    {
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            null,
+            checkpointEnd: null,
+            Today,
+            Lookback,
+            new WorkerOptions { MinSyncDate = new DateTime(2007, 10, 1) }
+        );
+
+        start.Should().Be(new DateOnly(2007, 10, 1));
+    }
+
+    [Fact]
     public void Falls_back_to_the_default_floor_when_the_table_is_empty_and_unconfigured()
     {
         var start = GovernmentContractsImportService.ResolveStartDate(
@@ -126,6 +155,20 @@ public class GovernmentContractsImportServiceCursorTests
     }
 
     [Fact]
+    public void Clamps_a_checkpoint_resume_before_the_usa_spending_epoch()
+    {
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            latestActionDate: null,
+            checkpointEnd: new DateOnly(2007, 9, 15),
+            Today,
+            Lookback,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(new DateOnly(2007, 10, 1));
+    }
+
+    [Fact]
     public void A_checkpoint_carries_the_scan_forward_past_a_lagging_watermark()
     {
         // Even with no rows inserted past 2022-01-13 (every window since was empty or matched
@@ -142,10 +185,14 @@ public class GovernmentContractsImportServiceCursorTests
     }
 
     [Fact]
-    public void A_checkpoint_behind_ingested_data_never_resumes_behind_the_watermark()
+    public void A_checkpoint_behind_ingested_data_resumes_from_the_checkpoint_not_the_watermark()
     {
-        // Defensive: the checkpoint should always lead the watermark, but if it somehow lags,
-        // resume after the newer ingested data rather than re-scanning already-stored rows.
+        // The checkpoint marks the last CONTIGUOUSLY scanned day, so it legitimately lags the
+        // newest ingested action date: a cycle that fails one window keeps scanning the later
+        // ones, which insert rows past the frozen frontier. Letting max(ActionDate) win here
+        // would step straight over the failed window and lose its awards permanently once it
+        // aged out of the trailing lookback. Re-scanning the days in between is harmless —
+        // inserts deduplicate on AwardUniqueKey.
         var start = GovernmentContractsImportService.ResolveStartDate(
             latestActionDate: new DateOnly(2022, 1, 20),
             checkpointEnd: new DateOnly(2022, 1, 10),
@@ -154,7 +201,7 @@ public class GovernmentContractsImportServiceCursorTests
             new WorkerOptions()
         );
 
-        start.Should().Be(new DateOnly(2022, 1, 21));
+        start.Should().Be(new DateOnly(2022, 1, 11));
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
@@ -1,9 +1,12 @@
+using System.Net;
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Configuration;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
 using Equibles.GovernmentContracts.Data;
 using Equibles.GovernmentContracts.HostedService.Configuration;
 using Equibles.GovernmentContracts.HostedService.Services;
@@ -25,18 +28,108 @@ namespace Equibles.UnitTests.GovernmentContracts;
 public class GovernmentContractsImportServiceHttpAbortTests
 {
     [Fact]
-    public async Task Import_FirstWindowThrowsHttpRequestException_AbortsCycleWithoutScanningLaterWindows()
+    public async Task Import_ResponseLessHttpRequestException_AbortsCycleWithoutScanningLaterWindows()
     {
-        // Contract (from Import's window-loop comment): a transport-level failure —
-        // HttpRequestException, the API unreachable even after the client's own retries —
-        // is systemic, so every remaining window would fail identically. The cycle must
-        // STOP and RETHROW rather than hammer the API once per window: the worker's
-        // consecutive-failure streak owns reporting (one Error row per outage), so the
-        // service must not write its own row per cycle — that's exactly the flood that
-        // put 13 identical rows on the Errors page in one day. With a multi-day scan
-        // split into one-day windows, the first window failing with HttpRequestException
-        // must propagate and leave every later window un-fetched: the client is called
-        // exactly once, not once per window.
+        await AssertSystemicFailureAborts(new HttpRequestException("USAspending unreachable"));
+    }
+
+    [Fact]
+    public async Task Import_Http5xxResponse_AbortsCycleWithoutScanningLaterWindows()
+    {
+        await AssertSystemicFailureAborts(
+            new HttpRequestException(
+                "USAspending unavailable",
+                inner: null,
+                statusCode: HttpStatusCode.ServiceUnavailable
+            )
+        );
+    }
+
+    [Fact]
+    public async Task Import_Timeout_AbortsCycleWithoutScanningLaterWindows()
+    {
+        await AssertSystemicFailureAborts(new TaskCanceledException("USAspending timed out"));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.NotFound)]
+    public async Task Import_SystemicSub500Status_AbortsCycleWithoutScanningLaterWindows(
+        HttpStatusCode status
+    )
+    {
+        // These reach the import loop only after UsaSpendingClient exhausted its own retry
+        // ladder (429/408) or hit a rejection that is about our credentials/endpoint rather
+        // than the dates asked for (401/403/404). None of them is window-specific, so
+        // continuing would restart the full backoff ladder against every remaining window —
+        // hammering a source that already said stop. They must abort like a 5xx.
+        await AssertSystemicFailureAborts(
+            new HttpRequestException($"USAspending returned {status}", inner: null, status)
+        );
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.UnprocessableEntity)]
+    [InlineData(HttpStatusCode.BadRequest)]
+    public async Task Import_RequestLevel4xx_ScansEveryRemainingWindowWithoutThrowing(
+        HttpStatusCode status
+    )
+    {
+        // The counterpart to the theory above, pinning the boundary from the other side: a
+        // rejection of THIS window (422 out-of-range dates, 400 malformed) says nothing about
+        // the rest of the scan, so every remaining window must still be attempted and nothing
+        // may escape to the worker.
+        var options = NewDbOptions();
+        using (var seed = NewContext(options))
+        {
+            seed.Add(
+                new CommonStock
+                {
+                    Ticker = "LMT",
+                    Name = "Lockheed Martin Corporation",
+                    Cik = "1",
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = ScopeFactory(options);
+        var client = Substitute.For<IUsaSpendingClient>();
+        client
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(
+                new HttpRequestException($"USAspending returned {status}", inner: null, status)
+            );
+
+        // Five days back with one-day windows yields six windows.
+        var service = NewService(scopeFactory, client, DateTime.UtcNow.Date.AddDays(-5));
+
+        var act = () => service.Import(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        await client
+            .Received(6)
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    private static async Task AssertSystemicFailureAborts(Exception failure)
+    {
+        // A response-less HTTP failure, exhausted 5xx response, or timeout is systemic:
+        // later windows would fail identically, so the first failure must propagate after
+        // one client call and let the worker own outage reporting and backoff.
         var options = NewDbOptions();
         using (var seed = NewContext(options))
         {
@@ -62,37 +155,17 @@ public class GovernmentContractsImportServiceHttpAbortTests
                 Arg.Any<decimal>(),
                 Arg.Any<CancellationToken>()
             )
-            .ThrowsAsync(new HttpRequestException("USAspending unreachable"));
+            .ThrowsAsync(failure);
 
         // Empty GovernmentContract table -> DetermineStartDate falls back to MinSyncDate.
         // Five days back with one-day windows yields six windows; an un-aborted scan would
         // call the client six times.
-        var workerOptions = Options.Create(
-            new WorkerOptions { MinSyncDate = DateTime.UtcNow.Date.AddDays(-5) }
-        );
-        var scraperOptions = Options.Create(
-            new GovernmentContractsScraperOptions
-            {
-                WindowDays = 1,
-                MinimumAwardAmount = 1_000_000m,
-            }
-        );
-
-        var service = new GovernmentContractsImportService(
-            scopeFactory,
-            NullLogger<GovernmentContractsImportService>.Instance,
-            client,
-            new RecipientResolver(scopeFactory),
-            scraperOptions,
-            workerOptions,
-            new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
-        );
+        var service = NewService(scopeFactory, client, DateTime.UtcNow.Date.AddDays(-5));
 
         var act = () => service.Import(CancellationToken.None);
 
-        // The transport failure must propagate (the worker's streak reporting depends on
-        // seeing the throw) after exactly one client call — no later window is scanned.
-        await act.Should().ThrowAsync<HttpRequestException>();
+        var thrown = await act.Should().ThrowAsync<Exception>();
+        thrown.Which.GetType().Should().Be(failure.GetType());
         await client
             .Received(1)
             .GetContractAwards(
@@ -102,6 +175,27 @@ public class GovernmentContractsImportServiceHttpAbortTests
                 Arg.Any<CancellationToken>()
             );
     }
+
+    private static GovernmentContractsImportService NewService(
+        IServiceScopeFactory scopeFactory,
+        IUsaSpendingClient client,
+        DateTime minSyncDate
+    ) =>
+        new(
+            scopeFactory,
+            NullLogger<GovernmentContractsImportService>.Instance,
+            client,
+            new RecipientResolver(scopeFactory),
+            Options.Create(
+                new GovernmentContractsScraperOptions
+                {
+                    WindowDays = 1,
+                    MinimumAwardAmount = 1_000_000m,
+                }
+            ),
+            Options.Create(new WorkerOptions { MinSyncDate = minSyncDate }),
+            new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
+        );
 
     private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
         new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
@@ -118,6 +212,7 @@ public class GovernmentContractsImportServiceHttpAbortTests
             new IModuleConfiguration[]
             {
                 new CommonStocksModuleConfiguration(),
+                new ErrorsModuleConfiguration(),
                 new GovernmentContractsModuleConfiguration(),
             }
         );
@@ -132,6 +227,8 @@ public class GovernmentContractsImportServiceHttpAbortTests
         var services = new ServiceCollection();
         services.AddScoped(_ => NewContext(options));
         services.AddScoped<CommonStockRepository>();
+        services.AddScoped<ErrorRepository>();
+        services.AddScoped<ErrorManager>();
         services.AddScoped<GovernmentContractRepository>();
         services.AddScoped<GovernmentContractsScanStateRepository>();
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
@@ -89,16 +89,14 @@ public class GovernmentContractsImportServiceHttpAbortTests
         );
     }
 
-    [Theory]
-    [InlineData(HttpStatusCode.UnprocessableEntity)]
-    public async Task Import_RequestLevel4xx_ScansEveryRemainingWindowWithoutThrowing(
-        HttpStatusCode status
-    )
+    [Fact]
+    public async Task Import_EveryWindowReturns422_AbortsOnceTheFailureLooksSourceWide()
     {
-        // The counterpart to the theory above, pinning the boundary from the other side: a
-        // rejection of THIS window (422 out-of-range dates, 400 malformed) says nothing about
-        // the rest of the scan, so every remaining window must still be attempted and nothing
-        // may escape to the worker.
+        // 422 is USAspending's validation rejection for the WHOLE request, not only its dates,
+        // so a bad request-invariant field 422s on every window alike. Stepping over each one
+        // would write an Error row per window — thousands of them from the 2007 epoch — while
+        // the worker still recorded a successful cycle and never backed off. A run of them must
+        // therefore stop the cycle even though a LONE 422 is stepped over (covered below).
         var options = NewDbOptions();
         using (var seed = NewContext(options))
         {
@@ -123,7 +121,74 @@ public class GovernmentContractsImportServiceHttpAbortTests
                 Arg.Any<CancellationToken>()
             )
             .ThrowsAsync(
-                new HttpRequestException($"USAspending returned {status}", inner: null, status)
+                new HttpRequestException(
+                    "USAspending rejected the request",
+                    inner: null,
+                    HttpStatusCode.UnprocessableEntity
+                )
+            );
+
+        // Twenty days back with one-day windows yields twenty-one windows — far more than the
+        // consecutive-failure cap, so an uncapped fan-out would be plainly visible.
+        var service = NewService(scopeFactory, client, DateTime.UtcNow.Date.AddDays(-20));
+
+        var act = () => service.Import(CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        client
+            .ReceivedCalls()
+            .Should()
+            .HaveCountLessThan(
+                10,
+                "the cycle must stop once the 422s look source-wide, not walk the whole range"
+            );
+    }
+
+    [Fact]
+    public async Task Import_SingleWindowReturns422_ScansEveryRemainingWindowWithoutThrowing()
+    {
+        // The other side of the boundary: one window rejected on its own dates — the failure
+        // this classifier exists for — says nothing about the rest of the scan, so the
+        // remaining windows must still be attempted and nothing may escape to the worker.
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var failingWindow = today.AddDays(-3);
+        using (var seed = NewContext(options))
+        {
+            seed.Add(
+                new CommonStock
+                {
+                    Ticker = "LMT",
+                    Name = "Lockheed Martin Corporation",
+                    Cik = "1",
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = ScopeFactory(options);
+        var client = Substitute.For<IUsaSpendingClient>();
+        client
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(new List<UsaSpendingAwardRecord>()));
+        client
+            .GetContractAwards(
+                failingWindow,
+                failingWindow,
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(
+                new HttpRequestException(
+                    "USAspending rejected the window",
+                    inner: null,
+                    HttpStatusCode.UnprocessableEntity
+                )
             );
 
         // Five days back with one-day windows yields six windows.

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceHttpAbortTests.cs
@@ -57,15 +57,33 @@ public class GovernmentContractsImportServiceHttpAbortTests
     [InlineData(HttpStatusCode.Unauthorized)]
     [InlineData(HttpStatusCode.Forbidden)]
     [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.BadRequest)]
     public async Task Import_SystemicSub500Status_AbortsCycleWithoutScanningLaterWindows(
         HttpStatusCode status
     )
     {
-        // These reach the import loop only after UsaSpendingClient exhausted its own retry
-        // ladder (429/408) or hit a rejection that is about our credentials/endpoint rather
-        // than the dates asked for (401/403/404). None of them is window-specific, so
-        // continuing would restart the full backoff ladder against every remaining window —
-        // hammering a source that already said stop. They must abort like a 5xx.
+        // None of these is about the dates asked for: 429/408 mean the source is throttling or
+        // timing out, 401/403/404 are about our credentials or the endpoint, and a 400
+        // "malformed" most plausibly refers to the filter fields every window shares. Stepping
+        // over any of them would fan the same failure across the whole range.
+        await AssertSystemicFailureAborts(
+            new HttpRequestException($"USAspending returned {status}", inner: null, status)
+        );
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Gone)]
+    [InlineData(HttpStatusCode.MethodNotAllowed)]
+    [InlineData(HttpStatusCode.UnsupportedMediaType)]
+    [InlineData(HttpStatusCode.Conflict)]
+    public async Task Import_UnrecognisedSub500Status_DefaultsToAbortingTheCycle(
+        HttpStatusCode status
+    )
+    {
+        // Pins the classifier's DEFAULT rather than its listed cases. Continuing is the
+        // dangerous direction — it fans a source-wide defect across ~6,900 windows — so an
+        // status nobody has reasoned about must abort, not scan on. A classifier written as
+        // "everything under 500 continues" passes the theory above and fails here.
         await AssertSystemicFailureAborts(
             new HttpRequestException($"USAspending returned {status}", inner: null, status)
         );
@@ -73,7 +91,6 @@ public class GovernmentContractsImportServiceHttpAbortTests
 
     [Theory]
     [InlineData(HttpStatusCode.UnprocessableEntity)]
-    [InlineData(HttpStatusCode.BadRequest)]
     public async Task Import_RequestLevel4xx_ScansEveryRemainingWindowWithoutThrowing(
         HttpStatusCode status
     )

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
@@ -391,18 +391,23 @@ public class GovernmentContractsImportServiceWindowContinueTests
                 "a window-specific (non-transport) failure must not abort the scan"
             );
 
-        // ...and the later window that succeeded must not have banked a frontier past the hole.
+        // ...and the hole must be recorded durably. There was no checkpoint row when the very
+        // first window failed, so one has to be OPENED behind it: leaving the table empty would
+        // send the next cycle down the cold-start path, which resolves off MAX(ActionDate) —
+        // and the later windows of this cycle are inserting rows past the failure. The
+        // watermark would then carry the scan straight over the day that never ran.
         using var context = NewContext(options);
         var checkpoint = await context
             .Set<GovernmentContractsScanState>()
             .AsNoTracking()
-            .SingleOrDefaultAsync();
+            .SingleAsync();
 
         checkpoint
-            .Should()
-            .BeNull(
-                "the first window failed, so nothing behind it was ever contiguously scanned "
-                    + "and no frontier may be recorded"
+            .LastCompletedWindowEnd.Should()
+            .Be(
+                failingWindow.AddDays(-1),
+                "a first-window failure must open the frontier behind itself, not leave the "
+                    + "next cycle to infer a cursor from data the later windows ingested"
             );
     }
 

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
@@ -197,6 +197,100 @@ public class GovernmentContractsImportServiceWindowContinueTests
     }
 
     [Fact]
+    public async Task Import_TrailingRescanWindowFails_RetractsTheCheckpointBehindIt()
+    {
+        // The steady-state hole, and the one freezing alone cannot close. Once the scan has
+        // caught up, the checkpoint LEADS the trailing lookback window, so a failure inside
+        // that window sits BEHIND the frontier: declining to advance changes nothing, and the
+        // next cycle's lookback slides one day forward and steps over the failed day for good.
+        // The checkpoint must therefore be pulled BACK behind the failure.
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var lookbackStart = today.AddDays(-6);
+
+        using (var seed = NewContext(options))
+        {
+            seed.Add(
+                new CommonStock
+                {
+                    Ticker = "LMT",
+                    Name = "Lockheed Martin Corporation",
+                    Cik = "1",
+                }
+            );
+            // A caught-up scan: the frontier already reaches yesterday, well ahead of the
+            // trailing window about to be re-covered.
+            seed.Add(
+                new GovernmentContractsScanState
+                {
+                    Name = "award-scan",
+                    LastCompletedWindowEnd = today.AddDays(-1),
+                    UpdatedAt = DateTime.UtcNow,
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = ScopeFactory(options);
+        var client = Substitute.For<IUsaSpendingClient>();
+        client
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(new List<UsaSpendingAwardRecord>()));
+        client
+            .GetContractAwards(
+                lookbackStart,
+                lookbackStart,
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(
+                new HttpRequestException(
+                    "USAspending rejected the window",
+                    inner: null,
+                    statusCode: HttpStatusCode.UnprocessableEntity
+                )
+            );
+
+        var service = new GovernmentContractsImportService(
+            scopeFactory,
+            NullLogger<GovernmentContractsImportService>.Instance,
+            client,
+            new RecipientResolver(scopeFactory),
+            Options.Create(
+                new GovernmentContractsScraperOptions
+                {
+                    WindowDays = 1,
+                    MinimumAwardAmount = 1_000_000m,
+                    RescanLookbackDays = 7,
+                }
+            ),
+            Options.Create(new WorkerOptions()),
+            new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
+        );
+
+        await service.Import(CancellationToken.None);
+
+        using var context = NewContext(options);
+        var checkpoint = await context
+            .Set<GovernmentContractsScanState>()
+            .AsNoTracking()
+            .SingleAsync();
+
+        checkpoint
+            .LastCompletedWindowEnd.Should()
+            .Be(
+                lookbackStart.AddDays(-1),
+                "an unresolved day behind the frontier must pull the frontier back to it, or "
+                    + "the sliding lookback abandons it next cycle"
+            );
+    }
+
+    [Fact]
     public void Import_HistoricalWindowFails_NextCycleResumesAtTheFailedWindow()
     {
         // The other half of the guard: freezing the checkpoint is only useful if the next cycle
@@ -220,14 +314,15 @@ public class GovernmentContractsImportServiceWindowContinueTests
     [Fact]
     public async Task Import_WindowThrowsNonTransportException_ContinuesScanningRemainingWindows()
     {
-        // Contract (from Import's window-loop comment): only a transport failure
-        // (HttpRequestException) is systemic enough to abort the cycle. A window-specific
-        // failure — anything that is NOT an HttpRequestException — is reported but falls
-        // through so the scan continues to the remaining windows. With a two-day scan split
-        // into one-day windows where the first window throws a non-transport exception, the
-        // client must therefore still be invoked for the later window: the cycle is NOT
-        // aborted (which would leave it called exactly once).
+        // Contract (from Import's window-loop comment): a non-HTTP failure is window-specific.
+        // It is reported and falls through so the scan continues to the remaining windows, so
+        // with a two-day scan split into one-day windows the client must still be invoked for
+        // the later window — an abort would leave it called exactly once. It must ALSO freeze
+        // the frontier: the failure is a hole like any other, and a guard that only fired for
+        // HttpRequestException would pass the call-count assertion while silently banking a
+        // checkpoint past the unscanned day.
         var options = NewDbOptions();
+        var failingWindow = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
         using (var seed = NewContext(options))
         {
             seed.Add(
@@ -248,6 +343,14 @@ public class GovernmentContractsImportServiceWindowContinueTests
             .GetContractAwards(
                 Arg.Any<DateOnly>(),
                 Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(new List<UsaSpendingAwardRecord>()));
+        client
+            .GetContractAwards(
+                failingWindow,
+                failingWindow,
                 Arg.Any<decimal>(),
                 Arg.Any<CancellationToken>()
             )
@@ -286,6 +389,20 @@ public class GovernmentContractsImportServiceWindowContinueTests
             .HaveCountGreaterThan(
                 1,
                 "a window-specific (non-transport) failure must not abort the scan"
+            );
+
+        // ...and the later window that succeeded must not have banked a frontier past the hole.
+        using var context = NewContext(options);
+        var checkpoint = await context
+            .Set<GovernmentContractsScanState>()
+            .AsNoTracking()
+            .SingleOrDefaultAsync();
+
+        checkpoint
+            .Should()
+            .BeNull(
+                "the first window failed, so nothing behind it was ever contiguously scanned "
+                    + "and no frontier may be recorded"
             );
     }
 

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
@@ -1,10 +1,15 @@
+using System.Net;
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Configuration;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Data.Models;
+using Equibles.Errors.Repositories;
 using Equibles.GovernmentContracts.Data;
+using Equibles.GovernmentContracts.Data.Models;
 using Equibles.GovernmentContracts.HostedService.Configuration;
 using Equibles.GovernmentContracts.HostedService.Services;
 using Equibles.GovernmentContracts.Repositories;
@@ -24,6 +29,194 @@ namespace Equibles.UnitTests.GovernmentContracts;
 
 public class GovernmentContractsImportServiceWindowContinueTests
 {
+    [Fact]
+    public async Task Import_FirstWindowThrowsHttp4xx_ReportsFailureAndContinuesScanningLaterWindows()
+    {
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        using (var seed = NewContext(options))
+        {
+            seed.Add(
+                new CommonStock
+                {
+                    Ticker = "LMT",
+                    Name = "Lockheed Martin Corporation",
+                    Cik = "1",
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = ScopeFactory(options);
+        var firstWindow = today.AddDays(-1);
+        var client = Substitute.For<IUsaSpendingClient>();
+        client
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(new List<UsaSpendingAwardRecord>()));
+        client
+            .GetContractAwards(
+                firstWindow,
+                firstWindow,
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(
+                new HttpRequestException(
+                    "USAspending rejected the window",
+                    inner: null,
+                    statusCode: HttpStatusCode.UnprocessableEntity
+                )
+            );
+
+        var service = new GovernmentContractsImportService(
+            scopeFactory,
+            NullLogger<GovernmentContractsImportService>.Instance,
+            client,
+            new RecipientResolver(scopeFactory),
+            Options.Create(
+                new GovernmentContractsScraperOptions
+                {
+                    WindowDays = 1,
+                    MinimumAwardAmount = 1_000_000m,
+                }
+            ),
+            Options.Create(
+                new WorkerOptions { MinSyncDate = firstWindow.ToDateTime(TimeOnly.MinValue) }
+            ),
+            new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
+        );
+
+        await service.Import(CancellationToken.None);
+
+        await client
+            .Received(1)
+            .GetContractAwards(today, today, Arg.Any<decimal>(), Arg.Any<CancellationToken>());
+
+        using var context = NewContext(options);
+        var reported = await context.Set<Error>().AsNoTracking().SingleAsync();
+        reported.Source.Should().Be(ErrorSource.GovernmentContractsScraper);
+        reported.Context.Should().Be("GovernmentContractsImport.ImportWindow");
+        reported.Message.Should().Contain("USAspending rejected the window");
+        reported.RequestSummary.Should().Be($"window: {firstWindow}..{firstWindow}");
+    }
+
+    [Fact]
+    public async Task Import_HistoricalWindowFails_FreezesTheCheckpointBehindTheFailedWindow()
+    {
+        // The data-hole guard. A 4xx on a historical window is stepped over so the rest of the
+        // scan still runs — but the checkpoint records the CONTIGUOUS frontier, so it must stop
+        // at the day before the failure even though later windows completed. Advancing it to the
+        // last successful window would drop the failed day's awards for good the moment it aged
+        // out of the trailing rescan lookback.
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var scanStart = today.AddDays(-5);
+        var failingWindow = today.AddDays(-3);
+
+        using (var seed = NewContext(options))
+        {
+            seed.Add(
+                new CommonStock
+                {
+                    Ticker = "LMT",
+                    Name = "Lockheed Martin Corporation",
+                    Cik = "1",
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = ScopeFactory(options);
+        var client = Substitute.For<IUsaSpendingClient>();
+        client
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(new List<UsaSpendingAwardRecord>()));
+        client
+            .GetContractAwards(
+                failingWindow,
+                failingWindow,
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(
+                new HttpRequestException(
+                    "USAspending rejected the window",
+                    inner: null,
+                    statusCode: HttpStatusCode.UnprocessableEntity
+                )
+            );
+
+        var service = new GovernmentContractsImportService(
+            scopeFactory,
+            NullLogger<GovernmentContractsImportService>.Instance,
+            client,
+            new RecipientResolver(scopeFactory),
+            Options.Create(
+                new GovernmentContractsScraperOptions
+                {
+                    WindowDays = 1,
+                    MinimumAwardAmount = 1_000_000m,
+                }
+            ),
+            Options.Create(
+                new WorkerOptions { MinSyncDate = scanStart.ToDateTime(TimeOnly.MinValue) }
+            ),
+            new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
+        );
+
+        await service.Import(CancellationToken.None);
+
+        // Every later window still ran — the failure was stepped over, not fatal.
+        await client
+            .Received(1)
+            .GetContractAwards(today, today, Arg.Any<decimal>(), Arg.Any<CancellationToken>());
+
+        using var context = NewContext(options);
+        var checkpoint = await context
+            .Set<GovernmentContractsScanState>()
+            .AsNoTracking()
+            .SingleAsync();
+
+        checkpoint
+            .LastCompletedWindowEnd.Should()
+            .Be(
+                failingWindow.AddDays(-1),
+                "the frontier must freeze at the last contiguously-scanned day, not jump to the "
+                    + "last successful window and strand the failed one"
+            );
+    }
+
+    [Fact]
+    public void Import_HistoricalWindowFails_NextCycleResumesAtTheFailedWindow()
+    {
+        // The other half of the guard: freezing the checkpoint is only useful if the next cycle
+        // actually re-covers the hole. Feed the frozen checkpoint back through the cursor policy
+        // together with a watermark from the LATER windows that succeeded — the resume date must
+        // land on the failed window, not past it.
+        var today = new DateOnly(2026, 7, 17);
+        var failedWindow = new DateOnly(2026, 3, 2);
+
+        var start = GovernmentContractsImportService.ResolveStartDate(
+            latestActionDate: new DateOnly(2026, 3, 20),
+            checkpointEnd: failedWindow.AddDays(-1),
+            today,
+            rescanLookbackDays: 7,
+            new WorkerOptions()
+        );
+
+        start.Should().Be(failedWindow);
+    }
+
     [Fact]
     public async Task Import_WindowThrowsNonTransportException_ContinuesScanningRemainingWindows()
     {
@@ -111,6 +304,7 @@ public class GovernmentContractsImportServiceWindowContinueTests
             new IModuleConfiguration[]
             {
                 new CommonStocksModuleConfiguration(),
+                new ErrorsModuleConfiguration(),
                 new GovernmentContractsModuleConfiguration(),
             }
         );
@@ -125,6 +319,8 @@ public class GovernmentContractsImportServiceWindowContinueTests
         var services = new ServiceCollection();
         services.AddScoped(_ => NewContext(options));
         services.AddScoped<CommonStockRepository>();
+        services.AddScoped<ErrorRepository>();
+        services.AddScoped<ErrorManager>();
         services.AddScoped<GovernmentContractRepository>();
         services.AddScoped<GovernmentContractsScanStateRepository>();
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();


### PR DESCRIPTION
## Summary

Fixes #4272. The government-contracts award scan could wedge permanently: a self-hosted deployment sat at zero rows for 8 days across 108 consecutive failed cycles.

On a cold start the cursor fell through to the global `Worker:MinSyncDate`. USAspending rejects any `start_date` before its 2007-10-01 award epoch with a 422. `Import` treated every `HttpRequestException` as systemic and aborted the cycle, but the checkpoint only advances on a *successful* window — so the next cycle recomputed the identical impossible date and failed the same way, forever.

Fixing the deadlock naively opens a worse problem: stepping over a failed window lets the checkpoint advance past it, and once that day ages out of the trailing rescan lookback its awards are lost with no retry. Most of this PR is about closing that hole rather than the original 422.

## Code changes

**`GovernmentContractsImportService`**

- **Clamp to the source epoch.** Every `ResolveStartDate` path is clamped to 2007-10-01 without lowering a later cursor, so a low global `MinSyncDate` is harmless instead of fatal.
- **Abort by default; 422 is the only exit.** `IsSystemicHttpFailure` is now `StatusCode != UnprocessableEntity`. Continuing is the dangerous direction — it fans one failure across the whole range — so anything nobody has reasoned about aborts and lets the worker's failure streak back off. 422 is the sole request-level rejection, the one this classifier exists for.
- **Cap the fan-out.** 422 is USAspending's validation error for the *whole request*, not just its dates, so a bad request-invariant field rejects every window alike. Five consecutive window failures abort the cycle: an isolated bad day is still stepped over, a source-wide pattern is not. The cap counts failures, not statuses, so no future classification change can reopen it.
- **Keep the frontier contiguous.** The checkpoint records the last contiguously-scanned day. The first failure of a cycle pulls it back behind that window (new `RetractCheckpoint`) and stops it advancing; later windows still run and ingest. Freezing alone was not enough — once the scan is caught up the checkpoint *leads* the trailing rescan window, so a failure there sits behind the frontier and the sliding lookback would abandon it.
- **Open the frontier on a first-window failure.** With no checkpoint row yet, retraction used to no-op, and the next cycle's cold-start path resolved off `MAX(ActionDate)` — which the later windows had already pushed past the hole. The row is now created behind the failed window.
- **`MAX(ActionDate)` no longer drags the cursor forward** past the checkpoint. A cycle that fails one window keeps scanning later ones, so ingested data routinely leads the frontier; letting the watermark win would step over the hole and defeat the guard. It still seeds the cold-start path.

**Tests** — `Equibles.UnitTests/GovernmentContracts`, 105 tests in the area (was 90).

New coverage for the epoch clamp, the systemic/request-level status split including the classifier's *default*, the fan-out cap, checkpoint freeze and retraction, the first-window-failure case, and the next cycle's resume date.

One previously-pinned contract is deliberately inverted: `A_checkpoint_behind_ingested_data_never_resumes_behind_the_watermark` pinned the rule this fix reverses, and is rewritten to pin the new one with its reasoning rather than deleted.

## Verification

- `dotnet build Equibles.sln -c Release` clean.
- Full `Equibles.UnitTests` suite: 3,935/3,935 passing on the rebased branch.
- Mutation-tested — every fix was reverted in turn to confirm the tests fail without it: classifier default (10 tests), fan-out cap (1), checkpoint freeze (1), checkpoint retraction (1), first-window retraction (1), watermark change (2).

## Known and accepted

- A day that fails persistently pins the checkpoint, so the re-scanned range grows by one window per cycle. That is visible in the logs and on the Errors page rather than silent, which is the trade this lane wants.
- HTTP 408 is treated as systemic although the client's retry ladder only covers 429 and 5xx, so it aborts on the first occurrence.
- The documented `2007-09-30` bootstrap seed now forces a full historical replay against an already-populated table. Idempotent, but expensive.
- The scan-state writes are unlocked read-modify-write. Filed separately — it predates this change and affects every scraper lane, not just this one.