### PR TITLE
fix(worker): give the lane lease its own connection pool

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.10" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="Equibles.ParadeDB.EntityFrameworkCore" Version="2.1.0" />
     <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />

--- a/src/Equibles.Core/Configuration/WorkerOptions.cs
+++ b/src/Equibles.Core/Configuration/WorkerOptions.cs
@@ -12,6 +12,12 @@ public class WorkerOptions
     public bool LaneLeaseEnabled { get; set; } = true;
 
     /// <summary>
+    /// Caps the number of scraper cycles that may hold a lease concurrently in one worker process.
+    /// Lease sessions use their own pool, separate from normal query connections.
+    /// </summary>
+    public int LaneLeasePoolSize { get; set; } = 8;
+
+    /// <summary>
     /// Caps how many stocks the split-price back-adjustment pass re-syncs per cycle, so the
     /// one-time universe backfill throttles against Yahoo's shared request limiter instead of
     /// re-pulling every stock's full history at once. Stocks beyond the cap stay pending and are

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -155,7 +155,7 @@ builder.Services.AutoWireServicesFrom<Equibles.Sec.BusinessLogic.SecDocumentHtml
 builder.Services.AutoWireServicesFrom<Equibles.InsiderTrading.BusinessLogic.InsiderTransactionPriceValidator>();
 
 // Register worker services and all scrapers
-builder.Services.AddWorkerServices();
+builder.Services.AddWorkerServices(connectionString);
 builder.Services.AddSecWorker();
 builder.Services.AddSecFinancialFactsWorker();
 builder.Services.AddFinraWorker();

--- a/src/Equibles.Worker.Host/appsettings.json
+++ b/src/Equibles.Worker.Host/appsettings.json
@@ -3,6 +3,10 @@
     "DefaultConnection": "Host=localhost;Database=equibles;Username=postgres;Password=postgres",
     "TransportConnection": "Host=localhost;Database=equibles;Username=postgres;Password=postgres"
   },
+  "Worker": {
+    "LaneLeaseEnabled": true,
+    "LaneLeasePoolSize": 8
+  },
   "MassTransit": {
     "RunMigration": true
   },

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -14,6 +14,9 @@ namespace Equibles.Worker;
 
 public abstract class BaseScraperWorker : BackgroundService
 {
+    private const int LeasePoolRetryBaseSeconds = 15;
+    private const int LeasePoolRetrySpreadSeconds = 30;
+
     protected readonly ILogger Logger;
     protected readonly IServiceScopeFactory ScopeFactory;
     protected readonly ErrorReporter ErrorReporter;
@@ -23,6 +26,13 @@ public abstract class BaseScraperWorker : BackgroundService
     private int _consecutiveFailures;
     private bool _errorReportedForStreak;
     private bool? _laneLeaseEnabled;
+
+    private enum CycleRunResult
+    {
+        Ran,
+        LeaseHeldElsewhere,
+        LeasePoolUnavailable,
+    }
 
     protected abstract string WorkerName { get; }
     protected abstract TimeSpan SleepInterval { get; }
@@ -141,6 +151,21 @@ public abstract class BaseScraperWorker : BackgroundService
     /// </summary>
     protected virtual int ErrorReportThreshold => 1;
 
+    /// <summary>
+    /// Short, lane-stable stagger after the dedicated lease pool rejects an acquisition. Retrying
+    /// sooner than SleepInterval prevents a worker restart from parking skipped lanes for hours;
+    /// staggering prevents those lanes from returning as another synchronized startup wave.
+    /// </summary>
+    protected virtual TimeSpan LeasePoolRetryInterval
+    {
+        get
+        {
+            var laneHash = unchecked((ulong)ScraperLease.ComputeLockKey(LaneId));
+            var spreadSeconds = (int)(laneHash % LeasePoolRetrySpreadSeconds);
+            return TimeSpan.FromSeconds(LeasePoolRetryBaseSeconds + spreadSeconds);
+        }
+    }
+
     protected BaseScraperWorker(
         ILogger logger,
         IServiceScopeFactory scopeFactory,
@@ -245,11 +270,11 @@ public abstract class BaseScraperWorker : BackgroundService
             _retrySoonRequested = false;
             _continuationRequested = false;
             var faulted = false;
-            var cycleRan = false;
+            var cycleResult = CycleRunResult.LeaseHeldElsewhere;
 
             try
             {
-                cycleRan = await RunCycle(stoppingToken);
+                cycleResult = await RunCycle(stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -303,14 +328,29 @@ public abstract class BaseScraperWorker : BackgroundService
                 }
             }
 
-            if (!cycleRan && !faulted)
+            if (cycleResult != CycleRunResult.Ran && !faulted)
             {
-                Logger.LogInformation(
-                    "{Worker} lane lease is held by another instance; skipping cycle and sleeping for {Interval}",
-                    WorkerName,
-                    SleepInterval
-                );
-                await WaitForNextCycle(SleepInterval, stoppingToken);
+                var skipInterval =
+                    cycleResult == CycleRunResult.LeasePoolUnavailable
+                        ? LeasePoolRetryInterval
+                        : SleepInterval;
+                if (cycleResult == CycleRunResult.LeasePoolUnavailable)
+                {
+                    Logger.LogInformation(
+                        "{Worker} dedicated lane lease pool is at capacity; skipping cycle and retrying in {Interval}",
+                        WorkerName,
+                        FormatInterval(skipInterval)
+                    );
+                }
+                else
+                {
+                    Logger.LogInformation(
+                        "{Worker} lane lease is held by another instance; skipping cycle and sleeping for {Interval}",
+                        WorkerName,
+                        skipInterval
+                    );
+                }
+                await WaitForNextCycle(skipInterval, stoppingToken);
                 continue;
             }
 
@@ -383,14 +423,22 @@ public abstract class BaseScraperWorker : BackgroundService
         }
     }
 
-    private async Task<bool> RunCycle(CancellationToken stoppingToken)
+    private async Task<CycleRunResult> RunCycle(CancellationToken stoppingToken)
     {
         IAsyncDisposable lease = null;
         if (LaneLeaseEnabled)
         {
-            lease = await TryAcquireLaneLease(stoppingToken);
+            try
+            {
+                lease = await TryAcquireLaneLease(stoppingToken);
+            }
+            catch (ScraperLeasePoolUnavailableException)
+            {
+                return CycleRunResult.LeasePoolUnavailable;
+            }
+
             if (lease is null)
-                return false;
+                return CycleRunResult.LeaseHeldElsewhere;
         }
 
         await using (lease)
@@ -399,7 +447,7 @@ public abstract class BaseScraperWorker : BackgroundService
             await DoWork(stoppingToken);
         }
 
-        return true;
+        return CycleRunResult.Ran;
     }
 
     private static string FormatInterval(TimeSpan interval)

--- a/src/Equibles.Worker/Equibles.Worker.csproj
+++ b/src/Equibles.Worker/Equibles.Worker.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Equibles.Core.AutoWiring" />
     <PackageReference Include="MassTransit" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Npgsql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equibles.Worker/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Worker/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,9 @@
 using Equibles.Core.AutoWiring;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Equibles.Worker.Extensions;
 
@@ -7,7 +11,43 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddWorkerServices(this IServiceCollection services)
     {
+        return AddWorkerServices(services, ResolveFinancialConnectionString);
+    }
+
+    public static IServiceCollection AddWorkerServices(
+        this IServiceCollection services,
+        string connectionString
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        return AddWorkerServices(services, _ => connectionString);
+    }
+
+    private static IServiceCollection AddWorkerServices(
+        IServiceCollection services,
+        Func<IServiceProvider, string> connectionStringFactory
+    )
+    {
         services.AutoWireServicesFrom<TickerMapService>();
+        services.AddSingleton(serviceProvider =>
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<WorkerOptions>>().Value;
+            return new ScraperLeaseDataSource(
+                connectionStringFactory(serviceProvider),
+                options.LaneLeasePoolSize
+            );
+        });
         return services;
+    }
+
+    private static string ResolveFinancialConnectionString(IServiceProvider serviceProvider)
+    {
+        using var scope = serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        return dbContext.Database.GetConnectionString()
+            ?? throw new InvalidOperationException(
+                "EquiblesFinancialDbContext has no connection string. Call AddWorkerServices with "
+                    + "the worker database connection string."
+            );
     }
 }

--- a/src/Equibles.Worker/ScraperLease.cs
+++ b/src/Equibles.Worker/ScraperLease.cs
@@ -1,8 +1,6 @@
 using System.Data;
 using System.Data.Common;
 using System.Text;
-using Equibles.Data;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -17,6 +15,7 @@ internal sealed class ScraperLease : IAsyncDisposable
     private const ulong FnvPrime = 1099511628211UL;
 
     private readonly AsyncServiceScope _scope;
+    private readonly ScraperLeaseDataSource _dataSource;
     private readonly DbConnection _connection;
     private readonly long _lockKey;
     private readonly string _workerName;
@@ -25,6 +24,7 @@ internal sealed class ScraperLease : IAsyncDisposable
 
     private ScraperLease(
         AsyncServiceScope scope,
+        ScraperLeaseDataSource dataSource,
         DbConnection connection,
         long lockKey,
         string workerName,
@@ -32,6 +32,7 @@ internal sealed class ScraperLease : IAsyncDisposable
     )
     {
         _scope = scope;
+        _dataSource = dataSource;
         _connection = connection;
         _lockKey = lockKey;
         _workerName = workerName;
@@ -53,35 +54,41 @@ internal sealed class ScraperLease : IAsyncDisposable
     {
         var lockKey = ComputeLockKey(laneId);
         var scope = scopeFactory.CreateAsyncScope();
-        DbConnection connection;
-        bool acquired;
+        ScraperLeaseDataSource dataSource = null;
+        DbConnection connection = null;
+        var reservationHeld = false;
+        var retainResources = false;
 
         try
         {
-            var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
-
-            // PostgreSQL advisory locks belong to a database session. A dedicated DbContext scope
-            // reuses the host's provider configuration while keeping this exact connection open for
-            // the entire scraper cycle, so pooling cannot return the owning session early.
-            await dbContext.Database.OpenConnectionAsync(cancellationToken);
-            connection = dbContext.Database.GetDbConnection();
+            dataSource = scope.ServiceProvider.GetRequiredService<ScraperLeaseDataSource>();
+            dataSource.ReserveConnection();
+            reservationHeld = true;
+            connection = await dataSource.OpenConnection(cancellationToken);
 
             await using var command = CreateCommand(connection, AcquireSql, lockKey);
-            acquired = await command.ExecuteScalarAsync(cancellationToken) is true;
-        }
-        catch
-        {
-            await scope.DisposeAsync();
-            throw;
-        }
+            if (await command.ExecuteScalarAsync(cancellationToken) is not true)
+                return null;
 
-        if (!acquired)
-        {
-            await scope.DisposeAsync();
-            return null;
+            // PostgreSQL advisory locks belong to a database session. This exact connection remains
+            // open until DisposeAsync releases the lock after the whole scraper cycle completes.
+            retainResources = true;
+            return new ScraperLease(scope, dataSource, connection, lockKey, workerName, logger);
         }
-
-        return new ScraperLease(scope, connection, lockKey, workerName, logger);
+        finally
+        {
+            if (!retainResources)
+            {
+                await ReleaseAcquisitionResources(
+                    scope,
+                    dataSource,
+                    connection,
+                    reservationHeld,
+                    workerName,
+                    logger
+                );
+            }
+        }
     }
 
     internal static long ComputeLockKey(string workerName)
@@ -120,8 +127,8 @@ internal sealed class ScraperLease : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            // Cleanup must not replace a DoWork exception. Closing the dedicated session below is
-            // PostgreSQL's fail-safe release path when an explicit unlock cannot be delivered.
+            // Cleanup must not replace a DoWork exception. Disposing the connection below resets a
+            // healthy pooled session or drops a broken physical session after unlock cannot run.
             _logger.LogWarning(
                 ex,
                 "Failed to explicitly release scraper lane lease for {Worker}",
@@ -132,13 +139,26 @@ internal sealed class ScraperLease : IAsyncDisposable
         {
             try
             {
-                await _connection.CloseAsync();
+                await _connection.DisposeAsync();
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(
                     ex,
                     "Failed to close scraper lane lease connection for {Worker}",
+                    _workerName
+                );
+            }
+
+            try
+            {
+                _dataSource.ReleaseConnection();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to release scraper lane lease pool capacity for {Worker}",
                     _workerName
                 );
             }
@@ -155,6 +175,61 @@ internal sealed class ScraperLease : IAsyncDisposable
                     _workerName
                 );
             }
+        }
+    }
+
+    private static async ValueTask ReleaseAcquisitionResources(
+        AsyncServiceScope scope,
+        ScraperLeaseDataSource dataSource,
+        DbConnection connection,
+        bool reservationHeld,
+        string workerName,
+        ILogger logger
+    )
+    {
+        if (connection is not null)
+        {
+            try
+            {
+                await connection.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Failed to close unacquired scraper lane lease connection for {Worker}",
+                    workerName
+                );
+            }
+        }
+
+        if (reservationHeld)
+        {
+            try
+            {
+                dataSource.ReleaseConnection();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Failed to release unacquired scraper lane lease pool capacity for {Worker}",
+                    workerName
+                );
+            }
+        }
+
+        try
+        {
+            await scope.DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to dispose unacquired scraper lane lease scope for {Worker}",
+                workerName
+            );
         }
     }
 

--- a/src/Equibles.Worker/ScraperLeaseDataSource.cs
+++ b/src/Equibles.Worker/ScraperLeaseDataSource.cs
@@ -1,0 +1,59 @@
+using System.Data.Common;
+using Npgsql;
+
+namespace Equibles.Worker;
+
+internal sealed class ScraperLeaseDataSource : IAsyncDisposable
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly SemaphoreSlim _availableConnections;
+    private int _disposed;
+
+    internal ScraperLeaseDataSource(string connectionString, int maximumPoolSize)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumPoolSize, 1);
+
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            Pooling = true,
+            MinPoolSize = 0,
+            MaxPoolSize = maximumPoolSize,
+            // A multiplexed logical connection does not own one stable PostgreSQL session, which
+            // would invalidate a session-scoped advisory lock held across the scraper cycle.
+            Multiplexing = false,
+            // Npgsql's normal DISCARD ALL reset releases advisory locks if explicit cleanup fails.
+            NoResetOnClose = false,
+        };
+
+        // Lease sessions live for a whole scraper cycle. Keeping them in a small, separate data
+        // source prevents lane count from consuming the query pool, while the matching gate turns
+        // excess startup demand into an immediate skip instead of an Npgsql pool timeout.
+        _dataSource = NpgsqlDataSource.Create(connectionStringBuilder.ConnectionString);
+        _availableConnections = new SemaphoreSlim(maximumPoolSize, maximumPoolSize);
+        MaximumPoolSize = maximumPoolSize;
+    }
+
+    internal string ConnectionString => _dataSource.ConnectionString;
+    internal int MaximumPoolSize { get; }
+
+    internal void ReserveConnection()
+    {
+        if (!_availableConnections.Wait(0))
+            throw new ScraperLeasePoolUnavailableException();
+    }
+
+    internal void ReleaseConnection() => _availableConnections.Release();
+
+    internal async ValueTask<DbConnection> OpenConnection(CancellationToken cancellationToken) =>
+        await _dataSource.OpenConnectionAsync(cancellationToken);
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        await _dataSource.DisposeAsync();
+        _availableConnections.Dispose();
+    }
+}

--- a/src/Equibles.Worker/ScraperLeasePoolUnavailableException.cs
+++ b/src/Equibles.Worker/ScraperLeasePoolUnavailableException.cs
@@ -1,0 +1,7 @@
+namespace Equibles.Worker;
+
+internal sealed class ScraperLeasePoolUnavailableException : Exception
+{
+    internal ScraperLeasePoolUnavailableException()
+        : base("The dedicated scraper lease connection pool is at capacity.") { }
+}

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerLaneLeaseTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerLaneLeaseTests.cs
@@ -58,6 +58,84 @@ public class BaseScraperWorkerLaneLeaseTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_LeasePoolUnavailable_SkipsWorkWithoutFaultOrError()
+    {
+        var bus = Substitute.For<IBus>();
+        using var services = CreateWorkerServices(new WorkerOptions(), bus);
+        var reporterScopeFactory = Substitute.For<IServiceScopeFactory>();
+        var logger = Substitute.For<ILogger>();
+        using var worker = new LeaseTestWorker(
+            logger,
+            services.GetRequiredService<IServiceScopeFactory>(),
+            CreateErrorReporter(reporterScopeFactory),
+            (_, _) => throw new ScraperLeasePoolUnavailableException(),
+            _ => Task.CompletedTask,
+            errorReportThreshold: 1
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        var interval = await worker.FirstWait.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.LeaseAttempts.Should().Be(1);
+        worker.DoWorkCalls.Should().Be(0);
+        interval.Should().Be(worker.PoolUnavailableRetryInterval);
+        interval.Should().NotBe(worker.FaultBackoffInterval);
+        reporterScopeFactory.DidNotReceive().CreateScope();
+        logger
+            .DidNotReceive()
+            .Log(
+                LogLevel.Critical,
+                Arg.Any<EventId>(),
+                Arg.Any<object>(),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+        bus.ReceivedCalls()
+            .Select(call => call.GetArguments().FirstOrDefault())
+            .OfType<ScraperActivity>()
+            .Should()
+            .NotContain(activity =>
+                activity.Severity == ScraperActivitySeverity.Warn
+                || activity.Severity == ScraperActivitySeverity.Error
+            );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonResourceLeaseFailure_RemainsFaultedAndReported()
+    {
+        using var services = CreateWorkerServices(new WorkerOptions());
+        var reporterScopeFactory = Substitute.For<IServiceScopeFactory>();
+        var logger = Substitute.For<ILogger>();
+        using var worker = new LeaseTestWorker(
+            logger,
+            services.GetRequiredService<IServiceScopeFactory>(),
+            CreateErrorReporter(reporterScopeFactory),
+            (_, _) => throw new InvalidOperationException("invalid lease configuration"),
+            _ => Task.CompletedTask,
+            errorReportThreshold: 1
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        var interval = await worker.FirstWait.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.LeaseAttempts.Should().Be(1);
+        worker.DoWorkCalls.Should().Be(0);
+        interval.Should().Be(worker.FaultBackoffInterval);
+        reporterScopeFactory.Received().CreateScope();
+        logger
+            .Received()
+            .Log(
+                LogLevel.Critical,
+                Arg.Any<EventId>(),
+                Arg.Any<object>(),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+    }
+
+    [Fact]
     public async Task ExecuteAsync_LeaseFree_RunsWorkNormally()
     {
         var lease = new TrackingLease();
@@ -209,6 +287,7 @@ public class BaseScraperWorkerLaneLeaseTests
             TaskCreationOptions.RunContinuationsAsynchronously
         );
         private readonly int _cyclesBeforeBlocking;
+        private readonly int _errorReportThreshold;
         private int _leaseAttempts;
         private int _doWorkCalls;
         private int _cyclesObserved;
@@ -219,13 +298,15 @@ public class BaseScraperWorkerLaneLeaseTests
             ErrorReporter errorReporter,
             Func<int, CancellationToken, ValueTask<IAsyncDisposable>> tryAcquire,
             Func<CancellationToken, Task> doWork,
-            int cyclesBeforeBlocking = 1
+            int cyclesBeforeBlocking = 1,
+            int errorReportThreshold = 2
         )
             : base(logger, scopeFactory, errorReporter)
         {
             _tryAcquire = tryAcquire;
             _doWork = doWork;
             _cyclesBeforeBlocking = cyclesBeforeBlocking;
+            _errorReportThreshold = errorReportThreshold;
         }
 
         public Task<TimeSpan> FirstWait => _firstWait.Task;
@@ -234,13 +315,14 @@ public class BaseScraperWorkerLaneLeaseTests
         public string ExposedWorkerName => WorkerName;
         public TimeSpan NormalSleepInterval => SleepInterval;
         public TimeSpan FaultBackoffInterval => ErrorBackoffInterval;
+        public TimeSpan PoolUnavailableRetryInterval => LeasePoolRetryInterval;
         public int LeaseAttempts => _leaseAttempts;
         public int DoWorkCalls => _doWorkCalls;
 
         protected override string WorkerName => "Lease test worker";
         protected override TimeSpan SleepInterval => TimeSpan.FromHours(1);
         protected override TimeSpan ErrorBackoffInterval => TimeSpan.FromSeconds(1);
-        protected override int ErrorReportThreshold => 2;
+        protected override int ErrorReportThreshold => _errorReportThreshold;
         protected override ErrorSource ErrorSource => ErrorSource.Other;
 
         protected override ValueTask<IAsyncDisposable> TryAcquireLaneLease(

--- a/tests/Equibles.UnitTests/Worker/ScraperLeaseDataSourceTests.cs
+++ b/tests/Equibles.UnitTests/Worker/ScraperLeaseDataSourceTests.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+using Equibles.Worker;
+
+namespace Equibles.UnitTests.Worker;
+
+public class ScraperLeaseDataSourceTests
+{
+    private const string ConnectionString =
+        "Host=localhost;Database=equibles;Username=postgres;Password=postgres";
+
+    [Fact]
+    public async Task ReserveConnection_ConfiguredCapacity_RejectsAnotherLeaseImmediately()
+    {
+        await using var dataSource = new ScraperLeaseDataSource(ConnectionString, 2);
+        dataSource.ReserveConnection();
+        dataSource.ReserveConnection();
+
+        try
+        {
+            var act = dataSource.ReserveConnection;
+
+            act.Should().Throw<ScraperLeasePoolUnavailableException>();
+        }
+        finally
+        {
+            dataSource.ReleaseConnection();
+            dataSource.ReleaseConnection();
+        }
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveCapacity_ThrowsConfigurationError()
+    {
+        var act = () => new ScraperLeaseDataSource(ConnectionString, 0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/Equibles.UnitTests/Worker/ServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Worker/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,10 @@
+using Equibles.Core.Configuration;
+using Equibles.Data.Extensions;
 using Equibles.Worker;
 using Equibles.Worker.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Npgsql;
 
 namespace Equibles.UnitTests.Worker;
 
@@ -24,5 +28,62 @@ public class ServiceCollectionExtensionsTests
         services.AddWorkerServices();
 
         services.Should().Contain(d => d.ServiceType == typeof(TickerMapService));
+    }
+
+    [Fact]
+    public async Task AddWorkerServices_ConnectionString_IsolatesAndBoundsTheLeasePool()
+    {
+        const string queryConnectionString =
+            "Host=localhost;Database=equibles;Username=postgres;Password=postgres;"
+            + "Pooling=false;Minimum Pool Size=24;Maximum Pool Size=24;Multiplexing=true;"
+            + "No Reset On Close=true";
+        var workerOptions = new WorkerOptions();
+        var services = new ServiceCollection();
+        services.AddSingleton<IOptions<WorkerOptions>>(Options.Create(workerOptions));
+
+        services.AddWorkerServices(queryConnectionString);
+
+        await using var provider = services.BuildServiceProvider();
+        var leaseDataSource = provider.GetRequiredService<ScraperLeaseDataSource>();
+        var leaseSettings = new NpgsqlConnectionStringBuilder(leaseDataSource.ConnectionString);
+        var querySettings = new NpgsqlConnectionStringBuilder(queryConnectionString);
+
+        workerOptions.LaneLeasePoolSize.Should().Be(8);
+        leaseDataSource.MaximumPoolSize.Should().Be(workerOptions.LaneLeasePoolSize);
+        leaseSettings.Pooling.Should().BeTrue();
+        leaseSettings.MinPoolSize.Should().Be(0);
+        leaseSettings.MaxPoolSize.Should().Be(workerOptions.LaneLeasePoolSize);
+        leaseSettings.Multiplexing.Should().BeFalse();
+        leaseSettings.NoResetOnClose.Should().BeFalse();
+        querySettings.Pooling.Should().BeFalse();
+        querySettings.MinPoolSize.Should().Be(24);
+        querySettings.MaxPoolSize.Should().Be(24);
+        querySettings.Multiplexing.Should().BeTrue();
+        querySettings.NoResetOnClose.Should().BeTrue();
+        provider
+            .GetRequiredService<ScraperLeaseDataSource>()
+            .Should()
+            .BeSameAs(leaseDataSource, "one process must share one dedicated lease pool");
+    }
+
+    [Fact]
+    public async Task AddWorkerServices_WithoutConnectionString_UsesTheFinancialDbContextSettings()
+    {
+        const string queryConnectionString =
+            "Host=database.internal;Database=equibles;Username=postgres;Password=postgres;"
+            + "Maximum Pool Size=24";
+        var services = new ServiceCollection();
+        services.AddSingleton<IOptions<WorkerOptions>>(Options.Create(new WorkerOptions()));
+        services.AddEquiblesFinancialDbContext(queryConnectionString, _ => { });
+
+        services.AddWorkerServices();
+
+        await using var provider = services.BuildServiceProvider();
+        var leaseDataSource = provider.GetRequiredService<ScraperLeaseDataSource>();
+        var leaseSettings = new NpgsqlConnectionStringBuilder(leaseDataSource.ConnectionString);
+
+        leaseSettings.Host.Should().Be("database.internal");
+        leaseSettings.Database.Should().Be("equibles");
+        leaseSettings.MaxPoolSize.Should().Be(new WorkerOptions().LaneLeasePoolSize);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4283, a regression from the lane lease in #4276 observed in production.

Sixteen seconds after the worker started, ~40 lanes took their lease at once and drained the Npgsql pool, logging fatal and writing an `Errors` row per affected lane.

The cause is structural. The lease holds one connection for a whole cycle by design — a PostgreSQL advisory lock is session-scoped and cannot be handed back mid-cycle — so its connection cost equals the number of concurrently running lanes. There are **60 lanes** (27 here, 33 in the commercial repo sharing this `BaseScraperWorker`) against a **24**-connection pool, and at startup none has staggered yet. The lanes that lost the race then could not do their real work either, because that needs the same pool.

It self-healed as cycle timings spread, but recurred on every restart and worsened with each lane added.

## Code changes

- **`ScraperLeaseDataSource`** (new) — a dedicated `NpgsqlDataSource` for leases, capped at 8, so leases take **nothing** from the 24 query slots. `Multiplexing=false` because a multiplexed logical connection does not own one stable session, which would invalidate the lock. Pool reset stays on: `DISCARD ALL` runs `pg_advisory_unlock_all()`, the backstop if explicit release ever fails.
- **Non-blocking capacity gate** — `SemaphoreSlim.Wait(0)`; excess demand becomes an immediate skip instead of an Npgsql pool timeout.
- **A capacity skip is not a fault** — informational log, no fault backoff, no `Errors` row, no fatal. Genuine auth, config, network and SQL failures still surface exactly as before.
- **Fast, staggered retry** — a capacity-skipped lane retries after a lane-stable 15–44s rather than its full sleep interval, so a restart cannot park lanes for hours, and the spread stops them returning as another synchronized wave.
- **`Worker__LaneLeasePoolSize`** tunes the cap with no code change.

## Connection accounting

| | Before | After |
|---|---|---|
| Lease connections from the query pool | up to 60 competing for 24 | **0** |
| Dedicated lease pool | — | ≤ 8 |
| Max sessions per worker process | 24 | 32 |

With all 60 lanes contending, 8 run and 52 skip and retry within 15–44s.

## Verification

- Build clean. Full `Equibles.UnitTests` **3,956/3,956**. csharpier clean tree-wide.
- Mutations killed: capacity classification (1), capacity-exception handling (1), fast-retry interval (1), `Multiplexing` flipped on (1).

## Trade-off

Concurrent cycles are now bounded at 8. That is deliberate — it is what protects query capacity — but it does mean long-running lanes hold slots. `LaneLeasePoolSize` is the lever if that proves too tight in practice.