### PR TITLE
fix(cboe): quarantine impossible VIX candles

### DIFF
--- a/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
+++ b/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
@@ -223,21 +223,41 @@ public class CboeImportService : IImporter
             var records = await _cboeClient.DownloadVixHistory();
             _logger.LogDebug("CBOE VIX: downloaded {Count} records", records.Count);
 
-            if (records.Count == 0)
-                return;
+            // Keep this validation even though CboeClient enforces the same boundary: alternate
+            // ICboeClient implementations and test doubles must not be able to persist impossible
+            // candles. The official file currently contains legacy invalid rows.
+            var validRecords = records.Where(IsValidVixRecord).ToList();
+            var rejected = records.Count - validRecords.Count;
+            if (rejected > 0)
+            {
+                _logger.LogWarning(
+                    "CBOE VIX: rejected {Count} records with impossible OHLC",
+                    rejected
+                );
+            }
 
-            DateOnly latestStoredDate;
+            HashSet<DateOnly> existingDates;
             using (var scope = _scopeFactory.CreateScope())
             {
                 var repo = scope.ServiceProvider.GetRequiredService<CboeVixDailyRepository>();
-                latestStoredDate = await repo.GetLatestDate()
-                    .FirstOrDefaultAsync(cancellationToken);
+                var removed = await repo.GetInvalidOhlc().ExecuteDeleteAsync(cancellationToken);
+                if (removed > 0)
+                {
+                    _logger.LogWarning(
+                        "CBOE VIX: removed {Count} historically stored records with impossible OHLC",
+                        removed
+                    );
+                }
+
+                existingDates = await repo.GetAll()
+                    .Select(r => r.Date)
+                    .ToHashSetAsync(cancellationToken);
             }
 
-            var newRecords =
-                latestStoredDate != default
-                    ? records.Where(r => r.Date > latestStoredDate).ToList()
-                    : records;
+            // Compare the full official history by date rather than advancing only from MAX(Date).
+            // If CBOE later corrects a quarantined historical candle, that old date must be able to
+            // return even when newer valid rows already exist.
+            var newRecords = validRecords.Where(r => !existingDates.Contains(r.Date)).ToList();
 
             if (newRecords.Count == 0)
             {
@@ -270,4 +290,15 @@ public class CboeImportService : IImporter
             await _errorReporter.Report(ErrorSource.CboeScraper, "CboeImport.ImportVixHistory", ex);
         }
     }
+
+    private static bool IsValidVixRecord(CboeVixRecord record) =>
+        record.Open > 0
+        && record.High > 0
+        && record.Low > 0
+        && record.Close > 0
+        && record.High >= record.Open
+        && record.High >= record.Close
+        && record.Low <= record.Open
+        && record.Low <= record.Close
+        && record.High >= record.Low;
 }

--- a/src/Equibles.Cboe.Repositories/CboeVixDailyRepository.cs
+++ b/src/Equibles.Cboe.Repositories/CboeVixDailyRepository.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Equibles.Cboe.Data.Models;
 using Equibles.Data;
 using Equibles.Data.Extensions;
@@ -6,16 +7,40 @@ namespace Equibles.Cboe.Repositories;
 
 public class CboeVixDailyRepository : BaseRepository<CboeVixDaily>
 {
+    private static readonly Expression<Func<CboeVixDaily, bool>> ValidOhlc = v =>
+        v.Open > 0
+        && v.High > 0
+        && v.Low > 0
+        && v.Close > 0
+        && v.High >= v.Open
+        && v.High >= v.Close
+        && v.Low <= v.Open
+        && v.Low <= v.Close
+        && v.High >= v.Low;
+
+    private static readonly Expression<Func<CboeVixDaily, bool>> InvalidOhlc = v =>
+        v.Open <= 0
+        || v.High <= 0
+        || v.Low <= 0
+        || v.Close <= 0
+        || v.High < v.Open
+        || v.High < v.Close
+        || v.Low > v.Open
+        || v.Low > v.Close
+        || v.High < v.Low;
+
     public CboeVixDailyRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
 
     public IQueryable<CboeVixDaily> GetByDateRange(DateOnly startDate, DateOnly endDate)
     {
-        return GetAll().Where(v => v.Date >= startDate && v.Date <= endDate);
+        return GetAll().Where(ValidOhlc).Where(v => v.Date >= startDate && v.Date <= endDate);
     }
 
     public IQueryable<DateOnly> GetLatestDate()
     {
-        return GetAll().LatestValue(v => v.Date);
+        return GetAll().Where(ValidOhlc).LatestValue(v => v.Date);
     }
+
+    public IQueryable<CboeVixDaily> GetInvalidOhlc() => GetAll().Where(InvalidOhlc);
 }

--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -338,6 +338,12 @@ public class CboeClient : ICboeClient
             if (!TryDec(4, out var close))
                 continue;
 
+            // A complete row can still be internally impossible. CBOE's current history contains
+            // legacy candles whose High/Low do not contain Open and Close; they are not valid
+            // market observations and must not cross the integration boundary.
+            if (!IsValidOhlc(open, high, low, close))
+                continue;
+
             records.Add(
                 new CboeVixRecord
                 {
@@ -351,6 +357,17 @@ public class CboeClient : ICboeClient
         }
         return records;
     }
+
+    private static bool IsValidOhlc(decimal open, decimal high, decimal low, decimal close) =>
+        open > 0
+        && high > 0
+        && low > 0
+        && close > 0
+        && high >= open
+        && high >= close
+        && low <= open
+        && low <= close
+        && high >= low;
 
     // First line is the header; subsequent blank or short rows are skipped.
     private static IEnumerable<string[]> EnumerateCsvRows(string content, int minFields)

--- a/tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs
@@ -248,11 +248,11 @@ public class CboeImportServiceFullPipelineTests : IAsyncLifetime
             .Returns([
                 new CboeVixRecord
                 {
-                    Date = new DateOnly(2026, 4, 1), // older than stored → filtered out
-                    Open = 1m,
-                    High = 1m,
-                    Low = 1m,
-                    Close = 1m,
+                    Date = new DateOnly(2026, 4, 10),
+                    Open = 14m,
+                    High = 15m,
+                    Low = 13m,
+                    Close = 14.5m,
                 },
             ]);
 
@@ -264,6 +264,111 @@ public class CboeImportServiceFullPipelineTests : IAsyncLifetime
         var rows = await verify.Set<CboeVixDaily>().ToListAsync();
         rows.Should().ContainSingle("the only row is the pre-seeded one — nothing new inserted");
         rows[0].Close.Should().Be(14.5m);
+    }
+
+    [Fact]
+    public async Task Import_InvalidHistoricalVixCorrectedBySource_ReplacesItBehindNewerRows()
+    {
+        var today = new DateOnly(2026, 4, 10);
+        await SeedAllTypesAt(today);
+        var invalidDate = new DateOnly(1990, 1, 3);
+        var newerDate = new DateOnly(2026, 4, 9);
+        using (var seed = FreshContext())
+        {
+            seed.Set<CboeVixDaily>()
+                .AddRange(
+                    new CboeVixDaily
+                    {
+                        Date = invalidDate,
+                        Open = 17.24m,
+                        High = 18.19m,
+                        Low = 17.35m,
+                        Close = 18.19m,
+                    },
+                    new CboeVixDaily
+                    {
+                        Date = newerDate,
+                        Open = 20m,
+                        High = 22m,
+                        Low = 19m,
+                        Close = 21m,
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var client = EmptyClient();
+        client
+            .DownloadVixHistory()
+            .Returns([
+                new CboeVixRecord
+                {
+                    Date = invalidDate,
+                    Open = 17.24m,
+                    High = 18.25m,
+                    Low = 17.20m,
+                    Close = 18.19m,
+                },
+                new CboeVixRecord
+                {
+                    Date = newerDate,
+                    Open = 20m,
+                    High = 22m,
+                    Low = 19m,
+                    Close = 21m,
+                },
+            ]);
+
+        await CreateSut(CreateScopeFactory(), client, today).Import(CancellationToken.None);
+
+        using var verify = FreshContext();
+        var rows = await verify.Set<CboeVixDaily>().OrderBy(v => v.Date).ToListAsync();
+        rows.Should().HaveCount(2);
+        rows[0].Date.Should().Be(invalidDate);
+        rows[0].High.Should().Be(18.25m);
+        rows[0].Low.Should().Be(17.20m);
+    }
+
+    [Fact]
+    public async Task Import_InvalidHistoricalVixStillInvalidAtSource_RemovesIt()
+    {
+        var today = new DateOnly(2026, 4, 10);
+        await SeedAllTypesAt(today);
+        var invalidDate = new DateOnly(1990, 1, 3);
+        using (var seed = FreshContext())
+        {
+            seed.Set<CboeVixDaily>()
+                .Add(
+                    new CboeVixDaily
+                    {
+                        Date = invalidDate,
+                        Open = 17.24m,
+                        High = 18.19m,
+                        Low = 17.35m,
+                        Close = 18.19m,
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var client = EmptyClient();
+        client
+            .DownloadVixHistory()
+            .Returns([
+                new CboeVixRecord
+                {
+                    Date = invalidDate,
+                    Open = 17.24m,
+                    High = 18.19m,
+                    Low = 17.35m,
+                    Close = 18.19m,
+                },
+            ]);
+
+        await CreateSut(CreateScopeFactory(), client, today).Import(CancellationToken.None);
+
+        using var verify = FreshContext();
+        (await verify.Set<CboeVixDaily>().CountAsync()).Should().Be(0);
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Cboe/CboeRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Cboe/CboeRepositoryTests.cs
@@ -452,6 +452,23 @@ public class CboeVixDailyRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task GetByDateRange_ImpossibleOhlc_IsNotPublished()
+    {
+        var date = new DateOnly(1990, 1, 3);
+        _dbContext
+            .Set<CboeVixDaily>()
+            .AddRange(
+                CreateVix(date, open: 17.24m, high: 18.19m, low: 17.35m, close: 18.19m),
+                CreateVix(date.AddDays(1), open: 18m, high: 19m, low: 17m, close: 18.5m)
+            );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetByDateRange(date, date.AddDays(1)).ToListAsync();
+
+        result.Should().ContainSingle().Which.Date.Should().Be(date.AddDays(1));
+    }
+
+    [Fact]
     public async Task GetByDateRange_NoMatches_ReturnsEmpty()
     {
         _dbContext.Set<CboeVixDaily>().Add(CreateVix(new DateOnly(2025, 6, 1)));
@@ -478,7 +495,7 @@ public class CboeVixDailyRepositoryTests : IDisposable
     public async Task GetByDateRange_SingleDay_ReturnsMatchingRecord()
     {
         var date = new DateOnly(2025, 3, 15);
-        _dbContext.Set<CboeVixDaily>().Add(CreateVix(date, close: 22.50m));
+        _dbContext.Set<CboeVixDaily>().Add(CreateVix(date, high: 23m, low: 14.80m, close: 22.50m));
         await _dbContext.SaveChangesAsync();
 
         var result = await _repository.GetByDateRange(date, date).ToListAsync();

--- a/tests/Equibles.UnitTests/Cboe/CboeClientTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeClientTests.cs
@@ -146,6 +146,24 @@ public class CboeClientTests
     }
 
     [Fact]
+    public async Task DownloadVixHistory_ImpossibleOhlcRows_ReturnsOnlyValidCandles()
+    {
+        var csv =
+            "DATE,OPEN,HIGH,LOW,CLOSE\n"
+            + "07/30/2026,14.00,15.00,13.50,14.50\n"
+            // Complete but impossible: Low is above both Open and Close.
+            + "07/31/2026,14.00,15.00,14.75,14.50\n"
+            // Complete but impossible: High is below Close.
+            + "08/03/2026,14.00,14.25,13.50,14.50\n";
+        var handler = new ScriptedHandler((HttpStatusCode.OK, csv));
+        var sut = CreateSut(handler);
+
+        var result = await sut.DownloadVixHistory();
+
+        result.Should().ContainSingle().Which.Date.Should().Be(new DateOnly(2026, 7, 30));
+    }
+
+    [Fact]
     public async Task DownloadWithRetry_TooManyRequestsThenOk_RetriesAndReturnsParsedContent()
     {
         // 429 path: the loop must back off (RateLimiter.PauseFor + Task.Delay)


### PR DESCRIPTION
## Summary
- Reject VIX rows whose OHLC values violate candle invariants.
- Prevent previously stored invalid rows from reaching data consumers.
- Remove historical corruption and allow corrected old dates to return.

## Code changes
- Validate OHLC at both CSV parsing and persistence boundaries.
- Filter repository date queries to valid candles.
- Reconcile the complete official date set after cleanup instead of relying only on the latest stored date.

Closes #4280