### PR TITLE
feat(common-stocks): operator-attachable secondary CIKs backfill financial facts

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -354,14 +354,17 @@ public class CommonStockManager
     {
         ArgumentNullException.ThrowIfNull(commonStock);
 
+        // Normalize BOTH sides: AttachSecondaryCik always stores normalized values,
+        // but the company sync's subsidiary attach writes SEC's value verbatim — a
+        // zero-padded stored CIK must still be removable.
         var normalized = NormalizeCik(cik);
-        if (normalized == null || !commonStock.SecondaryCiks.Contains(normalized))
+        if (normalized == null || !commonStock.SecondaryCiks.Any(c => NormalizeCik(c) == normalized))
         {
             return $"CIK {cik} is not attached to this stock.";
         }
 
         commonStock.SecondaryCiks = commonStock
-            .SecondaryCiks.Where(c => c != normalized)
+            .SecondaryCiks.Where(c => NormalizeCik(c) != normalized)
             .ToList();
         await _commonStockRepository.SaveChanges();
         return null;

--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -295,6 +295,91 @@ public class CommonStockManager
     }
 
     /// <summary>
+    /// Attaches an additional CIK to a stock — a predecessor registrant after a holdco
+    /// reorganisation (Exxon's 2026 reorg moved XOM to a new CIK and left the entire
+    /// filing and fact history on the old one, GH-7041) or a co-registrant subsidiary.
+    /// Operator-driven: no SEC feed states successorship in structured form, so the
+    /// association is a human decision; everything downstream is automatic — filing
+    /// discovery and the document scraper enumerate every attached CIK each sweep, and
+    /// the published <see cref="StockSecondaryCikAttached"/> resets the financial-facts
+    /// checkpoint so the predecessor's full XBRL history imports on the next cycle.
+    /// Returns null on success, otherwise a reason the attachment was refused.
+    /// </summary>
+    public async Task<string> AttachSecondaryCik(CommonStock commonStock, string cik)
+    {
+        ArgumentNullException.ThrowIfNull(commonStock);
+
+        var normalized = NormalizeCik(cik);
+        if (normalized == null)
+        {
+            return $"'{cik}' is not a valid CIK — expected up to ten digits.";
+        }
+        if (normalized == NormalizeCik(commonStock.Cik))
+        {
+            return $"CIK {normalized} is already this stock's primary CIK.";
+        }
+        if (commonStock.SecondaryCiks.Contains(normalized))
+        {
+            return $"CIK {normalized} is already attached to this stock.";
+        }
+
+        // One CIK belongs to one stock, ever — attaching a CIK another row owns
+        // (as primary or secondary) would merge two companies' filings.
+        var owner = await _commonStockRepository
+            .GetAll()
+            .Where(cs => cs.Cik == normalized || cs.SecondaryCiks.Contains(normalized))
+            .Select(cs => new { cs.Ticker })
+            .FirstOrDefaultAsync();
+        if (owner != null)
+        {
+            return $"CIK {normalized} already belongs to {owner.Ticker}.";
+        }
+
+        commonStock.SecondaryCiks = [.. commonStock.SecondaryCiks, normalized];
+        await _commonStockRepository.SaveChanges();
+
+        // Publish via the root bus (bypasses any bus outbox) after the write commits.
+        await _bus.Publish(
+            new StockSecondaryCikAttached(commonStock.Id, commonStock.Ticker, normalized)
+        );
+        return null;
+    }
+
+    /// <summary>
+    /// Removes a previously attached secondary CIK. Already-imported documents and
+    /// facts stay (they were the operator's deliberate backfill); the scrapers simply
+    /// stop sweeping the detached CIK. Returns null on success, otherwise a reason.
+    /// </summary>
+    public async Task<string> DetachSecondaryCik(CommonStock commonStock, string cik)
+    {
+        ArgumentNullException.ThrowIfNull(commonStock);
+
+        var normalized = NormalizeCik(cik);
+        if (normalized == null || !commonStock.SecondaryCiks.Contains(normalized))
+        {
+            return $"CIK {cik} is not attached to this stock.";
+        }
+
+        commonStock.SecondaryCiks = commonStock
+            .SecondaryCiks.Where(c => c != normalized)
+            .ToList();
+        await _commonStockRepository.SaveChanges();
+        return null;
+    }
+
+    // CIKs are stored with leading zeros trimmed (matching SEC filer CIKs elsewhere in
+    // the model); a CIK is one to ten digits.
+    internal static string NormalizeCik(string cik)
+    {
+        var trimmed = cik?.Trim().TrimStart('0');
+        if (string.IsNullOrEmpty(trimmed) || trimmed.Length > 10 || !trimmed.All(char.IsAsciiDigit))
+        {
+            return null;
+        }
+        return trimmed;
+    }
+
+    /// <summary>
     /// Stages a <see cref="CommonStockTickerAlias"/> for a primary ticker the stock is
     /// abandoning, so URLs published under the old symbol can 301 to the current one.
     /// Stages only — no SaveChanges: the caller is the SEC sync mid-rename, and the alias

--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -358,7 +358,10 @@ public class CommonStockManager
         // but the company sync's subsidiary attach writes SEC's value verbatim — a
         // zero-padded stored CIK must still be removable.
         var normalized = NormalizeCik(cik);
-        if (normalized == null || !commonStock.SecondaryCiks.Any(c => NormalizeCik(c) == normalized))
+        if (
+            normalized == null
+            || !commonStock.SecondaryCiks.Any(c => NormalizeCik(c) == normalized)
+        )
         {
             return $"CIK {cik} is not attached to this stock.";
         }

--- a/src/Equibles.CommonStocks.BusinessLogic/Equibles.CommonStocks.BusinessLogic.csproj
+++ b/src/Equibles.CommonStocks.BusinessLogic/Equibles.CommonStocks.BusinessLogic.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <InternalsVisibleTo Include="Equibles.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Equibles.Core.AutoWiring" />
   </ItemGroup>
 

--- a/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
+++ b/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
@@ -5,6 +5,10 @@ namespace Equibles.Integrations.Sec.Models;
 public class CompanyMetadata
 {
     public string Cik { get; set; }
+
+    /// <summary>SEC's registrant name for the CIK (submissions "name").</summary>
+    public string Name { get; set; }
+
     public string EntityType { get; set; }
 
     /// <summary>

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -213,6 +213,7 @@ public class SecEdgarClient : ISecEdgarClient
             return new CompanyMetadata
             {
                 Cik = cik,
+                Name = apiResponse.Name,
                 EntityType = apiResponse.EntityType,
                 Sic = apiResponse.Sic,
                 Exchanges = apiResponse.Exchanges ?? [],

--- a/src/Equibles.Messaging/Contracts/CommonStocks/StockSecondaryCikAttached.cs
+++ b/src/Equibles.Messaging/Contracts/CommonStocks/StockSecondaryCikAttached.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Messaging.Contracts.CommonStocks;
+
+// Raised when an operator attaches an additional CIK (a predecessor registrant
+// after a holdco reorganisation, or a co-registrant subsidiary) to a stock.
+// Filing discovery and the document scraper re-enumerate every CIK each sweep,
+// so documents backfill on their own — but the financial-facts lane checkpoints
+// on the newest filed date it has seen, and a predecessor's facts are all OLDER
+// than that watermark. The consumer resets the stock's facts checkpoint so the
+// next cycle re-imports the full (now multi-CIK) companyfacts history.
+public record StockSecondaryCikAttached(Guid CommonStockId, string Ticker, string Cik);

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Consumers/StockSecondaryCikAttachedConsumer.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Consumers/StockSecondaryCikAttachedConsumer.cs
@@ -1,0 +1,48 @@
+using Equibles.Messaging.Attributes;
+using Equibles.Messaging.Contracts.CommonStocks;
+using Equibles.Sec.FinancialFacts.Repositories;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.FinancialFacts.HostedService.Consumers;
+
+/// <summary>
+/// A newly attached CIK's facts are all OLDER than the stock's facts checkpoint
+/// (<c>FinancialFactsSyncStatus.LastFiledDateSeen</c> tracks the newest filed date
+/// seen, and a predecessor registrant stopped filing when the ticker moved), so
+/// without a reset the import's nothing-new-since short-circuit would skip the
+/// attached history forever. Deleting the status row makes the stock look never
+/// synced: the next facts cycle re-imports the full multi-CIK history (upsert on
+/// the natural key, so re-reading the primary's facts is idempotent). Deletion is
+/// idempotent too — a duplicate event finds no row and does nothing.
+/// </summary>
+[Consumer]
+public class StockSecondaryCikAttachedConsumer : IConsumer<StockSecondaryCikAttached>
+{
+    private readonly FinancialFactsSyncStatusRepository _syncStatusRepository;
+    private readonly ILogger<StockSecondaryCikAttachedConsumer> _logger;
+
+    public StockSecondaryCikAttachedConsumer(
+        FinancialFactsSyncStatusRepository syncStatusRepository,
+        ILogger<StockSecondaryCikAttachedConsumer> logger
+    )
+    {
+        _syncStatusRepository = syncStatusRepository;
+        _logger = logger;
+    }
+
+    public async Task Consume(ConsumeContext<StockSecondaryCikAttached> context)
+    {
+        var cleared = await _syncStatusRepository
+            .GetAll()
+            .Where(s => s.CommonStockId == context.Message.CommonStockId)
+            .ExecuteDeleteAsync(context.CancellationToken);
+
+        _logger.LogInformation(
+            "Secondary CIK {Cik} attached to {Ticker} — facts checkpoint {Outcome}",
+            context.Message.Cik,
+            context.Message.Ticker,
+            cleared > 0 ? "reset for full re-import" : "was already absent"
+        );
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Equibles.Sec.FinancialFacts.HostedService.csproj
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Equibles.Sec.FinancialFacts.HostedService.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Equibles.Media.BusinessLogic\Equibles.Media.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.BusinessLogic\Equibles.Sec.FinancialFacts.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Repositories\Equibles.Sec.FinancialFacts.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
     <ProjectReference Include="..\Equibles.Sec.Repositories\Equibles.Sec.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -64,7 +64,7 @@ public class FinancialFactsImportService
         // unique in SEC. Any CIK failing to download skips the whole cycle so the
         // checkpoint never advances past an unread source.
         var parsed = new List<ParsedFact>();
-        foreach (var cik in new[] { stock.Cik }.Concat(stock.SecondaryCiks ?? []))
+        foreach (var cik in CiksFor(stock))
         {
             CompanyFactsResponse response;
             try
@@ -477,6 +477,15 @@ public class FinancialFactsImportService
             AccessionNumber = p.Accession,
             Frame = p.Frame,
         };
+    }
+
+    // The CIK set one facts import reads: primary first, then every attached
+    // secondary. Distinct because the subsidiary-attach path writes SEC's value
+    // verbatim — a duplicate would double the companyfacts download and the
+    // parsed set held in memory. Internal static so the unit suite pins it.
+    internal static IEnumerable<string> CiksFor(CommonStock stock)
+    {
+        return new[] { stock.Cik }.Concat(stock.SecondaryCiks ?? []).Distinct();
     }
 
     private async Task<bool> CommonStockStillExists(

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -55,23 +55,38 @@ public class FinancialFactsImportService
         if (string.IsNullOrEmpty(stock.Cik))
             return;
 
-        CompanyFactsResponse response;
-        try
+        // Every attached CIK contributes to ONE fact set: a holdco reorganisation
+        // moves the ticker to a NEW registrant while the entire XBRL history stays
+        // on the predecessor CIK (Exxon's 2026 reorg left XOM with six documents
+        // and no pre-2026 facts, GH-7041), and a co-registrant subsidiary can file
+        // facts of its own. Cross-CIK duplicates are impossible downstream: the
+        // natural key carries the AccessionNumber, and accessions are globally
+        // unique in SEC. Any CIK failing to download skips the whole cycle so the
+        // checkpoint never advances past an unread source.
+        var parsed = new List<ParsedFact>();
+        foreach (var cik in new[] { stock.Cik }.Concat(stock.SecondaryCiks ?? []))
         {
-            response = await _secEdgarClient.GetCompanyFacts(stock.Cik);
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Company Facts download failed for {Ticker} (CIK {Cik}), skipping this cycle",
-                stock.Ticker,
-                stock.Cik
-            );
-            return;
+            CompanyFactsResponse response;
+            try
+            {
+                response = await _secEdgarClient.GetCompanyFacts(cik);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Company Facts download failed for {Ticker} (CIK {Cik}), skipping this cycle",
+                    stock.Ticker,
+                    cik
+                );
+                return;
+            }
+
+            if (response != null && response.Facts.Count > 0)
+                parsed.AddRange(ParseFacts(response, stock));
         }
 
-        // Guards GH-1591: the stock can be deleted during the network call
+        // Guards GH-1591: the stock can be deleted during the network calls
         // above. Without this check, every UpsertSyncStatus and FlushFacts
         // path below trips FK_*_CommonStock_CommonStockId on Postgres. The
         // cycle is per-stock, so a single existence check covers all writes.
@@ -85,13 +100,6 @@ public class FinancialFactsImportService
             return;
         }
 
-        if (response == null || response.Facts.Count == 0)
-        {
-            await UpsertSyncStatus(stock, null, cancellationToken);
-            return;
-        }
-
-        var parsed = ParseFacts(response, stock).ToList();
         if (parsed.Count == 0)
         {
             await UpsertSyncStatus(stock, null, cancellationToken);

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -10,6 +10,8 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
+using Equibles.Messaging.Contracts.CommonStocks;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -32,13 +34,15 @@ public class CompanySyncService : ICompanySyncService
     private readonly WorkerOptions _workerOptions;
     private readonly ILogger<CompanySyncService> _logger;
     private readonly ErrorReporter _errorReporter;
+    private readonly IBus _bus;
 
     public CompanySyncService(
         IServiceScopeFactory serviceScopeFactory,
         ISecEdgarClient secEdgarClient,
         IOptions<WorkerOptions> workerOptions,
         ILogger<CompanySyncService> logger,
-        ErrorReporter errorReporter
+        ErrorReporter errorReporter,
+        IBus bus
     )
     {
         _serviceScopeFactory = serviceScopeFactory;
@@ -46,6 +50,7 @@ public class CompanySyncService : ICompanySyncService
         _workerOptions = workerOptions.Value;
         _logger = logger;
         _errorReporter = errorReporter;
+        _bus = bus;
     }
 
     public async Task SyncCompaniesFromSecApi()
@@ -569,6 +574,13 @@ public class CompanySyncService : ICompanySyncService
         // an unnecessary round-trip for a SecondaryCiks-only mutation.
         await state.CommonStockRepository.SaveChanges();
         state.SecondaryCikToParent[incoming.Cik] = incumbent;
+
+        // Same signal the operator attach publishes (root bus, after the commit):
+        // without it the financial-facts checkpoint is never reset, so the newly
+        // attached CIK's older facts are skipped until the primary next files.
+        await _bus.Publish(
+            new StockSecondaryCikAttached(incumbent.Id, incumbent.Ticker, incoming.Cik)
+        );
 
         _logger.LogInformation(
             "Attached subsidiary CIK {Cik} ({Name}) to parent {Ticker} (CIK: {ParentCik})",

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceActiveTickerCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceActiveTickerCollisionTests.cs
@@ -94,8 +94,9 @@ public class CompanySyncServiceActiveTickerCollisionTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceActiveTickerCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceActiveTickerCollisionTests.cs
@@ -95,7 +95,7 @@ public class CompanySyncServiceActiveTickerCollisionTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceCreateNewStockCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceCreateNewStockCatchTests.cs
@@ -67,7 +67,7 @@ public class CompanySyncServiceCreateNewStockCatchTests : ParadeDbMcpTestBase
             Options.Create(new WorkerOptions { TickersToSync = [] }),
             Substitute.For<ILogger<CompanySyncService>>(),
             new ErrorReporter(errorScopeFactory, Substitute.For<ILogger<ErrorReporter>>())
-        );
+        , Substitute.For<IBus>());
 
         // The whole sync must complete (the bad entry is caught, not rethrown).
         await sut.SyncCompaniesFromSecApi();

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceCreateNewStockCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceCreateNewStockCatchTests.cs
@@ -66,8 +66,9 @@ public class CompanySyncServiceCreateNewStockCatchTests : ParadeDbMcpTestBase
             secEdgarClient,
             Options.Create(new WorkerOptions { TickersToSync = [] }),
             Substitute.For<ILogger<CompanySyncService>>(),
-            new ErrorReporter(errorScopeFactory, Substitute.For<ILogger<ErrorReporter>>())
-        , Substitute.For<IBus>());
+            new ErrorReporter(errorScopeFactory, Substitute.For<ILogger<ErrorReporter>>()),
+            Substitute.For<IBus>()
+        );
 
         // The whole sync must complete (the bad entry is caught, not rethrown).
         await sut.SyncCompaniesFromSecApi();

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
@@ -51,7 +51,7 @@ public class CompanySyncServiceDispatchTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
     }
 
     private static CompanyInfo Company(string cik, string ticker, string name) =>

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
@@ -50,8 +50,9 @@ public class CompanySyncServiceDispatchTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
     }
 
     private static CompanyInfo Company(string cik, string ticker, string name) =>

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceOrchestrationSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceOrchestrationSkipTests.cs
@@ -96,8 +96,9 @@ public class CompanySyncServiceOrchestrationSkipTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceOrchestrationSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceOrchestrationSkipTests.cs
@@ -97,7 +97,7 @@ public class CompanySyncServiceOrchestrationSkipTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCaseMismatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCaseMismatchTests.cs
@@ -85,8 +85,9 @@ public class CompanySyncServiceReplaceObsoleteCaseMismatchTests : ParadeDbMcpTes
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCaseMismatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCaseMismatchTests.cs
@@ -86,7 +86,7 @@ public class CompanySyncServiceReplaceObsoleteCaseMismatchTests : ParadeDbMcpTes
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
@@ -82,7 +82,7 @@ public class CompanySyncServiceReplaceObsoleteCatchTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
@@ -81,8 +81,9 @@ public class CompanySyncServiceReplaceObsoleteCatchTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
@@ -102,8 +102,9 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
@@ -103,7 +103,7 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
@@ -118,7 +118,7 @@ public class CompanySyncServiceResolveCollisionTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
@@ -117,8 +117,9 @@ public class CompanySyncServiceResolveCollisionTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTests.cs
@@ -76,8 +76,9 @@ public class CompanySyncServiceTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTests.cs
@@ -77,7 +77,7 @@ public class CompanySyncServiceTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTickerFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTickerFilterTests.cs
@@ -75,8 +75,9 @@ public class CompanySyncServiceTickerFilterTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTickerFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTickerFilterTests.cs
@@ -76,7 +76,7 @@ public class CompanySyncServiceTickerFilterTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
@@ -58,8 +58,9 @@ public class CompanySyncServiceUpdateExistingCollisionTests : ParadeDbMcpTestBas
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
@@ -59,7 +59,7 @@ public class CompanySyncServiceUpdateExistingCollisionTests : ParadeDbMcpTestBas
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingRollbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingRollbackTests.cs
@@ -83,8 +83,9 @@ public class CompanySyncServiceUpdateExistingRollbackTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingRollbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingRollbackTests.cs
@@ -84,7 +84,7 @@ public class CompanySyncServiceUpdateExistingRollbackTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
@@ -81,8 +81,9 @@ public class CompanySyncServiceUpdateExistingTests : ParadeDbMcpTestBase
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
@@ -82,7 +82,7 @@ public class CompanySyncServiceUpdateExistingTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         await sut.SyncCompaniesFromSecApi();
 

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerAttachSecondaryCikTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerAttachSecondaryCikTests.cs
@@ -28,7 +28,12 @@ public class CommonStockManagerAttachSecondaryCikTests
         );
     }
 
-    private static (CommonStockManager Manager, CommonStockRepository Repo, IBus Bus, EquiblesFinancialDbContext Db) NewSut()
+    private static (
+        CommonStockManager Manager,
+        CommonStockRepository Repo,
+        IBus Bus,
+        EquiblesFinancialDbContext Db
+    ) NewSut()
     {
         var db = NewDb();
         var repo = Substitute.ForPartsOf<CommonStockRepository>(db);
@@ -40,7 +45,12 @@ public class CommonStockManagerAttachSecondaryCikTests
     public async Task Attach_NewCik_AppendsNormalizedPublishesAndSaves()
     {
         var (sut, _, bus, db) = NewSut();
-        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+        };
         db.Add(stock);
         await db.SaveChangesAsync();
 
@@ -60,7 +70,12 @@ public class CommonStockManagerAttachSecondaryCikTests
     public async Task Attach_PrimaryCikOfSameStock_RefusesWithoutPublishing()
     {
         var (sut, repo, bus, db) = NewSut();
-        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+        };
         db.Add(stock);
         await db.SaveChangesAsync();
 
@@ -97,8 +112,18 @@ public class CommonStockManagerAttachSecondaryCikTests
     public async Task Attach_CikOwnedByAnotherStockAsPrimary_Refuses()
     {
         var (sut, _, bus, db) = NewSut();
-        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
-        var other = new CommonStock { Ticker = "CVX", Name = "Chevron", Cik = "93410" };
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+        };
+        var other = new CommonStock
+        {
+            Ticker = "CVX",
+            Name = "Chevron",
+            Cik = "93410",
+        };
         db.Add(stock);
         db.Add(other);
         await db.SaveChangesAsync();
@@ -114,7 +139,12 @@ public class CommonStockManagerAttachSecondaryCikTests
     public async Task Attach_CikOwnedByAnotherStockAsSecondary_Refuses()
     {
         var (sut, _, bus, db) = NewSut();
-        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+        };
         var other = new CommonStock
         {
             Ticker = "CVX",
@@ -136,7 +166,12 @@ public class CommonStockManagerAttachSecondaryCikTests
     public async Task Attach_InvalidCik_Refuses()
     {
         var (sut, _, bus, db) = NewSut();
-        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+        };
         db.Add(stock);
         await db.SaveChangesAsync();
 
@@ -193,7 +228,12 @@ public class CommonStockManagerAttachSecondaryCikTests
     public async Task Detach_NotAttachedCik_Refuses()
     {
         var (sut, repo, _, db) = NewSut();
-        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+        };
         db.Add(stock);
         await db.SaveChangesAsync();
 

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerAttachSecondaryCikTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerAttachSecondaryCikTests.cs
@@ -1,0 +1,206 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Messaging.Contracts.CommonStocks;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+// AttachSecondaryCik/DetachSecondaryCik contract (GH-7041): an attached CIK is
+// normalized (leading zeros trimmed), refused when it is the stock's own primary,
+// already attached, or owned by ANY other stock (primary or secondary — one CIK
+// belongs to one stock, ever), and a successful attach publishes
+// StockSecondaryCikAttached via the root bus so the facts checkpoint resets.
+public class CommonStockManagerAttachSecondaryCikTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[] { new CommonStocksModuleConfiguration() }
+        );
+    }
+
+    private static (CommonStockManager Manager, CommonStockRepository Repo, IBus Bus, EquiblesFinancialDbContext Db) NewSut()
+    {
+        var db = NewDb();
+        var repo = Substitute.ForPartsOf<CommonStockRepository>(db);
+        var bus = Substitute.For<IBus>();
+        return (new CommonStockManager(repo, bus), repo, bus, db);
+    }
+
+    [Fact]
+    public async Task Attach_NewCik_AppendsNormalizedPublishesAndSaves()
+    {
+        var (sut, _, bus, db) = NewSut();
+        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        var error = await sut.AttachSecondaryCik(stock, "0000034088");
+
+        error.Should().BeNull();
+        stock.SecondaryCiks.Should().Contain("34088");
+        await bus.Received(1)
+            .Publish(
+                Arg.Is<StockSecondaryCikAttached>(e =>
+                    e.CommonStockId == stock.Id && e.Ticker == "XOM" && e.Cik == "34088"
+                )
+            );
+    }
+
+    [Fact]
+    public async Task Attach_PrimaryCikOfSameStock_RefusesWithoutPublishing()
+    {
+        var (sut, repo, bus, db) = NewSut();
+        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        // Leading zeros must not disguise the stock's own primary CIK.
+        var error = await sut.AttachSecondaryCik(stock, "0002115436");
+
+        error.Should().Contain("already this stock's primary CIK");
+        stock.SecondaryCiks.Should().BeEmpty();
+        await bus.DidNotReceive().Publish(Arg.Any<StockSecondaryCikAttached>());
+        await repo.DidNotReceive().SaveChanges();
+    }
+
+    [Fact]
+    public async Task Attach_AlreadyAttachedCik_Refuses()
+    {
+        var (sut, _, bus, db) = NewSut();
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+            SecondaryCiks = ["34088"],
+        };
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        var error = await sut.AttachSecondaryCik(stock, "34088");
+
+        error.Should().Contain("already attached");
+        await bus.DidNotReceive().Publish(Arg.Any<StockSecondaryCikAttached>());
+    }
+
+    [Fact]
+    public async Task Attach_CikOwnedByAnotherStockAsPrimary_Refuses()
+    {
+        var (sut, _, bus, db) = NewSut();
+        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        var other = new CommonStock { Ticker = "CVX", Name = "Chevron", Cik = "93410" };
+        db.Add(stock);
+        db.Add(other);
+        await db.SaveChangesAsync();
+
+        var error = await sut.AttachSecondaryCik(stock, "93410");
+
+        error.Should().Contain("already belongs to CVX");
+        stock.SecondaryCiks.Should().BeEmpty();
+        await bus.DidNotReceive().Publish(Arg.Any<StockSecondaryCikAttached>());
+    }
+
+    [Fact]
+    public async Task Attach_CikOwnedByAnotherStockAsSecondary_Refuses()
+    {
+        var (sut, _, bus, db) = NewSut();
+        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        var other = new CommonStock
+        {
+            Ticker = "CVX",
+            Name = "Chevron",
+            Cik = "93410",
+            SecondaryCiks = ["34088"],
+        };
+        db.Add(stock);
+        db.Add(other);
+        await db.SaveChangesAsync();
+
+        var error = await sut.AttachSecondaryCik(stock, "34088");
+
+        error.Should().Contain("already belongs to CVX");
+        await bus.DidNotReceive().Publish(Arg.Any<StockSecondaryCikAttached>());
+    }
+
+    [Fact]
+    public async Task Attach_InvalidCik_Refuses()
+    {
+        var (sut, _, bus, db) = NewSut();
+        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        (await sut.AttachSecondaryCik(stock, "not-a-cik")).Should().Contain("not a valid CIK");
+        (await sut.AttachSecondaryCik(stock, "")).Should().Contain("not a valid CIK");
+        (await sut.AttachSecondaryCik(stock, "12345678901")).Should().Contain("not a valid CIK");
+        await bus.DidNotReceive().Publish(Arg.Any<StockSecondaryCikAttached>());
+    }
+
+    [Fact]
+    public async Task Detach_AttachedCik_RemovesWithoutTouchingOthers()
+    {
+        var (sut, _, _, db) = NewSut();
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+            SecondaryCiks = ["34088", "99999"],
+        };
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        var error = await sut.DetachSecondaryCik(stock, "0000034088");
+
+        error.Should().BeNull();
+        stock.SecondaryCiks.Should().Equal("99999");
+    }
+
+    [Fact]
+    public async Task Detach_NotAttachedCik_Refuses()
+    {
+        var (sut, repo, _, db) = NewSut();
+        var stock = new CommonStock { Ticker = "XOM", Name = "Exxon Mobil", Cik = "2115436" };
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        var error = await sut.DetachSecondaryCik(stock, "34088");
+
+        error.Should().Contain("not attached");
+        await repo.DidNotReceive().SaveChanges();
+    }
+
+    [Theory]
+    [InlineData("0000034088", "34088")]
+    [InlineData(" 34088 ", "34088")]
+    [InlineData("34088", "34088")]
+    [InlineData("1234567890", "1234567890")]
+    public void NormalizeCik_ValidForms_TrimAndDropLeadingZeros(string raw, string expected)
+    {
+        CommonStockManager.NormalizeCik(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("0")]
+    [InlineData("0000")]
+    [InlineData("34O88")]
+    [InlineData("12345678901")]
+    [InlineData("-34088")]
+    public void NormalizeCik_InvalidForms_ReturnNull(string raw)
+    {
+        CommonStockManager.NormalizeCik(raw).Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerAttachSecondaryCikTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerAttachSecondaryCikTests.cs
@@ -167,6 +167,29 @@ public class CommonStockManagerAttachSecondaryCikTests
     }
 
     [Fact]
+    public async Task Detach_ZeroPaddedStoredCik_StillRemoves()
+    {
+        // The company sync's subsidiary attach stores SEC's value verbatim, so a
+        // zero-padded CIK can live in the column; the detach comparison must
+        // normalize BOTH sides or that entry becomes unremovable.
+        var (sut, _, _, db) = NewSut();
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+            SecondaryCiks = ["0000034088"],
+        };
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        var error = await sut.DetachSecondaryCik(stock, "34088");
+
+        error.Should().BeNull();
+        stock.SecondaryCiks.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Detach_NotAttachedCik_Refuses()
     {
         var (sut, repo, _, db) = NewSut();

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentDuplicateTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentDuplicateTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -64,6 +65,6 @@ public class CompanySyncServiceBuildSecondaryCikToParentDuplicateTests
             Substitute.For<IServiceScopeFactory>(),
             Substitute.For<ILogger<ErrorReporter>>()
         );
-        return new CompanySyncService(scopeFactory, secEdgarClient, options, logger, errorReporter);
+        return new CompanySyncService(scopeFactory, secEdgarClient, options, logger, errorReporter, Substitute.For<IBus>());
     }
 }

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentDuplicateTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentDuplicateTests.cs
@@ -4,11 +4,11 @@ using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -65,6 +65,13 @@ public class CompanySyncServiceBuildSecondaryCikToParentDuplicateTests
             Substitute.For<IServiceScopeFactory>(),
             Substitute.For<ILogger<ErrorReporter>>()
         );
-        return new CompanySyncService(scopeFactory, secEdgarClient, options, logger, errorReporter, Substitute.For<IBus>());
+        return new CompanySyncService(
+            scopeFactory,
+            secEdgarClient,
+            options,
+            logger,
+            errorReporter,
+            Substitute.For<IBus>()
+        );
     }
 }

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentTests.cs
@@ -4,11 +4,11 @@ using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -38,8 +38,9 @@ public class CompanySyncServiceBuildSecondaryCikToParentTests
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         var firstParent = new CommonStock
         {

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -38,7 +39,7 @@ public class CompanySyncServiceBuildSecondaryCikToParentTests
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         var firstParent = new CommonStock
         {

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceResolveTickerCollisionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceResolveTickerCollisionTests.cs
@@ -5,12 +5,12 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
-using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -34,8 +34,9 @@ public class CompanySyncServiceResolveTickerCollisionTests
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
         return (sut, client);
     }
 

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceResolveTickerCollisionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceResolveTickerCollisionTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
+using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -34,7 +35,7 @@ public class CompanySyncServiceResolveTickerCollisionTests
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
         return (sut, client);
     }
 

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceShouldIncumbentWinIsListedPriorityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceShouldIncumbentWinIsListedPriorityTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -63,7 +64,7 @@ public class CompanySyncServiceShouldIncumbentWinIsListedPriorityTests
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             )
-        );
+        , Substitute.For<IBus>());
 
         var incoming = new CompanyInfo { Cik = "0000001111", Name = "Incoming Co" };
         var incumbent = new CommonStock

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceShouldIncumbentWinIsListedPriorityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceShouldIncumbentWinIsListedPriorityTests.cs
@@ -5,11 +5,11 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -63,8 +63,9 @@ public class CompanySyncServiceShouldIncumbentWinIsListedPriorityTests
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
-        , Substitute.For<IBus>());
+            ),
+            Substitute.For<IBus>()
+        );
 
         var incoming = new CompanyInfo { Cik = "0000001111", Name = "Incoming Co" };
         var incumbent = new CommonStock

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -320,7 +321,7 @@ public class CompanySyncServiceTests
             Substitute.For<ILogger<ErrorReporter>>()
         );
 
-        return new CompanySyncService(scopeFactory, secEdgarClient, options, logger, errorReporter);
+        return new CompanySyncService(scopeFactory, secEdgarClient, options, logger, errorReporter, Substitute.For<IBus>());
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceTests.cs
@@ -4,11 +4,11 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -321,7 +321,14 @@ public class CompanySyncServiceTests
             Substitute.For<ILogger<ErrorReporter>>()
         );
 
-        return new CompanySyncService(scopeFactory, secEdgarClient, options, logger, errorReporter, Substitute.For<IBus>());
+        return new CompanySyncService(
+            scopeFactory,
+            secEdgarClient,
+            options,
+            logger,
+            errorReporter,
+            Substitute.For<IBus>()
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
@@ -52,7 +52,8 @@ public class CompanySyncServiceUpdateExistingBranchATests
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<IBus>()
         );
 
     private static object BuildState(

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingWebsiteRefillTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingWebsiteRefillTests.cs
@@ -58,7 +58,8 @@ public class CompanySyncServiceUpdateExistingWebsiteRefillTests
             new ErrorReporter(
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
-            )
+            ),
+            Substitute.For<IBus>()
         );
 
     private static object BuildState(EquiblesFinancialDbContext db, CommonStock existingStock)

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceMultiCikTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceMultiCikTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models.Responses;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Equibles.UnitTests.Sec;
+
+// The multi-CIK facts contract (GH-7041): one import reads the primary plus every
+// attached secondary CIK, and a fetch failure on ANY of them must abort the cycle
+// before a single write — otherwise the checkpoint advances past an unread source
+// and a predecessor's older facts are skipped forever.
+public class FinancialFactsImportServiceMultiCikTests
+{
+    [Fact]
+    public void CiksFor_PrimaryFirstThenSecondaries()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+            SecondaryCiks = ["34088", "99999"],
+        };
+
+        FinancialFactsImportService.CiksFor(stock).Should().Equal("2115436", "34088", "99999");
+    }
+
+    [Fact]
+    public void CiksFor_DuplicateSecondary_IsReadOnce()
+    {
+        // The company sync's subsidiary attach writes SEC's value verbatim, so a
+        // duplicate can exist in the column; reading it twice would double the
+        // companyfacts download and the in-memory parsed set.
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+            SecondaryCiks = ["34088", "34088", "2115436"],
+        };
+
+        FinancialFactsImportService.CiksFor(stock).Should().Equal("2115436", "34088");
+    }
+
+    [Fact]
+    public void CiksFor_NoSecondaries_IsJustThePrimary()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "320193",
+            SecondaryCiks = [],
+        };
+
+        FinancialFactsImportService.CiksFor(stock).Should().Equal("320193");
+    }
+
+    [Fact]
+    public async Task Import_SecondaryCikFetchFails_WritesNothing()
+    {
+        // Primary answers (no data), the attached CIK's download fails: the whole
+        // cycle must abort BEFORE any repository scope is opened. If a refactor
+        // turns the failure `return` into a `continue`, the import persists a
+        // partial union and advances the checkpoint — this pins the early return.
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient.GetCompanyFacts("2115436").Returns((CompanyFactsResponse)null);
+        secEdgarClient
+            .GetCompanyFacts("34088")
+            .ThrowsAsync(new HttpRequestException("boom", null, HttpStatusCode.ServiceUnavailable));
+
+        var sut = new FinancialFactsImportService(
+            scopeFactory,
+            secEdgarClient,
+            Substitute.For<ILogger<FinancialFactsImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+        var stock = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil",
+            Cik = "2115436",
+            SecondaryCiks = ["34088"],
+        };
+
+        await sut.Import(stock, CancellationToken.None);
+
+        await secEdgarClient.Received(1).GetCompanyFacts("34088");
+        scopeFactory.DidNotReceive().CreateScope();
+    }
+}


### PR DESCRIPTION
## Summary

A holding-company reorganisation re-registers a company under a NEW CIK and leaves the entire filing and XBRL fact history on the predecessor (Exxon's 2026 reorg moved XOM to CIK 2115436 while all pre-2026 history stayed on CIK 34088). Documents, insiders, 13F and NPORT already sweep every `SecondaryCiks` entry, but there was no supported way to attach a CIK, and the financial-facts import only read the primary CIK — its newest-filed-date checkpoint would skip a predecessor's older facts forever even once attached.

## Code changes

- **`FinancialFactsImportService`** — one import now fetches companyfacts for the primary plus every secondary CIK (`CiksFor`, internal static + Distinct, test-pinned) and unions the parsed facts; the natural key includes the accession number, so the cross-CIK merge is collision-free. A fetch failure on ANY CIK aborts the cycle before a single write, so the checkpoint can never advance past an unread source (test-pinned).
- **`CommonStockManager.AttachSecondaryCik`/`DetachSecondaryCik`** — validation lives here: normalized CIK (leading zeros trimmed, 1–10 digits), refuse the stock's own primary, duplicates, and any CIK another stock owns as primary or secondary (one CIK belongs to one stock, ever). A successful attach publishes `StockSecondaryCikAttached` on the root bus after the commit, mirroring `SetCusip`. Detach normalizes both sides of the comparison so a zero-padded stored value stays removable.
- **`StockSecondaryCikAttachedConsumer`** — deletes the stock's `FinancialFactsSyncStatus` row (idempotent), so the next facts cycle re-imports the full multi-CIK history.
- **`CompanySyncService.AttachAsSubsidiary`** — the automatic subsidiary attach now publishes the same event, closing the same stale-checkpoint gap on that path.
- **`CompanyMetadata.Name`** — the registrant name from the submissions payload, so callers can confirm a CIK's identity before acting on it.
- **Tests** — 25 new (attach/detach/normalize contract, multi-CIK set, the any-fetch-failure-writes-nothing early return); `CompanySyncService` test constructors gain the bus argument.

Unit suite: 4,106 pass. CompanySyncService integration tests: 17 pass.

https://claude.ai/code/session_016ot9jjyt7oCYfCUjxZynYA