### PR TITLE
fix(insider-trading): validate prices on both split bases and band-guard repairs

### DIFF
--- a/src/Equibles.CorporateActions.Data/SplitBasisResolver.cs
+++ b/src/Equibles.CorporateActions.Data/SplitBasisResolver.cs
@@ -1,0 +1,125 @@
+using Equibles.CorporateActions.Data.Models;
+
+namespace Equibles.CorporateActions.Data;
+
+/// <summary>
+/// Resolves the split factor between a historical as-of date and the present price basis.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Stored daily prices are rewritten onto TODAY'S post-split basis whenever a split's price
+/// reconciliation runs, while historical figures quoted as-of a date (a 13F share count, a
+/// Form 4 per-share price) stay on that date's basis. Any comparison or product across the two
+/// is off by exactly the product of the intervening split ratios. The factor returned here
+/// restates between them: an as-of share count × factor lands on the present count basis, and
+/// a present-basis close × factor lands back on the as-of per-share price basis.
+/// </para>
+/// <para>
+/// The restatement is only trustworthy while the stored series really is on today's basis.
+/// Between a split being captured and its price reconciliation running, the series mixes both
+/// bases; that window — and a split whose series attribution cannot be established — is
+/// reported as unresolvable (<c>false</c>) instead of guessed at.
+/// </para>
+/// </remarks>
+public static class SplitBasisResolver
+{
+    /// <summary>
+    /// Resolves the factor between figures quoted as-of <paramref name="asOfDate"/> and the
+    /// stored price series' present basis. Returns <c>false</c> when a split that would move
+    /// the figure has not had its price adjustment applied yet — the stored prices then
+    /// straddle two bases and no honest restatement exists; <paramref name="factor"/> is then
+    /// 1 and must not be used.
+    /// <para>
+    /// <paramref name="listedTicker"/> names the exact security; null means the filer's
+    /// primary (<paramref name="primaryTicker"/>). A PRIMARY figure uses every split captured
+    /// from its own series — unattributed legacy rows included, since only the primary series
+    /// could produce them. A SECONDARY figure may only be moved by splits attributed to that
+    /// listing — and while ANY post-date split of the issuer is attributed elsewhere (or to no
+    /// listing), the class's own split history is unknowable from stored data, so the caller
+    /// honestly defers rather than assuming the classes split together.
+    /// </para>
+    /// </summary>
+    public static bool TryResolveFactor(
+        DateOnly asOfDate,
+        IReadOnlyList<StockSplit> splits,
+        string listedTicker,
+        string primaryTicker,
+        IReadOnlyCollection<string> secondaryTickers,
+        out decimal factor
+    )
+    {
+        factor = 1m;
+
+        if (splits == null || splits.Count == 0)
+        {
+            return true;
+        }
+
+        var positionSeries = listedTicker ?? primaryTicker;
+        var resolved = 1m;
+        foreach (var split in splits)
+        {
+            // A figure dated on the effective date is already post-split, so the comparison is
+            // strict — the same boundary SplitAdjustment.ShareCountFactor uses.
+            if (split.EffectiveDate <= asOfDate)
+            {
+                continue;
+            }
+
+            var belongsToSeries =
+                split.PriceSeriesTicker == null
+                    ? listedTicker == null
+                    : string.Equals(
+                        split.PriceSeriesTicker,
+                        positionSeries,
+                        StringComparison.OrdinalIgnoreCase
+                    );
+            if (!belongsToSeries)
+            {
+                // Another listing of the same issuer split after the as-of date: for a
+                // secondary it means the class's own basis cannot be established from
+                // stored data — defer.
+                if (listedTicker != null)
+                {
+                    return false;
+                }
+
+                // For the primary, a split attributed to a KNOWN sibling listing moves
+                // nothing here. But an attribution matching neither the current primary
+                // nor any current secondary is a stale symbol (the primary renamed after
+                // capture, and the attribution is preserved verbatim) — that split very
+                // likely IS this series' own, so silently skipping it re-creates the
+                // ratio-sized error this class exists to prevent. Unknown basis: defer.
+                var attributedToKnownSibling =
+                    secondaryTickers != null
+                    && secondaryTickers.Contains(
+                        split.PriceSeriesTicker,
+                        StringComparer.OrdinalIgnoreCase
+                    );
+                if (!attributedToKnownSibling)
+                {
+                    return false;
+                }
+                continue;
+            }
+
+            if (split.PriceAdjustmentAppliedTime == null)
+            {
+                return false;
+            }
+
+            // Mirrors SplitAdjustment: a non-positive denominator is a malformed ratio, skipped
+            // rather than allowed to divide by zero. It cannot make the basis ambiguous because
+            // it moves no figure.
+            if (split.Denominator <= 0)
+            {
+                continue;
+            }
+
+            resolved *= split.Numerator / split.Denominator;
+        }
+
+        factor = resolved;
+        return true;
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueBasis.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueBasis.cs
@@ -1,3 +1,4 @@
+using Equibles.CorporateActions.Data;
 using Equibles.CorporateActions.Data.Models;
 
 namespace Equibles.Holdings.HostedService.Services;
@@ -61,78 +62,16 @@ internal static class HoldingValueBasis
         out decimal shareCountFactor
     )
     {
-        shareCountFactor = 1m;
-
-        if (splits == null || splits.Count == 0)
-        {
-            return true;
-        }
-
-        var positionSeries = listedTicker ?? primaryTicker;
-        var factor = 1m;
-        foreach (var split in splits)
-        {
-            // A report dated on the effective date already counts post-split shares, so the
-            // comparison is strict — the same boundary SplitAdjustment.ShareCountFactor uses.
-            if (split.EffectiveDate <= reportDate)
-            {
-                continue;
-            }
-
-            var belongsToSeries =
-                split.PriceSeriesTicker == null
-                    ? listedTicker == null
-                    : string.Equals(
-                        split.PriceSeriesTicker,
-                        positionSeries,
-                        StringComparison.OrdinalIgnoreCase
-                    );
-            if (!belongsToSeries)
-            {
-                // Another listing of the same issuer split after the report date: for a
-                // secondary it means the class's own basis cannot be established from
-                // stored data — stay pending.
-                if (listedTicker != null)
-                {
-                    return false;
-                }
-
-                // For the primary, a split attributed to a KNOWN sibling listing moves
-                // nothing here. But an attribution matching neither the current primary
-                // nor any current secondary is a stale symbol (the primary renamed after
-                // capture, and the attribution is preserved verbatim) — that split very
-                // likely IS this series' own, so silently skipping it re-creates the
-                // ratio-sized error this class exists to prevent. Unknown basis: pending.
-                var attributedToKnownSibling =
-                    secondaryTickers != null
-                    && secondaryTickers.Contains(
-                        split.PriceSeriesTicker,
-                        StringComparer.OrdinalIgnoreCase
-                    );
-                if (!attributedToKnownSibling)
-                {
-                    return false;
-                }
-                continue;
-            }
-
-            if (split.PriceAdjustmentAppliedTime == null)
-            {
-                return false;
-            }
-
-            // Mirrors SplitAdjustment: a non-positive denominator is a malformed ratio, skipped
-            // rather than allowed to divide by zero. It cannot make the basis ambiguous because it
-            // moves no count.
-            if (split.Denominator <= 0)
-            {
-                continue;
-            }
-
-            factor *= split.Numerator / split.Denominator;
-        }
-
-        shareCountFactor = factor;
-        return true;
+        // The walk itself lives in SplitBasisResolver (Equibles.CorporateActions.Data) so the
+        // insider price lane restates on the identical rules; this wrapper keeps the holdings
+        // vocabulary and remarks at the call sites.
+        return SplitBasisResolver.TryResolveFactor(
+            reportDate,
+            splits,
+            listedTicker,
+            primaryTicker,
+            secondaryTickers,
+            out shareCountFactor
+        );
     }
 }

--- a/src/Equibles.InsiderTrading.BusinessLogic/Equibles.InsiderTrading.BusinessLogic.csproj
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Equibles.InsiderTrading.BusinessLogic.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Equibles.InsiderTrading.Repositories\Equibles.InsiderTrading.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Sec\Equibles.Integrations.Sec.csproj" />

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderDailyBars.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderDailyBars.cs
@@ -1,0 +1,48 @@
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.InsiderTrading.BusinessLogic.Models;
+
+namespace Equibles.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// Builds the <see cref="DailyBarContext"/> a price evaluation runs against: the stored bar
+/// plus the split factor between the transaction date and the series' present basis. One
+/// implementation for all three persisting call sites (ingest, backfill, reprocess) so they
+/// can never disagree on the basis rules.
+/// </summary>
+public static class InsiderDailyBars
+{
+    /// <summary>
+    /// Insider rows are issuer-level and priced against the primary series, so the resolver
+    /// runs with <c>listedTicker = null</c>: unattributed splits count, sibling-attributed
+    /// splits are skipped, and an unattributable one marks the basis ambiguous (pending)
+    /// rather than guessed at.
+    /// </summary>
+    public static DailyBarContext Build(
+        decimal? close,
+        decimal? low,
+        decimal? high,
+        DateOnly transactionDate,
+        IReadOnlyList<StockSplit> splits,
+        string primaryTicker,
+        IReadOnlyCollection<string> secondaryTickers
+    )
+    {
+        var ambiguous = !SplitBasisResolver.TryResolveFactor(
+            transactionDate,
+            splits,
+            listedTicker: null,
+            primaryTicker,
+            secondaryTickers,
+            out var factor
+        );
+        return new DailyBarContext
+        {
+            Close = close,
+            Low = low,
+            High = high,
+            SplitFactorToPresent = factor,
+            SplitBasisAmbiguous = ambiguous,
+        };
+    }
+}

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -1,6 +1,9 @@
 using System.Text;
 using System.Xml.Linq;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.InsiderTrading.BusinessLogic.Models;
 using Equibles.InsiderTrading.Data.Models;
@@ -47,6 +50,7 @@ public class InsiderFilingReprocessManager
     private readonly InsiderTransactionRepository _transactionRepository;
     private readonly InsiderFilingRepository _filingRepository;
     private readonly DailyStockPriceRepository _dailyStockPriceRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
     private readonly InsiderTransactionPriceValidator _validator;
     private readonly ISecEdgarClient _secEdgarClient;
     private readonly IFileManager _fileManager;
@@ -57,6 +61,7 @@ public class InsiderFilingReprocessManager
         InsiderTransactionRepository transactionRepository,
         InsiderFilingRepository filingRepository,
         DailyStockPriceRepository dailyStockPriceRepository,
+        StockSplitRepository stockSplitRepository,
         InsiderTransactionPriceValidator validator,
         ISecEdgarClient secEdgarClient,
         IFileManager fileManager,
@@ -67,6 +72,7 @@ public class InsiderFilingReprocessManager
         _transactionRepository = transactionRepository;
         _filingRepository = filingRepository;
         _dailyStockPriceRepository = dailyStockPriceRepository;
+        _stockSplitRepository = stockSplitRepository;
         _validator = validator;
         _secEdgarClient = secEdgarClient;
         _fileManager = fileManager;
@@ -308,22 +314,41 @@ public class InsiderFilingReprocessManager
 
         // Date corrections must land before close lookup so price validation uses the
         // repaired trading day rather than the impossible source typo.
-        var closes = await FetchCloses(first.CommonStockId, rows);
+        var bars = await FetchBars(first.CommonStockId, rows);
+        var splits = await _stockSplitRepository
+            .GetAll()
+            .Where(sp => sp.CommonStockId == first.CommonStockId)
+            .ToListAsync();
+        var identity = await _dbContext
+            .Set<CommonStock>()
+            .Where(cs => cs.Id == first.CommonStockId)
+            .Select(cs => new { cs.Ticker, cs.SecondaryTickers })
+            .FirstOrDefaultAsync();
 
         foreach (var row in rows)
         {
-            decimal? close = closes.TryGetValue(row.TransactionDate, out var value) ? value : null;
+            bars.TryGetValue(row.TransactionDate, out var barRow);
+            var bar = InsiderDailyBars.Build(
+                barRow?.Close,
+                barRow?.Low,
+                barRow?.High,
+                row.TransactionDate,
+                splits,
+                identity?.Ticker,
+                identity?.SecondaryTickers ?? []
+            );
 
             var evaluation = _validator.Evaluate(
                 row.ReportedPricePerShare,
                 row.Shares,
                 row.SecurityKind,
                 row.SecurityTitle,
-                close,
+                bar,
                 row.Notes
             );
             row.PricePerShare = evaluation.EffectivePrice;
             row.IsPriceValid = evaluation.IsPriceValid;
+            row.PriceWasRepaired = evaluation.WasRepaired;
             if (evaluation.WasRepaired)
                 result.Repaired++;
 
@@ -436,7 +461,11 @@ public class InsiderFilingReprocessManager
             row.ParserVersion = InsiderTransaction.CurrentParserVersion;
     }
 
-    private async Task<Dictionary<DateOnly, decimal>> FetchCloses(
+    private sealed record BarRow(decimal Close, decimal Low, decimal High);
+
+    // The stored bars are on TODAY'S split-adjusted basis; the evaluation carries the split
+    // factor so a pre-split filed price is validated on its own basis instead of "repaired".
+    private async Task<Dictionary<DateOnly, BarRow>> FetchBars(
         Guid stockId,
         List<InsiderTransaction> rows
     )
@@ -447,18 +476,24 @@ public class InsiderFilingReprocessManager
         var prices = await _dailyStockPriceRepository
             .GetAll()
             .Where(p => p.CommonStockId == stockId && p.Date >= minDate && p.Date <= maxDate)
-            .Select(p => new { p.Date, p.Close })
+            .Select(p => new
+            {
+                p.Date,
+                p.Close,
+                p.Low,
+                p.High,
+            })
             .OrderByDescending(p => p.Date)
             .ToListAsync();
 
-        var result = new Dictionary<DateOnly, decimal>();
+        var result = new Dictionary<DateOnly, BarRow>();
         foreach (var row in rows)
         {
             if (result.ContainsKey(row.TransactionDate))
                 continue;
             var match = prices.FirstOrDefault(p => p.Date <= row.TransactionDate);
             if (match != null)
-                result[row.TransactionDate] = match.Close;
+                result[row.TransactionDate] = new BarRow(match.Close, match.Low, match.High);
         }
         return result;
     }

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderMisrepairedPriceSweep.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderMisrepairedPriceSweep.cs
@@ -1,0 +1,93 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// Restores rows the old basis-blind validator "repaired": it compared the as-filed price
+/// against the split-ADJUSTED close believing it unadjusted, so every pre-split filing looked
+/// implausible and got its correct price divided by the share count — 15,822 rows across 257
+/// stocks, all self-sealed <c>IsPriceValid = true</c> (AMZN's pre-20:1 $3,300.24 became $8.42).
+/// </summary>
+/// <remarks>
+/// A misrepaired row carries its own signature: the stored price times the share count lands
+/// back on the as-filed figure (<c>|PricePerShare × Shares − ReportedPricePerShare| &lt; 0.01</c>)
+/// while the two prices differ. The sweep restores <c>PricePerShare = ReportedPricePerShare</c>
+/// and nulls <c>IsPriceValid</c> so the fixed both-bases validator re-evaluates through the
+/// ordinary pending path. Genuine fat-fingers share the signature — restoring them is correct
+/// too: re-evaluation repairs them again, this time stamping
+/// <see cref="InsiderTransaction.PriceWasRepaired"/>, which excludes them from every later
+/// sweep. Self-terminating: a restored row's prices are equal, so it can never match again.
+/// Bounded per cycle; a no-op scan once drained.
+/// </remarks>
+[Service]
+public class InsiderMisrepairedPriceSweep
+{
+    internal const int MaxRowsPerCycle = 25_000;
+
+    private readonly InsiderTransactionRepository _transactionRepository;
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly ILogger<InsiderMisrepairedPriceSweep> _logger;
+
+    public InsiderMisrepairedPriceSweep(
+        InsiderTransactionRepository transactionRepository,
+        EquiblesFinancialDbContext dbContext,
+        ILogger<InsiderMisrepairedPriceSweep> logger
+    )
+    {
+        _transactionRepository = transactionRepository;
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<int> Run(CancellationToken cancellationToken = default)
+    {
+        if (_dbContext.Database.IsRelational())
+        {
+            _dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+        }
+
+        // Only rows the OLD validator sealed: valid, price diverging from reported, and not
+        // stamped by the band-guarded repair (every new repair stamps PriceWasRepaired). The
+        // decimal product runs server-side so an oversized share count cannot overflow Int64.
+        var rows = await _transactionRepository
+            .GetAll()
+            .Where(t =>
+                t.IsPriceValid == true
+                && !t.PriceWasRepaired
+                && t.ReportedPricePerShare > 0m
+                && t.PricePerShare != t.ReportedPricePerShare
+                && Math.Abs(t.PricePerShare * t.Shares - t.ReportedPricePerShare) < 0.01m
+            )
+            .OrderBy(t => t.TransactionDate)
+            .ThenBy(t => t.Id)
+            .Take(MaxRowsPerCycle)
+            .ToListAsync(cancellationToken);
+
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var row in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            row.PricePerShare = row.ReportedPricePerShare;
+            row.IsPriceValid = null;
+        }
+
+        await _transactionRepository.SaveChanges();
+
+        _logger.LogWarning(
+            "Misrepaired-price sweep: restored {Count} row(s) to their as-filed price for "
+                + "re-evaluation under the split-basis-aware validator",
+            rows.Count
+        );
+
+        return rows.Count;
+    }
+}

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderMisrepairedPriceSweep.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderMisrepairedPriceSweep.cs
@@ -90,4 +90,57 @@ public class InsiderMisrepairedPriceSweep
 
         return rows.Count;
     }
+
+    /// <summary>
+    /// Re-opens the second cohort the old basis-blind comparison stranded: rows it flagged
+    /// invalid via its <c>shares &lt;= 0</c> branch. Their price was never touched (nothing to
+    /// restore), but the verdict came from the wrong comparison and no other heal path reaches
+    /// <c>IsPriceValid == false</c> — nulling the verdict routes them through the fixed
+    /// validator, which accepts a correct pre-split price as filed even with no usable share
+    /// count. NOT self-terminating: a row the fixed validator re-flags invalid matches this
+    /// predicate again, so the caller must gate this behind a one-shot marker rather than
+    /// running it every cycle.
+    /// </summary>
+    public async Task<int> ReopenShareslessVerdicts(CancellationToken cancellationToken = default)
+    {
+        if (_dbContext.Database.IsRelational())
+        {
+            _dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+        }
+
+        var stranded = await _transactionRepository
+            .GetAll()
+            .Where(t =>
+                t.IsPriceValid == false
+                && !t.PriceWasRepaired
+                && t.Shares <= 0
+                && t.ReportedPricePerShare > 0m
+                && t.PricePerShare == t.ReportedPricePerShare
+            )
+            .OrderBy(t => t.TransactionDate)
+            .ThenBy(t => t.Id)
+            .Take(MaxRowsPerCycle)
+            .ToListAsync(cancellationToken);
+
+        if (stranded.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var row in stranded)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            row.IsPriceValid = null;
+        }
+
+        await _transactionRepository.SaveChanges();
+
+        _logger.LogWarning(
+            "Misrepaired-price sweep: re-opened {Count} shareless invalid verdict(s) for "
+                + "re-evaluation under the split-basis-aware validator",
+            stranded.Count
+        );
+
+        return stranded.Count;
+    }
 }

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
@@ -68,7 +68,8 @@ public class InsiderTransactionPriceBackfillManager
     }
 
     public async Task<InsiderTransactionPriceBackfillResult> Run(
-        Func<InsiderTransactionPriceBackfillResult, Task> onProgress = null
+        Func<InsiderTransactionPriceBackfillResult, Task> onProgress = null,
+        CancellationToken cancellationToken = default
     )
     {
         // Snapshot of the work-set size for the progress bar. The live parser
@@ -98,6 +99,10 @@ public class InsiderTransactionPriceBackfillManager
         var lastId = Guid.Empty;
         while (true)
         {
+            // Between batches only: a granted stop lands after the current batch's
+            // SaveChanges, so no evaluation is half-persisted and the next run resumes
+            // from the surviving null rows.
+            cancellationToken.ThrowIfCancellationRequested();
             var batch = await _transactionRepository
                 .GetAll()
                 .Where(t => t.IsPriceValid == null)
@@ -107,7 +112,7 @@ public class InsiderTransactionPriceBackfillManager
                 .OrderBy(t => t.TransactionDate)
                 .ThenBy(t => t.Id)
                 .Take(BatchSize)
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             if (batch.Count == 0)
                 break;

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
@@ -1,4 +1,7 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.InsiderTrading.BusinessLogic.Models;
 using Equibles.InsiderTrading.Data.Models;
@@ -13,10 +16,13 @@ namespace Equibles.InsiderTrading.BusinessLogic;
 /// <summary>
 /// Evaluates the not-yet-checked insider transactions — those whose
 /// <see cref="InsiderTransaction.IsPriceValid"/> is still <c>null</c>. Each
-/// row's reported price is cross-checked against the Yahoo unadjusted close
-/// on the transaction date (most recent prior trading day for weekends /
-/// holidays) via <see cref="InsiderTransactionPriceValidator"/>; implausible
-/// rows are repaired (reported total ÷ shares) and the raw value preserved in
+/// row's reported price is cross-checked against the stored close on the
+/// transaction date (most recent prior trading day for weekends / holidays)
+/// via <see cref="InsiderTransactionPriceValidator"/>. The stored close is on
+/// TODAY'S split-adjusted basis while the filed price is on the transaction
+/// date's basis, so each check carries the split factor and runs on both
+/// bases; implausible rows are repaired (reported total ÷ shares) only inside
+/// the session's price band, and the raw value is preserved in
 /// <see cref="InsiderTransaction.ReportedPricePerShare"/>.
 ///
 /// Only null rows are touched, so a row is evaluated exactly once and re-runs
@@ -39,6 +45,7 @@ public class InsiderTransactionPriceBackfillManager
 
     private readonly InsiderTransactionRepository _transactionRepository;
     private readonly DailyStockPriceRepository _dailyStockPriceRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
     private readonly InsiderTransactionPriceValidator _validator;
     private readonly EquiblesFinancialDbContext _dbContext;
     private readonly ILogger<InsiderTransactionPriceBackfillManager> _logger;
@@ -46,6 +53,7 @@ public class InsiderTransactionPriceBackfillManager
     public InsiderTransactionPriceBackfillManager(
         InsiderTransactionRepository transactionRepository,
         DailyStockPriceRepository dailyStockPriceRepository,
+        StockSplitRepository stockSplitRepository,
         InsiderTransactionPriceValidator validator,
         EquiblesFinancialDbContext dbContext,
         ILogger<InsiderTransactionPriceBackfillManager> logger
@@ -53,6 +61,7 @@ public class InsiderTransactionPriceBackfillManager
     {
         _transactionRepository = transactionRepository;
         _dailyStockPriceRepository = dailyStockPriceRepository;
+        _stockSplitRepository = stockSplitRepository;
         _validator = validator;
         _dbContext = dbContext;
         _logger = logger;
@@ -103,24 +112,38 @@ public class InsiderTransactionPriceBackfillManager
             if (batch.Count == 0)
                 break;
 
-            var closes = await FetchCloses(batch);
+            var bars = await FetchBars(batch);
+            var (splitsByStock, identityByStock) = await FetchSplitContext(batch);
 
             foreach (var transaction in batch)
             {
                 var key = (transaction.CommonStockId, transaction.TransactionDate);
-                decimal? close = closes.TryGetValue(key, out var value) ? value : null;
+                bars.TryGetValue(key, out var barRow);
+                splitsByStock.TryGetValue(transaction.CommonStockId, out var splits);
+                identityByStock.TryGetValue(transaction.CommonStockId, out var identity);
+
+                var bar = InsiderDailyBars.Build(
+                    barRow?.Close,
+                    barRow?.Low,
+                    barRow?.High,
+                    transaction.TransactionDate,
+                    splits ?? [],
+                    identity?.Ticker,
+                    identity?.SecondaryTickers
+                );
 
                 var evaluation = _validator.Evaluate(
                     transaction.ReportedPricePerShare,
                     transaction.Shares,
                     transaction.SecurityKind,
                     transaction.SecurityTitle,
-                    close,
+                    bar,
                     transaction.Notes
                 );
 
                 transaction.PricePerShare = evaluation.EffectivePrice;
                 transaction.IsPriceValid = evaluation.IsPriceValid;
+                transaction.PriceWasRepaired = evaluation.WasRepaired;
 
                 if (evaluation.IsPriceValid == null)
                     result.Pending++;
@@ -159,15 +182,22 @@ public class InsiderTransactionPriceBackfillManager
         return result;
     }
 
+    private sealed record BarRow(decimal Close, decimal Low, decimal High);
+
+    private sealed record StockIdentity(
+        string Ticker,
+        IReadOnlyCollection<string> SecondaryTickers
+    );
+
     /// <summary>
-    /// Fetch one close per distinct (CommonStockId, TransactionDate) — the
-    /// most recent <see cref="DailyStockPrice.Close"/> on or before that
-    /// date. Uses the unadjusted Close, never AdjustedClose: a reverse
-    /// split between the transaction date and today would otherwise shift
-    /// the historical adjusted close away from the raw price the filer
-    /// reported and produce false rejections.
+    /// Fetch one bar per distinct (CommonStockId, TransactionDate) — the most
+    /// recent <see cref="DailyStockPrice"/> on or before that date. The stored
+    /// Close/Low/High are on TODAY'S split-adjusted basis (the split
+    /// reconciliation rewrites the whole listed series), which is exactly why
+    /// the evaluation carries the split factor rather than treating the close
+    /// as the raw price the filer saw.
     /// </summary>
-    private async Task<Dictionary<(Guid, DateOnly), decimal>> FetchCloses(
+    private async Task<Dictionary<(Guid, DateOnly), BarRow>> FetchBars(
         List<InsiderTransaction> batch
     )
     {
@@ -185,6 +215,8 @@ public class InsiderTransactionPriceBackfillManager
                 p.CommonStockId,
                 p.Date,
                 p.Close,
+                p.Low,
+                p.High,
             })
             .ToListAsync();
 
@@ -192,7 +224,7 @@ public class InsiderTransactionPriceBackfillManager
             .GroupBy(p => p.CommonStockId)
             .ToDictionary(g => g.Key, g => g.OrderByDescending(p => p.Date).ToList());
 
-        var result = new Dictionary<(Guid, DateOnly), decimal>();
+        var result = new Dictionary<(Guid, DateOnly), BarRow>();
         foreach (var transaction in batch)
         {
             var key = (transaction.CommonStockId, transaction.TransactionDate);
@@ -202,8 +234,45 @@ public class InsiderTransactionPriceBackfillManager
                 continue;
             var match = stockPrices.FirstOrDefault(p => p.Date <= transaction.TransactionDate);
             if (match != null)
-                result[key] = match.Close;
+                result[key] = new BarRow(match.Close, match.Low, match.High);
         }
         return result;
+    }
+
+    /// <summary>
+    /// Splits and ticker identity per stock in the batch — the inputs the
+    /// split-basis resolver needs to restate the stored close onto each
+    /// transaction date's basis (or declare it ambiguous).
+    /// </summary>
+    private async Task<(
+        Dictionary<Guid, List<StockSplit>> SplitsByStock,
+        Dictionary<Guid, StockIdentity> IdentityByStock
+    )> FetchSplitContext(List<InsiderTransaction> batch)
+    {
+        var stockIds = batch.Select(t => t.CommonStockId).Distinct().ToList();
+
+        var splitsByStock = (
+            await _stockSplitRepository
+                .GetAll()
+                .Where(sp => stockIds.Contains(sp.CommonStockId))
+                .ToListAsync()
+        )
+            .GroupBy(sp => sp.CommonStockId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var identityByStock = (
+            await _dbContext
+                .Set<CommonStock>()
+                .Where(cs => stockIds.Contains(cs.Id))
+                .Select(cs => new
+                {
+                    cs.Id,
+                    cs.Ticker,
+                    cs.SecondaryTickers,
+                })
+                .ToListAsync()
+        ).ToDictionary(cs => cs.Id, cs => new StockIdentity(cs.Ticker, cs.SecondaryTickers ?? []));
+
+        return (splitsByStock, identityByStock);
     }
 }

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
@@ -11,24 +11,53 @@ namespace Equibles.InsiderTrading.BusinessLogic;
 /// (a per-share field), which then explodes the dashboard's Shares × Price
 /// sort into nonsense numbers (trillions, quadrillions).
 ///
-/// Stateless and pure — the close price is passed in by the caller. Lookup
-/// is done by callers that have repository access (parser at ingest time;
-/// backfill manager during one-off recomputes).
+/// Stateless and pure — the daily bar and split basis are passed in by the
+/// caller. Lookup is done by callers that have repository access (parser at
+/// ingest time; backfill manager during recomputes).
+///
+/// The stored close is on TODAY'S split-adjusted basis while the filed price
+/// is on the transaction date's basis, so every check runs on BOTH bases
+/// (raw, and × the split factor). Comparing a pre-split price against the
+/// adjusted close as if it were unadjusted once "repaired" 15,822 correct
+/// prices into nonsense — AMZN's pre-20:1 $3,300.24 became $8.42, self-sealed
+/// as valid.
 /// </summary>
 [Service]
 public class InsiderTransactionPriceValidator
 {
     /// <summary>
-    /// Reject when the reported per-share price exceeds the unadjusted close
-    /// by more than this multiple. Real intraday spreads vs. close are well
-    /// under 2×; common stocks above $100k/share don't exist outside BRK.A;
-    /// 10× is a generous ceiling that still catches the actual failure mode
-    /// (per-share field containing the total dollar value, which is
+    /// Reject when the reported per-share price exceeds the close (on both
+    /// bases) by more than this multiple. Real intraday spreads vs. close are
+    /// well under 2×; common stocks above $100k/share don't exist outside
+    /// BRK.A; 10× is a generous ceiling that still catches the actual failure
+    /// mode (per-share field containing the total dollar value, which is
     /// Shares × close = thousands of times the unit price).
     /// </summary>
     public const decimal MaxPriceToCloseMultiplier = 10m;
 
-    public bool IsPlausible(decimal pricePerShare, string securityTitle, decimal? unadjustedClose)
+    /// <summary>
+    /// Slack around the session range when accepting a repaired price: the
+    /// candidate must land inside [Low × 0.9, High × 1.1] on one of the two
+    /// bases. A genuine fat-finger's total ÷ shares reproduces a real fill
+    /// inside the day's range; a coincidence does not.
+    /// </summary>
+    public const decimal RepairBandLowFactor = 0.9m;
+    public const decimal RepairBandHighFactor = 1.1m;
+
+    /// <summary>
+    /// Fallback repair band when the bar carries no usable Low/High: half to
+    /// double the close, on either basis. Wider than the range band because a
+    /// close alone says nothing about the day's extremes.
+    /// </summary>
+    public const decimal RepairFallbackLowFactor = 0.5m;
+    public const decimal RepairFallbackHighFactor = 2m;
+
+    /// <summary>
+    /// Quick single-basis plausibility probe against a close. Basis-naive by
+    /// design (no split context) — kept for spot checks; the persisting paths
+    /// all go through <see cref="Evaluate"/>, which checks both bases.
+    /// </summary>
+    public bool IsPlausible(decimal pricePerShare, string securityTitle, decimal? close)
     {
         // Holdings (Form 3 sentinels) and post-transaction-only rows report
         // 0 price by design — not a real per-share price to validate.
@@ -49,28 +78,33 @@ public class InsiderTransactionPriceValidator
 
         // No close on file (delisted, brand-new IPO, foreign listing not in
         // the Yahoo feed). Can't validate — don't penalize.
-        if (!unadjustedClose.HasValue || unadjustedClose.Value <= 0m)
+        if (!close.HasValue || close.Value <= 0m)
             return true;
 
         // Compare via division rather than close * multiplier: an extreme-but-
         // legal close (near decimal.MaxValue) overflows the product, and this
         // method must always return a verdict, never throw.
-        return pricePerShare / MaxPriceToCloseMultiplier <= unadjustedClose.Value;
+        return pricePerShare / MaxPriceToCloseMultiplier <= close.Value;
     }
 
     /// <summary>
     /// Full tri-state evaluation of a reported per-share price, plus the repair.
-    /// Pure — the caller supplies the close and persists the outcome.
+    /// Pure — the caller supplies the daily bar + split basis and persists the
+    /// outcome.
     ///
-    /// Differs from <see cref="IsPlausible"/> in two ways:
+    /// Differs from <see cref="IsPlausible"/> in three ways:
     /// <list type="bullet">
-    /// <item>A missing close yields a <em>pending</em> result (null) instead of
-    /// valid, so the row is re-checked by a later recompute once the close
-    /// lands rather than being silently accepted.</item>
-    /// <item>An implausible real price is <em>repaired</em>: the per-share
-    /// field almost always holds the total transaction value, so dividing by
-    /// <paramref name="shares"/> recovers the unit price. Rows with no share
-    /// count can't be divided and stay flagged invalid.</item>
+    /// <item>A missing close — or an ambiguous split basis — yields a
+    /// <em>pending</em> result (null) instead of valid, so the row is
+    /// re-checked once the close lands or the basis settles rather than being
+    /// silently accepted (or worse, silently repaired).</item>
+    /// <item>Plausibility runs on both bases: the stored close as-is, and the
+    /// close restated onto the as-filed basis via the split factor. A pre-split
+    /// price is VALID AS FILED, never a repair candidate.</item>
+    /// <item>An implausible price is repaired (total ÷ shares) only when the
+    /// candidate lands inside the session's price band on one of the two bases
+    /// — a repair must reproduce a price the market actually traded at, never
+    /// fabricate one. Outside the band the row is flagged invalid, unrepaired.</item>
     /// </list>
     ///
     /// Derivative classification uses the authoritative <paramref name="kind"/>
@@ -89,7 +123,7 @@ public class InsiderTransactionPriceValidator
         long shares,
         InsiderSecurityKind kind,
         string securityTitle,
-        decimal? unadjustedClose,
+        DailyBarContext bar,
         IReadOnlyList<string> notes = null
     )
     {
@@ -120,8 +154,12 @@ public class InsiderTransactionPriceValidator
         )
             basePrice = reportedPrice / ratio;
 
-        // A real price we can't yet check stays pending (null), not valid.
-        if (!unadjustedClose.HasValue || unadjustedClose.Value <= 0m)
+        // A real price we can't yet check stays pending (null), not valid —
+        // and a series whose split basis is unsettled is exactly as
+        // uncheckable as a missing close: any verdict would be a guess off by
+        // the split ratio.
+        var close = bar?.Close;
+        if (!close.HasValue || close.Value <= 0m || bar.SplitBasisAmbiguous)
         {
             return new InsiderTransactionPriceEvaluation
             {
@@ -130,9 +168,14 @@ public class InsiderTransactionPriceValidator
             };
         }
 
-        // Plausible against the close — keep as filed. Divide rather than
-        // multiply the close so a near-decimal.MaxValue close can't overflow.
-        if (basePrice / MaxPriceToCloseMultiplier <= unadjustedClose.Value)
+        // Plausible against the close on EITHER basis — keep as filed. The
+        // factor-scaled comparison is what accepts a correct pre-split price
+        // (AMZN $3,300.24 vs the adjusted $165 close, factor 20). Divide
+        // rather than multiply the price side so a near-decimal.MaxValue
+        // close can't overflow.
+        var factor = bar.SplitFactorToPresent > 0m ? bar.SplitFactorToPresent : 1m;
+        var scaled = basePrice / MaxPriceToCloseMultiplier;
+        if (scaled <= close.Value || scaled / factor <= close.Value)
         {
             return new InsiderTransactionPriceEvaluation
             {
@@ -155,14 +198,46 @@ public class InsiderTransactionPriceValidator
             };
         }
 
-        // Implausible — repair by dividing the mis-entered total by the share
-        // count and accept the result as the per-share price.
+        // Repair candidate: the mis-entered total divided by the share count.
+        // Accepted only when it reproduces a price inside the session's band
+        // on one of the two bases — otherwise flag, never fabricate.
+        var candidate = basePrice / shares;
+        if (IsInsideRepairBand(candidate, bar, factor))
+        {
+            return new InsiderTransactionPriceEvaluation
+            {
+                IsPriceValid = true,
+                EffectivePrice = candidate,
+                WasRepaired = true,
+            };
+        }
+
         return new InsiderTransactionPriceEvaluation
         {
-            IsPriceValid = true,
-            EffectivePrice = basePrice / shares,
-            WasRepaired = true,
+            IsPriceValid = false,
+            EffectivePrice = basePrice,
         };
+    }
+
+    private static bool IsInsideRepairBand(decimal candidate, DailyBarContext bar, decimal factor)
+    {
+        decimal bandLow;
+        decimal bandHigh;
+        if (bar.Low is > 0m && bar.High >= bar.Low)
+        {
+            bandLow = bar.Low.Value * RepairBandLowFactor;
+            bandHigh = bar.High.Value * RepairBandHighFactor;
+        }
+        else
+        {
+            bandLow = bar.Close.Value * RepairFallbackLowFactor;
+            bandHigh = bar.Close.Value * RepairFallbackHighFactor;
+        }
+
+        // Present basis, then the as-filed basis (band × factor).
+        if (candidate >= bandLow && candidate <= bandHigh)
+            return true;
+        return candidate >= bandLow * factor && candidate <= bandHigh * factor;
     }
 
     // Authoritative when the row carries a known kind (parsed from the Form 4

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
@@ -168,14 +168,18 @@ public class InsiderTransactionPriceValidator
             };
         }
 
-        // Plausible against the close on EITHER basis — keep as filed. The
-        // factor-scaled comparison is what accepts a correct pre-split price
-        // (AMZN $3,300.24 vs the adjusted $165 close, factor 20). Divide
-        // rather than multiply the price side so a near-decimal.MaxValue
-        // close can't overflow.
+        // Plausible against the close on the AS-FILED basis only. A filed price
+        // is definitionally on the transaction date's basis, and the resolver
+        // already went pending above when that basis was unknowable — so the
+        // one correct comparison is close × factor (AMZN $3,300.24 vs the
+        // adjusted $165 close, factor 20). A raw-basis "second opinion" would
+        // be dominated on forward splits and 1/factor too permissive on
+        // reverse splits. Divide the price side (not multiply) so a
+        // near-decimal.MaxValue price can't overflow; the close × factor side
+        // stays small because both are market-scale numbers.
         var factor = bar.SplitFactorToPresent > 0m ? bar.SplitFactorToPresent : 1m;
         var scaled = basePrice / MaxPriceToCloseMultiplier;
-        if (scaled <= close.Value || scaled / factor <= close.Value)
+        if (scaled <= close.Value * factor)
         {
             return new InsiderTransactionPriceEvaluation
             {
@@ -200,7 +204,7 @@ public class InsiderTransactionPriceValidator
 
         // Repair candidate: the mis-entered total divided by the share count.
         // Accepted only when it reproduces a price inside the session's band
-        // on one of the two bases — otherwise flag, never fabricate.
+        // on the as-filed basis — otherwise flag, never fabricate.
         var candidate = basePrice / shares;
         if (IsInsideRepairBand(candidate, bar, factor))
         {
@@ -234,9 +238,12 @@ public class InsiderTransactionPriceValidator
             bandHigh = bar.Close.Value * RepairFallbackHighFactor;
         }
 
-        // Present basis, then the as-filed basis (band × factor).
-        if (candidate >= bandLow && candidate <= bandHigh)
-            return true;
+        // As-filed basis only (band × factor; factor is 1 with no resolved
+        // split). The candidate comes from a filed total, so it is on the
+        // transaction date's basis — accepting it against the present-basis
+        // band when factor != 1 would stamp a price wrong by exactly the split
+        // ratio as an audited repair, the same shape as the corruption this
+        // validator exists to prevent.
         return candidate >= bandLow * factor && candidate <= bandHigh * factor;
     }
 

--- a/src/Equibles.InsiderTrading.BusinessLogic/Models/DailyBarContext.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Models/DailyBarContext.cs
@@ -1,0 +1,39 @@
+namespace Equibles.InsiderTrading.BusinessLogic.Models;
+
+/// <summary>
+/// The stored daily bar a reported insider price is checked against, plus the split basis
+/// linking the two.
+/// </summary>
+/// <remarks>
+/// The stored series is rewritten onto TODAY'S post-split basis by the split reconciliation,
+/// while the filer's price is quoted on the TRANSACTION DATE's basis. The two differ by
+/// <see cref="SplitFactorToPresent"/>: <c>Close × SplitFactorToPresent</c> is the close
+/// restated onto the as-filed basis. Validation must accept a price plausible on EITHER basis
+/// — treating the stored close as unadjusted once "repaired" 15,822 correct pre-split prices
+/// into nonsense (AMZN's pre-20:1 $3,300.24 became $8.42).
+/// </remarks>
+public class DailyBarContext
+{
+    /// <summary>Stored close on (or the most recent session before) the transaction date.</summary>
+    public decimal? Close { get; set; }
+
+    /// <summary>Session low of the same bar; null when the bar carries no usable range.</summary>
+    public decimal? Low { get; set; }
+
+    /// <summary>Session high of the same bar; null when the bar carries no usable range.</summary>
+    public decimal? High { get; set; }
+
+    /// <summary>
+    /// Product of the split ratios between the transaction date and the stored series' present
+    /// basis; 1 when no split intervened. Multiplying a stored figure by this lands it on the
+    /// as-filed basis.
+    /// </summary>
+    public decimal SplitFactorToPresent { get; set; } = 1m;
+
+    /// <summary>
+    /// True when the factor could not be established (a captured split's price adjustment has
+    /// not run yet, or a split's series attribution is unknown) — the stored series straddles
+    /// two bases and no honest verdict exists, so evaluation stays pending.
+    /// </summary>
+    public bool SplitBasisAmbiguous { get; set; }
+}

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -71,6 +71,14 @@ public class InsiderTransaction
     /// </summary>
     public decimal ReportedPricePerShare { get; set; }
 
+    /// <summary>
+    /// True when <see cref="PricePerShare"/> is a repaired value (the mis-entered total divided
+    /// by the share count) rather than the filed figure. Makes repairs auditable and lets the
+    /// misrepair sweep skip rows the current band-guarded validator repaired — rows repaired
+    /// before this column existed carry <c>false</c> and are exactly the sweep's candidates.
+    /// </summary>
+    public bool PriceWasRepaired { get; set; }
+
     public AcquiredDisposed AcquiredDisposed { get; set; }
     public long SharesOwnedAfter { get; set; }
     public OwnershipNature OwnershipNature { get; set; }

--- a/src/Equibles.Migrations/Migrations/20260805193206_AddInsiderPriceWasRepaired.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260805193206_AddInsiderPriceWasRepaired.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805193206_AddInsiderPriceWasRepaired")]
+    partial class AddInsiderPriceWasRepaired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260805193206_AddInsiderPriceWasRepaired.cs
+++ b/src/Equibles.Migrations/Migrations/20260805193206_AddInsiderPriceWasRepaired.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInsiderPriceWasRepaired : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "PriceWasRepaired",
+                table: "InsiderTransaction",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PriceWasRepaired",
+                table: "InsiderTransaction");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Equibles.Sec.HostedService.csproj
+++ b/src/Equibles.Sec.HostedService/Equibles.Sec.HostedService.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.InsiderTrading.Repositories\Equibles.InsiderTrading.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.InsiderTrading.BusinessLogic\Equibles.InsiderTrading.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Media.BusinessLogic\Equibles.Media.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />

--- a/src/Equibles.Sec.HostedService/InsiderFilingReprocessWorker.cs
+++ b/src/Equibles.Sec.HostedService/InsiderFilingReprocessWorker.cs
@@ -44,6 +44,16 @@ public class InsiderFilingReprocessWorker : BaseScraperWorker
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
+        // Restore rows the old basis-blind validator misrepaired BEFORE the version-driven
+        // reprocess, so the nulled rows join the pending population this same cycle drains.
+        // Bounded and self-terminating; a no-op scan once the back catalogue is clean.
+        await using (var sweepScope = ScopeFactory.CreateAsyncScope())
+        {
+            var sweep =
+                sweepScope.ServiceProvider.GetRequiredService<InsiderMisrepairedPriceSweep>();
+            await sweep.Run(stoppingToken);
+        }
+
         await using var scope = ScopeFactory.CreateAsyncScope();
         var manager = scope.ServiceProvider.GetRequiredService<InsiderFilingReprocessManager>();
 
@@ -51,5 +61,23 @@ public class InsiderFilingReprocessWorker : BaseScraperWorker
 
         if (result.Processed > 0)
             Logger.LogInformation("Insider filing reprocess cycle: {Summary}", result.Summary);
+
+        // Drain the pending (IsPriceValid = null) population — freshly restored rows above,
+        // plus rows whose close has since landed — through the same evaluation the backoffice
+        // recompute uses. DB-only work; no EDGAR budget consumed.
+        await using (var backfillScope = ScopeFactory.CreateAsyncScope())
+        {
+            var backfill =
+                backfillScope.ServiceProvider.GetRequiredService<InsiderTransactionPriceBackfillManager>();
+            var backfillResult = await backfill.Run();
+            if (backfillResult.Processed > 0)
+                Logger.LogInformation(
+                    "Insider price backfill cycle: processed {Processed}, repaired={Repaired}, invalid={Invalid}, pending={Pending}",
+                    backfillResult.Processed,
+                    backfillResult.Repaired,
+                    backfillResult.Invalid,
+                    backfillResult.Pending
+                );
+        }
     }
 }

--- a/src/Equibles.Sec.HostedService/InsiderFilingReprocessWorker.cs
+++ b/src/Equibles.Sec.HostedService/InsiderFilingReprocessWorker.cs
@@ -1,6 +1,8 @@
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
 using Equibles.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -42,16 +44,52 @@ public class InsiderFilingReprocessWorker : BaseScraperWorker
     )
         : base(logger, scopeFactory, errorReporter) { }
 
+    // One-shot marker for the sharesless-verdict reopen: unlike the signature restore, that
+    // pass is NOT self-terminating (a re-flagged row matches its predicate again), so it runs
+    // exactly once and the marker keeps it off every later cycle.
+    private const string ShareslessReopenMarker = "InsiderTrading.ShareslessVerdictReopen";
+
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
         // Restore rows the old basis-blind validator misrepaired BEFORE the version-driven
         // reprocess, so the nulled rows join the pending population this same cycle drains.
         // Bounded and self-terminating; a no-op scan once the back catalogue is clean.
-        await using (var sweepScope = ScopeFactory.CreateAsyncScope())
+        // Isolated failure domain: a sweep fault (timeout, deploy-time DB bounce) must not
+        // starve the reprocess and backfill stages below, which do not depend on it.
+        try
         {
+            await using var sweepScope = ScopeFactory.CreateAsyncScope();
             var sweep =
                 sweepScope.ServiceProvider.GetRequiredService<InsiderMisrepairedPriceSweep>();
             await sweep.Run(stoppingToken);
+
+            var backfillStateRepo =
+                sweepScope.ServiceProvider.GetRequiredService<BackfillStateRepository>();
+            if (await backfillStateRepo.GetByName(ShareslessReopenMarker) == null)
+            {
+                var reopened = await sweep.ReopenShareslessVerdicts(stoppingToken);
+                if (reopened < InsiderMisrepairedPriceSweep.MaxRowsPerCycle)
+                {
+                    // Drained in this pass — stamp the marker so the non-self-terminating
+                    // predicate never re-opens rows the fixed validator re-flagged.
+                    backfillStateRepo.Add(
+                        new BackfillState
+                        {
+                            Name = ShareslessReopenMarker,
+                            LastFullRescanAt = DateTime.UtcNow,
+                        }
+                    );
+                    await backfillStateRepo.SaveChanges();
+                }
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Misrepaired-price sweep failed; continuing with reprocess");
         }
 
         await using var scope = ScopeFactory.CreateAsyncScope();
@@ -69,7 +107,7 @@ public class InsiderFilingReprocessWorker : BaseScraperWorker
         {
             var backfill =
                 backfillScope.ServiceProvider.GetRequiredService<InsiderTransactionPriceBackfillManager>();
-            var backfillResult = await backfill.Run();
+            var backfillResult = await backfill.Run(cancellationToken: stoppingToken);
             if (backfillResult.Processed > 0)
                 Logger.LogInformation(
                     "Insider price backfill cycle: processed {Processed}, repaired={Repaired}, invalid={Invalid}, pending={Pending}",

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Xml.Linq;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.InsiderTrading.BusinessLogic;
@@ -118,6 +119,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
         var priceValidator =
             scope.ServiceProvider.GetRequiredService<InsiderTransactionPriceValidator>();
+        var stockSplitRepository = scope.ServiceProvider.GetRequiredService<StockSplitRepository>();
 
         var existing = await transactionRepository
             .GetByAccessionNumber(filing.AccessionNumber)
@@ -303,7 +305,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         await ApplyPriceValidity(
             transactions,
             companyId,
+            companyOutContext.Ticker,
+            companyOutContext.SecondaryTickers,
             dailyStockPriceRepository,
+            stockSplitRepository,
             priceValidator
         );
 
@@ -758,16 +763,22 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
     // filings dump the total transaction value (or a placeholder like the
     // share count) into that field, which then explodes the dashboard's
     // Shares × Price sort. Preserve the as-filed value in ReportedPricePerShare,
-    // then cross-check against Yahoo's unadjusted close on the TransactionDate
-    // (most recent prior trading day for weekends/holidays): plausible rows
-    // stay as filed, implausible rows are repaired (total ÷ shares). If the
-    // Yahoo feed hasn't caught up yet, IsPriceValid is left null (pending) —
-    // the backoffice maintenance recompute re-evaluates it once the close
-    // exists, rather than silently accepting it as valid.
+    // then cross-check against the stored close on the TransactionDate (most
+    // recent prior trading day for weekends/holidays). The stored close is on
+    // TODAY'S split-adjusted basis while the filed price is on the transaction
+    // date's basis, so the evaluation carries the split factor and checks both
+    // bases: plausible rows stay as filed, implausible rows are repaired
+    // (total ÷ shares) only inside the session's price band. If the price feed
+    // hasn't caught up yet — or the split basis is unsettled — IsPriceValid is
+    // left null (pending) and re-evaluated later, rather than silently
+    // accepted or guessed at.
     private static async Task ApplyPriceValidity(
         List<InsiderTransaction> transactions,
         Guid companyId,
+        string primaryTicker,
+        IReadOnlyCollection<string> secondaryTickers,
         DailyStockPriceRepository dailyStockPriceRepository,
+        StockSplitRepository stockSplitRepository,
         InsiderTransactionPriceValidator priceValidator
     )
     {
@@ -780,16 +791,33 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var prices = await dailyStockPriceRepository
             .GetAll()
             .Where(p => p.CommonStockId == companyId && p.Date >= minDate && p.Date <= maxDate)
-            .Select(p => new { p.Date, p.Close })
+            .Select(p => new
+            {
+                p.Date,
+                p.Close,
+                p.Low,
+                p.High,
+            })
             .OrderByDescending(p => p.Date)
+            .ToListAsync();
+
+        var splits = await stockSplitRepository
+            .GetAll()
+            .Where(sp => sp.CommonStockId == companyId)
             .ToListAsync();
 
         foreach (var transaction in transactions)
         {
-            var close = prices
-                .Where(p => p.Date <= transaction.TransactionDate)
-                .Select(p => (decimal?)p.Close)
-                .FirstOrDefault();
+            var barRow = prices.FirstOrDefault(p => p.Date <= transaction.TransactionDate);
+            var bar = InsiderDailyBars.Build(
+                barRow?.Close,
+                barRow?.Low,
+                barRow?.High,
+                transaction.TransactionDate,
+                splits,
+                primaryTicker,
+                secondaryTickers
+            );
 
             // Capture the as-filed price first; both this path and the backfill
             // manager evaluate from ReportedPricePerShare so the "reported is
@@ -801,11 +829,12 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 transaction.Shares,
                 transaction.SecurityKind,
                 transaction.SecurityTitle,
-                close,
+                bar,
                 transaction.Notes
             );
             transaction.PricePerShare = evaluation.EffectivePrice;
             transaction.IsPriceValid = evaluation.IsPriceValid;
+            transaction.PriceWasRepaired = evaluation.WasRepaired;
         }
     }
 }

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCancellationTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCancellationTests.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -120,6 +121,7 @@ public class InsiderFilingReprocessManagerCancellationTests : ParadeDbMcpTestBas
             new InsiderTransactionRepository(runCtx),
             new InsiderFilingRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             edgar,
             fileManager,

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerConcurrentInsertTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerConcurrentInsertTests.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -144,6 +145,7 @@ public class InsiderFilingReprocessManagerConcurrentInsertTests : ParadeDbMcpTes
             new InsiderTransactionRepository(runCtx),
             new InsiderFilingRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             edgar,
             fileManager,

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCorruptCacheTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCorruptCacheTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -150,6 +151,7 @@ public class InsiderFilingReprocessManagerCorruptCacheTests : ParadeDbMcpTestBas
             new InsiderTransactionRepository(runCtx),
             new InsiderFilingRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             edgar,
             fileManager,

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -129,6 +130,7 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
             new InsiderTransactionRepository(runCtx),
             new InsiderFilingRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             edgar,
             fileManager,

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFailureTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFailureTests.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -85,6 +86,7 @@ public class InsiderFilingReprocessManagerFailureTests : ParadeDbMcpTestBase
             new InsiderTransactionRepository(runCtx),
             new InsiderFilingRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             edgar,
             fileManager,

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFetchedTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerFetchedTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -125,6 +126,7 @@ public class InsiderFilingReprocessManagerFetchedTests : ParadeDbMcpTestBase
             new InsiderTransactionRepository(runCtx),
             new InsiderFilingRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             edgar,
             fileManager,

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerReclassifyTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerReclassifyTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -133,6 +134,7 @@ public class InsiderFilingReprocessManagerReclassifyTests : ParadeDbMcpTestBase
             new InsiderTransactionRepository(runCtx),
             new InsiderFilingRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             edgar,
             fileManager,

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRefusedRepairTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRefusedRepairTests.cs
@@ -1,0 +1,147 @@
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+using FileContent = Equibles.Media.Data.Models.FileContent;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+/// <summary>
+/// The refusal arm of the reprocess repair path: an implausible price whose share-count
+/// division does NOT land inside the session band is flagged invalid and left as filed —
+/// never divided and published. This is the exact fixture shape the old validator "repaired"
+/// into a fabricated $1,000 price ($1,000,000 over 1,000 shares against a $50 close, 20× the
+/// session), persisted end-to-end through the manager.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InsiderFilingReprocessManagerRefusedRepairTests : ParadeDbMcpTestBase
+{
+    public InsiderFilingReprocessManagerRefusedRepairTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Run_RepairCandidateOutsideTheBand_FlagsInvalidWithoutFabricating()
+    {
+        var date = new DateOnly(2024, 6, 14);
+        var accession = "0000320193-24-000056";
+
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0002",
+            Name = "Jane Insider",
+            City = "Cupertino",
+            StateOrCountry = "CA",
+            IsDirector = true,
+        };
+        var stale = new InsiderTransaction
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            InsiderOwnerId = owner.Id,
+            AccessionNumber = accession,
+            TransactionOrder = 0,
+            FilingDate = date,
+            TransactionDate = date,
+            TransactionCode = TransactionCode.Purchase,
+            Shares = 1_000,
+            PricePerShare = 1_000_000m,
+            ReportedPricePerShare = 1_000_000m,
+            AcquiredDisposed = AcquiredDisposed.Acquired,
+            SharesOwnedAfter = 5000,
+            OwnershipNature = OwnershipNature.Direct,
+            SecurityTitle = "Common Stock",
+            SecurityKind = InsiderSecurityKind.NonDerivative,
+            ParserVersion = 0,
+        };
+
+        var ownershipXml =
+            "<ownershipDocument>"
+            + "<nonDerivativeTable><nonDerivativeTransaction>"
+            + "<securityTitle><value>Common Stock</value></securityTitle>"
+            + "<transactionDate><value>2024-06-14</value></transactionDate>"
+            + "<transactionCoding><transactionCode>P</transactionCode></transactionCoding>"
+            + "<transactionAmounts>"
+            + "<transactionShares><value>1000</value></transactionShares>"
+            + "<transactionPricePerShare><value>1000000</value></transactionPricePerShare>"
+            + "</transactionAmounts>"
+            + "</nonDerivativeTransaction></nonDerivativeTable>"
+            + "</ownershipDocument>";
+        var rawBytes = Encoding.UTF8.GetBytes(ownershipXml);
+        var filing = new InsiderFiling
+        {
+            AccessionNumber = accession,
+            CaptureStatus = InsiderFilingCaptureStatus.Captured,
+            UncompressedSize = rawBytes.Length,
+            Content = new File
+            {
+                Name = accession,
+                Extension = "gz",
+                ContentType = "application/gzip",
+                FileContent = new FileContent { Bytes = GzipCompressor.Compress(rawBytes) },
+            },
+        };
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        DbContext.Add(
+            new DailyStockPrice
+            {
+                CommonStockId = stock.Id,
+                Date = date,
+                Close = 50m,
+            }
+        );
+        DbContext.Add(stale);
+        DbContext.Add(filing);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var edgar = Substitute.For<ISecEdgarClient>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runCtx),
+            new InsiderFilingRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            edgar,
+            fileManager,
+            runCtx,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Repaired.Should().Be(0, "a candidate 20x the session band is not a repair");
+        result.Failed.Should().Be(0);
+
+        await using var verify = Fixture.CreateDbContext();
+        var row = await verify.Set<InsiderTransaction>().FindAsync(stale.Id);
+        row!.PricePerShare.Should().Be(1_000_000m, "a refused repair must not fabricate a price");
+        row.ReportedPricePerShare.Should().Be(1_000_000m);
+        row.PriceWasRepaired.Should().BeFalse();
+        row.IsPriceValid.Should().Be(false);
+        row.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
+    }
+}

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRepairTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRepairTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -62,7 +63,7 @@ public class InsiderFilingReprocessManagerRepairTests : ParadeDbMcpTestBase
             FilingDate = date,
             TransactionDate = date,
             TransactionCode = TransactionCode.Purchase,
-            Shares = 1000,
+            Shares = 20_000,
             PricePerShare = 1_000_000m,
             ReportedPricePerShare = 1_000_000m,
             AcquiredDisposed = AcquiredDisposed.Acquired,
@@ -80,7 +81,7 @@ public class InsiderFilingReprocessManagerRepairTests : ParadeDbMcpTestBase
             + "<transactionDate><value>2024-06-14</value></transactionDate>"
             + "<transactionCoding><transactionCode>P</transactionCode></transactionCoding>"
             + "<transactionAmounts>"
-            + "<transactionShares><value>1000</value></transactionShares>"
+            + "<transactionShares><value>20000</value></transactionShares>"
             + "<transactionPricePerShare><value>1000000</value></transactionPricePerShare>"
             + "</transactionAmounts>"
             + "</nonDerivativeTransaction></nonDerivativeTable>"
@@ -123,6 +124,7 @@ public class InsiderFilingReprocessManagerRepairTests : ParadeDbMcpTestBase
             new InsiderTransactionRepository(runCtx),
             new InsiderFilingRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             edgar,
             fileManager,
@@ -138,8 +140,10 @@ public class InsiderFilingReprocessManagerRepairTests : ParadeDbMcpTestBase
 
         await using var verify = Fixture.CreateDbContext();
         var row = await verify.Set<InsiderTransaction>().FindAsync(stale.Id);
-        // Repaired to 1,000,000 / 1000 shares = 1,000 per share; the as-filed value is preserved.
-        row!.PricePerShare.Should().Be(1_000m);
+        // Repaired to 1,000,000 / 20,000 shares = $50 per share — the close itself, inside the
+        // repair band; the as-filed value is preserved and the repair is stamped auditable.
+        row!.PricePerShare.Should().Be(50m);
+        row.PriceWasRepaired.Should().BeTrue();
         row.ReportedPricePerShare.Should().Be(1_000_000m);
         row.IsPriceValid.Should().Be(true);
         row.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRetagHoldingTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRetagHoldingTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -126,6 +127,7 @@ public class InsiderFilingReprocessManagerRetagHoldingTests : ParadeDbMcpTestBas
             new InsiderTransactionRepository(runCtx),
             new InsiderFilingRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             edgar,
             fileManager,

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderMisrepairedPriceSweepTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderMisrepairedPriceSweepTests.cs
@@ -163,4 +163,59 @@ public class InsiderMisrepairedPriceSweepTests : IDisposable
         (await CreateSweep().Run(CancellationToken.None)).Should().Be(1);
         (await CreateSweep().Run(CancellationToken.None)).Should().Be(0);
     }
+
+    [Fact]
+    public async Task ReopenShareslessVerdicts_StrandedShareslessRow_NullsTheVerdict()
+    {
+        // The old basis-blind comparison flagged the row invalid via its shares <= 0 branch;
+        // the price was never touched, so only the verdict re-opens for the fixed validator.
+        var row = await Seed(
+            pricePerShare: 3_300.24m,
+            reportedPricePerShare: 3_300.24m,
+            shares: 0,
+            isPriceValid: false
+        );
+
+        var reopened = await CreateSweep().ReopenShareslessVerdicts(CancellationToken.None);
+
+        reopened.Should().Be(1);
+        var verify = CreateContext();
+        var updated = await verify.Set<InsiderTransaction>().SingleAsync(t => t.Id == row.Id);
+        updated.PricePerShare.Should().Be(3_300.24m, "the price was never corrupted");
+        updated.IsPriceValid.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReopenShareslessVerdicts_RowWithShares_IsNotTouched()
+    {
+        // An invalid verdict with a positive share count came from the repair-refusal path,
+        // not the sharesless branch — it stays.
+        var row = await Seed(
+            pricePerShare: 1_000_000m,
+            reportedPricePerShare: 1_000_000m,
+            shares: 1_000,
+            isPriceValid: false
+        );
+
+        (await CreateSweep().ReopenShareslessVerdicts(CancellationToken.None)).Should().Be(0);
+        (await CreateContext().Set<InsiderTransaction>().SingleAsync(t => t.Id == row.Id))
+            .IsPriceValid.Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public async Task Run_DoesNotTouchTheShareslessCohort()
+    {
+        // The two passes are separate on purpose: Run is self-terminating and safe every
+        // cycle; the sharesless reopen is one-shot (worker-gated) because a re-flagged row
+        // matches its predicate again.
+        await Seed(
+            pricePerShare: 3_300.24m,
+            reportedPricePerShare: 3_300.24m,
+            shares: 0,
+            isPriceValid: false
+        );
+
+        (await CreateSweep().Run(CancellationToken.None)).Should().Be(0);
+    }
 }

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderMisrepairedPriceSweepTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderMisrepairedPriceSweepTests.cs
@@ -1,0 +1,166 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Media.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+/// <summary>
+/// Pins the misrepaired-price restore: rows the old basis-blind validator "repaired" carry the
+/// signature <c>|PricePerShare × Shares − ReportedPricePerShare| &lt; 0.01</c> with diverging
+/// prices; the sweep restores the as-filed price and nulls the verdict so the fixed validator
+/// re-evaluates. Rows the band-guarded repair stamped (<c>PriceWasRepaired</c>) are never
+/// touched, and a second pass is a no-op.
+/// </summary>
+public class InsiderMisrepairedPriceSweepTests : IDisposable
+{
+    private static readonly IModuleConfiguration[] Modules =
+    [
+        new CommonStocksModuleConfiguration(),
+        new CorporateActionsModuleConfiguration(),
+        new MediaModuleConfiguration(),
+        new InsiderTradingModuleConfiguration(),
+    ];
+
+    private readonly string _dbName = Guid.NewGuid().ToString();
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public void Dispose()
+    {
+        foreach (var ctx in _contexts)
+        {
+            ctx.Dispose();
+        }
+    }
+
+    private EquiblesFinancialDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(_dbName)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(options, Modules);
+        ctx.Database.EnsureCreated();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private InsiderMisrepairedPriceSweep CreateSweep()
+    {
+        var ctx = CreateContext();
+        return new InsiderMisrepairedPriceSweep(
+            new InsiderTransactionRepository(ctx),
+            ctx,
+            Substitute.For<ILogger<InsiderMisrepairedPriceSweep>>()
+        );
+    }
+
+    private async Task<InsiderTransaction> Seed(
+        decimal pricePerShare,
+        decimal reportedPricePerShare,
+        long shares,
+        bool? isPriceValid = true,
+        bool priceWasRepaired = false
+    )
+    {
+        var ctx = CreateContext();
+        var row = new InsiderTransaction
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = Guid.NewGuid(),
+            InsiderOwnerId = Guid.NewGuid(),
+            AccessionNumber = Guid.NewGuid().ToString()[..20],
+            TransactionOrder = 0,
+            FilingDate = new DateOnly(2021, 2, 18),
+            TransactionDate = new DateOnly(2021, 2, 16),
+            TransactionCode = TransactionCode.Sale,
+            Shares = shares,
+            PricePerShare = pricePerShare,
+            ReportedPricePerShare = reportedPricePerShare,
+            IsPriceValid = isPriceValid,
+            PriceWasRepaired = priceWasRepaired,
+            AcquiredDisposed = AcquiredDisposed.Disposed,
+            OwnershipNature = OwnershipNature.Direct,
+            SecurityTitle = "Common Stock",
+            SecurityKind = InsiderSecurityKind.NonDerivative,
+        };
+        ctx.Add(row);
+        await ctx.SaveChangesAsync();
+        return row;
+    }
+
+    [Fact]
+    public async Task Run_MisrepairedRow_RestoresAsFiledPriceAndNullsTheVerdict()
+    {
+        // The production signature: Jassy's $3,300.24 divided by 392 shares → $8.42, sealed
+        // valid. 8.42 × 392 = 3,300.64… stored with full precision: 3300.24/392 × 392 lands
+        // back within a cent of the as-filed figure.
+        var row = await Seed(
+            pricePerShare: 3_300.24m / 392m,
+            reportedPricePerShare: 3_300.24m,
+            shares: 392
+        );
+
+        var restored = await CreateSweep().Run(CancellationToken.None);
+
+        restored.Should().Be(1);
+        var verify = CreateContext();
+        var updated = await verify.Set<InsiderTransaction>().SingleAsync(t => t.Id == row.Id);
+        updated.PricePerShare.Should().Be(3_300.24m);
+        updated
+            .IsPriceValid.Should()
+            .BeNull("the fixed validator re-evaluates through the pending path");
+    }
+
+    [Fact]
+    public async Task Run_BandGuardedRepair_IsNeverRestored()
+    {
+        // A repair the NEW validator made carries the stamp — restoring it would undo a
+        // correct fix every cycle forever.
+        var row = await Seed(
+            pricePerShare: 50m,
+            reportedPricePerShare: 1_000_000m,
+            shares: 20_000,
+            priceWasRepaired: true
+        );
+
+        var restored = await CreateSweep().Run(CancellationToken.None);
+
+        restored.Should().Be(0);
+        var verify = CreateContext();
+        var updated = await verify.Set<InsiderTransaction>().SingleAsync(t => t.Id == row.Id);
+        updated.PricePerShare.Should().Be(50m);
+        updated.IsPriceValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Run_OrdinaryValidRow_IsLeftAlone()
+    {
+        var row = await Seed(pricePerShare: 165.01m, reportedPricePerShare: 165.01m, shares: 392);
+
+        var restored = await CreateSweep().Run(CancellationToken.None);
+
+        restored.Should().Be(0);
+        (await CreateContext().Set<InsiderTransaction>().SingleAsync(t => t.Id == row.Id))
+            .IsPriceValid.Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public async Task Run_SecondPass_IsANoOp()
+    {
+        await Seed(pricePerShare: 3_300.24m / 392m, reportedPricePerShare: 3_300.24m, shares: 392);
+
+        (await CreateSweep().Run(CancellationToken.None)).Should().Be(1);
+        (await CreateSweep().Run(CancellationToken.None)).Should().Be(0);
+    }
+}

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerFetchClosesWeekendFallbackTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerFetchClosesWeekendFallbackTests.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data;
@@ -24,12 +26,14 @@ public class InsiderTransactionPriceBackfillManagerFetchClosesWeekendFallbackTes
     {
         _dbContext = TestDbContextFactory.Create(
             new CommonStocksModuleConfiguration(),
+            new CorporateActionsModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),
             new YahooModuleConfiguration()
         );
         _manager = new InsiderTransactionPriceBackfillManager(
             new InsiderTransactionRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
+            new StockSplitRepository(_dbContext),
             new InsiderTransactionPriceValidator(),
             _dbContext,
             NullLogger<InsiderTransactionPriceBackfillManager>.Instance
@@ -84,13 +88,16 @@ public class InsiderTransactionPriceBackfillManagerFetchClosesWeekendFallbackTes
         };
 
         var method = typeof(InsiderTransactionPriceBackfillManager).GetMethod(
-            "FetchCloses",
+            "FetchBars",
             BindingFlags.NonPublic | BindingFlags.Instance
         );
-        var closes = await (Task<Dictionary<(Guid, DateOnly), decimal>>)
-            method.Invoke(_manager, [batch]);
+        var barsTask = (Task)method.Invoke(_manager, [batch]);
+        await barsTask;
+        var bars = (System.Collections.IDictionary)
+            barsTask.GetType().GetProperty("Result").GetValue(barsTask);
 
-        closes.Should().ContainKey((stockId, saturday));
-        closes[(stockId, saturday)].Should().Be(50m);
+        bars.Contains((stockId, saturday)).Should().BeTrue();
+        var bar = bars[(stockId, saturday)];
+        ((decimal)bar.GetType().GetProperty("Close").GetValue(bar)).Should().Be(50m);
     }
 }

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerRunTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerRunTests.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -68,6 +69,7 @@ public class InsiderTransactionPriceBackfillManagerRunTests : ParadeDbMcpTestBas
         var manager = new InsiderTransactionPriceBackfillManager(
             new InsiderTransactionRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             runCtx,
             NullLogger<InsiderTransactionPriceBackfillManager>()
@@ -151,6 +153,7 @@ public class InsiderTransactionPriceBackfillManagerRunTests : ParadeDbMcpTestBas
         var manager = new InsiderTransactionPriceBackfillManager(
             new InsiderTransactionRepository(runCtx),
             new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
             new InsiderTransactionPriceValidator(),
             runCtx,
             NullLogger<InsiderTransactionPriceBackfillManager>()

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
@@ -94,6 +96,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
         var dbContext = TestDbContextFactory.Create(
             new InsiderTradingModuleConfiguration(),
             new CommonStocksModuleConfiguration(),
+            new CorporateActionsModuleConfiguration(),
             new ErrorsModuleConfiguration(),
             new YahooModuleConfiguration()
         );
@@ -114,7 +117,8 @@ public class InsiderTradingFilingProcessorAmendmentTests
             (typeof(IFileManager), Substitute.For<IFileManager>()),
             (typeof(ErrorManager), errorManager),
             (typeof(DailyStockPriceRepository), dailyStockPriceRepo),
-            (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator())
+            (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator()),
+            (typeof(StockSplitRepository), new StockSplitRepository(dbContext))
         );
 
         var processor = new InsiderTradingFilingProcessor(

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
@@ -40,6 +42,7 @@ public class InsiderTradingFilingProcessorMalformedOwnershipXmlTests
         var dbContext = TestDbContextFactory.Create(
             new InsiderTradingModuleConfiguration(),
             new CommonStocksModuleConfiguration(),
+            new CorporateActionsModuleConfiguration(),
             new ErrorsModuleConfiguration(),
             new YahooModuleConfiguration()
         );
@@ -55,7 +58,8 @@ public class InsiderTradingFilingProcessorMalformedOwnershipXmlTests
             (typeof(IFileManager), Substitute.For<IFileManager>()),
             (typeof(ErrorManager), new ErrorManager(new ErrorRepository(dbContext))),
             (typeof(DailyStockPriceRepository), new DailyStockPriceRepository(dbContext)),
-            (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator())
+            (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator()),
+            (typeof(StockSplitRepository), new StockSplitRepository(dbContext))
         );
         var processor = new InsiderTradingFilingProcessor(
             scopeFactory,

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
@@ -378,6 +380,7 @@ public class InsiderTradingFilingProcessorTests
         var dbContext = TestDbContextFactory.Create(
             new InsiderTradingModuleConfiguration(),
             new CommonStocksModuleConfiguration(),
+            new CorporateActionsModuleConfiguration(),
             new ErrorsModuleConfiguration(),
             new YahooModuleConfiguration()
         );
@@ -401,7 +404,8 @@ public class InsiderTradingFilingProcessorTests
             (typeof(IFileManager), fileManager),
             (typeof(ErrorManager), errorManager),
             (typeof(DailyStockPriceRepository), dailyStockPriceRepo),
-            (typeof(InsiderTransactionPriceValidator), priceValidator)
+            (typeof(InsiderTransactionPriceValidator), priceValidator),
+            (typeof(StockSplitRepository), new StockSplitRepository(dbContext))
         );
 
         var errorReporter = new ErrorReporter(

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderDailyBarsBuildTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderDailyBarsBuildTests.cs
@@ -1,0 +1,144 @@
+using Equibles.CorporateActions.Data.Models;
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// Pins the ONE production path that decides <c>SplitFactorToPresent</c> and
+/// <c>SplitBasisAmbiguous</c> for insider price evaluation. The validator tests hand-set those
+/// fields on the DTO; these prove real <see cref="StockSplit"/> rows produce them — in
+/// particular that a captured-but-unreconciled split (the mixed-basis window) reaches the
+/// validator as pending rather than as a guessed factor.
+/// </summary>
+public class InsiderDailyBarsBuildTests
+{
+    private static StockSplit Split(
+        DateOnly effective,
+        decimal numerator,
+        decimal denominator,
+        string priceSeriesTicker = null,
+        bool applied = true
+    ) =>
+        new()
+        {
+            EffectiveDate = effective,
+            Numerator = numerator,
+            Denominator = denominator,
+            PriceSeriesTicker = priceSeriesTicker,
+            PriceAdjustmentAppliedTime = applied ? DateTime.UtcNow : null,
+        };
+
+    private static readonly DateOnly TransactionDate = new(2021, 2, 16);
+
+    [Fact]
+    public void Build_AppliedForwardSplitAfterTheTransaction_YieldsTheFactor()
+    {
+        // AMZN's 20:1, reconciled: close × 20 restates onto the as-filed basis.
+        var bar = InsiderDailyBars.Build(
+            close: 165.01m,
+            low: 163m,
+            high: 166.5m,
+            TransactionDate,
+            [Split(new DateOnly(2022, 6, 6), 20m, 1m, "AMZN")],
+            primaryTicker: "AMZN",
+            secondaryTickers: []
+        );
+
+        bar.SplitBasisAmbiguous.Should().BeFalse();
+        bar.SplitFactorToPresent.Should().Be(20m);
+        bar.Close.Should().Be(165.01m);
+    }
+
+    [Fact]
+    public void Build_UnreconciledSplit_MarksTheBasisAmbiguous()
+    {
+        // Captured split whose price adjustment hasn't run: the stored series straddles two
+        // bases, so the evaluation must go pending — never a factor guess.
+        var bar = InsiderDailyBars.Build(
+            close: 165.01m,
+            low: null,
+            high: null,
+            TransactionDate,
+            [Split(new DateOnly(2022, 6, 6), 20m, 1m, "AMZN", applied: false)],
+            primaryTicker: "AMZN",
+            secondaryTickers: []
+        );
+
+        bar.SplitBasisAmbiguous.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Build_UnattributedLegacySplit_CountsForThePrimarySeries()
+    {
+        // Insider rows are issuer-level (listedTicker = null → primary), and only the primary
+        // series can have produced a pre-attribution legacy row.
+        var bar = InsiderDailyBars.Build(
+            close: 50m,
+            low: null,
+            high: null,
+            TransactionDate,
+            [Split(new DateOnly(2023, 1, 10), 1m, 10m)],
+            primaryTicker: "TICK",
+            secondaryTickers: []
+        );
+
+        bar.SplitBasisAmbiguous.Should().BeFalse();
+        bar.SplitFactorToPresent.Should().Be(0.1m, "a 1:10 reverse split divides the count");
+    }
+
+    [Fact]
+    public void Build_SiblingAttributedSplit_IsSkippedNotApplied()
+    {
+        // A split belonging to a KNOWN sibling listing moves nothing on the primary basis.
+        var bar = InsiderDailyBars.Build(
+            close: 50m,
+            low: null,
+            high: null,
+            TransactionDate,
+            [Split(new DateOnly(2023, 1, 10), 20m, 1m, "BRK-B")],
+            primaryTicker: "BRK-A",
+            secondaryTickers: ["BRK-B"]
+        );
+
+        bar.SplitBasisAmbiguous.Should().BeFalse();
+        bar.SplitFactorToPresent.Should().Be(1m);
+    }
+
+    [Fact]
+    public void Build_StaleAttributionMatchingNoCurrentListing_MarksAmbiguous()
+    {
+        // An attribution matching neither the primary nor any secondary is a stale symbol —
+        // very likely this series' own split under its old name. Guessing either way risks the
+        // ratio-sized error; the basis defers.
+        var bar = InsiderDailyBars.Build(
+            close: 50m,
+            low: null,
+            high: null,
+            TransactionDate,
+            [Split(new DateOnly(2023, 1, 10), 20m, 1m, "OLDNAME")],
+            primaryTicker: "NEWNAME",
+            secondaryTickers: []
+        );
+
+        bar.SplitBasisAmbiguous.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Build_SplitOnOrBeforeTheTransactionDate_DoesNotMoveTheFactor()
+    {
+        // A figure dated on the effective date is already post-split (strict comparison,
+        // mirroring SplitAdjustment.ShareCountFactor).
+        var bar = InsiderDailyBars.Build(
+            close: 165.01m,
+            low: null,
+            high: null,
+            TransactionDate,
+            [Split(TransactionDate, 20m, 1m, "AMZN")],
+            primaryTicker: "AMZN",
+            secondaryTickers: []
+        );
+
+        bar.SplitBasisAmbiguous.Should().BeFalse();
+        bar.SplitFactorToPresent.Should().Be(1m);
+    }
+}

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorAdsTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorAdsTests.cs
@@ -1,4 +1,5 @@
 using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.BusinessLogic.Models;
 using Equibles.InsiderTrading.Data.Models;
 
 namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
@@ -28,7 +29,7 @@ public class InsiderTransactionPriceValidatorAdsTests
             shares: 2_501_582_400L,
             kind: InsiderSecurityKind.NonDerivative,
             securityTitle: "Ordinary Shares",
-            unadjustedClose: 3.45m,
+            bar: new DailyBarContext { Close = 3.45m },
             notes: SvreNotes
         );
 
@@ -49,7 +50,7 @@ public class InsiderTransactionPriceValidatorAdsTests
             shares: 2_501_582_400L,
             kind: InsiderSecurityKind.NonDerivative,
             securityTitle: "Ordinary Shares",
-            unadjustedClose: 3.45m,
+            bar: new DailyBarContext { Close = 3.45m },
             notes: null
         );
 
@@ -66,7 +67,7 @@ public class InsiderTransactionPriceValidatorAdsTests
             shares: 1_000L,
             kind: InsiderSecurityKind.NonDerivative,
             securityTitle: "Common Stock",
-            unadjustedClose: 49m,
+            bar: new DailyBarContext { Close = 49m },
             notes: new[] { "Represents shares withheld to cover taxes." }
         );
 

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateBoundaryTests.cs
@@ -1,4 +1,5 @@
 using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.BusinessLogic.Models;
 using Equibles.InsiderTrading.Data.Models;
 
 namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
@@ -19,7 +20,7 @@ public class InsiderTransactionPriceValidatorEvaluateBoundaryTests
             shares: 1000,
             kind: InsiderSecurityKind.NonDerivative,
             securityTitle: "Common Stock",
-            unadjustedClose: 50m
+            bar: new DailyBarContext { Close = 50m }
         );
 
         result.IsPriceValid.Should().Be(true);

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateZeroCloseTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateZeroCloseTests.cs
@@ -1,4 +1,5 @@
 using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.BusinessLogic.Models;
 using Equibles.InsiderTrading.Data.Models;
 
 namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
@@ -20,7 +21,7 @@ public class InsiderTransactionPriceValidatorEvaluateZeroCloseTests
             shares: 1000,
             kind: InsiderSecurityKind.NonDerivative,
             securityTitle: "Common Stock",
-            unadjustedClose: 0m
+            bar: new DailyBarContext { Close = 0m }
         );
 
         result.IsPriceValid.Should().BeNull();

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorMaxValueCloseTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorMaxValueCloseTests.cs
@@ -1,4 +1,5 @@
 using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.BusinessLogic.Models;
 using Equibles.InsiderTrading.Data.Models;
 
 namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
@@ -35,7 +36,7 @@ public class InsiderTransactionPriceValidatorMaxValueCloseTests
                 shares: 10,
                 kind: InsiderSecurityKind.NonDerivative,
                 securityTitle: "Common Stock",
-                unadjustedClose: decimal.MaxValue
+                bar: new DailyBarContext { Close = decimal.MaxValue }
             );
 
         act.Should().NotThrow();

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorSplitBasisTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorSplitBasisTests.cs
@@ -138,6 +138,66 @@ public class InsiderTransactionPriceValidatorSplitBasisTests
     }
 
     [Fact]
+    public void Evaluate_ReverseSplit_RawBasisPriceIsNoLongerAdmitted()
+    {
+        // 1:10 reverse split after the transaction (factor 0.1): the as-filed basis is
+        // close × 0.1 = $5. A correct as-filed price stays valid; a junk figure that was
+        // plausible on the RAW close basis (the old either-basis union admitted anything up
+        // to 10 × close = $500) must now be flagged. Reverse splits concentrate in the
+        // penny-stock population with the junkiest per-share fields, so the raw branch was
+        // 1/factor = 10× too permissive exactly where it hurts most.
+        var correct = _validator.Evaluate(
+            reportedPrice: 5.20m,
+            shares: 1_000,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext { Close = 50m, SplitFactorToPresent = 0.1m }
+        );
+        correct.IsPriceValid.Should().BeTrue();
+        correct.WasRepaired.Should().BeFalse();
+
+        var rawBasisJunk = _validator.Evaluate(
+            reportedPrice: 400m,
+            shares: 3,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext { Close = 50m, SplitFactorToPresent = 0.1m }
+        );
+        rawBasisJunk.IsPriceValid.Should().BeFalse();
+        rawBasisJunk.WasRepaired.Should().BeFalse();
+        rawBasisJunk.EffectivePrice.Should().Be(400m);
+    }
+
+    [Fact]
+    public void Evaluate_RepairBand_NeverAcceptsACandidateOnTheWrongBasis()
+    {
+        // Factor 20: a candidate near the PRESENT-basis close ($150 on a $165 close) is off
+        // by exactly the split ratio on the as-filed basis. The old either-basis band would
+        // have stamped it as an audited repair — the same corruption shape this validator
+        // exists to prevent. ($45,000 total: implausible as filed since 45,000/10 > the
+        // as-filed close basis of ~$3,300; over 300 shares it divides to $150.)
+        var result = _validator.Evaluate(
+            reportedPrice: 45_000m,
+            shares: 300,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext
+            {
+                Close = 165.01m,
+                Low = 163.00m,
+                High = 166.50m,
+                SplitFactorToPresent = 20m,
+            }
+        );
+
+        result.IsPriceValid.Should().BeFalse();
+        result.WasRepaired.Should().BeFalse();
+        result
+            .EffectivePrice.Should()
+            .Be(45_000m, "a candidate on the present basis must be refused, not stamped");
+    }
+
+    [Fact]
     public void Evaluate_NoUsableRange_FallsBackToTheCloseBand()
     {
         // Bar without Low/High: the band is [close/2, close×2]. $120 on a $50 close is

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorSplitBasisTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorSplitBasisTests.cs
@@ -1,0 +1,166 @@
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.BusinessLogic.Models;
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// Pins the split-basis awareness behind the misrepair incident: the stored close is on
+/// TODAY'S split-adjusted basis while the filed price is on the transaction date's basis, and
+/// the old validator compared them as if both were raw — every pre-split filing looked 10×+
+/// implausible and got its correct price "repaired" by the share count (15,822 rows, all
+/// self-sealed valid; AMZN's pre-20:1 $3,300.24 became $8.42). Also pins the repair band:
+/// a repair must reproduce a price inside the session's range on one of the two bases, never
+/// fabricate one.
+/// </summary>
+public class InsiderTransactionPriceValidatorSplitBasisTests
+{
+    private readonly InsiderTransactionPriceValidator _validator = new();
+
+    [Fact]
+    public void Evaluate_PreSplitPriceAgainstAdjustedClose_IsValidAsFiledNotRepaired()
+    {
+        // The exact production corruption: AMZN 2021-02-16, as-filed $3,300.24, stored close
+        // $165.01 on the post-20:1 basis. 3,300.24 / 165.01 = 20× > the 10× cap on the raw
+        // basis — but dead-on the close on the as-filed basis (165.01 × 20 = 3,300.20).
+        var result = _validator.Evaluate(
+            reportedPrice: 3_300.24m,
+            shares: 392,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext
+            {
+                Close = 165.01m,
+                Low = 163.00m,
+                High = 166.50m,
+                SplitFactorToPresent = 20m,
+            }
+        );
+
+        result.IsPriceValid.Should().BeTrue();
+        result.WasRepaired.Should().BeFalse();
+        result
+            .EffectivePrice.Should()
+            .Be(3_300.24m, "a correct pre-split price must stay as filed");
+    }
+
+    [Fact]
+    public void Evaluate_AmbiguousSplitBasis_StaysPending()
+    {
+        // A captured split whose price adjustment hasn't run: the stored series straddles two
+        // bases, so ANY verdict would be a guess off by the ratio — pending, like a missing
+        // close, never silently accepted or repaired.
+        var result = _validator.Evaluate(
+            reportedPrice: 3_300.24m,
+            shares: 392,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext { Close = 165.01m, SplitBasisAmbiguous = true }
+        );
+
+        result.IsPriceValid.Should().BeNull();
+        result.WasRepaired.Should().BeFalse();
+        result.EffectivePrice.Should().Be(3_300.24m);
+    }
+
+    [Fact]
+    public void Evaluate_GenuineFatFinger_IsStillRepairedInsideTheBand()
+    {
+        // Total $1,000,000 typed into the per-share field over 20,000 shares → $50/share, the
+        // close itself. A real fill inside the session band — repair and stamp it.
+        var result = _validator.Evaluate(
+            reportedPrice: 1_000_000m,
+            shares: 20_000,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext
+            {
+                Close = 50m,
+                Low = 48m,
+                High = 52m,
+            }
+        );
+
+        result.IsPriceValid.Should().BeTrue();
+        result.WasRepaired.Should().BeTrue();
+        result.EffectivePrice.Should().Be(50m);
+    }
+
+    [Fact]
+    public void Evaluate_RepairCandidateOutsideTheBand_IsFlaggedInvalidNotRepaired()
+    {
+        // $1,000,000 over 1,000 shares → $1,000/share against a $50 close: 20× the close is
+        // not a price the market traded at. The old validator published it as a "repair";
+        // now the row is flagged and left unrepaired.
+        var result = _validator.Evaluate(
+            reportedPrice: 1_000_000m,
+            shares: 1_000,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext
+            {
+                Close = 50m,
+                Low = 48m,
+                High = 52m,
+            }
+        );
+
+        result.IsPriceValid.Should().BeFalse();
+        result.WasRepaired.Should().BeFalse();
+        result
+            .EffectivePrice.Should()
+            .Be(1_000_000m, "a refused repair must not fabricate a price");
+    }
+
+    [Fact]
+    public void Evaluate_RepairCandidateInsideTheFactorScaledBand_IsAccepted()
+    {
+        // A fat-fingered PRE-SPLIT total: $660,048 over 200 shares → $3,300.24, which is the
+        // real pre-split fill (close $165.01 × factor 20). The band scales by the factor, so
+        // the repair is accepted on the as-filed basis.
+        var result = _validator.Evaluate(
+            reportedPrice: 660_048m,
+            shares: 200,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext
+            {
+                Close = 165.01m,
+                Low = 163.00m,
+                High = 166.50m,
+                SplitFactorToPresent = 20m,
+            }
+        );
+
+        result.IsPriceValid.Should().BeTrue();
+        result.WasRepaired.Should().BeTrue();
+        result.EffectivePrice.Should().Be(3_300.24m);
+    }
+
+    [Fact]
+    public void Evaluate_NoUsableRange_FallsBackToTheCloseBand()
+    {
+        // Bar without Low/High: the band is [close/2, close×2]. $120 on a $50 close is
+        // outside it — refused; $80 is inside — repaired.
+        var refused = _validator.Evaluate(
+            reportedPrice: 120_000m,
+            shares: 1_000,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext { Close = 50m }
+        );
+        refused.IsPriceValid.Should().BeFalse();
+        refused.WasRepaired.Should().BeFalse();
+
+        var repaired = _validator.Evaluate(
+            reportedPrice: 80_000m,
+            shares: 1_000,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            bar: new DailyBarContext { Close = 50m }
+        );
+        repaired.IsPriceValid.Should().BeTrue();
+        repaired.WasRepaired.Should().BeTrue();
+        repaired.EffectivePrice.Should().Be(80m);
+    }
+}

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
@@ -1,4 +1,5 @@
 using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.BusinessLogic.Models;
 using Equibles.InsiderTrading.Data.Models;
 
 namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
@@ -64,7 +65,7 @@ public class InsiderTransactionPriceValidatorTests
         var result = _validator.IsPlausible(
             pricePerShare: 24_035_774.40m,
             securityTitle: "Common Stock",
-            unadjustedClose: 0.24m
+            close: 0.24m
         );
 
         result.Should().BeFalse();
@@ -78,7 +79,7 @@ public class InsiderTransactionPriceValidatorTests
         var result = _validator.IsPlausible(
             pricePerShare: 11_000_689.50m,
             securityTitle: "Common Stock",
-            unadjustedClose: 20.50m
+            close: 20.50m
         );
 
         result.Should().BeFalse();
@@ -132,7 +133,7 @@ public class InsiderTransactionPriceValidatorTests
             shares: 1000,
             InsiderSecurityKind.NonDerivative,
             "Common Stock",
-            unadjustedClose: null
+            bar: null
         );
 
         result.IsPriceValid.Should().BeNull();
@@ -151,7 +152,7 @@ public class InsiderTransactionPriceValidatorTests
             shares: 100_149_893, // 24,035,774.40 / 0.24
             kind: InsiderSecurityKind.NonDerivative,
             securityTitle: "Common Stock",
-            unadjustedClose: 0.24m
+            bar: new DailyBarContext { Close = 0.24m }
         );
 
         result.IsPriceValid.Should().BeTrue();
@@ -169,7 +170,7 @@ public class InsiderTransactionPriceValidatorTests
             shares: 0,
             InsiderSecurityKind.NonDerivative,
             "Common Stock",
-            unadjustedClose: 50m
+            bar: new DailyBarContext { Close = 50m }
         );
 
         result.IsPriceValid.Should().BeFalse();
@@ -185,7 +186,7 @@ public class InsiderTransactionPriceValidatorTests
             shares: 1000,
             InsiderSecurityKind.NonDerivative,
             "Common Stock",
-            unadjustedClose: 50m
+            bar: new DailyBarContext { Close = 50m }
         );
 
         result.IsPriceValid.Should().BeTrue();
@@ -204,7 +205,7 @@ public class InsiderTransactionPriceValidatorTests
             shares: 1000,
             InsiderSecurityKind.Derivative,
             "Stock Option (Right to Buy)",
-            unadjustedClose: 50m
+            bar: new DailyBarContext { Close = 50m }
         );
 
         result.IsPriceValid.Should().BeTrue();
@@ -223,7 +224,7 @@ public class InsiderTransactionPriceValidatorTests
             shares: 5_000_000,
             InsiderSecurityKind.Derivative,
             "Common Stock",
-            unadjustedClose: 1.20m
+            bar: new DailyBarContext { Close = 1.20m }
         );
 
         result.IsPriceValid.Should().BeTrue();
@@ -241,7 +242,7 @@ public class InsiderTransactionPriceValidatorTests
             shares: 1000,
             InsiderSecurityKind.Unknown,
             "Warrant",
-            unadjustedClose: 50m
+            bar: new DailyBarContext { Close = 50m }
         );
 
         result.IsPriceValid.Should().BeTrue();
@@ -257,7 +258,7 @@ public class InsiderTransactionPriceValidatorTests
             shares: 0,
             InsiderSecurityKind.NonDerivative,
             "Common Stock",
-            unadjustedClose: null
+            bar: null
         );
 
         result.IsPriceValid.Should().BeTrue();
@@ -280,7 +281,7 @@ public class InsiderTransactionPriceValidatorTests
             shares: -1000,
             kind: InsiderSecurityKind.NonDerivative,
             securityTitle: "Common Stock",
-            unadjustedClose: 50m
+            bar: new DailyBarContext { Close = 50m }
         );
 
         result.IsPriceValid.Should().NotBe(true);

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorUnknownKindBlankTitleTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorUnknownKindBlankTitleTests.cs
@@ -1,4 +1,5 @@
 using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.BusinessLogic.Models;
 using Equibles.InsiderTrading.Data.Models;
 
 namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
@@ -23,7 +24,7 @@ public class InsiderTransactionPriceValidatorUnknownKindBlankTitleTests
             shares: 1000,
             kind: InsiderSecurityKind.Unknown,
             securityTitle: "   ",
-            unadjustedClose: 50m
+            bar: new DailyBarContext { Close = 50m }
         );
 
         // Repaired (not waved through as a derivative): the mis-entered total is

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
@@ -55,6 +57,7 @@ public class InsiderTradingFilingProcessorSkipTombstoneTests
             new IModuleConfiguration[]
             {
                 new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
                 new MediaModuleConfiguration(),
                 new SecTombstoneModuleConfiguration(),
             }
@@ -77,6 +80,7 @@ public class InsiderTradingFilingProcessorSkipTombstoneTests
         services.AddScoped<InsiderFilingRepository>();
         services.AddScoped<FailedFilingIngestRepository>();
         services.AddScoped<DailyStockPriceRepository>();
+        services.AddScoped<StockSplitRepository>();
         services.AddScoped<InsiderTransactionPriceValidator>();
         var scopeFactory = services
             .BuildServiceProvider()


### PR DESCRIPTION
## Summary
The insider price validator compared as-filed prices against the stored close believing it unadjusted; the close is on TODAY'S split-adjusted basis, so every pre-split filing looked 10x+ implausible and had its correct price 'repaired' by the share count and self-sealed valid — 15,822 rows across 257 stocks in production (AMZN 2021-02-16: Jassy's $3,300.24 became $8.42).

## Code changes
- **SplitBasisResolver** (new, `Equibles.CorporateActions.Data`) — the split-factor resolution shared with the 13F lane, moved verbatim from `HoldingValueBasis` (which now delegates).
- **InsiderTransactionPriceValidator** — `Evaluate` takes a `DailyBarContext` (close/low/high + factor-to-present): plausibility and the repair band test the as-filed basis (close x factor); an ambiguous basis (captured-but-unreconciled split) stays pending; a repair candidate is accepted only inside the session band (`[low*0.9, high*1.1]`, close fallback `[close/2, close*2]`) on the as-filed basis — refused repairs flag the row invalid instead of fabricating a price.
- **InsiderTransaction.PriceWasRepaired** (additive migration) — repairs become auditable and protected from the restore sweep. Commercial twin migration rides the pin-bump PR.
- **InsiderMisrepairedPriceSweep** — restores rows carrying the misrepair signature (`|PricePerShare x Shares - ReportedPricePerShare| < 0.01` with diverging prices, unstamped) to the as-filed price and nulls the verdict; self-terminating, bounded 25k/cycle. A one-shot worker-gated pass also re-opens the sharesless invalid verdicts the old comparison stranded.
- **InsiderFilingReprocessWorker** — sweep runs in its own failure domain before the version-driven reprocess; the pending-price backfill then drains the restored rows the same cycle (DB-only, cancellable).
- All three persisting call sites (ingest processor, backfill manager, reprocess manager) build bars + splits through one `InsiderDailyBars.Build` and persist the repair stamp.

Reviewed and hardened (basis checks tightened to as-filed-only, isolated sweep failure domain, stranded cohort, CancellationToken plumbing, test gaps closed). Build + full OSS suites green locally (4,008 unit / 2,377 integration).