### PR TITLE
feat(government-contracts): resolve award recipients through SAM parents and short distinctive names

### DIFF
--- a/src/Equibles.GovernmentContracts.Data/GovernmentContractsModuleConfiguration.cs
+++ b/src/Equibles.GovernmentContracts.Data/GovernmentContractsModuleConfiguration.cs
@@ -9,5 +9,6 @@ public class GovernmentContractsModuleConfiguration : Equibles.Data.IFinancialMo
     {
         builder.Entity<GovernmentContract>();
         builder.Entity<GovernmentContractsScanState>();
+        builder.Entity<GovernmentContractRecipientParent>();
     }
 }

--- a/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractRecipientParent.cs
+++ b/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractRecipientParent.cs
@@ -30,16 +30,21 @@ public class GovernmentContractRecipientParent
     public string RecipientName { get; set; }
 
     /// <summary>
-    /// The parent's level-qualified recipient hash; null when the profile names no parent,
-    /// names more than one distinct parent (ambiguous — never guessed), or the recipient is
-    /// unknown to the profile endpoint.
+    /// A representative level-qualified hash for the parent registrant; null when the
+    /// profile names no parent, names more than one distinct REGISTRANT (ownership moved —
+    /// ambiguous, never guessed), or the recipient is unknown to the profile endpoint.
     /// </summary>
     [MaxLength(64)]
     public string ParentRecipientId { get; set; }
 
-    /// <summary>The parent's registered name; null under the same conditions.</summary>
-    [MaxLength(512)]
-    public string ParentName { get; set; }
+    /// <summary>
+    /// Every name the parent registrant has carried (legal renames are one owner),
+    /// newline-delimited; null under the same conditions as
+    /// <see cref="ParentRecipientId"/>. Resolution tries each name through the exact
+    /// normalised lookup, so whichever name our stock universe stores can match.
+    /// </summary>
+    [MaxLength(1024)]
+    public string ParentNames { get; set; }
 
     /// <summary>When the profile was last fetched (UTC) — drives point-of-use re-resolution.</summary>
     public DateTime ResolvedAt { get; set; }

--- a/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractRecipientParent.cs
+++ b/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractRecipientParent.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.GovernmentContracts.Data.Models;
+
+/// <summary>
+/// Cached corporate-parent resolution for one USAspending recipient, filled from the
+/// recipient-profile endpoint the first time an award's recipient name fails to match a
+/// public company directly. SAM registration data links an operating subsidiary
+/// ("Raytheon Company", "CACI Inc - Federal") to its registered parent, whose name is what
+/// our CommonStock universe carries — so the parent name is re-resolved through the same
+/// exact normalised-name lookup, never fuzzily.
+///
+/// A row with null parent fields is itself an answer ("this recipient has no usable
+/// parent") and stops the profile from being re-fetched on every award; rows re-resolve at
+/// point of use once <see cref="ResolvedAt"/> is older than the import's staleness window,
+/// because acquisitions move subsidiaries between listed parents.
+/// </summary>
+public class GovernmentContractRecipientParent
+{
+    /// <summary>
+    /// USAspending's level-qualified recipient hash (e.g. "abc123…-C"), as carried on award
+    /// rows — the profile endpoint's key.
+    /// </summary>
+    [Key]
+    [MaxLength(64)]
+    public string RecipientId { get; set; }
+
+    /// <summary>Recipient name as seen on the award that triggered the resolution.</summary>
+    [MaxLength(512)]
+    public string RecipientName { get; set; }
+
+    /// <summary>
+    /// The parent's level-qualified recipient hash; null when the profile names no parent,
+    /// names more than one distinct parent (ambiguous — never guessed), or the recipient is
+    /// unknown to the profile endpoint.
+    /// </summary>
+    [MaxLength(64)]
+    public string ParentRecipientId { get; set; }
+
+    /// <summary>The parent's registered name; null under the same conditions.</summary>
+    [MaxLength(512)]
+    public string ParentName { get; set; }
+
+    /// <summary>When the profile was last fetched (UTC) — drives point-of-use re-resolution.</summary>
+    public DateTime ResolvedAt { get; set; }
+}

--- a/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractsScanState.cs
+++ b/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractsScanState.cs
@@ -29,4 +29,14 @@ public class GovernmentContractsScanState
 
     /// <summary>When the checkpoint last advanced (UTC); null until the first advance.</summary>
     public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>
+    /// The recipient-matching code version this cursor's scanned range was matched under
+    /// (the parser-version pattern). Unmatched awards are dropped, not stored, so a matching
+    /// improvement can only recover them by re-scanning history: when the code's version is
+    /// newer than this stamp the import pulls the cursor back to the epoch once and re-walks
+    /// the whole range, deduplicated by AwardUniqueKey. Rows written before the column
+    /// existed read as 0 and therefore reset on first sight.
+    /// </summary>
+    public int MatchingVersion { get; set; }
 }

--- a/src/Equibles.GovernmentContracts.HostedService/Equibles.GovernmentContracts.HostedService.csproj
+++ b/src/Equibles.GovernmentContracts.HostedService/Equibles.GovernmentContracts.HostedService.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <InternalsVisibleTo Include="Equibles.UnitTests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Equibles.Core.AutoWiring" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -7,6 +7,7 @@ using Equibles.GovernmentContracts.Data.Models;
 using Equibles.GovernmentContracts.HostedService.Configuration;
 using Equibles.GovernmentContracts.Repositories;
 using Equibles.Integrations.GovernmentContracts.Contracts;
+using Equibles.Integrations.GovernmentContracts.Models;
 using Equibles.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +31,21 @@ public class GovernmentContractsImportService : IImporter
 
     // Single well-known row that persists the forward award scan's resume point.
     private const string ScanStateName = "award-scan";
+
+    // Version of the recipient-matching rules (normaliser + parent fallback). Unmatched
+    // awards are dropped, not stored, so a matching improvement is invisible to history
+    // until the range is re-walked: bump this when matching can newly resolve recipients it
+    // previously dropped, and the next cycle pulls the cursor back to the epoch once
+    // (deduplicated by AwardUniqueKey). Version 1 is the original exact-name matching;
+    // 2 added the 2-character key floor, EDGAR slash-marker stripping, and SAM
+    // parent-fallback resolution.
+    internal const int RecipientMatchingVersion = 2;
+
+    // Re-fetch a cached recipient-parent profile at point of use once it is older than
+    // this — acquisitions move subsidiaries between listed parents, and a permanently
+    // stale row would mis-attribute every future award. Encounter-driven, so recipients
+    // that stop appearing cost nothing.
+    private const int ParentCacheStalenessDays = 180;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<GovernmentContractsImportService> _logger;
@@ -69,6 +85,8 @@ public class GovernmentContractsImportService : IImporter
             return;
         }
 
+        await ApplyMatchingVersionReset(cancellationToken);
+
         var startDate = await DetermineStartDate(cancellationToken);
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
         if (startDate > today)
@@ -107,6 +125,13 @@ public class GovernmentContractsImportService : IImporter
         // days still completes.
         var consecutiveWindowFailures = 0;
 
+        // Recipient-parent resolutions already read or fetched THIS cycle, so a recipient
+        // appearing in many windows costs one profile lookup per cycle at most. Keyed by
+        // USAspending's level-qualified recipient hash.
+        var parentCache = new Dictionary<string, GovernmentContractRecipientParent>(
+            StringComparer.Ordinal
+        );
+
         for (
             var windowStart = startDate;
             windowStart <= today;
@@ -125,6 +150,7 @@ public class GovernmentContractsImportService : IImporter
                     windowStart,
                     windowEnd,
                     recipientLookup,
+                    parentCache,
                     cancellationToken
                 );
 
@@ -227,6 +253,7 @@ public class GovernmentContractsImportService : IImporter
         DateOnly windowStart,
         DateOnly windowEnd,
         IReadOnlyDictionary<string, Guid> recipientLookup,
+        Dictionary<string, GovernmentContractRecipientParent> parentCache,
         CancellationToken cancellationToken
     )
     {
@@ -240,16 +267,50 @@ public class GovernmentContractsImportService : IImporter
             return 0;
 
         // Resolve to public companies, map, and de-duplicate within the batch by unique key.
+        // Direct name matches first; recipients whose own name matched nothing get a second
+        // chance through their SAM-registered parent (operating subsidiaries — "CACI Inc -
+        // Federal" — award under names our CommonStock universe never carries).
+        var unmatched = new List<UsaSpendingAwardRecord>();
         var mapped = new Dictionary<string, GovernmentContract>(StringComparer.Ordinal);
         foreach (var award in awards)
         {
             var commonStockId = RecipientResolver.Resolve(award.RecipientName, recipientLookup);
             if (commonStockId == null)
+            {
+                if (award.RecipientId != null)
+                    unmatched.Add(award);
                 continue;
+            }
 
             var entity = UsaSpendingAwardMapper.Map(award, commonStockId.Value);
             if (entity != null)
                 mapped[entity.AwardUniqueKey] = entity;
+        }
+
+        if (unmatched.Count > 0)
+        {
+            // A profile fetch that fails transport-level propagates out of here and fails
+            // the WINDOW, exactly like the award search itself — the checkpoint machinery
+            // then re-covers it, so an outage can never silently drop this window's
+            // parent-resolved awards. A 404 never reaches this path (the client answers it
+            // as a null profile, cached as parentless).
+            await ResolveParents(unmatched, parentCache, cancellationToken);
+
+            foreach (var award in unmatched)
+            {
+                if (!parentCache.TryGetValue(award.RecipientId, out var parent))
+                    continue;
+                var commonStockId = RecipientResolver.ResolveViaParents(
+                    [parent.ParentName],
+                    recipientLookup
+                );
+                if (commonStockId == null)
+                    continue;
+
+                var entity = UsaSpendingAwardMapper.Map(award, commonStockId.Value);
+                if (entity != null)
+                    mapped[entity.AwardUniqueKey] = entity;
+            }
         }
 
         if (mapped.Count == 0)
@@ -274,6 +335,169 @@ public class GovernmentContractsImportService : IImporter
             awards.Count
         );
         return inserted;
+    }
+
+    /// <summary>
+    /// Ensure every unmatched award's recipient has a parent-resolution row in
+    /// <paramref name="parentCache"/>: stored rows are read in one batch, and recipients
+    /// with no stored row (or a stale one, per <see cref="ParentCacheStalenessDays"/>) get
+    /// one profile fetch each, persisted so the answer — including "no usable parent" —
+    /// survives across cycles. The fetch runs inside the caller's window try/catch on
+    /// purpose: a transport failure here must fail the window, not skip the recipient.
+    /// </summary>
+    private async Task ResolveParents(
+        IReadOnlyList<UsaSpendingAwardRecord> unmatched,
+        Dictionary<string, GovernmentContractRecipientParent> parentCache,
+        CancellationToken cancellationToken
+    )
+    {
+        var now = DateTime.UtcNow;
+        var staleBefore = now.AddDays(-ParentCacheStalenessDays);
+        var pending = unmatched
+            .Where(a => a.RecipientId != null && !parentCache.ContainsKey(a.RecipientId))
+            .GroupBy(a => a.RecipientId, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First().RecipientName, StringComparer.Ordinal);
+        if (pending.Count == 0)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var repository =
+            scope.ServiceProvider.GetRequiredService<GovernmentContractRecipientParentRepository>();
+
+        var stored = await repository.GetByRecipientIds(pending.Keys.ToList(), cancellationToken);
+        foreach (var row in stored.Where(r => r.ResolvedAt >= staleBefore))
+        {
+            parentCache[row.RecipientId] = row;
+            pending.Remove(row.RecipientId);
+        }
+        var staleRows = stored
+            .Where(r => r.ResolvedAt < staleBefore)
+            .ToDictionary(r => r.RecipientId, StringComparer.Ordinal);
+
+        if (pending.Count == 0)
+            return;
+
+        var persisted = 0;
+        foreach (var (recipientId, recipientName) in pending)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var profile = await _client.GetRecipientProfile(recipientId, cancellationToken);
+            var parent = ChooseParent(profile, recipientId);
+
+            if (staleRows.TryGetValue(recipientId, out var row))
+            {
+                row.ParentRecipientId = parent?.ParentId;
+                row.ParentName = parent?.ParentName;
+                row.ResolvedAt = now;
+                repository.Update(row);
+            }
+            else
+            {
+                row = new GovernmentContractRecipientParent
+                {
+                    RecipientId = recipientId,
+                    RecipientName = Truncate(recipientName, 512),
+                    ParentRecipientId = parent?.ParentId,
+                    ParentName = Truncate(parent?.ParentName, 512),
+                    ResolvedAt = now,
+                };
+                repository.Add(row);
+            }
+
+            parentCache[recipientId] = row;
+            persisted++;
+        }
+
+        if (persisted > 0)
+            await repository.SaveChanges();
+    }
+
+    /// <summary>
+    /// Pick the ONE parent a recipient profile supports, or null. The top-level
+    /// parent_id/parent_name pair is USAspending's current SAM linkage and wins when
+    /// present; otherwise the parents[] history is used only when it names a single
+    /// distinct parent — several distinct parents means ownership moved and guessing
+    /// between them could assert a wrong link. A parent that IS the recipient itself
+    /// (parent-level recipients self-reference) carries no new name to match and is
+    /// treated as no parent.
+    /// </summary>
+    internal static UsaSpendingRecipientParentRef ChooseParent(
+        UsaSpendingRecipientProfile profile,
+        string recipientId
+    )
+    {
+        if (profile == null)
+            return null;
+
+        var candidate =
+            !string.IsNullOrWhiteSpace(profile.ParentId)
+            && !string.IsNullOrWhiteSpace(profile.ParentName)
+                ? new UsaSpendingRecipientParentRef
+                {
+                    ParentId = profile.ParentId,
+                    ParentName = profile.ParentName,
+                }
+                : null;
+
+        if (candidate == null)
+        {
+            var distinct = (profile.Parents ?? [])
+                .Where(p =>
+                    !string.IsNullOrWhiteSpace(p?.ParentId)
+                    && !string.IsNullOrWhiteSpace(p.ParentName)
+                )
+                .GroupBy(p => p.ParentId, StringComparer.Ordinal)
+                .Select(g => g.First())
+                .ToList();
+            if (distinct.Count == 1)
+                candidate = distinct[0];
+        }
+
+        if (candidate == null || candidate.ParentId == recipientId)
+            return null;
+
+        return candidate;
+    }
+
+    private static string Truncate(string value, int maxLength) =>
+        value != null && value.Length > maxLength ? value[..maxLength] : value;
+
+    /// <summary>
+    /// Pull the scan cursor back to the epoch ONCE when the recipient-matching code is
+    /// newer than the version the stored range was matched under. Unmatched awards are
+    /// dropped rather than stored, so this rescan is the only way a matching improvement
+    /// reaches history; everything re-fetched deduplicates by AwardUniqueKey. Cursor and
+    /// version stamp move in one save — a crash between cycles just re-triggers the same
+    /// idempotent rescan. Unlike the checkpoint writes this is NOT best-effort: failing to
+    /// persist must fail the cycle, or the scan would advance and re-stamp under the new
+    /// version without ever having re-walked history.
+    /// </summary>
+    private async Task ApplyMatchingVersionReset(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var scope = _scopeFactory.CreateScope();
+        var repository =
+            scope.ServiceProvider.GetRequiredService<GovernmentContractsScanStateRepository>();
+
+        var state = await repository.GetByName(ScanStateName);
+        if (state == null || state.MatchingVersion >= RecipientMatchingVersion)
+            return;
+
+        _logger.LogInformation(
+            "Government contracts import: recipient matching upgraded (v{From} -> v{To}); "
+                + "rescanning from the {Epoch} epoch to recover previously unmatched awards",
+            state.MatchingVersion,
+            RecipientMatchingVersion,
+            UsaSpendingMinimumActionDate
+        );
+
+        state.LastCompletedWindowEnd = UsaSpendingMinimumActionDate.AddDays(-1);
+        state.MatchingVersion = RecipientMatchingVersion;
+        state.UpdatedAt = DateTime.UtcNow;
+        repository.Update(state);
+        await repository.SaveChanges();
     }
 
     private async Task<HashSet<string>> LoadExistingKeys(
@@ -394,7 +618,14 @@ public class GovernmentContractsImportService : IImporter
             var isNew = state == null;
             if (isNew)
             {
-                state = new GovernmentContractsScanState { Name = ScanStateName };
+                // A first row is born current: whatever range this install scans, it scans
+                // under today's matching rules, so stamping the version here keeps a fresh
+                // install from triggering the version-reset epoch rescan on its next cycle.
+                state = new GovernmentContractsScanState
+                {
+                    Name = ScanStateName,
+                    MatchingVersion = RecipientMatchingVersion,
+                };
             }
             else if (state.LastCompletedWindowEnd >= windowEnd)
             {
@@ -459,6 +690,7 @@ public class GovernmentContractsImportService : IImporter
                         Name = ScanStateName,
                         LastCompletedWindowEnd = windowEnd,
                         UpdatedAt = DateTime.UtcNow,
+                        MatchingVersion = RecipientMatchingVersion,
                     }
                 );
                 await repository.SaveChanges();

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -115,6 +115,11 @@ public class GovernmentContractsImportService : IImporter
         // rescan lookback.
         var frontierIsContiguous = true;
 
+        // A backfill (above all the matching-version epoch rescan) runs thousands of
+        // windows in one cycle; a periodic marker keeps a multi-hour walk distinguishable
+        // from a hang.
+        var windowsCompleted = 0;
+
         // Nothing stepped over may fan out across the range. 422 is USAspending's validation
         // rejection for the WHOLE request, not just its dates, so a bad request-invariant field
         // (a filter shape, an award-type code, an out-of-range amount bound) 422s on every
@@ -162,6 +167,17 @@ public class GovernmentContractsImportService : IImporter
                     await AdvanceCheckpoint(windowEnd);
 
                 consecutiveWindowFailures = 0;
+
+                if (++windowsCompleted % 250 == 0)
+                {
+                    _logger.LogInformation(
+                        "Government contracts import: {Windows} windows scanned, at {WindowEnd} "
+                            + "({Inserted} awards persisted so far)",
+                        windowsCompleted,
+                        windowEnd,
+                        totalInserted
+                    );
+                }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -289,11 +305,14 @@ public class GovernmentContractsImportService : IImporter
 
         if (unmatched.Count > 0)
         {
-            // A profile fetch that fails transport-level propagates out of here and fails
-            // the WINDOW, exactly like the award search itself — the checkpoint machinery
-            // then re-covers it, so an outage can never silently drop this window's
-            // parent-resolved awards. A 404 never reaches this path (the client answers it
-            // as a null profile, cached as parentless).
+            // A profile fetch that fails transport-level propagates out of here like the
+            // award search itself: non-422 is systemic, so the CYCLE aborts and the
+            // checkpoint machinery re-covers this window next cycle — an outage can never
+            // silently drop its parent-resolved awards. (Accepted trade-off: a recipient
+            // whose profile deterministically fails non-404 stalls ingestion at this
+            // window until the source recovers — freshness loss, never data loss.) A 404
+            // never reaches this path; the client answers it as a null profile, cached as
+            // parentless.
             await ResolveParents(unmatched, parentCache, cancellationToken);
 
             foreach (var award in unmatched)
@@ -301,7 +320,7 @@ public class GovernmentContractsImportService : IImporter
                 if (!parentCache.TryGetValue(award.RecipientId, out var parent))
                     continue;
                 var commonStockId = RecipientResolver.ResolveViaParents(
-                    [parent.ParentName],
+                    SplitParentNames(parent.ParentNames),
                     recipientLookup
                 );
                 if (commonStockId == null)
@@ -383,12 +402,12 @@ public class GovernmentContractsImportService : IImporter
             cancellationToken.ThrowIfCancellationRequested();
 
             var profile = await _client.GetRecipientProfile(recipientId, cancellationToken);
-            var parent = ChooseParent(profile, recipientId);
+            var parent = ChooseParent(profile);
 
             if (staleRows.TryGetValue(recipientId, out var row))
             {
                 row.ParentRecipientId = parent?.ParentId;
-                row.ParentName = parent?.ParentName;
+                row.ParentNames = JoinParentNames(parent?.Names);
                 row.ResolvedAt = now;
                 repository.Update(row);
             }
@@ -399,7 +418,7 @@ public class GovernmentContractsImportService : IImporter
                     RecipientId = recipientId,
                     RecipientName = Truncate(recipientName, 512),
                     ParentRecipientId = parent?.ParentId,
-                    ParentName = Truncate(parent?.ParentName, 512),
+                    ParentNames = JoinParentNames(parent?.Names),
                     ResolvedAt = now,
                 };
                 repository.Add(row);
@@ -414,51 +433,111 @@ public class GovernmentContractsImportService : IImporter
     }
 
     /// <summary>
-    /// Pick the ONE parent a recipient profile supports, or null. The top-level
-    /// parent_id/parent_name pair is USAspending's current SAM linkage and wins when
-    /// present; otherwise the parents[] history is used only when it names a single
-    /// distinct parent — several distinct parents means ownership moved and guessing
-    /// between them could assert a wrong link. A parent that IS the recipient itself
-    /// (parent-level recipients self-reference) carries no new name to match and is
-    /// treated as no parent.
+    /// Pick the ONE parent REGISTRANT a recipient profile supports, or null.
+    ///
+    /// The unit of ambiguity is the registrant, not the name or the hash: the same owner
+    /// appears under several names (legal renames — CACI International's history also
+    /// carries its former name Systemware) and several ids/UEIs (the DUNS→UEI migration
+    /// re-hashed identities), while genuinely different owners always carry different
+    /// DUNS. So the union of the profile's current top-level parent and its parents[]
+    /// history is grouped by DUNS (falling back to UEI, then id, for entries missing it),
+    /// and only a SINGLE surviving group resolves — every name that group has carried is
+    /// returned so exact-match resolution can try each. More than one group means
+    /// ownership moved over the recipient's history (Sikorsky lists both RTX and Lockheed
+    /// Martin), and one link cannot be right for awards spanning both eras — verified
+    /// live against USAspending, and the epoch rescan would make a guess permanent, so
+    /// ambiguity is always dropped. A recipient's own self-registration era (SAM lists
+    /// the recipient as its own parent, under a DIFFERENT registrant identity) forms its
+    /// own group and therefore contributes ambiguity by design: an era in which the
+    /// recipient answered to no listed parent must not have its awards attributed to a
+    /// later owner.
     /// </summary>
-    internal static UsaSpendingRecipientParentRef ChooseParent(
-        UsaSpendingRecipientProfile profile,
-        string recipientId
-    )
+    internal static RecipientParentChoice ChooseParent(UsaSpendingRecipientProfile profile)
     {
         if (profile == null)
             return null;
 
-        var candidate =
-            !string.IsNullOrWhiteSpace(profile.ParentId)
-            && !string.IsNullOrWhiteSpace(profile.ParentName)
-                ? new UsaSpendingRecipientParentRef
+        var candidates = new List<UsaSpendingRecipientParentRef>();
+        if (!string.IsNullOrWhiteSpace(profile.ParentName))
+        {
+            candidates.Add(
+                new UsaSpendingRecipientParentRef
                 {
                     ParentId = profile.ParentId,
                     ParentName = profile.ParentName,
+                    ParentDuns = profile.ParentDuns,
+                    ParentUei = profile.ParentUei,
                 }
-                : null;
-
-        if (candidate == null)
-        {
-            var distinct = (profile.Parents ?? [])
-                .Where(p =>
-                    !string.IsNullOrWhiteSpace(p?.ParentId)
-                    && !string.IsNullOrWhiteSpace(p.ParentName)
-                )
-                .GroupBy(p => p.ParentId, StringComparer.Ordinal)
-                .Select(g => g.First())
-                .ToList();
-            if (distinct.Count == 1)
-                candidate = distinct[0];
+            );
         }
+        candidates.AddRange(
+            (profile.Parents ?? []).Where(p => !string.IsNullOrWhiteSpace(p?.ParentName))
+        );
 
-        if (candidate == null || candidate.ParentId == recipientId)
+        var groups = candidates
+            .Select(c => (Key: RegistrantKey(c), Candidate: c))
+            .Where(x => x.Key != null)
+            .GroupBy(x => x.Key, StringComparer.Ordinal)
+            .ToList();
+        if (groups.Count != 1)
             return null;
 
-        return candidate;
+        var members = groups[0].Select(x => x.Candidate).ToList();
+        return new RecipientParentChoice
+        {
+            ParentId = members
+                .Select(m => m.ParentId)
+                .FirstOrDefault(id => !string.IsNullOrWhiteSpace(id)),
+            Names = members
+                .Select(m => m.ParentName.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+        };
     }
+
+    /// <summary>
+    /// The identity two parent entries must share to count as the SAME registrant. DUNS
+    /// first — it survives renames and the DUNS→UEI migration (Lockheed appears under one
+    /// DUNS but two UEIs/hashes). Entries missing every identity are unusable. Prefixed
+    /// so a DUNS value can never collide with a UEI or hash value.
+    /// </summary>
+    private static string RegistrantKey(UsaSpendingRecipientParentRef candidate)
+    {
+        if (!string.IsNullOrWhiteSpace(candidate.ParentDuns))
+            return "duns:" + candidate.ParentDuns;
+        if (!string.IsNullOrWhiteSpace(candidate.ParentUei))
+            return "uei:" + candidate.ParentUei;
+        if (!string.IsNullOrWhiteSpace(candidate.ParentId))
+            return "id:" + candidate.ParentId;
+        return null;
+    }
+
+    /// <summary>
+    /// The registrant's names pack newline-delimited into one bounded column; whole names
+    /// only — a name that would cross the 1024 bound is dropped, never cut mid-way into a
+    /// string that could exact-match the wrong company.
+    /// </summary>
+    internal static string JoinParentNames(IReadOnlyList<string> names)
+    {
+        if (names == null || names.Count == 0)
+            return null;
+
+        var kept = new List<string>();
+        var length = 0;
+        foreach (var name in names)
+        {
+            var cost = name.Length + (kept.Count > 0 ? 1 : 0);
+            if (length + cost > 1024)
+                continue;
+            kept.Add(name);
+            length += cost;
+        }
+
+        return kept.Count > 0 ? string.Join('\n', kept) : null;
+    }
+
+    internal static string[] SplitParentNames(string parentNames) =>
+        parentNames == null ? [] : parentNames.Split('\n');
 
     private static string Truncate(string value, int maxLength) =>
         value != null && value.Length > maxLength ? value[..maxLength] : value;
@@ -482,8 +561,25 @@ public class GovernmentContractsImportService : IImporter
             scope.ServiceProvider.GetRequiredService<GovernmentContractsScanStateRepository>();
 
         var state = await repository.GetByName(ScanStateName);
-        if (state == null || state.MatchingVersion >= RecipientMatchingVersion)
+        if (state == null)
+        {
+            // No checkpoint row yet. A truly fresh install needs no reset (whatever it
+            // scans, it scans under current rules, and AdvanceCheckpoint stamps its first
+            // row current) — but an install that already HOLDS contracts scanned them
+            // under older rules, and skipping here would let that history be marked
+            // current without ever re-walking it. Open the row as a version-0 reset.
+            var contractRepository =
+                scope.ServiceProvider.GetRequiredService<GovernmentContractRepository>();
+            if (!await contractRepository.GetAll().AnyAsync(cancellationToken))
+                return;
+
+            state = new GovernmentContractsScanState { Name = ScanStateName };
+            repository.Add(state);
+        }
+        else if (state.MatchingVersion >= RecipientMatchingVersion)
+        {
             return;
+        }
 
         _logger.LogInformation(
             "Government contracts import: recipient matching upgraded (v{From} -> v{To}); "
@@ -496,7 +592,6 @@ public class GovernmentContractsImportService : IImporter
         state.LastCompletedWindowEnd = UsaSpendingMinimumActionDate.AddDays(-1);
         state.MatchingVersion = RecipientMatchingVersion;
         state.UpdatedAt = DateTime.UtcNow;
-        repository.Update(state);
         await repository.SaveChanges();
     }
 

--- a/src/Equibles.GovernmentContracts.HostedService/Services/RecipientNameNormalizer.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/RecipientNameNormalizer.cs
@@ -24,8 +24,10 @@ public static partial class RecipientNameNormalizer
     // ("Caci International Inc /De/", "Nve Corp /New/", "Fnb Corp/Pa/") that USAspending
     // recipient names never do; left in place it lands a stray trailing token in the key and
     // defeats the exact match. Removing the marker is a mechanical format rule, not a
-    // heuristic — matching stays exact on what remains.
-    [GeneratedRegex("/[A-Za-z ]{1,8}/")]
+    // heuristic — matching stays exact on what remains. Anchored to the END of the name
+    // (markers are always trailing, possibly stacked) so interior slashes in a real name
+    // can never be mangled into a different key.
+    [GeneratedRegex(@"(?:/[A-Za-z ]{1,8}/\s*)+$")]
     private static partial Regex EdgarSlashMarker();
 
     private static readonly HashSet<string> LegalSuffixes = new(StringComparer.Ordinal)

--- a/src/Equibles.GovernmentContracts.HostedService/Services/RecipientNameNormalizer.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/RecipientNameNormalizer.cs
@@ -1,18 +1,32 @@
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Equibles.GovernmentContracts.HostedService.Services;
 
 /// <summary>
 /// Normalises a company/recipient legal name to a comparable key for exact-match
 /// resolution between USAspending recipients and our <c>CommonStock</c> universe.
-/// Deliberately conservative — it strips punctuation, a leading "THE", and trailing
+/// Deliberately conservative — it strips punctuation, a leading "THE", EDGAR's
+/// slash-wrapped incorporation markers ("/DE/", "/PA/", "/NEW/"), and trailing
 /// legal-entity suffixes (CORP/INC/LLC/…) so "Lockheed Martin Corporation" and
 /// "Lockheed Martin Corp" collapse to the same key, but it never fuzzy-matches.
 /// Returns null when nothing meaningful remains.
 /// </summary>
-public static class RecipientNameNormalizer
+public static partial class RecipientNameNormalizer
 {
-    private const int MinimumKeyLength = 4;
+    // Two characters, not more: with matching kept exact and ambiguous keys dropped by the
+    // resolver, short DISTINCTIVE names ("3M", "RTX", "V2X") are safe, and a floor of 4 was
+    // silently excluding those companies from resolution entirely. Single characters stay
+    // out — a one-letter key carries no identity.
+    private const int MinimumKeyLength = 2;
+
+    // EDGAR registrant names carry a slash-wrapped state-of-incorporation or vintage marker
+    // ("Caci International Inc /De/", "Nve Corp /New/", "Fnb Corp/Pa/") that USAspending
+    // recipient names never do; left in place it lands a stray trailing token in the key and
+    // defeats the exact match. Removing the marker is a mechanical format rule, not a
+    // heuristic — matching stays exact on what remains.
+    [GeneratedRegex("/[A-Za-z ]{1,8}/")]
+    private static partial Regex EdgarSlashMarker();
 
     private static readonly HashSet<string> LegalSuffixes = new(StringComparer.Ordinal)
     {
@@ -39,6 +53,8 @@ public static class RecipientNameNormalizer
     {
         if (string.IsNullOrWhiteSpace(name))
             return null;
+
+        name = EdgarSlashMarker().Replace(name, " ");
 
         var cleaned = new StringBuilder(name.Length);
         foreach (var c in name.ToUpperInvariant())

--- a/src/Equibles.GovernmentContracts.HostedService/Services/RecipientParentChoice.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/RecipientParentChoice.cs
@@ -1,0 +1,15 @@
+namespace Equibles.GovernmentContracts.HostedService.Services;
+
+/// <summary>
+/// The single registrant a recipient profile supports as parent: a representative
+/// level-qualified hash plus EVERY name that registrant has carried, so exact-match
+/// resolution can try the current legal name and its predecessors alike (a renamed
+/// registrant is one owner, and any of its names may be the one our stock universe
+/// stores).
+/// </summary>
+public class RecipientParentChoice
+{
+    public string ParentId { get; set; }
+
+    public List<string> Names { get; set; } = [];
+}

--- a/src/Equibles.GovernmentContracts.HostedService/Services/RecipientResolver.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/RecipientResolver.cs
@@ -68,4 +68,31 @@ public class RecipientResolver
 
         return lookup.TryGetValue(key, out var id) ? id : null;
     }
+
+    /// <summary>
+    /// Resolves a recipient through its SAM-registered parent name(s) when the recipient's
+    /// own name matched nothing. Each candidate name goes through the same exact normalised
+    /// lookup; the match holds only when every resolving candidate lands on ONE stock —
+    /// parents that resolve to different companies (ownership moved between listed parents
+    /// over the registration history) are ambiguous and dropped, so a wrong link is never
+    /// asserted.
+    /// </summary>
+    public static Guid? ResolveViaParents(
+        IEnumerable<string> parentNames,
+        IReadOnlyDictionary<string, Guid> lookup
+    )
+    {
+        Guid? resolved = null;
+        foreach (var name in parentNames)
+        {
+            var id = Resolve(name, lookup);
+            if (id == null)
+                continue;
+            if (resolved != null && resolved != id)
+                return null;
+            resolved = id;
+        }
+
+        return resolved;
+    }
 }

--- a/src/Equibles.GovernmentContracts.Repositories/GovernmentContractRecipientParentRepository.cs
+++ b/src/Equibles.GovernmentContracts.Repositories/GovernmentContractRecipientParentRepository.cs
@@ -1,0 +1,22 @@
+using Equibles.Data;
+using Equibles.GovernmentContracts.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.GovernmentContracts.Repositories;
+
+public class GovernmentContractRecipientParentRepository
+    : BaseRepository<GovernmentContractRecipientParent>
+{
+    public GovernmentContractRecipientParentRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public virtual async Task<List<GovernmentContractRecipientParent>> GetByRecipientIds(
+        IReadOnlyCollection<string> recipientIds,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await GetAll()
+            .Where(p => recipientIds.Contains(p.RecipientId))
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/Equibles.Integrations.GovernmentContracts/Contracts/IUsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Contracts/IUsaSpendingClient.cs
@@ -19,4 +19,16 @@ public interface IUsaSpendingClient
         decimal minimumAmount,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Fetches the recipient profile for a level-qualified recipient hash (the
+    /// <c>recipient_id</c> carried on award rows), exposing the SAM-registered corporate
+    /// family. Returns null when the endpoint answers 404 — an unknown or profileless
+    /// recipient is an answer, not a fault. Transport failures and server errors throw
+    /// after the client's retry ladder, exactly like the award search.
+    /// </summary>
+    Task<UsaSpendingRecipientProfile> GetRecipientProfile(
+        string recipientId,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingRecipientParentRef.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingRecipientParentRef.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.GovernmentContracts.Models;
+
+/// <summary>
+/// One entry of a recipient profile's <c>parents[]</c> registration history. The same
+/// registrant can appear several times under different names (legal renames) and under
+/// different ids/UEIs (the DUNS→UEI migration re-hashed identities), so
+/// <see cref="ParentDuns"/> is the identity to group by when comparing entries.
+/// </summary>
+public class UsaSpendingRecipientParentRef
+{
+    [JsonProperty("parent_id")]
+    public string ParentId { get; set; }
+
+    [JsonProperty("parent_name")]
+    public string ParentName { get; set; }
+
+    [JsonProperty("parent_duns")]
+    public string ParentDuns { get; set; }
+
+    [JsonProperty("parent_uei")]
+    public string ParentUei { get; set; }
+}

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingRecipientProfile.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingRecipientProfile.cs
@@ -5,7 +5,9 @@ namespace Equibles.Integrations.GovernmentContracts.Models;
 /// <summary>
 /// The slice of USAspending's <c>GET /api/v2/recipient/{recipient_id}/</c> profile this
 /// integration needs: the recipient's registered corporate family. The parent linkage comes
-/// from SAM registration data, so it is authoritative, not inferred.
+/// from SAM registration data, so it is authoritative, not inferred. The top-level parent
+/// fields carry the CURRENT linkage; <see cref="Parents"/> is the full registration
+/// history and can name several distinct parents when ownership moved.
 /// </summary>
 public class UsaSpendingRecipientProfile
 {
@@ -26,18 +28,20 @@ public class UsaSpendingRecipientProfile
     public string ParentName { get; set; }
 
     /// <summary>
+    /// The parent's DUNS — the most stable registrant identity across renames and the
+    /// DUNS→UEI migration, so it is the primary key for deciding whether two parent
+    /// entries are the SAME registrant or genuinely different owners.
+    /// </summary>
+    [JsonProperty("parent_duns")]
+    public string ParentDuns { get; set; }
+
+    [JsonProperty("parent_uei")]
+    public string ParentUei { get; set; }
+
+    /// <summary>
     /// Every parent SAM has registered for this recipient; can exceed one when ownership
     /// changed over the recipient's registration history.
     /// </summary>
     [JsonProperty("parents")]
     public List<UsaSpendingRecipientParentRef> Parents { get; set; } = [];
-}
-
-public class UsaSpendingRecipientParentRef
-{
-    [JsonProperty("parent_id")]
-    public string ParentId { get; set; }
-
-    [JsonProperty("parent_name")]
-    public string ParentName { get; set; }
 }

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingRecipientProfile.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingRecipientProfile.cs
@@ -1,0 +1,43 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.GovernmentContracts.Models;
+
+/// <summary>
+/// The slice of USAspending's <c>GET /api/v2/recipient/{recipient_id}/</c> profile this
+/// integration needs: the recipient's registered corporate family. The parent linkage comes
+/// from SAM registration data, so it is authoritative, not inferred.
+/// </summary>
+public class UsaSpendingRecipientProfile
+{
+    [JsonProperty("recipient_id")]
+    public string RecipientId { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>"R" (recipient), "P" (parent) or "C" (child) — the hash's level qualifier.</summary>
+    [JsonProperty("recipient_level")]
+    public string RecipientLevel { get; set; }
+
+    [JsonProperty("parent_id")]
+    public string ParentId { get; set; }
+
+    [JsonProperty("parent_name")]
+    public string ParentName { get; set; }
+
+    /// <summary>
+    /// Every parent SAM has registered for this recipient; can exceed one when ownership
+    /// changed over the recipient's registration history.
+    /// </summary>
+    [JsonProperty("parents")]
+    public List<UsaSpendingRecipientParentRef> Parents { get; set; } = [];
+}
+
+public class UsaSpendingRecipientParentRef
+{
+    [JsonProperty("parent_id")]
+    public string ParentId { get; set; }
+
+    [JsonProperty("parent_name")]
+    public string ParentName { get; set; }
+}

--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -17,6 +17,7 @@ namespace Equibles.Integrations.GovernmentContracts;
 public class UsaSpendingClient : IUsaSpendingClient
 {
     private const string SearchUrl = "https://api.usaspending.gov/api/v2/search/spending_by_award/";
+    private const string RecipientProfileUrlBase = "https://api.usaspending.gov/api/v2/recipient/";
 
     // USAspending's front-end intermittently accepts a connection and then closes it without
     // a response ("empty reply", surfaced by .NET as "the response ended prematurely") — in a
@@ -112,6 +113,41 @@ public class UsaSpendingClient : IUsaSpendingClient
             cancellationToken
         );
         return results;
+    }
+
+    public async Task<UsaSpendingRecipientProfile> GetRecipientProfile(
+        string recipientId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var url = RecipientProfileUrlBase + Uri.EscapeDataString(recipientId) + "/";
+        string content;
+        try
+        {
+            content = await SendWithRetry(
+                async () =>
+                {
+                    using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Headers.Accept.Add(
+                        new MediaTypeWithQualityHeaderValue("application/json")
+                    );
+                    // Same fresh-connection rule as PostQuery — the sick-backend roulette
+                    // lives in front of the whole API, not one endpoint.
+                    request.Headers.ConnectionClose = true;
+                    return await _httpClient.SendAsync(request, cancellationToken);
+                },
+                cancellationToken
+            );
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            // 404 is the endpoint's "no such recipient / no profile" answer, not a fault —
+            // rethrowing would fail the import window over a recipient that simply has no
+            // corporate-family record.
+            return null;
+        }
+
+        return JsonConvert.DeserializeObject<UsaSpendingRecipientProfile>(content);
     }
 
     /// <summary>

--- a/src/Equibles.Migrations/Migrations/20260809064707_AddGovernmentContractRecipientParents.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260809064707_AddGovernmentContractRecipientParents.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260809064707_AddGovernmentContractRecipientParents")]
+    partial class AddGovernmentContractRecipientParents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260809064707_AddGovernmentContractRecipientParents.cs
+++ b/src/Equibles.Migrations/Migrations/20260809064707_AddGovernmentContractRecipientParents.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGovernmentContractRecipientParents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MatchingVersion",
+                table: "GovernmentContractsScanState",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "GovernmentContractRecipientParent",
+                columns: table => new
+                {
+                    RecipientId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    RecipientName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    ParentRecipientId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    ParentName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    ResolvedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GovernmentContractRecipientParent", x => x.RecipientId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GovernmentContractRecipientParent");
+
+            migrationBuilder.DropColumn(
+                name: "MatchingVersion",
+                table: "GovernmentContractsScanState");
+        }
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260809071017_AddGovernmentContractRecipientParents.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260809071017_AddGovernmentContractRecipientParents.Designer.cs
@@ -14,7 +14,7 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    [Migration("20260809064707_AddGovernmentContractRecipientParents")]
+    [Migration("20260809071017_AddGovernmentContractRecipientParents")]
     partial class AddGovernmentContractRecipientParents
     {
         /// <inheritdoc />
@@ -1174,9 +1174,9 @@ namespace Equibles.Migrations.Migrations
                         .HasMaxLength(64)
                         .HasColumnType("character varying(64)");
 
-                    b.Property<string>("ParentName")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
+                    b.Property<string>("ParentNames")
+                        .HasMaxLength(1024)
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<string>("ParentRecipientId")
                         .HasMaxLength(64)

--- a/src/Equibles.Migrations/Migrations/20260809071017_AddGovernmentContractRecipientParents.cs
+++ b/src/Equibles.Migrations/Migrations/20260809071017_AddGovernmentContractRecipientParents.cs
@@ -25,7 +25,7 @@ namespace Equibles.Migrations.Migrations
                     RecipientId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
                     RecipientName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
                     ParentRecipientId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
-                    ParentName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    ParentNames = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
                     ResolvedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
                 constraints: table =>

--- a/src/Equibles.Migrations/Migrations/EquiblesDbContextModelSnapshot.cs
+++ b/src/Equibles.Migrations/Migrations/EquiblesDbContextModelSnapshot.cs
@@ -1171,9 +1171,9 @@ namespace Equibles.Migrations.Migrations
                         .HasMaxLength(64)
                         .HasColumnType("character varying(64)");
 
-                    b.Property<string>("ParentName")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
+                    b.Property<string>("ParentNames")
+                        .HasMaxLength(1024)
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<string>("ParentRecipientId")
                         .HasMaxLength(64)

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCheckpointTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceCheckpointTests.cs
@@ -167,6 +167,9 @@ public class GovernmentContractsImportServiceCheckpointTests
                     Name = ScanStateName,
                     LastCompletedWindowEnd = today,
                     UpdatedAt = DateTime.UtcNow,
+                    // Born current so the matching-version epoch rescan stays out of this
+                    // trailing-rescan scenario.
+                    MatchingVersion = GovernmentContractsImportService.RecipientMatchingVersion,
                 }
             );
             seed.SaveChanges();

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceChooseParentTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceChooseParentTests.cs
@@ -1,42 +1,145 @@
 using Equibles.GovernmentContracts.HostedService.Services;
 using Equibles.Integrations.GovernmentContracts.Models;
+using FluentAssertions;
+using Xunit;
 
 namespace Equibles.UnitTests.GovernmentContracts;
 
-// Contract: a recipient profile yields at most ONE parent to match through. The top-level
-// parent pair is USAspending's current SAM linkage and wins; the parents[] history only
-// substitutes when it names a single distinct parent — several distinct parents means
-// ownership moved, and guessing between them could assert a wrong link. Self-references
-// (parent-level recipients list themselves) carry no new name and count as no parent.
+// Contract: a recipient profile yields at most ONE parent REGISTRANT, judged over the
+// union of the top-level parent and the parents[] history grouped by DUNS (then UEI, then
+// hash). One registrant under several names (legal renames) collapses to a single choice
+// carrying every name; several registrants means ownership moved over the recipient's
+// history, and one link cannot be right for awards spanning both eras — always dropped,
+// never guessed. The fixtures mirror profiles verified live against USAspending
+// (Sikorsky: RTX + Lockheed; CACI, Inc. - Federal: CACI International + its former name
+// Systemware under one DUNS).
 public class GovernmentContractsImportServiceChooseParentTests
 {
     [Fact]
-    public void ChooseParent_TopLevelParent_Wins()
+    public void ChooseParent_OneRegistrantRenamedOverHistory_CollapsesToAllItsNames()
     {
+        // CACI, INC. - FEDERAL (live shape): top-level CACI INTERNATIONAL INC; history
+        // carries CACI INTERNATIONAL INC and SYSTEMWARE, INC. under the SAME DUNS.
         var profile = new UsaSpendingRecipientProfile
         {
-            RecipientId = "child-C",
-            ParentId = "parent-P",
-            ParentName = "CACI International Inc",
+            RecipientId = "28eee911-C",
+            ParentId = "5eb76328-P",
+            ParentName = "CACI INTERNATIONAL INC",
+            ParentDuns = "045534641",
+            ParentUei = "QSRTXLFKV857",
             Parents =
             [
                 new UsaSpendingRecipientParentRef
                 {
-                    ParentId = "old-P",
-                    ParentName = "Former Owner Corp",
+                    ParentId = "5eb76328-P",
+                    ParentName = "CACI INTERNATIONAL INC",
+                    ParentDuns = "045534641",
+                    ParentUei = "QSRTXLFKV857",
+                },
+                new UsaSpendingRecipientParentRef
+                {
+                    ParentId = "697f7757-P",
+                    ParentName = "SYSTEMWARE, INC.",
+                    ParentDuns = "045534641",
+                    ParentUei = "ZWJ2TPLX7MS2",
                 },
             ],
         };
 
-        var parent = GovernmentContractsImportService.ChooseParent(profile, "child-C");
+        var choice = GovernmentContractsImportService.ChooseParent(profile);
 
-        parent.Should().NotBeNull();
-        parent.ParentId.Should().Be("parent-P");
-        parent.ParentName.Should().Be("CACI International Inc");
+        choice.Should().NotBeNull();
+        choice.ParentId.Should().Be("5eb76328-P");
+        choice
+            .Names.Should()
+            .BeEquivalentTo(
+                ["CACI INTERNATIONAL INC", "SYSTEMWARE, INC."],
+                "every name the registrant has carried may be the one the stock universe stores"
+            );
     }
 
     [Fact]
-    public void ChooseParent_NoTopLevel_SingleHistoryParent_IsUsed()
+    public void ChooseParent_OwnershipMovedBetweenRegistrants_IsAmbiguousEvenWithATopLevelParent()
+    {
+        // SIKORSKY AIRCRAFT CORPORATION (live shape): top-level says RTX CORP, but the
+        // history also carries Lockheed Martin under a DIFFERENT DUNS (twice, under two
+        // hashes — the DUNS→UEI migration). Sikorsky was UTC/RTX before Nov 2015 and
+        // Lockheed after; one link cannot be right for both eras, so the top-level pair
+        // must NOT short-circuit the ambiguity check.
+        var profile = new UsaSpendingRecipientProfile
+        {
+            RecipientId = "d64537c9-C",
+            ParentId = "bb947c1e-P",
+            ParentName = "RTX CORP",
+            ParentDuns = "001344142",
+            ParentUei = "PPLZG8J3N9D4",
+            Parents =
+            [
+                new UsaSpendingRecipientParentRef
+                {
+                    ParentId = "bb947c1e-P",
+                    ParentName = "RTX CORP",
+                    ParentDuns = "001344142",
+                    ParentUei = "PPLZG8J3N9D4",
+                },
+                new UsaSpendingRecipientParentRef
+                {
+                    ParentId = "8e2862a3-P",
+                    ParentName = "LOCKHEED MARTIN CORPORATION",
+                    ParentDuns = "834951691",
+                    ParentUei = "JSQTW5L2SSM1",
+                },
+                new UsaSpendingRecipientParentRef
+                {
+                    ParentId = "b97d19b0-P",
+                    ParentName = "LOCKHEED MARTIN CORP",
+                    ParentDuns = "834951691",
+                    ParentUei = "ZFN2JJXBLZT3",
+                },
+            ],
+        };
+
+        GovernmentContractsImportService.ChooseParent(profile).Should().BeNull();
+    }
+
+    [Fact]
+    public void ChooseParent_SelfRegistrationEraBesideALaterOwner_IsAmbiguous()
+    {
+        // CACI NSS, LLC (live shape): SAM lists the recipient itself as a parent (its
+        // independent era, under its own registrant DUNS) beside CACI International. The
+        // independent era's awards must not be attributed to the later owner, so the
+        // self-group counts toward ambiguity by design.
+        var profile = new UsaSpendingRecipientProfile
+        {
+            RecipientId = "49aa319d-C",
+            ParentId = "d644a583-P",
+            ParentName = "CACI NSS, LLC",
+            ParentDuns = "043033294",
+            ParentUei = "Y9CDLHK3A125",
+            Parents =
+            [
+                new UsaSpendingRecipientParentRef
+                {
+                    ParentId = "d644a583-P",
+                    ParentName = "CACI NSS, LLC",
+                    ParentDuns = "043033294",
+                    ParentUei = "Y9CDLHK3A125",
+                },
+                new UsaSpendingRecipientParentRef
+                {
+                    ParentId = "5eb76328-P",
+                    ParentName = "CACI INTERNATIONAL INC",
+                    ParentDuns = "045534641",
+                    ParentUei = "QSRTXLFKV857",
+                },
+            ],
+        };
+
+        GovernmentContractsImportService.ChooseParent(profile).Should().BeNull();
+    }
+
+    [Fact]
+    public void ChooseParent_SameRegistrantMissingDuns_GroupsByUei()
     {
         var profile = new UsaSpendingRecipientProfile
         {
@@ -45,50 +148,60 @@ public class GovernmentContractsImportServiceChooseParentTests
             [
                 new UsaSpendingRecipientParentRef
                 {
-                    ParentId = "parent-P",
-                    ParentName = "CACI International Inc",
+                    ParentId = "a-P",
+                    ParentName = "Post-Migration Name Inc",
+                    ParentUei = "UEI111111111",
+                },
+                new UsaSpendingRecipientParentRef
+                {
+                    ParentId = "a-P",
+                    ParentName = "Post-Migration Name, Inc.",
+                    ParentUei = "UEI111111111",
                 },
             ],
         };
 
+        var choice = GovernmentContractsImportService.ChooseParent(profile);
+
+        choice.Should().NotBeNull();
+        choice.Names.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ChooseParent_NoParents_IsNull()
+    {
         GovernmentContractsImportService
-            .ChooseParent(profile, "child-C")
-            .ParentId.Should()
-            .Be("parent-P");
+            .ChooseParent(new UsaSpendingRecipientProfile { RecipientId = "solo-R" })
+            .Should()
+            .BeNull();
     }
 
     [Fact]
-    public void ChooseParent_NoTopLevel_MultipleDistinctHistoryParents_IsAmbiguous()
+    public void ChooseParent_NullProfile_IsNull()
     {
-        var profile = new UsaSpendingRecipientProfile
-        {
-            RecipientId = "child-C",
-            Parents =
-            [
-                new UsaSpendingRecipientParentRef { ParentId = "a-P", ParentName = "Owner A" },
-                new UsaSpendingRecipientParentRef { ParentId = "b-P", ParentName = "Owner B" },
-            ],
-        };
-
-        GovernmentContractsImportService.ChooseParent(profile, "child-C").Should().BeNull();
+        GovernmentContractsImportService.ChooseParent(null).Should().BeNull();
     }
 
     [Fact]
-    public void ChooseParent_SelfReference_IsNoParent()
+    public void JoinParentNames_RoundTrips_AndNeverCutsANameMidway()
     {
-        var profile = new UsaSpendingRecipientProfile
-        {
-            RecipientId = "parent-P",
-            ParentId = "parent-P",
-            ParentName = "CACI International Inc",
-        };
+        GovernmentContractsImportService
+            .SplitParentNames(
+                GovernmentContractsImportService.JoinParentNames(["Alpha Corp", "Beta Inc"])
+            )
+            .Should()
+            .BeEquivalentTo(["Alpha Corp", "Beta Inc"]);
 
-        GovernmentContractsImportService.ChooseParent(profile, "parent-P").Should().BeNull();
-    }
+        // A name that would cross the column bound is dropped whole — a truncated name
+        // could exact-match the wrong company.
+        var oversized = new string('A', 2000);
+        GovernmentContractsImportService
+            .JoinParentNames([oversized, "Beta Inc"])
+            .Should()
+            .Be("Beta Inc");
 
-    [Fact]
-    public void ChooseParent_NullProfile_IsNoParent()
-    {
-        GovernmentContractsImportService.ChooseParent(null, "child-C").Should().BeNull();
+        GovernmentContractsImportService.JoinParentNames([]).Should().BeNull();
+        GovernmentContractsImportService.JoinParentNames(null).Should().BeNull();
+        GovernmentContractsImportService.SplitParentNames(null).Should().BeEmpty();
     }
 }

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceChooseParentTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceChooseParentTests.cs
@@ -1,0 +1,94 @@
+using Equibles.GovernmentContracts.HostedService.Services;
+using Equibles.Integrations.GovernmentContracts.Models;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// Contract: a recipient profile yields at most ONE parent to match through. The top-level
+// parent pair is USAspending's current SAM linkage and wins; the parents[] history only
+// substitutes when it names a single distinct parent — several distinct parents means
+// ownership moved, and guessing between them could assert a wrong link. Self-references
+// (parent-level recipients list themselves) carry no new name and count as no parent.
+public class GovernmentContractsImportServiceChooseParentTests
+{
+    [Fact]
+    public void ChooseParent_TopLevelParent_Wins()
+    {
+        var profile = new UsaSpendingRecipientProfile
+        {
+            RecipientId = "child-C",
+            ParentId = "parent-P",
+            ParentName = "CACI International Inc",
+            Parents =
+            [
+                new UsaSpendingRecipientParentRef
+                {
+                    ParentId = "old-P",
+                    ParentName = "Former Owner Corp",
+                },
+            ],
+        };
+
+        var parent = GovernmentContractsImportService.ChooseParent(profile, "child-C");
+
+        parent.Should().NotBeNull();
+        parent.ParentId.Should().Be("parent-P");
+        parent.ParentName.Should().Be("CACI International Inc");
+    }
+
+    [Fact]
+    public void ChooseParent_NoTopLevel_SingleHistoryParent_IsUsed()
+    {
+        var profile = new UsaSpendingRecipientProfile
+        {
+            RecipientId = "child-C",
+            Parents =
+            [
+                new UsaSpendingRecipientParentRef
+                {
+                    ParentId = "parent-P",
+                    ParentName = "CACI International Inc",
+                },
+            ],
+        };
+
+        GovernmentContractsImportService
+            .ChooseParent(profile, "child-C")
+            .ParentId.Should()
+            .Be("parent-P");
+    }
+
+    [Fact]
+    public void ChooseParent_NoTopLevel_MultipleDistinctHistoryParents_IsAmbiguous()
+    {
+        var profile = new UsaSpendingRecipientProfile
+        {
+            RecipientId = "child-C",
+            Parents =
+            [
+                new UsaSpendingRecipientParentRef { ParentId = "a-P", ParentName = "Owner A" },
+                new UsaSpendingRecipientParentRef { ParentId = "b-P", ParentName = "Owner B" },
+            ],
+        };
+
+        GovernmentContractsImportService.ChooseParent(profile, "child-C").Should().BeNull();
+    }
+
+    [Fact]
+    public void ChooseParent_SelfReference_IsNoParent()
+    {
+        var profile = new UsaSpendingRecipientProfile
+        {
+            RecipientId = "parent-P",
+            ParentId = "parent-P",
+            ParentName = "CACI International Inc",
+        };
+
+        GovernmentContractsImportService.ChooseParent(profile, "parent-P").Should().BeNull();
+    }
+
+    [Fact]
+    public void ChooseParent_NullProfile_IsNoParent()
+    {
+        GovernmentContractsImportService.ChooseParent(null, "child-C").Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceMatchingVersionResetTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceMatchingVersionResetTests.cs
@@ -1,0 +1,221 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.GovernmentContracts.Data;
+using Equibles.GovernmentContracts.Data.Models;
+using Equibles.GovernmentContracts.HostedService.Configuration;
+using Equibles.GovernmentContracts.HostedService.Services;
+using Equibles.GovernmentContracts.Repositories;
+using Equibles.Integrations.GovernmentContracts.Contracts;
+using Equibles.Integrations.GovernmentContracts.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// Contract: unmatched awards are dropped, not stored, so a recipient-matching improvement
+// only reaches history by re-walking it. A stored checkpoint stamped with an older
+// MatchingVersion pulls the cursor back to the 2007-10-01 epoch exactly ONCE (cursor and
+// stamp move in one save; the re-walk deduplicates by AwardUniqueKey); a checkpoint born
+// under the current version never resets.
+public class GovernmentContractsImportServiceMatchingVersionResetTests
+{
+    private const string ScanStateName = "award-scan";
+    private static readonly DateOnly Epoch = new(2007, 10, 1);
+
+    [Fact]
+    public async Task Import_CheckpointStampedWithOlderMatchingVersion_RescansFromTheEpochOnce()
+    {
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SeedCompany(options);
+        using (var seed = NewContext(options))
+        {
+            // A caught-up pre-upgrade checkpoint: rows written before the column existed
+            // read as version 0.
+            seed.Add(
+                new GovernmentContractsScanState
+                {
+                    Name = ScanStateName,
+                    LastCompletedWindowEnd = today,
+                    UpdatedAt = DateTime.UtcNow,
+                    MatchingVersion = 0,
+                }
+            );
+            seed.SaveChanges();
+        }
+        var scopeFactory = ScopeFactory(options);
+
+        var client = EmptyClient();
+        await NewService(scopeFactory, client).Import(CancellationToken.None);
+
+        // The rescan starts at the epoch, not the trailing lookback.
+        await client
+            .Received()
+            .GetContractAwards(
+                Epoch,
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
+        ReadState(options)
+            .MatchingVersion.Should()
+            .Be(GovernmentContractsImportService.RecipientMatchingVersion);
+
+        // Once only: the next cycle resumes from the re-advanced checkpoint.
+        var secondClient = EmptyClient();
+        await NewService(scopeFactory, secondClient).Import(CancellationToken.None);
+        await secondClient
+            .DidNotReceive()
+            .GetContractAwards(
+                Epoch,
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task Import_FreshInstall_ChecksPointBornCurrent_NeverTriggersTheEpochRescan()
+    {
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SeedCompany(options);
+        var scopeFactory = ScopeFactory(options);
+
+        var client = EmptyClient();
+        await NewService(scopeFactory, client).Import(CancellationToken.None);
+
+        // The first cycle creates the row stamped current…
+        ReadState(options)
+            .MatchingVersion.Should()
+            .Be(GovernmentContractsImportService.RecipientMatchingVersion);
+
+        // …so the second cycle scans its configured range, never the 2007 epoch.
+        var secondClient = EmptyClient();
+        await NewService(scopeFactory, secondClient).Import(CancellationToken.None);
+        await secondClient
+            .DidNotReceive()
+            .GetContractAwards(
+                Epoch,
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
+        await secondClient
+            .Received()
+            .GetContractAwards(
+                today,
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    private static IUsaSpendingClient EmptyClient()
+    {
+        var client = Substitute.For<IUsaSpendingClient>();
+        client
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(new List<UsaSpendingAwardRecord>()));
+        return client;
+    }
+
+    private static GovernmentContractsImportService NewService(
+        IServiceScopeFactory scopeFactory,
+        IUsaSpendingClient client
+    )
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        return new(
+            scopeFactory,
+            NullLogger<GovernmentContractsImportService>.Instance,
+            client,
+            new RecipientResolver(scopeFactory),
+            // One huge window keeps the epoch rescan a single client call instead of ~6,900.
+            Options.Create(
+                new GovernmentContractsScraperOptions
+                {
+                    WindowDays = 100_000,
+                    RescanLookbackDays = 1,
+                    MinimumAwardAmount = 1_000_000m,
+                }
+            ),
+            Options.Create(new WorkerOptions { MinSyncDate = today.ToDateTime(TimeOnly.MinValue) }),
+            new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
+        );
+    }
+
+    private static void SeedCompany(DbContextOptions<EquiblesFinancialDbContext> options)
+    {
+        using var seed = NewContext(options);
+        seed.Add(
+            new CommonStock
+            {
+                Ticker = "LMT",
+                Name = "Lockheed Martin Corporation",
+                Cik = "1",
+            }
+        );
+        seed.SaveChanges();
+    }
+
+    private static GovernmentContractsScanState ReadState(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        using var ctx = NewContext(options);
+        return ctx.Set<GovernmentContractsScanState>()
+            .AsNoTracking()
+            .Single(s => s.Name == ScanStateName);
+    }
+
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new GovernmentContractsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static IServiceScopeFactory ScopeFactory(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => NewContext(options));
+        services.AddScoped<CommonStockRepository>();
+        services.AddScoped<GovernmentContractRepository>();
+        services.AddScoped<GovernmentContractsScanStateRepository>();
+        services.AddScoped<GovernmentContractRecipientParentRepository>();
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceParentFallbackTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceParentFallbackTests.cs
@@ -50,6 +50,7 @@ public class GovernmentContractsImportServiceParentFallbackTests
                     RecipientId = SubsidiaryRecipientId,
                     ParentId = "def456-P",
                     ParentName = "CACI INTERNATIONAL INC",
+                    ParentDuns = "045534641",
                 }
             );
 
@@ -63,7 +64,7 @@ public class GovernmentContractsImportServiceParentFallbackTests
         var cached = ctx.Set<GovernmentContractRecipientParent>().AsNoTracking().Single();
         cached.RecipientId.Should().Be(SubsidiaryRecipientId);
         cached.ParentRecipientId.Should().Be("def456-P");
-        cached.ParentName.Should().Be("CACI INTERNATIONAL INC");
+        cached.ParentNames.Should().Be("CACI INTERNATIONAL INC");
     }
 
     [Fact]
@@ -80,7 +81,7 @@ public class GovernmentContractsImportServiceParentFallbackTests
                     RecipientId = SubsidiaryRecipientId,
                     RecipientName = SubsidiaryName,
                     ParentRecipientId = "def456-P",
-                    ParentName = "CACI INTERNATIONAL INC",
+                    ParentNames = "CACI INTERNATIONAL INC",
                     ResolvedAt = DateTime.UtcNow.AddDays(-1),
                 }
             );
@@ -123,7 +124,7 @@ public class GovernmentContractsImportServiceParentFallbackTests
         using var ctx = NewContext(options);
         ctx.Set<GovernmentContract>().AsNoTracking().Should().BeEmpty();
         var cached = ctx.Set<GovernmentContractRecipientParent>().AsNoTracking().Single();
-        cached.ParentName.Should().BeNull();
+        cached.ParentNames.Should().BeNull();
         cached.ParentRecipientId.Should().BeNull();
     }
 

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceParentFallbackTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceParentFallbackTests.cs
@@ -1,0 +1,258 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.GovernmentContracts.Data;
+using Equibles.GovernmentContracts.Data.Models;
+using Equibles.GovernmentContracts.HostedService.Configuration;
+using Equibles.GovernmentContracts.HostedService.Services;
+using Equibles.GovernmentContracts.Repositories;
+using Equibles.Integrations.GovernmentContracts.Contracts;
+using Equibles.Integrations.GovernmentContracts.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// Contract: an award whose recipient name matches no public company gets ONE second chance
+// through its SAM-registered parent — resolved via the recipient-profile endpoint, matched
+// through the same exact normalised lookup, and cached (including the "no usable parent"
+// answer) so a recipient costs at most one profile fetch per staleness window. A profile
+// fetch that fails transport-level fails the WINDOW, never silently skips the recipient.
+public class GovernmentContractsImportServiceParentFallbackTests
+{
+    private const string SubsidiaryName = "CACI, INC. - FEDERAL";
+    private const string SubsidiaryRecipientId = "abc123-C";
+
+    [Fact]
+    public async Task Import_UnmatchedSubsidiary_ResolvesThroughItsParentAndCachesTheAnswer()
+    {
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var stockId = SeedCompany(options);
+        var scopeFactory = ScopeFactory(options);
+
+        var client = ClientReturning(AwardFor(today));
+        client
+            .GetRecipientProfile(SubsidiaryRecipientId, Arg.Any<CancellationToken>())
+            .Returns(
+                new UsaSpendingRecipientProfile
+                {
+                    RecipientId = SubsidiaryRecipientId,
+                    ParentId = "def456-P",
+                    ParentName = "CACI INTERNATIONAL INC",
+                }
+            );
+
+        await NewService(scopeFactory, client).Import(CancellationToken.None);
+
+        using var ctx = NewContext(options);
+        var contract = ctx.Set<GovernmentContract>().AsNoTracking().Single();
+        contract.CommonStockId.Should().Be(stockId, "the award resolves through its parent");
+        contract.RecipientName.Should().Be(SubsidiaryName);
+
+        var cached = ctx.Set<GovernmentContractRecipientParent>().AsNoTracking().Single();
+        cached.RecipientId.Should().Be(SubsidiaryRecipientId);
+        cached.ParentRecipientId.Should().Be("def456-P");
+        cached.ParentName.Should().Be("CACI INTERNATIONAL INC");
+    }
+
+    [Fact]
+    public async Task Import_FreshCachedParent_ResolvesWithoutRefetchingTheProfile()
+    {
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var stockId = SeedCompany(options);
+        using (var seed = NewContext(options))
+        {
+            seed.Add(
+                new GovernmentContractRecipientParent
+                {
+                    RecipientId = SubsidiaryRecipientId,
+                    RecipientName = SubsidiaryName,
+                    ParentRecipientId = "def456-P",
+                    ParentName = "CACI INTERNATIONAL INC",
+                    ResolvedAt = DateTime.UtcNow.AddDays(-1),
+                }
+            );
+            seed.SaveChanges();
+        }
+        var scopeFactory = ScopeFactory(options);
+
+        var client = ClientReturning(AwardFor(today));
+
+        await NewService(scopeFactory, client).Import(CancellationToken.None);
+
+        await client
+            .DidNotReceive()
+            .GetRecipientProfile(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        using var ctx = NewContext(options);
+        ctx.Set<GovernmentContract>().AsNoTracking().Single().CommonStockId.Should().Be(stockId);
+    }
+
+    [Fact]
+    public async Task Import_UnknownRecipient_CachesTheParentlessAnswerOnce()
+    {
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SeedCompany(options);
+        var scopeFactory = ScopeFactory(options);
+
+        // The client answers a profile 404 as null — an answer, not a fault.
+        var client = ClientReturning(AwardFor(today));
+        client
+            .GetRecipientProfile(SubsidiaryRecipientId, Arg.Any<CancellationToken>())
+            .Returns((UsaSpendingRecipientProfile)null);
+
+        await NewService(scopeFactory, client).Import(CancellationToken.None);
+        await NewService(scopeFactory, client).Import(CancellationToken.None);
+
+        // One fetch total across both cycles: the parentless answer was cached.
+        await client
+            .Received(1)
+            .GetRecipientProfile(SubsidiaryRecipientId, Arg.Any<CancellationToken>());
+        using var ctx = NewContext(options);
+        ctx.Set<GovernmentContract>().AsNoTracking().Should().BeEmpty();
+        var cached = ctx.Set<GovernmentContractRecipientParent>().AsNoTracking().Single();
+        cached.ParentName.Should().BeNull();
+        cached.ParentRecipientId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Import_ProfileFetchFailsTransportLevel_FailsTheWindowNotSilently()
+    {
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SeedCompany(options);
+        var scopeFactory = ScopeFactory(options);
+
+        var client = ClientReturning(AwardFor(today));
+        client
+            .GetRecipientProfile(SubsidiaryRecipientId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("USAspending bad spell"));
+
+        var act = () => NewService(scopeFactory, client).Import(CancellationToken.None);
+
+        // Non-422 is systemic: the cycle aborts so the checkpoint machinery re-covers the
+        // window instead of the recipient's awards being silently dropped.
+        await act.Should().ThrowAsync<HttpRequestException>();
+        using var ctx = NewContext(options);
+        ctx.Set<GovernmentContract>().AsNoTracking().Should().BeEmpty();
+        ctx.Set<GovernmentContractRecipientParent>().AsNoTracking().Should().BeEmpty();
+    }
+
+    private static UsaSpendingAwardRecord AwardFor(DateOnly actionDate) =>
+        new()
+        {
+            GeneratedInternalId = "CONT_AWD_SUB1",
+            AwardId = "FA0001",
+            RecipientName = SubsidiaryName,
+            RecipientId = SubsidiaryRecipientId,
+            Amount = 5_000_000m,
+            AwardingAgency = "Department of Defense",
+            ContractAwardType = "DEFINITIVE CONTRACT",
+            BaseObligationDate = actionDate.ToString("yyyy-MM-dd"),
+            StartDate = actionDate.ToString("yyyy-MM-dd"),
+            EndDate = actionDate.AddYears(2).ToString("yyyy-MM-dd"),
+            LastModifiedDate = actionDate.ToString("yyyy-MM-dd"),
+            Description = "SERVICES",
+        };
+
+    private static IUsaSpendingClient ClientReturning(params UsaSpendingAwardRecord[] awards)
+    {
+        var client = Substitute.For<IUsaSpendingClient>();
+        client
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(awards.ToList()));
+        return client;
+    }
+
+    private static GovernmentContractsImportService NewService(
+        IServiceScopeFactory scopeFactory,
+        IUsaSpendingClient client
+    )
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        return new(
+            scopeFactory,
+            NullLogger<GovernmentContractsImportService>.Instance,
+            client,
+            new RecipientResolver(scopeFactory),
+            Options.Create(
+                new GovernmentContractsScraperOptions
+                {
+                    WindowDays = 1,
+                    RescanLookbackDays = 1,
+                    MinimumAwardAmount = 1_000_000m,
+                }
+            ),
+            Options.Create(new WorkerOptions { MinSyncDate = today.ToDateTime(TimeOnly.MinValue) }),
+            new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
+        );
+    }
+
+    private static Guid SeedCompany(DbContextOptions<EquiblesFinancialDbContext> options)
+    {
+        using var seed = NewContext(options);
+        var stock = new CommonStock
+        {
+            Ticker = "CACI",
+            // The EDGAR-shaped stored name; the SAM parent name matches it only through the
+            // normaliser's slash-marker stripping.
+            Name = "Caci International Inc /De/",
+            Cik = "1",
+        };
+        seed.Add(stock);
+        seed.SaveChanges();
+        return stock.Id;
+    }
+
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new GovernmentContractsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static IServiceScopeFactory ScopeFactory(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => NewContext(options));
+        services.AddScoped<CommonStockRepository>();
+        services.AddScoped<GovernmentContractRepository>();
+        services.AddScoped<GovernmentContractsScanStateRepository>();
+        services.AddScoped<GovernmentContractRecipientParentRepository>();
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServiceWindowContinueTests.cs
@@ -226,6 +226,9 @@ public class GovernmentContractsImportServiceWindowContinueTests
                     Name = "award-scan",
                     LastCompletedWindowEnd = today.AddDays(-1),
                     UpdatedAt = DateTime.UtcNow,
+                    // Born current so the matching-version epoch rescan stays out of this
+                    // trailing-rescan scenario.
+                    MatchingVersion = GovernmentContractsImportService.RecipientMatchingVersion,
                 }
             );
             await seed.SaveChangesAsync();

--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerEdgarSlashMarkerTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerEdgarSlashMarkerTests.cs
@@ -1,0 +1,44 @@
+using Equibles.GovernmentContracts.HostedService.Services;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// EDGAR registrant names carry a slash-wrapped state-of-incorporation or vintage marker
+// ("/De/", "/Pa/", "/New/") that USAspending recipient/parent names never do. Left in
+// place, the marker survives suffix-stripping as a stray trailing token ("CACI
+// INTERNATIONAL INC DE") and defeats the exact match against the award side's "CACI
+// INTERNATIONAL INC" — which is how NOC, LHX and CACI awards resolved to nothing (#7044).
+// Removing the marker is a mechanical format rule; matching stays exact on what remains.
+public class RecipientNameNormalizerEdgarSlashMarkerTests
+{
+    [Theory]
+    [InlineData("Caci International Inc /De/", "CACI INTERNATIONAL")]
+    [InlineData("Northrop Grumman Corp /De/", "NORTHROP GRUMMAN")]
+    [InlineData("L3harris Technologies, Inc. /De/", "L3HARRIS TECHNOLOGIES")]
+    // No spaces around the marker — "Fnb Corp/Pa/" is a real stored shape.
+    [InlineData("Fnb Corp/Pa/", "FNB")]
+    // Non-state vintage marker.
+    [InlineData("Nve Corp /New/", "NVE")]
+    public void Normalize_StripsEdgarIncorporationMarkers(string name, string expectedKey)
+    {
+        RecipientNameNormalizer.Normalize(name).Should().Be(expectedKey);
+    }
+
+    [Fact]
+    public void Normalize_BothSidesOfTheMatchCollapseToTheSameKey()
+    {
+        // The stored stock name (EDGAR shape) and the USAspending parent name must land on
+        // one key — this equality IS the match the import performs.
+        RecipientNameNormalizer
+            .Normalize("Caci International Inc /De/")
+            .Should()
+            .Be(RecipientNameNormalizer.Normalize("CACI INTERNATIONAL INC"));
+    }
+
+    [Fact]
+    public void Normalize_SingleSlashSuffix_IsUntouchedByTheMarkerRule()
+    {
+        // "Slb Limited/Nv" has no closing slash, so the marker regex must not fire; the
+        // slash still splits tokens and NV/LIMITED strip as legal suffixes.
+        RecipientNameNormalizer.Normalize("Slb Limited/Nv").Should().Be("SLB");
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerEdgarSlashMarkerTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerEdgarSlashMarkerTests.cs
@@ -35,6 +35,15 @@ public class RecipientNameNormalizerEdgarSlashMarkerTests
     }
 
     [Fact]
+    public void Normalize_InteriorSlashes_AreNeverMangledByTheMarkerRule()
+    {
+        // The marker regex is anchored to the END of the name; interior short slash-wrapped
+        // segments (an unanchored pattern would pair "AB/CD EF/GH"'s inner slashes and
+        // silently drop "CD EF") keep the pre-existing slash-becomes-space behaviour.
+        RecipientNameNormalizer.Normalize("AB/CD EF/GH Corp").Should().Be("AB CD EF GH");
+    }
+
+    [Fact]
     public void Normalize_SingleSlashSuffix_IsUntouchedByTheMarkerRule()
     {
         // "Slb Limited/Nv" has no closing slash, so the marker regex must not fire; the

--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerMinimumKeyLengthBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerMinimumKeyLengthBoundaryTests.cs
@@ -2,15 +2,33 @@ using Equibles.GovernmentContracts.HostedService.Services;
 
 namespace Equibles.UnitTests.GovernmentContracts;
 
+// Contract: the minimum key length is 2 — matching is exact and the resolver drops
+// ambiguous keys, so short DISTINCTIVE names are safe, and the previous 4-char floor was
+// silently excluding real defense primes (RTX, 3M) from resolution entirely (#7044's root
+// cause alongside subsidiary naming). Only single-character keys are dropped: one letter
+// carries no identity.
 public class RecipientNameNormalizerMinimumKeyLengthBoundaryTests
 {
     [Fact]
     public void Normalize_KeyExactlyAtMinimumLength_IsReturned()
     {
-        // Contract: a key shorter than the 4-char minimum is dropped to null, so a key of
-        // EXACTLY 4 chars is the inclusive lower edge and must be kept. "Ford Inc" strips the
-        // INC suffix to "FORD" (4 chars). Guards >= against regressing to >, which would drop
-        // legitimate four-letter recipient names from exact-match resolution.
-        RecipientNameNormalizer.Normalize("Ford Inc").Should().Be("FORD");
+        // "3M Co" strips the CO suffix to "3M" (2 chars) — the inclusive lower edge.
+        // Guards >= against regressing to >, which would re-drop 3M.
+        RecipientNameNormalizer.Normalize("3M Co").Should().Be("3M");
+    }
+
+    [Theory]
+    [InlineData("RTX Corp", "RTX")]
+    [InlineData("V2X, Inc.", "V2X")]
+    [InlineData("Aar Corp", "AAR")]
+    public void Normalize_ShortDistinctivePrimeNames_Resolve(string name, string expectedKey)
+    {
+        RecipientNameNormalizer.Normalize(name).Should().Be(expectedKey);
+    }
+
+    [Fact]
+    public void Normalize_SingleCharacterKey_IsDropped()
+    {
+        RecipientNameNormalizer.Normalize("X Inc").Should().BeNull();
     }
 }

--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientResolverResolveViaParentsTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientResolverResolveViaParentsTests.cs
@@ -1,0 +1,67 @@
+using Equibles.GovernmentContracts.HostedService.Services;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// Contract: parent-fallback resolution goes through the SAME exact normalised lookup as
+// direct matching, and holds only when every resolving candidate lands on ONE stock — a
+// recipient whose registered parents resolve to different companies is ambiguous and must
+// never be linked.
+public class RecipientResolverResolveViaParentsTests
+{
+    private static readonly Guid CaciId = Guid.NewGuid();
+    private static readonly Guid OtherId = Guid.NewGuid();
+
+    private static IReadOnlyDictionary<string, Guid> Lookup() =>
+        new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            ["CACI INTERNATIONAL"] = CaciId,
+            ["LOCKHEED MARTIN"] = OtherId,
+        };
+
+    [Fact]
+    public void ResolveViaParents_SingleMatchingParent_Resolves()
+    {
+        RecipientResolver
+            .ResolveViaParents(["CACI International Inc"], Lookup())
+            .Should()
+            .Be(CaciId);
+    }
+
+    [Fact]
+    public void ResolveViaParents_NoParentMatches_ReturnsNull()
+    {
+        RecipientResolver
+            .ResolveViaParents(["Privately Held Parent LLC"], Lookup())
+            .Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void ResolveViaParents_ParentsResolveToDifferentStocks_IsAmbiguousAndDropped()
+    {
+        RecipientResolver
+            .ResolveViaParents(["CACI International Inc", "Lockheed Martin Corp"], Lookup())
+            .Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void ResolveViaParents_ParentsAgreeOnOneStock_Resolves()
+    {
+        // Two name variants (a rename in the registration history) that land on the same
+        // stock are agreement, not ambiguity.
+        RecipientResolver
+            .ResolveViaParents(["CACI International Inc", "CACI INTERNATIONAL"], Lookup())
+            .Should()
+            .Be(CaciId);
+    }
+
+    [Fact]
+    public void ResolveViaParents_NullAndUnresolvableNamesAreSkipped()
+    {
+        RecipientResolver
+            .ResolveViaParents([null, "The Company", "CACI International Inc"], Lookup())
+            .Should()
+            .Be(CaciId);
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientRecipientProfileTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingClientRecipientProfileTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using Equibles.Integrations.GovernmentContracts;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// Contract: the recipient-profile read is a GET on the level-qualified recipient hash that
+// keeps the client's wire rules (fresh connection per request), maps the corporate-family
+// fields, and answers a 404 as null — an unknown or profileless recipient is an answer,
+// not a fault, and turning it into an exception would fail whole import windows over
+// recipients that simply have no SAM family record.
+public class UsaSpendingClientRecipientProfileTests
+{
+    [Fact]
+    public async Task GetRecipientProfile_MapsTheCorporateFamilyFields()
+    {
+        var handler = new CapturingHandler(
+            HttpStatusCode.OK,
+            """
+            {
+              "recipient_id": "abc123-C",
+              "name": "CACI, INC. - FEDERAL",
+              "recipient_level": "C",
+              "parent_id": "def456-P",
+              "parent_name": "CACI INTERNATIONAL INC",
+              "parents": [
+                { "parent_id": "def456-P", "parent_name": "CACI INTERNATIONAL INC" }
+              ]
+            }
+            """
+        );
+        var sut = NewClient(handler);
+
+        var profile = await sut.GetRecipientProfile("abc123-C");
+
+        handler.RequestUri.Should().Be("https://api.usaspending.gov/api/v2/recipient/abc123-C/");
+        handler.Method.Should().Be(HttpMethod.Get);
+        handler
+            .ConnectionClose.Should()
+            .BeTrue("profile reads share the search endpoint's fresh-connection rule");
+        profile.Should().NotBeNull();
+        profile.RecipientLevel.Should().Be("C");
+        profile.ParentId.Should().Be("def456-P");
+        profile.ParentName.Should().Be("CACI INTERNATIONAL INC");
+        profile.Parents.Should().ContainSingle(p => p.ParentId == "def456-P");
+    }
+
+    [Fact]
+    public async Task GetRecipientProfile_NotFound_IsNullNotAFault()
+    {
+        var sut = NewClient(new CapturingHandler(HttpStatusCode.NotFound, "{}"));
+
+        var profile = await sut.GetRecipientProfile("unknown-hash-R");
+
+        profile.Should().BeNull();
+    }
+
+    private static UsaSpendingClient NewClient(HttpMessageHandler handler) =>
+        new(new HttpClient(handler), Substitute.For<ILogger<UsaSpendingClient>>());
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _body;
+
+        public string RequestUri { get; private set; }
+        public HttpMethod Method { get; private set; }
+        public bool? ConnectionClose { get; private set; }
+
+        public CapturingHandler(HttpStatusCode statusCode, string body)
+        {
+            _statusCode = statusCode;
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            RequestUri = request.RequestUri?.ToString();
+            Method = request.Method;
+            ConnectionClose = request.Headers.ConnectionClose;
+            return Task.FromResult(
+                new HttpResponseMessage(_statusCode) { Content = new StringContent(_body) }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

USAspending awards to major defense primes resolved to no public company (LMT carried 4,150 awards while RTX, NOC, GD, LHX, BAH, CACI and MMM all carried 0), for three stacked reasons: the normaliser's 4-character key floor dropped short distinctive names (RTX, 3M) outright; EDGAR-style slash-wrapped incorporation markers on stored stock names ("Northrop Grumman Corp /De/") defeated the exact match; and operating subsidiaries ("CACI, INC. - FEDERAL") award under names the CommonStock universe never carries.

## Code changes

- **RecipientNameNormalizer** — minimum key length 4 → 2 (matching stays exact and the resolver still drops ambiguous keys, so short distinctive names are safe; single characters stay null) and strips slash-wrapped EDGAR incorporation markers ("/De/", "/Pa/", "/New/") as a mechanical format rule.
- **UsaSpendingClient / IUsaSpendingClient** — new `GetRecipientProfile` GET on `/api/v2/recipient/{recipient_id}/` with the same fresh-connection and retry rules as the award search; a 404 answers null (unknown/profileless recipient is an answer, not a fault).
- **GovernmentContractsImportService** — awards whose recipient name matches nothing resolve through their SAM-registered parent name via the same exact normalised lookup; answers (including "no usable parent" and ambiguous multi-parent histories, which are never guessed) persist in the new `GovernmentContractRecipientParent` cache with 180-day point-of-use staleness. A transport-level profile failure fails the window so the checkpoint machinery re-covers it.
- **GovernmentContractsScanState.MatchingVersion** — unmatched awards are dropped rather than stored, so a matching upgrade pulls the cursor back to the 2007-10-01 epoch once and re-walks history (deduplicated by AwardUniqueKey). Pre-existing rows read version 0 and reset on first sight; fresh checkpoints are born current.
- **Migration** `AddGovernmentContractRecipientParents` — additive: new cache table + the MatchingVersion column.
- **Tests** — normaliser floor boundary re-pinned at 2 with RTX/3M/V2X named cases, slash-marker stripping incl. the both-sides-collapse equality, parent-fallback resolution + caching + window-failure semantics, ChooseParent selection rules, the one-shot epoch rescan, and the profile endpoint's wire contract. Full suite: 4,135 passed.