### PR TITLE
fix(mcp): surface tool faults as isError results and stop collapsing sub-dollar prices

### DIFF
--- a/src/Equibles.Mcp/Helpers/McpFormat.cs
+++ b/src/Equibles.Mcp/Helpers/McpFormat.cs
@@ -24,6 +24,42 @@ public static class McpFormat
     public static string Invariant<T>(T value, string format)
         where T : IFormattable => value.ToString(format, CultureInfo.InvariantCulture);
 
+    // Per-share price with magnitude-adaptive decimals: two decimals at or above $1, and
+    // below that enough decimals to keep at least two significant digits (capped at 8), so a
+    // sub-dollar OHLC row never collapses to one flat value — a $0.0072 close rendered "0.01"
+    // was 39% overstated and reported a 20% daily range as flat. The rule follows the VALUE,
+    // never a per-tool constant, so every price column shares one behaviour.
+    public static string Price(decimal value)
+    {
+        var abs = Math.Abs(value);
+        if (abs >= 1m || abs == 0m)
+        {
+            return value.ToString("F2", CultureInfo.InvariantCulture);
+        }
+
+        var decimals = 2;
+        var scaled = abs;
+        while (scaled < 0.1m && decimals < 8)
+        {
+            scaled *= 10m;
+            decimals++;
+        }
+        return value.ToString("F" + decimals, CultureInfo.InvariantCulture);
+    }
+
+    // Nullable companion to Price: em-dash when null.
+    public static string PriceOrDash(decimal? value) => value.HasValue ? Price(value.Value) : Dash;
+
+    // Signed price delta (change columns): explicit +/− with Price's adaptive decimals, so a
+    // sub-dollar move never rounds to a signless 0.00.
+    public static string SignedPrice(decimal value) =>
+        value switch
+        {
+            > 0 => "+" + Price(value),
+            < 0 => "-" + Price(Math.Abs(value)),
+            _ => Price(0m),
+        };
+
     // Compact USD for wide-magnitude dollar figures (market caps, dollar volumes):
     // $1.23T / $45.6B / $789M / $12.3K, em-dash when null. Invariant culture so MCP
     // markdown does not fork the decimal separator by host locale.

--- a/src/Equibles.Mcp/InvalidParamsTranslatingTool.cs
+++ b/src/Equibles.Mcp/InvalidParamsTranslatingTool.cs
@@ -42,6 +42,17 @@ public class InvalidParamsTranslatingTool : McpServerTool
         {
             return await _inner.InvokeAsync(request, cancellationToken);
         }
+        catch (McpToolFaultException ex)
+        {
+            // Already logged and reported by McpToolExecutor — this is only the transport
+            // translation: an in-band tool error the client (and the usage-recording
+            // middleware's isError detection) can see, instead of a success-shaped string.
+            return new CallToolResult
+            {
+                IsError = true,
+                Content = [new TextContentBlock { Text = ex.Message }],
+            };
+        }
         catch (Exception ex) when (ex is ArgumentException or JsonException)
         {
             _logger.LogInformation(

--- a/src/Equibles.Mcp/McpToolExecutor.cs
+++ b/src/Equibles.Mcp/McpToolExecutor.cs
@@ -49,23 +49,33 @@ public static class McpToolExecutor
         {
             return await action();
         }
+        catch (OperationCanceledException)
+        {
+            // A cancellation (host shutdown winding down an in-flight call, an aborted
+            // client) is not a fault worth an Errors row — same drop-by-type policy as
+            // ErrorReporter. Propagate it so the SDK handles the abort as an abort, but
+            // leave a trace: a cancellation storm (client aborting every call, a wedged
+            // upstream timing out as TaskCanceledException) must stay visible in logs.
+            logger.LogInformation("{ToolName} cancelled — {Context}", toolName, context);
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "{ToolName} failed — {Context}", toolName, context);
-            // A cancellation (host shutdown winding down an in-flight call, an aborted
-            // client) is not a fault worth an Errors row — same drop-by-type policy as
-            // ErrorReporter. The reporter receives the exception itself so the recorded
-            // row carries the flattened inner chain, not a wrapper's message.
-            if (ex is not OperationCanceledException)
+            // The reporter receives the exception itself so the recorded row carries the
+            // flattened inner chain, not a wrapper's message.
+            try
             {
-                try
-                {
-                    await reportError(toolName, ex, context);
-                }
-                catch { }
+                await reportError(toolName, ex, context);
             }
-            return errorMessage
-                ?? $"An error occurred while executing {toolName}. Please try again.";
+            catch { }
+            // Surface the fault as a fault: returning the message as ordinary tool text made
+            // the call count as a success (ErrorCount never moved) and left the calling model
+            // unable to tell a failure from an answer. InvalidParamsTranslatingTool turns
+            // this into an in-band isError tool result carrying the same message.
+            throw new McpToolFaultException(
+                errorMessage ?? $"An error occurred while executing {toolName}. Please try again."
+            );
         }
     }
 }

--- a/src/Equibles.Mcp/McpToolFaultException.cs
+++ b/src/Equibles.Mcp/McpToolFaultException.cs
@@ -1,0 +1,15 @@
+namespace Equibles.Mcp;
+
+/// <summary>
+/// An unexpected failure inside a tool body, carrying the user-facing message the tool wants
+/// the caller to read. Thrown by <see cref="McpToolExecutor.Execute"/> after the fault has been
+/// logged and reported, and translated by <see cref="InvalidParamsTranslatingTool"/> into an
+/// in-band tool error (<c>isError: true</c>) — returning the message as ordinary tool TEXT
+/// made every in-tool failure count as a success, so no tool error was ever visible to usage
+/// telemetry and a calling model could not tell a failure from an answer.
+/// </summary>
+public class McpToolFaultException : Exception
+{
+    public McpToolFaultException(string message)
+        : base(message) { }
+}

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -85,7 +85,7 @@ public class FailToDeliverTools
                     f =>
                     {
                         var value = f.Quantity * f.Price;
-                        return $"| {f.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(f.Quantity)} | ${McpFormat.Invariant(f.Price, "F2")} | ${McpFormat.WholeNumber(value)} |";
+                        return $"| {f.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(f.Quantity)} | ${McpFormat.Price(f.Price)} | ${McpFormat.WholeNumber(value)} |";
                     }
                 );
 

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -104,7 +104,7 @@ public class StockPriceTools
                 result.AppendRows(
                     records.OrderBy(p => p.Date),
                     p =>
-                        $"| {p.Date:yyyy-MM-dd} | {McpFormat.Invariant(p.Open, "F2")} | {McpFormat.Invariant(p.High, "F2")} | {McpFormat.Invariant(p.Low, "F2")} | {McpFormat.Invariant(p.Close, "F2")} | {McpFormat.WholeNumber(p.Volume)} |"
+                        $"| {p.Date:yyyy-MM-dd} | {McpFormat.Price(p.Open)} | {McpFormat.Price(p.High)} | {McpFormat.Price(p.Low)} | {McpFormat.Price(p.Close)} | {McpFormat.WholeNumber(p.Volume)} |"
                 );
 
                 AppendNewestKeptTruncationNote(result, records.Count, total);
@@ -204,7 +204,7 @@ public class StockPriceTools
                     if (previousClose != null)
                     {
                         var change = price.Close - previousClose.Value;
-                        changeCell = McpFormat.Invariant(change, "+0.00;-0.00;0.00");
+                        changeCell = McpFormat.SignedPrice(change);
                         changePctCell =
                             McpFormat.Invariant(
                                 change / previousClose.Value * 100m,
@@ -249,7 +249,7 @@ public class StockPriceTools
 
                     rowDates.Add(price.Date);
                     result.AppendLine(
-                        $"| {ticker} | {price.Date:yyyy-MM-dd} | {McpFormat.Invariant(price.Close, "F2")} | {changeCell} | {changePctCell} | {McpFormat.WholeNumber(price.Volume)} | {cells.High} | {cells.Low} | {cells.OffHigh} | {cells.AboveLow} |"
+                        $"| {ticker} | {price.Date:yyyy-MM-dd} | {McpFormat.Price(price.Close)} | {changeCell} | {changePctCell} | {McpFormat.WholeNumber(price.Volume)} | {cells.High} | {cells.Low} | {cells.OffHigh} | {cells.AboveLow} |"
                     );
                 }
 
@@ -583,9 +583,9 @@ public class StockPriceTools
                     maxResults,
                     i =>
                     {
-                        var lowerCell = McpFormat.OrDash(lower[i], "F2");
-                        var middleCell = McpFormat.OrDash(middle[i], "F2");
-                        var upperCell = McpFormat.OrDash(upper[i], "F2");
+                        var lowerCell = McpFormat.PriceOrDash(lower[i]);
+                        var middleCell = McpFormat.PriceOrDash(middle[i]);
+                        var upperCell = McpFormat.PriceOrDash(upper[i]);
                         var percentB = PercentB(closes[i], upper[i], lower[i]);
                         var bandwidth = Bandwidth(middle[i], upper[i], lower[i]);
                         return $"| {DateAndCloseCells(records[i])} | {lowerCell} | {middleCell} | {upperCell} | {McpFormat.OrDash(percentB, "F2")} | {McpFormat.OrDash(bandwidth, "F4")} |";
@@ -871,8 +871,8 @@ public class StockPriceTools
         // The row's own close must be positive too: a corrupt $0 bar would otherwise render
         // both distances as -100%, breaking the ≤0 / ≥0 sign contract the columns promise.
         return new FiftyTwoWeekCells(
-            McpFormat.Invariant(high, "F2") + star,
-            McpFormat.Invariant(low, "F2") + star,
+            McpFormat.Price(high) + star,
+            McpFormat.Price(low) + star,
             high > 0 && close > 0
                 ? McpFormat.Invariant((close / high - 1m) * 100m, "+0.00;-0.00;0.00") + "%"
                 : "—",
@@ -891,7 +891,7 @@ public class StockPriceTools
     // Leading "Date | Close" cells shared by every technical-indicator table row;
     // keeps the date format and close precision in sync across the four tables.
     private static string DateAndCloseCells(DailyStockPrice record) =>
-        $"{record.Date:yyyy-MM-dd} | {McpFormat.Invariant(record.Close, "F2")}";
+        $"{record.Date:yyyy-MM-dd} | {McpFormat.Price(record.Close)}";
 
     private static (
         List<decimal> Highs,

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesErrorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesErrorTests.cs
@@ -1,5 +1,6 @@
 using Equibles.Errors.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Mcp;
 using Equibles.Media.BusinessLogic;
 using Equibles.Sec.Mcp.Tools;
 using Equibles.Sec.Repositories;
@@ -23,7 +24,7 @@ public class DocumentTextToolsReadLinesErrorTests : ParadeDbMcpTestBase
         : base(fixture) { }
 
     [Fact]
-    public async Task ReadDocumentLines_RepositoryThrows_LogsReportsAndReturnsFallback()
+    public async Task ReadDocumentLines_RepositoryThrows_LogsReportsAndThrowsFault()
     {
         // A repository over a disposed context throws on first access, driving
         // the catch arm. The error manager uses the live base context.
@@ -37,9 +38,13 @@ public class DocumentTextToolsReadLinesErrorTests : ParadeDbMcpTestBase
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 
-        var output = await sut.ReadDocumentLines(Guid.NewGuid(), startLine: 1, endLine: 10);
+        var act = () => sut.ReadDocumentLines(Guid.NewGuid(), startLine: 1, endLine: 10);
 
-        output.Should().Be("An error occurred while reading document lines. Please try again.");
+        // The failure surfaces as a tool fault (translated to an in-band isError result by
+        // the decorator) instead of success-shaped text, so it is countable as an error.
+        (await act.Should().ThrowAsync<McpToolFaultException>()).WithMessage(
+            "An error occurred while reading document lines. Please try again."
+        );
 
         await using var verify = Fixture.CreateDbContext();
         var reported = await verify

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordErrorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordErrorTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Mcp;
 using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
@@ -29,7 +30,7 @@ public class DocumentTextToolsSearchKeywordErrorTests : ParadeDbMcpTestBase
         : base(fixture) { }
 
     [Fact]
-    public async Task SearchDocumentKeyword_NullKeyword_LogsReportsAndReturnsFallback()
+    public async Task SearchDocumentKeyword_NullKeyword_LogsReportsAndThrowsFault()
     {
         var content = "Some filing text on the only line.";
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
@@ -64,9 +65,13 @@ public class DocumentTextToolsSearchKeywordErrorTests : ParadeDbMcpTestBase
             Substitute.For<ILogger<DocumentTextTools>>()
         );
 
-        var output = await sut.SearchDocumentKeyword(document.Id, keyword: null);
+        var act = () => sut.SearchDocumentKeyword(document.Id, keyword: null);
 
-        output.Should().Be("An error occurred while searching the document. Please try again.");
+        // The failure surfaces as a tool fault (translated to an in-band isError result by
+        // the decorator) instead of success-shaped text, so it is countable as an error.
+        (await act.Should().ThrowAsync<McpToolFaultException>()).WithMessage(
+            "An error occurred while searching the document. Please try again."
+        );
 
         await using var verify = Fixture.CreateDbContext();
         var reported = await verify

--- a/tests/Equibles.UnitTests/Mcp/InvalidParamsTranslatingToolFaultTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InvalidParamsTranslatingToolFaultTests.cs
@@ -1,0 +1,64 @@
+using Equibles.Mcp;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Mcp;
+
+/// <summary>
+/// The transport half of the tool-fault contract: <see cref="McpToolExecutor"/> throws
+/// <see cref="McpToolFaultException"/> after logging and reporting, and the decorator turns it
+/// into an in-band <c>isError</c> tool result — the shape the usage-recording middleware's
+/// error detection counts. Without this pair, every in-tool failure serialised as a SUCCESS.
+/// </summary>
+public class InvalidParamsTranslatingToolFaultTests
+{
+    private sealed class ThrowingTool : McpServerTool
+    {
+        private readonly Exception _exception;
+
+        public ThrowingTool(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public override Tool ProtocolTool => new() { Name = "ThrowingTool" };
+
+        public override IReadOnlyList<object> Metadata => [];
+
+        public override ValueTask<CallToolResult> InvokeAsync(
+            RequestContext<CallToolRequestParams> request,
+            CancellationToken cancellationToken = default
+        ) => throw _exception;
+    }
+
+    private static InvalidParamsTranslatingTool Wrap(Exception exception) =>
+        new(new ThrowingTool(exception), Substitute.For<ILogger<InvalidParamsTranslatingTool>>());
+
+    [Fact]
+    public async Task InvokeAsync_ToolFault_ReturnsIsErrorResultWithTheFaultMessage()
+    {
+        var result = await Wrap(
+                new McpToolFaultException(
+                    "An error occurred while executing GetMostHeldStocks. Please try again."
+                )
+            )
+            .InvokeAsync(null!);
+
+        result.IsError.Should().BeTrue();
+        result
+            .Content.OfType<TextContentBlock>()
+            .Single()
+            .Text.Should()
+            .Be("An error occurred while executing GetMostHeldStocks. Please try again.");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Cancellation_Propagates()
+    {
+        var act = () => Wrap(new OperationCanceledException()).InvokeAsync(null!).AsTask();
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/McpFormatPriceTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpFormatPriceTests.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpFormatPriceTests
+{
+    [Theory]
+    [InlineData("123.456", "123.46")] // at or above $1 keeps the classic two decimals
+    [InlineData("1", "1.00")]
+    [InlineData("0.99", "0.99")] // two decimals still carry two significant digits here
+    [InlineData("0.0072", "0.0072")] // the DPLS close that rendered as 0.01 (39% overstated)
+    [InlineData("0.0060", "0.0060")] // must stay distinguishable from 0.0072 in one table
+    [InlineData("0.06", "0.060")]
+    [InlineData("0.000012", "0.000012")]
+    [InlineData("0.000000004", "0.00000000")] // decimals cap at 8 — never an unbounded tail
+    [InlineData("0", "0.00")]
+    public void Price_AdaptsDecimalsToMagnitude(string value, string expected)
+    {
+        McpFormat.Price(decimal.Parse(value, CultureInfo.InvariantCulture)).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Price_SubDollarRange_NeverCollapsesHighAndLow()
+    {
+        // The guard the bug report asked for: a rendered OHLC row may not report
+        // high == low when the source row has high != low (0.0060–0.0072 was a 20% range
+        // served as flat).
+        McpFormat.Price(0.0072m).Should().NotBe(McpFormat.Price(0.0060m));
+    }
+
+    [Fact]
+    public void PriceOrDash_Null_ReturnsDash()
+    {
+        McpFormat.PriceOrDash(null).Should().Be("—");
+        McpFormat.PriceOrDash(0.0072m).Should().Be("0.0072");
+    }
+
+    [Theory]
+    [InlineData("0.0012", "+0.0012")] // a sub-dollar move must not round to a signless 0.00
+    [InlineData("-0.0012", "-0.0012")]
+    [InlineData("2.5", "+2.50")]
+    [InlineData("-2.5", "-2.50")]
+    [InlineData("0", "0.00")]
+    public void SignedPrice_KeepsSignAndSubDollarPrecision(string value, string expected)
+    {
+        McpFormat
+            .SignedPrice(decimal.Parse(value, CultureInfo.InvariantCulture))
+            .Should()
+            .Be(expected);
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/McpToolExecutorTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpToolExecutorTests.cs
@@ -31,17 +31,20 @@ public class McpToolExecutorTests
     }
 
     [Fact]
-    public async Task Execute_ActionThrows_ReturnsDefaultErrorMessage()
+    public async Task Execute_ActionThrows_ThrowsFaultWithDefaultMessage()
     {
-        var result = await McpToolExecutor.Execute(
-            () => throw new InvalidOperationException("boom"),
-            _logger,
-            "TestTool",
-            "ticker=AAPL",
-            _reportError
-        );
+        var act = () =>
+            McpToolExecutor.Execute(
+                () => throw new InvalidOperationException("boom"),
+                _logger,
+                "TestTool",
+                "ticker=AAPL",
+                _reportError
+            );
 
-        result.Should().Be("An error occurred while executing TestTool. Please try again.");
+        (await act.Should().ThrowAsync<McpToolFaultException>()).WithMessage(
+            "An error occurred while executing TestTool. Please try again."
+        );
     }
 
     [Fact]
@@ -49,30 +52,35 @@ public class McpToolExecutorTests
     {
         var exception = new InvalidOperationException("boom");
 
-        await McpToolExecutor.Execute(
-            () => throw exception,
-            _logger,
-            "TestTool",
-            "ticker=AAPL",
-            _reportError
-        );
+        var act = () =>
+            McpToolExecutor.Execute(
+                () => throw exception,
+                _logger,
+                "TestTool",
+                "ticker=AAPL",
+                _reportError
+            );
 
+        await act.Should().ThrowAsync<McpToolFaultException>();
         await _reportError.Received(1).Invoke("TestTool", exception, "ticker=AAPL");
     }
 
     [Fact]
-    public async Task Execute_ActionThrows_WithCustomErrorMessage_ReturnsCustomMessage()
+    public async Task Execute_ActionThrows_WithCustomErrorMessage_ThrowsFaultWithCustomMessage()
     {
-        var result = await McpToolExecutor.Execute(
-            () => throw new InvalidOperationException("boom"),
-            _logger,
-            "TestTool",
-            "ticker=AAPL",
-            _reportError,
-            errorMessage: "Something went wrong with your request."
-        );
+        var act = () =>
+            McpToolExecutor.Execute(
+                () => throw new InvalidOperationException("boom"),
+                _logger,
+                "TestTool",
+                "ticker=AAPL",
+                _reportError,
+                errorMessage: "Something went wrong with your request."
+            );
 
-        result.Should().Be("Something went wrong with your request.");
+        (await act.Should().ThrowAsync<McpToolFaultException>()).WithMessage(
+            "Something went wrong with your request."
+        );
     }
 
     [Fact]
@@ -80,13 +88,15 @@ public class McpToolExecutorTests
     {
         var exception = new InvalidOperationException("boom");
 
-        await McpToolExecutor.Execute(
-            () => throw exception,
-            _logger,
-            "TestTool",
-            "ticker=AAPL",
-            _reportError
-        );
+        var act = () =>
+            McpToolExecutor.Execute(
+                () => throw exception,
+                _logger,
+                "TestTool",
+                "ticker=AAPL",
+                _reportError
+            );
+        await act.Should().ThrowAsync<McpToolFaultException>();
 
         _logger
             .Received(1)
@@ -108,30 +118,35 @@ public class McpToolExecutorTests
             .Invoke(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<string>())
             .ThrowsAsync(new Exception("reporting failed"));
 
-        var result = await McpToolExecutor.Execute(
-            () => throw new InvalidOperationException("boom"),
-            _logger,
-            "TestTool",
-            "ticker=AAPL",
-            _reportError
-        );
+        var act = () =>
+            McpToolExecutor.Execute(
+                () => throw new InvalidOperationException("boom"),
+                _logger,
+                "TestTool",
+                "ticker=AAPL",
+                _reportError
+            );
 
-        result.Should().Be("An error occurred while executing TestTool. Please try again.");
+        // The reporter's own failure never masks the tool fault the caller must see.
+        (await act.Should().ThrowAsync<McpToolFaultException>()).WithMessage(
+            "An error occurred while executing TestTool. Please try again."
+        );
     }
 
     [Fact]
-    public async Task Execute_ActionThrowsCancellation_ReturnsMessageWithoutReporting()
+    public async Task Execute_ActionThrowsCancellation_PropagatesWithoutReporting()
     {
-        var result = await McpToolExecutor.Execute(
-            () => throw new OperationCanceledException("call aborted"),
-            _logger,
-            "TestTool",
-            "ticker=AAPL",
-            _reportError
-        );
+        var act = () =>
+            McpToolExecutor.Execute(
+                () => throw new OperationCanceledException("call aborted"),
+                _logger,
+                "TestTool",
+                "ticker=AAPL",
+                _reportError
+            );
 
-        // A wound-down call still answers, but no Errors row: cancellations are noise.
-        result.Should().Be("An error occurred while executing TestTool. Please try again.");
+        // An abort stays an abort — no Errors row, no fault translation: cancellations are noise.
+        await act.Should().ThrowAsync<OperationCanceledException>();
         await _reportError
             .DidNotReceive()
             .Invoke(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<string>());


### PR DESCRIPTION
## Summary

Two shared-plumbing fixes (commercial issues #7047 and #7042):

**Tool faults counted as successes.** `McpToolExecutor.Execute` caught every exception and returned the message as ordinary tool text — the SDK serialises that as a SUCCESS, so no in-tool failure could ever reach an error counter and a calling model could not tell a rejection from an answer. Execute now rethrows cancellations untouched (with an information-level log so a timeout storm stays visible) and wraps real faults into a new `McpToolFaultException` after logging + reporting; `InvalidParamsTranslatingTool` translates it into an in-band `isError: true` tool result with the same message. Verified against the pinned SDKs that nothing above the decorator intercepts the exception first, and that all ~200 runner call sites are tail-position returns with no post-processing.

**Sub-dollar price collapse.** Fixed `F2` masks rendered a $0.0060–0.0072 session as four identical `0.01` cells. New `McpFormat.Price` / `PriceOrDash` / `SignedPrice` adapt decimals to magnitude (≥ $1 unchanged at two decimals; below, enough for two significant digits, capped at 8), applied to daily OHLC, latest prices + change column, 52-week cells, the indicator tables' close cells, Bollinger bands, and the fails-to-deliver price column.

## Code changes

- `Equibles.Mcp/McpToolExecutor.cs` — cancellation passthrough + fault rethrow; `McpToolFaultException.cs` new; `InvalidParamsTranslatingTool.cs` — fault → isError translation.
- `Equibles.Mcp/Helpers/McpFormat.cs` — the three price formatters.
- `Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs`, `Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — render-site sweep.
- Tests: executor contract rewritten to the fault shape; new decorator-translation and price-format suites; two integration tests moved to the fault contract.

Verified: build clean; 4,081 unit + 2,382 integration tests pass (Docker up for Testcontainers).

https://claude.ai/code/session_016ot9jjyt7oCYfCUjxZynYA