### PR TITLE
fix(prices): raise the default price-history cap to cover its own default window

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -58,9 +58,11 @@ public class StockPriceTools
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
             string endDate = null,
         [Description(
-            "Maximum number of records to return (default: 250, max: 500). When the range holds more rows the newest are kept; rows are always listed oldest to newest."
+            "Maximum number of records to return (default: 260, max: 500). When the range holds more rows the newest are kept; rows are always listed oldest to newest."
         )]
-            int maxResults = 250
+        // 260 covers the default 1-year window: a year holds ~251 trading sessions, so the
+        // old default of 250 silently dropped the oldest day(s) of its own default range.
+        int maxResults = 260
     )
     {
         return _runner.Execute(

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
@@ -241,4 +241,32 @@ public class StockPriceToolsTests : ParadeDbMcpTestBase
         var rows = result.Split('\n').Count(line => line.StartsWith("| AAPL |"));
         rows.Should().Be(1);
     }
+
+    [Fact]
+    public async Task GetStockPrices_DefaultWindowWithFullTradingYear_ReturnsEveryRow()
+    {
+        // A year holds ~251 trading sessions, so the old default maxResults of 250 silently
+        // dropped the oldest day(s) of the tool's own default 1-year window. The default cap
+        // must cover a full trading year: seed 251 rows inside the window and expect all back.
+        var aapl = AaplStock();
+        DbContext.Set<CommonStock>().Add(aapl);
+        var date = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2);
+        var seeded = 0;
+        while (seeded < 251)
+        {
+            if (date.DayOfWeek is not (DayOfWeek.Saturday or DayOfWeek.Sunday))
+            {
+                DbContext.Set<DailyStockPrice>().Add(PriceFor(aapl, date));
+                seeded++;
+            }
+            date = date.AddDays(-1);
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetStockPrices("AAPL");
+
+        var rows = result.Split('\n').Count(line => line.StartsWith("| 2"));
+        rows.Should().Be(251, "the default cap must not truncate the default 1-year window");
+        result.Should().NotContain("Showing the");
+    }
 }


### PR DESCRIPTION
## Summary
GetStockPrices defaults to a 1-year window (~251 trading sessions) but capped maxResults at 250, so a default call silently truncated the oldest day(s) of its own default range (audit finding: default AMZN request returned 250 of 251 rows with a truncation note).

## Code changes
- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — default `maxResults` 250 → 260 (+ description string); explicit 500 max unchanged.
- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs` — pins that a 251-session year inside the default window returns every row with no truncation note.

Build + full OSS suites green locally (3,994 unit / 2,369 integration).