### PR TITLE
fix(yahoo): keep a chart response when one price value is unrepresentable

### DIFF
--- a/src/Equibles.Integrations.Yahoo/Models/Responses/TolerantDecimalListConverter.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/TolerantDecimalListConverter.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json.Linq;
+
+namespace Equibles.Integrations.Yahoo.Models.Responses;
+
+/// <summary>
+/// Price arrays. A magnitude outside <see cref="decimal"/> becomes null rather than aborting
+/// the response — see <see cref="TolerantNumberListConverter{T}"/> for why that matters.
+/// </summary>
+public class TolerantDecimalListConverter : TolerantNumberListConverter<decimal>
+{
+    // decimal tops out around 7.9E28. Compared as a double because that is what the reader
+    // hands us; the bound is deliberately exclusive-safe rather than exact, since a value
+    // within rounding distance of the ceiling is not a real price either.
+    private const double MaxDecimal = 7.9e28;
+
+    protected override decimal? Convert(JToken element)
+    {
+        var value = AsDouble(element);
+        if (value == null || !double.IsFinite(value.Value) || Math.Abs(value.Value) > MaxDecimal)
+            return null;
+        return (decimal)value.Value;
+    }
+}

--- a/src/Equibles.Integrations.Yahoo/Models/Responses/TolerantLongListConverter.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/TolerantLongListConverter.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json.Linq;
+
+namespace Equibles.Integrations.Yahoo.Models.Responses;
+
+/// <summary>
+/// Volume arrays. Same contract as <see cref="TolerantDecimalListConverter"/>: an impossible
+/// magnitude degrades to null (read downstream as "no volume reported") instead of costing the
+/// listing its whole response.
+/// </summary>
+public class TolerantLongListConverter : TolerantNumberListConverter<long>
+{
+    protected override long? Convert(JToken element)
+    {
+        var value = AsDouble(element);
+        if (
+            value == null
+            || !double.IsFinite(value.Value)
+            || value.Value > long.MaxValue
+            || value.Value < long.MinValue
+        )
+            return null;
+        return (long)value.Value;
+    }
+}

--- a/src/Equibles.Integrations.Yahoo/Models/Responses/TolerantNumberListConverter.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/TolerantNumberListConverter.cs
@@ -1,0 +1,96 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Equibles.Integrations.Yahoo.Models.Responses;
+
+/// <summary>
+/// Reads a chart price/volume array, mapping any element the CLR type cannot represent to
+/// null instead of throwing.
+///
+/// The feed occasionally publishes a nonsense magnitude for a single field of a single
+/// listing — an <c>adjclose</c> of <c>1.2036464262466904E35</c> was served for one ADR every
+/// pass from 2026-08-05. That exceeds <see cref="decimal.MaxValue"/> (~7.9E28), so the default
+/// binding threw mid-parse and Newtonsoft abandoned the WHOLE chart response: the listing lost
+/// its open/high/low/close/volume too, though every one of those was valid, and it re-failed
+/// identically on every later cycle because the upstream value never self-corrects.
+///
+/// A null element already means "unavailable" everywhere downstream — the row builder treats
+/// a missing adjusted close as a fall-back to the day's close, and rejects a row whose OHLC
+/// is incomplete. So degrading one impossible field to null keeps the rest of the response,
+/// and keeps a single poisoned value from costing a listing its entire history.
+/// </summary>
+public abstract class TolerantNumberListConverter<T> : JsonConverter<List<T?>>
+    where T : struct
+{
+    public override List<T?> ReadJson(
+        JsonReader reader,
+        Type objectType,
+        List<T?> existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer
+    )
+    {
+        var token = JToken.Load(reader);
+        if (token.Type != JTokenType.Array)
+            return [];
+
+        var values = new List<T?>();
+        foreach (var element in token.Children())
+            values.Add(Convert(element));
+        return values;
+    }
+
+    public override void WriteJson(JsonWriter writer, List<T?> value, JsonSerializer serializer)
+    {
+        writer.WriteStartArray();
+        foreach (var item in value ?? [])
+        {
+            if (item.HasValue)
+                writer.WriteValue(item.Value);
+            else
+                writer.WriteNull();
+        }
+        writer.WriteEndArray();
+    }
+
+    /// <summary>
+    /// The element's value, or null when it is absent, non-numeric, or outside what
+    /// <typeparamref name="T"/> can hold.
+    /// </summary>
+    protected abstract T? Convert(JToken element);
+
+    /// <summary>
+    /// The element read as a double — the widest type the JSON reader parses a float into, so
+    /// an out-of-range magnitude arrives here as a finite-or-infinite double rather than an
+    /// exception. Null for a JSON null, a non-numeric token, or an unparseable string.
+    /// </summary>
+    protected static double? AsDouble(JToken element)
+    {
+        switch (element.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                try
+                {
+                    return element.Value<double>();
+                }
+                catch (OverflowException)
+                {
+                    // An integer literal too large even for double (the feed has never sent
+                    // one, but the array is attacker-shaped data from our side of the wire).
+                    return null;
+                }
+            case JTokenType.String:
+                return double.TryParse(
+                    (string)element,
+                    System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var parsed
+                )
+                    ? parsed
+                    : null;
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
@@ -89,26 +89,34 @@ public class ChartIndicators
     public List<ChartAdjClose> AdjClose { get; set; } = [];
 }
 
+// Every price/volume array is read tolerantly: one element the CLR type cannot hold must not
+// discard the whole response. See TolerantNumberListConverter for the incident behind it.
 public class ChartQuote
 {
     [JsonProperty("open")]
+    [JsonConverter(typeof(TolerantDecimalListConverter))]
     public List<decimal?> Open { get; set; } = [];
 
     [JsonProperty("high")]
+    [JsonConverter(typeof(TolerantDecimalListConverter))]
     public List<decimal?> High { get; set; } = [];
 
     [JsonProperty("low")]
+    [JsonConverter(typeof(TolerantDecimalListConverter))]
     public List<decimal?> Low { get; set; } = [];
 
     [JsonProperty("close")]
+    [JsonConverter(typeof(TolerantDecimalListConverter))]
     public List<decimal?> Close { get; set; } = [];
 
     [JsonProperty("volume")]
+    [JsonConverter(typeof(TolerantLongListConverter))]
     public List<long?> Volume { get; set; } = [];
 }
 
 public class ChartAdjClose
 {
     [JsonProperty("adjclose")]
+    [JsonConverter(typeof(TolerantDecimalListConverter))]
     public List<decimal?> AdjustedClose { get; set; } = [];
 }

--- a/tests/Equibles.UnitTests/Yahoo/YahooChartTolerantNumberParsingTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooChartTolerantNumberParsingTests.cs
@@ -1,0 +1,138 @@
+using Equibles.Integrations.Yahoo.Models.Responses;
+using Newtonsoft.Json;
+
+namespace Equibles.UnitTests.Yahoo;
+
+// A single impossible number must cost that one field, never the whole response.
+//
+// Production incident (2026-08-05 onwards): the feed served an adjusted close of
+// 1.2036464262466904E35 for one ADR listing. decimal tops out near 7.9E28, so binding threw
+// mid-parse and the listing lost its open/high/low/close/volume as well — every one of which
+// was valid — on every cycle, because the upstream value never self-corrects.
+public class YahooChartTolerantNumberParsingTests
+{
+    // The exact shape and value logged in production, trimmed to one row.
+    private const string PoisonedAdjCloseJson = """
+        {
+          "chart": {
+            "result": [{
+              "timestamp": [1585569600],
+              "indicators": {
+                "quote": [{
+                  "open": [130.25],
+                  "high": [137.98],
+                  "low": [129.89],
+                  "close": [137.06],
+                  "volume": [5765400]
+                }],
+                "adjclose": [{
+                  "adjclose": [1.2036464262466904E35]
+                }]
+              }
+            }],
+            "error": null
+          }
+        }
+        """;
+
+    [Fact]
+    public void Deserialize_AdjustedCloseBeyondDecimal_DoesNotThrow()
+    {
+        var parse = () => JsonConvert.DeserializeObject<YahooChartResponse>(PoisonedAdjCloseJson);
+
+        parse.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Deserialize_AdjustedCloseBeyondDecimal_YieldsNullForThatFieldOnly()
+    {
+        var response = JsonConvert.DeserializeObject<YahooChartResponse>(PoisonedAdjCloseJson);
+
+        var result = response.Chart.Result[0];
+        result.Indicators.AdjClose[0].AdjustedClose[0].Should().BeNull();
+
+        // The whole point: the rest of the bar survives.
+        var quote = result.Indicators.Quote[0];
+        quote.Open[0].Should().Be(130.25m);
+        quote.High[0].Should().Be(137.98m);
+        quote.Low[0].Should().Be(129.89m);
+        quote.Close[0].Should().Be(137.06m);
+        quote.Volume[0].Should().Be(5765400);
+    }
+
+    [Theory]
+    [InlineData("1.2036464262466904E35")] // the production value
+    [InlineData("-1.2036464262466904E35")] // same magnitude, negative
+    [InlineData("1E308")] // near double's ceiling
+    [InlineData("\"not-a-number\"")] // a string where a number belongs
+    [InlineData("true")] // a wholly wrong token type
+    public void Deserialize_UnrepresentablePrice_BecomesNull(string literal)
+    {
+        var json = $$"""
+            { "chart": { "result": [{ "indicators": {
+              "quote": [{ "close": [{{literal}}] }] } }] } }
+            """;
+
+        var response = JsonConvert.DeserializeObject<YahooChartResponse>(json);
+
+        response.Chart.Result[0].Indicators.Quote[0].Close[0].Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserialize_VolumeBeyondLong_BecomesNull()
+    {
+        var json = """
+            { "chart": { "result": [{ "indicators": {
+              "quote": [{ "volume": [1.2036464262466904E35] }] } }] } }
+            """;
+
+        var response = JsonConvert.DeserializeObject<YahooChartResponse>(json);
+
+        response.Chart.Result[0].Indicators.Quote[0].Volume[0].Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserialize_NullHoles_StayNull()
+    {
+        // A holiday-edge row: the tolerant read must not turn a legitimate null into a zero.
+        var json = """
+            { "chart": { "result": [{ "indicators": {
+              "quote": [{ "close": [137.06, null, 138.50] }] } }] } }
+            """;
+
+        var response = JsonConvert.DeserializeObject<YahooChartResponse>(json);
+
+        var close = response.Chart.Result[0].Indicators.Quote[0].Close;
+        close.Should().HaveCount(3);
+        close[0].Should().Be(137.06m);
+        close[1].Should().BeNull();
+        close[2].Should().Be(138.50m);
+    }
+
+    [Fact]
+    public void Deserialize_OrdinaryPrices_KeepFourDecimalPrecision()
+    {
+        // Guards the tolerant path against silently coarsening real values.
+        var json = """
+            { "chart": { "result": [{ "indicators": {
+              "quote": [{ "close": [0.0001, 1234.5678, 137.05999755859375] }] } }] } }
+            """;
+
+        var response = JsonConvert.DeserializeObject<YahooChartResponse>(json);
+
+        var close = response.Chart.Result[0].Indicators.Quote[0].Close;
+        close[0].Should().Be(0.0001m);
+        close[1].Should().Be(1234.5678m);
+        Math.Round(close[2].Value, 4).Should().Be(137.06m);
+    }
+
+    [Fact]
+    public void Deserialize_MissingArray_IsEmptyNotNull()
+    {
+        var json = """{ "chart": { "result": [{ "indicators": { "quote": [{}] } }] } }""";
+
+        var response = JsonConvert.DeserializeObject<YahooChartResponse>(json);
+
+        response.Chart.Result[0].Indicators.Quote[0].Close.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

One listing has been failing its price import on every pass since 2026-08-05, with 10 errors logged:

```
Input string '1.2036464262466904E35' is not a valid decimal.
Path 'chart.result[0].indicators.adjclose[0].adjclose[0]'
```

The feed publishes a nonsense adjusted close for that listing. `1.2E35` exceeds `decimal.MaxValue` (~7.9E28), so binding threw mid-parse and Newtonsoft abandoned the **whole** chart response — the listing lost its open, high, low, close and volume as well, though every one of those was valid. The upstream value drifts slightly between calls but never self-corrects, so it re-failed identically forever and that listing stayed permanently without prices.

The defect is ours: one poisoned field should not discard an entire otherwise-valid response.

## Code changes

- **`TolerantNumberListConverter<T>`** (new) — reads a chart price/volume array element by element, mapping anything the CLR type cannot represent to `null` instead of throwing. Values arrive as `double` (the widest type the reader parses a float into), so an out-of-range magnitude reaches the converter as a number rather than an exception.
- **`TolerantDecimalListConverter` / `TolerantLongListConverter`** (new) — the `decimal` and `long` bounds checks.
- **`YahooChartResponse.cs`** — applies the converters to all five price arrays plus volume, not just the field that happened to break, since the same class of failure applies to each.

A `null` element already means "unavailable" throughout the row builder: a missing adjusted close falls back to the day's close (`YahooFinanceClient.cs:260-266`), and a row with incomplete OHLC is rejected. So degrading one impossible field to `null` lands on well-trodden behaviour.

## Tests

`YahooChartTolerantNumberParsingTests` — 11 cases built on the exact production payload: the poisoned value parses without throwing, yields `null` for that field only while every other field of the bar survives, and the same holds for negative magnitudes, near-`double`-ceiling values, wrong token types, and an out-of-range volume. Legitimate `null` holes stay `null` (never coerced to zero) and ordinary four-decimal precision is preserved.

Mutation-verified: removing the converter from `adjclose` fails exactly the two tests that replay the production payload.

4,036 unit tests pass; `csharpier check .` clean across 3,258 files.