### PR TITLE
fix(yahoo): resettle daily OHLC and repair history

### DIFF
--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -223,10 +223,9 @@ public class YahooFinanceClient : IYahooFinanceClient
     // Yahoo occasionally returns a ragged payload — a timestamp array longer than the
     // OHLC/volume columns, a column with a null hole on a holiday / early-close row, or a
     // zeroed OHLC quartet for a delisted / halted ticker. Bound every column access and
-    // require a strictly-positive OHLC quartet: an incomplete or non-positive row is
-    // skipped rather than emitted as an impossible bar (e.g. Close=0 on a day with
-    // Volume>0, which corrupts market cap and price-derived rankings) or aborting the
-    // whole import.
+    // require a coherent, strictly-positive OHLC quartet: an incomplete, non-positive,
+    // or internally impossible row is skipped rather than emitted as a corrupt bar (e.g.
+    // Close=0 with Volume>0, or Low above Open) or aborting the whole import.
     private static HistoricalPrice TryBuildPrice(
         ChartQuote quote,
         List<decimal?> adjCloseList,
@@ -244,6 +243,11 @@ public class YahooFinanceClient : IYahooFinanceClient
         // A real trading bar has every OHLC value present and strictly positive; a null
         // hole or a $0/negative price (delisted/halted ticker) is not a tradeable price.
         if (open is not > 0 || high is not > 0 || low is not > 0 || close is not > 0)
+            return null;
+
+        // Yahoo can briefly publish a complete but still-partial candle after UTC rollover.
+        // Presence alone is insufficient: High and Low must contain both endpoint prices.
+        if (high < open || high < close || low > open || low > close || high < low)
             return null;
 
         return new HistoricalPrice

--- a/src/Equibles.Yahoo.HostedService/Configuration/YahooPriceScraperOptions.cs
+++ b/src/Equibles.Yahoo.HostedService/Configuration/YahooPriceScraperOptions.cs
@@ -14,15 +14,21 @@ public class YahooPriceScraperOptions : ScraperOptions
     public int EnrichmentIntervalHours { get; set; } = 24;
 
     /// <summary>
-    /// How many days back a stored bar's volume is still re-read from the feed and corrected
-    /// upward. A bar is stored as soon as its date rolls over in UTC — four hours after the US
-    /// close — but the feed is still serving an unsettled volume then, and revises it upward
-    /// overnight as the closing cross and late-reported off-exchange prints land. Without a
-    /// re-read the first, short figure is permanent (the importer is otherwise insert-only).
+    /// How many days back a stored bar is still re-read from the feed. A bar is stored as soon as
+    /// its date rolls over in UTC — four hours after the US close — but the feed can still revise
+    /// its OHLC and volume overnight. Without a re-read the first partial figure is permanent (the
+    /// importer is otherwise insert-only).
     /// The default covers the previous session across a weekend, which is all steady-state
-    /// operation needs. Raise it temporarily to repair a longer stretch of stored volumes: the
+    /// operation needs. Raise it temporarily to resettle a longer stretch of stored bars: the
     /// window only ever widens a fetch that was already going to happen, so a wider setting costs
     /// no extra upstream calls, only a larger response and more rows compared per stock.
     /// </summary>
     public int VolumeResettleWindowDays { get; set; } = 5;
+
+    /// <summary>
+    /// Maximum number of historically-invalid OHLC rows repaired after each ordinary price pass.
+    /// The repair is deliberately bounded so old corruption cannot delay current prices without
+    /// limit. Set to zero to disable it.
+    /// </summary>
+    public int OhlcRepairBatchSize { get; set; } = 100;
 }

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -549,8 +549,10 @@ public class YahooPriceImportService
     )
     {
         var overflowDates = WarnAndCollectOverflowDates(prices, ticker);
+        var invalidOhlcDates = WarnAndCollectInvalidOhlcDates(prices, ticker);
         return prices
             .Where(p => !overflowDates.Contains(p.Date))
+            .Where(p => !invalidOhlcDates.Contains(p.Date))
             .Where(p => IsSettledDailyBar(p.Date, today))
             .Select(p => new DailyStockPrice
             {
@@ -666,10 +668,10 @@ public class YahooPriceImportService
 
         var freshRows = MapFreshRows(commonStockId, prices, ticker, today);
 
-        // Runs before the insert path's early return: a stock whose only unsettled bar is one it
-        // ALREADY stored has nothing new to insert, and that is exactly the stock whose volume
-        // still needs correcting.
-        await ResettleVolumes(ticker, commonStockId, freshRows, today, cancellationToken);
+        // Runs before the insert path's early return: a stock whose only revised bar is one it
+        // ALREADY stored has nothing new to insert, and that is exactly the stock whose settled
+        // OHLC/volume still needs correcting.
+        await ResettleStoredBars(ticker, commonStockId, freshRows, today, cancellationToken);
 
         var newPrices = freshRows.Where(p => !existingDates.Contains(p.Date)).ToList();
 
@@ -682,19 +684,18 @@ public class YahooPriceImportService
         return inserted;
     }
 
-    // Corrects stored volumes that were captured before the feed settled them.
+    // Corrects stored bars that were captured before the feed settled them.
     //
     // A bar becomes storable the moment its date rolls over in UTC, which is only four hours after
     // the 20:00 UTC close. The feed serves a daily bar that early with an unsettled volume — the
-    // closing cross and late-reported off-exchange prints are still landing — and revises it upward
-    // overnight. OHLC is right from the start; only volume moves, and for names whose volume
-    // settles late it moves a lot (a quarter of the day's shares is routine). PersistPrices is
-    // insert-only, so that first short figure used to be permanent.
+    // closing cross and late-reported off-exchange prints are still landing — and can revise both
+    // OHLC and volume overnight. PersistPrices is insert-only, so that first partial figure used to
+    // be permanent.
     //
     // Re-reading the window off the SAME chart response the stock was already fetching costs no
     // extra upstream call — ResolveStartDate only widens a request that was going to happen anyway.
-    // Steady state therefore corrects each session's volume when the next session syncs.
-    private async Task<int> ResettleVolumes(
+    // Steady state therefore corrects each session when the next session syncs.
+    private async Task<int> ResettleStoredBars(
         string ticker,
         Guid commonStockId,
         List<DailyStockPrice> freshRows,
@@ -729,19 +730,37 @@ public class YahooPriceImportService
             if (!fetched.TryGetValue(row.Date, out var bar))
                 continue;
 
-            // Both records must describe the session on the SAME split basis before their volumes
-            // can be compared at all — see IsSameSplitBasis.
+            // Both records must describe the session on the SAME split basis before any price or
+            // volume field can be reconciled — see IsSameSplitBasis.
             if (!IsSameSplitBasis(row.Close, bar.Close))
             {
                 skippedOnBasis++;
                 continue;
             }
 
-            if (!IsVolumeUpgrade(row.Volume, bar.Volume))
-                continue;
+            var changed = false;
+            if (
+                row.Open != bar.Open
+                || row.High != bar.High
+                || row.Low != bar.Low
+                || row.Close != bar.Close
+            )
+            {
+                row.Open = bar.Open;
+                row.High = bar.High;
+                row.Low = bar.Low;
+                row.Close = bar.Close;
+                changed = true;
+            }
 
-            row.Volume = bar.Volume;
-            corrected++;
+            if (IsVolumeUpgrade(row.Volume, bar.Volume))
+            {
+                row.Volume = bar.Volume;
+                changed = true;
+            }
+
+            if (changed)
+                corrected++;
         }
 
         // A basis mismatch is the only place the store's divergence from the feed's served basis
@@ -750,7 +769,7 @@ public class YahooPriceImportService
         if (skippedOnBasis > 0)
         {
             _logger.LogInformation(
-                "Skipped {Count} stored volumes for {Ticker}: stored close disagrees with the feed's split basis",
+                "Skipped {Count} stored bars for {Ticker}: stored close disagrees with the feed's split basis",
                 skippedOnBasis,
                 ticker
             );
@@ -759,12 +778,153 @@ public class YahooPriceImportService
         if (corrected == 0)
             return 0;
 
-        // The rows are tracked, so saving the mutated Volume is enough — no repo.Update, which
+        // The rows are tracked, so saving the mutations is enough — no repo.Update, which
         // would mark every column dirty and clobber a concurrent split reconcile's price basis.
         await repo.SaveChanges();
-        _logger.LogDebug("Corrected {Count} stored volumes for {Ticker}", corrected, ticker);
+        _logger.LogDebug("Corrected {Count} stored bars for {Ticker}", corrected, ticker);
         return corrected;
     }
+
+    /// <summary>
+    /// Repairs a bounded batch of impossible historical OHLC rows from a fresh authoritative
+    /// response. A row with no valid same-basis replacement is removed rather than continuing to
+    /// publish data that is known to be impossible. Returns true once the corpus is clean.
+    /// </summary>
+    public async Task<bool> RepairInvalidOhlc(CancellationToken cancellationToken)
+    {
+        var batchSize = Math.Max(_scraperOptions.OhlcRepairBatchSize, 0);
+        if (batchSize == 0)
+            return true;
+
+        List<InvalidOhlcTarget> targets;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+            targets = await repo.GetAll()
+                .AsNoTracking()
+                .Where(p =>
+                    p.Open <= 0
+                    || p.High <= 0
+                    || p.Low <= 0
+                    || p.Close <= 0
+                    || p.High < p.Open
+                    || p.High < p.Close
+                    || p.Low > p.Open
+                    || p.Low > p.Close
+                    || p.High < p.Low
+                )
+                .OrderBy(p => p.CreationTime)
+                .ThenBy(p => p.Id)
+                .Take(batchSize)
+                .Select(p => new InvalidOhlcTarget(
+                    p.Id,
+                    p.CommonStockId,
+                    p.CommonStock.Ticker,
+                    p.Date
+                ))
+                .ToListAsync(cancellationToken);
+        }
+
+        if (targets.Count == 0)
+            return true;
+
+        var replacements = new Dictionary<Guid, DailyStockPrice>();
+        var deferredStockIds = new HashSet<Guid>();
+
+        foreach (var group in targets.GroupBy(t => new { t.CommonStockId, t.Ticker }))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrWhiteSpace(group.Key.Ticker))
+                continue;
+
+            try
+            {
+                var startDate = group.Min(t => t.Date);
+                var endDate = group.Max(t => t.Date);
+                var chartData = await _yahooClient.GetChart(group.Key.Ticker, startDate, endDate);
+                var fetchedByDate = MapFreshRows(
+                        group.Key.CommonStockId,
+                        chartData.Prices,
+                        group.Key.Ticker,
+                        endDate.AddDays(1)
+                    )
+                    .GroupBy(p => p.Date)
+                    .ToDictionary(g => g.Key, g => g.Last());
+
+                foreach (var target in group)
+                {
+                    if (fetchedByDate.TryGetValue(target.Date, out var replacement))
+                        replacements[target.PriceId] = replacement;
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                deferredStockIds.Add(group.Key.CommonStockId);
+                _logger.LogWarning(
+                    ex,
+                    "Failed to fetch OHLC repair data for {Ticker}; deferring its invalid rows",
+                    group.Key.Ticker
+                );
+            }
+        }
+
+        var repaired = 0;
+        var removed = 0;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+            var targetIds = targets.Select(t => t.PriceId).ToList();
+            var storedRows = await repo.GetAll()
+                .Where(p => targetIds.Contains(p.Id))
+                .ToListAsync(cancellationToken);
+
+            foreach (var row in storedRows)
+            {
+                if (deferredStockIds.Contains(row.CommonStockId))
+                    continue;
+
+                if (
+                    replacements.TryGetValue(row.Id, out var replacement)
+                    && IsSameSplitBasis(row.Close, replacement.Close)
+                )
+                {
+                    row.Open = replacement.Open;
+                    row.High = replacement.High;
+                    row.Low = replacement.Low;
+                    row.Close = replacement.Close;
+                    if (IsVolumeUpgrade(row.Volume, replacement.Volume))
+                        row.Volume = replacement.Volume;
+                    repaired++;
+                }
+                else
+                {
+                    repo.Delete(row);
+                    removed++;
+                }
+            }
+
+            if (repaired > 0 || removed > 0)
+                await repo.SaveChanges();
+        }
+
+        _logger.LogInformation(
+            "Historical OHLC repair processed {Count} rows: {Repaired} repaired, {Removed} removed, {Deferred} deferred",
+            targets.Count,
+            repaired,
+            removed,
+            deferredStockIds.Count
+        );
+
+        return targets.Count < batchSize && deferredStockIds.Count == 0;
+    }
+
+    private sealed record InvalidOhlcTarget(
+        Guid PriceId,
+        Guid CommonStockId,
+        string Ticker,
+        DateOnly Date
+    );
 
     // Settled volume only ever accrues, so a fetched figure below the stored one is a degraded
     // response (a partial re-serve, a venue dropping out), never a correction. Accepting only
@@ -1242,9 +1402,9 @@ public class YahooPriceImportService
         if (!HasSettledTradingDay(forwardOnly, today))
             return forwardOnly;
 
-        // Past the same gate, pull the start back over the volume-resettle window so the response
-        // carries the recently-stored bars whose volume may not have settled yet (see
-        // ResettleVolumes). Same ride-along rule as the heal below: it widens a request that was
+        // Past the same gate, pull the start back over the resettle window so the response carries
+        // the recently-stored bars whose OHLC/volume may not have settled yet (see
+        // ResettleStoredBars). Same ride-along rule as the heal below: it widens a request that was
         // already being made, never triggers one, so an up-to-date stock still costs zero calls.
         var startDate = Min(
             forwardOnly,
@@ -1362,6 +1522,42 @@ public class YahooPriceImportService
 
         return outOfRange.Select(p => p.Date).ToHashSet();
     }
+
+    private HashSet<DateOnly> WarnAndCollectInvalidOhlcDates(
+        List<HistoricalPrice> prices,
+        string ticker
+    )
+    {
+        var invalid = prices.Where(p => IsInvalidOhlc(p)).ToList();
+        if (invalid.Count > 0)
+        {
+            var sample = invalid[0];
+            _logger.LogWarning(
+                "Skipping {Count} prices for {Ticker} with impossible OHLC. "
+                    + "Sample: {Date} O={Open} H={High} L={Low} C={Close}",
+                invalid.Count,
+                ticker,
+                sample.Date,
+                sample.Open,
+                sample.High,
+                sample.Low,
+                sample.Close
+            );
+        }
+
+        return invalid.Select(p => p.Date).ToHashSet();
+    }
+
+    private static bool IsInvalidOhlc(HistoricalPrice price) =>
+        price.Open <= 0
+        || price.High <= 0
+        || price.Low <= 0
+        || price.Close <= 0
+        || price.High < price.Open
+        || price.High < price.Close
+        || price.Low > price.Open
+        || price.Low > price.Close
+        || price.High < price.Low;
 
     private static bool HasOverflowPrice(HistoricalPrice p) =>
         Math.Abs(p.Open) > MaxPriceValue

--- a/src/Equibles.Yahoo.HostedService/YahooPriceScraperWorker.cs
+++ b/src/Equibles.Yahoo.HostedService/YahooPriceScraperWorker.cs
@@ -14,6 +14,7 @@ public class YahooPriceScraperWorker : BaseScraperWorker
 {
     private readonly WorkerOptions _workerOptions;
     private readonly TimeSpan _enrichmentInterval;
+    private bool _ohlcRepairComplete;
 
     // UTC stamp of the last cycle that carried the enrichment calls. In-memory on purpose, which
     // means every process start RE-RUNS enrichment on its first cycle (default stamp = due). That
@@ -73,6 +74,13 @@ public class YahooPriceScraperWorker : BaseScraperWorker
         );
         var importService = scope.ServiceProvider.GetRequiredService<YahooPriceImportService>();
         await importService.Import(includeEnrichment, stoppingToken);
+
+        // Historical corruption is repaired in bounded batches after current prices, so cleanup
+        // never queues the time-sensitive daily pass behind old work. Once a scan finds no more
+        // rows, keep the result in memory and avoid a table scan on every quiet cycle. A restart
+        // intentionally verifies the invariant once more.
+        if (!_ohlcRepairComplete)
+            _ohlcRepairComplete = await importService.RepairInvalidOhlc(stoppingToken);
 
         // Stamp only after the sweep ran to completion — an interrupted enrichment cycle (deploy,
         // crash) leaves the stamp unset so the next cycle retries it.

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalPartialRaggedOhlcTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalPartialRaggedOhlcTests.cs
@@ -65,6 +65,31 @@ public class YahooFinanceClientHistoricalPartialRaggedOhlcTests
         prices.Should().OnlyContain(p => p.High >= p.Open && p.High >= p.Close && p.Low <= p.Close);
     }
 
+    [Fact]
+    public async Task GetHistoricalPrices_CompleteButImpossibleOhlc_SkipsTheBar()
+    {
+        var timestamp = new DateTimeOffset(2026, 7, 31, 0, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds();
+        var json =
+            "{\"chart\":{\"result\":[{\"timestamp\":["
+            + timestamp
+            + "],\"indicators\":{\"quote\":[{"
+            + "\"open\":[287.54],\"high\":[310.88],\"low\":[287.76],"
+            + "\"close\":[310.23],\"volume\":[1686983]}]}}]}}";
+
+        var sut = new YahooFinanceClient(
+            new HttpClient(new StubHandler(json)),
+            Substitute.For<ILogger<YahooFinanceClient>>()
+        );
+
+        var prices = await sut.GetHistoricalPrices(
+            "CBOE",
+            new DateOnly(2026, 7, 31),
+            new DateOnly(2026, 7, 31)
+        );
+
+        prices.Should().BeEmpty();
+    }
+
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly string _body;

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
@@ -25,7 +25,7 @@ using NSubstitute;
 namespace Equibles.IntegrationTests.Yahoo;
 
 /// <summary>
-/// End-to-end cover for the volume resettle. The pure rules are pinned in the unit suite; what
+/// End-to-end cover for stored-bar resettlement. The pure rules are pinned in the unit suite; what
 /// these need to prove is the WIRING, which is where the bug actually lived: the fetch window has
 /// to reach back far enough to re-request an already-stored bar, and the correction has to run
 /// before the insert path's "nothing new to insert" early return.
@@ -147,6 +147,83 @@ public class YahooPriceImportServiceVolumeResettleTests : IDisposable
     }
 
     [Fact]
+    public async Task Import_FeedRevisesRecentOhlc_CorrectsPricesButPreservesAdjustedClose()
+    {
+        var stock = SeedStock("CBOE");
+        var (newest, previous) = TwoMostRecentSettledSessions();
+        var stored = SeedPrice(stock, previous, UnsettledVolume, 310.23m);
+        stored.Open = 287.54m;
+        stored.High = 310.88m;
+        stored.Low = 287.76m;
+        stored.AdjustedClose = 309.11m;
+        await _priceRepo.SaveChanges();
+
+        _yahooClient
+            .GetChart("CBOE", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(
+                Chart(
+                    Bar(previous, 287.54m, 311.06m, 287.54m, 310.23m, SettledVolume),
+                    Bar(newest, 310.50m, 312.00m, 309.90m, 311.40m, SettledVolume)
+                )
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        var corrected = _priceRepo.GetAll().Single(p => p.Date == previous);
+        corrected.Open.Should().Be(287.54m);
+        corrected.High.Should().Be(311.06m);
+        corrected.Low.Should().Be(287.54m);
+        corrected.Close.Should().Be(310.23m);
+        corrected.AdjustedClose.Should().Be(309.11m);
+        corrected.Volume.Should().Be(SettledVolume);
+    }
+
+    [Fact]
+    public async Task RepairInvalidOhlc_AuthoritativeBarExists_ReplacesHistoricalPrices()
+    {
+        var stock = SeedStock("CBOE");
+        var date = new DateOnly(2026, 7, 31);
+        var stored = SeedPrice(stock, date, UnsettledVolume, 310.23m);
+        stored.Open = 287.54m;
+        stored.High = 310.88m;
+        stored.Low = 287.76m;
+        stored.AdjustedClose = 309.11m;
+        await _priceRepo.SaveChanges();
+
+        _yahooClient
+            .GetChart("CBOE", date, date)
+            .Returns(Chart(Bar(date, 287.54m, 311.06m, 287.54m, 310.23m, SettledVolume)));
+
+        var complete = await _service.RepairInvalidOhlc(CancellationToken.None);
+
+        complete.Should().BeTrue();
+        var repaired = _priceRepo.GetAll().Single();
+        repaired.Open.Should().Be(287.54m);
+        repaired.High.Should().Be(311.06m);
+        repaired.Low.Should().Be(287.54m);
+        repaired.Close.Should().Be(310.23m);
+        repaired.AdjustedClose.Should().Be(309.11m);
+        repaired.Volume.Should().Be(SettledVolume);
+    }
+
+    [Fact]
+    public async Task RepairInvalidOhlc_NoValidAuthoritativeBar_RemovesKnownBadRow()
+    {
+        var stock = SeedStock("CBOE");
+        var date = new DateOnly(2026, 7, 31);
+        var stored = SeedPrice(stock, date, UnsettledVolume, 310.23m);
+        stored.Low = 311m;
+        await _priceRepo.SaveChanges();
+
+        _yahooClient.GetChart("CBOE", date, date).Returns(new YahooChartData());
+
+        var complete = await _service.RepairInvalidOhlc(CancellationToken.None);
+
+        complete.Should().BeTrue();
+        _priceRepo.GetAll().Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Import_BarOlderThanTheWindow_IsLeftAlone()
     {
         // The window bounds the repair. A bar from before it keeps its stored volume even when the
@@ -240,6 +317,28 @@ public class YahooPriceImportServiceVolumeResettleTests : IDisposable
     private static YahooChartData Chart(params (DateOnly Date, long Volume)[] bars) =>
         Chart(close: 39.41m, bars);
 
+    private static YahooChartData Chart(params HistoricalPrice[] bars) =>
+        new() { Prices = bars.ToList() };
+
+    private static HistoricalPrice Bar(
+        DateOnly date,
+        decimal open,
+        decimal high,
+        decimal low,
+        decimal close,
+        long volume
+    ) =>
+        new()
+        {
+            Date = date,
+            Open = open,
+            High = high,
+            Low = low,
+            Close = close,
+            AdjustedClose = close,
+            Volume = volume,
+        };
+
     // The close is what proves the split basis, so a case about basis has to be able to set it.
     private static YahooChartData Chart(decimal close, (DateOnly Date, long Volume)[] bars) =>
         new()
@@ -271,21 +370,26 @@ public class YahooPriceImportServiceVolumeResettleTests : IDisposable
         return stock;
     }
 
-    private void SeedPrice(CommonStock stock, DateOnly date, long volume, decimal close = 39.41m)
+    private DailyStockPrice SeedPrice(
+        CommonStock stock,
+        DateOnly date,
+        long volume,
+        decimal close = 39.41m
+    )
     {
-        _priceRepo.Add(
-            new DailyStockPrice
-            {
-                CommonStockId = stock.Id,
-                Date = date,
-                Open = close,
-                High = close,
-                Low = close,
-                Close = close,
-                AdjustedClose = close,
-                Volume = volume,
-            }
-        );
+        var price = new DailyStockPrice
+        {
+            CommonStockId = stock.Id,
+            Date = date,
+            Open = close,
+            High = close,
+            Low = close,
+            Close = close,
+            AdjustedClose = close,
+            Volume = volume,
+        };
+        _priceRepo.Add(price);
         _priceRepo.SaveChanges().GetAwaiter().GetResult();
+        return price;
     }
 }

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBasisGuardTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBasisGuardTests.cs
@@ -4,7 +4,7 @@ using Equibles.Yahoo.HostedService.Services;
 namespace Equibles.UnitTests.Yahoo;
 
 /// <summary>
-/// Pins <c>YahooPriceImportService.IsSameSplitBasis</c>, the guard that stops the volume resettle
+/// Pins <c>YahooPriceImportService.IsSameSplitBasis</c>, the guard that stops bar resettlement
 /// from comparing two records of the same session that sit on different split bases.
 ///
 /// The stored series and the feed disagree in BOTH orderings, so the guard must be

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
@@ -4,7 +4,7 @@ using Equibles.Yahoo.HostedService.Services;
 namespace Equibles.UnitTests.Yahoo;
 
 /// <summary>
-/// Pins the two pure rules behind the volume resettle: which stored bars are still re-read
+/// Pins the two pure rules behind stored-bar resettlement: which stored bars are still re-read
 /// (<c>ResettleWindowStart</c>) and which fetched figure is allowed to replace a stored one
 /// (<c>IsVolumeUpgrade</c>).
 ///
@@ -73,7 +73,7 @@ public class YahooPriceImportServiceVolumeResettleTests
     [Fact]
     public void ResettleWindowStart_WidenedWindow_ReachesBackFurther()
     {
-        // Raising the setting is how a longer stretch of stored volumes gets repaired: the window
+        // Raising the setting is how a longer stretch of stored bars gets resettled: the window
         // only widens a fetch that was already happening, so a wider setting buys a longer repair
         // at no extra upstream calls.
         ResettleWindowStart(Today, 120).Should().Be(new DateOnly(2026, 3, 31));


### PR DESCRIPTION
## Summary
- Reject complete but impossible Yahoo candles before persistence.
- Resettle recent OHLC values and increasing volume after overnight revisions.
- Repair historical invalid rows in bounded batches and remove rows without a valid same-basis replacement.

## Code changes
- Add OHLC coherence validation at parsing and persistence boundaries.
- Extend the existing resettlement window to OHLC while preserving adjusted close and split-basis safeguards.
- Add post-price historical cleanup with regression coverage for the observed CBOE candle.

Closes #4278