### PR TITLE
fix(government-contracts): skip poisoned recipient profiles instead of wedging the scan

### DIFF
--- a/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractRecipientParent.cs
+++ b/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractRecipientParent.cs
@@ -48,4 +48,14 @@ public class GovernmentContractRecipientParent
 
     /// <summary>When the profile was last fetched (UTC) — drives point-of-use re-resolution.</summary>
     public DateTime ResolvedAt { get; set; }
+
+    /// <summary>
+    /// True when this row records a profile fetch that kept FAILING server-side for this
+    /// one recipient (USAspending 502s some individual profiles permanently — observed
+    /// live on the first epoch-rescan window, where one such recipient wedged the whole
+    /// lane for hours). A failure row answers "no usable parent" like a parentless row,
+    /// but re-resolves on a much shorter staleness window because the answer is an
+    /// unavailability, not a reading.
+    /// </summary>
+    public bool ProfileFetchFailed { get; set; }
 }

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -47,6 +47,19 @@ public class GovernmentContractsImportService : IImporter
     // that stop appearing cost nothing.
     private const int ParentCacheStalenessDays = 180;
 
+    // A failure row (ProfileFetchFailed) re-resolves much sooner: it records an
+    // unavailability, not a reading, so it should not silence the recipient for the full
+    // staleness window if the server-side fault clears.
+    private const int FailedProfileRetryDays = 7;
+
+    // How many recipients per window may have their profile fetch fail server-side before
+    // the failure stops looking recipient-specific and starts looking like a source
+    // outage. Isolated poisoned profiles (USAspending 502s some individual recipients
+    // permanently) are skipped with a short-TTL failure row so one broken profile can
+    // never wedge the scan; past this budget the window fails and the checkpoint
+    // machinery re-covers it — an outage must never mass-cache "no parent" answers.
+    private const int MaxProfileFailuresPerWindow = 3;
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<GovernmentContractsImportService> _logger;
     private readonly IUsaSpendingClient _client;
@@ -371,7 +384,6 @@ public class GovernmentContractsImportService : IImporter
     )
     {
         var now = DateTime.UtcNow;
-        var staleBefore = now.AddDays(-ParentCacheStalenessDays);
         var pending = unmatched
             .Where(a => a.RecipientId != null && !parentCache.ContainsKey(a.RecipientId))
             .GroupBy(a => a.RecipientId, StringComparer.Ordinal)
@@ -384,48 +396,101 @@ public class GovernmentContractsImportService : IImporter
             scope.ServiceProvider.GetRequiredService<GovernmentContractRecipientParentRepository>();
 
         var stored = await repository.GetByRecipientIds(pending.Keys.ToList(), cancellationToken);
-        foreach (var row in stored.Where(r => r.ResolvedAt >= staleBefore))
+        foreach (var row in stored.Where(r => IsFresh(r, now)))
         {
             parentCache[row.RecipientId] = row;
             pending.Remove(row.RecipientId);
         }
         var staleRows = stored
-            .Where(r => r.ResolvedAt < staleBefore)
+            .Where(r => !IsFresh(r, now))
             .ToDictionary(r => r.RecipientId, StringComparer.Ordinal);
 
         if (pending.Count == 0)
             return;
 
+        // Successful resolutions persist even when a later fetch aborts the window —
+        // without this, one failing recipient forces every earlier one to be re-fetched
+        // on every retry of the same window.
         var persisted = 0;
-        foreach (var (recipientId, recipientName) in pending)
+        var profileFailures = 0;
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var profile = await _client.GetRecipientProfile(recipientId, cancellationToken);
-            var parent = ChooseParent(profile);
-
-            if (staleRows.TryGetValue(recipientId, out var row))
+            foreach (var (recipientId, recipientName) in pending)
             {
-                row.ParentRecipientId = parent?.ParentId;
-                row.ParentNames = JoinParentNames(parent?.Names);
-                row.ResolvedAt = now;
-                repository.Update(row);
-            }
-            else
-            {
-                row = new GovernmentContractRecipientParent
+                cancellationToken.ThrowIfCancellationRequested();
+
+                UsaSpendingRecipientProfile profile = null;
+                var fetchFailed = false;
+                try
                 {
-                    RecipientId = recipientId,
-                    RecipientName = Truncate(recipientName, 512),
-                    ParentRecipientId = parent?.ParentId,
-                    ParentNames = JoinParentNames(parent?.Names),
-                    ResolvedAt = now,
-                };
-                repository.Add(row);
-            }
+                    profile = await _client.GetRecipientProfile(recipientId, cancellationToken);
+                }
+                catch (HttpRequestException ex) when ((int?)ex.StatusCode >= 500)
+                {
+                    // A server error that survived the client's whole retry ladder for
+                    // THIS recipient. Isolated, that is a poisoned profile (observed
+                    // live: some recipients 502 permanently) — record the unavailability
+                    // on a short retry window and keep scanning. Repeated, it is a source
+                    // outage: rethrow so the window fails and nothing gets mass-cached.
+                    if (++profileFailures > MaxProfileFailuresPerWindow)
+                        throw;
 
-            parentCache[recipientId] = row;
-            persisted++;
+                    fetchFailed = true;
+                    _logger.LogWarning(
+                        ex,
+                        "Government contracts import: recipient profile {RecipientId} keeps "
+                            + "failing server-side; caching as unavailable for {Days} days",
+                        recipientId,
+                        FailedProfileRetryDays
+                    );
+                }
+
+                var parent = ChooseParent(profile);
+
+                if (staleRows.TryGetValue(recipientId, out var row))
+                {
+                    row.ParentRecipientId = parent?.ParentId;
+                    row.ParentNames = JoinParentNames(parent?.Names);
+                    row.ResolvedAt = now;
+                    row.ProfileFetchFailed = fetchFailed;
+                    repository.Update(row);
+                }
+                else
+                {
+                    row = new GovernmentContractRecipientParent
+                    {
+                        RecipientId = recipientId,
+                        RecipientName = Truncate(recipientName, 512),
+                        ParentRecipientId = parent?.ParentId,
+                        ParentNames = JoinParentNames(parent?.Names),
+                        ResolvedAt = now,
+                        ProfileFetchFailed = fetchFailed,
+                    };
+                    repository.Add(row);
+                }
+
+                parentCache[recipientId] = row;
+                persisted++;
+            }
+        }
+        catch when (persisted > 0)
+        {
+            // Best-effort save of the resolutions completed before the abort; the window
+            // still fails and is re-covered, but the finished lookups are banked.
+            try
+            {
+                await repository.SaveChanges();
+            }
+            catch (Exception saveEx)
+            {
+                _logger.LogWarning(
+                    saveEx,
+                    "Government contracts import: failed to bank {Count} parent resolutions "
+                        + "before the window abort",
+                    persisted
+                );
+            }
+            throw;
         }
 
         if (persisted > 0)
@@ -535,6 +600,17 @@ public class GovernmentContractsImportService : IImporter
 
         return kept.Count > 0 ? string.Join('\n', kept) : null;
     }
+
+    /// <summary>
+    /// Whether a cached parent row still answers for its recipient. A reading holds for
+    /// <see cref="ParentCacheStalenessDays"/>; a failure row (an unavailability, not a
+    /// reading) re-resolves after <see cref="FailedProfileRetryDays"/>.
+    /// </summary>
+    internal static bool IsFresh(GovernmentContractRecipientParent row, DateTime now) =>
+        row.ResolvedAt
+        >= now.AddDays(
+            -(row.ProfileFetchFailed ? FailedProfileRetryDays : ParentCacheStalenessDays)
+        );
 
     internal static string[] SplitParentNames(string parentNames) =>
         parentNames == null ? [] : parentNames.Split('\n');

--- a/src/Equibles.Migrations/Migrations/20260809182844_AddRecipientParentProfileFetchFailed.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260809182844_AddRecipientParentProfileFetchFailed.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260809182844_AddRecipientParentProfileFetchFailed")]
+    partial class AddRecipientParentProfileFetchFailed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260809182844_AddRecipientParentProfileFetchFailed.cs
+++ b/src/Equibles.Migrations/Migrations/20260809182844_AddRecipientParentProfileFetchFailed.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRecipientParentProfileFetchFailed : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ProfileFetchFailed",
+                table: "GovernmentContractRecipientParent",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProfileFetchFailed",
+                table: "GovernmentContractRecipientParent");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServicePoisonedProfileTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsImportServicePoisonedProfileTests.cs
@@ -1,0 +1,276 @@
+using System.Net;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.GovernmentContracts.Data;
+using Equibles.GovernmentContracts.Data.Models;
+using Equibles.GovernmentContracts.HostedService.Configuration;
+using Equibles.GovernmentContracts.HostedService.Services;
+using Equibles.GovernmentContracts.Repositories;
+using Equibles.Integrations.GovernmentContracts.Contracts;
+using Equibles.Integrations.GovernmentContracts.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+// Contract: USAspending 502s some individual recipient profiles PERMANENTLY (observed
+// live: the first epoch-rescan window carried one, and treating its 5xx as systemic
+// wedged the whole lane for hours — 22 aborted cycles). An isolated post-retry-ladder
+// server error on one recipient is therefore cached as a short-TTL unavailability row and
+// the scan continues; only repeated failures in one window (a source outage) still fail
+// the window, so an outage can never mass-cache "no parent" answers. Resolutions
+// completed before an abort are banked so retries don't refetch them.
+public class GovernmentContractsImportServicePoisonedProfileTests
+{
+    [Fact]
+    public async Task Import_OnePoisonedProfile_IsSkippedCachedShortTtl_AndTheWindowCompletes()
+    {
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var stockId = SeedCompany(options);
+        var scopeFactory = ScopeFactory(options);
+
+        // Two unmatched recipients: one healthy (resolves via parent), one poisoned.
+        var client = ClientReturning(
+            Award("CONT_AWD_1", "CACI, INC. - FEDERAL", "good-C", today),
+            Award("CONT_AWD_2", "BROKEN PROFILE LLC", "poisoned-C", today)
+        );
+        client
+            .GetRecipientProfile("good-C", Arg.Any<CancellationToken>())
+            .Returns(
+                new UsaSpendingRecipientProfile
+                {
+                    RecipientId = "good-C",
+                    ParentId = "par-P",
+                    ParentName = "CACI INTERNATIONAL INC",
+                    ParentDuns = "045534641",
+                }
+            );
+        client
+            .GetRecipientProfile("poisoned-C", Arg.Any<CancellationToken>())
+            .ThrowsAsync(
+                new HttpRequestException("502", inner: null, statusCode: HttpStatusCode.BadGateway)
+            );
+
+        await NewService(scopeFactory, client).Import(CancellationToken.None);
+
+        using var ctx = NewContext(options);
+        ctx.Set<GovernmentContract>()
+            .AsNoTracking()
+            .Single()
+            .CommonStockId.Should()
+            .Be(stockId, "the healthy recipient still resolves in the same window");
+
+        var rows = ctx.Set<GovernmentContractRecipientParent>().AsNoTracking().ToList();
+        rows.Should().HaveCount(2);
+        var poisoned = rows.Single(r => r.RecipientId == "poisoned-C");
+        poisoned.ProfileFetchFailed.Should().BeTrue();
+        poisoned.ParentNames.Should().BeNull();
+        rows.Single(r => r.RecipientId == "good-C").ProfileFetchFailed.Should().BeFalse();
+
+        // The next cycle answers the poisoned recipient from the failure row.
+        var secondClient = ClientReturning(
+            Award("CONT_AWD_3", "BROKEN PROFILE LLC", "poisoned-C", today)
+        );
+        await NewService(scopeFactory, secondClient).Import(CancellationToken.None);
+        await secondClient
+            .DidNotReceive()
+            .GetRecipientProfile(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void IsFresh_FailureRows_ReResolveOnTheShortWindow()
+    {
+        var now = DateTime.UtcNow;
+        var reading = new GovernmentContractRecipientParent { ResolvedAt = now.AddDays(-30) };
+        var failure = new GovernmentContractRecipientParent
+        {
+            ResolvedAt = now.AddDays(-30),
+            ProfileFetchFailed = true,
+        };
+
+        GovernmentContractsImportService.IsFresh(reading, now).Should().BeTrue();
+        GovernmentContractsImportService
+            .IsFresh(failure, now)
+            .Should()
+            .BeFalse("an unavailability must retry long before the 180-day reading window");
+        GovernmentContractsImportService
+            .IsFresh(
+                new GovernmentContractRecipientParent
+                {
+                    ResolvedAt = now.AddDays(-2),
+                    ProfileFetchFailed = true,
+                },
+                now
+            )
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public async Task Import_ManyProfileFailuresInOneWindow_IsAnOutage_FailsTheWindow_ButBanksSuccesses()
+    {
+        var options = NewDbOptions();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SeedCompany(options);
+        var scopeFactory = ScopeFactory(options);
+
+        // One healthy resolution first, then four distinct server-failing profiles —
+        // past the per-window budget, so the window must fail (source outage semantics).
+        var awards = new List<UsaSpendingAwardRecord>
+        {
+            Award("CONT_AWD_OK", "CACI, INC. - FEDERAL", "good-C", today),
+        };
+        for (var i = 0; i < 4; i++)
+            awards.Add(Award($"CONT_AWD_BAD{i}", $"OUTAGE VICTIM {i} LLC", $"bad{i}-C", today));
+
+        var client = ClientReturning(awards.ToArray());
+        client
+            .GetRecipientProfile("good-C", Arg.Any<CancellationToken>())
+            .Returns(
+                new UsaSpendingRecipientProfile
+                {
+                    RecipientId = "good-C",
+                    ParentId = "par-P",
+                    ParentName = "CACI INTERNATIONAL INC",
+                    ParentDuns = "045534641",
+                }
+            );
+        foreach (var i in Enumerable.Range(0, 4))
+            client
+                .GetRecipientProfile($"bad{i}-C", Arg.Any<CancellationToken>())
+                .ThrowsAsync(
+                    new HttpRequestException(
+                        "502",
+                        inner: null,
+                        statusCode: HttpStatusCode.BadGateway
+                    )
+                );
+
+        var act = () => NewService(scopeFactory, client).Import(CancellationToken.None);
+        await act.Should().ThrowAsync<HttpRequestException>();
+
+        using var ctx = NewContext(options);
+        // No contracts (the window aborted before mapping), but the completed resolutions
+        // — including the in-budget failure rows — are banked for the retry.
+        ctx.Set<GovernmentContract>().AsNoTracking().Should().BeEmpty();
+        var rows = ctx.Set<GovernmentContractRecipientParent>().AsNoTracking().ToList();
+        rows.Should().Contain(r => r.RecipientId == "good-C" && !r.ProfileFetchFailed);
+        rows.Count(r => r.ProfileFetchFailed).Should().Be(3, "the in-budget failures bank too");
+    }
+
+    private static UsaSpendingAwardRecord Award(
+        string id,
+        string recipientName,
+        string recipientId,
+        DateOnly actionDate
+    ) =>
+        new()
+        {
+            GeneratedInternalId = id,
+            AwardId = id,
+            RecipientName = recipientName,
+            RecipientId = recipientId,
+            Amount = 5_000_000m,
+            ContractAwardType = "DEFINITIVE CONTRACT",
+            BaseObligationDate = actionDate.ToString("yyyy-MM-dd"),
+        };
+
+    private static IUsaSpendingClient ClientReturning(params UsaSpendingAwardRecord[] awards)
+    {
+        var client = Substitute.For<IUsaSpendingClient>();
+        client
+            .GetContractAwards(
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<decimal>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(awards.ToList()));
+        return client;
+    }
+
+    private static GovernmentContractsImportService NewService(
+        IServiceScopeFactory scopeFactory,
+        IUsaSpendingClient client
+    )
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        return new(
+            scopeFactory,
+            NullLogger<GovernmentContractsImportService>.Instance,
+            client,
+            new RecipientResolver(scopeFactory),
+            Options.Create(
+                new GovernmentContractsScraperOptions
+                {
+                    WindowDays = 1,
+                    RescanLookbackDays = 1,
+                    MinimumAwardAmount = 1_000_000m,
+                }
+            ),
+            Options.Create(new WorkerOptions { MinSyncDate = today.ToDateTime(TimeOnly.MinValue) }),
+            new ErrorReporter(scopeFactory, NullLogger<ErrorReporter>.Instance)
+        );
+    }
+
+    private static Guid SeedCompany(DbContextOptions<EquiblesFinancialDbContext> options)
+    {
+        using var seed = NewContext(options);
+        var stock = new CommonStock
+        {
+            Ticker = "CACI",
+            Name = "Caci International Inc /De/",
+            Cik = "1",
+        };
+        seed.Add(stock);
+        seed.SaveChanges();
+        return stock.Id;
+    }
+
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new GovernmentContractsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static IServiceScopeFactory ScopeFactory(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => NewContext(options));
+        services.AddScoped<CommonStockRepository>();
+        services.AddScoped<GovernmentContractRepository>();
+        services.AddScoped<GovernmentContractsScanStateRepository>();
+        services.AddScoped<GovernmentContractRecipientParentRepository>();
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+}


### PR DESCRIPTION
## Summary

The #4327 epoch rescan wedged in production on its very first window: USAspending's recipient-profile endpoint 502s one specific recipient (`f10ee812…-C`) permanently (verified: 502 while sibling profiles answer 200), and the transport-failure-is-systemic rule turned that one broken profile into 22 consecutive aborted cycles — freezing both the backfill and new-award ingestion.

## Code changes

- `GovernmentContractsImportService.ResolveParents` — an isolated post-retry-ladder server error (status ≥ 500) on one recipient is cached as a short-TTL unavailability row and the scan continues; past three such failures in a window the pattern is a source outage and the window still fails, so an outage can never mass-cache "no parent" answers. Status-less transport failures keep the old systemic behaviour. Resolutions completed before an abort are now banked (saved before the rethrow) so window retries stop refetching them.
- `GovernmentContractRecipientParent.ProfileFetchFailed` — marks failure rows; `IsFresh` gives them a 7-day retry window instead of the 180-day reading window. Additive migration.
- Tests: poisoned-profile skip + short-TTL + cached-across-cycles, outage budget fails the window while banking in-budget rows, and the IsFresh split. Full suite 4,141 green.