### PR TITLE
fix(sec): retry feed-flagged filings until the submissions JSON lists them

### DIFF
--- a/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
@@ -45,6 +45,28 @@ public class DocumentScraperOptions
     // still unseen (first poll after a boot, or a heavy burst).
     public int RecentFeedMaxPages { get; set; } = 5;
 
+    // A feed-flagged filing can be invisible to the company's submissions JSON
+    // for minutes — the JSON is served through a CDN that lags acceptance, so a
+    // company enumerated seconds after its feed flag legitimately finds nothing
+    // and would otherwise drop the filing until the daily-index backstop next
+    // morning. Such accessions stay pending and re-dirty their company until
+    // the enumeration sees them: at most one retry per this many seconds …
+    public int FeedPendingRetrySeconds { get; set; } = 120;
+
+    // … at most this many retries per filing (past a handful the JSON is not
+    // merely lagging — abandon with a warning; the daily index owns recovery) …
+    public int FeedPendingMaxRetries { get; set; } = 10;
+
+    // … abandoned regardless after this many minutes of wall clock (covers
+    // entries that never got an enumeration attempt at all) …
+    public int FeedPendingExpiryMinutes { get; set; } = 360;
+
+    // … and at most this many pending re-flags admitted per cycle (oldest
+    // first), so a submissions-JSON stall cannot turn every recently flagged
+    // filer into a simultaneous re-enumeration storm — the same bounding idea
+    // as MaxReconciliationsPerCycle.
+    public int MaxPendingReflagsPerCycle { get; set; } = 50;
+
     // A company whose last full filing enumeration is older than this gets a
     // reconciliation re-sweep — the correctness backstop that converges on the
     // authoritative submissions JSON no matter what the realtime layers missed.

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -330,6 +330,13 @@ public class DocumentScraper : IDocumentScraper
                 documentRepository
             );
 
+            // Only collected while a feed-flagged filing awaits confirmation —
+            // a full-history company enumerates tens of thousands of
+            // accessions, and building that set every pass would be waste.
+            var enumeratedFilings = _filingDiscoveryService.HasPendingFeedAccessions
+                ? new HashSet<(string AccessionNumber, string Cik)>()
+                : null;
+
             foreach (var documentType in _options.DocumentTypesToSync)
             {
                 var secFilter = documentType.ToSecEdgarFilter();
@@ -348,9 +355,17 @@ public class DocumentScraper : IDocumentScraper
                     secFilter.Value,
                     result,
                     secEdgarClient,
-                    persistenceService
+                    persistenceService,
+                    enumeratedFilings
                 );
             }
+
+            // Confirm feed-flagged filings this enumeration saw — anything the
+            // feed promised that is NOT in this set stays pending in discovery
+            // and re-dirties the company (the submissions JSON lags acceptance,
+            // so an enumeration right after the flag can legitimately miss it).
+            if (enumeratedFilings != null)
+                _filingDiscoveryService.MarkAccessionsEnumerated(enumeratedFilings);
 
             var duration = DateTime.UtcNow - startTime;
             _logger.LogInformation(
@@ -485,7 +500,8 @@ public class DocumentScraper : IDocumentScraper
         DocumentTypeFilter secFilter,
         ScrapingResult result,
         ISecEdgarClient secEdgarClient,
-        IDocumentPersistenceService persistenceService
+        IDocumentPersistenceService persistenceService,
+        HashSet<(string AccessionNumber, string Cik)> enumeratedFilings
     )
     {
         _logger.LogDebug(
@@ -503,6 +519,15 @@ public class DocumentScraper : IDocumentScraper
                 result,
                 secEdgarClient
             );
+
+            if (enumeratedFilings != null)
+            {
+                foreach (var filing in filings)
+                {
+                    if (!string.IsNullOrEmpty(filing.AccessionNumber))
+                        enumeratedFilings.Add((filing.AccessionNumber, filing.Cik));
+                }
+            }
 
             result.DocumentsFound += filings.Count;
 

--- a/src/Equibles.Sec.HostedService/Services/FilingDiscoveryService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FilingDiscoveryService.cs
@@ -23,6 +23,22 @@ public class FilingDiscoveryService : IFilingDiscoveryService
     private static readonly ConcurrentDictionary<string, DateTime> SeenFeedEntries = new();
     private static readonly TimeSpan SeenFeedEntryRetention = TimeSpan.FromHours(12);
 
+    // Feed-flagged filings not yet confirmed by their company's submissions
+    // enumeration, keyed "accession|numericCik" — the same two-sided discipline
+    // as SeenFeedEntries, because one accession appears once per associated
+    // entity and each tracked side needs its own confirmation. The submissions
+    // JSON trails acceptance by minutes, so an enumeration run seconds after
+    // the feed flag can miss the filing; entries here keep re-dirtying the
+    // company until MarkAccessionsEnumerated sees the accession under that CIK,
+    // else the filing silently waits ~a day for the daily-index backstop.
+    private static readonly ConcurrentDictionary<
+        string,
+        PendingFeedAccession
+    > PendingFeedAccessions = new();
+
+    private static string PendingKey(string accessionNumber, long numericCik) =>
+        $"{accessionNumber}|{numericCik}";
+
     private const int FeedPageSize = 100;
 
     private static readonly TimeZoneInfo EasternTimeZone = ResolveEasternTimeZone();
@@ -54,10 +70,146 @@ public class FilingDiscoveryService : IFilingDiscoveryService
         var syncedForms = BuildSyncedFormSet();
         var dirty = new Dictionary<Guid, CommonStock>();
 
+        // Captured before the collectors run so entries seeded during this
+        // pass's feed poll can never look retry-due in this same pass, even
+        // when a slow multi-page poll makes the pass span minutes.
+        var utcNow = DateTime.UtcNow;
+
         await CollectFromRecentFeed(cikToCompany, syncedForms, dirty, cancellationToken);
         await CollectFromDailyIndex(cikToCompany, syncedForms, dirty, cancellationToken);
+        ReflagPendingAccessions(cikToCompany, dirty, utcNow);
 
         return [.. dirty.Values];
+    }
+
+    /// <inheritdoc />
+    public bool HasPendingFeedAccessions => !PendingFeedAccessions.IsEmpty;
+
+    /// <inheritdoc />
+    public void MarkAccessionsEnumerated(
+        IReadOnlyCollection<(string AccessionNumber, string Cik)> enumeratedFilings
+    )
+    {
+        if (enumeratedFilings == null || enumeratedFilings.Count == 0)
+            return;
+        if (PendingFeedAccessions.IsEmpty)
+            return;
+
+        foreach (var (accessionNumber, cik) in enumeratedFilings)
+        {
+            if (string.IsNullOrEmpty(accessionNumber) || !long.TryParse(cik, out var numericCik))
+                continue;
+
+            if (
+                !PendingFeedAccessions.TryRemove(
+                    PendingKey(accessionNumber, numericCik),
+                    out var pending
+                )
+            )
+                continue;
+
+            if (pending.RetryLogged)
+            {
+                _logger.LogInformation(
+                    "Feed-flagged filing {AccessionNumber} appeared in CIK {Cik}'s submissions enumeration {Minutes:F1} minutes after its feed flag",
+                    accessionNumber,
+                    numericCik,
+                    (DateTime.UtcNow - pending.FirstSeenAtUtc).TotalMinutes
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Keeps companies with unconfirmed feed-flagged filings dirty so they are
+    /// re-enumerated until the submissions JSON catches up. Without this, a
+    /// company enumerated inside the JSON's lag window is stamped as synced,
+    /// its feed entry stays "seen" for 12h, and the filing silently waits for
+    /// the next-morning daily index — exactly the after-the-bell earnings 8-Ks
+    /// the realtime layer exists for. Retries are rate-limited per accession
+    /// and give up after the configured expiry (the daily index still owns
+    /// recovery past that).
+    /// </summary>
+    private void ReflagPendingAccessions(
+        Dictionary<long, CommonStock> cikToCompany,
+        Dictionary<Guid, CommonStock> dirty,
+        DateTime utcNow
+    )
+    {
+        if (PendingFeedAccessions.IsEmpty)
+            return;
+
+        var due = new List<(string Key, PendingFeedAccession Pending, CommonStock Company)>();
+
+        foreach (var (key, pending) in PendingFeedAccessions)
+        {
+            var expired =
+                utcNow - pending.FirstSeenAtUtc
+                > TimeSpan.FromMinutes(_options.FeedPendingExpiryMinutes);
+            if (expired || pending.RetryCount >= _options.FeedPendingMaxRetries)
+            {
+                PendingFeedAccessions.TryRemove(key, out _);
+                _logger.LogWarning(
+                    "Feed-flagged filing {PendingKey} never appeared in the submissions enumeration ({Reason}: {Retries} retries over {Minutes:F0} minutes) — abandoning the realtime retry; the daily index will backstop it",
+                    key,
+                    expired ? "expired" : "retries exhausted",
+                    pending.RetryCount,
+                    (utcNow - pending.FirstSeenAtUtc).TotalMinutes
+                );
+                continue;
+            }
+
+            // The filer left the tracked universe mid-retry (delisted or
+            // dropped by company sync) — nothing to re-enumerate.
+            if (!cikToCompany.TryGetValue(pending.Cik, out var company))
+            {
+                PendingFeedAccessions.TryRemove(key, out _);
+                continue;
+            }
+
+            if (
+                utcNow - pending.LastRetriedAtUtc
+                < TimeSpan.FromSeconds(_options.FeedPendingRetrySeconds)
+            )
+                continue;
+
+            due.Add((key, pending, company));
+        }
+
+        // Oldest first under a per-cycle cap: a submissions-JSON stall must not
+        // turn every recently flagged filer into one simultaneous
+        // re-enumeration storm against an already-degraded EDGAR.
+        foreach (
+            var (key, pending, company) in due.OrderBy(d => d.Pending.FirstSeenAtUtc)
+                .Take(_options.MaxPendingReflagsPerCycle)
+        )
+        {
+            pending.LastRetriedAtUtc = utcNow;
+            pending.RetryCount++;
+            dirty[company.Id] = company;
+
+            // Expected-path event (the JSON routinely lags acceptance), so
+            // Information — the warnings-only file sink stays reserved for the
+            // abandonment above.
+            if (!pending.RetryLogged)
+            {
+                pending.RetryLogged = true;
+                _logger.LogInformation(
+                    "Filing {PendingKey} for {Ticker} was feed-flagged {Minutes:F0} minutes ago but is not yet enumerable in the submissions JSON — keeping the company flagged for re-enumeration",
+                    key,
+                    company.Ticker,
+                    (utcNow - pending.FirstSeenAtUtc).TotalMinutes
+                );
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Re-flagging {Ticker} for pending feed accession {PendingKey}",
+                    company.Ticker,
+                    key
+                );
+            }
+        }
     }
 
     /// <summary>
@@ -125,8 +277,31 @@ public class FilingDiscoveryService : IFilingDiscoveryService
                 if (!syncedForms.Contains(entry.FormType))
                     continue;
 
-                if (TryResolveCompany(cikToCompany, entry.Cik, out var company))
-                    dirty[company.Id] = company;
+                if (
+                    !long.TryParse(entry.Cik, out var numericCik)
+                    || !cikToCompany.TryGetValue(numericCik, out var company)
+                )
+                    continue;
+
+                dirty[company.Id] = company;
+
+                // Track the accession until the company's enumeration confirms
+                // it under this CIK — the submissions JSON may not list it yet
+                // (see ReflagPendingAccessions). LastRetriedAtUtc starts now:
+                // the company is already dirty this cycle, so the first re-flag
+                // waits a full retry interval.
+                if (!string.IsNullOrEmpty(entry.AccessionNumber))
+                {
+                    PendingFeedAccessions.TryAdd(
+                        PendingKey(entry.AccessionNumber, numericCik),
+                        new PendingFeedAccession
+                        {
+                            Cik = numericCik,
+                            FirstSeenAtUtc = utcNow,
+                            LastRetriedAtUtc = utcNow,
+                        }
+                    );
+                }
             }
 
             // Overlap with the previous poll (or a short page) means the window
@@ -335,5 +510,6 @@ public class FilingDiscoveryService : IFilingDiscoveryService
     {
         _lastFeedPollAtUtc = default;
         SeenFeedEntries.Clear();
+        PendingFeedAccessions.Clear();
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/IFilingDiscoveryService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IFilingDiscoveryService.cs
@@ -17,4 +17,22 @@ public interface IFilingDiscoveryService
         IReadOnlyList<CommonStock> trackedCompanies,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// True while any feed-flagged filing awaits confirmation by a company
+    /// enumeration — the scraper only collects enumerated accessions for
+    /// <see cref="MarkAccessionsEnumerated"/> when this is set.
+    /// </summary>
+    bool HasPendingFeedAccessions { get; }
+
+    /// <summary>
+    /// Reports the (accession, filer CIK) pairs a company enumeration actually
+    /// returned, confirming any feed-flagged filings still pending under that
+    /// CIK. A filing the feed flagged but the (lagging) submissions JSON hasn't
+    /// listed yet stays pending and keeps its company in the discovery set
+    /// until confirmed here or abandoned (retry/expiry bounds).
+    /// </summary>
+    void MarkAccessionsEnumerated(
+        IReadOnlyCollection<(string AccessionNumber, string Cik)> enumeratedFilings
+    );
 }

--- a/src/Equibles.Sec.HostedService/Services/PendingFeedAccession.cs
+++ b/src/Equibles.Sec.HostedService/Services/PendingFeedAccession.cs
@@ -1,0 +1,22 @@
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Cross-cycle memo for a filing the realtime feed flagged but the company's
+/// submissions enumeration hasn't confirmed yet — the submissions JSON lags
+/// acceptance, so the first enumeration after a flag can legitimately miss the
+/// filing (see <see cref="FilingDiscoveryService"/>).
+/// </summary>
+internal sealed class PendingFeedAccession
+{
+    public long Cik { get; set; }
+
+    public DateTime FirstSeenAtUtc { get; set; }
+
+    public DateTime LastRetriedAtUtc { get; set; }
+
+    /// <summary>How many times the company was re-dirtied for this filing.</summary>
+    public int RetryCount { get; set; }
+
+    /// <summary>Whether the one-time "not yet enumerable" notice fired.</summary>
+    public bool RetryLogged { get; set; }
+}

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperEnumeratedAccessionReportingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperEnumeratedAccessionReportingTests.cs
@@ -1,0 +1,241 @@
+using System.Reflection;
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Media.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins that <c>DocumentScraper.ProcessCompanyDocumentsWithScope</c> reports
+/// every accession the enumeration returned — including already-ingested ones
+/// — to <c>IFilingDiscoveryService.MarkAccessionsEnumerated</c>. That report is
+/// what releases a pending feed-flagged filing from the discovery retry
+/// ledger; skipping it would keep re-enumerating the company forever.
+/// </summary>
+public class DocumentScraperEnumeratedAccessionReportingTests
+{
+    private readonly ISecEdgarClient _secEdgarClient = Substitute.For<ISecEdgarClient>();
+    private readonly IDocumentPersistenceService _persistence =
+        Substitute.For<IDocumentPersistenceService>();
+    private readonly IFilingDiscoveryService _discovery = Substitute.For<IFilingDiscoveryService>();
+
+    private static EquiblesFinancialDbContext NewDbContext()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new DocumentOnlyModuleConfiguration(),
+                new MediaModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private DocumentScraper BuildScraper(
+        EquiblesFinancialDbContext dbContext,
+        DocumentScraperOptions options
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(dbContext);
+        services.AddScoped<CommonStockRepository>();
+        services.AddScoped<DocumentRepository>();
+        services.AddSingleton(Substitute.For<IBus>());
+        services.AddScoped<CommonStockManager>();
+        services.AddSingleton(_secEdgarClient);
+        services.AddSingleton(_persistence);
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        return new DocumentScraper(
+            scopeFactory,
+            Substitute.For<ICompanySyncService>(),
+            _discovery,
+            new List<IFilingProcessor>(),
+            Options.Create(options),
+            Options.Create(new WorkerOptions()),
+            Substitute.For<ILogger<DocumentScraper>>(),
+            new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>())
+        );
+    }
+
+    private static CommonStock SeedCompany(EquiblesFinancialDbContext db)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "EBS",
+            Name = "Emergent BioSolutions Inc.",
+            Cik = "1367644",
+        };
+        db.Set<CommonStock>().Add(stock);
+        db.SaveChanges();
+        return stock;
+    }
+
+    private static Task InvokeProcess(
+        DocumentScraper scraper,
+        CommonStock company,
+        ScrapingResult result
+    )
+    {
+        var m = typeof(DocumentScraper).GetMethod(
+            "ProcessCompanyDocumentsWithScope",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        return (Task)m.Invoke(scraper, [company, result]);
+    }
+
+    [Fact]
+    public async Task ProcessCompanyDocumentsWithScope_ReportsEnumeratedAccessions_EvenWhenAlreadyIngested()
+    {
+        using var db = NewDbContext();
+        var company = SeedCompany(db);
+        const string newAccession = "0001367644-26-000080";
+        const string knownAccession = "0001367644-26-000070";
+
+        _discovery.HasPendingFeedAccessions.Returns(true);
+        _secEdgarClient
+            .GetCompanyFilings(
+                Arg.Any<string>(),
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            )
+            .Returns([
+                new FilingData
+                {
+                    AccessionNumber = newAccession,
+                    Cik = "1367644",
+                    Form = "8-K",
+                },
+                new FilingData
+                {
+                    AccessionNumber = knownAccession,
+                    Cik = "1367644",
+                    Form = "8-K",
+                },
+            ]);
+        // Both filings already ingested: the report must still carry them, since
+        // "enumeration saw it" — not "ingest succeeded" — releases the pending
+        // retry in discovery.
+        _persistence
+            .GetKnownFilingKeys(
+                Arg.Any<CommonStock>(),
+                Arg.Any<DocumentType>(),
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(
+                (
+                    new HashSet<string> { newAccession, knownAccession },
+                    new HashSet<(DateOnly, DateOnly)>()
+                )
+            );
+
+        var scraper = BuildScraper(
+            db,
+            new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.EightK] }
+        );
+
+        await InvokeProcess(scraper, company, new ScrapingResult());
+
+        _discovery
+            .Received(1)
+            .MarkAccessionsEnumerated(
+                Arg.Is<IReadOnlyCollection<(string AccessionNumber, string Cik)>>(a =>
+                    a.Any(p => p.AccessionNumber == newAccession && p.Cik == "1367644")
+                    && a.Any(p => p.AccessionNumber == knownAccession && p.Cik == "1367644")
+                )
+            );
+    }
+
+    [Fact]
+    public async Task ProcessCompanyDocumentsWithScope_EnumerationFailure_ReportsNothingForThatType()
+    {
+        using var db = NewDbContext();
+        var company = SeedCompany(db);
+
+        _discovery.HasPendingFeedAccessions.Returns(true);
+        // A dead enumeration must not report accessions it never saw — the
+        // pending entry has to survive so the company is retried.
+        _secEdgarClient
+            .GetCompanyFilings(
+                Arg.Any<string>(),
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            )
+            .Returns<Task<List<FilingData>>>(_ => throw new HttpRequestException("edgar down"));
+
+        var scraper = BuildScraper(
+            db,
+            new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.EightK] }
+        );
+
+        await InvokeProcess(scraper, company, new ScrapingResult());
+
+        _discovery
+            .Received(1)
+            .MarkAccessionsEnumerated(
+                Arg.Is<IReadOnlyCollection<(string AccessionNumber, string Cik)>>(a => a.Count == 0)
+            );
+    }
+
+    [Fact]
+    public async Task ProcessCompanyDocumentsWithScope_NothingPending_SkipsCollectionAndReport()
+    {
+        using var db = NewDbContext();
+        var company = SeedCompany(db);
+
+        _discovery.HasPendingFeedAccessions.Returns(false);
+        _secEdgarClient
+            .GetCompanyFilings(
+                Arg.Any<string>(),
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            )
+            .Returns([]);
+
+        var scraper = BuildScraper(
+            db,
+            new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.EightK] }
+        );
+
+        await InvokeProcess(scraper, company, new ScrapingResult());
+
+        _discovery
+            .DidNotReceive()
+            .MarkAccessionsEnumerated(
+                Arg.Any<IReadOnlyCollection<(string AccessionNumber, string Cik)>>()
+            );
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperProcessDocTypeCatchTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperProcessDocTypeCatchTests.cs
@@ -76,6 +76,7 @@ public class DocumentScraperProcessDocTypeCatchTests
                     result,
                     secEdgarClient,
                     Substitute.For<IDocumentPersistenceService>(),
+                    null,
                 ]
             );
 

--- a/tests/Equibles.UnitTests/Sec/FilingDiscoveryServiceDiscoveryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FilingDiscoveryServiceDiscoveryTests.cs
@@ -23,6 +23,9 @@ namespace Equibles.UnitTests.Sec;
 /// client's prefix-matched rows with an exact form comparison so "4" cannot
 /// dirty a 424B2 filer.
 /// </summary>
+// Shares FilingDiscoveryService's cross-cycle statics with the pending-accession
+// suite; serialize them so one class's reset can't land mid-test in the other.
+[Collection("SecFilingDiscoveryStatics")]
 public class FilingDiscoveryServiceDiscoveryTests
 {
     private static readonly DateOnly LatestFinalDay = FilingDiscoveryService.LatestFinalIndexDay(

--- a/tests/Equibles.UnitTests/Sec/FilingDiscoveryServicePendingAccessionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FilingDiscoveryServicePendingAccessionTests.cs
@@ -1,0 +1,259 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the pending-accession retry contract: a filing the realtime feed
+/// flagged stays pending until the company's submissions enumeration confirms
+/// its accession under that CIK (the submissions JSON lags acceptance, so the
+/// enumeration run right after the flag can miss it — the EBS after-the-bell
+/// 8-K case, where the company was enumerated 91 seconds after acceptance,
+/// found nothing, and the filing silently waited ~14h for the daily index).
+/// While pending, the company is re-dirtied at most once per retry interval
+/// and at most the configured retry count, confirmation removes the entry per
+/// CIK, expiry abandons it to the daily-index backstop, a filer that leaves
+/// the tracked universe is dropped, and a failed feed poll does not stop the
+/// retries.
+/// </summary>
+[Collection("SecFilingDiscoveryStatics")]
+public class FilingDiscoveryServicePendingAccessionTests
+{
+    private const string Accession = "0001367644-26-000080";
+
+    private sealed class BackfillStateOnlyModuleConfiguration : IModuleConfiguration
+    {
+        public void ConfigureEntities(ModelBuilder builder)
+        {
+            builder.Entity<BackfillState>();
+        }
+    }
+
+    private static EquiblesFinancialDbContext CreateContext() =>
+        new(
+            new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .EnableServiceProviderCaching(false)
+                .Options,
+            new IModuleConfiguration[] { new BackfillStateOnlyModuleConfiguration() }
+        );
+
+    private static FilingDiscoveryService CreateService(
+        ISecEdgarClient secEdgarClient,
+        EquiblesFinancialDbContext context,
+        DocumentScraperOptions options
+    ) =>
+        new(
+            secEdgarClient,
+            new BackfillStateRepository(context),
+            Options.Create(options),
+            Substitute.For<ILogger<FilingDiscoveryService>>()
+        );
+
+    // Every poll may run (no feed throttle) so consecutive Discover calls model
+    // consecutive scrape cycles; the retry gate is what each test varies.
+    private static DocumentScraperOptions OptionsWithRetryGate(int retrySeconds) =>
+        new() { RecentFeedPollSeconds = 0, FeedPendingRetrySeconds = retrySeconds };
+
+    private static CommonStock Tracked(string ticker, string cik) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Cik = cik,
+        };
+
+    private static ISecEdgarClient ClientWithFeed(params EdgarRecentFilingEntry[] entries)
+    {
+        var client = Substitute.For<ISecEdgarClient>();
+        client
+            .GetRecentFilings(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([.. entries]);
+        client
+            .GetDailyIndexForForms(
+                Arg.Any<DateOnly>(),
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+        return client;
+    }
+
+    private static EdgarRecentFilingEntry EbsEightK() =>
+        new()
+        {
+            Cik = "0001367644",
+            FormType = "8-K",
+            AccessionNumber = Accession,
+        };
+
+    public FilingDiscoveryServicePendingAccessionTests()
+    {
+        FilingDiscoveryService.ResetCrossCycleStateForTests();
+    }
+
+    [Fact]
+    public async Task UnconfirmedFeedAccession_RedirtiesCompanyOnLaterPass()
+    {
+        await using var context = CreateContext();
+        var company = Tracked("EBS", "1367644");
+        var service = CreateService(ClientWithFeed(EbsEightK()), context, OptionsWithRetryGate(0));
+
+        var firstPass = await service.DiscoverCompaniesWithNewFilings([company]);
+        // Second pass: the feed entry is already seen, so only the pending
+        // ledger can dirty the company again.
+        var secondPass = await service.DiscoverCompaniesWithNewFilings([company]);
+
+        firstPass.Should().ContainSingle().Which.Should().BeSameAs(company);
+        secondPass.Should().ContainSingle().Which.Should().BeSameAs(company);
+    }
+
+    [Fact]
+    public async Task ConfirmedFeedAccession_IsNotReflagged()
+    {
+        await using var context = CreateContext();
+        var company = Tracked("EBS", "1367644");
+        var service = CreateService(ClientWithFeed(EbsEightK()), context, OptionsWithRetryGate(0));
+
+        await service.DiscoverCompaniesWithNewFilings([company]);
+        // The bare CIK the enumeration reports matches the feed's padded one
+        // numerically.
+        service.MarkAccessionsEnumerated([(Accession, "1367644")]);
+        var secondPass = await service.DiscoverCompaniesWithNewFilings([company]);
+
+        secondPass.Should().BeEmpty("the enumeration confirmed the accession");
+    }
+
+    [Fact]
+    public async Task ConfirmationUnderAnotherCik_DoesNotReleaseThisCompany()
+    {
+        await using var context = CreateContext();
+        var issuer = Tracked("EBS", "1367644");
+        var owner = Tracked("HOLD", "2000001");
+        // The same accession appears once per associated entity, each with its
+        // own CIK — confirming one side must not release the other.
+        var ownerSideEntry = new EdgarRecentFilingEntry
+        {
+            Cik = "0002000001",
+            FormType = "8-K",
+            AccessionNumber = Accession,
+        };
+        var service = CreateService(
+            ClientWithFeed(EbsEightK(), ownerSideEntry),
+            context,
+            OptionsWithRetryGate(0)
+        );
+
+        await service.DiscoverCompaniesWithNewFilings([issuer, owner]);
+        service.MarkAccessionsEnumerated([(Accession, "1367644")]);
+        var secondPass = await service.DiscoverCompaniesWithNewFilings([issuer, owner]);
+
+        secondPass
+            .Should()
+            .ContainSingle("only the issuer's side was confirmed")
+            .Which.Should()
+            .BeSameAs(owner);
+    }
+
+    [Fact]
+    public async Task UnconfirmedFeedAccession_InsideRetryGate_IsNotReflagged()
+    {
+        await using var context = CreateContext();
+        var company = Tracked("EBS", "1367644");
+        // Real-sized gate: an immediate next pass must not burn an extra
+        // enumeration on a filing flagged seconds ago.
+        var service = CreateService(
+            ClientWithFeed(EbsEightK()),
+            context,
+            OptionsWithRetryGate(retrySeconds: 300)
+        );
+
+        await service.DiscoverCompaniesWithNewFilings([company]);
+        var secondPass = await service.DiscoverCompaniesWithNewFilings([company]);
+
+        secondPass.Should().BeEmpty("the retry interval has not elapsed");
+    }
+
+    [Fact]
+    public async Task UnconfirmedFeedAccession_RetriesExhausted_IsAbandoned()
+    {
+        await using var context = CreateContext();
+        var company = Tracked("EBS", "1367644");
+        var options = OptionsWithRetryGate(0);
+        options.FeedPendingMaxRetries = 1;
+        var service = CreateService(ClientWithFeed(EbsEightK()), context, options);
+
+        var flagPass = await service.DiscoverCompaniesWithNewFilings([company]);
+        var retryPass = await service.DiscoverCompaniesWithNewFilings([company]);
+        var abandonedPass = await service.DiscoverCompaniesWithNewFilings([company]);
+
+        flagPass.Should().ContainSingle("the feed flag dirties the company");
+        retryPass.Should().ContainSingle("the single allowed retry runs");
+        abandonedPass.Should().BeEmpty("the retry budget is spent");
+    }
+
+    [Fact]
+    public async Task ExpiredFeedAccession_IsAbandoned()
+    {
+        await using var context = CreateContext();
+        var company = Tracked("EBS", "1367644");
+        var options = OptionsWithRetryGate(0);
+        // Negative expiry makes every pending entry instantly stale without
+        // needing a clock seam.
+        options.FeedPendingExpiryMinutes = -1;
+        var service = CreateService(ClientWithFeed(EbsEightK()), context, options);
+
+        var firstPass = await service.DiscoverCompaniesWithNewFilings([company]);
+        var secondPass = await service.DiscoverCompaniesWithNewFilings([company]);
+
+        firstPass.Should().ContainSingle("the feed flag itself still dirties the company");
+        secondPass.Should().BeEmpty("the expired entry is dropped for the daily index to backstop");
+    }
+
+    [Fact]
+    public async Task PendingAccessionForUntrackedCompany_IsDropped()
+    {
+        await using var context = CreateContext();
+        var company = Tracked("EBS", "1367644");
+        var service = CreateService(ClientWithFeed(EbsEightK()), context, OptionsWithRetryGate(0));
+
+        await service.DiscoverCompaniesWithNewFilings([company]);
+        // The filer leaves the tracked universe: its pending entry is removed,
+        // so re-tracking it later must not resurrect the retry.
+        var withoutCompany = await service.DiscoverCompaniesWithNewFilings([]);
+        var trackedAgain = await service.DiscoverCompaniesWithNewFilings([company]);
+
+        withoutCompany.Should().BeEmpty();
+        trackedAgain.Should().BeEmpty("the pending entry was dropped with the company");
+    }
+
+    [Fact]
+    public async Task FailedFeedPoll_DoesNotStopPendingRetries()
+    {
+        await using var context = CreateContext();
+        var company = Tracked("EBS", "1367644");
+        var client = ClientWithFeed(EbsEightK());
+        var service = CreateService(client, context, OptionsWithRetryGate(0));
+
+        await service.DiscoverCompaniesWithNewFilings([company]);
+        // The feed layer is best-effort; the pending ledger must keep retrying
+        // even when the next poll dies.
+        client
+            .GetRecentFilings(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("feed down"));
+        var secondPass = await service.DiscoverCompaniesWithNewFilings([company]);
+
+        secondPass.Should().ContainSingle().Which.Should().BeSameAs(company);
+    }
+}


### PR DESCRIPTION
## Summary
The realtime "Latest Filings" ATOM feed flags a new filing within ~60s of acceptance, but the data.sec.gov submissions JSON is CDN-served and lags acceptance by minutes. A company enumerated inside that lag window finds nothing, gets stamped as synced, and its feed entry stays in the 12h seen-dedup — so the filing silently waits ~14h for the next-morning daily-index backstop. Production case: Emergent BioSolutions' after-the-bell Q2 earnings 8-K (accepted 16:06 ET) — the company was enumerated 91 seconds after acceptance, nothing was ingested, and nothing was logged.

This adds a pending-accession ledger to the discovery service: feed-flagged accessions stay pending (keyed accession|CIK, mirroring the seen-dedup's two-sided keying) and keep re-dirtying their company until the enumeration reports the accession under that CIK. Satisfaction means "enumeration saw it", not "ingest succeeded" — ingest failures remain owned by the tombstone/deferred-retry/reconciliation paths.

Retries are bounded three ways: a per-accession interval (`FeedPendingRetrySeconds`, 120s), an attempt cap (`FeedPendingMaxRetries`, 10), and a per-cycle oldest-first admission cap (`MaxPendingReflagsPerCycle`, 50) so a submissions-JSON stall cannot become a simultaneous re-enumeration storm. Abandonment (`FeedPendingExpiryMinutes`, 360, or retries exhausted) logs a warning — the previously silent skip is now observable in the warnings-only file sink.

## Code changes
- `FilingDiscoveryService` — pending ledger + capped oldest-first re-flag pass + `MarkAccessionsEnumerated`/`HasPendingFeedAccessions`; single clock capture per discovery pass so a slow multi-page poll can't make freshly seeded entries look retry-due.
- `IFilingDiscoveryService` — the two new members.
- `DocumentScraper` — collects (accession, filer CIK) pairs per enumeration (only while something is pending) and reports them after the per-type loop.
- `DocumentScraperOptions` — the four new knobs.
- `PendingFeedAccession` — the ledger entry.
- Tests: 8-case pending-ledger suite + 3-case scraper reporting suite; the two discovery test classes now share an xUnit collection because they mutate the service's cross-cycle statics (parallel classes raced each other's resets).

Full unit suite: 4025/4025 green (run twice for the parallelism fix), csharpier clean.