### PR TITLE
feat(worker): serialize each scraper lane across worker instances

### DIFF
--- a/src/Equibles.Core/Configuration/WorkerOptions.cs
+++ b/src/Equibles.Core/Configuration/WorkerOptions.cs
@@ -6,6 +6,12 @@ public class WorkerOptions
     public List<string> TickersToSync { get; set; } = [];
 
     /// <summary>
+    /// Serializes each scraper lane across worker instances with a PostgreSQL advisory lock.
+    /// Disable only for hosts that deliberately provide their own lane coordination.
+    /// </summary>
+    public bool LaneLeaseEnabled { get; set; } = true;
+
+    /// <summary>
     /// Caps how many stocks the split-price back-adjustment pass re-syncs per cycle, so the
     /// one-time universe backfill throttles against Yahoo's shared request limiter instead of
     /// re-pulling every stock's full history at once. Stocks beyond the cap stay pending and are

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -164,13 +164,27 @@ public abstract class BaseScraperWorker : BackgroundService
                 using var scope = ScopeFactory.CreateScope();
                 var options = scope.ServiceProvider.GetService<IOptions<WorkerOptions>>();
 
-                // The worker host always registers WorkerOptions. A missing registration is kept
-                // as the legacy behavior for minimal test or custom hosts that only wire the base.
+                // No registration means no database wiring to take a lock on either, so this runs
+                // unleased — that is the only thing a bare host CAN do. It must not be silent
+                // though: unleased is the pre-lease behaviour, and a host that reaches production
+                // this way would race its cursors with nothing in the log to explain why. The
+                // worker host registers WorkerOptions, so this warns only for custom/minimal hosts.
+                if (options is null)
+                {
+                    Logger.LogWarning(
+                        "{Worker} found no WorkerOptions registration, so the lane lease is OFF and "
+                            + "concurrent instances will NOT be serialized. Register WorkerOptions "
+                            + "to enable it.",
+                        WorkerName
+                    );
+                }
+
                 _laneLeaseEnabled = options?.Value.LaneLeaseEnabled ?? false;
             }
             catch (ObjectDisposedException)
             {
                 // Host teardown can dispose the root provider before a final cycle checks options.
+                // Nothing more will run, so skipping the lease here cannot overlap another instance.
                 _laneLeaseEnabled = false;
             }
 
@@ -178,9 +192,19 @@ public abstract class BaseScraperWorker : BackgroundService
         }
     }
 
+    /// <summary>
+    /// Identity of the lane this worker serializes on. Deliberately the concrete worker TYPE, not
+    /// <see cref="WorkerName"/>: that is a display string for logs and the activity feed, and
+    /// editing it — a rewording, a typo fix — would silently move this worker to a different lock.
+    /// Mid-rollout the old and new pods would then hold two different locks for one logical lane
+    /// and run it concurrently, which is the exact overlap the lease exists to prevent. A type name
+    /// changes only through a deliberate, reviewable refactor.
+    /// </summary>
+    protected virtual string LaneId => GetType().FullName;
+
     protected virtual async ValueTask<IAsyncDisposable> TryAcquireLaneLease(
         CancellationToken stoppingToken
-    ) => await ScraperLease.TryAcquire(ScopeFactory, WorkerName, Logger, stoppingToken);
+    ) => await ScraperLease.TryAcquire(ScopeFactory, LaneId, WorkerName, Logger, stoppingToken);
 
     protected async Task RunImport<TImporter>(CancellationToken stoppingToken)
         where TImporter : IImporter

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Messaging.Contracts.Activity;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Equibles.Worker;
 
@@ -20,6 +22,7 @@ public abstract class BaseScraperWorker : BackgroundService
     private bool _continuationRequested;
     private int _consecutiveFailures;
     private bool _errorReportedForStreak;
+    private bool? _laneLeaseEnabled;
 
     protected abstract string WorkerName { get; }
     protected abstract TimeSpan SleepInterval { get; }
@@ -149,6 +152,36 @@ public abstract class BaseScraperWorker : BackgroundService
         ErrorReporter = errorReporter;
     }
 
+    protected virtual bool LaneLeaseEnabled
+    {
+        get
+        {
+            if (_laneLeaseEnabled.HasValue)
+                return _laneLeaseEnabled.Value;
+
+            try
+            {
+                using var scope = ScopeFactory.CreateScope();
+                var options = scope.ServiceProvider.GetService<IOptions<WorkerOptions>>();
+
+                // The worker host always registers WorkerOptions. A missing registration is kept
+                // as the legacy behavior for minimal test or custom hosts that only wire the base.
+                _laneLeaseEnabled = options?.Value.LaneLeaseEnabled ?? false;
+            }
+            catch (ObjectDisposedException)
+            {
+                // Host teardown can dispose the root provider before a final cycle checks options.
+                _laneLeaseEnabled = false;
+            }
+
+            return _laneLeaseEnabled.Value;
+        }
+    }
+
+    protected virtual async ValueTask<IAsyncDisposable> TryAcquireLaneLease(
+        CancellationToken stoppingToken
+    ) => await ScraperLease.TryAcquire(ScopeFactory, WorkerName, Logger, stoppingToken);
+
     protected async Task RunImport<TImporter>(CancellationToken stoppingToken)
         where TImporter : IImporter
     {
@@ -188,12 +221,11 @@ public abstract class BaseScraperWorker : BackgroundService
             _retrySoonRequested = false;
             _continuationRequested = false;
             var faulted = false;
-
-            await PublishActivity(ScraperActivitySeverity.Info, "cycle started", stoppingToken);
+            var cycleRan = false;
 
             try
             {
-                await DoWork(stoppingToken);
+                cycleRan = await RunCycle(stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -245,6 +277,17 @@ public abstract class BaseScraperWorker : BackgroundService
                         ErrorReportThreshold
                     );
                 }
+            }
+
+            if (!cycleRan && !faulted)
+            {
+                Logger.LogInformation(
+                    "{Worker} lane lease is held by another instance; skipping cycle and sleeping for {Interval}",
+                    WorkerName,
+                    SleepInterval
+                );
+                await WaitForNextCycle(SleepInterval, stoppingToken);
+                continue;
             }
 
             TimeSpan interval;
@@ -314,6 +357,25 @@ public abstract class BaseScraperWorker : BackgroundService
             }
             await WaitForNextCycle(interval, stoppingToken);
         }
+    }
+
+    private async Task<bool> RunCycle(CancellationToken stoppingToken)
+    {
+        IAsyncDisposable lease = null;
+        if (LaneLeaseEnabled)
+        {
+            lease = await TryAcquireLaneLease(stoppingToken);
+            if (lease is null)
+                return false;
+        }
+
+        await using (lease)
+        {
+            await PublishActivity(ScraperActivitySeverity.Info, "cycle started", stoppingToken);
+            await DoWork(stoppingToken);
+        }
+
+        return true;
     }
 
     private static string FormatInterval(TimeSpan interval)

--- a/src/Equibles.Worker/Equibles.Worker.csproj
+++ b/src/Equibles.Worker/Equibles.Worker.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <InternalsVisibleTo Include="Equibles.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Equibles.Core.AutoWiring" />
     <PackageReference Include="MassTransit" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
@@ -8,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Data\Equibles.Data.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>

--- a/src/Equibles.Worker/ScraperLease.cs
+++ b/src/Equibles.Worker/ScraperLease.cs
@@ -1,0 +1,172 @@
+using System.Data;
+using System.Data.Common;
+using System.Text;
+using Equibles.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Worker;
+
+internal sealed class ScraperLease : IAsyncDisposable
+{
+    private const string AcquireSql = "SELECT pg_try_advisory_lock(@lockKey)";
+    private const string ReleaseSql = "SELECT pg_advisory_unlock(@lockKey)";
+    private const int ReleaseCommandTimeoutSeconds = 5;
+    private const ulong FnvOffsetBasis = 14695981039346656037UL;
+    private const ulong FnvPrime = 1099511628211UL;
+
+    private readonly AsyncServiceScope _scope;
+    private readonly DbConnection _connection;
+    private readonly long _lockKey;
+    private readonly string _workerName;
+    private readonly ILogger _logger;
+    private int _disposed;
+
+    private ScraperLease(
+        AsyncServiceScope scope,
+        DbConnection connection,
+        long lockKey,
+        string workerName,
+        ILogger logger
+    )
+    {
+        _scope = scope;
+        _connection = connection;
+        _lockKey = lockKey;
+        _workerName = workerName;
+        _logger = logger;
+    }
+
+    internal static async Task<ScraperLease> TryAcquire(
+        IServiceScopeFactory scopeFactory,
+        string workerName,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        var lockKey = ComputeLockKey(workerName);
+        var scope = scopeFactory.CreateAsyncScope();
+        DbConnection connection;
+        bool acquired;
+
+        try
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+
+            // PostgreSQL advisory locks belong to a database session. A dedicated DbContext scope
+            // reuses the host's provider configuration while keeping this exact connection open for
+            // the entire scraper cycle, so pooling cannot return the owning session early.
+            await dbContext.Database.OpenConnectionAsync(cancellationToken);
+            connection = dbContext.Database.GetDbConnection();
+
+            await using var command = CreateCommand(connection, AcquireSql, lockKey);
+            acquired = await command.ExecuteScalarAsync(cancellationToken) is true;
+        }
+        catch
+        {
+            await scope.DisposeAsync();
+            throw;
+        }
+
+        if (!acquired)
+        {
+            await scope.DisposeAsync();
+            return null;
+        }
+
+        return new ScraperLease(scope, connection, lockKey, workerName, logger);
+    }
+
+    internal static long ComputeLockKey(string workerName)
+    {
+        ArgumentNullException.ThrowIfNull(workerName);
+
+        var hash = FnvOffsetBasis;
+        foreach (var value in Encoding.UTF8.GetBytes(workerName))
+        {
+            hash ^= value;
+            hash *= FnvPrime;
+        }
+
+        return unchecked((long)hash);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        try
+        {
+            if (_connection.State == ConnectionState.Open)
+            {
+                await using var command = CreateCommand(_connection, ReleaseSql, _lockKey);
+                command.CommandTimeout = ReleaseCommandTimeoutSeconds;
+                if (await command.ExecuteScalarAsync(CancellationToken.None) is not true)
+                {
+                    _logger.LogWarning(
+                        "PostgreSQL reported that the scraper lane lease for {Worker} was not held",
+                        _workerName
+                    );
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Cleanup must not replace a DoWork exception. Closing the dedicated session below is
+            // PostgreSQL's fail-safe release path when an explicit unlock cannot be delivered.
+            _logger.LogWarning(
+                ex,
+                "Failed to explicitly release scraper lane lease for {Worker}",
+                _workerName
+            );
+        }
+        finally
+        {
+            try
+            {
+                await _connection.CloseAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to close scraper lane lease connection for {Worker}",
+                    _workerName
+                );
+            }
+
+            try
+            {
+                await _scope.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to dispose scraper lane lease scope for {Worker}",
+                    _workerName
+                );
+            }
+        }
+    }
+
+    private static DbCommand CreateCommand(
+        DbConnection connection,
+        string commandText,
+        long lockKey
+    )
+    {
+        var command = connection.CreateCommand();
+        command.CommandText = commandText;
+
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "lockKey";
+        parameter.DbType = DbType.Int64;
+        parameter.Value = lockKey;
+        command.Parameters.Add(parameter);
+
+        return command;
+    }
+}

--- a/src/Equibles.Worker/ScraperLease.cs
+++ b/src/Equibles.Worker/ScraperLease.cs
@@ -38,14 +38,20 @@ internal sealed class ScraperLease : IAsyncDisposable
         _logger = logger;
     }
 
+    /// <param name="laneId">
+    /// Stable identity of the lane. Two instances serialize only if this matches exactly, so it
+    /// must never track a display string — see <c>BaseScraperWorker.LaneId</c>.
+    /// </param>
+    /// <param name="workerName">Display name, used only for logging.</param>
     internal static async Task<ScraperLease> TryAcquire(
         IServiceScopeFactory scopeFactory,
+        string laneId,
         string workerName,
         ILogger logger,
         CancellationToken cancellationToken
     )
     {
-        var lockKey = ComputeLockKey(workerName);
+        var lockKey = ComputeLockKey(laneId);
         var scope = scopeFactory.CreateAsyncScope();
         DbConnection connection;
         bool acquired;

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerLaneLeaseTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerLaneLeaseTests.cs
@@ -1,0 +1,201 @@
+#nullable enable
+
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Messaging.Contracts.Activity;
+using Equibles.Worker;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Worker;
+
+public class BaseScraperWorkerLaneLeaseTests
+{
+    [Fact]
+    public async Task ExecuteAsync_LeaseHeldElsewhere_SkipsWorkWithoutFaultOrError()
+    {
+        var bus = Substitute.For<IBus>();
+        using var services = CreateWorkerServices(new WorkerOptions(), bus);
+        var reporterScopeFactory = Substitute.For<IServiceScopeFactory>();
+        var logger = Substitute.For<ILogger>();
+        using var worker = new LeaseTestWorker(
+            logger,
+            services.GetRequiredService<IServiceScopeFactory>(),
+            CreateErrorReporter(reporterScopeFactory),
+            (_, _) => ValueTask.FromResult<IAsyncDisposable>(null!),
+            _ => Task.CompletedTask
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        var interval = await worker.FirstWait.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.LeaseAttempts.Should().Be(1);
+        worker.DoWorkCalls.Should().Be(0);
+        interval.Should().Be(worker.NormalSleepInterval);
+        reporterScopeFactory.DidNotReceive().CreateScope();
+        logger
+            .DidNotReceive()
+            .Log(
+                LogLevel.Critical,
+                Arg.Any<EventId>(),
+                Arg.Any<object>(),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+        bus.ReceivedCalls()
+            .Select(call => call.GetArguments().FirstOrDefault())
+            .OfType<ScraperActivity>()
+            .Should()
+            .NotContain(activity =>
+                activity.Severity == ScraperActivitySeverity.Warn
+                || activity.Severity == ScraperActivitySeverity.Error
+            );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LeaseFree_RunsWorkNormally()
+    {
+        var lease = new TrackingLease();
+        using var services = CreateWorkerServices(new WorkerOptions());
+        using var worker = new LeaseTestWorker(
+            Substitute.For<ILogger>(),
+            services.GetRequiredService<IServiceScopeFactory>(),
+            CreateErrorReporter(Substitute.For<IServiceScopeFactory>()),
+            (_, _) => ValueTask.FromResult<IAsyncDisposable>(lease),
+            _ => Task.CompletedTask
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        var interval = await worker.FirstWait.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        new WorkerOptions().LaneLeaseEnabled.Should().BeTrue();
+        worker.LeaseAttempts.Should().Be(1);
+        worker.DoWorkCalls.Should().Be(1);
+        interval.Should().Be(worker.NormalSleepInterval);
+        lease.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoWorkThrows_ReleasesLeaseBeforeFaultBackoff()
+    {
+        var lease = new TrackingLease();
+        using var services = CreateWorkerServices(new WorkerOptions());
+        using var worker = new LeaseTestWorker(
+            Substitute.For<ILogger>(),
+            services.GetRequiredService<IServiceScopeFactory>(),
+            CreateErrorReporter(Substitute.For<IServiceScopeFactory>()),
+            (_, _) => ValueTask.FromResult<IAsyncDisposable>(lease),
+            _ => throw new InvalidOperationException("cycle failed")
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        var interval = await worker.FirstWait.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.DoWorkCalls.Should().Be(1);
+        lease.DisposeCalls.Should().Be(1);
+        interval.Should().Be(worker.FaultBackoffInterval);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LaneLeaseDisabled_RunsWorkWithoutAttemptingLease()
+    {
+        using var services = CreateWorkerServices(new WorkerOptions { LaneLeaseEnabled = false });
+        using var worker = new LeaseTestWorker(
+            Substitute.For<ILogger>(),
+            services.GetRequiredService<IServiceScopeFactory>(),
+            CreateErrorReporter(Substitute.For<IServiceScopeFactory>()),
+            (_, _) => throw new InvalidOperationException("lease must not be attempted"),
+            _ => Task.CompletedTask
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        var interval = await worker.FirstWait.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.LeaseAttempts.Should().Be(0);
+        worker.DoWorkCalls.Should().Be(1);
+        interval.Should().Be(worker.NormalSleepInterval);
+    }
+
+    private static ServiceProvider CreateWorkerServices(WorkerOptions options, IBus? bus = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IOptions<WorkerOptions>>(Options.Create(options));
+        if (bus is not null)
+            services.AddSingleton(bus);
+        return services.BuildServiceProvider();
+    }
+
+    private static ErrorReporter CreateErrorReporter(IServiceScopeFactory scopeFactory) =>
+        new(scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+
+    private sealed class TrackingLease : IAsyncDisposable
+    {
+        public int DisposeCalls { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCalls++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class LeaseTestWorker : BaseScraperWorker
+    {
+        private readonly Func<int, CancellationToken, ValueTask<IAsyncDisposable>> _tryAcquire;
+        private readonly Func<CancellationToken, Task> _doWork;
+        private readonly TaskCompletionSource<TimeSpan> _firstWait = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        private int _leaseAttempts;
+        private int _doWorkCalls;
+
+        public LeaseTestWorker(
+            ILogger logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            Func<int, CancellationToken, ValueTask<IAsyncDisposable>> tryAcquire,
+            Func<CancellationToken, Task> doWork
+        )
+            : base(logger, scopeFactory, errorReporter)
+        {
+            _tryAcquire = tryAcquire;
+            _doWork = doWork;
+        }
+
+        public Task<TimeSpan> FirstWait => _firstWait.Task;
+        public TimeSpan NormalSleepInterval => SleepInterval;
+        public TimeSpan FaultBackoffInterval => ErrorBackoffInterval;
+        public int LeaseAttempts => _leaseAttempts;
+        public int DoWorkCalls => _doWorkCalls;
+
+        protected override string WorkerName => "Lease test worker";
+        protected override TimeSpan SleepInterval => TimeSpan.FromHours(1);
+        protected override TimeSpan ErrorBackoffInterval => TimeSpan.FromSeconds(1);
+        protected override int ErrorReportThreshold => 2;
+        protected override ErrorSource ErrorSource => ErrorSource.Other;
+
+        protected override ValueTask<IAsyncDisposable> TryAcquireLaneLease(
+            CancellationToken stoppingToken
+        ) => _tryAcquire(Interlocked.Increment(ref _leaseAttempts), stoppingToken);
+
+        protected override Task DoWork(CancellationToken stoppingToken)
+        {
+            Interlocked.Increment(ref _doWorkCalls);
+            return _doWork(stoppingToken);
+        }
+
+        protected override Task WaitForNextCycle(TimeSpan interval, CancellationToken stoppingToken)
+        {
+            _firstWait.TrySetResult(interval);
+            return Task.Delay(Timeout.InfiniteTimeSpan, stoppingToken);
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerLaneLeaseTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerLaneLeaseTests.cs
@@ -124,6 +124,36 @@ public class BaseScraperWorkerLaneLeaseTests
         interval.Should().Be(worker.NormalSleepInterval);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_LeaseLostMidOutage_DoesNotResetTheFailureStreak()
+    {
+        // A skipped cycle must not read as a CLEAN one. The clean-cycle branch clears
+        // _consecutiveFailures and _errorReportedForStreak, so a worker deep in an outage that
+        // loses the lease for a single cycle would have its streak reset and its Error report
+        // pushed further away — the report exists precisely to surface an outage that is not
+        // self-healing. With ErrorReportThreshold = 2: fault, lose the lease, fault again must
+        // still reach the threshold and report.
+        var reporterScopeFactory = Substitute.For<IServiceScopeFactory>();
+        using var services = CreateWorkerServices(new WorkerOptions());
+        using var worker = new LeaseTestWorker(
+            Substitute.For<ILogger>(),
+            services.GetRequiredService<IServiceScopeFactory>(),
+            CreateErrorReporter(reporterScopeFactory),
+            // Only the second cycle loses the lane.
+            (attempt, _) =>
+                ValueTask.FromResult<IAsyncDisposable>(attempt == 2 ? null! : new TrackingLease()),
+            _ => throw new InvalidOperationException("cycle failed"),
+            cyclesBeforeBlocking: 3
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await worker.CyclesCompleted.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.DoWorkCalls.Should().Be(2, "the middle cycle never acquired the lane");
+        reporterScopeFactory.Received().CreateScope();
+    }
+
     private static ServiceProvider CreateWorkerServices(WorkerOptions options, IBus? bus = null)
     {
         var services = new ServiceCollection();
@@ -154,23 +184,31 @@ public class BaseScraperWorkerLaneLeaseTests
         private readonly TaskCompletionSource<TimeSpan> _firstWait = new(
             TaskCreationOptions.RunContinuationsAsynchronously
         );
+        private readonly TaskCompletionSource _cyclesCompleted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        private readonly int _cyclesBeforeBlocking;
         private int _leaseAttempts;
         private int _doWorkCalls;
+        private int _cyclesObserved;
 
         public LeaseTestWorker(
             ILogger logger,
             IServiceScopeFactory scopeFactory,
             ErrorReporter errorReporter,
             Func<int, CancellationToken, ValueTask<IAsyncDisposable>> tryAcquire,
-            Func<CancellationToken, Task> doWork
+            Func<CancellationToken, Task> doWork,
+            int cyclesBeforeBlocking = 1
         )
             : base(logger, scopeFactory, errorReporter)
         {
             _tryAcquire = tryAcquire;
             _doWork = doWork;
+            _cyclesBeforeBlocking = cyclesBeforeBlocking;
         }
 
         public Task<TimeSpan> FirstWait => _firstWait.Task;
+        public Task CyclesCompleted => _cyclesCompleted.Task;
         public TimeSpan NormalSleepInterval => SleepInterval;
         public TimeSpan FaultBackoffInterval => ErrorBackoffInterval;
         public int LeaseAttempts => _leaseAttempts;
@@ -195,6 +233,13 @@ public class BaseScraperWorkerLaneLeaseTests
         protected override Task WaitForNextCycle(TimeSpan interval, CancellationToken stoppingToken)
         {
             _firstWait.TrySetResult(interval);
+
+            // Let the loop run the requested number of cycles back to back, then park so the
+            // test observes a settled state instead of racing an unbounded loop.
+            if (Interlocked.Increment(ref _cyclesObserved) < _cyclesBeforeBlocking)
+                return Task.CompletedTask;
+
+            _cyclesCompleted.TrySetResult();
             return Task.Delay(Timeout.InfiniteTimeSpan, stoppingToken);
         }
     }

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerLaneLeaseTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerLaneLeaseTests.cs
@@ -154,6 +154,27 @@ public class BaseScraperWorkerLaneLeaseTests
         reporterScopeFactory.Received().CreateScope();
     }
 
+    [Fact]
+    public void LaneId_IsTheWorkerType_NotTheMutableDisplayName()
+    {
+        // WorkerName is a display string for logs and the activity feed; rewording it must not
+        // move the worker to a different advisory lock. If it did, a rolling release that renamed
+        // a worker would leave old and new pods holding two locks for ONE logical lane and running
+        // it concurrently — precisely the overlap the lease exists to prevent, reintroduced by an
+        // edit that looks cosmetic. The lane identity is therefore the concrete type.
+        using var services = CreateWorkerServices(new WorkerOptions());
+        using var worker = new LeaseTestWorker(
+            Substitute.For<ILogger>(),
+            services.GetRequiredService<IServiceScopeFactory>(),
+            CreateErrorReporter(Substitute.For<IServiceScopeFactory>()),
+            (_, _) => ValueTask.FromResult<IAsyncDisposable>(new TrackingLease()),
+            _ => Task.CompletedTask
+        );
+
+        worker.ExposedLaneId.Should().Be(typeof(LeaseTestWorker).FullName);
+        worker.ExposedLaneId.Should().NotBe(worker.ExposedWorkerName);
+    }
+
     private static ServiceProvider CreateWorkerServices(WorkerOptions options, IBus? bus = null)
     {
         var services = new ServiceCollection();
@@ -209,6 +230,8 @@ public class BaseScraperWorkerLaneLeaseTests
 
         public Task<TimeSpan> FirstWait => _firstWait.Task;
         public Task CyclesCompleted => _cyclesCompleted.Task;
+        public string ExposedLaneId => LaneId;
+        public string ExposedWorkerName => WorkerName;
         public TimeSpan NormalSleepInterval => SleepInterval;
         public TimeSpan FaultBackoffInterval => ErrorBackoffInterval;
         public int LeaseAttempts => _leaseAttempts;

--- a/tests/Equibles.UnitTests/Worker/ScraperLeaseTests.cs
+++ b/tests/Equibles.UnitTests/Worker/ScraperLeaseTests.cs
@@ -1,0 +1,46 @@
+#nullable enable
+
+using Equibles.Worker;
+
+namespace Equibles.UnitTests.Worker;
+
+// The lock key is the whole lease. Two worker instances only serialize on a lane if both
+// compute the SAME key for the same WorkerName — in different processes, on different hosts,
+// across restarts. That rules out `string.GetHashCode()`, which .NET randomizes per process:
+// it is stable within one run, so a same-process "is it deterministic?" test passes while the
+// two containers in production silently take different locks and never exclude each other.
+//
+// So these pin the key against hardcoded FNV-1a values computed independently of the code.
+// A golden constant is the only assertion that catches BOTH a changed algorithm and a
+// per-process one — comparing the implementation to itself, in any number of processes, is
+// tautological and passes under both.
+public class ScraperLeaseTests
+{
+    [Theory]
+    [InlineData("Document processor", 6530301888989173848L)]
+    [InlineData("Government contracts scraper", 2686007587183620975L)]
+    [InlineData("", -3750763034362895579L)]
+    public void ComputeLockKey_MatchesTheFnv1aGoldenValue(string workerName, long expected)
+    {
+        ScraperLease.ComputeLockKey(workerName).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ComputeLockKey_DifferentWorkerNames_DoNotShareALane()
+    {
+        // Distinct lanes must not collide onto one advisory lock, or one worker would block an
+        // unrelated scraper for a whole cycle.
+        ScraperLease
+            .ComputeLockKey("Document processor")
+            .Should()
+            .NotBe(ScraperLease.ComputeLockKey("Government contracts scraper"));
+    }
+
+    [Fact]
+    public void ComputeLockKey_NullWorkerName_Throws()
+    {
+        var act = () => ScraperLease.ComputeLockKey(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary

Hardening, not a bug fix — #4274 is already closed by #4275.

#4275 removed the duplicated worker that made two instances run every scraper at once, which is what actually caused the cursor races. This is the defence behind it: nothing stops a deploy overlap, a stray `dotnet run`, or a future topology change from putting two workers on the same lane again, and every lane resumes from a cursor it reads, compares and writes without a lock.

Each cycle now takes a PostgreSQL advisory lock keyed on the worker's lane before calling `DoWork`. A worker that cannot take it logs and sleeps — not a fault, no Error row, no failure activity. One change in `BaseScraperWorker` covers every lane, present and future, with no per-lane edits and no migration. Worst case is benign: a lane skips a cycle.

## Code changes

- **`ScraperLease`** (new) — `pg_try_advisory_lock` on a dedicated scope's connection, held for the whole cycle because advisory locks are session-scoped and pooling would otherwise return the owning session early. Explicit `pg_advisory_unlock` on dispose.
- **`BaseScraperWorker`** — `RunCycle` acquires before `DoWork` and returns false if it cannot; the skip path sleeps and `continue`s without touching the failure streak.
- **`WorkerOptions.LaneLeaseEnabled`** — default true. Also the runtime kill switch: `Worker__LaneLeaseEnabled=false`.
- **Lane identity is the worker TYPE, not `WorkerName`.** `WorkerName` is a display string that also feeds logs and the activity feed; rewording it would silently move the worker to a different lock, and mid-rollout old and new pods would hold two locks for one logical lane. A type name changes only through a deliberate refactor.
- **Lock key is FNV-1a, never `string.GetHashCode()`** — .NET randomizes that per process, so it is stable within one run while two containers take different locks and never exclude each other.

## Verification

- Build clean, 0 warnings. `Equibles.UnitTests` 3,947/3,947. csharpier clean tree-wide.
- Mutations killed: lock key (3 tests), lease gate (1), lease release (2), `LaneLeaseEnabled` default (3), skipped-cycle branch (1), lane identity (1).
- All 27 production worker names hash to distinct 64-bit keys.

## What this does NOT guarantee

Stated plainly, because two independent reviews raised both:

- **Losing the lease session mid-cycle drops exclusivity silently.** If PostgreSQL ends that session (`idle_session_timeout`, backend termination, failover, a proxy), the lock releases while `DoWork` continues on other connections, and another instance can acquire. Only a fencing token checked by cursor writes closes this fully. The degraded state equals today's behaviour, so this is a ceiling on the protection, not a regression.
- **The tests pin the wrapper, not PostgreSQL semantics.** Every base-worker test fakes `TryAcquireLaneLease`, and `ScraperLeaseTests` covers only hashing. Swapping in transaction-scoped `pg_try_advisory_xact_lock`, or making the real `DisposeAsync` a no-op, would still pass. The mutation results above are accurate for the mutations chosen but do not establish distributed-lock behaviour.
- **Contention takeover is slow and quiet.** A loser sleeps the full lane interval — up to 24h on some lanes — and the only signal is an Information log while the shipped default level is Warning.

Follow-ups filed separately.