### PR TITLE
fix(finra): match FINRA symbols ordinally and heal case-fold collisions

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
@@ -93,9 +93,14 @@ public class OffExchangeVolumeImportService
             scopeKey
         );
 
+        // Ordinal for the same reason as the daily lane: FINRA symbol casing is identity
+        // (lowercase suffix = a different security), so a case-insensitive map merges two
+        // securities' weekly volumes. Historical corrupt weeks outside FINRA's rolling
+        // publication window cannot be re-imported and are not healed here.
         var tickerMap = await _tickerMapService.Build(
             _workerOptions.TickersToSync,
-            cancellationToken
+            cancellationToken,
+            StringComparer.Ordinal
         );
         foreach (var week in weeks)
         {

--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
@@ -17,7 +17,12 @@ namespace Equibles.Finra.HostedService.Services;
 [Service]
 public class OffExchangeVolumeImportService
 {
-    private const string Dataset = "off-exchange-weekly-v1";
+    // v2: v1 partitions were imported through the case-insensitive ticker map that folded
+    // FINRA's lowercase sibling-security symbols onto common tickers. The bump orphans the v1
+    // markers so every week still inside FINRA's rolling publication window (~1 year)
+    // re-imports and the upsert replaces the corrupted totals; weeks that have aged out of the
+    // window cannot be re-fetched and stay as stored.
+    private const string Dataset = "off-exchange-weekly-v2";
     private const int CorrectionLookbackWeeks = 8;
     private static readonly TimeSpan RecentPartitionRefreshInterval = TimeSpan.FromHours(24);
     private static readonly HashSet<string> CompletePublicationTiers = new(
@@ -95,8 +100,8 @@ public class OffExchangeVolumeImportService
 
         // Ordinal for the same reason as the daily lane: FINRA symbol casing is identity
         // (lowercase suffix = a different security), so a case-insensitive map merges two
-        // securities' weekly volumes. Historical corrupt weeks outside FINRA's rolling
-        // publication window cannot be re-imported and are not healed here.
+        // securities' weekly volumes. The dataset-key bump above re-imports every week FINRA
+        // still publishes; only weeks that have aged out of the rolling window stay corrupt.
         var tickerMap = await _tickerMapService.Build(
             _workerOptions.TickersToSync,
             cancellationToken,

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -20,7 +20,12 @@ namespace Equibles.Finra.HostedService.Services;
 [Service]
 public class ShortVolumeImportService
 {
-    private const string Dataset = "daily-short-volume-files-v1";
+    // v2: v1 partitions were imported through a case-insensitive ticker map that folded
+    // FINRA's lowercase preferred/when-issued symbols onto common tickers (TpC summed into
+    // TPC) — the aggregates are corrupt wherever a case-variant sibling traded. The bump
+    // orphans every v1 marker, so CandidateDates re-imports the full history newest-first
+    // (bounded per cycle) and the upsert REPLACES the corrupted sums.
+    private const string Dataset = "daily-short-volume-files-v2";
     private const int CorrectionLookbackDays = 7;
     private static readonly DateOnly FirstConsolidatedFileDate = new(2018, 8, 1);
     private static readonly TimeSpan RecentPartitionRefreshInterval = TimeSpan.FromHours(24);
@@ -96,9 +101,12 @@ public class ShortVolumeImportService
             scopeKey
         );
 
+        // Ordinal: FINRA symbol casing is identity (lowercase suffix = preferred/when-issued,
+        // a different security) — a case-insensitive map merges two securities' volumes.
         var tickerMap = await _tickerMapService.Build(
             _workerOptions.TickersToSync,
-            cancellationToken
+            cancellationToken,
+            StringComparer.Ordinal
         );
         foreach (var date in dates)
         {
@@ -145,7 +153,13 @@ public class ShortVolumeImportService
         {
             var records = await _finraClient.GetDailyShortVolume(date, cancellationToken);
             var aggregated = AggregateVolumesByStock(records, tickerMap, date);
-            var totalImported = await UpsertDay(aggregated.Values, date, cancellationToken);
+            var collisionOnlyStocks = CollisionOnlyStocks(records, tickerMap, aggregated);
+            var totalImported = await UpsertDay(
+                aggregated.Values,
+                collisionOnlyStocks,
+                date,
+                cancellationToken
+            );
             await _partitionTracker.MarkImported(
                 Dataset,
                 scopeKey,
@@ -193,6 +207,7 @@ public class ShortVolumeImportService
 
     private async Task<int> UpsertDay(
         IEnumerable<DailyShortVolume> volumes,
+        IReadOnlySet<Guid> collisionOnlyStocks,
         DateOnly date,
         CancellationToken cancellationToken
     )
@@ -214,8 +229,56 @@ public class ShortVolumeImportService
         foreach (var volume in validBatch)
             UpsertVolume(repo, existing, volume);
 
+        var stale = existing
+            .Values.Where(volume => collisionOnlyStocks.Contains(volume.CommonStockId))
+            .ToList();
+        if (stale.Count > 0)
+        {
+            repo.Delete(stale);
+            _logger.LogInformation(
+                "Deleted {Count} case-fold-only short volume rows for {Date}",
+                stale.Count,
+                date
+            );
+        }
+
         await repo.SaveChanges();
         return validBatch.Count;
+    }
+
+    /// <summary>
+    /// Stocks whose stored row for the day can only have come from the retired case-fold: the
+    /// day's file carries a case-variant of the stock's ticker (a different security) but not
+    /// the ticker itself, so the ordinal re-import produces no aggregate to overwrite the
+    /// corrupt row and it must be deleted instead. A stock the file doesn't reference at all is
+    /// left alone — its stored row may be legitimate history from another source scope.
+    /// </summary>
+    private static HashSet<Guid> CollisionOnlyStocks(
+        List<ShortVolumeRecord> records,
+        IReadOnlyDictionary<string, Guid> tickerMap,
+        IReadOnlyDictionary<Guid, DailyShortVolume> aggregated
+    )
+    {
+        var fileSymbolsOrdinal = new HashSet<string>(StringComparer.Ordinal);
+        var fileSymbolsCaseInsensitive = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var record in records)
+        {
+            if (string.IsNullOrEmpty(record.Symbol))
+                continue;
+            fileSymbolsOrdinal.Add(record.Symbol);
+            fileSymbolsCaseInsensitive.Add(record.Symbol);
+        }
+
+        var collisionOnly = new HashSet<Guid>();
+        foreach (var (ticker, stockId) in tickerMap)
+        {
+            if (aggregated.ContainsKey(stockId))
+                continue;
+            if (fileSymbolsCaseInsensitive.Contains(ticker) && !fileSymbolsOrdinal.Contains(ticker))
+                collisionOnly.Add(stockId);
+        }
+
+        return collisionOnly;
     }
 
     private void LogDroppedRows(int dropped, DateOnly date)

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -247,11 +247,15 @@ public class ShortVolumeImportService
     }
 
     /// <summary>
-    /// Stocks whose stored row for the day can only have come from the retired case-fold: the
-    /// day's file carries a case-variant of the stock's ticker (a different security) but not
-    /// the ticker itself, so the ordinal re-import produces no aggregate to overwrite the
-    /// corrupt row and it must be deleted instead. A stock the file doesn't reference at all is
-    /// left alone — its stored row may be legitimate history from another source scope.
+    /// Stocks whose stored row for the day is attributable to the retired case-fold: the day's
+    /// file carries a case-variant of the stock's ticker (a different security) but not the
+    /// ticker itself, so the ordinal re-import produces no aggregate to overwrite the corrupt
+    /// row and it is deleted instead. A stock the file doesn't reference at all is left alone —
+    /// its stored row may be legitimate history. This rests on two stated assumptions: every
+    /// stored ticker is all-uppercase (enforced below — a hypothetical mixed-case ticker would
+    /// otherwise be deleted daily), and the stock's primary ticker hasn't changed since the
+    /// partition date (a renamed ticker whose OLD file happens to carry a case-variant of the
+    /// NEW symbol would lose that day — measured exposure in production is near zero).
     /// </summary>
     private static HashSet<Guid> CollisionOnlyStocks(
         List<ShortVolumeRecord> records,
@@ -274,6 +278,17 @@ public class ShortVolumeImportService
         {
             if (aggregated.ContainsKey(stockId))
                 continue;
+            // Deletion is unrecoverable, so it is confined to the population the case-fold
+            // could actually corrupt: all-uppercase tickers (every stored ticker today). A
+            // mixed-case ticker would permanently miss the ordinal map, and flagging it here
+            // would delete its rows every day the file mentions its symbol.
+            if (ticker.Any(char.IsLower))
+                continue;
+            // The ordinal-absence clause is redundant TODAY (a symbol equal to the ticker
+            // would have aggregated, so the ContainsKey guard already skipped this stock) but
+            // deliberately kept load-bearing: the moment AggregateVolumesByStock learns to
+            // filter records (e.g. dropping zero-volume rows), a filtered-but-present exact
+            // symbol must still protect the stock from deletion.
             if (fileSymbolsCaseInsensitive.Contains(ticker) && !fileSymbolsOrdinal.Contains(ticker))
                 collisionOnly.Add(stockId);
         }

--- a/src/Equibles.Worker/TickerMapService.cs
+++ b/src/Equibles.Worker/TickerMapService.cs
@@ -15,9 +15,17 @@ public class TickerMapService
         _scopeFactory = scopeFactory;
     }
 
+    /// <summary>
+    /// Maps stored primary tickers to stock ids. The default comparer is case-insensitive for
+    /// sources that vary letter case of the SAME security's symbol. Sources whose casing is
+    /// itself identity — FINRA writes preferred/when-issued suffixes in lowercase (TpC is a
+    /// DIFFERENT security from TPC) — must pass <see cref="StringComparer.Ordinal"/>, or the
+    /// case-fold silently merges two securities onto one stock.
+    /// </summary>
     public async Task<Dictionary<string, Guid>> Build(
         List<string> tickersToSync,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        StringComparer comparer = null
     )
     {
         using var scope = _scopeFactory.CreateScope();
@@ -29,7 +37,7 @@ public class TickerMapService
         return await query.ToDictionaryAsync(
             s => s.Ticker,
             s => s.Id,
-            StringComparer.OrdinalIgnoreCase,
+            comparer ?? StringComparer.OrdinalIgnoreCase,
             cancellationToken
         );
     }

--- a/tests/Equibles.IntegrationTests/Finra/FinraImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraImportServiceTests.cs
@@ -127,7 +127,7 @@ public class ShortVolumeImportServiceTests : IDisposable
         _partitionRepo.Add(
             new FinraImportPartition
             {
-                Dataset = "daily-short-volume-files-v1",
+                Dataset = "daily-short-volume-files-v2",
                 PartitionDate = date,
                 ScopeKey = scopeKey,
                 ImportedAt = importedAt ?? Now.UtcDateTime,
@@ -289,7 +289,7 @@ public class ShortVolumeImportServiceTests : IDisposable
 
         await _finraClient.Received(1).GetDailyShortVolume(today);
         _partitionRepo
-            .GetPartition("daily-short-volume-files-v1", "all", today)
+            .GetPartition("daily-short-volume-files-v2", "all", today)
             .Should()
             .ContainSingle();
     }
@@ -326,7 +326,7 @@ public class ShortVolumeImportServiceTests : IDisposable
         volumes.Should().Contain(v => v.CommonStockId == apple.Id && v.ShortVolume == 200_000);
         volumes.Should().Contain(v => v.CommonStockId == microsoft.Id && v.ShortVolume == 300_000);
         _partitionRepo
-            .GetPartition("daily-short-volume-files-v1", "all", existingDate)
+            .GetPartition("daily-short-volume-files-v2", "all", existingDate)
             .Should()
             .ContainSingle();
 

--- a/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
@@ -159,7 +159,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
 
         await _service.Import(CancellationToken.None);
 
-        _partitionRepo.GetPartition("off-exchange-weekly-v1", "all", week).Should().BeEmpty();
+        _partitionRepo.GetPartition("off-exchange-weekly-v2", "all", week).Should().BeEmpty();
         _volumeRepo.GetByWeek(week).Should().BeEmpty();
 
         await _service.Import(CancellationToken.None);
@@ -167,7 +167,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
         var row = _volumeRepo.GetByWeek(week).Single(v => v.CommonStockId == apple.Id);
         row.AtsVolume.Should().Be(5_000);
         row.NonAtsOtcVolume.Should().Be(3_000);
-        _partitionRepo.GetPartition("off-exchange-weekly-v1", "all", week).Should().ContainSingle();
+        _partitionRepo.GetPartition("off-exchange-weekly-v2", "all", week).Should().ContainSingle();
 
         _finraClient.ClearReceivedCalls();
         await _service.Import(CancellationToken.None);
@@ -222,7 +222,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
         row.NonAtsOtcVolume.Should().Be(4_000);
         row.NonAtsOtcTradeCount.Should().Be(40);
         _partitionRepo
-            .GetPartition("off-exchange-weekly-v1", "all", week)
+            .GetPartition("off-exchange-weekly-v2", "all", week)
             .Single()
             .ImportedAt.Should()
             .Be(previousImport);
@@ -233,7 +233,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
         _partitionRepo.Add(
             new FinraImportPartition
             {
-                Dataset = "off-exchange-weekly-v1",
+                Dataset = "off-exchange-weekly-v2",
                 PartitionDate = week,
                 ScopeKey = "all",
                 ImportedAt = importedAt ?? Now.UtcDateTime,

--- a/tests/Equibles.IntegrationTests/Finra/ShortVolumeImportServiceCollisionRowHealTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortVolumeImportServiceCollisionRowHealTests.cs
@@ -1,0 +1,206 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Calendars;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.HostedService.Configuration;
+using Equibles.Finra.HostedService.Services;
+using Equibles.Finra.Repositories;
+using Equibles.Integrations.Finra.Contracts;
+using Equibles.Integrations.Finra.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Finra;
+
+/// <summary>
+/// End-to-end pin of the case-fold collision heal. The v1 importer's case-insensitive
+/// ticker map folded FINRA's lowercase preferred symbols onto common tickers, so a stock
+/// could hold a stored row for a day its own symbol never traded. The v2 re-import must
+/// DELETE such a row (no aggregate exists to overwrite it), must leave rows alone when the
+/// file simply doesn't mention the ticker, and must not be blocked by v1 partition markers
+/// (the dataset-key bump orphans them, which is the heal's re-import lever).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class ShortVolumeImportServiceCollisionRowHealTests : ParadeDbMcpTestBase
+{
+    public ShortVolumeImportServiceCollisionRowHealTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private CommonStock _stock;
+    private DateOnly _corruptDate;
+
+    private async Task SeedStockAndCorruptRow()
+    {
+        _stock = new CommonStock
+        {
+            Cik = "0000000778",
+            Ticker = "TESTW",
+            Name = "Collision Heal Test Inc.",
+        };
+        _corruptDate = PreviousTradingDay(DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1));
+        DbContext.Add(_stock);
+        // The collision artifact: a row for a day whose file (stubbed below) only ever
+        // carried the lowercase sibling security's symbol.
+        DbContext.Add(
+            new DailyShortVolume
+            {
+                CommonStockId = _stock.Id,
+                Date = _corruptDate,
+                ShortVolume = 5_000,
+                TotalVolume = 9_000,
+            }
+        );
+        // A v1 marker for the same day: the dataset bump must orphan it so the day
+        // re-imports at all.
+        DbContext.Add(
+            new FinraImportPartition
+            {
+                Dataset = "daily-short-volume-files-v1",
+                PartitionDate = _corruptDate,
+                ScopeKey = "all",
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+    }
+
+    private static DateOnly PreviousTradingDay(DateOnly date)
+    {
+        while (!UsMarketCalendar.IsTradingDay(date))
+            date = date.AddDays(-1);
+        return date;
+    }
+
+    private ShortVolumeImportService BuildService(IFinraClient finraClient)
+    {
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
+            (typeof(DailyShortVolumeRepository), new DailyShortVolumeRepository(DbContext))
+        );
+        return new ShortVolumeImportService(
+            scopeFactory,
+            Substitute.For<ILogger<ShortVolumeImportService>>(),
+            finraClient,
+            new TickerMapService(scopeFactory),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(
+                new WorkerOptions { TickersToSync = [], MinSyncDate = DateTime.UtcNow.AddDays(-7) }
+            ),
+            Options.Create(new FinraScraperOptions()),
+            new FinraImportPartitionTracker(new FinraImportPartitionRepository(DbContext)),
+            TimeProvider.System
+        );
+    }
+
+    [Fact]
+    public async Task Import_FileCarriesOnlyTheCaseVariant_DeletesTheCollisionRow()
+    {
+        await SeedStockAndCorruptRow();
+
+        var finraClient = Substitute.For<IFinraClient>();
+        finraClient
+            .GetDailyShortVolume(Arg.Any<DateOnly>())
+            .Returns(
+                new List<ShortVolumeRecord>
+                {
+                    // Only the sibling security's lowercase symbol — under the ordinal map
+                    // it maps to nothing, so the stored row is a collision artifact.
+                    new()
+                    {
+                        Symbol = "TESTw",
+                        ShortVolume = 5_000,
+                        TotalVolume = 9_000,
+                    },
+                }
+            );
+
+        await BuildService(finraClient).Import(CancellationToken.None);
+
+        await using var verify = Fixture.CreateDbContext();
+        var remaining = await verify
+            .Set<DailyShortVolume>()
+            .AsNoTracking()
+            .AnyAsync(v => v.CommonStockId == _stock.Id && v.Date == _corruptDate);
+        remaining.Should().BeFalse("the row's only source was the case-folded sibling security");
+    }
+
+    [Fact]
+    public async Task Import_FileDoesNotMentionTheTicker_KeepsTheStoredRow()
+    {
+        await SeedStockAndCorruptRow();
+
+        var finraClient = Substitute.For<IFinraClient>();
+        finraClient
+            .GetDailyShortVolume(Arg.Any<DateOnly>())
+            .Returns(
+                new List<ShortVolumeRecord>
+                {
+                    new()
+                    {
+                        Symbol = "OTHER",
+                        ShortVolume = 1_000,
+                        TotalVolume = 2_000,
+                    },
+                }
+            );
+
+        await BuildService(finraClient).Import(CancellationToken.None);
+
+        await using var verify = Fixture.CreateDbContext();
+        var remaining = await verify
+            .Set<DailyShortVolume>()
+            .AsNoTracking()
+            .AnyAsync(v => v.CommonStockId == _stock.Id && v.Date == _corruptDate);
+        remaining
+            .Should()
+            .BeTrue("absence from one day's file is not evidence the row was a collision");
+    }
+
+    [Fact]
+    public async Task Import_FileCarriesTheExactSymbol_OverwritesInsteadOfDeleting()
+    {
+        await SeedStockAndCorruptRow();
+
+        var finraClient = Substitute.For<IFinraClient>();
+        finraClient
+            .GetDailyShortVolume(Arg.Any<DateOnly>())
+            .Returns(
+                new List<ShortVolumeRecord>
+                {
+                    new()
+                    {
+                        Symbol = "TESTW",
+                        ShortVolume = 90_492,
+                        TotalVolume = 117_265,
+                    },
+                    new()
+                    {
+                        Symbol = "TESTw",
+                        ShortVolume = 5_000,
+                        TotalVolume = 9_000,
+                    },
+                }
+            );
+
+        await BuildService(finraClient).Import(CancellationToken.None);
+
+        await using var verify = Fixture.CreateDbContext();
+        var row = await verify
+            .Set<DailyShortVolume>()
+            .AsNoTracking()
+            .SingleAsync(v => v.CommonStockId == _stock.Id && v.Date == _corruptDate);
+        row.ShortVolume.Should().Be(90_492, "the upsert replaces the corrupted sum");
+        row.TotalVolume.Should().Be(117_265);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Integrations/TickerMapServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Integrations/TickerMapServiceTests.cs
@@ -180,6 +180,22 @@ public class TickerMapServiceTests : IDisposable
         result["aapl"].Should().Be(apple.Id);
     }
 
+    [Fact]
+    public async Task Build_OrdinalComparer_DoesNotFoldCaseVariants()
+    {
+        // FINRA writes preferred/when-issued suffixes in lowercase (TpC is a different
+        // security from TPC), so its importers request an ordinal map: a case-variant
+        // lookup must MISS instead of folding two securities onto one stock.
+        var tpc = CreateStock("TPC", "Tutor Perini Corp");
+        await SeedStocks(tpc);
+
+        var result = await _service.Build(null, CancellationToken.None, StringComparer.Ordinal);
+
+        result.Should().ContainKey("TPC").WhoseValue.Should().Be(tpc.Id);
+        result.Should().NotContainKey("TpC");
+        result.Should().NotContainKey("tpc");
+    }
+
     // ── Build with secondary tickers ──────────────────────────────────
 
     [Fact]

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceCaseVariantSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceCaseVariantSymbolTests.cs
@@ -98,6 +98,50 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
     }
 
     [Fact]
+    public void CollisionOnlyStocks_ExactSymbolInFileButAbsentFromAggregate_DoesNotFlag()
+    {
+        // Pins the ordinal-absence clause directly (not via the aggregated guard): if the
+        // aggregator ever learns to FILTER records (e.g. dropping zero-volume rows), a stock
+        // whose exact symbol is in the file but produced no aggregate must still be protected
+        // from deletion — its absence is a filter decision, not a case-fold artifact.
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TPC"] = stockId };
+        var records = new List<ShortVolumeRecord>
+        {
+            new() { Symbol = "TPC", ShortVolume = 0 },
+            new() { Symbol = "TpC", ShortVolume = 5_000 },
+        };
+        var emptyAggregate = new Dictionary<Guid, DailyShortVolume>();
+
+        var result =
+            (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, emptyAggregate]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CollisionOnlyStocks_MixedCaseTicker_IsNeverFlaggedForDeletion()
+    {
+        // Deletion containment: a hypothetical mixed-case stored ticker would permanently
+        // miss the ordinal map AND read as "case-variant present, exact absent" every single
+        // day — flagging it would delete its rows daily. Confine deletion to the
+        // all-uppercase population the case-fold could actually have corrupted.
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TpC"] = stockId };
+        var records = new List<ShortVolumeRecord>
+        {
+            new() { Symbol = "TPC", ShortVolume = 90_492 },
+        };
+        var aggregated =
+            (Dictionary<Guid, DailyShortVolume>)
+                Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
+
+        var result = (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
     public void CollisionOnlyStocks_FileDoesNotReferenceTheTickerAtAll_DoesNotFlag()
     {
         // A stock the day's file never mentions keeps its stored row — absence from one

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceCaseVariantSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceCaseVariantSymbolTests.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.HostedService.Services;
+using Equibles.Integrations.Finra.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Pins the case-fold collision fix: FINRA writes preferred/when-issued suffixes in
+/// lowercase, so <c>TpC</c> is a DIFFERENT security from <c>TPC</c>. The old
+/// case-insensitive ticker map folded both onto the common stock and SUMMED them daily.
+/// With the ordinal map the case variant misses; the same-symbol multi-venue summing
+/// (pinned separately) is unaffected because venue rows repeat the identical spelling.
+/// </summary>
+public class ShortVolumeImportServiceCaseVariantSymbolTests
+{
+    private static readonly MethodInfo Aggregate = typeof(ShortVolumeImportService).GetMethod(
+        "AggregateVolumesByStock",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    private static readonly MethodInfo CollisionOnly = typeof(ShortVolumeImportService).GetMethod(
+        "CollisionOnlyStocks",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    [Fact]
+    public void AggregateVolumesByStock_OrdinalMap_CaseVariantSymbolIsSkippedNotSummed()
+    {
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TPC"] = stockId };
+        var records = new List<ShortVolumeRecord>
+        {
+            new()
+            {
+                Symbol = "TPC",
+                ShortVolume = 90_492,
+                TotalVolume = 117_265,
+            },
+            // The preferred security's row — folding it in overstated TPC's volumes.
+            new()
+            {
+                Symbol = "TpC",
+                ShortVolume = 5_000,
+                TotalVolume = 9_000,
+            },
+        };
+
+        var result =
+            (Dictionary<Guid, DailyShortVolume>)
+                Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
+
+        result.Should().HaveCount(1);
+        result[stockId].ShortVolume.Should().Be(90_492);
+        result[stockId].TotalVolume.Should().Be(117_265);
+    }
+
+    [Fact]
+    public void CollisionOnlyStocks_FileCarriesOnlyTheCaseVariant_FlagsTheStock()
+    {
+        // The stored row for this day can only have come from the retired case-fold:
+        // the file has TpC but no TPC, so the ordinal re-import writes nothing and the
+        // corrupt row must be deleted rather than left behind.
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TPC"] = stockId };
+        var records = new List<ShortVolumeRecord>
+        {
+            new() { Symbol = "TpC", ShortVolume = 5_000 },
+        };
+        var aggregated =
+            (Dictionary<Guid, DailyShortVolume>)
+                Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
+
+        var result = (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+
+        result.Should().ContainSingle().Which.Should().Be(stockId);
+    }
+
+    [Fact]
+    public void CollisionOnlyStocks_FileCarriesTheExactSymbolToo_DoesNotFlag()
+    {
+        // The common stock traded that day: the ordinal re-import overwrites the stored
+        // row with the correct TPC-only figures, so nothing may be deleted.
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TPC"] = stockId };
+        var records = new List<ShortVolumeRecord>
+        {
+            new() { Symbol = "TPC", ShortVolume = 90_492 },
+            new() { Symbol = "TpC", ShortVolume = 5_000 },
+        };
+        var aggregated =
+            (Dictionary<Guid, DailyShortVolume>)
+                Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
+
+        var result = (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CollisionOnlyStocks_FileDoesNotReferenceTheTickerAtAll_DoesNotFlag()
+    {
+        // A stock the day's file never mentions keeps its stored row — absence from one
+        // file is not evidence the row was a collision artifact.
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            ["TPC"] = Guid.NewGuid(),
+        };
+        var records = new List<ShortVolumeRecord>
+        {
+            new() { Symbol = "AAPL", ShortVolume = 1_000 },
+        };
+        var aggregated =
+            (Dictionary<Guid, DailyShortVolume>)
+                Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
+
+        var result = (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
FINRA writes preferred/when-issued suffixes in lowercase, so TpC (Tutor Perini preferred) is a different security from common TPC. The case-insensitive ticker map folded both onto the common stock: the daily aggregator SUMMED the two securities' volumes (prod TPC 2026-08-04 stored exactly TPC + TpC), and the weekly off-exchange merge folded them the same way.

## Code changes
- **TickerMapService.Build** — optional trailing `StringComparer` (default unchanged for the other five consumers); both FINRA volume importers pass `StringComparer.Ordinal` so a case-variant symbol misses instead of merging. Same-symbol multi-venue summing is unaffected (identical spellings).
- **Daily lane** — dataset key `daily-short-volume-files-v1` → `v2` orphans every marker so the full history re-imports newest-first (bounded 100 dates/cycle); the upsert replaces corrupted sums. A stored row is deleted only when the day's file carries a case-variant of the stock's ticker but not the ticker itself — confined to all-uppercase tickers (deletion is unrecoverable; a hypothetical mixed-case ticker would otherwise be deleted daily), and never on mere absence from the file.
- **Weekly lane** — `off-exchange-weekly-v1` → `v2`: FINRA still publishes ~1 year of weekly datasets while the correction lookback only refreshed 8 weeks, so the bump re-imports every still-published corrupt week; weeks aged out of the rolling window stay as stored (tracked in #4311).
- Tests pin the ordinal aggregation, all deletion gates (including the deliberately-redundant ordinal-absence clause that becomes load-bearing if the aggregator ever filters records), the mixed-case containment, and the end-to-end heal (v1 marker orphaned → collision row deleted / kept / overwritten).

Reviewed against the real FINRA files and production data. Build + full OSS suites green locally (4,014 unit / 2,381 integration).