### PR TITLE
fix(insider-trading): reprocess implausible transaction dates

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -147,6 +147,20 @@ public static class InsiderFilingParser
             : null;
     }
 
+    /// <summary>
+    /// The transaction-period anchor declared by the ownership document. Null when
+    /// absent or unparseable, so callers can retain existing data rather than infer a
+    /// financial date.
+    /// </summary>
+    internal static DateOnly? ParsePeriodOfReport(XElement root)
+    {
+        var raw = root.Element("periodOfReport")?.Value?.Trim();
+        if (string.IsNullOrEmpty(raw))
+            return null;
+
+        return TryParseTransactionDate(raw, out var date) ? date : null;
+    }
+
     internal static bool DeclaresNoSecuritiesOwned(XElement root) =>
         ParseBool(root.Element("noSecuritiesOwned")?.Value);
 

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -19,8 +19,9 @@ namespace Equibles.InsiderTrading.BusinessLogic;
 /// <see cref="InsiderTransaction.CurrentParserVersion"/>. For each such filing it
 /// replays the parse from the cached ownership XML — fetching and caching the XML
 /// from EDGAR the first time — then updates each row's authoritative
-/// <see cref="InsiderTransaction.SecurityKind"/>, re-runs price validity from the
-/// as-filed price, and stamps the current parser version.
+/// <see cref="InsiderTransaction.SecurityKind"/>, restores corrected dates from the
+/// document's period of report, re-runs price validity from the as-filed price, and
+/// stamps the current parser version.
 ///
 /// The parser version is the single selector: once a filing's rows are stamped at
 /// the current version they drop out, so the run terminates and is resumable —
@@ -176,11 +177,12 @@ public class InsiderFilingReprocessManager
             }
 
             _logger.LogInformation(
-                "Insider filing reprocess: {Processed}/{Total} filings, reclassified={Reclassified}, repaired={Repaired}, failed={Failed}",
+                "Insider filing reprocess: {Processed}/{Total} filings, reclassified={Reclassified}, repaired={Repaired}, dates corrected={DatesCorrected}, failed={Failed}",
                 result.Processed,
                 result.Total,
                 result.Reclassified,
                 result.Repaired,
+                result.DatesCorrected,
                 result.Failed
             );
 
@@ -243,7 +245,10 @@ public class InsiderFilingReprocessManager
         {
             AccessionNumber = accession,
             FilingDate = first.FilingDate,
-            ReportDate = first.TransactionDate,
+            // periodOfReport is the authoritative fallback used by the parser when a
+            // filer keyed an impossible transaction date. Falling back to the stored
+            // date preserves legacy behavior only for malformed documents that omit it.
+            ReportDate = InsiderFilingParser.ParsePeriodOfReport(root) ?? first.TransactionDate,
         };
 
         // Re-parse in the same document order the ingest used; map back onto the
@@ -274,12 +279,15 @@ public class InsiderFilingReprocessManager
             );
         }
 
-        var closes = await FetchCloses(first.CommonStockId, rows);
-
         foreach (var row in rows)
         {
             if (parsedByOrder.TryGetValue(row.TransactionOrder, out var reparsed))
             {
+                if (row.TransactionDate != reparsed.TransactionDate)
+                {
+                    row.TransactionDate = reparsed.TransactionDate;
+                    result.DatesCorrected++;
+                }
                 if (row.SecurityKind != reparsed.SecurityKind)
                 {
                     row.SecurityKind = reparsed.SecurityKind;
@@ -296,7 +304,14 @@ public class InsiderFilingReprocessManager
                 // Re-derive footnotes (added in parser v2); cheap to always copy.
                 row.Notes = reparsed.Notes;
             }
+        }
 
+        // Date corrections must land before close lookup so price validation uses the
+        // repaired trading day rather than the impossible source typo.
+        var closes = await FetchCloses(first.CommonStockId, rows);
+
+        foreach (var row in rows)
+        {
             decimal? close = closes.TryGetValue(row.TransactionDate, out var value) ? value : null;
 
             var evaluation = _validator.Evaluate(

--- a/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderFilingReprocessResult.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderFilingReprocessResult.cs
@@ -4,8 +4,8 @@ namespace Equibles.InsiderTrading.BusinessLogic.Models;
 /// Progress/outcome of a version-driven insider-filing reprocess pass. Filings
 /// whose transactions sit below the current parser version are re-parsed from
 /// their cached ownership XML (fetched and cached on first encounter), which
-/// re-derives <c>SecurityKind</c> from the source table and re-runs price
-/// validity from the as-filed price.
+/// re-derives transaction fields from the source and re-runs price validity
+/// from the as-filed price.
 /// </summary>
 public class InsiderFilingReprocessResult
 {
@@ -24,11 +24,14 @@ public class InsiderFilingReprocessResult
     /// <summary>Rows whose price was repaired (total ÷ shares) this run.</summary>
     public int Repaired { get; set; }
 
+    /// <summary>Rows whose implausible transaction date was corrected from source XML.</summary>
+    public int DatesCorrected { get; set; }
+
     /// <summary>Filings that could not be fetched or parsed this run.</summary>
     public int Failed { get; set; }
 
     public string Summary =>
         FormattableString.Invariant(
-            $"Reprocessed {Processed:N0}/{Total:N0} filings ({Fetched:N0} fetched, {Reclassified:N0} rows reclassified, {Repaired:N0} prices repaired, {Failed:N0} failed)."
+            $"Reprocessed {Processed:N0}/{Total:N0} filings ({Fetched:N0} fetched, {Reclassified:N0} rows reclassified, {Repaired:N0} prices repaired, {DatesCorrected:N0} dates corrected, {Failed:N0} failed)."
         );
 }

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -33,9 +33,11 @@ public class InsiderTransaction
     /// holding-only rows (parsed from a <c>nonDerivativeHolding</c>/
     /// <c>derivativeHolding</c> element) as <see cref="TransactionCode.Holding"/>
     /// instead of <see cref="TransactionCode.Other"/>, so the reprocess re-tags
-    /// every historical holding row and transaction lists can exclude them.
+    /// every historical holding row and transaction lists can exclude them; v6
+    /// re-derives transaction dates after implausible-date validation was added,
+    /// anchoring source typos to the filing's period of report.
     /// </summary>
-    public const int CurrentParserVersion = 5;
+    public const int CurrentParserVersion = 6;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerReclassifyTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerReclassifyTests.cs
@@ -21,9 +21,9 @@ namespace Equibles.IntegrationTests.InsiderTrading;
 /// relational provider (it calls Database.SetCommandTimeout, unsupported by the
 /// in-memory provider). Contract: a row below the current parser version is
 /// re-parsed from its cached ownership XML — a local read, not an EDGAR fetch —
-/// SecurityKind is re-derived from the source table (authoritative over the
-/// stored value), and the row is stamped with the current parser version so it
-/// drops out of future runs.
+/// SecurityKind and corrected dates are re-derived from the source (authoritative
+/// over stored values), and the row is stamped with the current parser version so
+/// it drops out of future runs.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
@@ -32,9 +32,11 @@ public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
         : base(fixture) { }
 
     [Fact]
-    public async Task Run_StaleRowWithCachedXml_ReclassifiesFromSourceTableAndStampsVersion()
+    public async Task Run_V5RowWithCachedXml_ReclassifiesAndCorrectsDateFromSource()
     {
-        var date = new DateOnly(2024, 6, 14);
+        var reportDate = new DateOnly(2024, 6, 14);
+        var filingDate = new DateOnly(2024, 6, 17);
+        var impossibleDate = new DateOnly(2035, 6, 14);
         var accession = "0000320193-24-000001";
 
         var stock = new CommonStock
@@ -54,10 +56,9 @@ public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
             IsDirector = true,
         };
 
-        // Stored row is mis-classified as Derivative and stuck at the legacy
-        // version; the cached XML below places it in the non-derivative table, so
-        // the run must flip it to NonDerivative — the table, never the prior value,
-        // is authoritative.
+        // This v5 row predates the parser generation for date correction. Its source
+        // date is impossible and its security type is wrong; cached XML authoritatively
+        // supplies both the table classification and the period-of-report fallback.
         var stale = new InsiderTransaction
         {
             Id = Guid.NewGuid(),
@@ -65,8 +66,8 @@ public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
             InsiderOwnerId = owner.Id,
             AccessionNumber = accession,
             TransactionOrder = 0,
-            FilingDate = date,
-            TransactionDate = date,
+            FilingDate = filingDate,
+            TransactionDate = impossibleDate,
             TransactionCode = TransactionCode.Purchase,
             Shares = 1000,
             PricePerShare = 55m,
@@ -76,16 +77,17 @@ public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
             OwnershipNature = OwnershipNature.Direct,
             SecurityTitle = "Common Stock",
             SecurityKind = InsiderSecurityKind.Derivative,
-            ParserVersion = 0,
+            ParserVersion = 5,
         };
 
         // The reprocess maps a re-parsed row onto the stored row by TransactionOrder,
         // so the cached XML's single non-derivative transaction (order 0) lines up.
         var ownershipXml =
             "<ownershipDocument>"
+            + "<periodOfReport>2024-06-14</periodOfReport>"
             + "<nonDerivativeTable><nonDerivativeTransaction>"
             + "<securityTitle><value>Common Stock</value></securityTitle>"
-            + "<transactionDate><value>2024-06-14</value></transactionDate>"
+            + "<transactionDate><value>2035-06-14</value></transactionDate>"
             + "<transactionCoding><transactionCode>P</transactionCode></transactionCoding>"
             + "<transactionAmounts>"
             + "<transactionShares><value>1000</value></transactionShares>"
@@ -114,7 +116,7 @@ public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
             new DailyStockPrice
             {
                 CommonStockId = stock.Id,
-                Date = date,
+                Date = reportDate,
                 Close = 55m,
             }
         );
@@ -144,6 +146,7 @@ public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
         result.Processed.Should().Be(1);
         result.Reclassified.Should().Be(1);
         result.Repaired.Should().Be(0);
+        result.DatesCorrected.Should().Be(1);
         result.Failed.Should().Be(0);
         // Served entirely from the cached blob — no EDGAR round-trip.
         result.Fetched.Should().Be(0);
@@ -152,6 +155,7 @@ public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
         await using var verify = Fixture.CreateDbContext();
         var reprocessed = await verify.Set<InsiderTransaction>().FindAsync(stale.Id);
         reprocessed!.SecurityKind.Should().Be(InsiderSecurityKind.NonDerivative);
+        reprocessed.TransactionDate.Should().Be(reportDate);
         reprocessed.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
     }
 }

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs
@@ -40,6 +40,7 @@ public class InsiderFilingReprocessResultSummaryCultureInvarianceTests
             Fetched = 9012,
             Reclassified = 3456,
             Repaired = 7890,
+            DatesCorrected = 6789,
             Failed = 2345,
         };
 
@@ -52,7 +53,7 @@ public class InsiderFilingReprocessResultSummaryCultureInvarianceTests
                 .Summary.Should()
                 .Be(
                     "Reprocessed 1,234/5,678 filings (9,012 fetched, 3,456 rows reclassified, "
-                        + "7,890 prices repaired, 2,345 failed).",
+                        + "7,890 prices repaired, 6,789 dates corrected, 2,345 failed).",
                     "log helpers in this repo are culture-invariant (cf. BaseScraperWorker.FormatInterval, "
                         + "FactMarkdown.Value); a non-invariant group separator forks operator log output by host locale"
                 );


### PR DESCRIPTION
## Summary
- Re-enroll parser-v5 Form 3/4/5 rows after the date-validity correction.
- Repair historical date typos from the SEC ownership document instead of retaining the bad stored value.

## Code changes
- Advance the insider parser generation to v6.
- Read `periodOfReport` from cached SEC XML as the authoritative fallback date.
- Persist corrected dates before close-price validation.
- Include corrected-date counts in reprocess progress.
- Cover a v5 row containing a 2035 typo with unit and integration regression tests.

## Verification
- 189 insider-focused unit tests passed.
- 169 insider-focused integration tests passed.
- Unit and integration projects build successfully.
- Formatting check passed.