### PR TITLE
fix(sec): scope the FTD absence claim to the data's dense coverage window

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -34,7 +34,7 @@ public class FailToDeliverTools
 
     [McpServerTool(Name = "GetFailsToDeliver", Title = "Fails-to-Deliver Data", ReadOnly = true)]
     [Description(
-        "Get fails-to-deliver (FTD) data for a stock from the SEC's twice-monthly FTD files. Quantity is the aggregate net fail-to-deliver position OUTSTANDING on each settlement date — a balance, not that day's new fails, so never sum Quantity across dates. Price is the previous trading day's closing price (SEC file convention, not a settlement price) and Value = Quantity × Price. Dates absent from the table had no reported fails; the SEC publishes each half-month batch with roughly a two-week lag, so the newest rows trail today. High or persistent FTD balances may indicate naked short selling or settlement issues."
+        "Get fails-to-deliver (FTD) data for a stock from the SEC's twice-monthly FTD files. Quantity is the aggregate net fail-to-deliver position OUTSTANDING on each settlement date — a balance, not that day's new fails, so never sum Quantity across dates. Price is the previous trading day's closing price (SEC file convention, not a settlement price) and Value = Quantity × Price. Within the covered window (the output names the earliest covered settlement date), dates absent from the table had no reported fails; earlier dates are simply not covered. The SEC publishes each half-month batch with roughly a two-week lag, so the newest rows trail today. High or persistent FTD balances may indicate naked short selling or settlement issues."
     )]
     public Task<string> GetFailsToDeliver(
         [Description("Stock ticker symbol (e.g., AAPL, GME, AMC)")] string ticker,
@@ -70,6 +70,18 @@ public class FailToDeliverTools
                     .Where(f => f.SettlementDate >= start && f.SettlementDate <= end);
 
                 var total = await query.CountAsync();
+
+                // The lane is forward-only from its first run, so the table's earliest
+                // settlement date is a coverage floor: "absent = no reported fails"
+                // only holds at or after it, and stating it unscoped converted the
+                // floor into a false factual claim (#7045).
+                var coverageFloor = await _ftdRepository.GetEarliestDate().FirstOrDefaultAsync();
+                var coverageNote =
+                    coverageFloor == default
+                        ? "No FTD data is covered yet."
+                        : $"Coverage starts {coverageFloor:yyyy-MM-dd}: within the covered window, dates absent from the table had no reported fails; earlier dates are not covered.";
+                var footnote =
+                    $"_Quantity is the outstanding FTD position on each settlement date (a balance — do not sum across dates); Prior Close is the previous trading day's closing price per SEC convention; Value = Quantity × Prior Close. {coverageNote} The SEC publishes in half-month batches with a ~2-week lag._";
                 var records = await query
                     .OrderByDescending(f => f.SettlementDate)
                     .Take(maxResults)
@@ -79,7 +91,7 @@ public class FailToDeliverTools
                     records.OrderBy(f => f.SettlementDate).ToList(),
                     $"No FTD data found for {stock.Ticker} in the specified date range.",
                     $"Fails-to-deliver for {stock.Ticker} ({stock.Name}):",
-                    "_Quantity is the outstanding FTD position on each settlement date (a balance — do not sum across dates); Prior Close is the previous trading day's closing price per SEC convention; Value = Quantity × Prior Close. Dates absent from the table had no reported fails; the SEC publishes in half-month batches with a ~2-week lag._",
+                    footnote,
                     "| Settlement Date | Quantity | Prior Close | Value |",
                     "|----------------|---------|-------------|-------|",
                     f =>

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -5,9 +5,11 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Extensions;
 using Equibles.Mcp.Helpers;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -18,23 +20,26 @@ public class FailToDeliverTools
 {
     private readonly FailToDeliverRepository _ftdRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly IMemoryCache _memoryCache;
     private readonly McpToolRunner _runner;
 
     public FailToDeliverTools(
         FailToDeliverRepository ftdRepository,
         CommonStockRepository commonStockRepository,
+        IMemoryCache memoryCache,
         ErrorManager errorManager,
         ILogger<FailToDeliverTools> logger
     )
     {
         _ftdRepository = ftdRepository;
         _commonStockRepository = commonStockRepository;
+        _memoryCache = memoryCache;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetFailsToDeliver", Title = "Fails-to-Deliver Data", ReadOnly = true)]
     [Description(
-        "Get fails-to-deliver (FTD) data for a stock from the SEC's twice-monthly FTD files. Quantity is the aggregate net fail-to-deliver position OUTSTANDING on each settlement date — a balance, not that day's new fails, so never sum Quantity across dates. Price is the previous trading day's closing price (SEC file convention, not a settlement price) and Value = Quantity × Price. Within the covered window (the output names the earliest covered settlement date), dates absent from the table had no reported fails; earlier dates are simply not covered. The SEC publishes each half-month batch with roughly a two-week lag, so the newest rows trail today. High or persistent FTD balances may indicate naked short selling or settlement issues."
+        "Get fails-to-deliver (FTD) data for a stock from the SEC's twice-monthly FTD files. Quantity is the aggregate net fail-to-deliver position OUTSTANDING on each settlement date — a balance, not that day's new fails, so never sum Quantity across dates. Price is the previous trading day's closing price (SEC file convention, not a settlement price) and Value = Quantity × Price. Within the covered window (the output names the earliest fully covered settlement date), dates absent from the table had no reported fails; earlier dates are only partially covered, so their absence is not evidence of no fails. The SEC publishes each half-month batch with roughly a two-week lag, so the newest rows trail today. High or persistent FTD balances may indicate naked short selling or settlement issues."
     )]
     public Task<string> GetFailsToDeliver(
         [Description("Stock ticker symbol (e.g., AAPL, GME, AMC)")] string ticker,
@@ -71,15 +76,24 @@ public class FailToDeliverTools
 
                 var total = await query.CountAsync();
 
-                // The lane is forward-only from its first run, so the table's earliest
-                // settlement date is a coverage floor: "absent = no reported fails"
-                // only holds at or after it, and stating it unscoped converted the
-                // floor into a false factual claim (#7045).
-                var coverageFloor = await _ftdRepository.GetEarliestDate().FirstOrDefaultAsync();
+                // The dense-coverage floor: "absent = no reported fails" only holds
+                // from the first full-universe settlement date onward — a raw earliest
+                // date would let years of sparse pre-full-universe trickle masquerade
+                // as covered, the exact defect #7045 names. Cached per process: the
+                // grouping query scans the whole table.
+                var coverageFloor = await _memoryCache.GetOrCreateSafeAsync(
+                    FailToDeliverRepository.DenseCoverageFloorCacheKey,
+                    FailToDeliverRepository.DenseCoverageFloorCacheDuration,
+                    () =>
+                        _ftdRepository
+                            .GetDenseCoverageFloor()
+                            .Select(d => (DateOnly?)d)
+                            .FirstOrDefaultAsync()
+                );
                 var coverageNote =
-                    coverageFloor == default
+                    coverageFloor == null
                         ? "No FTD data is covered yet."
-                        : $"Coverage starts {coverageFloor:yyyy-MM-dd}: within the covered window, dates absent from the table had no reported fails; earlier dates are not covered.";
+                        : $"Full-universe coverage begins {coverageFloor:yyyy-MM-dd}: within the covered window, dates absent from the table had no reported fails; earlier dates are only partially covered, so absence before {coverageFloor:yyyy-MM-dd} is not evidence of no fails.";
                 var footnote =
                     $"_Quantity is the outstanding FTD position on each settlement date (a balance — do not sum across dates); Prior Close is the previous trading day's closing price per SEC convention; Value = Quantity × Prior Close. {coverageNote} The SEC publishes in half-month batches with a ~2-week lag._";
                 var records = await query

--- a/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
+++ b/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
@@ -19,4 +19,15 @@ public class FailToDeliverRepository : BaseRepository<FailToDeliver>
     {
         return GetAll().LatestValue(f => f.SettlementDate, distinct: true);
     }
+
+    /// <summary>
+    /// The earliest settlement date on file across the whole table — the ingest lane is
+    /// forward-only from its first run, so this is the data's coverage floor. Absence
+    /// of a date can only be read as "no reported fails" INSIDE the covered window;
+    /// surfaces must scope that claim with this value.
+    /// </summary>
+    public IQueryable<DateOnly> GetEarliestDate()
+    {
+        return GetAll().OrderBy(f => f.SettlementDate).Select(f => f.SettlementDate).Take(1);
+    }
 }

--- a/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
+++ b/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
@@ -21,13 +21,38 @@ public class FailToDeliverRepository : BaseRepository<FailToDeliver>
     }
 
     /// <summary>
-    /// The earliest settlement date on file across the whole table — the ingest lane is
-    /// forward-only from its first run, so this is the data's coverage floor. Absence
-    /// of a date can only be read as "no reported fails" INSIDE the covered window;
-    /// surfaces must scope that claim with this value.
+    /// A settlement date only counts as covered when its per-date row count reaches this
+    /// threshold. The table holds two eras: a sparse pre-full-universe trickle (a handful
+    /// of rows per YEAR, single tickers) and full-universe ingestion (thousands of rows
+    /// per DAY) — a raw MIN over both converts years of partial ingestion into an
+    /// "absent = no reported fails" claim. The threshold measures OUR ingestion
+    /// completeness, not the data itself (it is not a data-classification heuristic), so
+    /// the authoritative-data rule does not apply.
     /// </summary>
-    public IQueryable<DateOnly> GetEarliestDate()
+    public const int MinRowsPerCoveredDate = 50;
+
+    /// <summary>
+    /// Cache key + duration for the dense-coverage floor: the query scans and groups the
+    /// whole table, so every surface reads it through a per-process memory cache. The
+    /// floor only ever moves when ingestion history changes, so a long TTL is safe.
+    /// </summary>
+    public const string DenseCoverageFloorCacheKey = "FailToDeliver:DenseCoverageFloor";
+    public static readonly TimeSpan DenseCoverageFloorCacheDuration = TimeSpan.FromHours(6);
+
+    /// <summary>
+    /// The earliest settlement date with full-universe ingestion (per-date row count at
+    /// least <see cref="MinRowsPerCoveredDate"/>) — the data's dense-coverage floor.
+    /// Absence of a date can only be read as "no reported fails" AT OR AFTER this date;
+    /// earlier dates are at best partially covered, and surfaces must scope the absence
+    /// claim with this value. Empty result when no date qualifies yet.
+    /// </summary>
+    public IQueryable<DateOnly> GetDenseCoverageFloor()
     {
-        return GetAll().OrderBy(f => f.SettlementDate).Select(f => f.SettlementDate).Take(1);
+        return GetAll()
+            .GroupBy(f => f.SettlementDate)
+            .Where(g => g.Count() >= MinRowsPerCoveredDate)
+            .Select(g => g.Key)
+            .OrderBy(d => d)
+            .Take(1);
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests.cs
@@ -5,6 +5,7 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
 using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -16,6 +17,7 @@ public class FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests : ParadeD
         new(
             new FailToDeliverRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<FailToDeliverTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsStrictDatesAndTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsStrictDatesAndTruncationTests.cs
@@ -4,6 +4,7 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
 using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -22,6 +23,7 @@ public class FailToDeliverToolsStrictDatesAndTruncationTests : ParadeDbMcpTestBa
         new(
             new FailToDeliverRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<FailToDeliverTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsTests.cs
@@ -4,6 +4,7 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Mcp.Tools;
 using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -15,6 +16,7 @@ public class FailToDeliverToolsTests : ParadeDbMcpTestBase
         new(
             new FailToDeliverRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new MemoryCache(new MemoryCacheOptions()),
             ErrorManager,
             NullLogger<FailToDeliverTools>()
         );

--- a/tests/Equibles.UnitTests/Sec/FailToDeliverToolsCoverageFloorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FailToDeliverToolsCoverageFloorTests.cs
@@ -1,0 +1,126 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+// Contract (#7045): "an absent date means no reported fails" is only true INSIDE the
+// covered window — the ingest lane is forward-only from its first run, so the earliest
+// stored settlement date is a coverage floor, and the tool must scope the absence claim
+// with it instead of converting the floor into a factual claim about earlier dates.
+public class FailToDeliverToolsCoverageFloorTests
+{
+    [Fact]
+    public async Task GetFailsToDeliver_ScopesTheAbsenceClaimToTheCoverageFloor()
+    {
+        var options = NewDbOptions();
+        Guid stockId;
+        using (var seed = NewContext(options))
+        {
+            var stock = new CommonStock
+            {
+                Ticker = "FTDC",
+                Name = "Coverage Corp",
+                Cik = "1",
+            };
+            seed.Add(stock);
+            seed.SaveChanges();
+            stockId = stock.Id;
+            seed.Add(
+                new FailToDeliver
+                {
+                    CommonStockId = stockId,
+                    SettlementDate = new DateOnly(2026, 3, 2),
+                    Quantity = 1000,
+                    Price = 10m,
+                }
+            );
+            // Another stock's older row sets the GLOBAL floor — the claim is about the
+            // whole table's coverage, not one ticker's rows.
+            var other = new CommonStock
+            {
+                Ticker = "FTDO",
+                Name = "Other Corp",
+                Cik = "2",
+            };
+            seed.Add(other);
+            seed.SaveChanges();
+            seed.Add(
+                new FailToDeliver
+                {
+                    CommonStockId = other.Id,
+                    SettlementDate = new DateOnly(2026, 1, 15),
+                    Quantity = 5,
+                    Price = 1m,
+                }
+            );
+            seed.SaveChanges();
+        }
+
+        using var ctx = NewContext(options);
+        var tools = new FailToDeliverTools(
+            new FailToDeliverRepository(ctx),
+            new CommonStockRepository(ctx),
+            new ErrorManager(null),
+            NullLogger<FailToDeliverTools>.Instance
+        );
+
+        var result = await tools.GetFailsToDeliver(
+            "FTDC",
+            startDate: "2026-01-01",
+            endDate: "2026-04-01"
+        );
+
+        result.Should().Contain("Coverage starts 2026-01-15");
+        result
+            .Should()
+            .Contain(
+                "within the covered window, dates absent from the table had no reported fails",
+                "the absence promise must be scoped, never absolute"
+            );
+        result.Should().Contain("earlier dates are not covered");
+    }
+
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                // The full Sec module registers document entities whose smart-enum
+                // constructors the in-memory provider cannot bind; the test only needs
+                // the FTD table.
+                new FailToDeliverOnlyModule(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private sealed class FailToDeliverOnlyModule : Equibles.Data.IFinancialModule
+    {
+        public void ConfigureEntities(ModelBuilder builder)
+        {
+            builder.Entity<FailToDeliver>();
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FailToDeliverToolsCoverageFloorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FailToDeliverToolsCoverageFloorTests.cs
@@ -9,22 +9,23 @@ using Equibles.Sec.Repositories;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Equibles.UnitTests.Sec;
 
 // Contract (#7045): "an absent date means no reported fails" is only true INSIDE the
-// covered window — the ingest lane is forward-only from its first run, so the earliest
-// stored settlement date is a coverage floor, and the tool must scope the absence claim
-// with it instead of converting the floor into a factual claim about earlier dates.
+// fully covered window. The table holds a sparse pre-full-universe trickle era and a
+// full-universe era — the floor must be the first DENSE settlement date (per-date row
+// count at or above the repository threshold), because a raw earliest date would let
+// years of partial ingestion masquerade as covered.
 public class FailToDeliverToolsCoverageFloorTests
 {
     [Fact]
-    public async Task GetFailsToDeliver_ScopesTheAbsenceClaimToTheCoverageFloor()
+    public async Task GetFailsToDeliver_ScopesTheAbsenceClaimToTheDenseCoverageFloor()
     {
         var options = NewDbOptions();
-        Guid stockId;
         using (var seed = NewContext(options))
         {
             var stock = new CommonStock
@@ -35,18 +36,18 @@ public class FailToDeliverToolsCoverageFloorTests
             };
             seed.Add(stock);
             seed.SaveChanges();
-            stockId = stock.Id;
             seed.Add(
                 new FailToDeliver
                 {
-                    CommonStockId = stockId,
+                    CommonStockId = stock.Id,
                     SettlementDate = new DateOnly(2026, 3, 2),
                     Quantity = 1000,
                     Price = 10m,
                 }
             );
-            // Another stock's older row sets the GLOBAL floor — the claim is about the
-            // whole table's coverage, not one ticker's rows.
+            // Another stock carries a sparse trickle-era row BELOW the per-date
+            // threshold — it must NOT set the floor — plus enough same-date rows to
+            // make 2026-03-02 the first dense date.
             var other = new CommonStock
             {
                 Ticker = "FTDO",
@@ -64,16 +65,23 @@ public class FailToDeliverToolsCoverageFloorTests
                     Price = 1m,
                 }
             );
+            for (var i = 0; i < FailToDeliverRepository.MinRowsPerCoveredDate; i++)
+            {
+                seed.Add(
+                    new FailToDeliver
+                    {
+                        CommonStockId = other.Id,
+                        SettlementDate = new DateOnly(2026, 3, 2),
+                        Quantity = 10 + i,
+                        Price = 1m,
+                    }
+                );
+            }
             seed.SaveChanges();
         }
 
         using var ctx = NewContext(options);
-        var tools = new FailToDeliverTools(
-            new FailToDeliverRepository(ctx),
-            new CommonStockRepository(ctx),
-            new ErrorManager(null),
-            NullLogger<FailToDeliverTools>.Instance
-        );
+        var tools = NewTools(ctx);
 
         var result = await tools.GetFailsToDeliver(
             "FTDC",
@@ -81,15 +89,96 @@ public class FailToDeliverToolsCoverageFloorTests
             endDate: "2026-04-01"
         );
 
-        result.Should().Contain("Coverage starts 2026-01-15");
+        result.Should().Contain("Full-universe coverage begins 2026-03-02");
         result
             .Should()
             .Contain(
                 "within the covered window, dates absent from the table had no reported fails",
                 "the absence promise must be scoped, never absolute"
             );
-        result.Should().Contain("earlier dates are not covered");
+        result
+            .Should()
+            .Contain(
+                "earlier dates are only partially covered",
+                "the sparse trickle era must not read as covered"
+            );
+        result
+            .Should()
+            .NotContain("begins 2026-01-15", "a below-threshold date must not set the floor");
     }
+
+    [Fact]
+    public async Task DenseCoverageFloor_IgnoresSparseDatesBelowThreshold()
+    {
+        var options = NewDbOptions();
+        using (var seed = NewContext(options))
+        {
+            var stock = new CommonStock
+            {
+                Ticker = "FTDS",
+                Name = "Sparse Corp",
+                Cik = "3",
+            };
+            seed.Add(stock);
+            seed.SaveChanges();
+            // One row short of the threshold on the earlier date: not covered.
+            for (var i = 0; i < FailToDeliverRepository.MinRowsPerCoveredDate - 1; i++)
+            {
+                seed.Add(
+                    new FailToDeliver
+                    {
+                        CommonStockId = stock.Id,
+                        SettlementDate = new DateOnly(2025, 6, 2),
+                        Quantity = i + 1,
+                        Price = 1m,
+                    }
+                );
+            }
+            // Exactly the threshold on the later date: the floor.
+            for (var i = 0; i < FailToDeliverRepository.MinRowsPerCoveredDate; i++)
+            {
+                seed.Add(
+                    new FailToDeliver
+                    {
+                        CommonStockId = stock.Id,
+                        SettlementDate = new DateOnly(2026, 3, 2),
+                        Quantity = i + 1,
+                        Price = 1m,
+                    }
+                );
+            }
+            seed.SaveChanges();
+        }
+
+        using var ctx = NewContext(options);
+        var floor = await new FailToDeliverRepository(ctx)
+            .GetDenseCoverageFloor()
+            .Select(d => (DateOnly?)d)
+            .FirstOrDefaultAsync();
+
+        floor.Should().Be(new DateOnly(2026, 3, 2));
+    }
+
+    [Fact]
+    public async Task DenseCoverageFloor_EmptyTable_YieldsNull()
+    {
+        using var ctx = NewContext(NewDbOptions());
+        var floor = await new FailToDeliverRepository(ctx)
+            .GetDenseCoverageFloor()
+            .Select(d => (DateOnly?)d)
+            .FirstOrDefaultAsync();
+
+        floor.Should().BeNull();
+    }
+
+    private static FailToDeliverTools NewTools(EquiblesFinancialDbContext ctx) =>
+        new(
+            new FailToDeliverRepository(ctx),
+            new CommonStockRepository(ctx),
+            new MemoryCache(new MemoryCacheOptions()),
+            new ErrorManager(null),
+            NullLogger<FailToDeliverTools>.Instance
+        );
 
     private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
         new DbContextOptionsBuilder<EquiblesFinancialDbContext>()


### PR DESCRIPTION
## Summary

The GetFailsToDeliver tool (and its REST mirror in the commercial repo) promised that "dates absent from the table had no reported fails" — converting an ingestion boundary into a false factual claim. The FTD lane is forward-only from wherever it first ran, so a deployment's history has a hard floor (production: a sparse per-ticker trickle from 2020, full-universe coverage only from 2026-03-02), and absence before that floor is a coverage gap, not evidence.

## Code changes

- `FailToDeliverRepository.GetDenseCoverageFloor()` — the earliest settlement date whose per-date row count meets `MinRowsPerCoveredDate` (50), so a sparse pre-lane trickle can't masquerade as coverage. The threshold measures our own ingestion completeness, not data classification. Cached 6h via the existing `IMemoryCache.GetOrCreateSafeAsync` single-flight extension (cache key + TTL are shared constants so the commercial REST mirror reads the same entry).
- `FailToDeliverTools` — description and footnote now scope the promise: within the covered window absent dates had no reported fails; before the floor, absence is not evidence. Empty table renders "No FTD data is covered yet."
- Tests: below-threshold trickle rows must not set the floor; empty table → null; tool wording pinned. Full suite 4,141 green.