### PR TITLE
fix(finra): cache the short-squeeze universe in the MCP tool

### DIFF
--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -52,6 +52,21 @@ namespace Equibles.Finra.BusinessLogic;
 [Service]
 public class ShortSqueezeScoreManager
 {
+    /// <summary>
+    /// Cache identity for the computed universe, owned here so every read-side
+    /// surface that caches <see cref="Compute"/> shares ONE entry per process —
+    /// the MCP tool reads through it, and a host may refresh the same key in the
+    /// background so interactive callers never pay the whole-universe computation.
+    /// </summary>
+    public const string UniverseCacheKey = "short-squeeze-scores";
+
+    /// <summary>
+    /// How long a cached universe stays valid. Short interest refreshes
+    /// bi-monthly and the daily inputs settle overnight, so an hour of staleness
+    /// is invisible next to the data's own cadence.
+    /// </summary>
+    public static readonly TimeSpan UniverseCacheDuration = TimeSpan.FromHours(1);
+
     /// <summary>Each trend window pools two calendar weeks of daily short-volume rows.</summary>
     public const int TrendWindowDays = 14;
 

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -57,6 +57,8 @@ public class ShortSqueezeScoreManager
     /// surface that caches <see cref="Compute"/> shares ONE entry per process —
     /// the MCP tool reads through it, and a host may refresh the same key in the
     /// background so interactive callers never pay the whole-universe computation.
+    /// The cached list is handed to concurrent readers: treat it as immutable —
+    /// filter or sort into a copy, never in place.
     /// </summary>
     public const string UniverseCacheKey = "short-squeeze-scores";
 

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -14,8 +14,10 @@ using Equibles.Finra.BusinessLogic.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Repositories;
 using Equibles.Mcp;
+using Equibles.Mcp.Extensions;
 using Equibles.Mcp.Helpers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -34,6 +36,7 @@ public class ShortDataTools
     private readonly CommonStockRepository _commonStockRepository;
     private readonly ShortSqueezeScoreManager _shortSqueezeScoreManager;
     private readonly StockSplitRepository _stockSplitRepository;
+    private readonly IMemoryCache _memoryCache;
     private readonly McpToolRunner _runner;
 
     public ShortDataTools(
@@ -42,6 +45,7 @@ public class ShortDataTools
         CommonStockRepository commonStockRepository,
         ShortSqueezeScoreManager shortSqueezeScoreManager,
         StockSplitRepository stockSplitRepository,
+        IMemoryCache memoryCache,
         ErrorManager errorManager,
         ILogger<ShortDataTools> logger
     )
@@ -51,6 +55,7 @@ public class ShortDataTools
         _commonStockRepository = commonStockRepository;
         _shortSqueezeScoreManager = shortSqueezeScoreManager;
         _stockSplitRepository = stockSplitRepository;
+        _memoryCache = memoryCache;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -613,7 +618,17 @@ public class ShortDataTools
         return _runner.Execute(
             async () =>
             {
-                var scores = await _shortSqueezeScoreManager.Compute();
+                // The score is peer-relative, so it is always computed for the whole
+                // universe at once — a per-call Compute() made every request pay that
+                // multi-second build. Cached under the manager-owned shared key so any
+                // host-side background refresh of the same entry serves this tool warm.
+                // The factory takes no cancellation token: an abandoned request must
+                // not kill a build every later caller would reuse.
+                var scores = await _memoryCache.GetOrCreateSafeAsync(
+                    ShortSqueezeScoreManager.UniverseCacheKey,
+                    ShortSqueezeScoreManager.UniverseCacheDuration,
+                    () => _shortSqueezeScoreManager.Compute()
+                );
                 if (scores.Count == 0)
                     return "No short-squeeze scores available — no short interest data on file.";
 

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -620,8 +620,13 @@ public class ShortDataTools
             {
                 // The score is peer-relative, so it is always computed for the whole
                 // universe at once — a per-call Compute() made every request pay that
-                // multi-second build. Cached under the manager-owned shared key so any
-                // host-side background refresh of the same entry serves this tool warm.
+                // multi-second build. Cached under the manager-owned shared key so a
+                // host-side background refresh of the same entry serves this tool warm:
+                // a refresher replaces the entry in place (the old value stays readable
+                // throughout), so this tool only computes when the entry is genuinely
+                // absent — process cold start, or a refresher that stopped. Its
+                // single-flight is local to this extension's lock table, so that cold
+                // window can at worst run one build alongside a host's own; accepted.
                 // The factory takes no cancellation token: an abandoned request must
                 // not kill a build every later caller would reuse.
                 var scores = await _memoryCache.GetOrCreateSafeAsync(

--- a/src/Equibles.Mcp/Extensions/MemoryCacheExtensions.cs
+++ b/src/Equibles.Mcp/Extensions/MemoryCacheExtensions.cs
@@ -13,6 +13,10 @@ public static class MemoryCacheExtensions
     // each paying the computation. The wait is cancellable so a queued caller can
     // abandon the wait with its own request; cancelling never aborts the in-flight
     // factory, which keeps running for whoever owns the lock.
+    //
+    // Keys must come from a bounded, program-controlled set (compile-time
+    // constants) — never per-request input: lock entries are kept for the process
+    // lifetime, so an unbounded key space grows the table forever.
     public static async Task<T> GetOrCreateSafeAsync<T>(
         this IMemoryCache cache,
         string key,

--- a/src/Equibles.Mcp/Extensions/MemoryCacheExtensions.cs
+++ b/src/Equibles.Mcp/Extensions/MemoryCacheExtensions.cs
@@ -1,0 +1,47 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Equibles.Mcp.Extensions;
+
+public static class MemoryCacheExtensions
+{
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> Locks = new();
+
+    // Single-flight get-or-create for tools that cache an expensive whole-universe
+    // computation: concurrent cold callers for the same key queue on a per-key
+    // semaphore behind the one running the factory and reuse its result instead of
+    // each paying the computation. The wait is cancellable so a queued caller can
+    // abandon the wait with its own request; cancelling never aborts the in-flight
+    // factory, which keeps running for whoever owns the lock.
+    public static async Task<T> GetOrCreateSafeAsync<T>(
+        this IMemoryCache cache,
+        string key,
+        TimeSpan duration,
+        Func<Task<T>> factory,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (cache.TryGetValue(key, out T cached))
+        {
+            return cached;
+        }
+
+        var semaphore = Locks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+        await semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            if (cache.TryGetValue(key, out cached))
+            {
+                return cached;
+            }
+
+            var result = await factory();
+            cache.Set(key, result, duration);
+            return result;
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+}

--- a/src/Equibles.Mcp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Mcp/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,11 @@ public static class ServiceCollectionExtensions
     )
     {
         var mcpServerBuilder = services.AddMcpServer().WithHttpTransport();
+        // Tools that cache an expensive whole-universe computation (e.g. the
+        // short-squeeze board) resolve IMemoryCache, so the builder guarantees it
+        // regardless of what the host registers. AddMemoryCache is TryAdd-based —
+        // a host that already registered its own cache keeps it.
+        services.AddMemoryCache();
         var mcpBuilder = new EquiblesMcpBuilder(services, mcpServerBuilder);
         configureMcp(mcpBuilder);
         WrapToolsWithInvalidParamsTranslation(services);

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
@@ -9,6 +9,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -31,6 +32,7 @@ public class ShortDataToolsGetLargestShortVolumeCultureInvarianceTests : ParadeD
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
@@ -9,6 +9,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -32,6 +33,7 @@ public class ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
@@ -9,6 +9,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -31,6 +32,7 @@ public class ShortDataToolsGetShortInterestCultureInvarianceTests : ParadeDbMcpT
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
@@ -9,6 +9,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -31,6 +32,7 @@ public class ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests : Para
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
@@ -9,6 +9,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -40,6 +41,7 @@ public class ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTes
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -9,6 +9,7 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
 using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -31,6 +32,7 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
@@ -9,6 +9,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -31,6 +32,7 @@ public class ShortDataToolsGetShortVolumeCultureInvarianceTests : ParadeDbMcpTes
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
@@ -9,6 +9,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -38,6 +39,7 @@ public class ShortDataToolsHistoryOutputNotesTests : ParadeDbMcpTestBase
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsLargestShortVolumeSortAndLegendTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsLargestShortVolumeSortAndLegendTests.cs
@@ -8,6 +8,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -36,6 +37,7 @@ public class ShortDataToolsLargestShortVolumeSortAndLegendTests : ParadeDbMcpTes
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsSnapshotSentinelTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsSnapshotSentinelTests.cs
@@ -8,6 +8,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -38,6 +39,7 @@ public class ShortDataToolsSnapshotSentinelTests : ParadeDbMcpTestBase
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsStrictDateArgumentsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsStrictDateArgumentsTests.cs
@@ -8,6 +8,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -38,6 +39,7 @@ public class ShortDataToolsStrictDateArgumentsTests : ParadeDbMcpTestBase
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -8,6 +8,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -30,6 +31,7 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
@@ -8,6 +8,7 @@ using Equibles.Finra.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Repositories;
 using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -42,6 +43,7 @@ public class ShortDataToolsZeroChangeTests : ParadeDbMcpTestBase
                 []
             ),
             new StockSplitRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerCacheContractTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezeScoreManagerCacheContractTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Finra.BusinessLogic;
+
+namespace Equibles.UnitTests.Finra;
+
+public class ShortSqueezeScoreManagerCacheContractTests
+{
+    // The key is a cross-process contract, not an implementation detail: the MCP
+    // tool caches Compute() under it, and downstream deployments (the commercial
+    // repo's ShortSqueezeScoreProvider and its background warmer) reference the
+    // same constant so ONE entry per process serves every surface. Renaming the
+    // literal would silently split that entry into per-surface copies — each
+    // paying its own whole-universe build — with nothing else failing.
+    [Fact]
+    public void UniverseCacheKey_IsThePinnedCrossRepoLiteral()
+    {
+        ShortSqueezeScoreManager.UniverseCacheKey.Should().Be("short-squeeze-scores");
+    }
+
+    [Fact]
+    public void UniverseCacheDuration_StaysAtOneHour()
+    {
+        // Consumers size their background-refresh intervals under this lifetime;
+        // shortening it below a deployed warm interval would let entries expire
+        // between refreshes and reintroduce the cold-call cost.
+        ShortSqueezeScoreManager.UniverseCacheDuration.Should().Be(TimeSpan.FromHours(1));
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/EquiblesMcpServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/EquiblesMcpServiceCollectionExtensionsTests.cs
@@ -26,4 +26,23 @@ public class EquiblesMcpServiceCollectionExtensionsTests
 
         captured.Should().NotBeNull();
     }
+
+    [Fact]
+    public void AddEquiblesMcp_RegistersMemoryCache_ForToolsThatCacheUniverses()
+    {
+        // Tools that cache an expensive whole-universe computation (the
+        // short-squeeze board) resolve IMemoryCache from the container. The
+        // builder guarantees the registration so a host that never called
+        // AddMemoryCache itself still constructs those tools; without it, tool
+        // construction fails at first use with an unresolvable-service error.
+        var services = new ServiceCollection();
+
+        services.AddEquiblesMcp(_ => { });
+
+        services
+            .Should()
+            .Contain(d =>
+                d.ServiceType == typeof(Microsoft.Extensions.Caching.Memory.IMemoryCache)
+            );
+    }
 }

--- a/tests/Equibles.UnitTests/Mcp/EquiblesMcpServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/EquiblesMcpServiceCollectionExtensionsTests.cs
@@ -45,4 +45,25 @@ public class EquiblesMcpServiceCollectionExtensionsTests
                 d.ServiceType == typeof(Microsoft.Extensions.Caching.Memory.IMemoryCache)
             );
     }
+
+    [Fact]
+    public void AddEquiblesMcp_KeepsAHostsOwnMemoryCacheRegistration()
+    {
+        // The guarantee is TryAdd-based: a host that registered its own cache
+        // before AddEquiblesMcp must keep it — the builder fills the gap, it
+        // never replaces the host's choice.
+        var services = new ServiceCollection();
+        var hostsOwnCache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+            new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions()
+        );
+        services.AddSingleton<Microsoft.Extensions.Caching.Memory.IMemoryCache>(hostsOwnCache);
+
+        services.AddEquiblesMcp(_ => { });
+
+        using var provider = services.BuildServiceProvider();
+        provider
+            .GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()
+            .Should()
+            .BeSameAs(hostsOwnCache);
+    }
 }

--- a/tests/Equibles.UnitTests/Mcp/MemoryCacheExtensionsGetOrCreateSafeAsyncTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MemoryCacheExtensionsGetOrCreateSafeAsyncTests.cs
@@ -100,6 +100,55 @@ public class MemoryCacheExtensionsGetOrCreateSafeAsyncTests
         second.Should().Be(42);
     }
 
+    // A queued caller may abandon its wait with its own request's token — it
+    // throws OperationCanceledException — but cancelling the WAIT never aborts
+    // the in-flight factory, which completes and caches for everyone else.
+    [Fact]
+    public async Task GetOrCreateSafeAsync_WaiterCancelled_FactoryStillCompletesAndCaches()
+    {
+        var factoryEntered = new SemaphoreSlim(0, 1);
+        var factoryRelease = new TaskCompletionSource<int>();
+        var factoryCalls = 0;
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var key = $"waiter-cancelled-{Guid.NewGuid()}";
+
+        var task1 = cache.GetOrCreateSafeAsync(
+            key,
+            TimeSpan.FromMinutes(5),
+            async () =>
+            {
+                Interlocked.Increment(ref factoryCalls);
+                factoryEntered.Release();
+                return await factoryRelease.Task;
+            }
+        );
+
+        await factoryEntered.WaitAsync();
+
+        using var waiterCancellation = new CancellationTokenSource();
+        var task2 = cache.GetOrCreateSafeAsync(
+            key,
+            TimeSpan.FromMinutes(5),
+            () => Task.FromResult(99),
+            waiterCancellation.Token
+        );
+        waiterCancellation.Cancel();
+
+        var abandoned = async () => await task2;
+        await abandoned.Should().ThrowAsync<OperationCanceledException>();
+
+        factoryRelease.SetResult(42);
+        (await task1).Should().Be(42);
+
+        var later = await cache.GetOrCreateSafeAsync(
+            key,
+            TimeSpan.FromMinutes(5),
+            () => Task.FromResult(7)
+        );
+        later.Should().Be(42);
+        factoryCalls.Should().Be(1);
+    }
+
     // A factory that legitimately produces null has that null cached and served:
     // TryGetValue reports the entry as present, so later calls do not re-run the
     // factory just because the value is null.

--- a/tests/Equibles.UnitTests/Mcp/MemoryCacheExtensionsGetOrCreateSafeAsyncTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MemoryCacheExtensionsGetOrCreateSafeAsyncTests.cs
@@ -1,0 +1,125 @@
+using Equibles.Mcp.Extensions;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class MemoryCacheExtensionsGetOrCreateSafeAsyncTests
+{
+    // Contract: a get-or-create — the factory builds the value on a miss, the
+    // result is cached, and a later call for the same key is served from the
+    // cache without re-running the factory. Two sequential calls must run the
+    // (expensive) factory exactly once.
+    [Fact]
+    public async Task GetOrCreateSafeAsync_SecondCallForSameKey_ServesCachedAndDoesNotReinvokeFactory()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var key = $"served-once-{Guid.NewGuid()}";
+        var factoryCalls = 0;
+        Task<int> Factory()
+        {
+            factoryCalls++;
+            return Task.FromResult(42);
+        }
+
+        var first = await cache.GetOrCreateSafeAsync(key, TimeSpan.FromMinutes(5), Factory);
+        var second = await cache.GetOrCreateSafeAsync(key, TimeSpan.FromMinutes(5), Factory);
+
+        first.Should().Be(42);
+        second.Should().Be(42);
+        factoryCalls.Should().Be(1);
+    }
+
+    // Contract: the "Safe" is stampede protection — concurrent callers for the
+    // same uncached key run the factory exactly once; the rest queue on the
+    // per-key lock and pick up the first caller's cached result. Without this a
+    // cold cache under load runs N identical whole-universe computations.
+    [Fact]
+    public async Task GetOrCreateSafeAsync_ConcurrentCallsSameKey_ExecutesFactoryExactlyOnce()
+    {
+        var factoryEntered = new SemaphoreSlim(0, 1);
+        var factoryRelease = new TaskCompletionSource<int>();
+        var callCount = 0;
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var key = $"stampede-{Guid.NewGuid()}";
+
+        var task1 = cache.GetOrCreateSafeAsync(
+            key,
+            TimeSpan.FromMinutes(5),
+            async () =>
+            {
+                Interlocked.Increment(ref callCount);
+                factoryEntered.Release();
+                return await factoryRelease.Task;
+            }
+        );
+
+        await factoryEntered.WaitAsync();
+
+        var task2 = cache.GetOrCreateSafeAsync(
+            key,
+            TimeSpan.FromMinutes(5),
+            async () =>
+            {
+                Interlocked.Increment(ref callCount);
+                return 99;
+            }
+        );
+
+        factoryRelease.SetResult(42);
+
+        var result1 = await task1;
+        var result2 = await task2;
+
+        result1.Should().Be(42);
+        result2.Should().Be(42);
+        callCount.Should().Be(1);
+    }
+
+    // A throwing factory must propagate but release the per-key semaphore in the
+    // finally — otherwise every later caller of that key deadlocks. And nothing
+    // is cached, so a later call re-runs the factory and can succeed.
+    [Fact]
+    public async Task GetOrCreateSafeAsync_FactoryThrows_ReleasesLockAndCachesNothing()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var key = $"throws-{Guid.NewGuid()}";
+
+        var first = async () =>
+            await cache.GetOrCreateSafeAsync<int>(
+                key,
+                TimeSpan.FromMinutes(5),
+                () => throw new InvalidOperationException("boom")
+            );
+        await first.Should().ThrowAsync<InvalidOperationException>();
+
+        var second = await cache.GetOrCreateSafeAsync(
+            key,
+            TimeSpan.FromMinutes(5),
+            () => Task.FromResult(42)
+        );
+        second.Should().Be(42);
+    }
+
+    // A factory that legitimately produces null has that null cached and served:
+    // TryGetValue reports the entry as present, so later calls do not re-run the
+    // factory just because the value is null.
+    [Fact]
+    public async Task GetOrCreateSafeAsync_FactoryReturnsNull_CachesAndServesTheNull()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var key = $"null-{Guid.NewGuid()}";
+        var factoryCalls = 0;
+        Task<string> Factory()
+        {
+            factoryCalls++;
+            return Task.FromResult<string>(null);
+        }
+
+        var first = await cache.GetOrCreateSafeAsync(key, TimeSpan.FromMinutes(5), Factory);
+        var second = await cache.GetOrCreateSafeAsync(key, TimeSpan.FromMinutes(5), Factory);
+
+        first.Should().BeNull();
+        second.Should().BeNull();
+        factoryCalls.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary

`GetShortSqueezeScores` recomputed the whole peer-relative universe on every call — production telemetry showed a 16.1s p95 over 30 days (330 calls, 16 distinct users), with agent harnesses likely abandoning many of those calls before the reply arrived. The score is peer-relative by construction, so per-call computation buys nothing: the ranking only changes when the underlying FINRA/price data does.

The tool now reads through `IMemoryCache` with a 1-hour TTL and single-flight stampede protection. The cache key and TTL live on `ShortSqueezeScoreManager` (`UniverseCacheKey` / `UniverseCacheDuration`) so every surface that caches `Compute()` shares one entry per process — and a host can refresh that same entry in the background to keep interactive calls permanently warm.

## Code changes

- `Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs` — new `UniverseCacheKey` + `UniverseCacheDuration` constants; the manager owns the cache identity, callers share it.
- `Equibles.Mcp/Extensions/MemoryCacheExtensions.cs` (new) — `GetOrCreateSafeAsync`: per-key semaphore single-flight get-or-create for tools caching expensive universe computations.
- `Equibles.Mcp/Extensions/ServiceCollectionExtensions.cs` — `AddEquiblesMcp` registers `AddMemoryCache()` (TryAdd-based, so a host's own registration wins) so tool construction never fails on a host that didn't wire a cache.
- `Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — injects `IMemoryCache`; `GetShortSqueezeScores` reads the universe through the shared key. The factory deliberately takes no cancellation token: an abandoned request must not kill a build every later caller would reuse.
- `tests/Equibles.UnitTests/Mcp/` — new `GetOrCreateSafeAsync` suite (cache hit, stampede, factory-throws, cached null) and an `AddEquiblesMcp` registration pin.
- `tests/Equibles.IntegrationTests/Mcp/ShortDataTools*.cs` — constructor sites gain a fresh per-test `MemoryCache` so no state crosses tests.

Verified: full build green, unit suite 4041/4041, `ShortDataTools` integration tests 63/63 (full integration suite run separately before merge).

https://claude.ai/code/session_01HpZme8KvPd2FTDZNkSzna2
