### PR TITLE
feat(holdings): import sibling share-class 13F positions per listing

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -68,6 +68,16 @@ public class CommonStockManager
             .Select(a => a.Cusip)
             .ToListAsync();
         var taken = new HashSet<string>(alreadyRecorded, StringComparer.OrdinalIgnoreCase);
+        // A CUSIP recorded as a sibling LISTING is a different security's current identity —
+        // aliasing it would outrank the listing at resolution time and merge the two classes'
+        // positions into one row. One CUSIP identifies one security, in both directions.
+        taken.UnionWith(
+            await _commonStockRepository
+                .GetListedCusips()
+                .Where(l => candidates.Contains(l.Cusip.ToUpper()))
+                .Select(l => l.Cusip)
+                .ToListAsync()
+        );
 
         var recorded = 0;
         foreach (var cusip in candidates.Where(c => !taken.Contains(c)))
@@ -138,11 +148,25 @@ public class CommonStockManager
                 !string.IsNullOrWhiteSpace(c.ListedTicker) && !string.IsNullOrWhiteSpace(c.Cusip)
             )
             .Select(c => (Ticker: c.ListedTicker.Trim(), Cusip: c.Cusip.Trim().ToUpperInvariant()))
+            // Store the SecondaryTickers-side spelling, not the caller's: every consumer joins
+            // on this string, and one canonical spelling per listing keeps those joins exact.
+            .Select(c =>
+                secondaryTickers.TryGetValue(c.Ticker, out var canonical)
+                    ? (Ticker: canonical, c.Cusip)
+                    : c
+            )
             .Where(c =>
                 secondaryTickers.Contains(c.Ticker)
                 && !string.Equals(c.Cusip, commonStock.Cusip, StringComparison.OrdinalIgnoreCase)
             )
-            .DistinctBy(c => c.Cusip, StringComparer.OrdinalIgnoreCase)
+            // A CUSIP offered under TWO listed tickers is contradictory feed data; keeping an
+            // arbitrary pairing would price the class from the other sibling's series. Drop it —
+            // the same refusal the sweep applies to ambiguous symbols.
+            .GroupBy(c => c.Cusip, StringComparer.OrdinalIgnoreCase)
+            .Where(g =>
+                g.Select(c => c.Ticker).Distinct(StringComparer.OrdinalIgnoreCase).Count() == 1
+            )
+            .Select(g => g.First())
             .ToList();
         if (cleaned.Count == 0)
         {

--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -96,6 +96,115 @@ public class CommonStockManager
     }
 
     /// <summary>
+    /// Records the CUSIPs of a stock's OTHER listed securities — the sibling share
+    /// classes, units, and fund series named in <see cref="CommonStock.SecondaryTickers"/> —
+    /// as <see cref="CommonStockListedCusip"/> rows keyed to the exact listed ticker.
+    /// <para>
+    /// Distinct from <see cref="RecordRetiredCusipAliases"/> on purpose: an alias is a
+    /// retired identity of the PRIMARY security, while these are the current identities
+    /// of DIFFERENT securities sharing the filer row. The holdings lane resolves a 13F
+    /// line filed under one of these CUSIPs to (stock, listed ticker), so the position
+    /// imports as its own class instead of being dropped — or worse, merged into the
+    /// primary class's row.
+    /// </para>
+    /// <para>
+    /// Callers must have established the pairing from authoritative symbol+CUSIP data.
+    /// A CUSIP already claimed anywhere — as a primary, an alias, or another listing —
+    /// keeps its first owner (one CUSIP identifies one security, ever). Candidates whose
+    /// ticker is not currently one of the stock's secondary tickers are skipped: the
+    /// primary's CUSIP identity lives on the stock row and the alias table alone.
+    /// </para>
+    /// <para>
+    /// Recording anything publishes <see cref="StockCusipChanged"/> for the same reason
+    /// the alias recorder does: data sets already marked processed hold no rows for
+    /// lines filed under the newly-resolvable CUSIP, and the consumer clears that ledger
+    /// so the Holdings worker re-imports them. A burst collapses to a no-op once cleared.
+    /// </para>
+    /// </summary>
+    public async Task<int> RecordListedTickerCusips(
+        CommonStock commonStock,
+        IReadOnlyCollection<(string ListedTicker, string Cusip)> candidates
+    )
+    {
+        ArgumentNullException.ThrowIfNull(commonStock);
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        var secondaryTickers = new HashSet<string>(
+            commonStock.SecondaryTickers ?? [],
+            StringComparer.OrdinalIgnoreCase
+        );
+        var cleaned = candidates
+            .Where(c =>
+                !string.IsNullOrWhiteSpace(c.ListedTicker) && !string.IsNullOrWhiteSpace(c.Cusip)
+            )
+            .Select(c => (Ticker: c.ListedTicker.Trim(), Cusip: c.Cusip.Trim().ToUpperInvariant()))
+            .Where(c =>
+                secondaryTickers.Contains(c.Ticker)
+                && !string.Equals(c.Cusip, commonStock.Cusip, StringComparison.OrdinalIgnoreCase)
+            )
+            .DistinctBy(c => c.Cusip, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (cleaned.Count == 0)
+        {
+            return 0;
+        }
+
+        var candidateCusips = cleaned.Select(c => c.Cusip).ToList();
+        var taken = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        taken.UnionWith(
+            await _commonStockRepository
+                .GetListedCusips()
+                .Where(l => candidateCusips.Contains(l.Cusip.ToUpper()))
+                .Select(l => l.Cusip)
+                .ToListAsync()
+        );
+        taken.UnionWith(
+            await _commonStockRepository
+                .GetCusipAliases()
+                .Where(a => candidateCusips.Contains(a.Cusip.ToUpper()))
+                .Select(a => a.Cusip)
+                .ToListAsync()
+        );
+        taken.UnionWith(
+            await _commonStockRepository
+                .GetAll()
+                .Where(cs => cs.Cusip != null && candidateCusips.Contains(cs.Cusip.ToUpper()))
+                .Select(cs => cs.Cusip)
+                .ToListAsync()
+        );
+
+        var recorded = 0;
+        foreach (var candidate in cleaned.Where(c => !taken.Contains(c.Cusip)))
+        {
+            _commonStockRepository.AddListedCusip(
+                new CommonStockListedCusip
+                {
+                    CommonStockId = commonStock.Id,
+                    ListedTicker = candidate.Ticker,
+                    Cusip = candidate.Cusip,
+                }
+            );
+            recorded++;
+        }
+
+        if (recorded == 0)
+        {
+            return 0;
+        }
+
+        await _commonStockRepository.SaveChanges();
+
+        // Root bus, after the write commits — same reasoning as SetCusip: this flow only
+        // saves the financial context, so a bus outbox on another context would capture
+        // the publish and never deliver it.
+        await _bus.Publish(
+            new StockCusipChanged(commonStock.Id, commonStock.Ticker, null, commonStock.Cusip)
+        );
+
+        return recorded;
+    }
+
+    /// <summary>
     /// Sets a stock's CUSIP. When the value actually changes, publishes
     /// <see cref="StockCusipChanged"/> after SaveChanges so the Holdings module can
     /// backfill quarterly 13F data sets that were processed while this stock

--- a/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
+++ b/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
@@ -10,6 +10,7 @@ public class CommonStocksModuleConfiguration : Equibles.Data.IFinancialModule
     {
         builder.Entity<CommonStock>();
         builder.Entity<CommonStockCusipAlias>();
+        builder.Entity<CommonStockListedCusip>();
         builder.Entity<CommonStockTickerAlias>();
         builder.Entity<Industry>();
         builder.Entity<Sector>();

--- a/src/Equibles.CommonStocks.Data/Models/CommonStockListedCusip.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStockListedCusip.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// The CUSIP of one of a filer's OTHER listed securities — a sibling share class,
+/// unit, or separate fund series named in <see cref="CommonStock.SecondaryTickers"/>.
+/// <para>
+/// <see cref="CommonStock.Cusip"/> identifies only the primary listing, so 13F lines
+/// filed under a sibling class's CUSIP (Alphabet Class C at 02079K107 beside GOOGL's
+/// 02079K305) matched nothing and were dropped at import. This table gives each
+/// authoritative secondary listing its own CUSIP identity so those positions resolve
+/// to the filer row WITHOUT being merged into the primary class: the holdings lane
+/// keys the resulting rows by the listed ticker recorded here.
+/// </para>
+/// <para>
+/// Deliberately separate from <see cref="CommonStockCusipAlias"/>: an alias is a
+/// retired identity of the PRIMARY security and maps to the primary series, while a
+/// row here is the current identity of a DIFFERENT security. Folding these together
+/// would re-create the class collapse the table exists to prevent.
+/// </para>
+/// <para>
+/// Rows are recorded only from the SEC's CNS fails feed, where the SEC itself
+/// publishes SYMBOL and CUSIP on one row — never from name matching. One CUSIP
+/// identifies one security, ever: the unique index keeps the first owner.
+/// </para>
+/// </summary>
+[Index(nameof(Cusip), IsUnique = true)]
+[Index(nameof(CommonStockId))]
+public class CommonStockListedCusip
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+
+    public virtual CommonStock CommonStock { get; set; }
+
+    /// <summary>The exact canonical listed symbol, as spelled in SecondaryTickers (dash form).</summary>
+    [Required]
+    [MaxLength(32)]
+    public string ListedTicker { get; set; }
+
+    [Required]
+    [MaxLength(9)]
+    public string Cusip { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -172,6 +172,22 @@ public class CommonStockRepository : BaseRepository<CommonStock>
     }
 
     /// <summary>
+    /// CUSIPs of a filer's OTHER listed securities (sibling share classes, units),
+    /// keyed to the exact secondary ticker they identify. Same aggregate reasoning
+    /// as the CUSIP aliases: no independent lifecycle, so access lives here.
+    /// </summary>
+    public IQueryable<CommonStockListedCusip> GetListedCusips()
+    {
+        return DbContext.Set<CommonStockListedCusip>().AsQueryable();
+    }
+
+    public CommonStockListedCusip AddListedCusip(CommonStockListedCusip listedCusip)
+    {
+        DbContext.Set<CommonStockListedCusip>().Add(listedCusip);
+        return listedCusip;
+    }
+
+    /// <summary>
     /// Retired primary tickers recorded when the SEC sync renamed a stock's symbol.
     /// Same aggregate reasoning as the CUSIP aliases: no independent lifecycle, so
     /// access lives here rather than in a dedicated repository. Consulted only on

--- a/src/Equibles.Core/Contracts/IStockPriceProvider.cs
+++ b/src/Equibles.Core/Contracts/IStockPriceProvider.cs
@@ -1,18 +1,25 @@
 namespace Equibles.Core.Contracts;
 
 /// <summary>
-/// Provides stock closing prices by (CommonStockId, Date).
+/// Provides stock closing prices by (CommonStockId, ListedTicker, Date).
 /// If the exact date is not a trading day, implementations should return
 /// the closest prior trading day's price.
 /// </summary>
 public interface IStockPriceProvider
 {
     /// <summary>
-    /// Batch-fetches closing prices for the requested (stock, date) pairs.
-    /// Returns only pairs where a price was found.
+    /// Batch-fetches closing prices for the requested (stock, listing, date) triples.
+    /// Returns only triples where a price was found, keyed exactly as requested.
+    /// <para>
+    /// A null <c>ListedTicker</c> means the filer's current PRIMARY listing. A non-null
+    /// value names one of the filer's other listed securities (a sibling share class,
+    /// unit, or fund series) and must be priced from that exact series — sibling classes
+    /// trade at their own prices (BRK-A ≈ 1500× BRK-B), so substituting the primary's
+    /// close is never acceptable.
+    /// </para>
     /// </summary>
-    Task<Dictionary<(Guid CommonStockId, DateOnly Date), decimal>> GetClosingPrices(
-        IEnumerable<(Guid CommonStockId, DateOnly Date)> requests,
+    Task<Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal>> GetClosingPrices(
+        IEnumerable<(Guid CommonStockId, string ListedTicker, DateOnly Date)> requests,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -18,6 +18,7 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
                 h.ShareType,
                 h.OptionType,
                 h.FilingType,
+                h.ListedTicker,
             })
             .IsUnique()
             .AreNullsDistinct(false);

--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
@@ -70,6 +70,23 @@ public class InstitutionalHolding
     [MaxLength(9)]
     public string Cusip { get; set; }
 
+    /// <summary>
+    /// The exact listed security this position is in, when the filed CUSIP resolved to
+    /// one of the filer's SECONDARY listings (a sibling share class, unit, or fund
+    /// series — <c>CommonStockListedCusip</c>). Null when the CUSIP resolved to the
+    /// primary security or one of its retired aliases — the overwhelming majority, so
+    /// existing rows keep meaning "the primary class" without a rewrite.
+    /// </summary>
+    /// <remarks>
+    /// Part of the position's identity: it joins the unique upsert key (nulls not
+    /// distinct) so GOOGL and GOOG positions held by one filer in one quarter are two
+    /// rows instead of a silent merge. Aggregating surfaces that sum a stock's
+    /// holdings now include every class; per-row surfaces should display the class
+    /// when this is non-null.
+    /// </remarks>
+    [MaxLength(32)]
+    public string ListedTicker { get; set; }
+
     [MaxLength(32)]
     public string AccessionNumber { get; set; }
 

--- a/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
@@ -47,8 +47,15 @@ public class ProcessedDataSet
     /// split this way. The re-import credits each leg to the first referenced
     /// manager and keeps the raw list on SharedManagerNumbers, healing the
     /// sets version 5 imported with the nulled legs.
+    /// Version 7: resolve sibling-listing CUSIPs to their exact listed ticker
+    /// (#4247). CUSIPs of a filer's OTHER listed securities (Alphabet Class C at
+    /// 02079K107 beside GOOGL's 02079K305) matched nothing, so every such 13F
+    /// line was dropped at import — Alphabet's institutional ownership was
+    /// missing its entire Class C side. The re-import maps them through
+    /// CommonStockListedCusip, keys the rows by (…, ListedTicker), and values
+    /// them from the class's own exact price series.
     /// </summary>
-    public const int CurrentParserVersion = 6;
+    public const int CurrentParserVersion = 7;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 

--- a/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
+++ b/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
@@ -4,6 +4,13 @@ using Equibles.Holdings.HostedService.Services;
 
 namespace Equibles.Holdings.HostedService.Models;
 
+/// <summary>
+/// The exact security a filed CUSIP resolves to: the filer's <see cref="CommonStockId"/>,
+/// plus the listed ticker when the CUSIP identifies one of the filer's SECONDARY listings.
+/// Null <see cref="ListedTicker"/> = the primary security (or a retired alias of it).
+/// </summary>
+public readonly record struct CusipTarget(Guid CommonStockId, string ListedTicker);
+
 public class ImportContext
 {
     // Immutable inputs
@@ -14,7 +21,12 @@ public class ImportContext
     // Populated by phases
     public Dictionary<string, SubmissionRow> Submissions { get; set; }
     public Dictionary<string, CoverPageRow> CoverPages { get; set; }
-    public Dictionary<string, Guid> CusipMapping { get; set; }
+
+    // CUSIP → the exact security it identifies: the filer row plus the listed ticker when
+    // the CUSIP belongs to one of the filer's SECONDARY listings (null = the primary or a
+    // retired alias of it). The listing is part of the position's identity — GOOGL and
+    // GOOG lines must never merge — so it rides the mapping from resolution to upsert.
+    public Dictionary<string, CusipTarget> CusipMapping { get; set; }
     public Dictionary<string, Guid> CikToHolderId { get; set; }
 
     // Summary-page other managers (the positions this filing reports on behalf of):
@@ -34,8 +46,15 @@ public class ImportContext
     // whole (reportDate, filingType) slice.
     public Dictionary<string, HashSet<Guid>> ScheduleAccessionStockIds { get; set; } = [];
 
-    // Yahoo stock prices: (CommonStockId, ReportDate) → closing price
-    public Dictionary<(Guid, DateOnly), decimal> StockPrices { get; set; } = [];
+    // Yahoo stock prices: (CommonStockId, ListedTicker, ReportDate) → closing price. The
+    // listing (null = primary series) is load-bearing: a sibling class trades at its own
+    // price, and BRK-A priced at the BRK-B close is off by ~1500x with no guard firing.
+    public Dictionary<(Guid, string, DateOnly), decimal> StockPrices { get; set; } = [];
+
+    // CommonStockId → current primary ticker for every mapped stock. HoldingValueBasis needs it
+    // to decide which splits belong to a position's own series: captured splits are attributed
+    // to the primary's symbol, while legacy rows carry no attribution at all.
+    public Dictionary<Guid, string> PrimaryTickers { get; set; } = [];
 
     // Issuer size: CommonStockId → (shares outstanding, market capitalization). Used only to
     // reject a position larger than the company it is in (ImpossiblePositionGuard); a stock

--- a/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
+++ b/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
@@ -44,7 +44,7 @@ public class ImportContext
     // of the issuer(s) the filing reports. A 13D/G covers a single issuer, so its
     // amendment delete must be scoped to that issuer rather than the holder's
     // whole (reportDate, filingType) slice.
-    public Dictionary<string, HashSet<Guid>> ScheduleAccessionStockIds { get; set; } = [];
+    public Dictionary<string, HashSet<CusipTarget>> ScheduleAccessionTargets { get; set; } = [];
 
     // Yahoo stock prices: (CommonStockId, ListedTicker, ReportDate) → closing price. The
     // listing (null = primary series) is load-bearing: a sibling class trades at its own
@@ -55,6 +55,11 @@ public class ImportContext
     // to decide which splits belong to a position's own series: captured splits are attributed
     // to the primary's symbol, while legacy rows carry no attribution at all.
     public Dictionary<Guid, string> PrimaryTickers { get; set; } = [];
+
+    // CommonStockId → current secondary tickers. HoldingValueBasis uses it to tell a split
+    // attributed to a KNOWN sibling listing (moves nothing for the primary) from one carrying
+    // a stale symbol after a primary rename (unknown basis — the row stays pending).
+    public Dictionary<Guid, List<string>> SecondaryTickers { get; set; } = [];
 
     // Issuer size: CommonStockId → (shares outstanding, market capitalization). Used only to
     // reject a position larger than the company it is in (ImpossiblePositionGuard); a stock

--- a/src/Equibles.Holdings.HostedService/Services/Corrupt13FShareCountRepairer.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Corrupt13FShareCountRepairer.cs
@@ -58,7 +58,7 @@ internal static class Corrupt13FShareCountRepairer
     /// </summary>
     internal static Corrupt13FRepairOutcome Repair(
         List<BufferedHoldingRow> rows,
-        IReadOnlyDictionary<(Guid StockId, DateOnly ReportDate), decimal> stockPrices
+        IReadOnlyDictionary<(Guid StockId, string ListedTicker, DateOnly ReportDate), decimal> stockPrices
     )
     {
         var repaired = 0;
@@ -78,7 +78,7 @@ internal static class Corrupt13FShareCountRepairer
 
             if (
                 stockPrices.TryGetValue(
-                    (holding.CommonStockId, holding.ReportDate),
+                    (holding.CommonStockId, holding.ListedTicker, holding.ReportDate),
                     out var closePrice
                 )
                 && closePrice > 0

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueBasis.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueBasis.cs
@@ -57,6 +57,7 @@ internal static class HoldingValueBasis
         IReadOnlyList<StockSplit> splits,
         string listedTicker,
         string primaryTicker,
+        IReadOnlyCollection<string> secondaryTickers,
         out decimal shareCountFactor
     )
     {
@@ -78,19 +79,37 @@ internal static class HoldingValueBasis
                 continue;
             }
 
-            var belongsToSeries = split.PriceSeriesTicker == null
-                ? listedTicker == null
-                : string.Equals(
-                    split.PriceSeriesTicker,
-                    positionSeries,
-                    StringComparison.OrdinalIgnoreCase
-                );
+            var belongsToSeries =
+                split.PriceSeriesTicker == null
+                    ? listedTicker == null
+                    : string.Equals(
+                        split.PriceSeriesTicker,
+                        positionSeries,
+                        StringComparison.OrdinalIgnoreCase
+                    );
             if (!belongsToSeries)
             {
-                // Another listing of the same issuer split after the report date. For the
-                // primary that split moves nothing here; for a secondary it means the class's
-                // own basis cannot be established from stored data — stay pending.
+                // Another listing of the same issuer split after the report date: for a
+                // secondary it means the class's own basis cannot be established from
+                // stored data — stay pending.
                 if (listedTicker != null)
+                {
+                    return false;
+                }
+
+                // For the primary, a split attributed to a KNOWN sibling listing moves
+                // nothing here. But an attribution matching neither the current primary
+                // nor any current secondary is a stale symbol (the primary renamed after
+                // capture, and the attribution is preserved verbatim) — that split very
+                // likely IS this series' own, so silently skipping it re-creates the
+                // ratio-sized error this class exists to prevent. Unknown basis: pending.
+                var attributedToKnownSibling =
+                    secondaryTickers != null
+                    && secondaryTickers.Contains(
+                        split.PriceSeriesTicker,
+                        StringComparer.OrdinalIgnoreCase
+                    );
+                if (!attributedToKnownSibling)
                 {
                     return false;
                 }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueBasis.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueBasis.cs
@@ -40,10 +40,23 @@ internal static class HoldingValueBasis
     /// move the count has not had its price adjustment applied yet, meaning the stored prices
     /// straddle two bases and no honest value can be derived; <paramref name="shareCountFactor"/>
     /// is then 1 and must not be used.
+    /// <para>
+    /// <paramref name="listedTicker"/> names the exact security being valued; null is the
+    /// filer's primary (<paramref name="primaryTicker"/>). A PRIMARY position uses every split
+    /// captured from its own series — unattributed legacy rows included, since only the primary
+    /// series could produce them. A SECONDARY position's count may only be moved by splits
+    /// attributed to that listing — and while ANY post-report split of the issuer is attributed
+    /// elsewhere (or to no listing), the class's own split history is unknowable from stored
+    /// data, so the row honestly stays pending rather than getting a value that assumes the
+    /// classes split together. Per-class split capture is the deferred follow-up that drains
+    /// those pendings.
+    /// </para>
     /// </summary>
     internal static bool TryResolveShareCountFactor(
         DateOnly reportDate,
         IReadOnlyList<StockSplit> splits,
+        string listedTicker,
+        string primaryTicker,
         out decimal shareCountFactor
     )
     {
@@ -54,6 +67,7 @@ internal static class HoldingValueBasis
             return true;
         }
 
+        var positionSeries = listedTicker ?? primaryTicker;
         var factor = 1m;
         foreach (var split in splits)
         {
@@ -61,6 +75,25 @@ internal static class HoldingValueBasis
             // comparison is strict — the same boundary SplitAdjustment.ShareCountFactor uses.
             if (split.EffectiveDate <= reportDate)
             {
+                continue;
+            }
+
+            var belongsToSeries = split.PriceSeriesTicker == null
+                ? listedTicker == null
+                : string.Equals(
+                    split.PriceSeriesTicker,
+                    positionSeries,
+                    StringComparison.OrdinalIgnoreCase
+                );
+            if (!belongsToSeries)
+            {
+                // Another listing of the same issuer split after the report date. For the
+                // primary that split moves nothing here; for a secondary it means the class's
+                // own basis cannot be established from stored data — stay pending.
+                if (listedTicker != null)
+                {
+                    return false;
+                }
                 continue;
             }
 

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -476,15 +476,42 @@ public class HoldingsImportService
             .ToListAsync(cancellationToken);
 
         // Precedence on a collision (defended against at write time, kept coherent here):
-        // the primary CUSIP wins over a retired alias, which wins over a listing claim.
+        // the primary CUSIP wins over a retired alias, which wins over a listing claim —
+        // EXCEPT when a CUSIP is claimed as both an alias and a listing. An alias maps to
+        // the primary series and a listing to a different security, so preferring either
+        // silently merges two securities' positions; the CUSIP is dropped instead (its
+        // lines accrue as unmapped) until the write-time guards converge the tables.
         var cusipMapping = new Dictionary<string, CusipTarget>(StringComparer.OrdinalIgnoreCase);
         foreach (var listed in listedCusips)
         {
-            cusipMapping[listed.Cusip] = new CusipTarget(listed.CommonStockId, listed.ListedTicker);
+            var listedTicker = string.IsNullOrWhiteSpace(listed.ListedTicker)
+                ? null
+                : listed.ListedTicker;
+            cusipMapping[listed.Cusip] = new CusipTarget(listed.CommonStockId, listedTicker);
         }
+        var listedClaims = new HashSet<string>(
+            listedCusips.Select(l => l.Cusip),
+            StringComparer.OrdinalIgnoreCase
+        );
+        var contested = new List<string>();
         foreach (var alias in cusipAliases)
         {
+            if (listedClaims.Contains(alias.Cusip))
+            {
+                contested.Add(alias.Cusip);
+                cusipMapping.Remove(alias.Cusip);
+                continue;
+            }
             cusipMapping[alias.Cusip] = new CusipTarget(alias.CommonStockId, null);
+        }
+        if (contested.Count > 0)
+        {
+            _logger.LogWarning(
+                "Dropped {Count} CUSIP(s) claimed as both a retired alias and a secondary "
+                    + "listing ({Cusips}) — resolving either way would merge two securities",
+                contested.Count,
+                string.Join(", ", contested)
+            );
         }
         foreach (var stock in stocksWithCusip)
         {
@@ -510,20 +537,30 @@ public class HoldingsImportService
         context.CusipMapping = cusipMapping;
         var mappedStockIds = cusipMapping.Values.Select(t => t.CommonStockId).Distinct().ToList();
         context.IssuerSizes = await LoadIssuerSizes(stockRepo, mappedStockIds, cancellationToken);
-        context.PrimaryTickers = await stockRepo
+        var tickerIdentities = await stockRepo
             .GetByIds(mappedStockIds)
-            .Select(cs => new { cs.Id, cs.Ticker })
-            .ToDictionaryAsync(cs => cs.Id, cs => cs.Ticker, cancellationToken);
+            .Select(cs => new
+            {
+                cs.Id,
+                cs.Ticker,
+                cs.SecondaryTickers,
+            })
+            .ToListAsync(cancellationToken);
+        context.PrimaryTickers = tickerIdentities.ToDictionary(cs => cs.Id, cs => cs.Ticker);
+        context.SecondaryTickers = tickerIdentities.ToDictionary(
+            cs => cs.Id,
+            cs => cs.SecondaryTickers ?? []
+        );
 
         foreach (var (accession, cusips) in scheduleCusipsByAccession)
         {
-            var stockIds = new HashSet<Guid>();
+            var targets = new HashSet<CusipTarget>();
             foreach (var cusip in cusips)
             {
                 if (cusipMapping.TryGetValue(cusip, out var target))
-                    stockIds.Add(target.CommonStockId);
+                    targets.Add(target);
             }
-            context.ScheduleAccessionStockIds[accession] = stockIds;
+            context.ScheduleAccessionTargets[accession] = targets;
         }
 
         return CusipMappingOutcome.Mapped;
@@ -1317,31 +1354,45 @@ public class HoldingsImportService
                 );
 
             // A 13F restatement replaces the holder's whole portfolio for the
-            // quarter, but a Schedule 13D/G filing covers a SINGLE issuer — its
-            // delete must be scoped to the issuer(s) the amendment itself
-            // reports. Passive filers amend many issuers with the same event
-            // date (year/quarter end); an unscoped delete let each 13G/A wipe
-            // every other issuer's stake at that date, and since the wiped
+            // quarter, but a Schedule 13D/G filing covers a SINGLE security — its
+            // delete must be scoped to the exact (issuer, listing) pairs the
+            // amendment itself reports, not the whole issuer. Passive filers
+            // amend many issuers with the same event date (year/quarter end);
+            // an unscoped delete let each 13G/A wipe every other issuer's stake
+            // at that date, and a stock-grained one wipes the SIBLING CLASS's
+            // stake when a filer holds two classes — and since the wiped
             // accessions stay recorded as processed and no bulk data set exists
-            // for 13D/G, the loss was permanent and silent.
+            // for 13D/G, either loss is permanent and silent.
+            var deleted = 0;
             if (filingType != FilingType.Form13F)
             {
                 if (
-                    !context.ScheduleAccessionStockIds.TryGetValue(accession, out var issuerStocks)
-                    || issuerStocks.Count == 0
+                    !context.ScheduleAccessionTargets.TryGetValue(accession, out var issuerTargets)
+                    || issuerTargets.Count == 0
                 )
                     continue;
 
-                var issuerStockIds = issuerStocks.ToList();
-                existingQuery = existingQuery.Where(h => issuerStockIds.Contains(h.CommonStockId));
+                foreach (var target in issuerTargets)
+                {
+                    // One DELETE per (issuer, listing) pair — an accession names one
+                    // security, at most a handful. A null listing compares as IS NULL.
+                    deleted += await existingQuery
+                        .Where(h =>
+                            h.CommonStockId == target.CommonStockId
+                            && h.ListedTicker == target.ListedTicker
+                        )
+                        .ExecuteDeleteAsync(cancellationToken);
+                }
             }
-
-            // Set-based delete: materialising a large filer's whole portfolio
-            // into the change tracker (and deleting row-by-id) accumulated
-            // hundreds of thousands of tracked entities across a bulk data
-            // set's restatements; one DELETE statement per amendment does the
-            // same work with zero materialisation.
-            var deleted = await existingQuery.ExecuteDeleteAsync(cancellationToken);
+            else
+            {
+                // Set-based delete: materialising a large filer's whole portfolio
+                // into the change tracker (and deleting row-by-id) accumulated
+                // hundreds of thousands of tracked entities across a bulk data
+                // set's restatements; one DELETE statement per amendment does the
+                // same work with zero materialisation.
+                deleted = await existingQuery.ExecuteDeleteAsync(cancellationToken);
+            }
 
             if (deleted > 0)
             {
@@ -1653,11 +1704,13 @@ public class HoldingsImportService
         // conservative rule while per-class split capture does not exist yet.
         context.StockSplits.TryGetValue(commonStockId, out var splits);
         context.PrimaryTickers.TryGetValue(commonStockId, out var primaryTicker);
+        context.SecondaryTickers.TryGetValue(commonStockId, out var secondaryTickers);
         var basisKnown = HoldingValueBasis.TryResolveShareCountFactor(
             reportDate,
             splits,
             target.ListedTicker,
             primaryTicker,
+            secondaryTickers,
             out var shareCountFactor
         );
         var canValue = hasPrice && basisKnown;

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -459,20 +459,43 @@ public class HoldingsImportService
             .Select(a => new { a.CommonStockId, a.Cusip })
             .ToListAsync(cancellationToken);
 
-        var cusipMapping = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
+        // The filer's OTHER listed securities (sibling share classes, units) carry their own
+        // CUSIPs. They resolve to the same filer row but keep the listed ticker: the class is
+        // part of the position's identity, and the exact price series it must be valued from.
+        var listedCusips = await stockRepo
+            .GetListedCusips()
+            .Where(l =>
+                uniqueCusipsList.Contains(l.Cusip) && stockIdsQuery.Contains(l.CommonStockId)
+            )
+            .Select(l => new
+            {
+                l.CommonStockId,
+                l.ListedTicker,
+                l.Cusip,
+            })
+            .ToListAsync(cancellationToken);
+
+        // Precedence on a collision (defended against at write time, kept coherent here):
+        // the primary CUSIP wins over a retired alias, which wins over a listing claim.
+        var cusipMapping = new Dictionary<string, CusipTarget>(StringComparer.OrdinalIgnoreCase);
+        foreach (var listed in listedCusips)
+        {
+            cusipMapping[listed.Cusip] = new CusipTarget(listed.CommonStockId, listed.ListedTicker);
+        }
         foreach (var alias in cusipAliases)
         {
-            cusipMapping[alias.Cusip] = alias.CommonStockId;
+            cusipMapping[alias.Cusip] = new CusipTarget(alias.CommonStockId, null);
         }
         foreach (var stock in stocksWithCusip)
         {
-            cusipMapping[stock.Cusip] = stock.Id;
+            cusipMapping[stock.Cusip] = new CusipTarget(stock.Id, null);
         }
 
         _logger.LogInformation(
-            "Mapped {Count} CUSIPs to tracked stocks ({AliasCount} retired aliases, out of {Total} in data set)",
+            "Mapped {Count} CUSIPs to tracked stocks ({AliasCount} retired aliases, {ListedCount} secondary listings, out of {Total} in data set)",
             cusipMapping.Count,
             cusipAliases.Count,
+            listedCusips.Count,
             uniqueCusips.Count
         );
 
@@ -485,19 +508,20 @@ public class HoldingsImportService
         }
 
         context.CusipMapping = cusipMapping;
-        context.IssuerSizes = await LoadIssuerSizes(
-            stockRepo,
-            cusipMapping.Values.Distinct().ToList(),
-            cancellationToken
-        );
+        var mappedStockIds = cusipMapping.Values.Select(t => t.CommonStockId).Distinct().ToList();
+        context.IssuerSizes = await LoadIssuerSizes(stockRepo, mappedStockIds, cancellationToken);
+        context.PrimaryTickers = await stockRepo
+            .GetByIds(mappedStockIds)
+            .Select(cs => new { cs.Id, cs.Ticker })
+            .ToDictionaryAsync(cs => cs.Id, cs => cs.Ticker, cancellationToken);
 
         foreach (var (accession, cusips) in scheduleCusipsByAccession)
         {
             var stockIds = new HashSet<Guid>();
             foreach (var cusip in cusips)
             {
-                if (cusipMapping.TryGetValue(cusip, out var stockId))
-                    stockIds.Add(stockId);
+                if (cusipMapping.TryGetValue(cusip, out var target))
+                    stockIds.Add(target.CommonStockId);
             }
             context.ScheduleAccessionStockIds[accession] = stockIds;
         }
@@ -546,9 +570,13 @@ public class HoldingsImportService
                 reportDates.Add(date);
         }
 
-        var stockIds = context.CusipMapping.Values.Distinct().ToList();
+        var listings = context.CusipMapping.Values.Distinct().ToList();
 
-        var requests = reportDates.SelectMany(date => stockIds.Select(id => (id, date))).ToList();
+        var requests = reportDates
+            .SelectMany(date =>
+                listings.Select(listing => (listing.CommonStockId, listing.ListedTicker, date))
+            )
+            .ToList();
 
         context.StockPrices = await _stockPriceProvider.GetClosingPrices(
             requests,
@@ -570,7 +598,7 @@ public class HoldingsImportService
     /// </summary>
     private async Task BuildSplitMap(ImportContext context, CancellationToken cancellationToken)
     {
-        var stockIds = context.CusipMapping.Values.Distinct().ToList();
+        var stockIds = context.CusipMapping.Values.Select(t => t.CommonStockId).Distinct().ToList();
 
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
@@ -1421,7 +1449,7 @@ public class HoldingsImportService
                 continue;
 
             var cusip = GetValue(row, "CUSIP");
-            if (!context.CusipMapping.TryGetValue(cusip, out var commonStockId))
+            if (!context.CusipMapping.TryGetValue(cusip, out var target))
             {
                 totalSkipped++;
                 RecordUnmappedCusip(context, row, cusip, accession, submission);
@@ -1438,7 +1466,7 @@ public class HoldingsImportService
                 row,
                 accession,
                 cusip,
-                commonStockId,
+                target,
                 holderId,
                 filingDate,
                 reportDate,
@@ -1587,13 +1615,14 @@ public class HoldingsImportService
         Dictionary<string, string> row,
         string accession,
         string cusip,
-        Guid commonStockId,
+        CusipTarget target,
         Guid holderId,
         DateOnly filingDate,
         DateOnly reportDate,
         ImportContext context
     )
     {
+        var commonStockId = target.CommonStockId;
         var shareType = ParseShareType(GetValue(row, "SSHPRNAMTTYPE"));
         var optionType = ParseOptionType(GetValue(row, "PUTCALL"));
 
@@ -1613,17 +1642,22 @@ public class HoldingsImportService
         var votingAuthNone = ParseLongField("VOTING_AUTH_NONE");
 
         var hasPrice = context.StockPrices.TryGetValue(
-            (commonStockId, reportDate),
+            (commonStockId, target.ListedTicker, reportDate),
             out var closePrice
         );
         // The count is quoted as of the report date while the stored price is on today's
         // post-split basis, so the count has to be restated before the two are multiplied. While a
         // captured split is still awaiting its price adjustment the series straddles both bases and
-        // no honest value exists — the row stays pending for the repricing lane.
+        // no honest value exists — the row stays pending for the repricing lane. For a SECONDARY
+        // listing the factor must come from that class's own splits; see HoldingValueBasis for the
+        // conservative rule while per-class split capture does not exist yet.
         context.StockSplits.TryGetValue(commonStockId, out var splits);
+        context.PrimaryTickers.TryGetValue(commonStockId, out var primaryTicker);
         var basisKnown = HoldingValueBasis.TryResolveShareCountFactor(
             reportDate,
             splits,
+            target.ListedTicker,
+            primaryTicker,
             out var shareCountFactor
         );
         var canValue = hasPrice && basisKnown;
@@ -1728,6 +1762,7 @@ public class HoldingsImportService
             VotingAuthNone = votingAuthNone,
             TitleOfClass = GetValue(row, "TITLEOFCLASS"),
             Cusip = cusip,
+            ListedTicker = target.ListedTicker,
             AccessionNumber = accession,
             IsAmendment = isAmendment,
             ValueUnavailable = valueUnavailable,
@@ -1786,6 +1821,7 @@ public class HoldingsImportService
                 h.ShareType,
                 h.OptionType,
                 h.FilingType,
+                h.ListedTicker,
             })
             .WhenMatched(
                 (existing, incoming) =>
@@ -1997,9 +2033,10 @@ public class HoldingsImportService
         DateOnly reportDate,
         ShareType shareType,
         OptionType? optionType,
-        FilingType filingType
+        FilingType filingType,
+        string listedTicker
     ) =>
-        $"{commonStockId}|{institutionalHolderId}|{reportDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}|{(int)shareType}|{optionType?.ToString() ?? ""}|{(int)filingType}";
+        $"{commonStockId}|{institutionalHolderId}|{reportDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}|{(int)shareType}|{optionType?.ToString() ?? ""}|{(int)filingType}|{listedTicker ?? ""}";
 
     private static string BuildHoldingKey(InstitutionalHolding h) =>
         BuildHoldingKey(
@@ -2008,7 +2045,8 @@ public class HoldingsImportService
             h.ReportDate,
             h.ShareType,
             h.OptionType,
-            h.FilingType
+            h.FilingType,
+            h.ListedTicker
         );
 
     private static bool IsYes(string raw) =>

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Contracts;
 using Equibles.CorporateActions.Data.Models;
@@ -49,7 +50,12 @@ public class HoldingsValueRecalculator
         var pendingPairs = await lookupContext
             .Set<InstitutionalHolding>()
             .Where(h => h.ValuePending)
-            .Select(h => new { h.CommonStockId, h.ReportDate })
+            .Select(h => new
+            {
+                h.CommonStockId,
+                h.ListedTicker,
+                h.ReportDate,
+            })
             .Distinct()
             .ToListAsync(cancellationToken);
 
@@ -60,11 +66,13 @@ public class HoldingsValueRecalculator
         }
 
         _logger.LogInformation(
-            "Found {Count} (stock, date) pairs with pending values",
+            "Found {Count} (stock, listing, date) pairs with pending values",
             pendingPairs.Count
         );
 
-        var requests = pendingPairs.Select(p => (p.CommonStockId, p.ReportDate)).ToList();
+        var requests = pendingPairs
+            .Select(p => (p.CommonStockId, p.ListedTicker, p.ReportDate))
+            .ToList();
         var prices = await _stockPriceProvider.GetClosingPrices(requests, cancellationToken);
 
         _logger.LogInformation(
@@ -87,10 +95,16 @@ public class HoldingsValueRecalculator
         )
             .GroupBy(s => s.CommonStockId)
             .ToDictionary(g => g.Key, g => g.ToList());
+        var primaryTickers = await lookupContext
+            .Set<CommonStock>()
+            .Where(cs => pendingStockIds.Contains(cs.Id))
+            .Select(cs => new { cs.Id, cs.Ticker })
+            .ToDictionaryAsync(cs => cs.Id, cs => cs.Ticker, cancellationToken);
 
         var (totalUpdated, totalDeferred) = await ResolveHoldingsWithNewPrices(
             prices,
             splitsByStock,
+            primaryTickers,
             cancellationToken
         );
 
@@ -103,8 +117,8 @@ public class HoldingsValueRecalculator
         }
 
         var unresolvedPairs = pendingPairs
-            .Where(p => !resolvedPairKeys.Contains((p.CommonStockId, p.ReportDate)))
-            .Select(p => (p.CommonStockId, p.ReportDate))
+            .Where(p => !resolvedPairKeys.Contains((p.CommonStockId, p.ListedTicker, p.ReportDate)))
+            .Select(p => (p.CommonStockId, p.ListedTicker, p.ReportDate))
             .ToList();
 
         var totalGivenUp = await IncrementRetryForUnresolved(
@@ -121,7 +135,7 @@ public class HoldingsValueRecalculator
     }
 
     private async Task<int> IncrementRetryForUnresolved(
-        IReadOnlyList<(Guid CommonStockId, DateOnly ReportDate)> unresolvedPairs,
+        IReadOnlyList<(Guid CommonStockId, string ListedTicker, DateOnly ReportDate)> unresolvedPairs,
         DateTime now,
         CancellationToken cancellationToken
     )
@@ -139,6 +153,7 @@ public class HoldingsValueRecalculator
                 .Where(h =>
                     h.ValuePending
                     && h.CommonStockId == pair.CommonStockId
+                    && h.ListedTicker == pair.ListedTicker
                     && h.ReportDate == pair.ReportDate
                 )
                 .ToListAsync(cancellationToken);
@@ -174,22 +189,26 @@ public class HoldingsValueRecalculator
     }
 
     private async Task<(int Updated, int Deferred)> ResolveHoldingsWithNewPrices(
-        Dictionary<(Guid CommonStockId, DateOnly Date), decimal> prices,
+        Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal> prices,
         Dictionary<Guid, List<StockSplit>> splitsByStock,
+        Dictionary<Guid, string> primaryTickers,
         CancellationToken cancellationToken
     )
     {
         var totalUpdated = 0;
         var totalDeferred = 0;
-        foreach (var ((stockId, reportDate), closePrice) in prices)
+        foreach (var ((stockId, listedTicker, reportDate), closePrice) in prices)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             splitsByStock.TryGetValue(stockId, out var splits);
+            primaryTickers.TryGetValue(stockId, out var primaryTicker);
             if (
                 !HoldingValueBasis.TryResolveShareCountFactor(
                     reportDate,
                     splits,
+                    listedTicker,
+                    primaryTicker,
                     out var shareCountFactor
                 )
             )
@@ -208,7 +227,10 @@ public class HoldingsValueRecalculator
                 .Set<InstitutionalHolding>()
                 .Include(h => h.ManagerEntries)
                 .Where(h =>
-                    h.ValuePending && h.CommonStockId == stockId && h.ReportDate == reportDate
+                    h.ValuePending
+                    && h.CommonStockId == stockId
+                    && h.ListedTicker == listedTicker
+                    && h.ReportDate == reportDate
                 )
                 .ToListAsync(cancellationToken);
 

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
@@ -95,16 +95,27 @@ public class HoldingsValueRecalculator
         )
             .GroupBy(s => s.CommonStockId)
             .ToDictionary(g => g.Key, g => g.ToList());
-        var primaryTickers = await lookupContext
+        var tickerIdentities = await lookupContext
             .Set<CommonStock>()
             .Where(cs => pendingStockIds.Contains(cs.Id))
-            .Select(cs => new { cs.Id, cs.Ticker })
-            .ToDictionaryAsync(cs => cs.Id, cs => cs.Ticker, cancellationToken);
+            .Select(cs => new
+            {
+                cs.Id,
+                cs.Ticker,
+                cs.SecondaryTickers,
+            })
+            .ToListAsync(cancellationToken);
+        var primaryTickers = tickerIdentities.ToDictionary(cs => cs.Id, cs => cs.Ticker);
+        var secondaryTickers = tickerIdentities.ToDictionary(
+            cs => cs.Id,
+            cs => cs.SecondaryTickers ?? []
+        );
 
         var (totalUpdated, totalDeferred) = await ResolveHoldingsWithNewPrices(
             prices,
             splitsByStock,
             primaryTickers,
+            secondaryTickers,
             cancellationToken
         );
 
@@ -135,7 +146,11 @@ public class HoldingsValueRecalculator
     }
 
     private async Task<int> IncrementRetryForUnresolved(
-        IReadOnlyList<(Guid CommonStockId, string ListedTicker, DateOnly ReportDate)> unresolvedPairs,
+        IReadOnlyList<(
+            Guid CommonStockId,
+            string ListedTicker,
+            DateOnly ReportDate
+        )> unresolvedPairs,
         DateTime now,
         CancellationToken cancellationToken
     )
@@ -192,6 +207,7 @@ public class HoldingsValueRecalculator
         Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal> prices,
         Dictionary<Guid, List<StockSplit>> splitsByStock,
         Dictionary<Guid, string> primaryTickers,
+        Dictionary<Guid, List<string>> secondaryTickersByStock,
         CancellationToken cancellationToken
     )
     {
@@ -203,12 +219,14 @@ public class HoldingsValueRecalculator
 
             splitsByStock.TryGetValue(stockId, out var splits);
             primaryTickers.TryGetValue(stockId, out var primaryTicker);
+            secondaryTickersByStock.TryGetValue(stockId, out var secondaryTickers);
             if (
                 !HoldingValueBasis.TryResolveShareCountFactor(
                     reportDate,
                     splits,
                     listedTicker,
                     primaryTicker,
+                    secondaryTickers,
                     out var shareCountFactor
                 )
             )

--- a/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
@@ -68,6 +68,7 @@ public class ImpossiblePositionRepairService
                     {
                         Holding = h,
                         cs.Ticker,
+                        cs.SecondaryTickers,
                         cs.SharesOutStanding,
                         cs.MarketCapitalization,
                     }
@@ -104,6 +105,7 @@ public class ImpossiblePositionRepairService
                     splits,
                     candidate.Holding.ListedTicker,
                     candidate.Ticker,
+                    candidate.SecondaryTickers,
                     out var shareCountFactor
                 )
             )

--- a/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
@@ -67,6 +67,7 @@ public class ImpossiblePositionRepairService
                     new
                     {
                         Holding = h,
+                        cs.Ticker,
                         cs.SharesOutStanding,
                         cs.MarketCapitalization,
                     }
@@ -101,6 +102,8 @@ public class ImpossiblePositionRepairService
                 !HoldingValueBasis.TryResolveShareCountFactor(
                     candidate.Holding.ReportDate,
                     splits,
+                    candidate.Holding.ListedTicker,
+                    candidate.Ticker,
                     out var shareCountFactor
                 )
             )

--- a/src/Equibles.Migrations/Migrations/20260805170853_PerListing13FIdentity.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260805170853_PerListing13FIdentity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805170853_PerListing13FIdentity")]
+    partial class PerListing13FIdentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260805170853_PerListing13FIdentity.cs
+++ b/src/Equibles.Migrations/Migrations/20260805170853_PerListing13FIdentity.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class PerListing13FIdentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_InstitutionalHolderId_Re~",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ListedTicker",
+                table: "InstitutionalHolding",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "CommonStockListedCusip",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ListedTicker = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Cusip = table.Column<string>(type: "character varying(9)", maxLength: 9, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CommonStockListedCusip", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CommonStockListedCusip_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_InstitutionalHolderId_Re~",
+                table: "InstitutionalHolding",
+                columns: new[] { "CommonStockId", "InstitutionalHolderId", "ReportDate", "ShareType", "OptionType", "FilingType", "ListedTicker" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStockListedCusip_CommonStockId",
+                table: "CommonStockListedCusip",
+                column: "CommonStockId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStockListedCusip_Cusip",
+                table: "CommonStockListedCusip",
+                column: "Cusip",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CommonStockListedCusip");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_InstitutionalHolderId_Re~",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.DropColumn(
+                name: "ListedTicker",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_InstitutionalHolderId_Re~",
+                table: "InstitutionalHolding",
+                columns: new[] { "CommonStockId", "InstitutionalHolderId", "ReportDate", "ShareType", "OptionType", "FilingType" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
@@ -66,5 +66,9 @@ public class FtdScraperWorker : BaseScraperWorker
         // this pipeline first ran — the live import above can only witness retirements
         // that happen while it is running.
         await ftdService.BackfillRetiredCusips(stoppingToken);
+
+        // And the sibling-listing sweep: secondary tickers' CUSIPs (share classes, units)
+        // recorded against the exact listed symbol so 13F lines filed under them resolve.
+        await ftdService.BackfillListedTickerCusips(stoppingToken);
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -163,7 +163,7 @@ public class FtdImportService
     /// </summary>
     public async Task BackfillRetiredCusips(CancellationToken cancellationToken)
     {
-        var fileNames = await NextAliasSweepFiles();
+        var fileNames = await NextSweepFiles(AliasSweepCursorName);
         if (fileNames.Count == 0)
         {
             return;
@@ -217,7 +217,7 @@ public class FtdImportService
         }
 
         var recorded = await RecordRetiredCusips(cusipsByTicker, cancellationToken);
-        await AdvanceAliasSweepFrontier(fileNames[^1]);
+        await AdvanceSweepFrontier(AliasSweepCursorName, fileNames[^1]);
 
         if (recorded > 0)
         {
@@ -227,6 +227,231 @@ public class FtdImportService
                 fileNames.Count
             );
         }
+    }
+
+    /// <summary>
+    /// Walks the FTD archive recording the CUSIPs of tracked stocks' SECONDARY listings —
+    /// sibling share classes, units, fund series — as <see cref="CommonStockListedCusip"/> rows.
+    /// <para>
+    /// The retired-CUSIP sweep above deliberately admits only PRIMARY symbols, so a sibling
+    /// class's CUSIP (Alphabet Class C, 02079K107 under symbol GOOG) was never captured and
+    /// every 13F line filed under it dropped at import. This sweep resolves the CNS feed's
+    /// symbol against the secondary-ticker space instead, pairing each hit's CUSIP with the
+    /// exact listed ticker so the holdings lane can key the class's positions separately.
+    /// </para>
+    /// <para>
+    /// Same authority and guards as the alias sweep: the SEC publishes SYMBOL and CUSIP on one
+    /// row (no name matching); a symbol that is any stock's PRIMARY ticker is left to the alias
+    /// sweep; a symbol two stocks' secondary lists collapse onto is dropped rather than guessed;
+    /// and the CUSIP must share the stock's issuer prefix, which blocks recycled symbols.
+    /// Sibling classes SHARE the issuer prefix — here that is the point, not a trap.
+    /// </para>
+    /// <para>
+    /// Own frontier (<see cref="ListedCusipSweepCursorName"/>) starting at the archive origin:
+    /// the alias sweep's cursor has already consumed the archive on long-running deployments,
+    /// and these rows were never collected on that pass.
+    /// </para>
+    /// </summary>
+    public async Task BackfillListedTickerCusips(CancellationToken cancellationToken)
+    {
+        var fileNames = await NextSweepFiles(ListedCusipSweepCursorName);
+        if (fileNames.Count == 0)
+        {
+            return;
+        }
+
+        var primaryMap = await BuildTickerMap(cancellationToken);
+        var secondaryMap = await BuildSecondaryTickerMap(primaryMap, cancellationToken);
+        if (secondaryMap.Count == 0)
+        {
+            // Nothing to resolve against — still advance so the sweep cannot wedge here.
+            await AdvanceSweepFrontier(ListedCusipSweepCursorName, fileNames[^1]);
+            return;
+        }
+
+        var strippedAliases = BuildStrippedSecondaryAliases(secondaryMap, primaryMap);
+        // stockId → (listedTicker → cusips seen for it)
+        var byStock = new Dictionary<Guid, Dictionary<string, HashSet<string>>>();
+
+        foreach (var fileName in fileNames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var records = await DownloadAndParse(fileName, cancellationToken);
+                foreach (var record in records)
+                {
+                    if (string.IsNullOrEmpty(record.Cusip) || string.IsNullOrEmpty(record.Symbol))
+                        continue;
+                    // A primary symbol is the alias sweep's business, and letting it
+                    // through here would record the primary's own CUSIP as a listing.
+                    if (primaryMap.ContainsKey(record.Symbol))
+                        continue;
+                    if (
+                        !secondaryMap.TryGetValue(record.Symbol, out var listing)
+                        && !(
+                            strippedAliases.TryGetValue(record.Symbol, out var spelled)
+                            && secondaryMap.TryGetValue(spelled, out listing)
+                        )
+                    )
+                        continue;
+
+                    if (!byStock.TryGetValue(listing.StockId, out var byTicker))
+                    {
+                        byTicker = new Dictionary<string, HashSet<string>>(
+                            StringComparer.OrdinalIgnoreCase
+                        );
+                        byStock[listing.StockId] = byTicker;
+                    }
+                    if (!byTicker.TryGetValue(listing.Ticker, out var cusips))
+                    {
+                        cusips = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        byTicker[listing.Ticker] = cusips;
+                    }
+                    cusips.Add(record.Cusip);
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                // A missing archive file costs coverage for that fortnight only; the
+                // frontier still advances so the sweep cannot wedge on one bad file.
+                _logger.LogWarning(
+                    ex,
+                    "Listed-CUSIP sweep: failed to download {File}, skipping",
+                    fileName
+                );
+            }
+        }
+
+        var recorded = await RecordListedCusips(byStock, cancellationToken);
+        await AdvanceSweepFrontier(ListedCusipSweepCursorName, fileNames[^1]);
+
+        if (recorded > 0)
+        {
+            _logger.LogInformation(
+                "Listed-CUSIP sweep: recorded {Count} listing CUSIP(s) across {Files} FTD file(s)",
+                recorded,
+                fileNames.Count
+            );
+        }
+    }
+
+    private async Task<int> RecordListedCusips(
+        Dictionary<Guid, Dictionary<string, HashSet<string>>> byStock,
+        CancellationToken cancellationToken
+    )
+    {
+        if (byStock.Count == 0)
+        {
+            return 0;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var stockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
+
+        var stocks = await stockRepo
+            .GetByIds(byStock.Keys)
+            .ToListAsync(cancellationToken);
+
+        var recorded = 0;
+        foreach (var stock in stocks)
+        {
+            // Without a current primary CUSIP there is no issuer prefix to anchor the
+            // recycled-symbol guard against — skip rather than record unverifiable identity.
+            if (stock.Cusip == null || !byStock.TryGetValue(stock.Id, out var byTicker))
+                continue;
+
+            var candidates = byTicker
+                .SelectMany(kv =>
+                    kv.Value.Where(c => CusipIdentity.SameIssuer(c, stock.Cusip))
+                        .Select(c => (ListedTicker: kv.Key, Cusip: c))
+                )
+                .ToList();
+            if (candidates.Count == 0)
+                continue;
+
+            recorded += await stockManager.RecordListedTickerCusips(stock, candidates);
+        }
+
+        return recorded;
+    }
+
+    /// <summary>
+    /// Secondary ticker → owning stock. A symbol that is any stock's primary ticker is
+    /// excluded (the primary space wins), and a symbol two stocks' secondary lists collapse
+    /// onto is dropped rather than guessed — same refusal the stripped-alias builder applies.
+    /// </summary>
+    private async Task<Dictionary<string, (Guid StockId, string Ticker)>> BuildSecondaryTickerMap(
+        Dictionary<string, Guid> primaryMap,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var query =
+            _workerOptions.TickersToSync?.Count > 0
+                ? stockRepo.GetByTickers(_workerOptions.TickersToSync)
+                : stockRepo.GetAll();
+        var stocks = await query
+            .Where(cs => cs.SecondaryTickers.Count > 0)
+            .Select(cs => new { cs.Id, cs.SecondaryTickers })
+            .ToListAsync(cancellationToken);
+
+        var map = new Dictionary<string, (Guid StockId, string Ticker)>(
+            StringComparer.OrdinalIgnoreCase
+        );
+        var ambiguous = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var stock in stocks)
+        {
+            foreach (var ticker in stock.SecondaryTickers.Where(t => !string.IsNullOrWhiteSpace(t)))
+            {
+                if (primaryMap.ContainsKey(ticker))
+                    continue;
+                if (!map.TryAdd(ticker, (stock.Id, ticker)) && map[ticker].StockId != stock.Id)
+                    ambiguous.Add(ticker);
+            }
+        }
+
+        foreach (var key in ambiguous)
+            map.Remove(key);
+
+        return map;
+    }
+
+    /// <summary>
+    /// CNS separator-stripped spellings of the secondary tickers ("BRKA" → "BRK-A"), never
+    /// shadowing a real primary or secondary symbol, ambiguous collapses dropped — the same
+    /// rules <see cref="BuildStrippedTickerAliases"/> applies to the primary space.
+    /// </summary>
+    private static Dictionary<string, string> BuildStrippedSecondaryAliases(
+        Dictionary<string, (Guid StockId, string Ticker)> secondaryMap,
+        Dictionary<string, Guid> primaryMap
+    )
+    {
+        var aliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var ambiguous = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var ticker in secondaryMap.Keys)
+        {
+            var stripped = string.Concat(ticker.Where(char.IsLetterOrDigit));
+            if (
+                stripped.Length == 0
+                || string.Equals(stripped, ticker, StringComparison.OrdinalIgnoreCase)
+            )
+                continue;
+            if (primaryMap.ContainsKey(stripped) || secondaryMap.ContainsKey(stripped))
+                continue;
+            if (!aliases.TryAdd(stripped, ticker))
+                ambiguous.Add(stripped);
+        }
+
+        foreach (var key in ambiguous)
+            aliases.Remove(key);
+
+        return aliases;
     }
 
     private async Task<int> RecordRetiredCusips(
@@ -266,13 +491,13 @@ public class FtdImportService
         return recorded;
     }
 
-    // The sweep runs oldest-first from the start of the archive and stops once the
+    // The sweeps run oldest-first from the start of the archive and stop once their
     // frontier passes the newest file — the live import owns everything from there.
-    private async Task<List<string>> NextAliasSweepFiles()
+    private async Task<List<string>> NextSweepFiles(string cursorName)
     {
         using var scope = _scopeFactory.CreateScope();
         var stateRepo = scope.ServiceProvider.GetRequiredService<BackfillStateRepository>();
-        var state = await stateRepo.GetByName(AliasSweepCursorName);
+        var state = await stateRepo.GetByName(cursorName);
 
         var all = GetFileNames(OldestAvailableDate);
         var startIndex = 0;
@@ -291,14 +516,14 @@ public class FtdImportService
         return all.Skip(startIndex).Take(AliasSweepFilesPerCycle).ToList();
     }
 
-    private async Task AdvanceAliasSweepFrontier(string lastFileName)
+    private async Task AdvanceSweepFrontier(string cursorName, string lastFileName)
     {
         using var scope = _scopeFactory.CreateScope();
         var stateRepo = scope.ServiceProvider.GetRequiredService<BackfillStateRepository>();
-        var state = await stateRepo.GetByName(AliasSweepCursorName);
+        var state = await stateRepo.GetByName(cursorName);
         if (state == null)
         {
-            state = new BackfillState { Name = AliasSweepCursorName };
+            state = new BackfillState { Name = cursorName };
             stateRepo.Add(state);
         }
 
@@ -328,6 +553,10 @@ public class FtdImportService
     }
 
     private const string AliasSweepCursorName = "Ftd.RetiredCusipSweep";
+
+    // Separate cursor: the alias sweep's frontier has already consumed the archive on
+    // long-running deployments, and listed-CUSIP rows were never collected on that pass.
+    private const string ListedCusipSweepCursorName = "Ftd.ListedCusipSweep";
 
     // Twelve fortnightly files ≈ six months of archive per daily cycle, so the whole
     // 2017→today range is swept in about a fortnight of cycles without ever making the

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -264,8 +264,10 @@ public class FtdImportService
         var secondaryMap = await BuildSecondaryTickerMap(primaryMap, cancellationToken);
         if (secondaryMap.Count == 0)
         {
-            // Nothing to resolve against — still advance so the sweep cannot wedge here.
-            await AdvanceSweepFrontier(ListedCusipSweepCursorName, fileNames[^1]);
+            // Nothing to resolve against (fresh install, company sync not yet run). Do NOT
+            // advance: consuming the archive now would permanently skip these files' rows,
+            // and the frontier has no reset path. Wedging is already prevented per-file by
+            // the download catch below; this state clears itself once stocks exist.
             return;
         }
 
@@ -351,9 +353,7 @@ public class FtdImportService
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var stockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
 
-        var stocks = await stockRepo
-            .GetByIds(byStock.Keys)
-            .ToListAsync(cancellationToken);
+        var stocks = await stockRepo.GetByIds(byStock.Keys).ToListAsync(cancellationToken);
 
         var recorded = 0;
         foreach (var stock in stocks)

--- a/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
@@ -17,12 +17,14 @@ public class YahooStockPriceProvider : IStockPriceProvider
         _dbContext = dbContext;
     }
 
-    public async Task<Dictionary<(Guid CommonStockId, DateOnly Date), decimal>> GetClosingPrices(
-        IEnumerable<(Guid CommonStockId, DateOnly Date)> requests,
+    public async Task<
+        Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal>
+    > GetClosingPrices(
+        IEnumerable<(Guid CommonStockId, string ListedTicker, DateOnly Date)> requests,
         CancellationToken cancellationToken = default
     )
     {
-        var result = new Dictionary<(Guid, DateOnly), decimal>();
+        var result = new Dictionary<(Guid, string, DateOnly), decimal>();
         var requestList = requests.ToList();
         if (requestList.Count == 0)
             return result;
@@ -30,35 +32,64 @@ public class YahooStockPriceProvider : IStockPriceProvider
         // Group by date so we can batch-query per reporting period
         var byDate = requestList
             .GroupBy(r => r.Date)
-            .ToDictionary(g => g.Key, g => g.Select(r => r.CommonStockId).Distinct().ToList());
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(r => (r.CommonStockId, r.ListedTicker)).Distinct().ToList()
+            );
 
-        foreach (var (date, stockIds) in byDate)
+        foreach (var (date, listings) in byDate)
         {
             var minDate = date.AddDays(-LookbackDays);
+            var stockIds = listings.Select(l => l.CommonStockId).Distinct().ToList();
+            var secondaryTickers = listings
+                .Where(l => l.ListedTicker != null)
+                .Select(l => l.ListedTicker)
+                .Distinct()
+                .ToList();
 
-            // Fetch candidate prices within the lookback window
+            // One window query per date: the primary series for every requested stock, plus
+            // the exact secondary series requested. The precise (stock, listing) pairing is
+            // re-applied in memory — the small overfetch beats a per-pair query.
             var prices = await _dbContext
                 .Set<DailyStockPrice>()
                 .Where(p =>
-                    p.ListedTicker == p.CommonStock.Ticker
-                    && stockIds.Contains(p.CommonStockId)
+                    stockIds.Contains(p.CommonStockId)
+                    && (
+                        p.ListedTicker == p.CommonStock.Ticker
+                        || secondaryTickers.Contains(p.ListedTicker)
+                    )
                     && p.Date >= minDate
                     && p.Date <= date
                 )
                 .Select(p => new
                 {
                     p.CommonStockId,
+                    p.ListedTicker,
+                    PrimaryTicker = p.CommonStock.Ticker,
                     p.Date,
                     p.Close,
                 })
                 .ToListAsync(cancellationToken);
 
-            // Pick the latest price per stock
-            var latestByStock = prices.LatestPerGroup(p => p.CommonStockId, p => p.Date);
+            // Pick the latest price per exact series
+            var latestBySeries = prices.LatestPerGroup(
+                p => (p.CommonStockId, p.ListedTicker),
+                p => p.Date
+            );
+            var byRequestedListing = latestBySeries.ToDictionary(p =>
+                (
+                    p.CommonStockId,
+                    // The caller addresses the primary series as null; a secondary by its symbol.
+                    ListedTicker: p.ListedTicker == p.PrimaryTicker ? null : p.ListedTicker
+                )
+            );
 
-            foreach (var price in latestByStock)
+            foreach (var listing in listings)
             {
-                result[(price.CommonStockId, date)] = price.Close;
+                if (byRequestedListing.TryGetValue(listing, out var price))
+                {
+                    result[(listing.CommonStockId, listing.ListedTicker, date)] = price.Close;
+                }
             }
         }
 

--- a/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
@@ -41,9 +41,11 @@ public class YahooStockPriceProvider : IStockPriceProvider
         {
             var minDate = date.AddDays(-LookbackDays);
             var stockIds = listings.Select(l => l.CommonStockId).Distinct().ToList();
+            // The stored series ticker is normalized uppercase; fold the request the same way
+            // so one non-canonical spelling can't silently park a class's positions pending.
             var secondaryTickers = listings
                 .Where(l => l.ListedTicker != null)
-                .Select(l => l.ListedTicker)
+                .Select(l => l.ListedTicker.ToUpperInvariant())
                 .Distinct()
                 .ToList();
 
@@ -79,14 +81,22 @@ public class YahooStockPriceProvider : IStockPriceProvider
             var byRequestedListing = latestBySeries.ToDictionary(p =>
                 (
                     p.CommonStockId,
-                    // The caller addresses the primary series as null; a secondary by its symbol.
-                    ListedTicker: p.ListedTicker == p.PrimaryTicker ? null : p.ListedTicker
+                    // The caller addresses the primary series as null; a secondary by its
+                    // symbol, folded uppercase to match the request normalization above.
+                    ListedTicker: string.Equals(
+                        p.ListedTicker,
+                        p.PrimaryTicker,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                        ? null
+                        : p.ListedTicker.ToUpperInvariant()
                 )
             );
 
             foreach (var listing in listings)
             {
-                if (byRequestedListing.TryGetValue(listing, out var price))
+                var lookup = (listing.CommonStockId, listing.ListedTicker?.ToUpperInvariant());
+                if (byRequestedListing.TryGetValue(lookup, out var price))
                 {
                     result[(listing.CommonStockId, listing.ListedTicker, date)] = price.Close;
                 }

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerRecordListedTickerCusipsTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerRecordListedTickerCusipsTests.cs
@@ -1,0 +1,166 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging.Contracts.CommonStocks;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.CommonStocks;
+
+/// <summary>
+/// Contract for recording a secondary listing's CUSIP (#4247). A row lands in
+/// <see cref="CommonStockListedCusip"/> — NEVER in <see cref="CommonStockCusipAlias"/>,
+/// which maps to the primary series and would collapse two securities into one row.
+/// Admission: the ticker must be one of the stock's CURRENT secondary tickers, the CUSIP
+/// must not be the stock's own primary, and a CUSIP already owned anywhere (a primary,
+/// an alias, or another listing) keeps its first owner. Recording publishes the
+/// stock-identity-changed signal so the holdings ledger re-imports history.
+/// </summary>
+public class CommonStockManagerRecordListedTickerCusipsTests
+{
+    private readonly CommonStockManager _sut;
+    private readonly CommonStockRepository _repository;
+    private readonly IBus _bus;
+
+    public CommonStockManagerRecordListedTickerCusipsTests()
+    {
+        var context = TestDbContextFactory.Create(new CommonStocksModuleConfiguration());
+        _repository = new CommonStockRepository(context);
+        _bus = Substitute.For<IBus>();
+        _sut = new CommonStockManager(_repository, _bus);
+    }
+
+    private async Task<CommonStock> SeedStock(
+        string ticker,
+        string cik,
+        string cusip = null,
+        List<string> secondaryTickers = null
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Test Co",
+            Cik = cik,
+            Cusip = cusip,
+            SecondaryTickers = secondaryTickers ?? [],
+        };
+        _repository.Add(stock);
+        await _repository.SaveChanges();
+        return stock;
+    }
+
+    [Fact]
+    public async Task RecordListedTickerCusips_SiblingClassCusip_RecordsListingAndSignalsReimport()
+    {
+        // The Alphabet shape: GOOG's CUSIP recorded as a LISTING of the GOOGL filer.
+        var stock = await SeedStock(
+            "GOOGL",
+            "1652044",
+            cusip: "02079K305",
+            secondaryTickers: ["GOOG"]
+        );
+
+        var recorded = await _sut.RecordListedTickerCusips(stock, [("GOOG", "02079K107")]);
+
+        recorded.Should().Be(1);
+        var listing = await _repository.GetListedCusips().SingleAsync();
+        listing.CommonStockId.Should().Be(stock.Id);
+        listing.ListedTicker.Should().Be("GOOG");
+        listing.Cusip.Should().Be("02079K107");
+
+        // The listing must never leak into the alias table — an alias maps to the
+        // PRIMARY series, which is exactly the class collapse this table prevents.
+        (await _repository.GetCusipAliases().AnyAsync())
+            .Should()
+            .BeFalse();
+
+        // New identity means data sets already marked processed hold none of these
+        // lines — the ledger-clear signal is what backfills them without a deploy.
+        await _bus.Received(1)
+            .Publish(
+                Arg.Is<StockCusipChanged>(e => e.CommonStockId == stock.Id),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task RecordListedTickerCusips_TickerNotACurrentSecondary_RecordsNothing()
+    {
+        // Only the stock's own authoritative secondary list admits a listing; an arbitrary
+        // symbol+CUSIP pair from the feed must not attach to this filer.
+        var stock = await SeedStock("GOOGL", "1652044", cusip: "02079K305");
+
+        var recorded = await _sut.RecordListedTickerCusips(stock, [("GOOG", "02079K107")]);
+
+        recorded.Should().Be(0);
+        (await _repository.GetListedCusips().AnyAsync()).Should().BeFalse();
+        await _bus.DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordListedTickerCusips_StocksOwnPrimaryCusip_RecordsNothing()
+    {
+        // The primary CUSIP resolving through the listing table would tag primary-class
+        // rows with a listed ticker; the primary's identity stays on the stock itself.
+        var stock = await SeedStock(
+            "GOOGL",
+            "1652044",
+            cusip: "02079K305",
+            secondaryTickers: ["GOOG"]
+        );
+
+        var recorded = await _sut.RecordListedTickerCusips(stock, [("GOOG", "02079K305")]);
+
+        recorded.Should().Be(0);
+        (await _repository.GetListedCusips().AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RecordListedTickerCusips_CusipAlreadyOwned_FirstOwnerKeepsIt()
+    {
+        // One CUSIP identifies one security, ever. Whether the prior owner holds it as a
+        // primary, an alias, or another listing, a later claim is dropped silently.
+        var owner = await SeedStock("AAA", "0000000001", cusip: "111111111");
+        var claimant = await SeedStock(
+            "BBB",
+            "0000000002",
+            cusip: "222222222",
+            secondaryTickers: ["BBB-A"]
+        );
+
+        var recorded = await _sut.RecordListedTickerCusips(claimant, [("BBB-A", "111111111")]);
+
+        recorded.Should().Be(0);
+        (await _repository.GetListedCusips().AnyAsync()).Should().BeFalse();
+        await _bus.DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordListedTickerCusips_SameCusipOfferedTwice_RecordsOnce()
+    {
+        // The FTD archive repeats a (symbol, CUSIP) pair across many files; both the batch
+        // dedupe and the unique index behind it must collapse the repeats.
+        var stock = await SeedStock(
+            "GOOGL",
+            "1652044",
+            cusip: "02079K305",
+            secondaryTickers: ["GOOG"]
+        );
+
+        var first = await _sut.RecordListedTickerCusips(
+            stock,
+            [("GOOG", "02079K107"), ("GOOG", "02079k107")]
+        );
+        var second = await _sut.RecordListedTickerCusips(stock, [("GOOG", "02079K107")]);
+
+        first.Should().Be(1);
+        second.Should().Be(0);
+        (await _repository.GetListedCusips().CountAsync()).Should().Be(1);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceAmendmentReconciliationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceAmendmentReconciliationTests.cs
@@ -108,13 +108,13 @@ public class HoldingsImportServiceAmendmentReconciliationTests : IAsyncLifetime
     }
 
     private static IStockPriceProvider PriceProviderReturning(
-        Dictionary<(Guid, DateOnly), decimal> prices
+        Dictionary<(Guid, string, DateOnly), decimal> prices
     )
     {
         var provider = Substitute.For<IStockPriceProvider>();
         provider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult(prices));
@@ -139,7 +139,7 @@ public class HoldingsImportServiceAmendmentReconciliationTests : IAsyncLifetime
         }
 
         var reportDate = new DateOnly(2024, 9, 30);
-        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 100m };
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 100m };
 
         const string cover =
             "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n";
@@ -247,10 +247,10 @@ public class HoldingsImportServiceAmendmentReconciliationTests : IAsyncLifetime
         }
 
         var reportDate = new DateOnly(2024, 9, 30);
-        var prices = new Dictionary<(Guid, DateOnly), decimal>
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>
         {
-            [(aapl.Id, reportDate)] = 100m,
-            [(msft.Id, reportDate)] = 100m,
+            [(aapl.Id, null, reportDate)] = 100m,
+            [(msft.Id, null, reportDate)] = 100m,
         };
 
         const string coverWithType =

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceBatchFlushAggregationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceBatchFlushAggregationTests.cs
@@ -113,13 +113,13 @@ public class HoldingsImportServiceBatchFlushAggregationTests : IAsyncLifetime
     }
 
     private static IStockPriceProvider PriceProviderReturning(
-        Dictionary<(Guid, DateOnly), decimal> prices
+        Dictionary<(Guid, string, DateOnly), decimal> prices
     )
     {
         var provider = Substitute.For<IStockPriceProvider>();
         provider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult(prices));
@@ -164,9 +164,9 @@ public class HoldingsImportServiceBatchFlushAggregationTests : IAsyncLifetime
         }
 
         var reportDate = new DateOnly(2025, 12, 31);
-        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(apple.Id, reportDate)] = 250m };
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal> { [(apple.Id, null, reportDate)] = 250m };
         foreach (var p in padding)
-            prices[(p.Id, reportDate)] = 1m;
+            prices[(p.Id, null, reportDate)] = 1m;
 
         const string coverHeader =
             "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n";

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCrossFilingTypeAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCrossFilingTypeAmendmentTests.cs
@@ -109,13 +109,13 @@ public class HoldingsImportServiceCrossFilingTypeAmendmentTests : IAsyncLifetime
     }
 
     private static IStockPriceProvider PriceProviderReturning(
-        Dictionary<(Guid, DateOnly), decimal> prices
+        Dictionary<(Guid, string, DateOnly), decimal> prices
     )
     {
         var provider = Substitute.For<IStockPriceProvider>();
         provider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult(prices));
@@ -142,7 +142,7 @@ public class HoldingsImportServiceCrossFilingTypeAmendmentTests : IAsyncLifetime
         // Quarter end shared by the 13F-HR portfolio and the 13G/A stake — the
         // exact collision BlackRock hits every December and March.
         var reportDate = new DateOnly(2024, 9, 30);
-        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 100m };
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 100m };
 
         const string cover = "ACCESSION_NUMBER\tISAMENDMENT\tAMENDMENTTYPE\tFILINGMANAGER_NAME\n";
         const string infoHeader =

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCusipAliasTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCusipAliasTests.cs
@@ -117,13 +117,13 @@ public class HoldingsImportServiceCusipAliasTests : IAsyncLifetime
     }
 
     private static IStockPriceProvider PriceProviderReturning(
-        Dictionary<(Guid, DateOnly), decimal> prices
+        Dictionary<(Guid, string, DateOnly), decimal> prices
     )
     {
         var provider = Substitute.For<IStockPriceProvider>();
         provider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult(prices));
@@ -168,7 +168,7 @@ public class HoldingsImportServiceCusipAliasTests : IAsyncLifetime
             ("INFOTABLE.tsv", infoTable)
         );
 
-        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 32m };
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 32m };
         var sut = CreateImporter(PriceProviderReturning(prices));
 
         var result = await sut.ImportDataSet(
@@ -233,10 +233,10 @@ public class HoldingsImportServiceCusipAliasTests : IAsyncLifetime
             ("INFOTABLE.tsv", infoTable)
         );
 
-        var prices = new Dictionary<(Guid, DateOnly), decimal>
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>
         {
-            [(stockA.Id, reportDate)] = 100m,
-            [(stockB.Id, reportDate)] = 100m,
+            [(stockA.Id, null, reportDate)] = 100m,
+            [(stockB.Id, null, reportDate)] = 100m,
         };
         var sut = CreateImporter(PriceProviderReturning(prices));
 

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFilingOtherManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFilingOtherManagerTests.cs
@@ -83,10 +83,10 @@ public class HoldingsImportServiceFilingOtherManagerTests : IAsyncLifetime
         var priceProvider = Substitute.For<IStockPriceProvider>();
         priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(Task.FromResult(new Dictionary<(Guid, DateOnly), decimal>()));
+            .Returns(Task.FromResult(new Dictionary<(Guid, string, DateOnly), decimal>()));
 
         return new HoldingsImportService(
             CreateScopeFactory(),

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFlushUnmappedCusipsTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFlushUnmappedCusipsTests.cs
@@ -141,7 +141,10 @@ public class HoldingsImportServiceFlushUnmappedCusipsTests : IAsyncLifetime
                     Cik = "1649339",
                 },
             },
-            CusipMapping = (mapped ?? []).ToDictionary(c => c, _ => Guid.NewGuid()),
+            CusipMapping = (mapped ?? []).ToDictionary(
+                c => c,
+                _ => new CusipTarget(Guid.NewGuid(), null)
+            ),
         };
 
         foreach (var (cusip, issuer, dollars) in tally)

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
@@ -121,13 +121,13 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
     }
 
     private static IStockPriceProvider PriceProviderReturning(
-        Dictionary<(Guid, DateOnly), decimal> prices
+        Dictionary<(Guid, string, DateOnly), decimal> prices
     )
     {
         var provider = Substitute.For<IStockPriceProvider>();
         provider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult(prices));
@@ -180,7 +180,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
             ("INFOTABLE.tsv", infoTable)
         );
 
-        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 150m };
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 150m };
         var sut = CreateImporter(PriceProviderReturning(prices));
 
         var result = await sut.ImportDataSet(
@@ -258,7 +258,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
         var priceProvider = Substitute.For<IStockPriceProvider>();
         priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(_ =>
@@ -270,10 +270,10 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
                 delete.Remove(staleApple);
                 delete.SaveChanges();
                 return Task.FromResult(
-                    new Dictionary<(Guid, DateOnly), decimal>
+                    new Dictionary<(Guid, string, DateOnly), decimal>
                     {
-                        [(apple.Id, reportDate)] = 150m,
-                        [(microsoft.Id, reportDate)] = 400m,
+                        [(apple.Id, null, reportDate)] = 150m,
+                        [(microsoft.Id, null, reportDate)] = 400m,
                     }
                 );
             });
@@ -336,7 +336,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
             ("SUMMARYPAGE.tsv", summaryPage)
         );
 
-        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 150m };
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 150m };
         var sut = CreateImporter(PriceProviderReturning(prices));
 
         var result = await sut.ImportDataSet(
@@ -392,9 +392,9 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
             ("INFOTABLE.tsv", infoTable)
         );
 
-        var prices = new Dictionary<(Guid, DateOnly), decimal>
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>
         {
-            [(stock.Id, new DateOnly(2024, 9, 30))] = 150m,
+            [(stock.Id, null, new DateOnly(2024, 9, 30))] = 150m,
         };
         var sut = CreateImporter(PriceProviderReturning(prices));
 
@@ -420,7 +420,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
         // closing price instead of the corrupt count.
         var reportDate = new DateOnly(2026, 3, 31);
         var stocks = new List<CommonStock>();
-        var prices = new Dictionary<(Guid, DateOnly), decimal>();
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>();
         var infoTable = new StringBuilder(
             "ACCESSION_NUMBER\tCUSIP\tVALUE\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
         );
@@ -436,7 +436,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
                 Cusip = $"11111111{i}",
             };
             stocks.Add(stock);
-            prices[(stock.Id, reportDate)] = 250m;
+            prices[(stock.Id, null, reportDate)] = 250m;
 
             // SSHPRNAMT duplicates VALUE — the defect under test.
             var dollarValue = i * 2_500_000L;
@@ -517,7 +517,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
         );
 
         var sut = CreateImporter(
-            PriceProviderReturning(new Dictionary<(Guid, DateOnly), decimal>())
+            PriceProviderReturning(new Dictionary<(Guid, string, DateOnly), decimal>())
         );
 
         var result = await sut.ImportDataSet(
@@ -703,9 +703,9 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
 
         var sut = CreateImporter(
             PriceProviderReturning(
-                new Dictionary<(Guid, DateOnly), decimal>
+                new Dictionary<(Guid, string, DateOnly), decimal>
                 {
-                    [(stock.Id, new DateOnly(2024, 9, 30))] = 100m,
+                    [(stock.Id, null, new DateOnly(2024, 9, 30))] = 100m,
                 }
             )
         );
@@ -804,7 +804,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
 
         var sut = CreateImporter(
             PriceProviderReturning(
-                new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 200m }
+                new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 200m }
             )
         );
 
@@ -915,7 +915,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
 
         var sut = CreateImporter(
             PriceProviderReturning(
-                new Dictionary<(Guid, DateOnly), decimal> { [(stockAmended.Id, eventDate)] = 200m }
+                new Dictionary<(Guid, string, DateOnly), decimal> { [(stockAmended.Id, null, eventDate)] = 200m }
             )
         );
 
@@ -1014,7 +1014,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
             ("OTHERMANAGER2.tsv", otherManager)
         );
 
-        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 150m };
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 150m };
         var sut = CreateImporter(PriceProviderReturning(prices));
 
         var result = await sut.ImportDataSet(
@@ -1072,7 +1072,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
             ("INFOTABLE.tsv", infoTable)
         );
 
-        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 150m };
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 150m };
         var sut = CreateImporter(PriceProviderReturning(prices));
 
         var result = await sut.ImportDataSet(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServicePublishesFilingsImportedTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServicePublishesFilingsImportedTests.cs
@@ -89,13 +89,13 @@ public class HoldingsImportServicePublishesFilingsImportedTests : IAsyncLifetime
     }
 
     private static IStockPriceProvider PriceProviderReturning(
-        Dictionary<(Guid, DateOnly), decimal> prices
+        Dictionary<(Guid, string, DateOnly), decimal> prices
     )
     {
         var provider = Substitute.For<IStockPriceProvider>();
         provider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult(prices));
@@ -145,7 +145,7 @@ public class HoldingsImportServicePublishesFilingsImportedTests : IAsyncLifetime
             NullLogger<HoldingsImportService>.Instance,
             Options.Create(new WorkerOptions()),
             PriceProviderReturning(
-                new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 150m }
+                new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 150m }
             ),
             bus
         );
@@ -208,10 +208,10 @@ public class HoldingsImportServicePublishesFilingsImportedTests : IAsyncLifetime
             NullLogger<HoldingsImportService>.Instance,
             Options.Create(new WorkerOptions()),
             PriceProviderReturning(
-                new Dictionary<(Guid, DateOnly), decimal>
+                new Dictionary<(Guid, string, DateOnly), decimal>
                 {
-                    [(stock.Id, q3)] = 150m,
-                    [(stock.Id, q4)] = 160m,
+                    [(stock.Id, null, q3)] = 150m,
+                    [(stock.Id, null, q4)] = 160m,
                 }
             ),
             bus

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceReducingAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceReducingAmendmentTests.cs
@@ -107,13 +107,13 @@ public class HoldingsImportServiceReducingAmendmentTests : IAsyncLifetime
     }
 
     private static IStockPriceProvider PriceProviderReturning(
-        Dictionary<(Guid, DateOnly), decimal> prices
+        Dictionary<(Guid, string, DateOnly), decimal> prices
     )
     {
         var provider = Substitute.For<IStockPriceProvider>();
         provider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult(prices));
@@ -146,10 +146,10 @@ public class HoldingsImportServiceReducingAmendmentTests : IAsyncLifetime
         }
 
         var reportDate = new DateOnly(2024, 9, 30);
-        var prices = new Dictionary<(Guid, DateOnly), decimal>
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>
         {
-            [(apple.Id, reportDate)] = 100m,
-            [(microsoft.Id, reportDate)] = 50m,
+            [(apple.Id, null, reportDate)] = 100m,
+            [(microsoft.Id, null, reportDate)] = 50m,
         };
 
         const string cover =

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceSharedManagerAttributionTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceSharedManagerAttributionTests.cs
@@ -84,10 +84,10 @@ public class HoldingsImportServiceSharedManagerAttributionTests : IAsyncLifetime
         var priceProvider = Substitute.For<IStockPriceProvider>();
         priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(Task.FromResult(new Dictionary<(Guid, DateOnly), decimal>()));
+            .Returns(Task.FromResult(new Dictionary<(Guid, string, DateOnly), decimal>()));
 
         return new HoldingsImportService(
             CreateScopeFactory(),

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceSiblingListingTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceSiblingListingTests.cs
@@ -1,0 +1,365 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Sibling share classes import as their own rows (#4247). Alphabet is the reference
+/// shape: GOOGL's CUSIP (02079K305) lives on the stock, Class C's (02079K107) matched
+/// nothing, and every GOOG 13F line — ~5,300 positions a quarter — was dropped at
+/// BuildCusipMapping. A <see cref="CommonStockListedCusip"/> row resolves the sibling
+/// CUSIP to the same filer WITHOUT collapsing the two securities: the holding row is
+/// keyed by ListedTicker and valued from the class's own price series. Merging them
+/// instead would overwrite one class's position with the other's (the upsert key had
+/// no security discriminator) and price BRK-A at BRK-B's close — ~1500x off.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServiceSiblingListingTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public HoldingsImportServiceSiblingListingTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.ResetAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private HoldingsImportService CreateImporter(IStockPriceProvider priceProvider)
+    {
+        return new HoldingsImportService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            priceProvider,
+            Substitute.For<MassTransit.IBus>()
+        );
+    }
+
+    private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)
+    {
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, body) in entries)
+            {
+                var entry = writer.CreateEntry(name);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(body);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    private static IStockPriceProvider PriceProviderReturning(
+        Dictionary<(Guid, string, DateOnly), decimal> prices
+    )
+    {
+        var provider = Substitute.For<IStockPriceProvider>();
+        provider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(prices));
+        return provider;
+    }
+
+    private static ZipArchive AlphabetBothClassesArchive()
+    {
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-201\t2026-05-08\t2026-03-31\t0001067983\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-201\tN\tSample Capital\tOmaha\tNE\t028-12345\t12345\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+            + "ACC-201\t02079K305\t1000\tSH\t\tSOLE\t1000\t0\t0\tCL A\t\n"
+            + "ACC-201\t02079K107\t500\tSH\t\tSOLE\t0\t0\t500\tCL C\t\n";
+
+        return BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+    }
+
+    private async Task<CommonStock> SeedAlphabet()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "GOOGL",
+            Name = "Alphabet Inc",
+            Cik = "1652044",
+            Cusip = "02079K305",
+            SecondaryTickers = ["GOOG"],
+        };
+        using var seed = FreshContext();
+        seed.Set<CommonStock>().Add(stock);
+        seed.Set<CommonStockListedCusip>()
+            .Add(
+                new CommonStockListedCusip
+                {
+                    CommonStockId = stock.Id,
+                    ListedTicker = "GOOG",
+                    Cusip = "02079K107",
+                }
+            );
+        await seed.SaveChangesAsync();
+        return stock;
+    }
+
+    [Fact]
+    public async Task ImportDataSet_BothClassesFiledSameQuarter_ImportsTwoRowsEachOnItsOwnPrice()
+    {
+        var stock = await SeedAlphabet();
+        var reportDate = new DateOnly(2026, 3, 31);
+
+        // Distinct closes so a cross-class pricing bug shows up in the derived values,
+        // not just in the row count.
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>
+        {
+            [(stock.Id, null, reportDate)] = 170m,
+            [(stock.Id, "GOOG", reportDate)] = 172m,
+        };
+        using var archive = AlphabetBothClassesArchive();
+        var sut = CreateImporter(PriceProviderReturning(prices));
+
+        var result = await sut.ImportDataSet(
+            archive,
+            new DateOnly(2026, 1, 1),
+            CancellationToken.None
+        );
+
+        result.IsComplete.Should().BeTrue();
+
+        using var verify = FreshContext();
+        var holdings = await verify.Set<InstitutionalHolding>().ToListAsync();
+        holdings.Should().HaveCount(2, "the two classes are two securities, never one row");
+
+        var primary = holdings.Single(h => h.ListedTicker == null);
+        primary.CommonStockId.Should().Be(stock.Id);
+        primary.Cusip.Should().Be("02079K305");
+        primary.Shares.Should().Be(1000);
+        primary.Value.Should().Be(170_000L);
+        primary.ValuePending.Should().BeFalse();
+
+        var classC = holdings.Single(h => h.ListedTicker == "GOOG");
+        classC.CommonStockId.Should().Be(stock.Id);
+        classC.Cusip.Should().Be("02079K107");
+        classC.Shares.Should().Be(500);
+        classC.Value.Should().Be(86_000L, "the Class C row prices at ITS class's close");
+        classC.ValuePending.Should().BeFalse();
+
+        var unmapped = await verify.Set<UnmappedCusip>().ToListAsync();
+        unmapped.Should().BeEmpty("the sibling CUSIP resolves instead of accruing as unmapped");
+    }
+
+    [Fact]
+    public async Task ImportDataSet_SecondaryWithUnattributedPostReportSplit_StaysHonestlyPending()
+    {
+        // An issuer split captured without per-series attribution proves nothing about the
+        // sibling class's own basis. The secondary row must import its SHARES but refuse a
+        // value; the primary row values normally with the factor applied.
+        var stock = await SeedAlphabet();
+        var reportDate = new DateOnly(2026, 3, 31);
+
+        using (var seed = FreshContext())
+        {
+            seed.Set<StockSplit>()
+                .Add(
+                    new StockSplit
+                    {
+                        CommonStockId = stock.Id,
+                        EffectiveDate = new DateOnly(2026, 4, 20),
+                        Numerator = 20m,
+                        Denominator = 1m,
+                        PriceSeriesTicker = null,
+                        PriceAdjustmentAppliedTime = new DateTime(
+                            2026,
+                            4,
+                            21,
+                            0,
+                            0,
+                            0,
+                            DateTimeKind.Utc
+                        ),
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>
+        {
+            [(stock.Id, null, reportDate)] = 8.50m,
+            [(stock.Id, "GOOG", reportDate)] = 8.60m,
+        };
+        using var archive = AlphabetBothClassesArchive();
+        var sut = CreateImporter(PriceProviderReturning(prices));
+
+        var result = await sut.ImportDataSet(
+            archive,
+            new DateOnly(2026, 1, 1),
+            CancellationToken.None
+        );
+
+        result.IsComplete.Should().BeTrue();
+
+        using var verify = FreshContext();
+        var holdings = await verify.Set<InstitutionalHolding>().ToListAsync();
+        holdings.Should().HaveCount(2);
+
+        var primary = holdings.Single(h => h.ListedTicker == null);
+        primary.ValuePending.Should().BeFalse();
+        primary.Value.Should().Be((long)(1000 * 20m * 8.50m));
+
+        var classC = holdings.Single(h => h.ListedTicker == "GOOG");
+        classC.Shares.Should().Be(500, "the position itself still imports and displays");
+        classC
+            .ValuePending.Should()
+            .BeTrue("no honest value exists until the class's own basis is known");
+        classC.Value.Should().Be(0L);
+    }
+
+    [Fact]
+    public async Task ImportDataSet_ListedCusipCollidesWithAnotherStocksCurrentCusip_CurrentCusipWins()
+    {
+        // Precedence pin, mirroring the alias rule: a CURRENT primary assignment outranks
+        // another stock's listed-cusip claim on the same CUSIP (a shape only bad data can
+        // produce). Primary > alias > listing.
+        var owner = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAA",
+            Name = "Current Owner Corp",
+            Cik = "0000000001",
+            Cusip = "999999999",
+        };
+        var claimant = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BBB",
+            Name = "Listing Claimant Corp",
+            Cik = "0000000002",
+            Cusip = "888888888",
+            SecondaryTickers = ["BBB-A"],
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().AddRange(owner, claimant);
+            seed.Set<CommonStockListedCusip>()
+                .Add(
+                    new CommonStockListedCusip
+                    {
+                        CommonStockId = claimant.Id,
+                        ListedTicker = "BBB-A",
+                        Cusip = "999999999",
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2026, 3, 31);
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-202\t2026-05-08\t2026-03-31\t0001067983\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-202\tN\tSample Capital\tOmaha\tNE\t028-12345\t12345\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+            + "ACC-202\t999999999\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t\n";
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>
+        {
+            [(owner.Id, null, reportDate)] = 100m,
+            [(claimant.Id, null, reportDate)] = 100m,
+        };
+        var sut = CreateImporter(PriceProviderReturning(prices));
+
+        var result = await sut.ImportDataSet(
+            archive,
+            new DateOnly(2026, 1, 1),
+            CancellationToken.None
+        );
+
+        result.IsComplete.Should().BeTrue();
+
+        using var verify = FreshContext();
+        var holding = await verify.Set<InstitutionalHolding>().SingleAsync();
+        holding.CommonStockId.Should().Be(owner.Id);
+        holding.ListedTicker.Should().BeNull();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionRevertGuardTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionRevertGuardTests.cs
@@ -182,14 +182,14 @@ public class HoldingsRealtimeIngestionRevertGuardTests : IAsyncLifetime
         var prices = Substitute.For<IStockPriceProvider>();
         prices
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(ci =>
             {
-                var dict = new Dictionary<(Guid, DateOnly), decimal>();
-                foreach (var (id, date) in ci.ArgAt<IEnumerable<(Guid, DateOnly)>>(0))
-                    dict[(id, date)] = 100m;
+                var dict = new Dictionary<(Guid, string, DateOnly), decimal>();
+                foreach (var (id, ticker, date) in ci.ArgAt<IEnumerable<(Guid, string, DateOnly)>>(0))
+                    dict[(id, ticker, date)] = 100m;
                 return Task.FromResult(dict);
             });
 

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionWindowDedupTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionWindowDedupTests.cs
@@ -174,14 +174,14 @@ public class HoldingsRealtimeIngestionWindowDedupTests : IAsyncLifetime
         var prices = Substitute.For<IStockPriceProvider>();
         prices
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(ci =>
             {
-                var dict = new Dictionary<(Guid, DateOnly), decimal>();
-                foreach (var (id, date) in ci.ArgAt<IEnumerable<(Guid, DateOnly)>>(0))
-                    dict[(id, date)] = 100m;
+                var dict = new Dictionary<(Guid, string, DateOnly), decimal>();
+                foreach (var (id, ticker, date) in ci.ArgAt<IEnumerable<(Guid, string, DateOnly)>>(0))
+                    dict[(id, ticker, date)] = 100m;
                 return Task.FromResult(dict);
             });
 

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionZeroHoldingsSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionZeroHoldingsSkipTests.cs
@@ -141,10 +141,10 @@ public class HoldingsRealtimeIngestionZeroHoldingsSkipTests : IAsyncLifetime
         var prices = Substitute.For<IStockPriceProvider>();
         prices
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(Task.FromResult(new Dictionary<(Guid, DateOnly), decimal>()));
+            .Returns(Task.FromResult(new Dictionary<(Guid, string, DateOnly), decimal>()));
 
         var importService = new HoldingsImportService(
             scopeFactory,

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsValueRecalculatorTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsValueRecalculatorTests.cs
@@ -153,11 +153,11 @@ public class HoldingsValueRecalculatorTests : IDisposable
 
         _priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
-                new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 150.50m }
+                new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 150.50m }
             );
 
         var scopeFactory = CreateScopeFactory();
@@ -220,10 +220,10 @@ public class HoldingsValueRecalculatorTests : IDisposable
 
         _priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 200m });
+            .Returns(new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 200m });
 
         var scopeFactory = CreateScopeFactory();
         var recalculator = CreateRecalculator(scopeFactory);
@@ -273,10 +273,10 @@ public class HoldingsValueRecalculatorTests : IDisposable
 
         _priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(new Dictionary<(Guid, DateOnly), decimal>());
+            .Returns(new Dictionary<(Guid, string, DateOnly), decimal>());
 
         var scopeFactory = CreateScopeFactory();
         var recalculator = CreateRecalculator(scopeFactory);
@@ -331,10 +331,10 @@ public class HoldingsValueRecalculatorTests : IDisposable
 
         _priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 100m });
+            .Returns(new Dictionary<(Guid, string, DateOnly), decimal> { [(stock.Id, null, reportDate)] = 100m });
 
         var scopeFactory = CreateScopeFactory();
         var recalculator = CreateRecalculator(scopeFactory);
@@ -383,10 +383,10 @@ public class HoldingsValueRecalculatorTests : IDisposable
 
         _priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(new Dictionary<(Guid, DateOnly), decimal>());
+            .Returns(new Dictionary<(Guid, string, DateOnly), decimal>());
 
         var scopeFactory = CreateScopeFactory();
         var recalculator = CreateRecalculator(scopeFactory);
@@ -446,13 +446,13 @@ public class HoldingsValueRecalculatorTests : IDisposable
 
         _priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
-                new Dictionary<(Guid, DateOnly), decimal>
+                new Dictionary<(Guid, string, DateOnly), decimal>
                 {
-                    [(stockWithPrice.Id, reportDate)] = 175m,
+                    [(stockWithPrice.Id, null, reportDate)] = 175m,
                 }
             );
 
@@ -486,7 +486,7 @@ public class HoldingsValueRecalculatorTests : IDisposable
         await _priceProvider
             .DidNotReceive()
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -526,7 +526,7 @@ public class HoldingsValueRecalculatorTests : IDisposable
         await _priceProvider
             .DidNotReceive()
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             );
     }

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionIncompleteImportTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionIncompleteImportTests.cs
@@ -161,10 +161,10 @@ public class Realtime13DGIngestionIncompleteImportTests : IAsyncLifetime
         var prices = Substitute.For<IStockPriceProvider>();
         prices
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(Task.FromResult(new Dictionary<(Guid, DateOnly), decimal>()));
+            .Returns(Task.FromResult(new Dictionary<(Guid, string, DateOnly), decimal>()));
 
         var importService = new HoldingsImportService(
             scopeFactory,

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionPoisonedFilingTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionPoisonedFilingTests.cs
@@ -209,14 +209,14 @@ public class Realtime13DGIngestionPoisonedFilingTests : IAsyncLifetime
         var prices = Substitute.For<IStockPriceProvider>();
         prices
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(ci =>
             {
-                var dict = new Dictionary<(Guid, DateOnly), decimal>();
-                foreach (var (id, date) in ci.ArgAt<IEnumerable<(Guid, DateOnly)>>(0))
-                    dict[(id, date)] = 10m;
+                var dict = new Dictionary<(Guid, string, DateOnly), decimal>();
+                foreach (var (id, ticker, date) in ci.ArgAt<IEnumerable<(Guid, string, DateOnly)>>(0))
+                    dict[(id, ticker, date)] = 10m;
                 return Task.FromResult(dict);
             });
 

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionTests.cs
@@ -186,14 +186,14 @@ public class Realtime13DGIngestionTests : IAsyncLifetime
         var prices = Substitute.For<IStockPriceProvider>();
         prices
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(ci =>
             {
-                var dict = new Dictionary<(Guid, DateOnly), decimal>();
-                foreach (var (id, date) in ci.ArgAt<IEnumerable<(Guid, DateOnly)>>(0))
-                    dict[(id, date)] = 10m;
+                var dict = new Dictionary<(Guid, string, DateOnly), decimal>();
+                foreach (var (id, ticker, date) in ci.ArgAt<IEnumerable<(Guid, string, DateOnly)>>(0))
+                    dict[(id, ticker, date)] = 10m;
                 return Task.FromResult(dict);
             });
 

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionCrashSafetyTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionCrashSafetyTests.cs
@@ -179,7 +179,7 @@ public class Realtime13FIngestionCrashSafetyTests : IAsyncLifetime
         var priceCalls = 0;
         prices
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(ci =>
@@ -187,9 +187,9 @@ public class Realtime13FIngestionCrashSafetyTests : IAsyncLifetime
                 if (Interlocked.Increment(ref priceCalls) == 1)
                     throw new InvalidOperationException("price service unavailable");
 
-                var dict = new Dictionary<(Guid, DateOnly), decimal>();
-                foreach (var (id, date) in ci.ArgAt<IEnumerable<(Guid, DateOnly)>>(0))
-                    dict[(id, date)] = 100m;
+                var dict = new Dictionary<(Guid, string, DateOnly), decimal>();
+                foreach (var (id, ticker, date) in ci.ArgAt<IEnumerable<(Guid, string, DateOnly)>>(0))
+                    dict[(id, ticker, date)] = 100m;
                 return Task.FromResult(dict);
             });
 

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionIncompleteImportTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionIncompleteImportTests.cs
@@ -160,10 +160,10 @@ public class Realtime13FIngestionIncompleteImportTests : IAsyncLifetime
         var prices = Substitute.For<IStockPriceProvider>();
         prices
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(Task.FromResult(new Dictionary<(Guid, DateOnly), decimal>()));
+            .Returns(Task.FromResult(new Dictionary<(Guid, string, DateOnly), decimal>()));
 
         var importService = new HoldingsImportService(
             scopeFactory,

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceRecordListedCusipsTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceRecordListedCusipsTests.cs
@@ -1,0 +1,204 @@
+using System.Reflection;
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.HostedService.Services;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// The listed-CUSIP sweep's issuer-prefix guard (#4247). The sweep resolves CNS symbols
+/// against the SECONDARY ticker space, and the only thing standing between a recycled
+/// secondary symbol and importing a delisted issuer's positions is
+/// <c>CusipIdentity.SameIssuer</c> against the stock's primary CUSIP. Sibling classes
+/// SHARE the first-six issuer prefix — for this table that is the admission ticket, not
+/// a trap. A stock with no primary CUSIP has no prefix to verify against and must
+/// record nothing.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FtdImportServiceRecordListedCusipsTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public FtdImportServiceRecordListedCusipsTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private FtdImportService BuildService()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(CommonStockManager))
+                    .Returns(
+                        new CommonStockManager(
+                            new CommonStockRepository(ctx),
+                            Substitute.For<IBus>()
+                        )
+                    );
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+
+        return new FtdImportService(
+            scopeFactory,
+            Substitute.For<ISecEdgarClient>(),
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions())
+        );
+    }
+
+    private static async Task<int> InvokeRecordListedCusips(
+        FtdImportService sut,
+        Dictionary<Guid, Dictionary<string, HashSet<string>>> byStock
+    )
+    {
+        var method = typeof(FtdImportService).GetMethod(
+            "RecordListedCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        return await (Task<int>)method.Invoke(sut, [byStock, CancellationToken.None])!;
+    }
+
+    private static Dictionary<Guid, Dictionary<string, HashSet<string>>> Candidates(
+        Guid stockId,
+        string listedTicker,
+        params string[] cusips
+    ) =>
+        new()
+        {
+            [stockId] = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                [listedTicker] = new HashSet<string>(cusips, StringComparer.OrdinalIgnoreCase),
+            },
+        };
+
+    [Fact]
+    public async Task RecordListedCusips_SiblingClassSharesIssuerPrefix_Records()
+    {
+        var alphabet = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "GOOGL",
+            Name = "Alphabet Inc",
+            Cik = "1652044",
+            Cusip = "02079K305",
+            SecondaryTickers = ["GOOG"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(alphabet);
+            await seed.SaveChangesAsync();
+        }
+
+        var recorded = await InvokeRecordListedCusips(
+            BuildService(),
+            Candidates(alphabet.Id, "GOOG", "02079K107")
+        );
+
+        recorded.Should().Be(1);
+        using var verify = FreshContext();
+        var listing = await verify.Set<CommonStockListedCusip>().SingleAsync();
+        listing.CommonStockId.Should().Be(alphabet.Id);
+        listing.ListedTicker.Should().Be("GOOG");
+        listing.Cusip.Should().Be("02079K107");
+    }
+
+    [Fact]
+    public async Task RecordListedCusips_ForeignIssuerPrefix_RecordsNothing()
+    {
+        // The recycled-symbol case: an old archive file pairs this secondary symbol with a
+        // DIFFERENT issuer's CUSIP (the symbol's previous owner). Without the prefix guard
+        // that delisted issuer's 13F lines would import as this filer's sibling class.
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAA",
+            Name = "Current Symbol Owner Inc",
+            Cik = "0000000001",
+            Cusip = "111111111",
+            SecondaryTickers = ["AAA-A"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var recorded = await InvokeRecordListedCusips(
+            BuildService(),
+            Candidates(stock.Id, "AAA-A", "999999109")
+        );
+
+        recorded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStockListedCusip>().AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RecordListedCusips_StockWithoutPrimaryCusip_RecordsNothing()
+    {
+        // No primary CUSIP means no issuer prefix to anchor the guard — unverifiable
+        // identity is skipped, not admitted on faith.
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BBB",
+            Name = "Unseeded Issuer Inc",
+            Cik = "0000000002",
+            SecondaryTickers = ["BBB-A"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var recorded = await InvokeRecordListedCusips(
+            BuildService(),
+            Candidates(stock.Id, "BBB-A", "22222R107")
+        );
+
+        recorded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStockListedCusip>().AnyAsync()).Should().BeFalse();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooRepositoryTests.cs
@@ -407,10 +407,67 @@ public class YahooStockPriceProviderTests : IDisposable
         var date = new DateOnly(2026, 3, 2);
         await SeedPrices(CreatePrice(_apple, date, 180m));
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, date)]);
+        var result = await _provider.GetClosingPrices([(_apple.Id, null, date)]);
 
         result.Should().ContainSingle();
-        result[(_apple.Id, date)].Should().Be(180m);
+        result[(_apple.Id, null, date)].Should().Be(180m);
+    }
+
+    [Fact]
+    public async Task GetClosingPrices_SecondaryListing_AnswersFromItsOwnSeriesOnly()
+    {
+        // The BRK magnitude case (#4247): the two classes trade ~1500x apart, so answering a
+        // BRK-A request with the BRK-B close is not a rounding problem — it is the exact error
+        // class the per-listing key exists to prevent, in both directions: the secondary
+        // request must get ITS series, and the primary request must never pick up the
+        // secondary's bar.
+        var date = new DateOnly(2026, 3, 2);
+        var brk = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BRK-B",
+            Name = "Berkshire Hathaway Inc.",
+            SecondaryTickers = ["BRK-A"],
+        };
+        _dbContext.Set<CommonStock>().Add(brk);
+        await _dbContext.SaveChangesAsync();
+
+        var classA = CreatePrice(brk, date, 774_300m);
+        classA.ListedTicker = "BRK-A";
+        await SeedPrices(CreatePrice(brk, date, 515.06m), classA);
+
+        var result = await _provider.GetClosingPrices([
+            (brk.Id, null, date),
+            (brk.Id, "BRK-A", date),
+        ]);
+
+        result.Should().HaveCount(2);
+        result[(brk.Id, null, date)].Should().Be(515.06m);
+        result[(brk.Id, "BRK-A", date)].Should().Be(774_300m);
+    }
+
+    [Fact]
+    public async Task GetClosingPrices_SecondaryListingWithNoSeries_IsAbsentNeverThePrimaryClose()
+    {
+        // A secondary listing whose exact series has no bars must come back ABSENT so the
+        // holding stays honestly pending — substituting the primary's close would value the
+        // position on the wrong security.
+        var date = new DateOnly(2026, 3, 2);
+        var brk = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BRK-B",
+            Name = "Berkshire Hathaway Inc.",
+            SecondaryTickers = ["BRK-A"],
+        };
+        _dbContext.Set<CommonStock>().Add(brk);
+        await _dbContext.SaveChangesAsync();
+
+        await SeedPrices(CreatePrice(brk, date, 515.06m));
+
+        var result = await _provider.GetClosingPrices([(brk.Id, "BRK-A", date)]);
+
+        result.Should().BeEmpty();
     }
 
     [Fact]
@@ -419,11 +476,14 @@ public class YahooStockPriceProviderTests : IDisposable
         var date = new DateOnly(2026, 3, 2);
         await SeedPrices(CreatePrice(_apple, date, 180m), CreatePrice(_microsoft, date, 400m));
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, date), (_microsoft.Id, date)]);
+        var result = await _provider.GetClosingPrices([
+            (_apple.Id, null, date),
+            (_microsoft.Id, null, date),
+        ]);
 
         result.Should().HaveCount(2);
-        result[(_apple.Id, date)].Should().Be(180m);
-        result[(_microsoft.Id, date)].Should().Be(400m);
+        result[(_apple.Id, null, date)].Should().Be(180m);
+        result[(_microsoft.Id, null, date)].Should().Be(400m);
     }
 
     // ── Fallback to nearest prior date ─────────────────────────────────
@@ -437,10 +497,10 @@ public class YahooStockPriceProviderTests : IDisposable
 
         await SeedPrices(CreatePrice(_apple, priceDate, 175m));
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, requestDate)]);
+        var result = await _provider.GetClosingPrices([(_apple.Id, null, requestDate)]);
 
         result.Should().ContainSingle();
-        result[(_apple.Id, requestDate)].Should().Be(175m);
+        result[(_apple.Id, null, requestDate)].Should().Be(175m);
     }
 
     [Fact]
@@ -454,10 +514,10 @@ public class YahooStockPriceProviderTests : IDisposable
             CreatePrice(_apple, new DateOnly(2026, 3, 10), 172m) // 5 days prior
         );
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, requestDate)]);
+        var result = await _provider.GetClosingPrices([(_apple.Id, null, requestDate)]);
 
         result.Should().ContainSingle();
-        result[(_apple.Id, requestDate)].Should().Be(175m);
+        result[(_apple.Id, null, requestDate)].Should().Be(175m);
     }
 
     [Fact]
@@ -469,10 +529,10 @@ public class YahooStockPriceProviderTests : IDisposable
 
         await SeedPrices(CreatePrice(_apple, priceDate, 165m));
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, requestDate)]);
+        var result = await _provider.GetClosingPrices([(_apple.Id, null, requestDate)]);
 
         result.Should().ContainSingle();
-        result[(_apple.Id, requestDate)].Should().Be(165m);
+        result[(_apple.Id, null, requestDate)].Should().Be(165m);
     }
 
     // ── No price within window ─────────────────────────────────────────
@@ -486,7 +546,7 @@ public class YahooStockPriceProviderTests : IDisposable
 
         await SeedPrices(CreatePrice(_apple, priceDate, 160m));
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, requestDate)]);
+        var result = await _provider.GetClosingPrices([(_apple.Id, null, requestDate)]);
 
         result.Should().BeEmpty();
     }
@@ -496,7 +556,7 @@ public class YahooStockPriceProviderTests : IDisposable
     {
         var requestDate = new DateOnly(2026, 3, 15);
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, requestDate)]);
+        var result = await _provider.GetClosingPrices([(_apple.Id, null, requestDate)]);
 
         result.Should().BeEmpty();
     }
@@ -509,7 +569,7 @@ public class YahooStockPriceProviderTests : IDisposable
 
         await SeedPrices(CreatePrice(_apple, futureDate, 190m));
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, requestDate)]);
+        var result = await _provider.GetClosingPrices([(_apple.Id, null, requestDate)]);
 
         result.Should().BeEmpty();
     }
@@ -525,11 +585,14 @@ public class YahooStockPriceProviderTests : IDisposable
         // No price for Microsoft
         );
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, date), (_microsoft.Id, date)]);
+        var result = await _provider.GetClosingPrices([
+            (_apple.Id, null, date),
+            (_microsoft.Id, null, date),
+        ]);
 
         result.Should().ContainSingle();
-        result.Should().ContainKey((_apple.Id, date));
-        result.Should().NotContainKey((_microsoft.Id, date));
+        result.Should().ContainKey((_apple.Id, null, date));
+        result.Should().NotContainKey((_microsoft.Id, null, date));
     }
 
     [Fact]
@@ -542,15 +605,15 @@ public class YahooStockPriceProviderTests : IDisposable
         );
 
         var result = await _provider.GetClosingPrices([
-            (_apple.Id, new DateOnly(2026, 1, 10)),
-            (_apple.Id, new DateOnly(2026, 2, 10)),
-            (_apple.Id, new DateOnly(2026, 3, 10)),
+            (_apple.Id, null, new DateOnly(2026, 1, 10)),
+            (_apple.Id, null, new DateOnly(2026, 2, 10)),
+            (_apple.Id, null, new DateOnly(2026, 3, 10)),
         ]);
 
         result.Should().HaveCount(3);
-        result[(_apple.Id, new DateOnly(2026, 1, 10))].Should().Be(170m);
-        result[(_apple.Id, new DateOnly(2026, 2, 10))].Should().Be(180m);
-        result[(_apple.Id, new DateOnly(2026, 3, 10))].Should().Be(190m);
+        result[(_apple.Id, null, new DateOnly(2026, 1, 10))].Should().Be(170m);
+        result[(_apple.Id, null, new DateOnly(2026, 2, 10))].Should().Be(180m);
+        result[(_apple.Id, null, new DateOnly(2026, 3, 10))].Should().Be(190m);
     }
 
     [Fact]
@@ -563,15 +626,15 @@ public class YahooStockPriceProviderTests : IDisposable
         );
 
         var result = await _provider.GetClosingPrices([
-            (_apple.Id, new DateOnly(2026, 3, 5)),
-            (_microsoft.Id, new DateOnly(2026, 3, 10)),
-            (_google.Id, new DateOnly(2026, 3, 15)),
+            (_apple.Id, null, new DateOnly(2026, 3, 5)),
+            (_microsoft.Id, null, new DateOnly(2026, 3, 10)),
+            (_google.Id, null, new DateOnly(2026, 3, 15)),
         ]);
 
         result.Should().HaveCount(3);
-        result[(_apple.Id, new DateOnly(2026, 3, 5))].Should().Be(180m);
-        result[(_microsoft.Id, new DateOnly(2026, 3, 10))].Should().Be(400m);
-        result[(_google.Id, new DateOnly(2026, 3, 15))].Should().Be(150m);
+        result[(_apple.Id, null, new DateOnly(2026, 3, 5))].Should().Be(180m);
+        result[(_microsoft.Id, null, new DateOnly(2026, 3, 10))].Should().Be(400m);
+        result[(_google.Id, null, new DateOnly(2026, 3, 15))].Should().Be(150m);
     }
 
     // ── Edge cases ─────────────────────────────────────────────────────
@@ -590,10 +653,13 @@ public class YahooStockPriceProviderTests : IDisposable
         var date = new DateOnly(2026, 3, 10);
         await SeedPrices(CreatePrice(_apple, date, 180m));
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, date), (_apple.Id, date)]);
+        var result = await _provider.GetClosingPrices([
+            (_apple.Id, null, date),
+            (_apple.Id, null, date),
+        ]);
 
         result.Should().ContainSingle();
-        result[(_apple.Id, date)].Should().Be(180m);
+        result[(_apple.Id, null, date)].Should().Be(180m);
     }
 
     [Fact]
@@ -606,9 +672,9 @@ public class YahooStockPriceProviderTests : IDisposable
             CreatePrice(_apple, requestDate, 180m)
         );
 
-        var result = await _provider.GetClosingPrices([(_apple.Id, requestDate)]);
+        var result = await _provider.GetClosingPrices([(_apple.Id, null, requestDate)]);
 
-        result[(_apple.Id, requestDate)].Should().Be(180m);
+        result[(_apple.Id, null, requestDate)].Should().Be(180m);
     }
 
     [Fact]
@@ -618,7 +684,10 @@ public class YahooStockPriceProviderTests : IDisposable
         await cts.CancelAsync();
 
         var act = async () =>
-            await _provider.GetClosingPrices([(_apple.Id, new DateOnly(2026, 3, 10))], cts.Token);
+            await _provider.GetClosingPrices(
+                [(_apple.Id, null, new DateOnly(2026, 3, 10))],
+                cts.Token
+            );
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }

--- a/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerPre2023VotingFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerPre2023VotingFallbackTests.cs
@@ -34,7 +34,7 @@ public class Corrupt13FShareCountRepairerPre2023VotingFallbackTests
 
         var outcome = Corrupt13FShareCountRepairer.Repair(
             rows,
-            new Dictionary<(Guid, DateOnly), decimal>()
+            new Dictionary<(Guid, string, DateOnly), decimal>()
         );
 
         outcome.Should().Be(new Corrupt13FRepairOutcome(RepairedRows: 1, DroppedRows: 0));

--- a/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerRepairValueOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerRepairValueOverflowTests.cs
@@ -24,9 +24,9 @@ public class Corrupt13FShareCountRepairerRepairValueOverflowTests
         // close: reportedDollars ÷ price ≈ 1.84e19 overflows Int64 at the (long) cast.
         var row = DuplicatedRow(value: long.MaxValue);
         var rows = new List<BufferedHoldingRow> { row };
-        var prices = new Dictionary<(Guid, DateOnly), decimal>
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>
         {
-            [(row.Holding.CommonStockId, row.Holding.ReportDate)] = 0.50m,
+            [(row.Holding.CommonStockId, row.Holding.ListedTicker, row.Holding.ReportDate)] = 0.50m,
         };
 
         var act = () => Corrupt13FShareCountRepairer.Repair(rows, prices);

--- a/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerTests.cs
@@ -104,7 +104,7 @@ public class Corrupt13FShareCountRepairerTests
 
         var outcome = Corrupt13FShareCountRepairer.Repair(
             rows,
-            new Dictionary<(Guid, DateOnly), decimal>()
+            new Dictionary<(Guid, string, DateOnly), decimal>()
         );
 
         outcome.Should().Be(new Corrupt13FRepairOutcome(RepairedRows: 1, DroppedRows: 0));
@@ -121,7 +121,7 @@ public class Corrupt13FShareCountRepairerTests
 
         var outcome = Corrupt13FShareCountRepairer.Repair(
             rows,
-            new Dictionary<(Guid, DateOnly), decimal>()
+            new Dictionary<(Guid, string, DateOnly), decimal>()
         );
 
         outcome.Should().Be(new Corrupt13FRepairOutcome(RepairedRows: 0, DroppedRows: 1));
@@ -195,8 +195,8 @@ public class Corrupt13FShareCountRepairerTests
         };
     }
 
-    private static Dictionary<(Guid, DateOnly), decimal> Prices(
+    private static Dictionary<(Guid, string, DateOnly), decimal> Prices(
         BufferedHoldingRow row,
         decimal closePrice
-    ) => new() { [(row.Holding.CommonStockId, row.Holding.ReportDate)] = closePrice };
+    ) => new() { [(row.Holding.CommonStockId, row.Holding.ListedTicker, row.Holding.ReportDate)] = closePrice };
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisBoundaryAndCompoundTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisBoundaryAndCompoundTests.cs
@@ -28,7 +28,14 @@ public class HoldingValueBasisBoundaryAndCompoundTests
         var splits = new List<StockSplit> { Applied(new DateOnly(2024, 6, 30), 10m, 1m) };
 
         HoldingValueBasis
-            .TryResolveShareCountFactor(new DateOnly(2024, 6, 30), splits, null, "TEST", out var factor)
+            .TryResolveShareCountFactor(
+                new DateOnly(2024, 6, 30),
+                splits,
+                null,
+                "TEST",
+                null,
+                out var factor
+            )
             .Should()
             .BeTrue();
 
@@ -48,7 +55,14 @@ public class HoldingValueBasisBoundaryAndCompoundTests
         };
 
         HoldingValueBasis
-            .TryResolveShareCountFactor(new DateOnly(2020, 12, 31), splits, null, "TEST", out var factor)
+            .TryResolveShareCountFactor(
+                new DateOnly(2020, 12, 31),
+                splits,
+                null,
+                "TEST",
+                null,
+                out var factor
+            )
             .Should()
             .BeTrue();
 
@@ -62,7 +76,14 @@ public class HoldingValueBasisBoundaryAndCompoundTests
         // path has to be an exact no-op: a factor of anything but 1 here would perturb every
         // value on the platform.
         HoldingValueBasis
-            .TryResolveShareCountFactor(new DateOnly(2024, 6, 30), [], null, "TEST", out var factor)
+            .TryResolveShareCountFactor(
+                new DateOnly(2024, 6, 30),
+                [],
+                null,
+                "TEST",
+                null,
+                out var factor
+            )
             .Should()
             .BeTrue();
 
@@ -82,7 +103,14 @@ public class HoldingValueBasisBoundaryAndCompoundTests
         };
 
         HoldingValueBasis
-            .TryResolveShareCountFactor(new DateOnly(2024, 12, 31), splits, null, "TEST", out var factor)
+            .TryResolveShareCountFactor(
+                new DateOnly(2024, 12, 31),
+                splits,
+                null,
+                "TEST",
+                null,
+                out var factor
+            )
             .Should()
             .BeTrue();
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisBoundaryAndCompoundTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisBoundaryAndCompoundTests.cs
@@ -28,7 +28,7 @@ public class HoldingValueBasisBoundaryAndCompoundTests
         var splits = new List<StockSplit> { Applied(new DateOnly(2024, 6, 30), 10m, 1m) };
 
         HoldingValueBasis
-            .TryResolveShareCountFactor(new DateOnly(2024, 6, 30), splits, out var factor)
+            .TryResolveShareCountFactor(new DateOnly(2024, 6, 30), splits, null, "TEST", out var factor)
             .Should()
             .BeTrue();
 
@@ -48,7 +48,7 @@ public class HoldingValueBasisBoundaryAndCompoundTests
         };
 
         HoldingValueBasis
-            .TryResolveShareCountFactor(new DateOnly(2020, 12, 31), splits, out var factor)
+            .TryResolveShareCountFactor(new DateOnly(2020, 12, 31), splits, null, "TEST", out var factor)
             .Should()
             .BeTrue();
 
@@ -62,7 +62,7 @@ public class HoldingValueBasisBoundaryAndCompoundTests
         // path has to be an exact no-op: a factor of anything but 1 here would perturb every
         // value on the platform.
         HoldingValueBasis
-            .TryResolveShareCountFactor(new DateOnly(2024, 6, 30), [], out var factor)
+            .TryResolveShareCountFactor(new DateOnly(2024, 6, 30), [], null, "TEST", out var factor)
             .Should()
             .BeTrue();
 
@@ -82,7 +82,7 @@ public class HoldingValueBasisBoundaryAndCompoundTests
         };
 
         HoldingValueBasis
-            .TryResolveShareCountFactor(new DateOnly(2024, 12, 31), splits, out var factor)
+            .TryResolveShareCountFactor(new DateOnly(2024, 12, 31), splits, null, "TEST", out var factor)
             .Should()
             .BeTrue();
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisForwardSplitTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisForwardSplitTests.cs
@@ -32,6 +32,8 @@ public class HoldingValueBasisForwardSplitTests
         var resolved = HoldingValueBasis.TryResolveShareCountFactor(
             new DateOnly(2023, 12, 31),
             splits,
+            null,
+            "TEST",
             out var factor
         );
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisForwardSplitTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisForwardSplitTests.cs
@@ -34,6 +34,7 @@ public class HoldingValueBasisForwardSplitTests
             splits,
             null,
             "TEST",
+            null,
             out var factor
         );
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisListedTickerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisListedTickerTests.cs
@@ -1,0 +1,157 @@
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// The per-listing split-attribution rules (#4247). A sibling-class 13F position is
+/// valued from its OWN class's price series, so its share count may only be restated
+/// by splits attributed to that same series. The classes of one issuer do not have to
+/// split together (Alphabet's A and C did; plenty of preferred/unit siblings do not),
+/// and the stored split table attributes each capture to exactly one price series via
+/// <see cref="StockSplit.PriceSeriesTicker"/> — null meaning the pre-attribution
+/// legacy capture, which only the primary series could have produced.
+/// </summary>
+public class HoldingValueBasisListedTickerTests
+{
+    private static StockSplit Applied(
+        DateOnly effectiveDate,
+        decimal numerator,
+        decimal denominator,
+        string priceSeriesTicker
+    ) =>
+        new()
+        {
+            EffectiveDate = effectiveDate,
+            Numerator = numerator,
+            Denominator = denominator,
+            PriceSeriesTicker = priceSeriesTicker,
+            PriceAdjustmentAppliedTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+    [Fact]
+    public void SecondaryPosition_SplitAttributedToItsOwnListing_RestatesTheCount()
+    {
+        // The happy path per-class split capture unlocks: a GOOG split recorded against the
+        // GOOG series restates GOOG positions exactly like a primary split restates primary ones.
+        var splits = new List<StockSplit> { Applied(new DateOnly(2022, 7, 18), 20m, 1m, "GOOG") };
+
+        HoldingValueBasis
+            .TryResolveShareCountFactor(
+                new DateOnly(2022, 3, 31),
+                splits,
+                "GOOG",
+                "GOOGL",
+                out var factor
+            )
+            .Should()
+            .BeTrue();
+
+        factor.Should().Be(20m);
+    }
+
+    [Fact]
+    public void SecondaryPosition_UnattributedPostReportSplit_RefusesToResolve()
+    {
+        // A legacy null-attribution split proves the ISSUER split after the report date, but says
+        // nothing about whether the secondary class's own series moved. Guessing "the classes
+        // split together" would be exactly the BRK-A-at-BRK-B's-price class of error — the row
+        // must stay pending until per-class capture can attribute it.
+        var splits = new List<StockSplit> { Applied(new DateOnly(2022, 7, 18), 20m, 1m, null) };
+
+        HoldingValueBasis
+            .TryResolveShareCountFactor(
+                new DateOnly(2022, 3, 31),
+                splits,
+                "GOOG",
+                "GOOGL",
+                out var factor
+            )
+            .Should()
+            .BeFalse();
+
+        factor.Should().Be(1m, "an unusable factor must be inert, never silently applied");
+    }
+
+    [Fact]
+    public void SecondaryPosition_SplitAttributedToAnotherSeries_RefusesToResolve()
+    {
+        // Same rule when the post-report split is attributed to the PRIMARY series: the issuer
+        // demonstrably restructured after the report date and the secondary's basis is unknowable.
+        var splits = new List<StockSplit> { Applied(new DateOnly(2022, 7, 18), 20m, 1m, "GOOGL") };
+
+        HoldingValueBasis
+            .TryResolveShareCountFactor(
+                new DateOnly(2022, 3, 31),
+                splits,
+                "GOOG",
+                "GOOGL",
+                out var factor
+            )
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void SecondaryPosition_ForeignSeriesSplitBeforeReportDate_IsIgnored()
+    {
+        // Only POST-report splits can move a count; an earlier split of any series is history the
+        // filed count already absorbed. The secondary must not be parked pending over it.
+        var splits = new List<StockSplit> { Applied(new DateOnly(2020, 8, 31), 4m, 1m, "GOOGL") };
+
+        HoldingValueBasis
+            .TryResolveShareCountFactor(
+                new DateOnly(2022, 3, 31),
+                splits,
+                "GOOG",
+                "GOOGL",
+                out var factor
+            )
+            .Should()
+            .BeTrue();
+
+        factor.Should().Be(1m);
+    }
+
+    [Fact]
+    public void PrimaryPosition_SplitAttributedToItsOwnSymbol_RestatesTheCount()
+    {
+        // A primary row must treat a split attributed to the primary's own symbol exactly like a
+        // legacy unattributed one — the attribution column filling in must not turn restatement off.
+        var splits = new List<StockSplit> { Applied(new DateOnly(2024, 6, 10), 10m, 1m, "NVDA") };
+
+        HoldingValueBasis
+            .TryResolveShareCountFactor(
+                new DateOnly(2023, 12, 31),
+                splits,
+                null,
+                "NVDA",
+                out var factor
+            )
+            .Should()
+            .BeTrue();
+
+        factor.Should().Be(10m);
+    }
+
+    [Fact]
+    public void PrimaryPosition_SplitAttributedToASecondaryListing_MovesNothing()
+    {
+        // A sibling class splitting does not restate the primary's count; the primary resolves
+        // with factor 1 rather than picking up a foreign series' ratio or parking pending.
+        var splits = new List<StockSplit> { Applied(new DateOnly(2024, 6, 10), 10m, 1m, "BRK-A") };
+
+        HoldingValueBasis
+            .TryResolveShareCountFactor(
+                new DateOnly(2023, 12, 31),
+                splits,
+                null,
+                "BRK-B",
+                out var factor
+            )
+            .Should()
+            .BeTrue();
+
+        factor.Should().Be(1m);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisListedTickerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisListedTickerTests.cs
@@ -42,6 +42,7 @@ public class HoldingValueBasisListedTickerTests
                 splits,
                 "GOOG",
                 "GOOGL",
+                ["GOOG"],
                 out var factor
             )
             .Should()
@@ -65,6 +66,7 @@ public class HoldingValueBasisListedTickerTests
                 splits,
                 "GOOG",
                 "GOOGL",
+                ["GOOG"],
                 out var factor
             )
             .Should()
@@ -86,6 +88,7 @@ public class HoldingValueBasisListedTickerTests
                 splits,
                 "GOOG",
                 "GOOGL",
+                ["GOOG"],
                 out var factor
             )
             .Should()
@@ -105,6 +108,7 @@ public class HoldingValueBasisListedTickerTests
                 splits,
                 "GOOG",
                 "GOOGL",
+                ["GOOG"],
                 out var factor
             )
             .Should()
@@ -126,12 +130,38 @@ public class HoldingValueBasisListedTickerTests
                 splits,
                 null,
                 "NVDA",
+                null,
                 out var factor
             )
             .Should()
             .BeTrue();
 
         factor.Should().Be(10m);
+    }
+
+    [Fact]
+    public void PrimaryPosition_SplitAttributedToAStaleSymbol_RefusesToResolve()
+    {
+        // The capture manager preserves a split's attribution verbatim forever, so after a
+        // primary RENAME (LC → HAPN) the stored attribution matches neither the current
+        // primary nor any secondary. That split very likely IS the primary series' own —
+        // silently skipping it publishes a value off by exactly the ratio, the error class
+        // this file exists to prevent. Unknown basis: the row stays pending instead.
+        var splits = new List<StockSplit> { Applied(new DateOnly(2024, 6, 10), 10m, 1m, "LC") };
+
+        HoldingValueBasis
+            .TryResolveShareCountFactor(
+                new DateOnly(2023, 12, 31),
+                splits,
+                null,
+                "HAPN",
+                [],
+                out var factor
+            )
+            .Should()
+            .BeFalse();
+
+        factor.Should().Be(1m, "an unusable factor must be inert, never silently applied");
     }
 
     [Fact]
@@ -147,6 +177,7 @@ public class HoldingValueBasisListedTickerTests
                 splits,
                 null,
                 "BRK-B",
+                ["BRK-A"],
                 out var factor
             )
             .Should()

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisReverseSplitTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisReverseSplitTests.cs
@@ -35,6 +35,8 @@ public class HoldingValueBasisReverseSplitTests
         var resolved = HoldingValueBasis.TryResolveShareCountFactor(
             new DateOnly(2024, 6, 30),
             splits,
+            null,
+            "TEST",
             out var factor
         );
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisReverseSplitTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisReverseSplitTests.cs
@@ -37,6 +37,7 @@ public class HoldingValueBasisReverseSplitTests
             splits,
             null,
             "TEST",
+            null,
             out var factor
         );
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisUnreconciledSplitTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisUnreconciledSplitTests.cs
@@ -33,6 +33,7 @@ public class HoldingValueBasisUnreconciledSplitTests
             splits,
             null,
             "TEST",
+            null,
             out var factor
         );
 
@@ -63,6 +64,7 @@ public class HoldingValueBasisUnreconciledSplitTests
             splits,
             null,
             "TEST",
+            null,
             out var factor
         );
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisUnreconciledSplitTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisUnreconciledSplitTests.cs
@@ -31,6 +31,8 @@ public class HoldingValueBasisUnreconciledSplitTests
         var resolved = HoldingValueBasis.TryResolveShareCountFactor(
             new DateOnly(2024, 6, 30),
             splits,
+            null,
+            "TEST",
             out var factor
         );
 
@@ -59,6 +61,8 @@ public class HoldingValueBasisUnreconciledSplitTests
         var resolved = HoldingValueBasis.TryResolveShareCountFactor(
             new DateOnly(2025, 3, 31),
             splits,
+            null,
+            "TEST",
             out var factor
         );
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyCultureInvarianceTests.cs
@@ -57,6 +57,7 @@ public class HoldingsImportServiceBuildHoldingKeyCultureInvarianceTests
                 typeof(ShareType),
                 typeof(OptionType?),
                 typeof(FilingType),
+                typeof(string),
             ]
         );
 
@@ -71,6 +72,7 @@ public class HoldingsImportServiceBuildHoldingKeyCultureInvarianceTests
             ShareType.Shares,
             (OptionType?)null,
             FilingType.Form13F,
+            null,
         ];
 
         var original = CultureInfo.CurrentCulture;

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyOptionTypeTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyOptionTypeTests.cs
@@ -42,6 +42,7 @@ public class HoldingsImportServiceBuildHoldingKeyOptionTypeTests
                 typeof(ShareType),
                 typeof(OptionType?),
                 typeof(FilingType),
+                typeof(string),
             ]
         );
 
@@ -59,6 +60,7 @@ public class HoldingsImportServiceBuildHoldingKeyOptionTypeTests
                     ShareType.Shares,
                     (OptionType?)OptionType.Call,
                     FilingType.Form13F,
+                    null,
                 ]
             );
         var putKey = (string)
@@ -71,6 +73,7 @@ public class HoldingsImportServiceBuildHoldingKeyOptionTypeTests
                     ShareType.Shares,
                     (OptionType?)OptionType.Put,
                     FilingType.Form13F,
+                    null,
                 ]
             );
 
@@ -90,6 +93,7 @@ public class HoldingsImportServiceBuildHoldingKeyOptionTypeTests
                 typeof(ShareType),
                 typeof(OptionType?),
                 typeof(FilingType),
+                typeof(string),
             ]
         );
 
@@ -107,6 +111,7 @@ public class HoldingsImportServiceBuildHoldingKeyOptionTypeTests
                     ShareType.Shares,
                     (OptionType?)null,
                     FilingType.Form13F,
+                    null,
                 ]
             );
         var key13D = (string)
@@ -119,6 +124,7 @@ public class HoldingsImportServiceBuildHoldingKeyOptionTypeTests
                     ShareType.Shares,
                     (OptionType?)null,
                     FilingType.Schedule13D,
+                    null,
                 ]
             );
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyShareTypeTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyShareTypeTests.cs
@@ -31,6 +31,7 @@ public class HoldingsImportServiceBuildHoldingKeyShareTypeTests
                 typeof(ShareType),
                 typeof(OptionType?),
                 typeof(FilingType),
+                typeof(string),
             ]
         );
 
@@ -48,6 +49,7 @@ public class HoldingsImportServiceBuildHoldingKeyShareTypeTests
                     ShareType.Shares,
                     (OptionType?)null,
                     FilingType.Form13F,
+                    null,
                 ]
             );
         var principalKey = (string)
@@ -60,6 +62,7 @@ public class HoldingsImportServiceBuildHoldingKeyShareTypeTests
                     ShareType.Principal,
                     (OptionType?)null,
                     FilingType.Form13F,
+                    null,
                 ]
             );
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowPricePresentTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowPricePresentTests.cs
@@ -52,16 +52,25 @@ public class HoldingsImportServiceParseHoldingRowPricePresentTests
         var context = new ImportContext
         {
             CoverPages = new Dictionary<string, CoverPageRow>(),
-            StockPrices = new Dictionary<(Guid, DateOnly), decimal>
+            StockPrices = new Dictionary<(Guid, string, DateOnly), decimal>
             {
-                [(commonStockId, reportDate)] = 12.50m,
+                [(commonStockId, null, reportDate)] = 12.50m,
             },
             OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(),
         };
 
         var result = method.Invoke(
             null,
-            [row, accession, "037833100", commonStockId, holderId, filingDate, reportDate, context]
+            [
+                row,
+                accession,
+                "037833100",
+                new CusipTarget(commonStockId, null),
+                holderId,
+                filingDate,
+                reportDate,
+                context,
+            ]
         );
 
         var holding = (InstitutionalHolding)result.GetType().GetField("Item1").GetValue(result);

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValueOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValueOverflowTests.cs
@@ -36,9 +36,9 @@ public class HoldingsImportServiceParseHoldingRowValueOverflowTests
         var context = new ImportContext
         {
             CoverPages = new Dictionary<string, CoverPageRow>(),
-            StockPrices = new Dictionary<(Guid, DateOnly), decimal>
+            StockPrices = new Dictionary<(Guid, string, DateOnly), decimal>
             {
-                [(stockId, reportDate)] = 2m,
+                [(stockId, null, reportDate)] = 2m,
             },
         };
         var args = new object[]

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValuePendingTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowValuePendingTests.cs
@@ -49,13 +49,22 @@ public class HoldingsImportServiceParseHoldingRowValuePendingTests
         var context = new ImportContext
         {
             CoverPages = new Dictionary<string, CoverPageRow>(),
-            StockPrices = new Dictionary<(Guid, DateOnly), decimal>(),
+            StockPrices = new Dictionary<(Guid, string, DateOnly), decimal>(),
             OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(),
         };
 
         var result = method.Invoke(
             null,
-            [row, accession, "037833100", commonStockId, holderId, filingDate, reportDate, context]
+            [
+                row,
+                accession,
+                "037833100",
+                new CusipTarget(commonStockId, null),
+                holderId,
+                filingDate,
+                reportDate,
+                context,
+            ]
         );
 
         var holding = (InstitutionalHolding)result.GetType().GetField("Item1").GetValue(result);

--- a/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorOversizedSharesOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorOversizedSharesOverflowTests.cs
@@ -38,13 +38,13 @@ public class HoldingsValueRecalculatorOversizedSharesOverflowTests
         var priceProvider = Substitute.For<IStockPriceProvider>();
         priceProvider
             .GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
-                new Dictionary<(Guid CommonStockId, DateOnly Date), decimal>
+                new Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal>
                 {
-                    [(stockId, reportDate)] = 2m,
+                    [(stockId, null, reportDate)] = 2m,
                 }
             );
         var recalculator = BuildRecalculator(db, priceProvider);

--- a/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorRetryAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorRetryAnchorTests.cs
@@ -36,10 +36,10 @@ public class HoldingsValueRecalculatorRetryAnchorTests
 
         harness
             .PriceProvider.GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(new Dictionary<(Guid CommonStockId, DateOnly Date), decimal>());
+            .Returns(new Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal>());
 
         await harness.BuildRecalculator(db).Recalculate(CancellationToken.None);
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorTests.cs
@@ -81,13 +81,13 @@ public class HoldingsValueRecalculatorTests
 
         harness
             .PriceProvider.GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
-                new Dictionary<(Guid CommonStockId, DateOnly Date), decimal>
+                new Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal>
                 {
-                    [(stockId, reportDate)] = 12.50m,
+                    [(stockId, null, reportDate)] = 12.50m,
                 }
             );
 
@@ -136,10 +136,10 @@ public class HoldingsValueRecalculatorTests
 
         harness
             .PriceProvider.GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(new Dictionary<(Guid CommonStockId, DateOnly Date), decimal>());
+            .Returns(new Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal>());
 
         await harness.BuildRecalculator(db).Recalculate(CancellationToken.None);
 
@@ -186,10 +186,10 @@ public class HoldingsValueRecalculatorTests
 
         harness
             .PriceProvider.GetClosingPrices(
-                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(new Dictionary<(Guid CommonStockId, DateOnly Date), decimal>());
+            .Returns(new Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal>());
 
         await harness.BuildRecalculator(db).Recalculate(CancellationToken.None);
 


### PR DESCRIPTION
## Summary

Part of #4247 (closed after production verification from the commercial rollout).

A filer's other listed securities file 13F lines under their own CUSIPs, and `BuildCusipMapping` resolved only the primary CUSIP plus retired aliases — so every sibling-class line (Alphabet Class C at 02079K107, ~5,300 positions a quarter) was dropped at import. Aliasing cannot fix it: the holding upsert key had no security discriminator, so a sibling CUSIP mapped to the filer row would merge two securities' positions into one row.

This gives each authoritative secondary listing its own CUSIP identity and threads the listing through the holding key and the valuation path, so sibling positions import as their own rows valued from their own class's exact price series.

## Code changes

- **CommonStockListedCusip** (new, CommonStocks.Data): a secondary listing's CUSIP identity — deliberately separate from `CommonStockCusipAlias` (an alias is a retired identity of the PRIMARY series). Recorded only from SEC CNS symbol+CUSIP rows; one CUSIP has one owner, ever, in both directions (the alias recorder's taken-set now covers listings too).
- **FtdImportService**: a listed-CUSIP sweep on its own frontier (`Ftd.ListedCusipSweep`, from the archive origin) resolving CNS symbols against the SECONDARY ticker space — primary symbols excluded, ambiguous symbols dropped, `CusipIdentity.SameIssuer` blocks recycled tickers, stocks without a primary CUSIP skipped. Recording publishes `StockCusipChanged` so already-processed history re-imports.
- **InstitutionalHolding.ListedTicker** (null = primary; existing rows untouched) joins all four key sites in lockstep: the unique index (`NULLS NOT DISTINCT`), `BuildHoldingKey`, the upsert `.On(...)` tuple, and the manager-entry reattachment.
- **IStockPriceProvider** keys by `(CommonStockId, ListedTicker, Date)`; the Yahoo provider answers a secondary request from that listing's exact series only — absent, never the primary's close, when it has none (BRK-A at BRK-B's price is ~1500x off). Listing spellings fold uppercase end to end.
- **HoldingValueBasis**: a secondary count is restated only by splits attributed to its own series; an unattributed or foreign-series post-report issuer split leaves the row honestly `ValuePending` (shares import and display; the value waits for per-class split capture — follow-up issue). A primary split carrying a STALE attribution (post-rename) also goes pending instead of being silently skipped.
- **BuildCusipMapping** precedence: primary > alias > listing; a CUSIP claimed as both an alias and a listing is DROPPED (missing beats merged). The 13D/G restatement delete is scoped to the amendment's exact (issuer, listing) pairs so a one-class 13G/A cannot wipe the sibling's stake.
- **ProcessedDataSet.CurrentParserVersion 6 → 7** re-imports all 13F history oldest-first.
- Migration `PerListing13FIdentity`: new table + nullable column + unique-index swap.
- Tests: new suites for the sibling-class import shapes, the split-attribution rules, the recorder guards, the sweep prefix guard, and the provider's own-series-only answers; all existing suites updated mechanically to the new key shape (no assertion weakened). Unit 3973 / integration 2343 green locally.

## Known accepted behavior

- Sibling positions filed before an unattributed issuer split (pre-2022 GOOG quarters) import with shares and a pending value — strictly more data than dropping the line, and pending is the state that self-heals once per-class split capture lands (follow-up issue).
- The unique-index swap on a large `InstitutionalHolding` table needs deploy-time care (pre-building the replacement index `CONCURRENTLY` before the migration adopts it); handled in the deployment plan, not in this repo.