### PR TITLE
feat(holdings): name the share class on 13F reader surfaces

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -217,8 +217,14 @@ public class InstitutionalHoldingsTools
                 // absolute share count is restated onto today's basis.
                 var pct = Percentage.Of(h.Shares, totalSharesAll);
                 var adjustedShares = SplitAdjustment.AdjustShareCount(h.Shares, shareFactor);
+                // A sibling-class row is a DIFFERENT security of the same issuer; the class
+                // qualifies the type in place so single-class stocks pay no extra column.
+                var positionType =
+                    h.ListedTicker == null
+                        ? PositionType(h.OptionType)
+                        : $"{PositionType(h.OptionType)} ({h.ListedTicker})";
                 return $"| {rank} | {h.InstitutionalHolder.Name} | "
-                    + $"{PositionType(h.OptionType)} | "
+                    + $"{positionType} | "
                     + $"{McpFormat.WholeNumber(adjustedShares)} | "
                     + $"{FormatMillions(h.Value)} | "
                     + $"{McpFormat.Invariant(pct, "F2")}% |";
@@ -493,7 +499,9 @@ public class InstitutionalHoldingsTools
                     SplitsFor(splitsByStock, h.CommonStockId)
                 );
                 var pct = Percentage.Of(h.Value, totalValue);
-                return $"| {rank} | {h.CommonStock.Ticker} | {h.CommonStock.Name} | "
+                // The exact listing held: a GOOG position must not render as GOOGL.
+                var listedTicker = h.ListedTicker ?? h.CommonStock.Ticker;
+                return $"| {rank} | {listedTicker} | {h.CommonStock.Name} | "
                     + $"{PositionType(h.OptionType)} | "
                     + $"{McpFormat.WholeNumber(shares)} | "
                     + $"{FormatMillions(h.Value)} | "

--- a/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
+++ b/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
@@ -108,7 +108,12 @@ public static class HoldingsPositionGrouper
                 g => new HolderAggregate
                 {
                     Holder = g.First().InstitutionalHolder,
-                    LatestHolding = g.OrderByDescending(h => h.FilingDate).First(),
+                    // Representative row for labels: prefer the PRIMARY class (null
+                    // ListedTicker) so a two-class holder's row isn't captioned with a
+                    // sibling listing's identity; latest filing breaks the tie.
+                    LatestHolding = g.OrderBy(h => h.ListedTicker == null ? 0 : 1)
+                        .ThenByDescending(h => h.FilingDate)
+                        .First(),
                     TotalShares = g.Sum(h => h.Shares),
                     TotalValue = g.Sum(h => h.Value),
                 }

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -214,7 +214,11 @@ public class StockTabService
                 {
                     InstitutionalHolderId = g.Key,
                     InstitutionalHolder = g.First().InstitutionalHolder,
-                    CurrentHolding = g.OrderByDescending(h => h.FilingDate).First(),
+                    // Prefer the primary-class row as the label-bearing representative,
+                    // mirroring HoldingsPositionGrouper.AggregateByHolder.
+                    CurrentHolding = g.OrderBy(h => h.ListedTicker == null ? 0 : 1)
+                        .ThenByDescending(h => h.FilingDate)
+                        .First(),
                     CurrentShares = g.Sum(h => h.Shares),
                     CurrentValue = g.Sum(h => h.Value),
                     ChangeType = PositionChangeType.Unchanged,


### PR DESCRIPTION
## Summary

Follow-up to #4294 (part of #4247): per-listing 13F rows are now on the read surfaces, so the MCP tools and the shared position grouper must name the exact class instead of rendering two indistinguishable rows (or captioning a merged holder row with a sibling listing's identity).

## Code changes

- `InstitutionalHoldingsTools.GetTopHolders`: the Type cell is qualified with the class on sibling-class rows only — `Shares (GOOG)` — so single-class stocks pay no wider table.
- `InstitutionalHoldingsTools.GetInstitutionPortfolio`: the Ticker column names the exact listing held (`ListedTicker ?? primary`); a GOOG position must not render as GOOGL.
- `HoldingsPositionGrouper.AggregateByHolder` and `StockTabService`'s inline twin: the representative holding for labels prefers the primary-class row, latest filing breaking the tie.

Unit 3973 / integration 2343 green locally.