### PR TITLE
fix(holdings): publish filed value when derivation fails and guard implausible closes

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -113,6 +113,26 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
             })
             .IncludeProperties(h => new { h.Shares, h.Value });
 
+        // Partial index for the repricing lane — in steady state ~0% of rows are
+        // pending, so a full btree wastes space; without any index the lane's
+        // "WHERE ValuePending" distinct-pair scan walks all ~33M rows and can
+        // outlive the command timeout. Columns match the lane's pair identity
+        // (CommonStockId, ListedTicker, ReportDate) — deliberately NOT the bare
+        // (CommonStockId, ReportDate) tuple, which would collide with (and
+        // silently replace) the covering index above. The [Index] attribute
+        // cannot express the HasFilter predicate (same trade-off as
+        // AumQuarterlySnapshot.DirtyAt).
+        builder
+            .Entity<InstitutionalHolding>()
+            .HasIndex(h => new
+            {
+                h.CommonStockId,
+                h.ListedTicker,
+                h.ReportDate,
+            })
+            .HasDatabaseName("IX_InstitutionalHolding_ValuePending_Pairs")
+            .HasFilter("\"ValuePending\"");
+
         builder.Entity<UnmappedCusip>();
         builder.Entity<FilingOtherManager>();
         builder.Entity<ProcessedDataSet>();

--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
@@ -106,13 +106,15 @@ public class InstitutionalHolding
     /// The position's dollar value could not be derived honestly, so <see cref="Value"/> is zero
     /// and means "unknown" rather than "nothing". Set when the reported share count is larger than
     /// the issuer itself — the tell of a count in different units from our price series, such as a
-    /// depositary-share issuer whose filer reports the underlying ordinary shares. The share count
-    /// is still what the filer reported; only the valuation is withheld.
+    /// depositary-share issuer whose filer reports the underlying ordinary shares — and when the
+    /// retry ladder exhausts with no price ever arriving and no <see cref="FiledValue"/> to fall
+    /// back on. The share count is still what the filer reported; only the valuation is withheld.
     /// </summary>
     /// <remarks>
     /// Distinct from <see cref="ValuePending"/>, which means "no price yet, retry later". This one
-    /// never resolves on its own: re-deriving from the same count would reproduce the same wrong
-    /// figure, so the repricing lane must leave these rows alone.
+    /// never resolves on its own: the unit-mismatch case would re-derive the same wrong figure,
+    /// and the exhausted case already spent its retries — so the repricing lane must leave these
+    /// rows alone.
     /// </remarks>
     public bool ValueUnavailable { get; set; }
 

--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
@@ -96,6 +96,13 @@ public class InstitutionalHolding
     public DateTime? ValueLastRetryAt { get; set; }
 
     /// <summary>
+    /// Whether <see cref="Value"/> is the derived figure or a fallback to the filer's own
+    /// <see cref="FiledValue"/>. Filed is used only when derivation is impossible or implausible —
+    /// see <see cref="Models.ValueSource"/> for the contract.
+    /// </summary>
+    public ValueSource ValueSource { get; set; }
+
+    /// <summary>
     /// The position's dollar value could not be derived honestly, so <see cref="Value"/> is zero
     /// and means "unknown" rather than "nothing". Set when the reported share count is larger than
     /// the issuer itself — the tell of a count in different units from our price series, such as a

--- a/src/Equibles.Holdings.Data/Models/ValueSource.cs
+++ b/src/Equibles.Holdings.Data/Models/ValueSource.cs
@@ -1,0 +1,24 @@
+namespace Equibles.Holdings.Data.Models;
+
+/// <summary>
+/// Where a holding's published <see cref="InstitutionalHolding.Value"/> came from.
+/// </summary>
+/// <remarks>
+/// The derived figure (shares × closing price on a reconciled basis) is preferred because it is
+/// comparable across filings, including Schedule 13D/G positions that carry no filed value at all.
+/// When no honest derivation exists — the price series never yields a usable close, or the derived
+/// figure grossly disagrees with the filer's own — the filer's reported value is published instead
+/// of a zero that reads as "nothing". This column records which of the two the row carries, so
+/// surfaces can disclose it and audits can count it.
+/// </remarks>
+public enum ValueSource
+{
+    /// <summary>Derived from shares × the report date's closing price (the default basis).</summary>
+    Derived = 0,
+
+    /// <summary>
+    /// Copied from the filer's own reported market value (<see cref="InstitutionalHolding.FiledValue"/>)
+    /// because no honest derivation was possible.
+    /// </summary>
+    Filed = 1,
+}

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -287,10 +287,13 @@ public class HoldingsScraperWorker : BaseScraperWorker
         {
             throw;
         }
-        catch (Exception ex) when (ex is NpgsqlException or TimeoutException)
+        catch (Exception ex)
+            when (ex is TimeoutException or NpgsqlException { InnerException: TimeoutException })
         {
             // A timed-out scan is a capacity signal, not a fault: the backlog is still there and
             // the next cycle retries it. Warn — an error here once hid a frozen lane for months.
+            // Only the client-side command timeout gets this treatment; every other database
+            // fault (constraint violation, deadlock, connection loss) is a real error below.
             Logger.LogWarning(
                 ex,
                 "Recalculating pending holding values timed out; retrying next cycle"

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -9,6 +9,7 @@ using Equibles.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
+using Npgsql;
 
 namespace Equibles.Holdings.HostedService;
 
@@ -133,6 +134,11 @@ public class HoldingsScraperWorker : BaseScraperWorker
         // Withdraw the derived value from stored positions bigger than their issuer. Self-
         // terminating once the back catalogue is clean, so it costs one query per cycle after that.
         await RepairImpossiblePositions(stoppingToken);
+
+        // Heal abandoned zero-value rows (publish the filed figure) and reset implausible
+        // derivations for honest repricing. Bounded per cycle; self-terminating like the pass
+        // above once the backlog drains.
+        await RepairAbandonedValues(stoppingToken);
     }
 
     private async Task RepairImpossiblePositions(CancellationToken cancellationToken)
@@ -281,9 +287,34 @@ public class HoldingsScraperWorker : BaseScraperWorker
         {
             throw;
         }
+        catch (Exception ex) when (ex is NpgsqlException or TimeoutException)
+        {
+            // A timed-out scan is a capacity signal, not a fault: the backlog is still there and
+            // the next cycle retries it. Warn — an error here once hid a frozen lane for months.
+            Logger.LogWarning(
+                ex,
+                "Recalculating pending holding values timed out; retrying next cycle"
+            );
+        }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to recalculate pending holding values");
+        }
+    }
+
+    private async Task RepairAbandonedValues(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var scope = ScopeFactory.CreateAsyncScope();
+            var repairer =
+                scope.ServiceProvider.GetRequiredService<HoldingValueFallbackRepairService>();
+            await repairer.Repair(cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            // Maintenance, not ingestion — same contract as the impossible-position pass.
+            Logger.LogWarning(exception, "Value fallback repair pass failed");
         }
     }
 

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
@@ -11,7 +11,7 @@ namespace Equibles.Holdings.HostedService.Services;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Two populations, two phases:
+/// Three populations, three phases:
 /// <list type="number">
 /// <item><b>Stuck zeros</b> — rows the repricing lane gave up on before the filed-value fallback
 /// existed: <c>Value = 0</c>, not pending, not unavailable, with a perfectly good
@@ -23,21 +23,33 @@ namespace Equibles.Holdings.HostedService.Services;
 /// One corrupt price series manufactured $102.8T of phantom value this way across 263 holders.
 /// The heal resets them to pending so the recalculator re-derives them under its sanity guard
 /// (which routes them to the filed value when the series is still corrupt).</item>
+/// <item><b>Unmarked zeros</b> — the same abandoned population as phase 1 but with no filed
+/// figure to publish. The ladder now stamps these <see cref="InstitutionalHolding.ValueUnavailable"/>
+/// on exhaustion, but rows abandoned before that change are indistinguishable from "position
+/// worth nothing", and every surface that discloses unvalued rows reads the flags. The heal
+/// stamps them so one state has one representation.</item>
 /// </list>
 /// </para>
 /// <para>
 /// Bounded per cycle and self-terminating: a healed row no longer matches its phase's candidate
-/// query, so once the backlog drains each pass costs one cheap indexed query. Affected filing
-/// rollups and AUM quarters are re-derived through <see cref="HoldingsRollupRefresher"/> in the
-/// same pass — a healed position with a stale rollup would just move the lie one aggregate up.
+/// query. Phase 2 terminates because the recalculator guards the same number this phase tests —
+/// the effective per-share price (factor × close) — so a reset row either re-derives under the
+/// cap, falls back to the filed value, or exhausts the ladder into <c>ValueUnavailable</c>; it
+/// can never re-derive back above the cap and be reset again. Neither candidate predicate is
+/// index-served (the zero test isn't selective enough to earn one and the per-share comparison
+/// isn't sargable), so a drained backlog still costs two bounded sequential scans per daily
+/// cycle — accepted for a 24h cadence. Affected filing rollups and AUM quarters are re-derived
+/// through <see cref="HoldingsRollupRefresher"/> in the same pass — a healed position with a
+/// stale rollup would just move the lie one aggregate up.
 /// </para>
 /// </remarks>
 [Service]
 public class HoldingValueFallbackRepairService
 {
-    // One cycle's ceiling per phase. The stuck-zero backlog is ~2.2M rows, so the drain takes a
-    // few daily cycles; the batch keeps each SaveChanges tracked set and the rollup refresh
-    // bounded rather than materialising millions of rows in one scope.
+    // One cycle's ceiling per phase. The stuck-zero backlog is ~2.2M rows, so at the worker's
+    // 24h cadence the drain takes ~44 daily cycles (about six weeks); the batch keeps each
+    // SaveChanges tracked set and the rollup refresh bounded rather than materialising millions
+    // of rows in one scope.
     internal const int MaxRowsPerCycle = 50_000;
 
     private readonly IServiceScopeFactory _scopeFactory;
@@ -56,19 +68,22 @@ public class HoldingValueFallbackRepairService
     {
         var healedZeros = await HealStuckZeros(cancellationToken);
         var resetImplausible = await ResetImplausibleDerivations(cancellationToken);
+        var markedUnavailable = await MarkAbandonedZerosUnavailable(cancellationToken);
 
-        if (healedZeros > 0 || resetImplausible > 0)
+        if (healedZeros > 0 || resetImplausible > 0 || markedUnavailable > 0)
         {
             _logger.LogWarning(
                 "Value fallback repair: published the filed value on {HealedZeros} abandoned "
-                    + "zero-value position(s) and reset {ResetImplausible} implausibly-derived "
-                    + "position(s) for honest repricing",
+                    + "zero-value position(s), reset {ResetImplausible} implausibly-derived "
+                    + "position(s) for honest repricing, and marked {MarkedUnavailable} "
+                    + "filed-value-less abandoned zero(s) as unavailable",
                 healedZeros,
-                resetImplausible
+                resetImplausible,
+                markedUnavailable
             );
         }
 
-        return healedZeros + resetImplausible;
+        return healedZeros + resetImplausible + markedUnavailable;
     }
 
     /// <summary>
@@ -144,8 +159,7 @@ public class HoldingValueFallbackRepairService
                 !h.ValuePending
                 && h.ValueSource != ValueSource.Filed
                 && h.Shares > 0
-                && (decimal)h.Value
-                    > HoldingValueSanityGuard.MaxPlausibleSharePrice * h.Shares
+                && (decimal)h.Value > HoldingValueSanityGuard.MaxPlausibleSharePrice * h.Shares
             )
             .OrderBy(h => h.Id)
             .Take(MaxRowsPerCycle)
@@ -181,6 +195,49 @@ public class HoldingValueFallbackRepairService
             cancellationToken
         );
 
+        return rows.Count;
+    }
+
+    /// <summary>
+    /// Stamps <see cref="InstitutionalHolding.ValueUnavailable"/> on zeros the old ladder
+    /// abandoned with no filed figure, so "unknown" stops masquerading as "worth nothing".
+    /// </summary>
+    private async Task<int> MarkAbandonedZerosUnavailable(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        if (dbContext.Database.IsRelational())
+        {
+            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+        }
+
+        // Value stays 0, so no rollup or AUM figure moves — the stamp only makes the row
+        // visible to every surface that discloses unvalued positions through the flags.
+        var rows = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h =>
+                h.Value == 0L
+                && !h.ValuePending
+                && !h.ValueUnavailable
+                && (h.FiledValue == null || h.FiledValue <= 0)
+                && h.ValueRetryCount > 0
+            )
+            .OrderBy(h => h.Id)
+            .Take(MaxRowsPerCycle)
+            .ToListAsync(cancellationToken);
+
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var holding in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            holding.ValueUnavailable = true;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
         return rows.Count;
     }
 }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
@@ -1,0 +1,186 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Heals stored positions whose published value is a known lie: silent zeros the old retry ladder
+/// abandoned, and derivations inflated by a corrupt close.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two populations, two phases:
+/// <list type="number">
+/// <item><b>Stuck zeros</b> — rows the repricing lane gave up on before the filed-value fallback
+/// existed: <c>Value = 0</c>, not pending, not unavailable, with a perfectly good
+/// <see cref="InstitutionalHolding.FiledValue"/> sitting unused in the same row. At its worst this
+/// population was 48% of a whole quarter's positions, hiding real top holdings (a $11.9B NVDA
+/// position sorted last) and understating every percentage. The heal publishes the filed figure.</item>
+/// <item><b>Implausible derivations</b> — rows whose implied per-share price
+/// (<c>Value / Shares</c>) exceeds <see cref="HoldingValueSanityGuard.MaxPlausibleSharePrice"/>.
+/// One corrupt price series manufactured $102.8T of phantom value this way across 263 holders.
+/// The heal resets them to pending so the recalculator re-derives them under its sanity guard
+/// (which routes them to the filed value when the series is still corrupt).</item>
+/// </list>
+/// </para>
+/// <para>
+/// Bounded per cycle and self-terminating: a healed row no longer matches its phase's candidate
+/// query, so once the backlog drains each pass costs one cheap indexed query. Affected filing
+/// rollups and AUM quarters are re-derived through <see cref="HoldingsRollupRefresher"/> in the
+/// same pass — a healed position with a stale rollup would just move the lie one aggregate up.
+/// </para>
+/// </remarks>
+[Service]
+public class HoldingValueFallbackRepairService
+{
+    // One cycle's ceiling per phase. The stuck-zero backlog is ~2.2M rows, so the drain takes a
+    // few daily cycles; the batch keeps each SaveChanges tracked set and the rollup refresh
+    // bounded rather than materialising millions of rows in one scope.
+    internal const int MaxRowsPerCycle = 50_000;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<HoldingValueFallbackRepairService> _logger;
+
+    public HoldingValueFallbackRepairService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<HoldingValueFallbackRepairService> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task<int> Repair(CancellationToken cancellationToken)
+    {
+        var healedZeros = await HealStuckZeros(cancellationToken);
+        var resetImplausible = await ResetImplausibleDerivations(cancellationToken);
+
+        if (healedZeros > 0 || resetImplausible > 0)
+        {
+            _logger.LogWarning(
+                "Value fallback repair: published the filed value on {HealedZeros} abandoned "
+                    + "zero-value position(s) and reset {ResetImplausible} implausibly-derived "
+                    + "position(s) for honest repricing",
+                healedZeros,
+                resetImplausible
+            );
+        }
+
+        return healedZeros + resetImplausible;
+    }
+
+    /// <summary>
+    /// Publishes the filed value on rows the old ladder abandoned at <c>Value = 0</c>.
+    /// </summary>
+    private async Task<int> HealStuckZeros(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        if (dbContext.Database.IsRelational())
+        {
+            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+        }
+
+        var rows = await dbContext
+            .Set<InstitutionalHolding>()
+            .Include(h => h.ManagerEntries)
+            .Where(h =>
+                h.Value == 0L
+                && !h.ValuePending
+                && !h.ValueUnavailable
+                && h.FiledValue != null
+                && h.FiledValue > 0
+            )
+            .OrderBy(h => h.Id)
+            .Take(MaxRowsPerCycle)
+            .ToListAsync(cancellationToken);
+
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var holding in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            HoldingsValueRecalculator.ApplyFiledValue(holding);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        await HoldingsRollupRefresher.Refresh(
+            dbContext,
+            rows.Select(h => h.AccessionNumber).ToHashSet(),
+            rows.Select(h => h.ReportDate).ToHashSet(),
+            cancellationToken
+        );
+
+        return rows.Count;
+    }
+
+    /// <summary>
+    /// Resets rows whose implied per-share price is impossible, so the recalculator re-derives
+    /// them under its sanity guard.
+    /// </summary>
+    private async Task<int> ResetImplausibleDerivations(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        if (dbContext.Database.IsRelational())
+        {
+            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+        }
+
+        // Decimal math server-side: 1M × a large share count overflows Int64, and the point of
+        // the predicate is exactly the rows where Value is astronomically large. Filed-value rows
+        // are excluded — that figure is the filer's own claim, not our derivation error, and
+        // resetting one would loop it through the fallback forever.
+        var rows = await dbContext
+            .Set<InstitutionalHolding>()
+            .Include(h => h.ManagerEntries)
+            .Where(h =>
+                !h.ValuePending
+                && h.ValueSource != ValueSource.Filed
+                && h.Shares > 0
+                && (decimal)h.Value
+                    > HoldingValueSanityGuard.MaxPlausibleSharePrice * h.Shares
+            )
+            .OrderBy(h => h.Id)
+            .Take(MaxRowsPerCycle)
+            .ToListAsync(cancellationToken);
+
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var holding in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            holding.Value = 0L;
+            holding.ValuePending = true;
+            holding.ValueRetryCount = 0;
+            holding.ValueLastRetryAt = null;
+            holding.ValueSource = ValueSource.Derived;
+
+            foreach (var entry in holding.ManagerEntries)
+            {
+                entry.Value = 0L;
+            }
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        await HoldingsRollupRefresher.Refresh(
+            dbContext,
+            rows.Select(h => h.AccessionNumber).ToHashSet(),
+            rows.Select(h => h.ReportDate).ToHashSet(),
+            cancellationToken
+        );
+
+        return rows.Count;
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueSanityGuard.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueSanityGuard.cs
@@ -1,0 +1,53 @@
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Plausibility gate for a derived holding value, applied wherever shares × close is computed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The derivation multiplies a filer-controlled share count by whatever the price lane stored, so a
+/// single corrupt close corrupts every position in that stock: one series carrying eight-figure
+/// per-share closes inflated 1,804 positions across 263 institutions by a combined $102.8T, and one
+/// of them rendered as 76.7% of the largest filer's portfolio. <see cref="ValueBasisAudit"/> already
+/// measured such disagreements but only logged them; this class is the acting version of the same
+/// signature.
+/// </para>
+/// <para>
+/// Two rules, in order of preference:
+/// <list type="number">
+/// <item><b>Relative</b> — when the filer reported a value, a derivation more than
+/// <see cref="DisagreementCapMultiple"/>× above it is basis-suspect and the filed figure is
+/// published instead. The cap sits far above <see cref="ValueBasisAudit.DisagreementMultiple"/>
+/// (ordinary mark drift) and far below any real units error (a missed split is ≥2×, the corrupt
+/// close was 12.5M×).</item>
+/// <item><b>Absolute</b> — with no filed value to compare against, a close above
+/// <see cref="MaxPlausibleSharePrice"/> is refused outright and the row stays pending. No US
+/// equity trades near $1M/share (BRK-A is ~$800k); the threshold must never be tightened below
+/// that.</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal static class HoldingValueSanityGuard
+{
+    /// <summary>
+    /// Ceiling on a per-share close used for valuation. BRK-A (~$800k) must stay below it.
+    /// </summary>
+    internal const decimal MaxPlausibleSharePrice = 1_000_000m;
+
+    /// <summary>
+    /// A derivation more than this multiple above the filer's own value is treated as a basis
+    /// error rather than published.
+    /// </summary>
+    internal const decimal DisagreementCapMultiple = 5m;
+
+    /// <summary>A close this large cannot honestly price anything — refuse to derive.</summary>
+    internal static bool IsImplausibleClose(decimal closePrice) =>
+        closePrice > MaxPlausibleSharePrice;
+
+    /// <summary>
+    /// Whether a derived value disagrees with the filed one grossly enough that the filed figure
+    /// must be published instead. Only meaningful when the filer reported a positive value.
+    /// </summary>
+    internal static bool GrosslyExceedsFiled(decimal derivedValue, long? filedValue) =>
+        filedValue is > 0 && derivedValue > DisagreementCapMultiple * filedValue.Value;
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1648,6 +1648,13 @@ public class HoldingsImportService
             // One unpriceable leg makes the merged position unpriceable: the surviving legs would
             // otherwise sum to a value that silently omits part of the holding.
             existing.ValueUnavailable |= holding.ValueUnavailable;
+            // Likewise one filed-value leg makes the merged figure partly filed: keeping the
+            // Derived label would present the mixed sum as a clean derivation — and expose it to
+            // the implausible-derivation reset, which must never touch a filer's own figure.
+            if (holding.ValueSource == ValueSource.Filed)
+            {
+                existing.ValueSource = ValueSource.Filed;
+            }
             existing.ManagerEntries.Add(managerEntry);
             return false;
         }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1713,7 +1713,11 @@ public class HoldingsImportService
             secondaryTickers,
             out var shareCountFactor
         );
-        var canValue = hasPrice && basisKnown;
+        // An implausible close (a corrupt bar in the price series) is no price at all: deriving
+        // from it once stated a $13.7T position for a $1.09M filing. The row stays pending and the
+        // repricing lane values it when the series heals — or falls back to the filed value.
+        var canValue =
+            hasPrice && basisKnown && !HoldingValueSanityGuard.IsImplausibleClose(closePrice);
 
         // shares comes from filer-controlled SSHPRNAMT; an oversized count makes the decimal
         // product exceed Int64, so range-check before the cast (mirrors Filing13DGXmlParser)
@@ -1770,6 +1774,16 @@ public class HoldingsImportService
             );
         }
 
+        // A derivation grossly above the filer's own figure is a basis error (a depositary ratio,
+        // a split the series never captured) — the audit above measures it; this acts on it.
+        // Publish the filed figure instead of the wrong derivation.
+        var valueSource = ValueSource.Derived;
+        if (value > 0 && HoldingValueSanityGuard.GrosslyExceedsFiled(value, filedValue))
+        {
+            value = filedValue.Value;
+            valueSource = ValueSource.Filed;
+        }
+
         var (otherManagerNumber, sharedManagerNumbers) = ParseOtherManagerAttribution(
             GetValue(row, "OTHERMANAGER")
         );
@@ -1820,6 +1834,7 @@ public class HoldingsImportService
             IsAmendment = isAmendment,
             ValueUnavailable = valueUnavailable,
             ValuePending = valuePending,
+            ValueSource = valueSource,
         };
 
         return (holding, managerEntry, valuePending, reportedValue);

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsRollupRefresher.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsRollupRefresher.cs
@@ -1,0 +1,152 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using FlexLabs.EntityFrameworkCore.Upsert;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Re-derives the stored rollups that carry a holding's value after that value changes in place.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two aggregates are written at import and never recomputed on read:
+/// <c>InstitutionalFiling.TotalValue</c> (what the AUM surfaces rank on) and the per-quarter
+/// <see cref="AumQuarterlySnapshot"/> (rebuilt by the drain worker, but only when its
+/// <c>DirtyAt</c> is stamped). Any pass that changes stored <c>Value</c> figures — the repricing
+/// lane, the filed-value fallback, the impossible-position repair — must route the affected
+/// accessions and quarters through here, or the aggregate keeps advertising the old figure.
+/// </para>
+/// <para>
+/// Idempotent and re-entrant: re-summing an already-correct filing writes nothing, and the dirty
+/// stamp is an insert-or-set-when-null upsert (the same statement
+/// <c>Filings13FImportedConsumer</c> uses), so concurrent stampers converge.
+/// </para>
+/// </remarks>
+internal static class HoldingsRollupRefresher
+{
+    internal static async Task Refresh(
+        EquiblesFinancialDbContext dbContext,
+        IReadOnlyCollection<string> accessionNumbers,
+        IReadOnlyCollection<DateOnly> reportDates,
+        CancellationToken cancellationToken
+    )
+    {
+        await RealignFilingTotals(dbContext, accessionNumbers, cancellationToken);
+        await MarkAumSnapshotsDirty(dbContext, reportDates, cancellationToken);
+    }
+
+    /// <summary>Re-sums <c>InstitutionalFiling.TotalValue</c> for the given accessions.</summary>
+    internal static async Task<int> RealignFilingTotals(
+        EquiblesFinancialDbContext dbContext,
+        IReadOnlyCollection<string> accessionNumbers,
+        CancellationToken cancellationToken
+    )
+    {
+        var accessions = accessionNumbers.Where(a => a != null).Distinct().ToList();
+        if (accessions.Count == 0)
+        {
+            return 0;
+        }
+
+        var totals = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => accessions.Contains(h.AccessionNumber))
+            .GroupBy(h => h.AccessionNumber)
+            .Select(g => new { AccessionNumber = g.Key, TotalValue = g.Sum(h => h.Value) })
+            .ToListAsync(cancellationToken);
+
+        var totalByAccession = totals.ToDictionary(t => t.AccessionNumber, t => t.TotalValue);
+
+        var filings = await dbContext
+            .Set<InstitutionalFiling>()
+            .Where(f => accessions.Contains(f.AccessionNumber))
+            .ToListAsync(cancellationToken);
+
+        var realigned = 0;
+        foreach (var filing in filings)
+        {
+            if (
+                totalByAccession.TryGetValue(filing.AccessionNumber, out var total)
+                && filing.TotalValue != total
+            )
+            {
+                filing.TotalValue = total;
+                realigned++;
+            }
+        }
+
+        if (realigned > 0)
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return realigned;
+    }
+
+    /// <summary>
+    /// Stamps the quarters' AUM snapshots dirty so the drain worker rebuilds them.
+    /// </summary>
+    internal static async Task MarkAumSnapshotsDirty(
+        EquiblesFinancialDbContext dbContext,
+        IReadOnlyCollection<DateOnly> reportDates,
+        CancellationToken cancellationToken
+    )
+    {
+        var quarters = reportDates.Distinct().ToList();
+        if (quarters.Count == 0)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var stubs = quarters
+            .Select(reportDate => new AumQuarterlySnapshot
+            {
+                ReportDate = reportDate,
+                TotalValue = 0L,
+                FilerCount = 0,
+                PositionCount = 0,
+                StockCount = 0,
+                FilingCount = 0,
+                ComputedAt = now,
+                DirtyAt = now,
+            })
+            .ToArray();
+
+        // The InMemory test provider gets a plain load-modify-save equivalent — the atomic upsert
+        // below is Postgres-specific and its semantics are already pinned on the real backend by
+        // the Filings13FImportedConsumer tests.
+        if (!dbContext.Database.IsRelational())
+        {
+            var existingRows = await dbContext
+                .Set<AumQuarterlySnapshot>()
+                .Where(s => quarters.Contains(s.ReportDate))
+                .ToListAsync(cancellationToken);
+            var existingByDate = existingRows.ToDictionary(s => s.ReportDate);
+            foreach (var stub in stubs)
+            {
+                if (existingByDate.TryGetValue(stub.ReportDate, out var existing))
+                {
+                    existing.DirtyAt ??= now;
+                }
+                else
+                {
+                    dbContext.Set<AumQuarterlySnapshot>().Add(stub);
+                }
+            }
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return;
+        }
+
+        await dbContext
+            .Set<AumQuarterlySnapshot>()
+            .UpsertRange(stubs)
+            .On(s => s.ReportDate)
+            .WhenMatched(
+                (existing, incoming) =>
+                    new AumQuarterlySnapshot { DirtyAt = existing.DirtyAt ?? incoming.DirtyAt }
+            )
+            .RunAsync(cancellationToken);
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsRollupRefresher.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsRollupRefresher.cs
@@ -25,6 +25,12 @@ namespace Equibles.Holdings.HostedService.Services;
 /// </remarks>
 internal static class HoldingsRollupRefresher
 {
+    // Each accession's re-sum scans every position of that filing (hundreds to thousands of
+    // rows), so a caller handing over a whole repair cycle's accessions in one statement turns
+    // the GROUP BY into a multi-million-row aggregate. Batching keeps each statement inside
+    // ordinary query cost while staying one logical pass.
+    private const int AccessionBatchSize = 500;
+
     internal static async Task Refresh(
         EquiblesFinancialDbContext dbContext,
         IReadOnlyCollection<string> accessionNumbers,
@@ -49,36 +55,43 @@ internal static class HoldingsRollupRefresher
             return 0;
         }
 
-        var totals = await dbContext
-            .Set<InstitutionalHolding>()
-            .Where(h => accessions.Contains(h.AccessionNumber))
-            .GroupBy(h => h.AccessionNumber)
-            .Select(g => new { AccessionNumber = g.Key, TotalValue = g.Sum(h => h.Value) })
-            .ToListAsync(cancellationToken);
-
-        var totalByAccession = totals.ToDictionary(t => t.AccessionNumber, t => t.TotalValue);
-
-        var filings = await dbContext
-            .Set<InstitutionalFiling>()
-            .Where(f => accessions.Contains(f.AccessionNumber))
-            .ToListAsync(cancellationToken);
-
         var realigned = 0;
-        foreach (var filing in filings)
+        foreach (var batch in accessions.Chunk(AccessionBatchSize))
         {
-            if (
-                totalByAccession.TryGetValue(filing.AccessionNumber, out var total)
-                && filing.TotalValue != total
-            )
-            {
-                filing.TotalValue = total;
-                realigned++;
-            }
-        }
+            cancellationToken.ThrowIfCancellationRequested();
 
-        if (realigned > 0)
-        {
-            await dbContext.SaveChangesAsync(cancellationToken);
+            var totals = await dbContext
+                .Set<InstitutionalHolding>()
+                .Where(h => batch.Contains(h.AccessionNumber))
+                .GroupBy(h => h.AccessionNumber)
+                .Select(g => new { AccessionNumber = g.Key, TotalValue = g.Sum(h => h.Value) })
+                .ToListAsync(cancellationToken);
+
+            var totalByAccession = totals.ToDictionary(t => t.AccessionNumber, t => t.TotalValue);
+
+            var filings = await dbContext
+                .Set<InstitutionalFiling>()
+                .Where(f => batch.Contains(f.AccessionNumber))
+                .ToListAsync(cancellationToken);
+
+            var batchRealigned = 0;
+            foreach (var filing in filings)
+            {
+                if (
+                    totalByAccession.TryGetValue(filing.AccessionNumber, out var total)
+                    && filing.TotalValue != total
+                )
+                {
+                    filing.TotalValue = total;
+                    batchRealigned++;
+                }
+            }
+
+            if (batchRealigned > 0)
+            {
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+            realigned += batchRealigned;
         }
 
         return realigned;

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
@@ -46,6 +46,13 @@ public class HoldingsValueRecalculator
         using var lookupScope = _scopeFactory.CreateScope();
         var lookupContext =
             lookupScope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        // The pending scan is served by the partial ValuePending index, but a first pass over a
+        // large backlog can still outlive the default timeout — and the worker's catch used to
+        // swallow that silently, freezing the whole lane.
+        if (lookupContext.Database.IsRelational())
+        {
+            lookupContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+        }
 
         var pendingPairs = await lookupContext
             .Set<InstitutionalHolding>()
@@ -111,7 +118,7 @@ public class HoldingsValueRecalculator
             cs => cs.SecondaryTickers ?? []
         );
 
-        var (totalUpdated, totalDeferred) = await ResolveHoldingsWithNewPrices(
+        var (totalUpdated, deferredPairKeys) = await ResolveHoldingsWithNewPrices(
             prices,
             splitsByStock,
             primaryTickers,
@@ -119,17 +126,20 @@ public class HoldingsValueRecalculator
             cancellationToken
         );
 
-        if (totalDeferred > 0)
+        if (deferredPairKeys.Count > 0)
         {
             _logger.LogInformation(
-                "Left {Deferred} (stock, date) pair(s) pending: a captured split has not had its price adjustment applied, so the share basis is still ambiguous",
-                totalDeferred
+                "Left {Deferred} (stock, date) pair(s) unvalued this pass: an ambiguous split basis or an implausible close blocked an honest derivation",
+                deferredPairKeys.Count
             );
         }
 
+        // A pair with a price that could not be used (basis ambiguous, close implausible) has NOT
+        // been resolved — it must advance the retry ladder like a priceless pair, or it sits at its
+        // current retry count forever. That escape once froze 828,603 rows at ValueRetryCount = 1.
         var unresolvedPairs = pendingPairs
-            .Where(p => !resolvedPairKeys.Contains((p.CommonStockId, p.ListedTicker, p.ReportDate)))
             .Select(p => (p.CommonStockId, p.ListedTicker, p.ReportDate))
+            .Where(key => !resolvedPairKeys.Contains(key) || deferredPairKeys.Contains(key))
             .ToList();
 
         var totalGivenUp = await IncrementRetryForUnresolved(
@@ -165,6 +175,7 @@ public class HoldingsValueRecalculator
 
             var holdings = await dbContext
                 .Set<InstitutionalHolding>()
+                .Include(h => h.ManagerEntries)
                 .Where(h =>
                     h.ValuePending
                     && h.CommonStockId == pair.CommonStockId
@@ -174,6 +185,7 @@ public class HoldingsValueRecalculator
                 .ToListAsync(cancellationToken);
 
             var changed = false;
+            var settledRows = new List<InstitutionalHolding>();
 
             foreach (var holding in holdings)
             {
@@ -188,7 +200,19 @@ public class HoldingsValueRecalculator
 
                 if (holding.ValueRetryCount > MaxRetries)
                 {
-                    holding.ValuePending = false;
+                    // The ladder is exhausted — derivation is not going to happen. Publish the
+                    // filer's own figure rather than a silent zero; only a row the filing itself
+                    // left unvalued is honestly unknowable.
+                    if (holding.FiledValue is > 0)
+                    {
+                        ApplyFiledValue(holding);
+                        settledRows.Add(holding);
+                    }
+                    else
+                    {
+                        holding.ValuePending = false;
+                        holding.ValueUnavailable = true;
+                    }
                     totalGivenUp++;
                 }
 
@@ -199,11 +223,24 @@ public class HoldingsValueRecalculator
             {
                 await dbContext.SaveChangesAsync(cancellationToken);
             }
+
+            if (settledRows.Count > 0)
+            {
+                await HoldingsRollupRefresher.Refresh(
+                    dbContext,
+                    settledRows.Select(h => h.AccessionNumber).ToHashSet(),
+                    settledRows.Select(h => h.ReportDate).ToHashSet(),
+                    cancellationToken
+                );
+            }
         }
         return totalGivenUp;
     }
 
-    private async Task<(int Updated, int Deferred)> ResolveHoldingsWithNewPrices(
+    private async Task<(
+        int Updated,
+        HashSet<(Guid CommonStockId, string ListedTicker, DateOnly Date)> DeferredPairKeys
+    )> ResolveHoldingsWithNewPrices(
         Dictionary<(Guid CommonStockId, string ListedTicker, DateOnly Date), decimal> prices,
         Dictionary<Guid, List<StockSplit>> splitsByStock,
         Dictionary<Guid, string> primaryTickers,
@@ -212,10 +249,19 @@ public class HoldingsValueRecalculator
     )
     {
         var totalUpdated = 0;
-        var totalDeferred = 0;
+        var deferredPairKeys = new HashSet<(Guid, string, DateOnly)>();
         foreach (var ((stockId, listedTicker, reportDate), closePrice) in prices)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            // A corrupt stored close prices every position in the stock at once, so the whole
+            // pair is refused rather than published; the pair advances the retry ladder and lands
+            // on the filed-value fallback when the ladder exhausts.
+            if (HoldingValueSanityGuard.IsImplausibleClose(closePrice))
+            {
+                deferredPairKeys.Add((stockId, listedTicker, reportDate));
+                continue;
+            }
 
             splitsByStock.TryGetValue(stockId, out var splits);
             primaryTickers.TryGetValue(stockId, out var primaryTicker);
@@ -234,7 +280,7 @@ public class HoldingsValueRecalculator
                 // The stored series straddles two share bases until the split's price adjustment
                 // runs. Leave the rows pending rather than publish a value off by the split ratio;
                 // the reconciliation stamps the split and a later cycle prices them honestly.
-                totalDeferred++;
+                deferredPairKeys.Add((stockId, listedTicker, reportDate));
                 continue;
             }
 
@@ -254,8 +300,20 @@ public class HoldingsValueRecalculator
 
             foreach (var holding in pendingHoldings)
             {
+                var derived = holding.Shares * shareCountFactor * closePrice;
+
+                // A per-row basis error (depositary ratio, split the series never captured) shows
+                // as a derivation grossly above the filer's own figure — publish the filed value
+                // rather than the wrong derivation.
+                if (HoldingValueSanityGuard.GrosslyExceedsFiled(derived, holding.FiledValue))
+                {
+                    ApplyFiledValue(holding);
+                    continue;
+                }
+
                 holding.Value = ToBoundedValue(holding.Shares, shareCountFactor, closePrice);
                 holding.ValuePending = false;
+                holding.ValueSource = ValueSource.Derived;
 
                 foreach (var entry in holding.ManagerEntries)
                 {
@@ -265,8 +323,40 @@ public class HoldingsValueRecalculator
 
             await dbContext.SaveChangesAsync(cancellationToken);
             totalUpdated += pendingHoldings.Count;
+
+            // Values moved from zero to real figures, so the per-accession rollups and the
+            // quarter's AUM snapshot are stale until re-derived.
+            if (pendingHoldings.Count > 0)
+            {
+                await HoldingsRollupRefresher.Refresh(
+                    dbContext,
+                    pendingHoldings.Select(h => h.AccessionNumber).ToHashSet(),
+                    [reportDate],
+                    cancellationToken
+                );
+            }
         }
-        return (totalUpdated, totalDeferred);
+        return (totalUpdated, deferredPairKeys);
+    }
+
+    /// <summary>
+    /// Publishes the filer's own reported value on a row no honest derivation can price, splitting
+    /// it across manager legs in proportion to their shares (the only allocation the filing
+    /// supports — legs carry counts, not values).
+    /// </summary>
+    internal static void ApplyFiledValue(InstitutionalHolding holding)
+    {
+        holding.Value = holding.FiledValue ?? 0L;
+        holding.ValuePending = false;
+        holding.ValueSource = ValueSource.Filed;
+
+        foreach (var entry in holding.ManagerEntries)
+        {
+            entry.Value =
+                holding.Shares > 0
+                    ? (long)(holding.Value * ((decimal)entry.Shares / holding.Shares))
+                    : 0L;
+        }
     }
 
     // shares comes from filer-controlled SSHPRNAMT; an oversized count makes the decimal

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
@@ -49,10 +49,7 @@ public class HoldingsValueRecalculator
         // The pending scan is served by the partial ValuePending index, but a first pass over a
         // large backlog can still outlive the default timeout — and the worker's catch used to
         // swallow that silently, freezing the whole lane.
-        if (lookupContext.Database.IsRelational())
-        {
-            lookupContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
-        }
+        ExtendCommandTimeout(lookupContext);
 
         var pendingPairs = await lookupContext
             .Set<InstitutionalHolding>()
@@ -166,12 +163,15 @@ public class HoldingsValueRecalculator
     )
     {
         var totalGivenUp = 0;
+        var settledAccessions = new HashSet<string>();
+        var settledReportDates = new HashSet<DateOnly>();
         foreach (var pair in unresolvedPairs)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+            ExtendCommandTimeout(dbContext);
 
             var holdings = await dbContext
                 .Set<InstitutionalHolding>()
@@ -224,16 +224,17 @@ public class HoldingsValueRecalculator
                 await dbContext.SaveChangesAsync(cancellationToken);
             }
 
-            if (settledRows.Count > 0)
+            foreach (var settled in settledRows)
             {
-                await HoldingsRollupRefresher.Refresh(
-                    dbContext,
-                    settledRows.Select(h => h.AccessionNumber).ToHashSet(),
-                    settledRows.Select(h => h.ReportDate).ToHashSet(),
-                    cancellationToken
-                );
+                settledAccessions.Add(settled.AccessionNumber);
+                settledReportDates.Add(settled.ReportDate);
             }
         }
+
+        // One rollup pass for everything that settled this cycle — the per-accession re-sum
+        // scans every position of every touched filing, so running it once per pair repeated
+        // that scan for every pair in the pass.
+        await RefreshRollups(settledAccessions, settledReportDates, cancellationToken);
         return totalGivenUp;
     }
 
@@ -250,6 +251,8 @@ public class HoldingsValueRecalculator
     {
         var totalUpdated = 0;
         var deferredPairKeys = new HashSet<(Guid, string, DateOnly)>();
+        var staleAccessions = new HashSet<string>();
+        var staleReportDates = new HashSet<DateOnly>();
         foreach (var ((stockId, listedTicker, reportDate), closePrice) in prices)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -284,8 +287,19 @@ public class HoldingsValueRecalculator
                 continue;
             }
 
+            // The published per-share figure is factor × close, so a plausible close behind a
+            // large restatement factor can still imply an impossible price. Guarding only the
+            // raw close would let the derivation through here while the fallback repair keeps
+            // resetting it — the two must test the same number or they chase each other forever.
+            if (HoldingValueSanityGuard.IsImplausibleClose(shareCountFactor * closePrice))
+            {
+                deferredPairKeys.Add((stockId, listedTicker, reportDate));
+                continue;
+            }
+
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+            ExtendCommandTimeout(dbContext);
 
             var pendingHoldings = await dbContext
                 .Set<InstitutionalHolding>()
@@ -311,6 +325,16 @@ public class HoldingsValueRecalculator
                     continue;
                 }
 
+                // A product past Int64 has no honest published form and no filed figure to fall
+                // back on (a filed figure that large would have routed above) — mark the row
+                // unknowable rather than publish the silent zero this lane exists to close.
+                if (derived > long.MaxValue)
+                {
+                    holding.ValuePending = false;
+                    holding.ValueUnavailable = true;
+                    continue;
+                }
+
                 holding.Value = ToBoundedValue(holding.Shares, shareCountFactor, closePrice);
                 holding.ValuePending = false;
                 holding.ValueSource = ValueSource.Derived;
@@ -324,19 +348,55 @@ public class HoldingsValueRecalculator
             await dbContext.SaveChangesAsync(cancellationToken);
             totalUpdated += pendingHoldings.Count;
 
-            // Values moved from zero to real figures, so the per-accession rollups and the
-            // quarter's AUM snapshot are stale until re-derived.
+            foreach (var holding in pendingHoldings)
+            {
+                staleAccessions.Add(holding.AccessionNumber);
+            }
             if (pendingHoldings.Count > 0)
             {
-                await HoldingsRollupRefresher.Refresh(
-                    dbContext,
-                    pendingHoldings.Select(h => h.AccessionNumber).ToHashSet(),
-                    [reportDate],
-                    cancellationToken
-                );
+                staleReportDates.Add(reportDate);
             }
         }
+
+        // Values moved from zero to real figures, so the per-accession rollups and each touched
+        // quarter's AUM snapshot are stale until re-derived. One pass for the whole cycle — the
+        // re-sum scans every position of every touched filing, so a per-pair refresh repeated
+        // that scan for every priced pair.
+        await RefreshRollups(staleAccessions, staleReportDates, cancellationToken);
         return (totalUpdated, deferredPairKeys);
+    }
+
+    private async Task RefreshRollups(
+        HashSet<string> accessions,
+        HashSet<DateOnly> reportDates,
+        CancellationToken cancellationToken
+    )
+    {
+        if (accessions.Count == 0)
+        {
+            return;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        ExtendCommandTimeout(dbContext);
+        await HoldingsRollupRefresher.Refresh(
+            dbContext,
+            accessions,
+            reportDates,
+            cancellationToken
+        );
+    }
+
+    // Per-pair scopes resolve fresh contexts with the default 30s command timeout; a large pair
+    // (every institution holding a mega-cap that quarter) needs the same headroom the lookup
+    // context gets, or the first heavy pair aborts the whole pass.
+    private static void ExtendCommandTimeout(EquiblesFinancialDbContext dbContext)
+    {
+        if (dbContext.Database.IsRelational())
+        {
+            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+        }
     }
 
     /// <summary>
@@ -346,7 +406,18 @@ public class HoldingsValueRecalculator
     /// </summary>
     internal static void ApplyFiledValue(InstitutionalHolding holding)
     {
-        holding.Value = holding.FiledValue ?? 0L;
+        // A Filed row with no filed figure would be a permanently invisible zero: matched by
+        // neither repair phase (phase 1 needs FiledValue > 0, phase 2 excludes Filed). Callers
+        // must gate on FiledValue is > 0; fail loudly rather than mint such a row.
+        if (holding.FiledValue is not > 0)
+        {
+            throw new ArgumentException(
+                "ApplyFiledValue requires a positive FiledValue",
+                nameof(holding)
+            );
+        }
+
+        holding.Value = holding.FiledValue.Value;
         holding.ValuePending = false;
         holding.ValueSource = ValueSource.Filed;
 

--- a/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
@@ -195,38 +195,10 @@ public class ImpossiblePositionRepairService
             return 0;
         }
 
-        var totals = await dbContext
-            .Set<InstitutionalHolding>()
-            .Where(h => accessionNumbers.Contains(h.AccessionNumber))
-            .GroupBy(h => h.AccessionNumber)
-            .Select(g => new { AccessionNumber = g.Key, TotalValue = g.Sum(h => h.Value) })
-            .ToListAsync(cancellationToken);
-
-        var totalByAccession = totals.ToDictionary(t => t.AccessionNumber, t => t.TotalValue);
-
-        var filings = await dbContext
-            .Set<InstitutionalFiling>()
-            .Where(f => accessionNumbers.Contains(f.AccessionNumber))
-            .ToListAsync(cancellationToken);
-
-        var realigned = 0;
-        foreach (var filing in filings)
-        {
-            if (
-                totalByAccession.TryGetValue(filing.AccessionNumber, out var total)
-                && filing.TotalValue != total
-            )
-            {
-                filing.TotalValue = total;
-                realigned++;
-            }
-        }
-
-        if (realigned > 0)
-        {
-            await dbContext.SaveChangesAsync(cancellationToken);
-        }
-
-        return realigned;
+        return await HoldingsRollupRefresher.RealignFilingTotals(
+            dbContext,
+            accessionNumbers,
+            cancellationToken
+        );
     }
 }

--- a/src/Equibles.Migrations/Migrations/20260805182558_AddHoldingValueSourceAndPendingIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260805182558_AddHoldingValueSourceAndPendingIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805182558_AddHoldingValueSourceAndPendingIndex")]
+    partial class AddHoldingValueSourceAndPendingIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260805182558_AddHoldingValueSourceAndPendingIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260805182558_AddHoldingValueSourceAndPendingIndex.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHoldingValueSourceAndPendingIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ValueSource",
+                table: "InstitutionalHolding",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_ValuePending_Pairs",
+                table: "InstitutionalHolding",
+                columns: new[] { "CommonStockId", "ListedTicker", "ReportDate" },
+                filter: "\"ValuePending\"");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_ValuePending_Pairs",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.DropColumn(
+                name: "ValueSource",
+                table: "InstitutionalHolding");
+        }
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260805182558_AddHoldingValueSourceAndPendingIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260805182558_AddHoldingValueSourceAndPendingIndex.cs
@@ -1,10 +1,20 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace Equibles.Migrations.Migrations
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Adds the value-provenance column and the pending-pair index behind the 13F filed-value
+    /// fallback.
+    ///
+    /// The index is built with raw SQL rather than the scaffolded CreateIndex: CONCURRENTLY
+    /// (suppressTransaction) because InstitutionalHolding holds tens of millions of rows and a
+    /// plain build takes ACCESS EXCLUSIVE for the whole scan — inside the deploy's migrate gate
+    /// that both stalls the release and locks out every holdings read — and IF NOT EXISTS so a
+    /// pre-built index is a no-op. The AddColumn with a default is metadata-only on this
+    /// PostgreSQL version and stays scaffolded.
+    /// </summary>
     public partial class AddHoldingValueSourceAndPendingIndex : Migration
     {
         /// <inheritdoc />
@@ -17,11 +27,22 @@ namespace Equibles.Migrations.Migrations
                 nullable: false,
                 defaultValue: 0);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_InstitutionalHolding_ValuePending_Pairs",
-                table: "InstitutionalHolding",
-                columns: new[] { "CommonStockId", "ListedTicker", "ReportDate" },
-                filter: "\"ValuePending\"");
+            // A failed CONCURRENTLY build leaves an INVALID index behind, which IF NOT EXISTS
+            // would then treat as "exists" forever — drop such a leftover first (an invalid
+            // index serves no queries, so the plain drop's brief lock is free), then build.
+            migrationBuilder.Sql(
+                "DO $$ BEGIN "
+                    + "IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                    + "WHERE c.relname = 'IX_InstitutionalHolding_ValuePending_Pairs' AND NOT i.indisvalid) THEN "
+                    + "EXECUTE 'DROP INDEX \"IX_InstitutionalHolding_ValuePending_Pairs\"'; END IF; END $$;",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_InstitutionalHolding_ValuePending_Pairs\" "
+                    + "ON \"InstitutionalHolding\" (\"CommonStockId\", \"ListedTicker\", \"ReportDate\") "
+                    + "WHERE \"ValuePending\";",
+                suppressTransaction: true
+            );
         }
 
         /// <inheritdoc />

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingValueFallbackRepairServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingValueFallbackRepairServiceTests.cs
@@ -1,0 +1,311 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins the back-catalogue heal: abandoned zero-value rows get the filer's figure published (and
+/// the rollups they feed re-derived), implausible derivations get reset for honest repricing, and
+/// a second pass over a healed database is a no-op.
+/// </summary>
+public class HoldingValueFallbackRepairServiceTests : IDisposable
+{
+    private static readonly IModuleConfiguration[] Modules =
+    [
+        new CommonStocksModuleConfiguration(),
+        new HoldingsModuleConfiguration(),
+        new CorporateActionsModuleConfiguration(),
+    ];
+
+    private readonly string _dbName = Guid.NewGuid().ToString();
+    private readonly ILogger<HoldingValueFallbackRepairService> _logger = Substitute.For<
+        ILogger<HoldingValueFallbackRepairService>
+    >();
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public void Dispose()
+    {
+        foreach (var ctx in _contexts)
+        {
+            ctx.Dispose();
+        }
+    }
+
+    private EquiblesFinancialDbContext CreateSharedContext()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(_dbName)
+            .Options;
+
+        var ctx = new EquiblesFinancialDbContext(options, Modules);
+        ctx.Database.EnsureCreated();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = CreateSharedContext();
+
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+
+        return scopeFactory;
+    }
+
+    private HoldingValueFallbackRepairService CreateService() =>
+        new(CreateScopeFactory(), _logger);
+
+    private async Task<InstitutionalHolding> SeedHolding(
+        long value,
+        long? filedValue,
+        long shares,
+        bool valuePending = false,
+        bool valueUnavailable = false,
+        ValueSource valueSource = ValueSource.Derived,
+        string accession = null
+    )
+    {
+        var seedContext = CreateSharedContext();
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = Guid.NewGuid().ToString()[..4],
+            Name = "Issuer",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Cik = Guid.NewGuid().ToString()[..10],
+            Name = "Filer",
+        };
+        var holding = new InstitutionalHolding
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            ReportDate = new DateOnly(2026, 3, 31),
+            FilingDate = new DateOnly(2026, 5, 10),
+            Shares = shares,
+            Value = value,
+            FiledValue = filedValue,
+            ValuePending = valuePending,
+            ValueUnavailable = valueUnavailable,
+            ValueSource = valueSource,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = accession ?? Guid.NewGuid().ToString()[..20],
+            ManagerEntries =
+            [
+                new HoldingManagerEntry
+                {
+                    ManagerNumber = 1,
+                    ManagerName = "Leg",
+                    Shares = shares,
+                    Value = value,
+                },
+            ],
+        };
+
+        seedContext.Set<CommonStock>().Add(stock);
+        seedContext.Set<InstitutionalHolder>().Add(holder);
+        seedContext.Set<InstitutionalHolding>().Add(holding);
+        await seedContext.SaveChangesAsync();
+        return holding;
+    }
+
+    private async Task<InstitutionalHolding> Reload(Guid holdingId)
+    {
+        var verifyContext = CreateSharedContext();
+        return await verifyContext
+            .Set<InstitutionalHolding>()
+            .Include(h => h.ManagerEntries)
+            .FirstAsync(h => h.Id == holdingId);
+    }
+
+    // ── Phase 1: stuck zeros ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Repair_AbandonedZeroWithFiledValue_PublishesFiledValue()
+    {
+        var holding = await SeedHolding(value: 0L, filedValue: 11_917_694_981L, shares: 68_335_407);
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(1);
+        var updated = await Reload(holding.Id);
+        updated.Value.Should().Be(11_917_694_981L);
+        updated.ValueSource.Should().Be(ValueSource.Filed);
+        updated.ManagerEntries.Single().Value.Should().Be(11_917_694_981L);
+    }
+
+    [Theory]
+    [InlineData(true, false)] // still pending — the repricing lane owns it
+    [InlineData(false, true)] // unavailable — deliberately withheld, not abandoned
+    public async Task Repair_PendingOrUnavailableZeroRows_AreLeftAlone(
+        bool pending,
+        bool unavailable
+    )
+    {
+        var holding = await SeedHolding(
+            value: 0L,
+            filedValue: 500_000L,
+            shares: 1000,
+            valuePending: pending,
+            valueUnavailable: unavailable
+        );
+
+        await CreateService().Repair(CancellationToken.None);
+
+        var updated = await Reload(holding.Id);
+        updated.Value.Should().Be(0L);
+        updated.ValueSource.Should().Be(ValueSource.Derived);
+    }
+
+    [Fact]
+    public async Task Repair_ZeroWithoutFiledValue_IsLeftAlone()
+    {
+        var holding = await SeedHolding(value: 0L, filedValue: null, shares: 1000);
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(0);
+        (await Reload(holding.Id)).Value.Should().Be(0L);
+    }
+
+    // ── Phase 2: implausible derivations ───────────────────────────────
+
+    [Fact]
+    public async Task Repair_ImplausibleImpliedPrice_ResetsRowForRepricing()
+    {
+        // The production signature: 273,201 shares carrying $13.66T — an implied
+        // $50M/share. Reset to pending so the guarded recalculator re-derives it.
+        var holding = await SeedHolding(
+            value: 13_660_050_000_000L,
+            filedValue: 1_092_804L,
+            shares: 273_201
+        );
+
+        await CreateService().Repair(CancellationToken.None);
+
+        var updated = await Reload(holding.Id);
+        updated.ValuePending.Should().BeTrue();
+        updated.Value.Should().Be(0L);
+        updated.ValueRetryCount.Should().Be(0);
+        updated.ValueLastRetryAt.Should().BeNull();
+        updated.ManagerEntries.Single().Value.Should().Be(0L);
+    }
+
+    [Fact]
+    public async Task Repair_BrkAClassImpliedPrice_IsNotTouched()
+    {
+        // ~$800k/share is a real price (BRK-A). Must never be treated as corrupt.
+        var holding = await SeedHolding(value: 80_000_000_000L, filedValue: null, shares: 100_000);
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(0);
+        (await Reload(holding.Id)).ValuePending.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Repair_FiledSourceRow_IsNeverReset()
+    {
+        // A filed value is the filer's own claim, not our derivation error — resetting it would
+        // loop it through the fallback forever.
+        var holding = await SeedHolding(
+            value: 5_000_000_000_000L,
+            filedValue: 5_000_000_000_000L,
+            shares: 100,
+            valueSource: ValueSource.Filed
+        );
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(0);
+        (await Reload(holding.Id)).ValuePending.Should().BeFalse();
+    }
+
+    // ── Rollups ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Repair_HealedRow_RealignsFilingTotalAndStampsAumSnapshotDirty()
+    {
+        var accession = "0000919079-26-000006";
+        var holding = await SeedHolding(
+            value: 0L,
+            filedValue: 9_571_400_000L,
+            shares: 37_713_677,
+            accession: accession
+        );
+
+        var seedContext = CreateSharedContext();
+        seedContext
+            .Set<InstitutionalFiling>()
+            .Add(
+                new InstitutionalFiling
+                {
+                    Id = Guid.NewGuid(),
+                    AccessionNumber = accession,
+                    InstitutionalHolderId = holding.InstitutionalHolderId,
+                    FilingDate = holding.FilingDate,
+                    ReportDate = holding.ReportDate,
+                    PositionCount = 1,
+                    TotalValue = 0L,
+                }
+            );
+        await seedContext.SaveChangesAsync();
+
+        await CreateService().Repair(CancellationToken.None);
+
+        var verifyContext = CreateSharedContext();
+        var filing = await verifyContext
+            .Set<InstitutionalFiling>()
+            .FirstAsync(f => f.AccessionNumber == accession);
+        filing
+            .TotalValue.Should()
+            .Be(9_571_400_000L, "a healed position with a stale rollup just moves the lie up");
+
+        var snapshot = await verifyContext
+            .Set<AumQuarterlySnapshot>()
+            .FirstAsync(s => s.ReportDate == holding.ReportDate);
+        snapshot.DirtyAt.Should().NotBeNull("the drain worker must rebuild the quarter");
+    }
+
+    // ── Idempotency ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Repair_SecondRunOverHealedDatabase_IsANoOp()
+    {
+        await SeedHolding(value: 0L, filedValue: 750_000L, shares: 500);
+        await SeedHolding(value: 2_000_000_000_000L, filedValue: 1_000_000L, shares: 100);
+
+        var service = CreateService();
+        var firstRun = await service.Repair(CancellationToken.None);
+        var secondRun = await service.Repair(CancellationToken.None);
+
+        firstRun.Should().Be(2);
+        secondRun.Should().Be(0);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingValueFallbackRepairServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingValueFallbackRepairServiceTests.cs
@@ -74,8 +74,7 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
         return scopeFactory;
     }
 
-    private HoldingValueFallbackRepairService CreateService() =>
-        new(CreateScopeFactory(), _logger);
+    private HoldingValueFallbackRepairService CreateService() => new(CreateScopeFactory(), _logger);
 
     private async Task<InstitutionalHolding> SeedHolding(
         long value,
@@ -84,7 +83,8 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
         bool valuePending = false,
         bool valueUnavailable = false,
         ValueSource valueSource = ValueSource.Derived,
-        string accession = null
+        string accession = null,
+        int valueRetryCount = 0
     )
     {
         var seedContext = CreateSharedContext();
@@ -113,6 +113,7 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
             ValuePending = valuePending,
             ValueUnavailable = valueUnavailable,
             ValueSource = valueSource,
+            ValueRetryCount = valueRetryCount,
             ShareType = ShareType.Shares,
             InvestmentDiscretion = InvestmentDiscretion.Sole,
             AccessionNumber = accession ?? Guid.NewGuid().ToString()[..20],
@@ -184,14 +185,42 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Repair_ZeroWithoutFiledValue_IsLeftAlone()
+    public async Task Repair_ZeroWithoutFiledValueAndNoRetries_IsLeftAlone()
     {
+        // ValueRetryCount = 0 means the row was never on the ladder — a legitimately derived
+        // zero (a sub-dollar position), not an abandoned one. No phase may touch it.
         var holding = await SeedHolding(value: 0L, filedValue: null, shares: 1000);
 
         var repaired = await CreateService().Repair(CancellationToken.None);
 
         repaired.Should().Be(0);
-        (await Reload(holding.Id)).Value.Should().Be(0L);
+        var updated = await Reload(holding.Id);
+        updated.Value.Should().Be(0L);
+        updated.ValueUnavailable.Should().BeFalse();
+    }
+
+    // ── Phase 3: abandoned zeros with no filed figure ──────────────────
+
+    [Fact]
+    public async Task Repair_AbandonedZeroWithoutFiledValue_IsMarkedUnavailable()
+    {
+        // The old ladder cleared ValuePending on give-up without stamping anything, leaving
+        // "unknown" indistinguishable from "worth nothing" — invisible to every surface that
+        // discloses unvalued rows through the flags.
+        var holding = await SeedHolding(
+            value: 0L,
+            filedValue: null,
+            shares: 1000,
+            valueRetryCount: 4
+        );
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(1);
+        var updated = await Reload(holding.Id);
+        updated.Value.Should().Be(0L);
+        updated.ValueUnavailable.Should().BeTrue();
+        updated.ValuePending.Should().BeFalse();
     }
 
     // ── Phase 2: implausible derivations ───────────────────────────────

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsValueRecalculatorFiledFallbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsValueRecalculatorFiledFallbackTests.cs
@@ -222,6 +222,48 @@ public class HoldingsValueRecalculatorFiledFallbackTests : IDisposable
             .Be(2, "a basis-deferred pair must not freeze at its current retry count");
     }
 
+    [Fact]
+    public async Task Recalculate_PlausibleCloseBehindLargeRestatementFactor_DefersInsteadOfPublishing()
+    {
+        var reportDate = new DateOnly(2024, 6, 30);
+        var (stock, holding) = await Seed(
+            reportDate,
+            shares: 1000,
+            filedValue: null,
+            retryCount: 0,
+            lastRetryAt: DateTime.UtcNow.AddDays(-2)
+        );
+
+        // An applied 100:1 forward split after the report date restates the count ×100, so a
+        // perfectly plausible $15,000 close implies $1.5M per as-filed share. The fallback
+        // repair resets published rows above that bound, so publishing here would put the two
+        // passes in a permanent reset/re-derive loop — the pair must defer instead.
+        var seedContext = CreateSharedContext();
+        seedContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    EffectiveDate = reportDate.AddDays(10),
+                    Numerator = 100,
+                    Denominator = 1,
+                    PriceAdjustmentAppliedTime = DateTime.UtcNow.AddDays(-1),
+                }
+            );
+        await seedContext.SaveChangesAsync();
+
+        SetPrices(new() { [(stock.Id, null, reportDate)] = 15_000m });
+
+        await CreateRecalculator().Recalculate(CancellationToken.None);
+
+        var updated = await Reload(holding.Id);
+        updated.ValuePending.Should().BeTrue("the effective per-share price is implausible");
+        updated.Value.Should().Be(0L);
+        updated.ValueRetryCount.Should().Be(1, "a refused derivation must advance the ladder");
+    }
+
     // ── Ladder exhaustion publishes the filed value ────────────────────
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsValueRecalculatorFiledFallbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsValueRecalculatorFiledFallbackTests.cs
@@ -1,0 +1,304 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.Contracts;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins the retry-ladder repair: pairs that HAVE a price but cannot be honestly valued (ambiguous
+/// split basis, implausible close) must advance the ladder instead of freezing at their current
+/// retry count — the escape that once left 828,603 production rows stuck at ValueRetryCount = 1 —
+/// and an exhausted ladder must publish the filer's own value rather than a silent zero.
+/// </summary>
+public class HoldingsValueRecalculatorFiledFallbackTests : IDisposable
+{
+    private static readonly IModuleConfiguration[] Modules =
+    [
+        new CommonStocksModuleConfiguration(),
+        new HoldingsModuleConfiguration(),
+        new CorporateActionsModuleConfiguration(),
+    ];
+
+    private readonly string _dbName = Guid.NewGuid().ToString();
+    private readonly IStockPriceProvider _priceProvider = Substitute.For<IStockPriceProvider>();
+    private readonly ILogger<HoldingsValueRecalculator> _logger = Substitute.For<
+        ILogger<HoldingsValueRecalculator>
+    >();
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public void Dispose()
+    {
+        foreach (var ctx in _contexts)
+        {
+            ctx.Dispose();
+        }
+    }
+
+    private EquiblesFinancialDbContext CreateSharedContext()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(_dbName)
+            .Options;
+
+        var ctx = new EquiblesFinancialDbContext(options, Modules);
+        ctx.Database.EnsureCreated();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = CreateSharedContext();
+
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+
+        return scopeFactory;
+    }
+
+    private HoldingsValueRecalculator CreateRecalculator() =>
+        new(CreateScopeFactory(), _priceProvider, _logger);
+
+    private void SetPrices(Dictionary<(Guid, string, DateOnly), decimal> prices)
+    {
+        _priceProvider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(prices);
+    }
+
+    private async Task<(CommonStock Stock, InstitutionalHolding Holding)> Seed(
+        DateOnly reportDate,
+        long shares,
+        long? filedValue,
+        int retryCount,
+        DateTime? lastRetryAt
+    )
+    {
+        var seedContext = CreateSharedContext();
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AZUL",
+            Name = "Azul SA",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Cik = Guid.NewGuid().ToString()[..10],
+            Name = "Test Filer",
+        };
+        var holding = new InstitutionalHolding
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(30),
+            Shares = shares,
+            Value = 0L,
+            FiledValue = filedValue,
+            ValuePending = true,
+            ValueRetryCount = retryCount,
+            ValueLastRetryAt = lastRetryAt,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = Guid.NewGuid().ToString()[..20],
+            ManagerEntries =
+            [
+                new HoldingManagerEntry
+                {
+                    ManagerNumber = 1,
+                    ManagerName = "Leg A",
+                    Shares = shares / 2,
+                    Value = 0L,
+                },
+            ],
+        };
+
+        seedContext.Set<CommonStock>().Add(stock);
+        seedContext.Set<InstitutionalHolder>().Add(holder);
+        seedContext.Set<InstitutionalHolding>().Add(holding);
+        await seedContext.SaveChangesAsync();
+        return (stock, holding);
+    }
+
+    private async Task<InstitutionalHolding> Reload(Guid holdingId)
+    {
+        var verifyContext = CreateSharedContext();
+        return await verifyContext
+            .Set<InstitutionalHolding>()
+            .Include(h => h.ManagerEntries)
+            .FirstAsync(h => h.Id == holdingId);
+    }
+
+    // ── Deferred pairs advance the ladder ──────────────────────────────
+
+    [Fact]
+    public async Task Recalculate_ImplausibleClose_StaysPendingAndAdvancesRetryCount()
+    {
+        var reportDate = new DateOnly(2024, 6, 30);
+        var (stock, holding) = await Seed(
+            reportDate,
+            shares: 273_201,
+            filedValue: 1_092_804L,
+            retryCount: 0,
+            lastRetryAt: DateTime.UtcNow.AddDays(-2)
+        );
+
+        // The corrupt-series close: a "price" no equity has ever traded at.
+        SetPrices(new() { [(stock.Id, null, reportDate)] = 285_249_984m });
+
+        await CreateRecalculator().Recalculate(CancellationToken.None);
+
+        var updated = await Reload(holding.Id);
+        updated.ValuePending.Should().BeTrue("an implausible close must not price anything");
+        updated.Value.Should().Be(0L);
+        updated.ValueRetryCount.Should().Be(1, "a refused price must advance the retry ladder");
+    }
+
+    [Fact]
+    public async Task Recalculate_AmbiguousSplitBasis_AdvancesRetryCountInsteadOfFreezing()
+    {
+        var reportDate = new DateOnly(2024, 6, 30);
+        var (stock, holding) = await Seed(
+            reportDate,
+            shares: 1000,
+            filedValue: 150_000L,
+            retryCount: 1,
+            lastRetryAt: DateTime.UtcNow.AddDays(-8)
+        );
+
+        // A captured split after the report date whose price adjustment has not run: the stored
+        // series straddles two bases, so the pair defers — and must still climb the ladder.
+        var seedContext = CreateSharedContext();
+        seedContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    EffectiveDate = reportDate.AddDays(10),
+                    Numerator = 10,
+                    Denominator = 1,
+                    PriceAdjustmentAppliedTime = null,
+                }
+            );
+        await seedContext.SaveChangesAsync();
+
+        SetPrices(new() { [(stock.Id, null, reportDate)] = 150m });
+
+        await CreateRecalculator().Recalculate(CancellationToken.None);
+
+        var updated = await Reload(holding.Id);
+        updated.ValuePending.Should().BeTrue();
+        updated
+            .ValueRetryCount.Should()
+            .Be(2, "a basis-deferred pair must not freeze at its current retry count");
+    }
+
+    // ── Ladder exhaustion publishes the filed value ────────────────────
+
+    [Fact]
+    public async Task Recalculate_ExhaustedLadderWithFiledValue_PublishesFiledValue()
+    {
+        var reportDate = new DateOnly(2024, 3, 31);
+        var (_, holding) = await Seed(
+            reportDate,
+            shares: 1000,
+            filedValue: 868_524L,
+            retryCount: 3,
+            lastRetryAt: DateTime.UtcNow.AddDays(-31)
+        );
+
+        // No price at all for the pair — the ladder's final rung expires.
+        SetPrices([]);
+
+        await CreateRecalculator().Recalculate(CancellationToken.None);
+
+        var updated = await Reload(holding.Id);
+        updated.ValuePending.Should().BeFalse();
+        updated.ValueUnavailable.Should().BeFalse();
+        updated.Value.Should().Be(868_524L, "the filer's own figure beats a silent zero");
+        updated.ValueSource.Should().Be(ValueSource.Filed);
+        updated
+            .ManagerEntries.Single()
+            .Value.Should()
+            .Be(434_262L, "legs split the filed value in proportion to their shares");
+    }
+
+    [Fact]
+    public async Task Recalculate_ExhaustedLadderWithoutFiledValue_MarksValueUnavailable()
+    {
+        var reportDate = new DateOnly(2024, 3, 31);
+        var (_, holding) = await Seed(
+            reportDate,
+            shares: 1000,
+            filedValue: null,
+            retryCount: 3,
+            lastRetryAt: DateTime.UtcNow.AddDays(-31)
+        );
+
+        SetPrices([]);
+
+        await CreateRecalculator().Recalculate(CancellationToken.None);
+
+        var updated = await Reload(holding.Id);
+        updated.ValuePending.Should().BeFalse();
+        updated.Value.Should().Be(0L);
+        updated
+            .ValueUnavailable.Should()
+            .BeTrue("a zero with no filed figure must read as unknown, not as nothing");
+    }
+
+    // ── Gross disagreement with the filed value on resolve ─────────────
+
+    [Fact]
+    public async Task Recalculate_DerivedValueGrosslyExceedsFiled_PublishesFiledValueInstead()
+    {
+        var reportDate = new DateOnly(2024, 6, 30);
+        var (stock, holding) = await Seed(
+            reportDate,
+            shares: 273_201,
+            filedValue: 1_092_804L,
+            retryCount: 0,
+            lastRetryAt: null
+        );
+
+        // Plausible as a share price, wrong for this stock by four orders of magnitude —
+        // derived $13.66B against a filed $1.09M.
+        SetPrices(new() { [(stock.Id, null, reportDate)] = 50_000m });
+
+        await CreateRecalculator().Recalculate(CancellationToken.None);
+
+        var updated = await Reload(holding.Id);
+        updated.ValuePending.Should().BeFalse();
+        updated.Value.Should().Be(1_092_804L);
+        updated.ValueSource.Should().Be(ValueSource.Filed);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueSanityGuardTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueSanityGuardTests.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using Equibles.Holdings.HostedService.Services;
+using FluentAssertions;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingValueSanityGuardTests
+{
+    // ── IsImplausibleClose ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("800000", false)] // BRK-A territory — must always stay valid
+    [InlineData("1000000", false)] // the ceiling itself is still allowed
+    [InlineData("1000000.01", true)]
+    [InlineData("285249984", true)] // the corrupt close that minted $102.8T of phantom value
+    [InlineData("0.0008", false)] // sub-penny OTC closes are legitimate
+    public void IsImplausibleClose_BoundsAtOneMillionPerShare(string close, bool expected)
+    {
+        HoldingValueSanityGuard
+            .IsImplausibleClose(decimal.Parse(close, CultureInfo.InvariantCulture))
+            .Should()
+            .Be(expected);
+    }
+
+    // ── GrosslyExceedsFiled ────────────────────────────────────────────
+
+    [Fact]
+    public void GrosslyExceedsFiled_NoFiledValue_NeverTrips()
+    {
+        HoldingValueSanityGuard.GrosslyExceedsFiled(1_000_000_000m, null).Should().BeFalse();
+        HoldingValueSanityGuard.GrosslyExceedsFiled(1_000_000_000m, 0L).Should().BeFalse();
+        HoldingValueSanityGuard.GrosslyExceedsFiled(1_000_000_000m, -5L).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("5000000", false)] // exactly 5× the filed 1M — ordinary drift ceiling, allowed
+    [InlineData("5000001", true)] // just past the cap
+    [InlineData("2000000", false)] // 2× — a stale mark, not a units error
+    public void GrosslyExceedsFiled_BoundsAtFiveTimesFiled(string derived, bool expected)
+    {
+        HoldingValueSanityGuard
+            .GrosslyExceedsFiled(decimal.Parse(derived, CultureInfo.InvariantCulture), 1_000_000L)
+            .Should()
+            .Be(expected);
+    }
+
+    [Fact]
+    public void GrosslyExceedsFiled_CorruptCloseSignature_Trips()
+    {
+        // The production case: 273,201 shares × a $50M close against a filed $1.09M —
+        // a 12.5-million-fold inflation that rendered as 76.7% of the filer's portfolio.
+        var derived = 273_201m * 50_000_000m;
+        HoldingValueSanityGuard.GrosslyExceedsFiled(derived, 1_092_804L).Should().BeTrue();
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowSanityGuardTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowSanityGuardTests.cs
@@ -1,0 +1,123 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// ParseHoldingRow's plausibility contract: a corrupt close must not price anything (the row
+/// stays pending), and a derivation grossly above the filer's own figure publishes the filed
+/// value instead. One corrupt series minted $102.8T of phantom value before these guards existed.
+/// </summary>
+public class HoldingsImportServiceParseHoldingRowSanityGuardTests
+{
+    private static (InstitutionalHolding Holding, bool ValuePending) Parse(
+        Guid commonStockId,
+        decimal? closePrice,
+        string filedValueField
+    )
+    {
+        var method = typeof(HoldingsImportService).GetMethod(
+            "ParseHoldingRow",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var holderId = Guid.NewGuid();
+        // Post-2023 filing date so VALUE is already in whole dollars.
+        var filingDate = new DateOnly(2024, 11, 15);
+        var reportDate = new DateOnly(2024, 9, 30);
+
+        var row = new Dictionary<string, string>
+        {
+            ["SSHPRNAMTTYPE"] = "SH",
+            ["PUTCALL"] = "",
+            ["SSHPRNAMT"] = "273201",
+            ["VALUE"] = filedValueField,
+            ["VOTING_AUTH_SOLE"] = "273201",
+            ["VOTING_AUTH_SHARED"] = "0",
+            ["VOTING_AUTH_NONE"] = "0",
+            ["OTHERMANAGER"] = "",
+            ["INVESTMENTDISCRETION"] = "SOLE",
+            ["TITLEOFCLASS"] = "COM",
+        };
+
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>();
+        if (closePrice.HasValue)
+        {
+            prices[(commonStockId, null, reportDate)] = closePrice.Value;
+        }
+
+        var context = new ImportContext
+        {
+            CoverPages = new Dictionary<string, CoverPageRow>(),
+            StockPrices = prices,
+            OtherManagers = new Dictionary<string, Dictionary<int, OtherManagerIdentity>>(),
+        };
+
+        var result = method.Invoke(
+            null,
+            [
+                row,
+                "0001086364-24-008417",
+                "05501M106",
+                new CusipTarget(commonStockId, null),
+                holderId,
+                filingDate,
+                reportDate,
+                context,
+            ]
+        );
+
+        var holding = (InstitutionalHolding)result.GetType().GetField("Item1").GetValue(result);
+        var valuePending = (bool)result.GetType().GetField("Item3").GetValue(result);
+        return (holding, valuePending);
+    }
+
+    [Fact]
+    public void ParseHoldingRow_ImplausibleClose_LeavesRowPendingInsteadOfDeriving()
+    {
+        // The corrupt-series close: $285M/share. Deriving from it once stated a $13.7T position
+        // against a $1.09M filing.
+        var (holding, valuePending) = Parse(
+            Guid.NewGuid(),
+            closePrice: 285_249_984m,
+            filedValueField: "1092804"
+        );
+
+        valuePending.Should().BeTrue();
+        holding.Value.Should().Be(0L);
+        holding.ValuePending.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseHoldingRow_DerivedGrosslyExceedsFiled_PublishesFiledValue()
+    {
+        // A plausible-looking close that is wrong for this stock by orders of magnitude:
+        // 273,201 × $50,000 = $13.66B against a filed $1.09M.
+        var (holding, valuePending) = Parse(
+            Guid.NewGuid(),
+            closePrice: 50_000m,
+            filedValueField: "1092804"
+        );
+
+        valuePending.Should().BeFalse();
+        holding.Value.Should().Be(1_092_804L);
+        holding.ValueSource.Should().Be(ValueSource.Filed);
+    }
+
+    [Fact]
+    public void ParseHoldingRow_OrdinaryDerivation_StaysDerived()
+    {
+        // 273,201 × $4 ≈ the filed $1.09M — inside the 5× drift ceiling, published as derived.
+        var (holding, valuePending) = Parse(
+            Guid.NewGuid(),
+            closePrice: 4m,
+            filedValueField: "1092804"
+        );
+
+        valuePending.Should().BeFalse();
+        holding.Value.Should().Be(273_201L * 4L);
+        holding.ValueSource.Should().Be(ValueSource.Derived);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorApplyFiledValueTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorApplyFiledValueTests.cs
@@ -1,0 +1,76 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using FluentAssertions;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsValueRecalculatorApplyFiledValueTests
+{
+    private static InstitutionalHolding MakeHolding(
+        long shares,
+        long? filedValue,
+        params long[] entryShares
+    )
+    {
+        return new InstitutionalHolding
+        {
+            Shares = shares,
+            FiledValue = filedValue,
+            Value = 0L,
+            ValuePending = true,
+            ManagerEntries = entryShares
+                .Select(s => new HoldingManagerEntry { Shares = s, Value = 0L })
+                .ToList(),
+        };
+    }
+
+    [Fact]
+    public void ApplyFiledValue_PublishesFiledFigureAndClearsPending()
+    {
+        var holding = MakeHolding(shares: 1000, filedValue: 868_524L);
+
+        HoldingsValueRecalculator.ApplyFiledValue(holding);
+
+        holding.Value.Should().Be(868_524L);
+        holding.ValuePending.Should().BeFalse();
+        holding.ValueSource.Should().Be(ValueSource.Filed);
+    }
+
+    [Fact]
+    public void ApplyFiledValue_SplitsAcrossLegsProportionallyToShares()
+    {
+        // Legs carry counts, not values, so shares are the only allocation basis the filing
+        // supports: 3,000 + 1,000 shares over a $1M filed value → $750k + $250k.
+        var holding = MakeHolding(shares: 4000, filedValue: 1_000_000L, 3000, 1000);
+
+        HoldingsValueRecalculator.ApplyFiledValue(holding);
+
+        holding.ManagerEntries[0].Value.Should().Be(750_000L);
+        holding.ManagerEntries[1].Value.Should().Be(250_000L);
+    }
+
+    [Fact]
+    public void ApplyFiledValue_ZeroShares_LeavesLegsAtZeroInsteadOfDividingByZero()
+    {
+        var holding = MakeHolding(shares: 0, filedValue: 500_000L, 100);
+
+        HoldingsValueRecalculator.ApplyFiledValue(holding);
+
+        holding.Value.Should().Be(500_000L);
+        holding.ManagerEntries[0].Value.Should().Be(0L);
+    }
+
+    [Fact]
+    public void ApplyFiledValue_NullFiledValue_PublishesZero()
+    {
+        // Callers gate on FiledValue > 0; if one slips through the row must not throw and must
+        // not invent a figure.
+        var holding = MakeHolding(shares: 1000, filedValue: null, 1000);
+
+        HoldingsValueRecalculator.ApplyFiledValue(holding);
+
+        holding.Value.Should().Be(0L);
+        holding.ValueSource.Should().Be(ValueSource.Filed);
+        holding.ValuePending.Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorApplyFiledValueTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorApplyFiledValueTests.cs
@@ -61,16 +61,16 @@ public class HoldingsValueRecalculatorApplyFiledValueTests
     }
 
     [Fact]
-    public void ApplyFiledValue_NullFiledValue_PublishesZero()
+    public void ApplyFiledValue_NullFiledValue_ThrowsInsteadOfMintingAnInvisibleZero()
     {
-        // Callers gate on FiledValue > 0; if one slips through the row must not throw and must
-        // not invent a figure.
+        // A Filed row with Value = 0 and no FiledValue is matched by neither repair phase, so it
+        // would be a permanently invisible zero — fail loudly instead of relying on every caller
+        // remembering the FiledValue > 0 gate.
         var holding = MakeHolding(shares: 1000, filedValue: null, 1000);
 
-        HoldingsValueRecalculator.ApplyFiledValue(holding);
+        var act = () => HoldingsValueRecalculator.ApplyFiledValue(holding);
 
-        holding.Value.Should().Be(0L);
-        holding.ValueSource.Should().Be(ValueSource.Filed);
-        holding.ValuePending.Should().BeFalse();
+        act.Should().Throw<ArgumentException>();
+        holding.ValuePending.Should().BeTrue("a refused fallback must leave the row untouched");
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorOversizedSharesOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsValueRecalculatorOversizedSharesOverflowTests.cs
@@ -55,6 +55,15 @@ public class HoldingsValueRecalculatorOversizedSharesOverflowTests
             .NotThrowAsync<OverflowException>(
                 "one oversized pending holding must degrade gracefully, not abort the whole nightly recalc pass and leave every other pending holding unresolved"
             );
+
+        // Graceful degradation must not mean a silent zero: with no filed figure to fall back
+        // on, the row is marked unknowable rather than published as a $0 position.
+        var holding = db.Set<InstitutionalHolding>().Single();
+        holding.ValuePending.Should().BeFalse();
+        holding
+            .ValueUnavailable.Should()
+            .BeTrue("an Int64-overflowing product has no honest published form");
+        holding.Value.Should().Be(0L);
     }
 
     private static EquiblesFinancialDbContext CreateDbContext()


### PR DESCRIPTION
## Summary

Fixes the three ingest defects behind the 13F audit's worst findings: 48% of a production quarter's positions serving `Value=$0` (a retry-ladder escape froze 828,603 rows at `ValueRetryCount=1`, and exhausted rows were abandoned as silent zeros), $102.8T of phantom value injected by one corrupt price series across 263 institutions, and the write-only `FiledValue` column never being used as a fallback.

## Code changes

- **`HoldingsValueRecalculator`** — pairs whose price cannot be used honestly (implausible close, implausible effective per-share price after split restatement, ambiguous split basis) now advance the retry ladder instead of freezing; ladder exhaustion publishes the filer's own `FiledValue` (proportional manager-leg allocation) or marks the row `ValueUnavailable`; Int64-overflow derivations route to `ValueUnavailable` instead of a silent zero; rollup refresh accumulates across the pass and runs once; 10-minute command timeout on every scope.
- **`HoldingValueSanityGuard`** (new) — refuses closes above $1M/share (BRK-A at ~$800k stays valid) and derivations grossly (5×) above the filer's own figure, in both the recalculator and `ParseHoldingRow`.
- **`HoldingValueFallbackRepairService`** (new) — bounded (50k rows/phase/cycle), idempotent back-catalogue heal: publishes filed values on abandoned zeros, resets implausible derivations for guarded repricing, stamps `ValueUnavailable` on filed-value-less abandoned zeros.
- **`HoldingsRollupRefresher`** (new) — re-sums `InstitutionalFiling.TotalValue` (batched 500 accessions/statement) and stamps `AumQuarterlySnapshot.DirtyAt` for every touched quarter.
- **`InstitutionalHolding.ValueSource`** (new column) + partial index on pending pairs, built `CONCURRENTLY` (33M-row table). Additive migration.
- **`HoldingsScraperWorker`** — recalc timeouts log as warnings and retry next cycle (only genuine timeouts; other DB faults stay errors); wires the repair pass.

## Tests

Full OSS suites green: 3,990 unit + 2,359 integration (real Postgres). New coverage: ladder advancement for deferred pairs, filed fallback + proportional legs, effective-price guard, sanity-guard bounds, all three repair phases + idempotency, rollup realignment.

Note: the commercial repo's twin migration ships with the submodule pin bump, before any deploy.