### PR TITLE
refactor(corporate-actions): use a neutral External source for non-primary integrations

### DIFF
--- a/src/Equibles.CorporateActions.Data/Models/CashDividendSource.cs
+++ b/src/Equibles.CorporateActions.Data/Models/CashDividendSource.cs
@@ -9,4 +9,8 @@ public enum CashDividendSource
 
     [Display(Name = "Manual")]
     Manual,
+
+    // A non-primary external data integration configured by the hosting deployment.
+    [Display(Name = "External")]
+    External,
 }

--- a/src/Equibles.CorporateActions.Data/Models/StockSplitSource.cs
+++ b/src/Equibles.CorporateActions.Data/Models/StockSplitSource.cs
@@ -7,8 +7,9 @@ public enum StockSplitSource
     [Display(Name = "Yahoo")]
     Yahoo,
 
-    [Display(Name = "Massive")]
-    Massive,
+    // A non-primary external data integration configured by the hosting deployment.
+    [Display(Name = "External")]
+    External,
 
     [Display(Name = "SEC Filing")]
     SecFiling,


### PR DESCRIPTION
## Summary
Corporate-action observations can come from integrations configured by the hosting deployment rather than the built-in lanes. The shared source vocabulary should model that with one neutral value instead of naming specific integrations.

## Code changes
- `StockSplitSource` — the unused vendor-specific value is renamed to `External`. The column stores enum names as strings and no stored rows carry the old value (verified against the live database before renaming), and no code writes it, so this is a pure identifier change with no migration.
- `CashDividendSource` — gains the matching `External` value (additive; string-stored, no migration).

Both capture managers already accept the source per observation (`CapturedSplit.Source` / `CapturedDividend.Source`), so no other changes are needed.

Build + full OSS suites green locally (3,994 unit / 2,369 integration).