### PR TITLE
feat(yahoo-mcp): add 52-week range and session anchoring to GetLatestPrices

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -21,6 +21,11 @@ namespace Equibles.Yahoo.Mcp.Tools;
 [McpServerToolType]
 public class StockPriceTools
 {
+    // A 52-week window whose oldest stored bar starts later than this many days past the
+    // year boundary is a shorter listed history, not a full year — markets close for
+    // holidays and weekends, but a window starting weeks late is a young listing.
+    private const int BaselineSlackDays = 14;
+
     private readonly DailyStockPriceRepository _priceRepository;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly McpToolRunner _runner;
@@ -111,11 +116,18 @@ public class StockPriceTools
 
     [McpServerTool(Name = "GetLatestPrices", Title = "Latest Prices", ReadOnly = true)]
     [Description(
-        "Get the most recent closing price (USD), daily change, and volume for one or more "
-            + "stocks. Useful for quick price checks across a portfolio or watchlist. The "
-            + "change columns are a ONE-SESSION move: they are shown only when the stored "
-            + "series holds the trading day immediately before the date on the row, and are "
-            + "\"—\" otherwise, so a change is never a multi-session move in disguise."
+        "Get the most recent closing price (USD), daily change, volume, and trailing 52-week "
+            + "range for one or more stocks. Useful for quick price checks across a portfolio "
+            + "or watchlist. The change columns are a ONE-SESSION move: they are shown only "
+            + "when the stored series holds the trading day immediately before the date on the "
+            + "row, and are \"—\" otherwise, so a change is never a multi-session move in "
+            + "disguise. Each row is that ticker's newest SETTLED daily bar and the Date column "
+            + "names its session: for a few hours after a US close some tickers still show the "
+            + "prior session while the fresh bar settles, so dates within one response can "
+            + "differ — anchor on the Date column, never the wall clock. 52W High/Low are the "
+            + "highest and lowest daily closes in the 365 days ending on the row's date "
+            + "(current split basis); Off High / Above Low are the close's percent distance "
+            + "from those bounds."
     )]
     public Task<string> GetLatestPrices(
         [Description(
@@ -143,14 +155,22 @@ public class StockPriceTools
 
                 var result = StartTable(
                     "Latest prices:",
-                    "| Ticker | Date | Close | Change | Change % | Volume |",
-                    "|--------|------|-------|--------|----------|--------|"
+                    "| Ticker | Date | Close | Change | Change % | Volume | 52W High | 52W Low | Off High | Above Low |",
+                    "|--------|------|-------|--------|----------|--------|----------|---------|----------|-----------|"
                 );
 
                 // Set when at least one ticker's change columns were withheld because its
                 // stored series skips the prior session, so the footnote explains the em-dash
                 // rather than leaving the caller to read it as missing coverage.
                 var gapped = false;
+
+                // Set when a ticker's 52-week window holds less than a full year of stored
+                // history (a recent listing), so the starred range is explained.
+                var shortWindow = false;
+
+                // Sessions of the rendered rows: more than one means the newest session is
+                // still settling for part of the batch, which earns its own footnote.
+                var rowDates = new HashSet<DateOnly>();
 
                 foreach (var ticker in tickerList)
                 {
@@ -197,8 +217,37 @@ public class StockPriceTools
                         gapped = true;
                     }
 
+                    // Trailing 52-week close range, anchored on the row's own session so a
+                    // stock that stopped trading doesn't fabricate a fresh range. Stored
+                    // closes are already on the current split basis, so raw closes compare.
+                    var cutoff = price.Date.AddDays(-365);
+                    var range = await _priceRepository
+                        .GetByStock(stock, priceTicker)
+                        .Where(p => p.Date >= cutoff && p.Close > 0)
+                        .GroupBy(p => 1)
+                        .Select(g => new
+                        {
+                            High = g.Max(p => p.Close),
+                            Low = g.Min(p => p.Close),
+                            Oldest = g.Min(p => p.Date),
+                        })
+                        .FirstOrDefaultAsync();
+
+                    var cells =
+                        range == null
+                            ? FiftyTwoWeekCells.Empty
+                            : BuildFiftyTwoWeekCells(
+                                price.Close,
+                                range.High,
+                                range.Low,
+                                range.Oldest,
+                                cutoff
+                            );
+                    shortWindow |= cells.Starred;
+
+                    rowDates.Add(price.Date);
                     result.AppendLine(
-                        $"| {ticker} | {price.Date:yyyy-MM-dd} | {McpFormat.Invariant(price.Close, "F2")} | {changeCell} | {changePctCell} | {McpFormat.WholeNumber(price.Volume)} |"
+                        $"| {ticker} | {price.Date:yyyy-MM-dd} | {McpFormat.Invariant(price.Close, "F2")} | {changeCell} | {changePctCell} | {McpFormat.WholeNumber(price.Volume)} | {cells.High} | {cells.Low} | {cells.OffHigh} | {cells.AboveLow} |"
                     );
                 }
 
@@ -210,6 +259,28 @@ public class StockPriceTools
                             + "before the date shown, so no one-day move can be stated. The close and "
                             + "volume on that row are still correct. Use GetStockPrices to see which "
                             + "sessions are present."
+                    );
+                }
+
+                if (rowDates.Count > 1)
+                {
+                    result.AppendLine();
+                    result.AppendLine(
+                        "Note: rows span more than one session (see the Date column). Each ticker "
+                            + "shows its newest SETTLED daily bar, and for a few hours after a US "
+                            + "close some tickers still show the prior session while the fresh bar "
+                            + "settles. Anchor any dated output on each row's Date, not on the "
+                            + "newest date in the batch."
+                    );
+                }
+
+                if (shortWindow)
+                {
+                    result.AppendLine();
+                    result.AppendLine(
+                        "Note: a 52-week value marked \\* covers a stored history shorter than 52 "
+                            + "weeks (for example a recent listing), so it is the range since the "
+                            + "history begins, not a full year."
                     );
                 }
 
@@ -757,10 +828,50 @@ public class StockPriceTools
         && previous.Date < latest.Date
         && previous.Date >= UsMarketCalendar.PreviousTradingDay(latest.Date);
 
+    // The four rendered 52-week cells for one row, plus whether the range earned the
+    // short-history star so the caller can emit the explaining footnote exactly once.
+    private sealed record FiftyTwoWeekCells(
+        string High,
+        string Low,
+        string OffHigh,
+        string AboveLow,
+        bool Starred
+    )
+    {
+        public static readonly FiftyTwoWeekCells Empty = new("—", "—", "—", "—", false);
+    }
+
+    // Renders the trailing 52-week range cells from the window aggregate. The window is
+    // anchored on the row's own session (cutoff = row date minus 365 days); a window whose
+    // oldest bar starts more than BaselineSlackDays past the cutoff covers a shorter listed
+    // history than a year, so its absolute values carry a star rather than being withheld.
+    private static FiftyTwoWeekCells BuildFiftyTwoWeekCells(
+        decimal close,
+        decimal high,
+        decimal low,
+        DateOnly oldest,
+        DateOnly cutoff
+    )
+    {
+        var starred = oldest > cutoff.AddDays(BaselineSlackDays);
+        var star = starred ? "\\*" : "";
+        return new FiftyTwoWeekCells(
+            McpFormat.Invariant(high, "F2") + star,
+            McpFormat.Invariant(low, "F2") + star,
+            high > 0
+                ? McpFormat.Invariant((close / high - 1m) * 100m, "+0.00;-0.00;0.00") + "%"
+                : "—",
+            low > 0
+                ? McpFormat.Invariant((close / low - 1m) * 100m, "+0.00;-0.00;0.00") + "%"
+                : "—",
+            starred
+        );
+    }
+
     // Placeholder row for a ticker with no price to show (unknown symbol or no data),
     // keeping the em-dash columns identical across the per-ticker fallback branches.
     private static string PlaceholderRow(string ticker, string status) =>
-        $"| {ticker} | — | {status} | — | — | — |";
+        $"| {ticker} | — | {status} | — | — | — | — | — | — | — |";
 
     // Leading "Date | Close" cells shared by every technical-indicator table row;
     // keeps the date format and close precision in sync across the four tables.

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -264,13 +264,24 @@ public class StockPriceTools
 
                 if (rowDates.Count > 1)
                 {
+                    // The settling explanation only holds when the spread is a single session;
+                    // a wider spread means some series are simply behind (stale or delisted
+                    // listings keep their last stored session) and blaming the nightly settle
+                    // would tell the caller a years-old close is a fresh artifact.
+                    var newest = rowDates.Max();
+                    var oneSessionSpread =
+                        rowDates.Min() >= UsMarketCalendar.PreviousTradingDay(newest);
                     result.AppendLine();
                     result.AppendLine(
-                        "Note: rows span more than one session (see the Date column). Each ticker "
-                            + "shows its newest SETTLED daily bar, and for a few hours after a US "
-                            + "close some tickers still show the prior session while the fresh bar "
-                            + "settles. Anchor any dated output on each row's Date, not on the "
-                            + "newest date in the batch."
+                        oneSessionSpread
+                            ? "Note: rows span two adjacent sessions (see the Date column). Each "
+                                + "ticker shows its newest SETTLED daily bar, and for a few hours "
+                                + "after a US close some tickers still show the prior session while "
+                                + "the fresh bar settles. Anchor any dated output on each row's "
+                                + "Date, not on the newest date in the batch."
+                            : "Note: rows span more than one session (see the Date column) — some "
+                                + "stored series end earlier than others, so anchor any dated "
+                                + "output on each row's Date, not on the newest date in the batch."
                     );
                 }
 
@@ -855,13 +866,15 @@ public class StockPriceTools
     {
         var starred = oldest > cutoff.AddDays(BaselineSlackDays);
         var star = starred ? "\\*" : "";
+        // The row's own close must be positive too: a corrupt $0 bar would otherwise render
+        // both distances as -100%, breaking the ≤0 / ≥0 sign contract the columns promise.
         return new FiftyTwoWeekCells(
             McpFormat.Invariant(high, "F2") + star,
             McpFormat.Invariant(low, "F2") + star,
-            high > 0
+            high > 0 && close > 0
                 ? McpFormat.Invariant((close / high - 1m) * 100m, "+0.00;-0.00;0.00") + "%"
                 : "—",
-            low > 0
+            low > 0 && close > 0
                 ? McpFormat.Invariant((close / low - 1m) * 100m, "+0.00;-0.00;0.00") + "%"
                 : "—",
             starred

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesDayChangeGapTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesDayChangeGapTests.cs
@@ -87,8 +87,14 @@ public class StockPriceToolsGetLatestPricesDayChangeGapTests : ParadeDbMcpTestBa
 
         var result = await Sut().GetLatestPrices("GAP");
 
-        result.Should().Contain("| GAP | 2026-07-27 | 110.00 | — | — |");
-        result.Should().NotContain("+10.00%");
+        // The +10% multi-session move may appear in the 52-week range columns — it IS the
+        // window's span — but never in the Change cells, which stay em-dashed. Pinning the
+        // full row keeps the two placements distinguishable.
+        result
+            .Should()
+            .Contain(
+                "| GAP | 2026-07-27 | 110.00 | — | — | 1,000,000 | 110.00\\* | 100.00\\* | 0.00% | +10.00% |"
+            );
         result.Should().Contain("no row for the session before");
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesMaxTickerBoundaryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesMaxTickerBoundaryTests.cs
@@ -39,6 +39,10 @@ public class StockPriceToolsGetLatestPricesMaxTickerBoundaryTests : ParadeDbMcpT
         var result = await Sut().GetLatestPrices(tickers);
 
         result.Should().NotContain("Maximum 25 tickers per request");
-        result.Should().Contain("| Ticker | Date | Close | Change | Change % | Volume |");
+        result
+            .Should()
+            .Contain(
+                "| Ticker | Date | Close | Change | Change % | Volume | 52W High | 52W Low | Off High | Above Low |"
+            );
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
@@ -183,12 +183,20 @@ public class StockPriceToolsTests : ParadeDbMcpTestBase
 
         var result = await Sut().GetLatestPrices("AAPL,MSFT");
 
-        result.Should().Contain("AAPL");
-        result.Should().Contain("MSFT");
-        result.Should().Contain("175.50");
-        result.Should().Contain("425.75");
-        result.Should().Contain("2026-04-05");
-        result.Should().NotContain("100.00"); // The older price must not show up.
+        // The older 100.00 close must never surface as a ROW price — it legitimately appears
+        // as AAPL's 52-week low. The full-row pins keep the two placements apart, and the
+        // date-scoped negative proves the older bar never becomes its own row.
+        result
+            .Should()
+            .Contain(
+                "| AAPL | 2026-04-05 | 175.50 | — | — | 50,000,000 | 175.50\\* | 100.00\\* | 0.00% | +75.50% |"
+            );
+        result
+            .Should()
+            .Contain(
+                "| MSFT | 2026-04-05 | 425.75 | — | — | 22,000,000 | 425.75\\* | 425.75\\* | 0.00% | 0.00% |"
+            );
+        result.Should().NotContain("| AAPL | 2026-04-01");
     }
 
     [Fact]
@@ -227,8 +235,10 @@ public class StockPriceToolsTests : ParadeDbMcpTestBase
 
         var result = await Sut().GetLatestPrices("AAPL,aapl,AAPL");
 
-        // One header line + one data line containing 175.50 — not three duplicates.
-        var occurrences = result.Split("175.50").Length - 1;
-        occurrences.Should().Be(1);
+        // Exactly one AAPL data row — not three duplicates. Counting rows, not the "175.50"
+        // substring, because the close legitimately repeats as the 52-week high/low of a
+        // single-bar series.
+        var rows = result.Split('\n').Count(line => line.StartsWith("| AAPL |"));
+        rows.Should().Be(1);
     }
 }

--- a/tests/Equibles.UnitTests/Mcp/StockPriceToolsFiftyTwoWeekCellsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/StockPriceToolsFiftyTwoWeekCellsTests.cs
@@ -105,6 +105,33 @@ public class StockPriceToolsFiftyTwoWeekCellsTests
     }
 
     [Fact]
+    public void NonPositiveClose_BlanksTheDistances()
+    {
+        // A corrupt $0 row close would otherwise render both distances as -100%, breaking the
+        // ≤0 / ≥0 sign contract; the absolute bounds still render.
+        var cells = Build(0m, 120m, 60m, Cutoff, Cutoff);
+
+        cells.High.Should().Be("120.00");
+        cells.Low.Should().Be("60.00");
+        cells.OffHigh.Should().Be("—");
+        cells.AboveLow.Should().Be("—");
+    }
+
+    [Fact]
+    public void PlaceholderRow_MatchesTheWidenedColumnCount()
+    {
+        // The placeholder must always carry the same cell count as the 10-column header, or a
+        // ticker fallback renders a broken markdown table with no other signal.
+        var method = typeof(StockPriceTools).GetMethod(
+            "PlaceholderRow",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var row = (string)method.Invoke(null, ["ZZZZ", "No data"]);
+
+        row.Count(c => c == '|').Should().Be(11);
+    }
+
+    [Fact]
     public void PercentFormatting_IsCultureInvariant()
     {
         var original = CultureInfo.CurrentCulture;

--- a/tests/Equibles.UnitTests/Mcp/StockPriceToolsFiftyTwoWeekCellsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/StockPriceToolsFiftyTwoWeekCellsTests.cs
@@ -1,0 +1,124 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Yahoo.Mcp.Tools;
+
+namespace Equibles.UnitTests.Mcp;
+
+// Pins GetLatestPrices' 52-week range cells: the absolute high/low of daily closes over the
+// 365 days ending on the row's own session, the percent distance of the close from each
+// bound, and the short-history star.
+//
+// The contract this defends: agent callers asked for the derived range so they don't have to
+// haul ~250 daily rows per ticker to compute two numbers. Off High must be zero-or-negative
+// and Above Low zero-or-positive by construction (the latest close is inside the window that
+// produced the bounds), and a window that begins more than a slack past the year boundary is
+// a shorter listed history — its values are starred, never silently presented as a full year.
+public class StockPriceToolsFiftyTwoWeekCellsTests
+{
+    private static MethodInfo Method() =>
+        typeof(StockPriceTools).GetMethod(
+            "BuildFiftyTwoWeekCells",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static (string High, string Low, string OffHigh, string AboveLow, bool Starred) Build(
+        decimal close,
+        decimal high,
+        decimal low,
+        DateOnly oldest,
+        DateOnly cutoff
+    )
+    {
+        var cells = Method().Invoke(null, [close, high, low, oldest, cutoff]);
+        var type = cells.GetType();
+        return (
+            (string)type.GetProperty("High").GetValue(cells),
+            (string)type.GetProperty("Low").GetValue(cells),
+            (string)type.GetProperty("OffHigh").GetValue(cells),
+            (string)type.GetProperty("AboveLow").GetValue(cells),
+            (bool)type.GetProperty("Starred").GetValue(cells)
+        );
+    }
+
+    private static readonly DateOnly Cutoff = new(2025, 8, 4);
+
+    [Fact]
+    public void ExposesThePrivateStaticHelper()
+    {
+        // Guards the reflection lookup itself: a rename would otherwise NRE rather than
+        // reporting that the pinned helper is gone.
+        Method().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void FullYearWindow_RendersBoundsAndPercentDistances()
+    {
+        var cells = Build(90m, 120m, 60m, Cutoff, Cutoff);
+
+        cells.High.Should().Be("120.00");
+        cells.Low.Should().Be("60.00");
+        cells.OffHigh.Should().Be("-25.00%");
+        cells.AboveLow.Should().Be("+50.00%");
+        cells.Starred.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CloseAtTheHigh_ReportsZeroOffHigh()
+    {
+        var cells = Build(120m, 120m, 60m, Cutoff, Cutoff);
+
+        cells.OffHigh.Should().Be("0.00%");
+        cells.AboveLow.Should().Be("+100.00%");
+    }
+
+    [Fact]
+    public void WindowStartingWithinTheSlack_IsNotStarred()
+    {
+        // Markets close for weekends and holidays, so a window whose first bar sits a few
+        // days past the exact year boundary is still a full year of listed history.
+        var cells = Build(90m, 120m, 60m, Cutoff.AddDays(14), Cutoff);
+
+        cells.Starred.Should().BeFalse();
+        cells.High.Should().Be("120.00");
+    }
+
+    [Fact]
+    public void ShorterListedHistory_StarsTheBoundsButKeepsTheDistances()
+    {
+        var cells = Build(90m, 120m, 60m, Cutoff.AddDays(15), Cutoff);
+
+        cells.Starred.Should().BeTrue();
+        cells.High.Should().Be("120.00\\*");
+        cells.Low.Should().Be("60.00\\*");
+        cells.OffHigh.Should().Be("-25.00%");
+        cells.AboveLow.Should().Be("+50.00%");
+    }
+
+    [Fact]
+    public void NonPositiveBounds_BlankTheDistancesNotTheRow()
+    {
+        // A corrupted zero bound can't produce a division, but the row itself still renders.
+        var cells = Build(90m, 0m, 0m, Cutoff, Cutoff);
+
+        cells.OffHigh.Should().Be("—");
+        cells.AboveLow.Should().Be("—");
+    }
+
+    [Fact]
+    public void PercentFormatting_IsCultureInvariant()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            var cells = Build(90m, 120m, 60m, Cutoff, Cutoff);
+
+            cells.OffHigh.Should().Be("-25.00%");
+            cells.High.Should().Be("120.00");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Customer feedback (agent-first API consumer): pricing a watchlist relative to its yearly range required pulling ~250 daily bars per ticker, and mixed session dates in one `GetLatestPrices` batch mis-anchored a dated brief. This makes the batch price tool answer both directly.

- `GetLatestPrices` always returns four extra columns per row: **52W High, 52W Low, Off High %, Above Low %** — max/min of daily closes over the 365 days ending on the row's own session (stored closes are already on the current split basis).
- Values computed from a stored history shorter than ~50 weeks are starred, with a footnote (recent listings never silently present a partial year as a full one).
- A batch whose rows span more than one session gets an explicit footnote: anchor dated output on each row's Date, not the wall clock (rows settle per ticker for a few hours after a US close).
- Tool description updated to state the settled-bar/session semantics and the range definition.

## Code changes
- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — widened table + per-ticker grouped EF aggregate for the range; new `BuildFiftyTwoWeekCells` helper + `FiftyTwoWeekCells` record; placeholder row widened; footnotes.
- `tests/Equibles.UnitTests/Mcp/StockPriceToolsFiftyTwoWeekCellsTests.cs` — pins the cell math, star threshold, zero-bound blanking, and culture invariance (7 tests).

Unit suite: 3,964 green locally.