### PR TITLE
fix(holdings): disclose unvalued positions in GetInstitutionPortfolio

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -406,6 +406,14 @@ public class InstitutionalHoldingsTools
                     .CountAsync();
                 var totalValue = await allHoldings.SumAsync(h => (long?)h.Value) ?? 0L;
 
+                // Tracked rows whose dollar value could not be derived (price still pending, or
+                // honestly unknowable). They sit in the table at $0 and sort last, so without a
+                // count the total and every percentage silently understate the filing — at its
+                // worst 48% of a quarter's positions, hiding a filer's real top holdings.
+                var unvaluedPositions = await allHoldings.CountAsync(h =>
+                    h.Value == 0L && (h.ValuePending || h.ValueUnavailable)
+                );
+
                 // What the filer itself declared for the quarter, from the latest filing's cover
                 // page — so the answer can say "7 of the 8 declared positions" instead of
                 // presenting the tracked subset as the whole filing. Null on rows ingested
@@ -437,6 +445,7 @@ public class InstitutionalHoldingsTools
                     splitsByStock,
                     totalPositions,
                     totalValue,
+                    unvaluedPositions,
                     declaringFiling,
                     JoinNotes(matchNote, dateNote)
                 );
@@ -453,6 +462,7 @@ public class InstitutionalHoldingsTools
         IReadOnlyDictionary<Guid, List<StockSplit>> splitsByStock,
         int totalPositions,
         long totalValue,
+        int unvaluedPositions,
         InstitutionalFiling declaringFiling,
         string notes
     )
@@ -463,7 +473,9 @@ public class InstitutionalHoldingsTools
 
         // The filer's own cover-page declaration, when captured, makes the coverage exact: the
         // reader learns how many positions the filing carries in total and what they are worth,
-        // so a tracked subset can never read as the whole filing.
+        // so a tracked subset can never read as the whole filing. The declared-vs-tracked gap has
+        // TWO causes and blaming coverage for both once hid real top holdings — unvalued rows are
+        // named separately below.
         if (
             declaringFiling
             is { DeclaredPositionCount: not null }
@@ -477,7 +489,22 @@ public class InstitutionalHoldingsTools
                 declaredParts.Add($"${FormatMillions(declaredValue)}M");
             subtitle +=
                 $" The filing itself declares {string.Join(" totalling ", declaredParts)}; "
-                + "the difference is security types outside this platform's coverage.";
+                + (
+                    unvaluedPositions > 0
+                        ? "the difference is security types outside this platform's coverage "
+                            + "plus the unvalued positions noted below."
+                        : "the difference is security types outside this platform's coverage."
+                );
+        }
+
+        // Rows at $0 are not "no position" — they are tracked positions with no derivable dollar
+        // value yet. Say so, or the total and every percentage read as the whole story.
+        if (unvaluedPositions > 0)
+        {
+            subtitle +=
+                $" NOTE: {McpFormat.WholeNumber(unvaluedPositions)} tracked position(s) have no "
+                + "derivable value and count as $0 here, so the total and the percentages "
+                + "understate the filing.";
         }
         if (notes != null)
             subtitle = $"{subtitle}\n{notes}";

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -400,19 +400,34 @@ public class InstitutionalHoldingsTools
                     return dateError;
 
                 var allHoldings = _holdingRepository.Get13FByHolderWithStock(holder, targetDate);
-                var totalPositions = await allHoldings
-                    .Select(h => h.CommonStockId)
-                    .Distinct()
-                    .CountAsync();
-                var totalValue = await allHoldings.SumAsync(h => (long?)h.Value) ?? 0L;
 
-                // Tracked rows whose dollar value could not be derived (price still pending, or
-                // honestly unknowable). They sit in the table at $0 and sort last, so without a
-                // count the total and every percentage silently understate the filing — at its
-                // worst 48% of a quarter's positions, hiding a filer's real top holdings.
-                var unvaluedPositions = await allHoldings.CountAsync(h =>
-                    h.Value == 0L && (h.ValuePending || h.ValueUnavailable)
-                );
+                // One grouped round trip for the three header scalars — this is the same table
+                // whose non-index-only scans once drained a connection pool, so the extra
+                // per-call queries matter. The unvalued count shares the header's distinct-stock
+                // basis (a filer's option and share rows must not double-count), and its
+                // predicate must catch every cohort of $0 rows: still pending, marked
+                // unknowable, AND rows the old retry ladder abandoned with neither flag set —
+                // those carry only the filer's own FiledValue as the tell. Counting just the
+                // flagged rows once reported "1 unvalued position" for a filer with 94 of its 96
+                // positions at $0 — the same dishonesty this disclosure exists to remove.
+                var summary = await allHoldings
+                    .GroupBy(h => 1)
+                    .Select(g => new
+                    {
+                        Positions = g.Select(h => h.CommonStockId).Distinct().Count(),
+                        Value = g.Sum(h => h.Value),
+                        Unvalued = g.Where(h =>
+                                h.Value == 0L
+                                && (h.ValuePending || h.ValueUnavailable || h.FiledValue > 0)
+                            )
+                            .Select(h => h.CommonStockId)
+                            .Distinct()
+                            .Count(),
+                    })
+                    .FirstOrDefaultAsync();
+                var totalPositions = summary?.Positions ?? 0;
+                var totalValue = summary?.Value ?? 0L;
+                var unvaluedPositions = summary?.Unvalued ?? 0;
 
                 // What the filer itself declared for the quarter, from the latest filing's cover
                 // page — so the answer can say "7 of the 8 declared positions" instead of
@@ -487,12 +502,15 @@ public class InstitutionalHoldingsTools
                 declaredParts.Add($"{McpFormat.WholeNumber(declaredCount)} positions");
             if (declaringFiling.DeclaredTotalValue is { } declaredValue)
                 declaredParts.Add($"${FormatMillions(declaredValue)}M");
+            // Unvalued rows are TRACKED — already inside the tracked position count — so they
+            // explain none of the position-count gap; they explain part of the VALUE gap only.
             subtitle +=
                 $" The filing itself declares {string.Join(" totalling ", declaredParts)}; "
                 + (
                     unvaluedPositions > 0
-                        ? "the difference is security types outside this platform's coverage "
-                            + "plus the unvalued positions noted below."
+                        ? "the position difference is security types outside this platform's "
+                            + "coverage, and the value difference also reflects the unvalued "
+                            + "positions noted below."
                         : "the difference is security types outside this platform's coverage."
                 );
         }
@@ -503,8 +521,8 @@ public class InstitutionalHoldingsTools
         {
             subtitle +=
                 $" NOTE: {McpFormat.WholeNumber(unvaluedPositions)} tracked position(s) have no "
-                + "derivable value and count as $0 here, so the total and the percentages "
-                + "understate the filing.";
+                + "derivable value and count as $0 in the total above, so the total and the "
+                + "percentages understate the filing.";
         }
         if (notes != null)
             subtitle = $"{subtitle}\n{notes}";

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioUnvaluedCountTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioUnvaluedCountTests.cs
@@ -1,0 +1,115 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the unvalued-position count behind GetInstitutionPortfolio's disclosure, on real
+/// Postgres so the single grouped projection is proven translatable. The predicate must catch
+/// every cohort of $0 rows: still pending, marked unknowable, AND rows the old retry ladder
+/// abandoned with neither flag set (their only tell is the filer's own FiledValue). Counting
+/// just the flagged rows once reported "1 unvalued position" for a filer with 94 of 96
+/// positions at $0.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetInstitutionPortfolioUnvaluedCountTests
+    : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetInstitutionPortfolioUnvaluedCountTests(
+        ParadeDbFixture fixture
+    )
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetInstitutionPortfolio_CountsEveryUnvaluedCohortOnTheDistinctStockBasis()
+    {
+        var holder = new InstitutionalHolder { Cik = "77", Name = "Gotham Asset Management" };
+        var valued = MakeStock("VALD");
+        var pending = MakeStock("PEND");
+        var unavailable = MakeStock("UNAV");
+        var abandoned = MakeStock("ABND");
+        var wortholess = MakeStock("ZERO");
+        DbContext.AddRange(holder, valued, pending, unavailable, abandoned, wortholess);
+
+        var reportDate = new DateOnly(2026, 3, 31);
+        DbContext.AddRange(
+            // A normally valued position.
+            MakeHolding(holder, valued, reportDate, value: 5_000_000L),
+            // Cohort 1: price still pending.
+            MakeHolding(holder, pending, reportDate, value: 0L, valuePending: true),
+            // Cohort 2: marked unknowable.
+            MakeHolding(holder, unavailable, reportDate, value: 0L, valueUnavailable: true),
+            // Cohort 3: the old ladder's give-up shape — both flags false, only the filer's
+            // own figure betrays that the $0 is a hole, not a position worth nothing.
+            MakeHolding(holder, abandoned, reportDate, value: 0L, filedValue: 2_500_000L),
+            // A genuine $0 with no flags and no filed figure is NOT unvalued.
+            MakeHolding(holder, wortholess, reportDate, value: 0L)
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var output = await Sut().GetInstitutionPortfolio("Gotham");
+
+        output.Should().Contain("3 tracked position(s) have no derivable value");
+        output.Should().Contain("of 5 tracked positions");
+    }
+
+    private InstitutionalHoldingsTools Sut()
+    {
+        var verify = Fixture.CreateDbContext();
+        return new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+    }
+
+    private static CommonStock MakeStock(string ticker) =>
+        new()
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Corp",
+            Cik = ticker.GetHashCode().ToString(),
+        };
+
+    private static InstitutionalHolding MakeHolding(
+        InstitutionalHolder holder,
+        CommonStock stock,
+        DateOnly reportDate,
+        long value,
+        long? filedValue = null,
+        bool valuePending = false,
+        bool valueUnavailable = false
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = 1_000,
+            Value = value,
+            FiledValue = filedValue,
+            ValuePending = valuePending,
+            ValueUnavailable = valueUnavailable,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stock.Ticker}",
+        };
+}

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
@@ -63,6 +63,7 @@ public class InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarian
             splitsByStock,
             holdings.Count,
             holdings.Sum(h => h.Value),
+            0, // unvaluedPositions
             null,
             null,
         ];

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclosureTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclosureTests.cs
@@ -79,12 +79,15 @@ public class InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclos
 
         var output = Render(unvaluedPositions: 507, declaringFiling: filing);
 
+        // The two gaps have different causes: unvalued rows are tracked, so they explain part
+        // of the VALUE difference but none of the position-count difference.
         output
             .Should()
             .Contain(
-                "security types outside this platform's coverage plus the unvalued positions",
+                "the position difference is security types outside this platform's coverage",
                 "blaming coverage alone once hid a valuation hole behind an excuse"
             );
+        output.Should().Contain("the value difference also reflects the unvalued positions");
     }
 
     [Fact]
@@ -99,7 +102,9 @@ public class InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclos
 
         var output = Render(unvaluedPositions: 0, declaringFiling: filing);
 
-        output.Should().Contain("the difference is security types outside this platform's coverage.");
-        output.Should().NotContain("plus the unvalued positions");
+        output
+            .Should()
+            .Contain("the difference is security types outside this platform's coverage.");
+        output.Should().NotContain("unvalued positions");
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclosureTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclosureTests.cs
@@ -1,0 +1,105 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins the unvalued-position disclosure: rows a filing tracks but the platform could not price
+/// sit in the table at $0, and the header must say so — attributing the whole declared-vs-tracked
+/// gap to "security types outside coverage" once hid a $92.1B valuation hole (48% of a quarter's
+/// positions) behind a coverage excuse.
+/// </summary>
+public class InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclosureTests
+{
+    private static string Render(int unvaluedPositions, InstitutionalFiling declaringFiling)
+    {
+        var method = typeof(InstitutionalHoldingsTools).GetMethod(
+            "RenderInstitutionPortfolio",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var holder = new InstitutionalHolder { Name = "ACME Capital", Cik = "0001234567" };
+        var stock = new CommonStock { Ticker = "NVDA", Name = "Nvidia Corp" };
+        var holdings = new List<InstitutionalHolding>
+        {
+            new()
+            {
+                CommonStock = stock,
+                Shares = 1_000,
+                Value = 5_000_000L,
+            },
+        };
+
+        return (string)
+            method.Invoke(
+                null,
+                [
+                    holder,
+                    new DateOnly(2026, 3, 31),
+                    holdings,
+                    new Dictionary<Guid, List<StockSplit>>(),
+                    holdings.Count,
+                    holdings.Sum(h => h.Value),
+                    unvaluedPositions,
+                    declaringFiling,
+                    null,
+                ]
+            );
+    }
+
+    [Fact]
+    public void RenderInstitutionPortfolio_UnvaluedPositions_AreDisclosedWithACount()
+    {
+        var output = Render(unvaluedPositions: 507, declaringFiling: null);
+
+        output.Should().Contain("507 tracked position(s) have no derivable value");
+        output.Should().Contain("understate the filing");
+    }
+
+    [Fact]
+    public void RenderInstitutionPortfolio_NoUnvaluedPositions_SaysNothingAboutThem()
+    {
+        var output = Render(unvaluedPositions: 0, declaringFiling: null);
+
+        output.Should().NotContain("no derivable value");
+    }
+
+    [Fact]
+    public void RenderInstitutionPortfolio_DeclaredGapWithUnvaluedRows_NamesBothCauses()
+    {
+        var filing = new InstitutionalFiling
+        {
+            AccessionNumber = "0000919079-26-000006",
+            DeclaredPositionCount = 1064,
+            DeclaredTotalValue = 162_486_869_017L,
+        };
+
+        var output = Render(unvaluedPositions: 507, declaringFiling: filing);
+
+        output
+            .Should()
+            .Contain(
+                "security types outside this platform's coverage plus the unvalued positions",
+                "blaming coverage alone once hid a valuation hole behind an excuse"
+            );
+    }
+
+    [Fact]
+    public void RenderInstitutionPortfolio_DeclaredGapWithoutUnvaluedRows_KeepsCoverageExplanation()
+    {
+        var filing = new InstitutionalFiling
+        {
+            AccessionNumber = "0000919079-26-000006",
+            DeclaredPositionCount = 1064,
+            DeclaredTotalValue = 162_486_869_017L,
+        };
+
+        var output = Render(unvaluedPositions: 0, declaringFiling: filing);
+
+        output.Should().Contain("the difference is security types outside this platform's coverage.");
+        output.Should().NotContain("plus the unvalued positions");
+    }
+}


### PR DESCRIPTION
## Summary

`GetInstitutionPortfolio` attributed the whole declared-vs-tracked gap to "security types outside this platform's coverage", which hid a $92.1B valuation hole (48% of a quarter's positions stored at $0) behind a coverage excuse. The tool now counts unvalued rows and says exactly what the total omits. `Value` stays the single published figure — no query-side coalesce; the data fix is #4298.

## Code changes

- **`InstitutionalHoldingsTools`** — one grouped round trip computes the three header scalars (distinct tracked positions, tracked value, unvalued positions). The unvalued predicate catches every $0 cohort: pending, unavailable, and rows the old ladder abandoned with neither flag (their only tell is `FiledValue > 0`), counted on the header's distinct-stock basis. New NOTE names the count and states that the total and percentages understate the filing; the declared-gap sentence attributes the position gap and the value gap separately.
- **Tests** — renderer disclosure tests (unit) plus a real-Postgres integration test proving the grouped projection translates and pinning all three cohorts.

Full OSS suites green: 3,977 unit + 2,344 integration.