### PR TITLE
fix(imports): tolerate stock replacement races

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.IO.Compression;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Core.Contracts;
@@ -92,14 +93,26 @@ public class HoldingsImportService
         await ParseOtherManagerCoverList(context, cancellationToken);
         await UpsertInstitutionalHolders(context, cancellationToken);
         await HandleAmendments(context, cancellationToken);
-        var insertedHoldings = await StreamAndInsertHoldings(context, cancellationToken);
+        var holdingsResult = await StreamAndInsertHoldings(context, cancellationToken);
         await FlushFilingOtherManagers(context, cancellationToken);
+        if (holdingsResult.SkippedStaleParent)
+        {
+            // CompanySync replaced at least one mapped CommonStock after the CUSIP lookup. Keep
+            // the valid positions already written, but leave this data set eligible for retry so
+            // the replacement stock is resolved on the next pass. Publishing summaries here
+            // would advertise a knowingly partial portfolio before that retry completes.
+            return new ImportResult(
+                submissionCount,
+                IsComplete: false,
+                InsertedHoldings: holdingsResult.Inserted
+            );
+        }
         await SyncFilingSummaries(context, cancellationToken);
         await PublishAffectedQuartersAsync(context, cancellationToken);
         return new ImportResult(
             submissionCount,
             IsComplete: true,
-            InsertedHoldings: insertedHoldings
+            InsertedHoldings: holdingsResult.Inserted
         );
     }
 
@@ -1356,7 +1369,7 @@ public class HoldingsImportService
         return true;
     }
 
-    private async Task<int> StreamAndInsertHoldings(
+    private async Task<HoldingsStreamResult> StreamAndInsertHoldings(
         ImportContext context,
         CancellationToken cancellationToken
     )
@@ -1367,6 +1380,7 @@ public class HoldingsImportService
         var totalSkipped = 0;
         var totalDuplicates = 0;
         var totalPending = 0;
+        var skippedStaleParent = false;
         string currentAccession = null;
 
         await foreach (var row in context.TsvParser.ParseEntry(infoTableEntry))
@@ -1398,6 +1412,7 @@ public class HoldingsImportService
                 totalInserted += flushed.Inserted;
                 totalDuplicates += flushed.Duplicates;
                 totalPending += flushed.Pending;
+                skippedStaleParent |= flushed.SkippedStaleParent;
                 bufferedRows.Clear();
             }
             currentAccession = accession;
@@ -1450,6 +1465,7 @@ public class HoldingsImportService
             totalInserted += flushed.Inserted;
             totalDuplicates += flushed.Duplicates;
             totalPending += flushed.Pending;
+            skippedStaleParent |= flushed.SkippedStaleParent;
             bufferedRows.Clear();
         }
 
@@ -1464,14 +1480,21 @@ public class HoldingsImportService
         LogValueBasisAudit(context);
         await FlushUnmappedCusips(context, cancellationToken);
 
-        return totalInserted;
+        return new HoldingsStreamResult(totalInserted, skippedStaleParent);
     }
+
+    private readonly record struct HoldingsStreamResult(int Inserted, bool SkippedStaleParent);
 
     // Runs the per-filing share-count repair over one accession's buffered rows,
     // merges them by upsert key, and flushes the batch. Repair must happen here —
     // after the whole filing is buffered, before any row merges — because the
     // duplicated-column signal is a property of the filing, not of a single row.
-    private async Task<(int Inserted, int Duplicates, int Pending)> RepairMergeAndFlush(
+    private async Task<(
+        int Inserted,
+        int Duplicates,
+        int Pending,
+        bool SkippedStaleParent
+    )> RepairMergeAndFlush(
         string accession,
         List<BufferedHoldingRow> bufferedRows,
         ImportContext context,
@@ -1507,12 +1530,12 @@ public class HoldingsImportService
             }
         }
 
-        var inserted =
+        var flushResult =
             holdingsMap.Count > 0
                 ? await FlushBatch(holdingsMap.Values.ToList(), cancellationToken)
-                : 0;
+                : new HoldingsFlushResult(0, SkippedStaleParent: false);
 
-        return (inserted, duplicates, pending);
+        return (flushResult.Inserted, duplicates, pending, flushResult.SkippedStaleParent);
     }
 
     // Buffers a parsed row by its upsert key. A 13F holder can split one security
@@ -1714,16 +1737,39 @@ public class HoldingsImportService
         return (holding, managerEntry, valuePending, reportedValue);
     }
 
-    private async Task<int> FlushBatch(
+    private readonly record struct HoldingsFlushResult(int Inserted, bool SkippedStaleParent);
+
+    private async Task<HoldingsFlushResult> FlushBatch(
         List<InstitutionalHolding> holdings,
         CancellationToken cancellationToken
     )
     {
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        // CompanySync can replace a CommonStock after BuildCusipMapping cached its id. Remove
+        // those stale children immediately before the write so one dangling FK cannot roll back
+        // every valid position in the accession. The caller leaves the data set unprocessed when
+        // any row is skipped, allowing the replacement stock to resolve on the next pass.
+        var safeHoldings = await stockRepo.FilterByExistingStocks(
+            holdings,
+            h => h.CommonStockId,
+            cancellationToken
+        );
+        var skipped = holdings.Count - safeHoldings.Count;
+        if (skipped > 0)
+        {
+            _logger.LogWarning(
+                "Holdings batch: skipping {Count} rows whose parent CommonStock was removed before flush",
+                skipped
+            );
+        }
+        if (safeHoldings.Count == 0)
+            return new HoldingsFlushResult(0, SkippedStaleParent: skipped > 0);
 
         var entriesByKey = new Dictionary<string, List<HoldingManagerEntry>>();
-        foreach (var h in holdings)
+        foreach (var h in safeHoldings)
         {
             entriesByKey[BuildHoldingKey(h)] = h.ManagerEntries.ToList();
             h.ManagerEntries.Clear();
@@ -1731,7 +1777,7 @@ public class HoldingsImportService
 
         await dbContext
             .Set<InstitutionalHolding>()
-            .UpsertRange(holdings)
+            .UpsertRange(safeHoldings)
             .On(h => new
             {
                 h.CommonStockId,
@@ -1769,7 +1815,7 @@ public class HoldingsImportService
             )
             .RunAsync(cancellationToken);
 
-        var accessions = holdings.Select(h => h.AccessionNumber).Distinct().ToList();
+        var accessions = safeHoldings.Select(h => h.AccessionNumber).Distinct().ToList();
         var dbHoldings = await dbContext
             .Set<InstitutionalHolding>()
             .Include(h => h.ManagerEntries)
@@ -1787,7 +1833,7 @@ public class HoldingsImportService
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return holdings.Count;
+        return new HoldingsFlushResult(safeHoldings.Count, SkippedStaleParent: skipped > 0);
     }
 
     // Recomputes the InstitutionalFiling rollup for every (holder, quarter) this

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -1109,6 +1109,15 @@ public class YahooPriceImportService
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
         var stock = await stockRepo.Get(commonStockId);
+        if (stock == null)
+        {
+            _logger.LogWarning(
+                "Skipping key statistics for {Ticker}: CommonStock {Id} was removed during the sync",
+                ticker,
+                commonStockId
+            );
+            return;
+        }
 
         // The SEC cover-page count (dei:EntityCommonStockSharesOutstanding) is authoritative and
         // current; Yahoo's figure is per-share-class and lags corporate actions. Defer to EDGAR
@@ -1213,7 +1222,8 @@ public class YahooPriceImportService
 
         if (!changed)
             return;
-        await stockRepo.SaveChanges();
+        if (!await SaveStockChanges(stockRepo, commonStockId, ticker, cancellationToken))
+            return;
 
         _logger.LogDebug(
             "Updated key stats for {Ticker}: shares={Shares} marketCap={MarketCap}",
@@ -1292,6 +1302,17 @@ public class YahooPriceImportService
         var industryRepo = scope.ServiceProvider.GetRequiredService<IndustryRepository>();
         var sectorRepo = scope.ServiceProvider.GetRequiredService<SectorRepository>();
 
+        var stock = await stockRepo.Get(commonStockId);
+        if (stock == null)
+        {
+            _logger.LogWarning(
+                "Skipping company profile for {Ticker}: CommonStock {Id} was removed during the sync",
+                ticker,
+                commonStockId
+            );
+            return;
+        }
+
         // Upsert by case-insensitive name. Yahoo uses a small stable vocabulary, so
         // collisions are rare and a flat scan over Sector/Industry is fine — both tables
         // hold tens of rows at steady state. Materialize the lookup once per call.
@@ -1303,12 +1324,12 @@ public class YahooPriceImportService
             cancellationToken
         );
 
-        var stock = await stockRepo.Get(commonStockId);
         if (stock.IndustryId == industry.Id)
             return;
 
         stock.IndustryId = industry.Id;
-        await stockRepo.SaveChanges();
+        if (!await SaveStockChanges(stockRepo, commonStockId, ticker, cancellationToken))
+            return;
 
         _logger.LogDebug(
             "Updated industry for {Ticker}: {Industry} (sector {Sector})",
@@ -1316,6 +1337,36 @@ public class YahooPriceImportService
             profile.Industry,
             profile.Sector ?? "?"
         );
+    }
+
+    private async Task<bool> SaveStockChanges(
+        CommonStockRepository stockRepo,
+        Guid commonStockId,
+        string ticker,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            await stockRepo.SaveChanges();
+            return true;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            var stillExists = await stockRepo
+                .GetAll()
+                .AsNoTracking()
+                .AnyAsync(s => s.Id == commonStockId, cancellationToken);
+            if (stillExists)
+                throw;
+
+            _logger.LogWarning(
+                "Skipping enrichment save for {Ticker}: CommonStock {Id} was removed during the write",
+                ticker,
+                commonStockId
+            );
+            return false;
+        }
     }
 
     private static async Task<Guid?> UpsertSectorIfPresent(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
@@ -214,6 +214,84 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ImportDataSet_StockReplacedAfterCusipMapping_PersistsSurvivorsAndRetries()
+    {
+        var apple = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        var microsoft = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "MSFT",
+            Name = "Microsoft Corp",
+            Cik = "0000789019",
+            Cusip = "594918104",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().AddRange(apple, microsoft);
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2024, 9, 30);
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-RACE\t2024-10-15\t2024-09-30\t0001067983\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-RACE\tN\tBerkshire Hathaway\tOmaha\tNE\t028-12345\t12345\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+            + "ACC-RACE\t037833100\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t\n"
+            + "ACC-RACE\t594918104\t2000\tSH\t\tSOLE\t2000\t0\t0\tCOM\t\n";
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+
+        var priceProvider = Substitute.For<IStockPriceProvider>();
+        priceProvider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ =>
+            {
+                // BuildCusipMapping has already cached both ids. Replacing AAPL here reproduces
+                // the production window while leaving MSFT valid in the same write batch.
+                using var delete = FreshContext();
+                var staleApple = delete.Set<CommonStock>().Single(s => s.Id == apple.Id);
+                delete.Remove(staleApple);
+                delete.SaveChanges();
+                return Task.FromResult(
+                    new Dictionary<(Guid, DateOnly), decimal>
+                    {
+                        [(apple.Id, reportDate)] = 150m,
+                        [(microsoft.Id, reportDate)] = 400m,
+                    }
+                );
+            });
+
+        var result = await CreateImporter(priceProvider)
+            .ImportDataSet(archive, new DateOnly(2024, 1, 1), CancellationToken.None);
+
+        result.IsComplete.Should().BeFalse();
+        result.InsertedHoldings.Should().Be(1);
+
+        using var verify = FreshContext();
+        var holdings = await verify.Set<InstitutionalHolding>().AsNoTracking().ToListAsync();
+        holdings.Should().ContainSingle();
+        holdings[0].CommonStockId.Should().Be(microsoft.Id);
+        holdings[0].Shares.Should().Be(2000);
+    }
+
+    [Fact]
     public async Task ImportDataSet_ArchiveCarriesASummaryPage_LandsTheFilersDeclaredTotalsOnTheRollup()
     {
         // The cover page's declared totals are the only authoritative statement of what the WHOLE

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceMissingCommonStockTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceMissingCommonStockTests.cs
@@ -9,6 +9,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Yahoo.Contracts;
 using Equibles.Integrations.Yahoo.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Worker;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Data.Models;
@@ -36,6 +37,7 @@ public class YahooPriceImportServiceMissingCommonStockTests : IDisposable
     private readonly DailyStockPriceRepository _priceRepo;
     private readonly CommonStockRepository _stockRepo;
     private readonly IYahooFinanceClient _yahooClient;
+    private readonly ISharesOutstandingProvider _sharesProvider;
     private readonly YahooPriceImportService _sut;
 
     public YahooPriceImportServiceMissingCommonStockTests()
@@ -48,6 +50,7 @@ public class YahooPriceImportServiceMissingCommonStockTests : IDisposable
         _stockRepo = new CommonStockRepository(_dbContext);
 
         _yahooClient = Substitute.For<IYahooFinanceClient>();
+        _sharesProvider = Substitute.For<ISharesOutstandingProvider>();
         var errorReporter = Substitute.For<ErrorReporter>(
             Substitute.For<IServiceScopeFactory>(),
             Substitute.For<ILogger<ErrorReporter>>()
@@ -59,6 +62,9 @@ public class YahooPriceImportServiceMissingCommonStockTests : IDisposable
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(DailyStockPriceRepository), _priceRepo),
             (typeof(CommonStockRepository), _stockRepo),
+            (typeof(IndustryRepository), new IndustryRepository(_dbContext)),
+            (typeof(SectorRepository), new SectorRepository(_dbContext)),
+            (typeof(ISharesOutstandingProvider), _sharesProvider),
             (
                 typeof(SplitPriceReconciliationManager),
                 new SplitPriceReconciliationManager(splitRepo)
@@ -128,5 +134,44 @@ public class YahooPriceImportServiceMissingCommonStockTests : IDisposable
 
         var prices = _priceRepo.GetAll().ToList();
         prices.Should().BeEmpty();
+        await _sharesProvider
+            .DidNotReceiveWithAnyArgs()
+            .GetCurrentSharesOutstanding(default, default);
+    }
+
+    [Fact]
+    public async Task Import_CommonStockDeletedBeforeProfileWrite_DoesNotCreateTaxonomyRows()
+    {
+        var apple = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "CIK-AAPL",
+        };
+        _stockRepo.Add(apple);
+        await _stockRepo.SaveChanges();
+
+        _yahooClient
+            .GetChart("AAPL", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new YahooChartData());
+        _yahooClient
+            .GetCompanyProfile("AAPL")
+            .Returns(_ =>
+            {
+                _dbContext.Remove(apple);
+                _dbContext.SaveChanges();
+                return new CompanyProfile
+                {
+                    Industry = "Consumer Electronics",
+                    Sector = "Technology",
+                };
+            });
+
+        await _sut.Import(CancellationToken.None);
+
+        _dbContext.Set<CommonStock>().Should().BeEmpty();
+        _dbContext.Set<Equibles.CommonStocks.Data.Models.Taxonomies.Industry>().Should().BeEmpty();
+        _dbContext.Set<Equibles.CommonStocks.Data.Models.Taxonomies.Sector>().Should().BeEmpty();
     }
 }


### PR DESCRIPTION
## Summary
- Preserve valid 13F positions when a mapped company row is replaced during import.
- Keep partially affected data sets eligible for retry.
- Stop Yahoo enrichment cleanly when its mapped company row disappears.

## Code changes
- Revalidate holding parent ids immediately before each database write.
- Propagate stale-parent skips to the import completion result and defer partial summaries.
- Guard enrichment reads and concurrency failures with regression coverage for both failure windows.

Closes #4279