### PR TITLE
fix(holdings): keep the derivation when a 13F filed value is on a thousands basis

### DIFF
--- a/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
@@ -54,8 +54,18 @@ public class ProcessedDataSet
     /// missing its entire Class C side. The re-import maps them through
     /// CommonStockListedCusip, keys the rows by (…, ListedTicker), and values
     /// them from the class's own exact price series.
+    /// Version 8: keep the derivation when the filed value is on a thousands
+    /// basis. Filers still reporting the VALUE column in thousands after the
+    /// SEC's 2023 whole-dollar switch made the correct derivation look 1,000×
+    /// "too big", so the sanity guard published the thousands-scale filed
+    /// figure and served their books 1,000× understated (Baupost's ~$5B book
+    /// read ~$5M). The re-import re-derives those rows under the banded guard
+    /// and heals the mis-published history. Open-quarter latency, accepted:
+    /// realtime-swept accessions are behind the realtime watermark, not this
+    /// ledger, so the current quarter's affected rows stay understated until
+    /// its bulk quarterly data set lands and re-imports them.
     /// </summary>
-    public const int CurrentParserVersion = 7;
+    public const int CurrentParserVersion = 8;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueSanityGuard.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueSanityGuard.cs
@@ -19,7 +19,8 @@ namespace Equibles.Holdings.HostedService.Services;
 /// <see cref="DisagreementCapMultiple"/>× above it is basis-suspect and the filed figure is
 /// published instead. The cap sits far above <see cref="ValueBasisAudit.DisagreementMultiple"/>
 /// (ordinary mark drift) and far below any real units error (a missed split is ≥2×, the corrupt
-/// close was 12.5M×).</item>
+/// close was 12.5M×). One carve-out: a disagreement clustered at ~1,000× is the FILED figure's
+/// units, not the derivation's — see <see cref="FiledLooksThousandsScaled"/>.</item>
 /// <item><b>Absolute</b> — with no filed value to compare against, a close above
 /// <see cref="MaxPlausibleSharePrice"/> is refused outright and the row stays pending. No US
 /// equity trades near $1M/share (BRK-A is ~$800k); the threshold must never be tightened below
@@ -45,9 +46,59 @@ internal static class HoldingValueSanityGuard
         closePrice > MaxPlausibleSharePrice;
 
     /// <summary>
+    /// Lower bound of the derived/filed ratio band read as "the filer reported thousands".
+    /// </summary>
+    internal const decimal ThousandsScaleMinMultiple = 900m;
+
+    /// <summary>
+    /// Upper bound of the derived/filed ratio band read as "the filer reported thousands".
+    /// </summary>
+    internal const decimal ThousandsScaleMaxMultiple = 1100m;
+
+    /// <summary>
     /// Whether a derived value disagrees with the filed one grossly enough that the filed figure
     /// must be published instead. Only meaningful when the filer reported a positive value.
     /// </summary>
     internal static bool GrosslyExceedsFiled(decimal derivedValue, long? filedValue) =>
         filedValue is > 0 && derivedValue > DisagreementCapMultiple * filedValue.Value;
+
+    /// <summary>
+    /// Whether the filed figure itself is on a thousands basis: some filers still report the
+    /// VALUE column in thousands after the SEC's 2023 whole-dollar switch (Baupost filed a ~$5B
+    /// book that served as ~$5M this way), so the derivation lands at ~1,000× the filed figure.
+    /// The band is deliberately tight (900×–1,100×): a derivation-side basis error CAN reach
+    /// this magnitude — a duplicated share-count column inflates by exactly the share price
+    /// (Corrupt13FShareCountRepairer), and depositary ratios reach 3,200×
+    /// (ImpossiblePositionGuard's NaaS case) — so only the unit signature itself (≈1,000×,
+    /// modulo mark drift) qualifies. The duplicated-column case is excluded structurally too:
+    /// there the shares column IS the value column, so <paramref name="shares"/> equals the
+    /// filed figure and the ratio is the share price, not a unit — a $900–$1,100 stock would
+    /// otherwise land inside the band. Residual, accepted: rows this rule cannot see (a
+    /// thousands filer whose price never arrives, published via the ladder-exhaust or
+    /// stuck-zero filed fallbacks) still serve the thousands-scale figure — there is no scale
+    /// signal without a derivation to compare against.
+    /// </summary>
+    internal static bool FiledLooksThousandsScaled(
+        decimal derivedValue,
+        long shares,
+        long? filedValue
+    ) =>
+        filedValue is > 0
+        && shares != filedValue.Value
+        && derivedValue >= ThousandsScaleMinMultiple * filedValue.Value
+        && derivedValue <= ThousandsScaleMaxMultiple * filedValue.Value;
+
+    /// <summary>
+    /// The one decision both valuation sites act on: publish the filed figure only when the
+    /// derivation grossly exceeds it AND the disagreement is not the filed figure's own
+    /// thousands basis. The import inline derivation and the repricing lane must share this
+    /// test, or the two publish different figures for the same row.
+    /// </summary>
+    internal static bool ShouldPublishFiledInsteadOfDerived(
+        decimal derivedValue,
+        long shares,
+        long? filedValue
+    ) =>
+        GrosslyExceedsFiled(derivedValue, filedValue)
+        && !FiledLooksThousandsScaled(derivedValue, shares, filedValue);
 }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1783,9 +1783,11 @@ public class HoldingsImportService
 
         // A derivation grossly above the filer's own figure is a basis error (a depositary ratio,
         // a split the series never captured) — the audit above measures it; this acts on it.
-        // Publish the filed figure instead of the wrong derivation.
+        // Publish the filed figure instead of the wrong derivation — unless the disagreement is
+        // the ~1,000× signature of a filer still reporting thousands, where the filed figure is
+        // the wrong one and the derivation stands.
         var valueSource = ValueSource.Derived;
-        if (value > 0 && HoldingValueSanityGuard.GrosslyExceedsFiled(value, filedValue))
+        if (HoldingValueSanityGuard.ShouldPublishFiledInsteadOfDerived(value, shares, filedValue))
         {
             value = filedValue.Value;
             valueSource = ValueSource.Filed;

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
@@ -318,8 +318,15 @@ public class HoldingsValueRecalculator
 
                 // A per-row basis error (depositary ratio, split the series never captured) shows
                 // as a derivation grossly above the filer's own figure — publish the filed value
-                // rather than the wrong derivation.
-                if (HoldingValueSanityGuard.GrosslyExceedsFiled(derived, holding.FiledValue))
+                // rather than the wrong derivation. A ~1,000× disagreement is the opposite case
+                // (the filer still reports thousands) and keeps the derivation.
+                if (
+                    HoldingValueSanityGuard.ShouldPublishFiledInsteadOfDerived(
+                        derived,
+                        holding.Shares,
+                        holding.FiledValue
+                    )
+                )
                 {
                     ApplyFiledValue(holding);
                     continue;

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsValueRecalculatorFiledFallbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsValueRecalculatorFiledFallbackTests.cs
@@ -343,4 +343,30 @@ public class HoldingsValueRecalculatorFiledFallbackTests : IDisposable
         updated.Value.Should().Be(1_092_804L);
         updated.ValueSource.Should().Be(ValueSource.Filed);
     }
+
+    [Fact]
+    public async Task Recalculate_FiledValueOnThousandsBasis_PublishesDerivedValue()
+    {
+        var reportDate = new DateOnly(2026, 3, 31);
+        // The Baupost signature: a filer still reporting the VALUE column in thousands after
+        // the SEC's 2023 whole-dollar switch. 3,118,754 shares × $208.40 derives ~$650M against
+        // a filed 649,543 — almost exactly 1,000×. The old guard read that as an implausible
+        // derivation and published the filed figure, serving the position 1,000× understated.
+        var (stock, holding) = await Seed(
+            reportDate,
+            shares: 3_118_754,
+            filedValue: 649_543L,
+            retryCount: 0,
+            lastRetryAt: null
+        );
+
+        SetPrices(new() { [(stock.Id, null, reportDate)] = 208.40m });
+
+        await CreateRecalculator().Recalculate(CancellationToken.None);
+
+        var updated = await Reload(holding.Id);
+        updated.ValuePending.Should().BeFalse();
+        updated.Value.Should().Be((long)(3_118_754m * 208.40m));
+        updated.ValueSource.Should().Be(ValueSource.Derived);
+    }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueSanityGuardTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueSanityGuardTests.cs
@@ -52,4 +52,125 @@ public class HoldingValueSanityGuardTests
         var derived = 273_201m * 50_000_000m;
         HoldingValueSanityGuard.GrosslyExceedsFiled(derived, 1_092_804L).Should().BeTrue();
     }
+
+    // ── FiledLooksThousandsScaled ──────────────────────────────────────
+
+    [Theory]
+    [InlineData("1000000000", true)] // exactly 1,000× — the canonical thousands filer
+    [InlineData("900000000", true)] // band floor (900×) — mark drift on top of the unit
+    [InlineData("1100000000", true)] // band ceiling (1,100×)
+    [InlineData("899999999", false)] // just under the floor — a real basis error, not units
+    [InlineData("1100000001", false)] // just past the ceiling — derivation-side error
+    [InlineData("5000001", false)] // ordinary gross disagreement (5×+) stays a derivation fault
+    public void FiledLooksThousandsScaled_RatioInsideTightBand_ReturnsTrue(
+        string derived,
+        bool expected
+    )
+    {
+        HoldingValueSanityGuard
+            .FiledLooksThousandsScaled(
+                decimal.Parse(derived, CultureInfo.InvariantCulture),
+                shares: 500_000L,
+                filedValue: 1_000_000L
+            )
+            .Should()
+            .Be(expected);
+    }
+
+    [Fact]
+    public void FiledLooksThousandsScaled_SharesEqualFiledValue_ReturnsFalse()
+    {
+        // The duplicated share-count column (Corrupt13FShareCountRepairer's population): the
+        // shares column IS the value column, so the derived/filed ratio equals the share
+        // price. A $1,000 stock lands exactly in the band — the structural exclusion, not
+        // the band, is what keeps it out.
+        HoldingValueSanityGuard
+            .FiledLooksThousandsScaled(1_000_000_000m, shares: 1_000_000L, filedValue: 1_000_000L)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void FiledLooksThousandsScaled_NoFiledValue_ReturnsFalse()
+    {
+        HoldingValueSanityGuard
+            .FiledLooksThousandsScaled(1_000_000_000m, 500_000L, null)
+            .Should()
+            .BeFalse();
+        HoldingValueSanityGuard
+            .FiledLooksThousandsScaled(1_000_000_000m, 500_000L, 0L)
+            .Should()
+            .BeFalse();
+    }
+
+    // ── ShouldPublishFiledInsteadOfDerived ─────────────────────────────
+
+    [Fact]
+    public void ShouldPublishFiledInsteadOfDerived_ThousandsFiler_KeepsDerivation()
+    {
+        // The Baupost signature: 3,118,754 AMZN shares derive ~$650M against a filed
+        // 649,543 (thousands). Publishing the filed figure served the book 1,000×
+        // understated — the derivation must stand.
+        var derived = 3_118_754m * 208.4m;
+        HoldingValueSanityGuard
+            .ShouldPublishFiledInsteadOfDerived(derived, 3_118_754L, 649_543L)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void ShouldPublishFiledInsteadOfDerived_CorruptClose_PublishesFiled()
+    {
+        var derived = 273_201m * 50_000_000m;
+        HoldingValueSanityGuard
+            .ShouldPublishFiledInsteadOfDerived(derived, 273_201L, 1_092_804L)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void ShouldPublishFiledInsteadOfDerived_DuplicatedShareCountRow_PublishesFiled()
+    {
+        // shares == filed value is the duplicated-column signature; even a ratio inside the
+        // thousands band must publish the filed figure there.
+        HoldingValueSanityGuard
+            .ShouldPublishFiledInsteadOfDerived(1_000_000_000m, 1_000_000L, 1_000_000L)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void ShouldPublishFiledInsteadOfDerived_CorruptCloseInsideBand_KeepsDerivation()
+    {
+        // The accepted trade-off, stated as a test: a genuinely corrupt close that inflates a
+        // NON-duplicated row by ~1,000× is indistinguishable from a thousands filer and now
+        // publishes the derivation. The tight 900×–1,100× band and the shares != filed
+        // exclusion bound the exposure; a wider corruption (12.5M× production case) still
+        // publishes filed.
+        HoldingValueSanityGuard
+            .ShouldPublishFiledInsteadOfDerived(1_000_000_000m, 500_000L, 1_000_000L)
+            .Should()
+            .BeFalse();
+    }
+
+    [Theory]
+    [InlineData("5000000", false)] // 5× — inside ordinary drift, derivation publishes
+    [InlineData("5000001", true)] // just past the cap and below the band — filed publishes
+    [InlineData("899999999", true)] // 900×−ε — still a derivation fault
+    [InlineData("1000000000", false)] // 1,000× — thousands basis, derivation publishes
+    [InlineData("1100000001", true)] // past the band — derivation fault, filed publishes
+    public void ShouldPublishFiledInsteadOfDerived_RatioAcrossBandEdges_PublishesFiledOutsideBandOnly(
+        string derived,
+        bool expected
+    )
+    {
+        HoldingValueSanityGuard
+            .ShouldPublishFiledInsteadOfDerived(
+                decimal.Parse(derived, CultureInfo.InvariantCulture),
+                shares: 500_000L,
+                filedValue: 1_000_000L
+            )
+            .Should()
+            .Be(expected);
+    }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowSanityGuardTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowSanityGuardTests.cs
@@ -107,6 +107,23 @@ public class HoldingsImportServiceParseHoldingRowSanityGuardTests
     }
 
     [Fact]
+    public void ParseHoldingRow_FiledValueOnThousandsBasis_PublishesDerivedValue()
+    {
+        // A filer still reporting VALUE in thousands after the 2023 whole-dollar switch:
+        // 273,201 × $208.40 derives $56.9M against a filed 56,935 — the ~1,000× unit
+        // signature. The heal runs through this exact path on re-import (parser version 8).
+        var (holding, valuePending) = Parse(
+            Guid.NewGuid(),
+            closePrice: 208.40m,
+            filedValueField: "56935"
+        );
+
+        valuePending.Should().BeFalse();
+        holding.Value.Should().Be((long)(273_201m * 208.40m));
+        holding.ValueSource.Should().Be(ValueSource.Derived);
+    }
+
+    [Fact]
     public void ParseHoldingRow_OrdinaryDerivation_StaysDerived()
     {
         // 273,201 × $4 ≈ the filed $1.09M — inside the 5× drift ceiling, published as derived.


### PR DESCRIPTION
## Summary

Some filers still report the 13F information table's VALUE column in **thousands** after the SEC's 2023 whole-dollar switch (Baupost among them). The correct derivation (shares × split-restated close) then sits at ~1,000× the filed figure, so `HoldingValueSanityGuard`'s relative bound (derived > 5× filed → publish filed) read it as a derivation-side basis error and published the thousands-scale filed number — serving those books 1,000× understated (a ~$5B portfolio answered as ~$5M), on a basis that flips quarter to quarter with the guard's row-by-row outcomes. Production shows 137,593 filed-published post-2023 rows across 1,844 filers in the candidate population.

## Code changes

- **`HoldingValueSanityGuard`** — new `FiledLooksThousandsScaled` carve-out and a single `ShouldPublishFiledInsteadOfDerived` decision. The carve-out is deliberately narrow: the derived/filed ratio must sit in a tight **900×–1,100×** band (depositary ratios reach 3,200× — the NaaS case — and duplicated share-count columns inflate by exactly the share price, so a wide band would misclassify real derivation faults), **and** the row's share count must differ from its filed value (the duplicated-column signature, where the ratio *is* the share price — keeps $900–$1,100 stocks out of the band).
- **`HoldingsImportService` / `HoldingsValueRecalculator`** — both valuation sites now act on the one shared decision, so the import's inline derivation and the repricing lane can never publish different figures for the same row.
- **`ProcessedDataSet`** — parser version 7 → 8: the re-import re-derives the mis-published history under the banded guard. Open-quarter latency documented (realtime-swept accessions heal when their bulk quarterly data set lands).
- **Tests** — guard unit tests for the band edges, the duplicated-column exclusion, and the named accepted trade-off (a genuine ~1,000× corrupt close on a non-duplicated row now publishes derived); a `ParseHoldingRow` case pinning the heal path itself; an integration test for the recalculator path.

Verified: full build clean, 4,063 unit tests + 7 integration tests pass.

https://claude.ai/code/session_016ot9jjyt7oCYfCUjxZynYA