### PR TITLE
fix(holdings): rank institution resolution by recency on 13F rollups only

### DIFF
--- a/src/Equibles.Holdings.Data/Models/InstitutionalFiling.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalFiling.cs
@@ -5,12 +5,21 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.Holdings.Data.Models;
 
 /// <summary>
-/// One row per 13F-HR submission, keyed by accession number — the filing-level
+/// One row per submission, keyed by accession number — the filing-level
 /// rollup of the per-position <see cref="InstitutionalHolding"/> rows that share
 /// that accession. Holdings are stored only at the position grain, so the
 /// "latest filings" feed used to reconstruct one row per filing with a
 /// table-wide GROUP BY on every request; this table is that rollup, written once
 /// at ingestion and read back with a plain indexed scan.
+///
+/// <para>
+/// Despite the class name, the rollup is NOT 13F-only: Schedule 13D/G imports
+/// flow through the same writer, so single-stake rows with event dates (not
+/// quarter ends) sit beside the 13F quarters. <see cref="FilingType"/> is the
+/// discriminator — any consumer treating a row as a 13F portfolio quarter
+/// (recency, size ranking, AUM) must filter on it, or a filer's newest "filing"
+/// is one 13D/G stake worth a fraction of its real book.
+/// </para>
 ///
 /// <para>
 /// <see cref="PositionCount"/> and <see cref="TotalValue"/> count only the
@@ -49,6 +58,13 @@ public class InstitutionalFiling
     public DateOnly FilingDate { get; set; }
     public DateOnly ReportDate { get; set; }
     public bool IsAmendment { get; set; }
+
+    /// <summary>
+    /// What kind of submission this rollup row summarises, copied from its holdings rows at
+    /// sync. Rows written before the column existed default to <see cref="FilingType.Form13F"/>
+    /// until the worker's backfill restamps the 13D/G ones from their holdings.
+    /// </summary>
+    public FilingType FilingType { get; set; }
 
     public int PositionCount { get; set; }
     public long TotalValue { get; set; }

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -139,6 +139,26 @@ public class HoldingsScraperWorker : BaseScraperWorker
         // derivations for honest repricing. Bounded per cycle; self-terminating like the pass
         // above once the backlog drains.
         await RepairAbandonedValues(stoppingToken);
+
+        // Restamp FilingType on filing rollup rows written before the column existed. Self-
+        // terminating like the pass above.
+        await BackfillFilingRollupTypes(stoppingToken);
+    }
+
+    private async Task BackfillFilingRollupTypes(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var scope = ScopeFactory.CreateAsyncScope();
+            var backfill =
+                scope.ServiceProvider.GetRequiredService<FilingRollupTypeBackfillService>();
+            await backfill.Backfill(cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            // Maintenance, not ingestion: its failure must not fail the import cycle.
+            Logger.LogWarning(exception, "Filing rollup type backfill pass failed");
+        }
     }
 
     private async Task RepairImpossiblePositions(CancellationToken cancellationToken)

--- a/src/Equibles.Holdings.HostedService/Services/Corrupt13FShareCountRepairer.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Corrupt13FShareCountRepairer.cs
@@ -58,7 +58,10 @@ internal static class Corrupt13FShareCountRepairer
     /// </summary>
     internal static Corrupt13FRepairOutcome Repair(
         List<BufferedHoldingRow> rows,
-        IReadOnlyDictionary<(Guid StockId, string ListedTicker, DateOnly ReportDate), decimal> stockPrices
+        IReadOnlyDictionary<
+            (Guid StockId, string ListedTicker, DateOnly ReportDate),
+            decimal
+        > stockPrices
     )
     {
         var repaired = 0;

--- a/src/Equibles.Holdings.HostedService/Services/FilingRollupTypeBackfillService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/FilingRollupTypeBackfillService.cs
@@ -1,0 +1,101 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Restamps <see cref="InstitutionalFiling.FilingType"/> on rollup rows written before the
+/// column existed, from the holdings rows the rollup summarises.
+/// </summary>
+/// <remarks>
+/// The column's migration defaults every existing row to <see cref="FilingType.Form13F"/>, which
+/// mislabels the Schedule 13D/G rollup rows — and those are exactly the rows whose event dates
+/// would otherwise pass for a filer's freshest "13F quarter" in recency-ranked resolution. The
+/// sync stamps new rows correctly, so this sweep only ever touches the pre-column backlog:
+/// bounded per cycle, self-terminating (a restamped row no longer matches), and a no-op scan
+/// once drained. Values are copied from the holdings' own <c>FilingType</c> — never inferred
+/// from date shape, because 13D/G rows dated on quarter ends exist.
+/// </remarks>
+[Service]
+public class FilingRollupTypeBackfillService
+{
+    internal const int MaxRowsPerCycle = 50_000;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FilingRollupTypeBackfillService> _logger;
+
+    public FilingRollupTypeBackfillService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<FilingRollupTypeBackfillService> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task<int> Backfill(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        if (dbContext.Database.IsRelational())
+        {
+            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+        }
+
+        var rows = await dbContext
+            .Set<InstitutionalFiling>()
+            .Where(f =>
+                f.FilingType == FilingType.Form13F
+                && dbContext
+                    .Set<InstitutionalHolding>()
+                    .Any(h =>
+                        h.AccessionNumber == f.AccessionNumber && h.FilingType != FilingType.Form13F
+                    )
+            )
+            .OrderBy(f => f.Id)
+            .Take(MaxRowsPerCycle)
+            .ToListAsync(cancellationToken);
+
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        var accessions = rows.Select(r => r.AccessionNumber).ToList();
+        var typeByAccession = (
+            await dbContext
+                .Set<InstitutionalHolding>()
+                .Where(h =>
+                    accessions.Contains(h.AccessionNumber) && h.FilingType != FilingType.Form13F
+                )
+                .Select(h => new { h.AccessionNumber, h.FilingType })
+                .Distinct()
+                .ToListAsync(cancellationToken)
+        )
+            .GroupBy(t => t.AccessionNumber, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First().FilingType, StringComparer.Ordinal);
+
+        var restamped = 0;
+        foreach (var filing in rows)
+        {
+            if (typeByAccession.TryGetValue(filing.AccessionNumber, out var filingType))
+            {
+                filing.FilingType = filingType;
+                restamped++;
+            }
+        }
+
+        if (restamped > 0)
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+            _logger.LogInformation(
+                "Restamped FilingType on {Count} pre-column filing rollup row(s)",
+                restamped
+            );
+        }
+
+        return restamped;
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1999,6 +1999,7 @@ public class HoldingsImportService
                 h.FilingDate,
                 h.ReportDate,
                 h.IsAmendment,
+                h.FilingType,
             })
             .Select(g => new
             {
@@ -2007,6 +2008,7 @@ public class HoldingsImportService
                 g.Key.FilingDate,
                 g.Key.ReportDate,
                 g.Key.IsAmendment,
+                g.Key.FilingType,
                 PositionCount = g.Count(),
                 TotalValue = g.Sum(h => h.Value),
             })
@@ -2033,6 +2035,7 @@ public class HoldingsImportService
                 FilingDate = r.FilingDate,
                 ReportDate = r.ReportDate,
                 IsAmendment = r.IsAmendment,
+                FilingType = r.FilingType,
                 PositionCount = r.PositionCount,
                 TotalValue = r.TotalValue,
                 DeclaredPositionCount = context.SummaryPages.TryGetValue(
@@ -2064,6 +2067,7 @@ public class HoldingsImportService
                             FilingDate = incoming.FilingDate,
                             ReportDate = incoming.ReportDate,
                             IsAmendment = incoming.IsAmendment,
+                            FilingType = incoming.FilingType,
                             PositionCount = incoming.PositionCount,
                             TotalValue = incoming.TotalValue,
                             DeclaredPositionCount = incoming.DeclaredPositionCount,

--- a/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
@@ -47,7 +47,7 @@ public class CloneBacktestTools
     )]
     public Task<string> GetFundCloneBacktest(
         [Description(
-            "Institution name or SEC CIK (e.g., 'Berkshire Hathaway', '1067983', or zero-padded '0001067983'; ambiguous names resolve to the largest 13F filer)"
+            "Institution name or SEC CIK (e.g., 'Berkshire Hathaway', '1067983', or zero-padded '0001067983'; ambiguous names resolve to the largest recently-active 13F filer)"
         )]
             string institution,
         [Description("Benchmark ticker to compare against (default: SPY)")]
@@ -143,7 +143,7 @@ public class CloneBacktestTools
         var notes = new List<string>();
         if (matches.Count > 1)
             notes.Add(
-                $"Note: matched {holder.Name} (CIK {holder.Cik}, largest 13F filer of the matches); other matches: "
+                $"Note: matched {holder.Name} (CIK {holder.Cik}, largest recently-active 13F filer of the matches); other matches: "
                     + $"{string.Join(", ", matches.Skip(1).Select(m => $"{m.Name} (CIK {m.Cik})"))}."
             );
         if (!explicitWindow && requestedYears != clampedYears)

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -590,7 +590,7 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Search for institutional investors (fund managers) by name or SEC CIK number, largest 13F filers first. Returns matching institutions with their SEC CIK number, city, and state/country. Use this to find the correct institution name before calling GetInstitutionPortfolio or to discover which institutions are tracked in the database."
+        "Search for institutional investors (fund managers) by name or SEC CIK number, largest recently-active 13F filers first. Returns matching institutions with their SEC CIK number, city, and state/country. Use this to find the correct institution name before calling GetInstitutionPortfolio or to discover which institutions are tracked in the database."
     )]
     public Task<string> SearchInstitutions(
         [Description("Search query — institution name, partial name, or CIK")] string query,
@@ -615,7 +615,7 @@ public class InstitutionalHoldingsTools
                 var table = MarkdownTable.Render(
                     holders,
                     $"No institutions found matching '{query}'.",
-                    $"Institutions matching '{query}' (largest 13F filers first):",
+                    $"Institutions matching '{query}' (largest recently-active 13F filers first):",
                     "| Institution | CIK | City | State/Country |",
                     "|------------|-----|------|--------------|",
                     h =>
@@ -1299,10 +1299,12 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Get the portfolio summary header for an institutional 13F filer — 13F reported value (long U.S. positions only, not total firm AUM), position count, top-10 / top-25 concentration, QoQ turnover, and the latest / prior report dates with the count of quarters tracked in this database. Use this to answer 'how big and how concentrated is this fund?' or to compare two funds at a glance. Search resolves by institution name or CIK (largest 13F filer wins on ambiguous names)."
+        "Get the portfolio summary header for an institutional 13F filer — 13F reported value (long U.S. positions only, not total firm AUM), position count, top-10 / top-25 concentration, QoQ turnover, and the latest / prior report dates with the count of quarters tracked in this database. Use this to answer 'how big and how concentrated is this fund?' or to compare two funds at a glance. Search resolves by institution name or CIK (the largest recently-active 13F filer wins on ambiguous names)."
     )]
     public Task<string> GetInstitutionSummary(
-        [Description("Institution name or CIK (partial names resolve to the largest 13F filer)")]
+        [Description(
+            "Institution name or CIK (partial names resolve to the largest recently-active 13F filer)"
+        )]
             string institutionName,
         [Description(
             "Quarter-end 13F report date in YYYY-MM-DD format (defaults to the holder's latest; an off-quarter date snaps to the nearest report on or before it)"
@@ -1446,7 +1448,9 @@ public class InstitutionalHoldingsTools
         "Get an institution's 13F portfolio allocation for a given report quarter (defaults to the latest), grouped by fine-grained industry (default) or rolled up by sector via `groupBy`. Returns a markdown table sorted by % of portfolio descending, with stocks lacking a classification collapsed into a single 'Unclassified' row at the end. Ambiguous names resolve to the largest matching 13F filer — use SearchInstitutions to disambiguate. Use this to answer 'is this fund concentrated in tech / energy / generalist?'"
     )]
     public Task<string> GetInstitutionSectorAllocation(
-        [Description("Institution name or CIK (partial names resolve to the largest 13F filer)")]
+        [Description(
+            "Institution name or CIK (partial names resolve to the largest recently-active 13F filer)"
+        )]
             string institutionName,
         [Description(
             "Quarter-end 13F report date in YYYY-MM-DD format (defaults to the holder's latest; an off-quarter date snaps to the nearest report on or before it)"
@@ -1505,7 +1509,9 @@ public class InstitutionalHoldingsTools
         "Get an institution's quarterly position-change activity — Initiated / Increased / Reduced / Exited stocks diffed against the immediately prior quarter. Returns the buckets as one markdown section per bucket, sorted by absolute Δ market-value desc (Δ Value includes price movement, not just trading). Use `bucket` to filter to a single bucket. Use this to answer 'what did this fund do this quarter?'"
     )]
     public Task<string> GetInstitutionQuarterlyActivity(
-        [Description("Institution name or CIK (partial names resolve to the largest 13F filer)")]
+        [Description(
+            "Institution name or CIK (partial names resolve to the largest recently-active 13F filer)"
+        )]
             string institutionName,
         [Description(
             "Quarter-end 13F report date in YYYY-MM-DD format (defaults to the holder's latest; an off-quarter date snaps to the nearest report on or before it)"
@@ -1676,11 +1682,11 @@ public class InstitutionalHoldingsTools
     )]
     public Task<string> GetFundOverlap(
         [Description(
-            "First institution name or CIK (partial names resolve to the largest 13F filer)"
+            "First institution name or CIK (partial names resolve to the largest recently-active 13F filer)"
         )]
             string institutionName1,
         [Description(
-            "Second institution name or CIK (partial names resolve to the largest 13F filer)"
+            "Second institution name or CIK (partial names resolve to the largest recently-active 13F filer)"
         )]
             string institutionName2,
         [Description(
@@ -1987,7 +1993,8 @@ public class InstitutionalHoldingsTools
         return result.ToString();
     }
 
-    // Best single match for a name or CIK: the largest 13F filer among the matches. The old
+    // Best single match for a name or CIK: the largest recently-active 13F filer among the
+    // matches (dormant re-registrations rank below live filers). The old
     // shortest-name-wins ordering silently resolved famous names to the wrong firm
     // ("Bridgewater" → Bridgewater Advisors Inc., a small RIA, instead of Bridgewater
     // Associates, LP) and the whole output would read as the wrong fund's portfolio.
@@ -2010,7 +2017,7 @@ public class InstitutionalHoldingsTools
         var holder = matches[0];
         var matchNote =
             matches.Count > 1
-                ? $"Note: '{name}' matched {holder.Name} (CIK {holder.Cik}, largest 13F filer of the matches); other matches: "
+                ? $"Note: '{name}' matched {holder.Name} (CIK {holder.Cik}, largest recently-active 13F filer of the matches); other matches: "
                     + $"{string.Join(", ", matches.Skip(1).Select(m => m.Name))} — pass a CIK or use SearchInstitutions to disambiguate."
                 : null;
         return (holder, matchNote, null);

--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -55,12 +55,22 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
         return unpadded.Length == 0 ? search : unpadded;
     }
 
-    // Resolves a name/CIK query to filers ranked largest-first by the biggest 13F filing on
-    // record (the InstitutionalFiling rollup's TotalValue). A bare famous name must resolve
-    // to the flagship filer: shortest-name and alphabetical orderings both sent "Bridgewater"
-    // to Bridgewater Advisors Inc. (a small RIA) instead of Bridgewater Associates, LP.
-    // Filers with no 13F rollup rows (13D/G-only filers) rank last; ties break on name length
-    // then name so an exact name still beats longer decorated variants at equal size.
+    // A filer whose newest 13F is within this window of the newest 13F among the matches is
+    // "live". One quarter (92 days) plus the 45-day filing deadline, with slack: mid filing
+    // season the flagship may not have filed the newest quarter yet, and must not lose its
+    // bucket to a smaller filer that filed a few days earlier.
+    private const int LiveFilerWindowDays = 135;
+
+    // Resolves a name/CIK query to filers ranked live-and-largest-first. Recency comes before
+    // size: corporate re-registrations leave the old CIK dormant with its giant historical
+    // filings intact, and pure size ranking then resolves the household name to the dead entity
+    // forever — "BlackRock" answered a two-year-stale portfolio off the retired filer while the
+    // live successor CIK filed on schedule. Within a bucket, size at the LATEST quarter ranks
+    // (not the all-time maximum, which rewards a filer for a past it no longer has); a bare
+    // famous name must still resolve to the flagship filer, not a small same-named RIA
+    // ("Bridgewater" → Bridgewater Associates, LP, never Bridgewater Advisors Inc.). Filers
+    // with no 13F rollup rows (13D/G-only filers) rank last; ties break on name length then
+    // name so an exact name still beats longer decorated variants at equal size.
     public async Task<List<InstitutionalHolder>> SearchNameOrCikLargestFirst(
         string search,
         int maxResults,
@@ -74,15 +84,50 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
             return [];
 
         var ids = matches.Select(m => m.Id).ToList();
-        var sizeByHolder = await DbContext
+        var quarterSizes = await DbContext
             .Set<InstitutionalFiling>()
             .Where(f => ids.Contains(f.InstitutionalHolderId))
-            .GroupBy(f => f.InstitutionalHolderId)
-            .Select(g => new { Id = g.Key, MaxTotalValue = g.Max(f => f.TotalValue) })
-            .ToDictionaryAsync(x => x.Id, x => x.MaxTotalValue, cancellationToken);
+            .GroupBy(f => new { f.InstitutionalHolderId, f.ReportDate })
+            .Select(g => new
+            {
+                g.Key.InstitutionalHolderId,
+                g.Key.ReportDate,
+                MaxTotalValue = g.Max(f => f.TotalValue),
+            })
+            .ToListAsync(cancellationToken);
+
+        // Per holder: the newest reported quarter, and the size of the largest filing IN that
+        // quarter (an amendment and its original are separate rollup rows; the largest is the
+        // fuller picture).
+        var statsByHolder = quarterSizes
+            .GroupBy(q => q.InstitutionalHolderId)
+            .ToDictionary(
+                g => g.Key,
+                g =>
+                {
+                    var latest = g.Max(q => q.ReportDate);
+                    return (
+                        LatestReportDate: latest,
+                        SizeAtLatest: g.Where(q => q.ReportDate == latest)
+                            .Max(q => q.MaxTotalValue)
+                    );
+                }
+            );
+
+        // The live window anchors on the newest quarter among the MATCHES, so an all-dormant
+        // match set (a genuinely defunct name) still ranks sensibly instead of losing its
+        // bucket to an empty threshold.
+        var liveThreshold = statsByHolder.Count > 0
+            ? statsByHolder.Values.Max(s => s.LatestReportDate).AddDays(-LiveFilerWindowDays)
+            : DateOnly.MinValue;
 
         var topIds = matches
-            .OrderByDescending(m => sizeByHolder.TryGetValue(m.Id, out var size) ? size : -1L)
+            .OrderByDescending(m =>
+                statsByHolder.TryGetValue(m.Id, out var s) && s.LatestReportDate >= liveThreshold
+            )
+            .ThenByDescending(m =>
+                statsByHolder.TryGetValue(m.Id, out var s) ? s.SizeAtLatest : -1L
+            )
             .ThenBy(m => m.Name.Length)
             .ThenBy(m => m.Name, StringComparer.Ordinal)
             .Take(maxResults)

--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -55,10 +55,13 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
         return unpadded.Length == 0 ? search : unpadded;
     }
 
-    // A filer whose newest 13F is within this window of the newest 13F among the matches is
-    // "live". One quarter (92 days) plus the 45-day filing deadline, with slack: mid filing
-    // season the flagship may not have filed the newest quarter yet, and must not lose its
-    // bucket to a smaller filer that filed a few days earlier.
+    // A filer whose newest 13F quarter is within this window of the newest 13F quarter among
+    // the matches is "live". The threshold compares report dates to report dates (never the
+    // wall clock), so the effective rule is "at most one quarter behind the newest match":
+    // consecutive quarter ends sit 90-92 days apart and two quarters sit 181-184 apart, and any
+    // constant between those bands behaves identically. Mid filing season the flagship may not
+    // have filed the newest quarter yet, and must not lose its bucket to a smaller filer that
+    // filed a few days earlier.
     private const int LiveFilerWindowDays = 135;
 
     // Resolves a name/CIK query to filers ranked live-and-largest-first. Recency comes before
@@ -70,7 +73,9 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
     // famous name must still resolve to the flagship filer, not a small same-named RIA
     // ("Bridgewater" → Bridgewater Associates, LP, never Bridgewater Advisors Inc.). Filers
     // with no 13F rollup rows (13D/G-only filers) rank last; ties break on name length then
-    // name so an exact name still beats longer decorated variants at equal size.
+    // name so an exact name still beats longer decorated variants at equal size. The live
+    // anchor is the newest quarter among the MATCHES, so the same filer can rank live for one
+    // query and dormant for a narrower one — deliberate, so a defunct name still ranks.
     public async Task<List<InstitutionalHolder>> SearchNameOrCikLargestFirst(
         string search,
         int maxResults,
@@ -84,42 +89,54 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
             return [];
 
         var ids = matches.Select(m => m.Id).ToList();
-        var quarterSizes = await DbContext
+        // 13F rows ONLY: the rollup also carries Schedule 13D/G rows, whose event dates are
+        // always fresher than the last quarter end and whose TotalValue is one stake — ranked
+        // unfiltered, "Millennium" resolves to whichever namesake filed a 13D/G most recently
+        // instead of the $79B flagship. (Rows predating the FilingType column default to 13F
+        // until the worker's backfill restamps them — the pre-existing failure mode, healed
+        // within its first pass.)
+        var thirteenFRollups = DbContext
             .Set<InstitutionalFiling>()
-            .Where(f => ids.Contains(f.InstitutionalHolderId))
-            .GroupBy(f => new { f.InstitutionalHolderId, f.ReportDate })
-            .Select(g => new
-            {
-                g.Key.InstitutionalHolderId,
-                g.Key.ReportDate,
-                MaxTotalValue = g.Max(f => f.TotalValue),
-            })
-            .ToListAsync(cancellationToken);
-
-        // Per holder: the newest reported quarter, and the size of the largest filing IN that
-        // quarter (an amendment and its original are separate rollup rows; the largest is the
-        // fuller picture).
-        var statsByHolder = quarterSizes
-            .GroupBy(q => q.InstitutionalHolderId)
-            .ToDictionary(
-                g => g.Key,
-                g =>
-                {
-                    var latest = g.Max(q => q.ReportDate);
-                    return (
-                        LatestReportDate: latest,
-                        SizeAtLatest: g.Where(q => q.ReportDate == latest)
-                            .Max(q => q.MaxTotalValue)
-                    );
-                }
+            .Where(f =>
+                ids.Contains(f.InstitutionalHolderId) && f.FilingType == FilingType.Form13F
             );
+
+        // One row per holder, aggregated in SQL: the newest reported quarter, and the size of
+        // the largest filing IN that quarter (an amendment and its original are separate rollup
+        // rows; the largest is the fuller picture). A grouped-subquery join keeps a broad match
+        // set from materialising every (holder, quarter) pair client-side.
+        var latestQuarters = thirteenFRollups
+            .GroupBy(f => f.InstitutionalHolderId)
+            .Select(g => new { Id = g.Key, Latest = g.Max(f => f.ReportDate) });
+        var stats = await (
+            from f in thirteenFRollups
+            join l in latestQuarters
+                on new { Id = f.InstitutionalHolderId, Date = f.ReportDate } equals new
+                {
+                    l.Id,
+                    Date = l.Latest,
+                }
+            group f by f.InstitutionalHolderId into g
+            select new
+            {
+                Id = g.Key,
+                LatestReportDate = g.Max(f => f.ReportDate),
+                SizeAtLatest = g.Max(f => f.TotalValue),
+            }
+        ).ToListAsync(cancellationToken);
+
+        var statsByHolder = stats.ToDictionary(
+            s => s.Id,
+            s => (s.LatestReportDate, s.SizeAtLatest)
+        );
 
         // The live window anchors on the newest quarter among the MATCHES, so an all-dormant
         // match set (a genuinely defunct name) still ranks sensibly instead of losing its
         // bucket to an empty threshold.
-        var liveThreshold = statsByHolder.Count > 0
-            ? statsByHolder.Values.Max(s => s.LatestReportDate).AddDays(-LiveFilerWindowDays)
-            : DateOnly.MinValue;
+        var liveThreshold =
+            statsByHolder.Count > 0
+                ? statsByHolder.Values.Max(s => s.LatestReportDate).AddDays(-LiveFilerWindowDays)
+                : DateOnly.MinValue;
 
         var topIds = matches
             .OrderByDescending(m =>

--- a/src/Equibles.Migrations/Migrations/20260805191501_AddInstitutionalFilingType.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260805191501_AddInstitutionalFilingType.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805191501_AddInstitutionalFilingType")]
+    partial class AddInstitutionalFilingType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260805191501_AddInstitutionalFilingType.cs
+++ b/src/Equibles.Migrations/Migrations/20260805191501_AddInstitutionalFilingType.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstitutionalFilingType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FilingType",
+                table: "InstitutionalFiling",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FilingType",
+                table: "InstitutionalFiling");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/FilingRollupTypeBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/FilingRollupTypeBackfillServiceTests.cs
@@ -1,0 +1,154 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins the FilingType restamp on pre-column filing rollup rows: the migration defaults every
+/// row to Form13F, mislabelling the Schedule 13D/G rollups whose fresh event dates would
+/// otherwise pass for a filer's newest 13F quarter in recency-ranked resolution. The truth is
+/// copied from the holdings rows — never inferred from date shape — and the sweep is a no-op
+/// once drained.
+/// </summary>
+public class FilingRollupTypeBackfillServiceTests : IDisposable
+{
+    private static readonly IModuleConfiguration[] Modules =
+    [
+        new CommonStocksModuleConfiguration(),
+        new HoldingsModuleConfiguration(),
+        new CorporateActionsModuleConfiguration(),
+    ];
+
+    private readonly string _dbName = Guid.NewGuid().ToString();
+    private readonly ILogger<FilingRollupTypeBackfillService> _logger = Substitute.For<
+        ILogger<FilingRollupTypeBackfillService>
+    >();
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public void Dispose()
+    {
+        foreach (var ctx in _contexts)
+        {
+            ctx.Dispose();
+        }
+    }
+
+    private EquiblesFinancialDbContext CreateSharedContext()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(_dbName)
+            .Options;
+
+        var ctx = new EquiblesFinancialDbContext(options, Modules);
+        ctx.Database.EnsureCreated();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = CreateSharedContext();
+
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+
+        return scopeFactory;
+    }
+
+    private FilingRollupTypeBackfillService CreateService() => new(CreateScopeFactory(), _logger);
+
+    private async Task Seed(string accession, FilingType rollupType, FilingType holdingType)
+    {
+        var seedContext = CreateSharedContext();
+        var holderId = Guid.NewGuid();
+        seedContext
+            .Set<InstitutionalHolder>()
+            .Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = Guid.NewGuid().ToString()[..10],
+                    Name = "Filer",
+                }
+            );
+        seedContext
+            .Set<InstitutionalFiling>()
+            .Add(
+                new InstitutionalFiling
+                {
+                    AccessionNumber = accession,
+                    InstitutionalHolderId = holderId,
+                    FilingDate = new DateOnly(2026, 7, 23),
+                    ReportDate = new DateOnly(2026, 7, 23),
+                    FilingType = rollupType,
+                    PositionCount = 1,
+                    TotalValue = 45_000_000L,
+                }
+            );
+        seedContext
+            .Set<InstitutionalHolding>()
+            .Add(
+                new InstitutionalHolding
+                {
+                    CommonStockId = Guid.NewGuid(),
+                    InstitutionalHolderId = holderId,
+                    FilingDate = new DateOnly(2026, 7, 23),
+                    ReportDate = new DateOnly(2026, 7, 23),
+                    FilingType = holdingType,
+                    Shares = 1_000,
+                    Value = 45_000_000L,
+                    ShareType = ShareType.Shares,
+                    InvestmentDiscretion = InvestmentDiscretion.Sole,
+                    AccessionNumber = accession,
+                }
+            );
+        await seedContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Backfill_MislabelledScheduleRollup_IsRestampedFromItsHoldings()
+    {
+        await Seed("acc-13g", rollupType: FilingType.Form13F, holdingType: FilingType.Schedule13G);
+        await Seed("acc-13f", rollupType: FilingType.Form13F, holdingType: FilingType.Form13F);
+
+        var restamped = await CreateService().Backfill(CancellationToken.None);
+
+        restamped.Should().Be(1);
+        var verify = CreateSharedContext();
+        (await verify.Set<InstitutionalFiling>().SingleAsync(f => f.AccessionNumber == "acc-13g"))
+            .FilingType.Should()
+            .Be(FilingType.Schedule13G);
+        (await verify.Set<InstitutionalFiling>().SingleAsync(f => f.AccessionNumber == "acc-13f"))
+            .FilingType.Should()
+            .Be(FilingType.Form13F, "a genuine 13F rollup row must not be touched");
+    }
+
+    [Fact]
+    public async Task Backfill_SecondPass_IsANoOp()
+    {
+        await Seed("acc-13d", rollupType: FilingType.Form13F, holdingType: FilingType.Schedule13D);
+
+        (await CreateService().Backfill(CancellationToken.None)).Should().Be(1);
+        (await CreateService().Backfill(CancellationToken.None)).Should().Be(0);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests.cs
@@ -7,13 +7,15 @@ using Xunit;
 namespace Equibles.IntegrationTests.Holdings;
 
 /// <summary>
-/// Pins the two resolution fixes behind the MCP audit's wrong-entity findings:
-/// (1) SearchNameOrCikLargestFirst ranks matches by 13F size (the InstitutionalFiling
-/// rollup's TotalValue), so "Bridgewater" resolves to Bridgewater Associates — not whichever
-/// small RIA has the shortest or alphabetically-first name — with rollup-less (13D/G-only)
-/// filers last; (2) an all-digit query strips its leading zeros before the CIK prefix match,
-/// so the SEC-canonical zero-padded '0001067983' resolves the same filer as the stored
-/// unpadded '1067983'.
+/// Pins the resolution ranking behind the MCP audit's wrong-entity findings:
+/// SearchNameOrCikLargestFirst buckets matches by 13F recency first (a dormant
+/// re-registration must not beat the live successor), then ranks by size at the latest 13F
+/// quarter, so "Bridgewater" resolves to Bridgewater Associates — not whichever small RIA has
+/// the shortest name — with rollup-less filers last. Recency and size read 13F rollup rows
+/// ONLY: Schedule 13D/G rows share the table with fresher event dates and one-stake values,
+/// and ranking on them resolves "Millennium" to whichever namesake filed a 13D/G last. Also
+/// pins the CIK normalization: an all-digit query strips its leading zeros, so the
+/// SEC-canonical zero-padded '0001067983' resolves the same filer as the stored '1067983'.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests : ParadeDbMcpTestBase
@@ -166,6 +168,121 @@ public class InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests : Par
                 "Bridgewater Associates, LP",
                 "one quarter of filing lag keeps the flagship inside the live window"
             );
+        matches[1].Name.Should().Be("Bridgewater Adv.");
+    }
+
+    [Fact]
+    public async Task SearchNameOrCikLargestFirst_Fresh13DGStake_DoesNotShadowTheFlagships13FBook()
+    {
+        // The rollup table also carries Schedule 13D/G rows: event dates always fresher than
+        // the last quarter end, TotalValue a single stake. Ranked unfiltered, "Millennium"
+        // resolved to whichever namesake filed a 13D/G most recently — a $45.6M stake outranked
+        // the $79.3B flagship book on production data.
+        var flagship = new InstitutionalHolder
+        {
+            Cik = "1273087",
+            Name = "Millennium Management LLC",
+        };
+        var namesake = new InstitutionalHolder
+        {
+            Cik = "1273099",
+            Name = "Millennium Advisors LLC",
+        };
+        DbContext.AddRange(flagship, namesake);
+        DbContext.AddRange(
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-flagship-13f",
+                InstitutionalHolderId = flagship.Id,
+                FilingDate = new DateOnly(2026, 5, 13),
+                ReportDate = new DateOnly(2026, 3, 31),
+                FilingType = FilingType.Form13F,
+                PositionCount = 4904,
+                TotalValue = 79_267_431_315L,
+            },
+            // The flagship's own newest rollup row: a one-position 13D/G stake dated AFTER the
+            // quarter end. It must move neither the flagship's recency nor its size.
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-flagship-13g",
+                InstitutionalHolderId = flagship.Id,
+                FilingDate = new DateOnly(2026, 7, 23),
+                ReportDate = new DateOnly(2026, 7, 23),
+                FilingType = FilingType.Schedule13G,
+                PositionCount = 1,
+                TotalValue = 45_595_645L,
+            },
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-namesake-13f",
+                InstitutionalHolderId = namesake.Id,
+                FilingDate = new DateOnly(2026, 5, 13),
+                ReportDate = new DateOnly(2026, 3, 31),
+                FilingType = FilingType.Form13F,
+                PositionCount = 120,
+                TotalValue = 1_500_000_000L,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var repository = new InstitutionalHolderRepository(verify);
+
+        var matches = await repository.SearchNameOrCikLargestFirst("Millennium", 2);
+
+        matches[0]
+            .Name.Should()
+            .Be(
+                "Millennium Management LLC",
+                "recency and size must come from 13F rollup rows only, never a 13D/G stake"
+            );
+        matches[1].Name.Should().Be("Millennium Advisors LLC");
+    }
+
+    [Fact]
+    public async Task SearchNameOrCikLargestFirst_AllDormantMatchSet_StillRanksBySizeWithRolluplessLast()
+    {
+        // A genuinely defunct name: the live window anchors on the match set's own newest
+        // quarter, so an all-dormant set keeps ranking by size instead of collapsing.
+        var big = new InstitutionalHolder { Cik = "4000001", Name = "Defunct Cap A" };
+        var small = new InstitutionalHolder { Cik = "4000002", Name = "Defunct Cap B" };
+        var noRollup = new InstitutionalHolder { Cik = "4000003", Name = "Defunct Cap C" };
+        DbContext.AddRange(big, small, noRollup);
+        DbContext.AddRange(
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-defunct-big",
+                InstitutionalHolderId = big.Id,
+                FilingDate = new DateOnly(2021, 8, 13),
+                ReportDate = new DateOnly(2021, 6, 30),
+                FilingType = FilingType.Form13F,
+                PositionCount = 300,
+                TotalValue = 10_000_000_000L,
+            },
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-defunct-small",
+                InstitutionalHolderId = small.Id,
+                FilingDate = new DateOnly(2021, 8, 13),
+                ReportDate = new DateOnly(2021, 6, 30),
+                FilingType = FilingType.Form13F,
+                PositionCount = 50,
+                TotalValue = 400_000_000L,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var repository = new InstitutionalHolderRepository(verify);
+
+        var matches = await repository.SearchNameOrCikLargestFirst("Defunct Cap", 3);
+
+        matches
+            .Select(m => m.Name)
+            .Should()
+            .ContainInOrder("Defunct Cap A", "Defunct Cap B", "Defunct Cap C");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests.cs
@@ -73,6 +73,151 @@ public class InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests : Par
     }
 
     [Fact]
+    public async Task SearchNameOrCikLargestFirst_LiveFilerBeatsLargerDormantOne()
+    {
+        // The corporate re-registration trap: the retired CIK keeps its giant historical
+        // filings, the live successor is smaller on paper — pure size ranking resolves the
+        // household name to the dead entity forever ("BlackRock" answered a two-year-stale
+        // portfolio this way).
+        var dormant = new InstitutionalHolder { Cik = "1364742", Name = "BlackRock Inc." };
+        var live = new InstitutionalHolder { Cik = "2012383", Name = "BlackRock, Inc." };
+        DbContext.AddRange(dormant, live);
+        DbContext.AddRange(
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-dormant",
+                InstitutionalHolderId = dormant.Id,
+                FilingDate = new DateOnly(2024, 8, 13),
+                ReportDate = new DateOnly(2024, 6, 30),
+                PositionCount = 3951,
+                TotalValue = 4_418_304_700_000L,
+            },
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-live",
+                InstitutionalHolderId = live.Id,
+                FilingDate = new DateOnly(2026, 5, 13),
+                ReportDate = new DateOnly(2026, 3, 31),
+                PositionCount = 4455,
+                TotalValue = 2_811_213_500_000L,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var repository = new InstitutionalHolderRepository(verify);
+
+        var matches = await repository.SearchNameOrCikLargestFirst("BlackRock", 2);
+
+        matches.Should().HaveCount(2);
+        matches[0].Cik.Should().Be("2012383", "a live filer must beat a larger dormant one");
+        matches[1].Cik.Should().Be("1364742");
+    }
+
+    [Fact]
+    public async Task SearchNameOrCikLargestFirst_FilingSeasonLag_DoesNotDemoteTheFlagship()
+    {
+        // Mid filing season the flagship has not filed the newest quarter yet while a small
+        // same-named filer has. One quarter of lag must not flip the resolution — the live
+        // window is a quarter plus the 45-day deadline, with slack.
+        var flagship = new InstitutionalHolder
+        {
+            Cik = "1350694",
+            Name = "Bridgewater Associates, LP",
+        };
+        var promptSmallFiler = new InstitutionalHolder
+        {
+            Cik = "1600319",
+            Name = "Bridgewater Adv.",
+        };
+        DbContext.AddRange(flagship, promptSmallFiler);
+        DbContext.AddRange(
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-flagship-lag",
+                InstitutionalHolderId = flagship.Id,
+                FilingDate = new DateOnly(2026, 2, 14),
+                ReportDate = new DateOnly(2025, 12, 31),
+                PositionCount = 700,
+                TotalValue = 23_255_201_987L,
+            },
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-prompt-small",
+                InstitutionalHolderId = promptSmallFiler.Id,
+                FilingDate = new DateOnly(2026, 4, 2),
+                ReportDate = new DateOnly(2026, 3, 31),
+                PositionCount = 300,
+                TotalValue = 592_929_169L,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var repository = new InstitutionalHolderRepository(verify);
+
+        var matches = await repository.SearchNameOrCikLargestFirst("Bridgewater", 2);
+
+        matches[0]
+            .Name.Should()
+            .Be(
+                "Bridgewater Associates, LP",
+                "one quarter of filing lag keeps the flagship inside the live window"
+            );
+    }
+
+    [Fact]
+    public async Task SearchNameOrCikLargestFirst_SizeRanksByLatestQuarterNotAllTimePeak()
+    {
+        // A filer that shrank must rank by what it is now, not by the quarter it peaked in —
+        // all-time-max ranking rewards a past the filer no longer has.
+        var shrunk = new InstitutionalHolder { Cik = "3000001", Name = "Alpha Cap A" };
+        var steady = new InstitutionalHolder { Cik = "3000002", Name = "Alpha Cap B" };
+        DbContext.AddRange(shrunk, steady);
+        DbContext.AddRange(
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-shrunk-peak",
+                InstitutionalHolderId = shrunk.Id,
+                FilingDate = new DateOnly(2025, 11, 14),
+                ReportDate = new DateOnly(2025, 9, 30),
+                PositionCount = 500,
+                TotalValue = 50_000_000_000L,
+            },
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-shrunk-now",
+                InstitutionalHolderId = shrunk.Id,
+                FilingDate = new DateOnly(2026, 5, 13),
+                ReportDate = new DateOnly(2026, 3, 31),
+                PositionCount = 100,
+                TotalValue = 1_000_000_000L,
+            },
+            new InstitutionalFiling
+            {
+                AccessionNumber = "acc-steady-now",
+                InstitutionalHolderId = steady.Id,
+                FilingDate = new DateOnly(2026, 5, 13),
+                ReportDate = new DateOnly(2026, 3, 31),
+                PositionCount = 200,
+                TotalValue = 5_000_000_000L,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var repository = new InstitutionalHolderRepository(verify);
+
+        var matches = await repository.SearchNameOrCikLargestFirst("Alpha Cap", 2);
+
+        matches[0].Name.Should().Be("Alpha Cap B");
+        matches[1].Name.Should().Be("Alpha Cap A");
+    }
+
+    [Fact]
     public async Task SearchNameOrCik_ZeroPaddedCik_ResolvesTheStoredUnpaddedFiler()
     {
         var holder = new InstitutionalHolder { Cik = "1067983", Name = "Berkshire Hathaway Inc" };


### PR DESCRIPTION
## Summary

`SearchNameOrCikLargestFirst` ranked purely by all-time 13F size, so a corporate re-registration left "BlackRock" resolving to the dormant CIK 1364742 (last quarter 2024-06-30) and serving a two-year-stale portfolio while the live successor 2012383 filed on schedule. Ranking now buckets by liveness first, then size at the latest quarter — and reads **13F rollup rows only**: the `InstitutionalFiling` table also carries Schedule 13D/G rows whose event dates are always fresher than the last quarter end and whose `TotalValue` is one stake, so an unfiltered recency rank resolved "Millennium" to whichever namesake filed a 13D/G most recently instead of the $79B flagship.

## Code changes

- **`InstitutionalFiling.FilingType`** (new column, additive migration) — stamped from the holdings rows in `SyncFilingSummaries`; existing rows default to 13F.
- **`FilingRollupTypeBackfillService`** (new, wired in `HoldingsScraperWorker`) — bounded, self-terminating restamp of pre-column 13D/G rollup rows from their holdings (never inferred from date shape; 13D/G rows dated on quarter ends exist).
- **`InstitutionalHolderRepository`** — live bucket = newest 13F quarter within 135 days of the match set's newest (filing-season slack: at most one quarter behind); then size at the LATEST quarter (not the all-time peak); then name length/ordinal. Stats aggregate in SQL, one row per holder — the per-quarter fan-out materialised ~184k rows client-side on a broad match. Rollup-less filers still rank last; matching predicate untouched.
- **Consumer prose** — every "largest 13F filer" description and match note becomes "largest recently-active 13F filer".

## Tests

Full OSS suites green: 3,973 unit + 2,350 integration (real Postgres). New coverage: dormant-vs-live, fresh-13D/G-stake shadowing, filing-season lag, size-at-latest vs all-time peak, all-dormant anchor, backfill restamp + no-op second pass.

Note: the commercial repo's twin migration and OpenAPI doc wording sync ship with the submodule pin bump.