### PR TITLE
fix(mcp): honest truncation notes, offset paging, and subset-count labels

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -197,13 +197,18 @@ public class CboeTools
     }
 
     // Appended after tables that keep the NEWEST rows but render oldest-to-newest, where
-    // the shared "Showing first N" wording would point at the wrong end of the table.
+    // the shared "Showing first N" wording would point at the wrong end of the table. At the
+    // cap "raise maxResults" is impossible advice, so the note names the cap instead.
     private static string AppendNewestKeptTruncationNote(string table, int shown, int total)
     {
         if (shown >= total)
             return table;
+        var advice =
+            shown >= McpLimit.MaxResults
+                ? $"maxResults is at its cap of {McpLimit.MaxResults}; narrow the date range to see older rows"
+                : "raise maxResults or narrow the date range to see older rows";
         return table
             + Environment.NewLine
-            + $"_Showing the newest {shown} of {total} records in the range - raise maxResults or narrow the date range to see older rows._";
+            + $"_Showing the newest {shown} of {total} records in the range - {advice}._";
     }
 }

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -127,7 +127,11 @@ public class CongressTools
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to today)")] string endDate = null,
         [Description("Maximum number of trades to return (default: 50, max: 500, newest first)")]
-            int maxResults = 50
+            int maxResults = 50,
+        [Description(
+            "Number of trades to skip before returning rows — pass the previous call's shown count to page past the maxResults cap (default: 0)"
+        )]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -152,13 +156,22 @@ public class CongressTools
                     query = query.Where(t => t.TransactionType == typeFilter);
 
                 maxResults = McpLimit.Clamp(maxResults);
+                offset = McpLimit.ClampOffset(offset);
                 var totalCount = await query.CountAsync();
 
+                // Same-day trades tie constantly, so the ordering ends on the row id — an
+                // offset over a partial order would silently repeat or skip trades between
+                // pages.
                 var trades = await query
                     .Include(t => t.CommonStock)
                     .OrderByDescending(t => t.TransactionDate)
+                    .ThenByDescending(t => t.FilingDate)
+                    .ThenBy(t => t.Id)
+                    .Skip(offset)
                     .Take(maxResults)
                     .ToListAsync();
+                if (trades.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {totalCount} trades match; lower offset.";
 
                 var table = MarkdownTable.Render(
                     trades,
@@ -173,10 +186,11 @@ public class CongressTools
                         return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {FormatOwner(t.OwnerType)} |";
                     }
                 );
-                return AppendTruncationNote(table, trades.Count, totalCount);
+                var note = McpOutput.PagedTruncationNote(trades.Count, totalCount, offset);
+                return note.Length == 0 ? table : $"{table}\n{note}";
             },
             "GetMemberTrades",
-            $"memberName: {memberName}"
+            $"memberName: {memberName}, offset: {offset}"
         );
     }
 

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -380,7 +380,9 @@ public class ShortSqueezeScoreManager
         }
 
         ApplyPercentiles(scores);
-        return scores.OrderByDescending(s => s.Score).ToList();
+        // Ticker tiebreak keeps equal scores in a total order, so consumers that page the
+        // board with an offset never repeat or skip rows between pages.
+        return scores.OrderByDescending(s => s.Score).ThenBy(s => s.Ticker).ToList();
     }
 
     /// <summary>

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -260,6 +260,10 @@ public class ShortDataTools
         [Description("Maximum number of results to return (default: 50, max: 500)")]
             int maxResults = 50,
         [Description(
+            "Number of ranked results to skip before returning rows — pass the previous call's last row number to page past the maxResults cap (default: 0)"
+        )]
+            int offset = 0,
+        [Description(
             "Minimum average daily share volume — set a floor (e.g. 100000) to drop illiquid names whose days-to-cover is inflated by a tiny volume denominator (default: 0 = no floor)"
         )]
             long minAvgDailyVolume = 0,
@@ -332,8 +336,14 @@ public class ShortDataTools
                     );
                 }
 
+                offset = McpLimit.ClampOffset(offset);
                 var total = await query.CountAsync();
-                var records = await ordered.Take(McpLimit.Clamp(maxResults)).ToListAsync();
+                var records = await ordered
+                    .Skip(offset)
+                    .Take(McpLimit.Clamp(maxResults))
+                    .ToListAsync();
+                if (records.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {total} rows match; lower offset.";
 
                 var volumeClause =
                     minAvgDailyVolume > 0
@@ -349,10 +359,13 @@ public class ShortDataTools
                     r => RenderShortInterestRow(r.CommonStock.Ticker, r)
                 );
 
-                return AppendNote(table, McpOutput.TruncationNote(records.Count, total));
+                return AppendNote(
+                    table,
+                    McpOutput.PagedTruncationNote(records.Count, total, offset)
+                );
             },
             "GetShortInterestSnapshot",
-            $"minDaysToCover: {minDaysToCover}, minAvgDailyVolume: {minAvgDailyVolume}, sortBy: {sortBy}"
+            $"minDaysToCover: {minDaysToCover}, minAvgDailyVolume: {minAvgDailyVolume}, sortBy: {sortBy}, offset: {offset}"
         );
     }
 
@@ -370,6 +383,10 @@ public class ShortDataTools
         [Description("Minimum short volume filter (default: 0)")] long minShortVolume = 0,
         [Description("Maximum number of results to return (default: 50, max: 500)")]
             int maxResults = 50,
+        [Description(
+            "Number of ranked results to skip before returning rows — pass the previous call's last row number to page past the maxResults cap (default: 0)"
+        )]
+            int offset = 0,
         [Description(
             "Sort key: shortVolume (default) or shortPercent — with shortPercent set a minTotalVolume floor, otherwise illiquid names dominate"
         )]
@@ -432,8 +449,14 @@ public class ShortDataTools
                     return McpOutput.InvalidArgument("sortBy", sortBy, "shortVolume, shortPercent");
                 }
 
+                offset = McpLimit.ClampOffset(offset);
                 var total = await query.CountAsync();
-                var records = await ordered.Take(McpLimit.Clamp(maxResults)).ToListAsync();
+                var records = await ordered
+                    .Skip(offset)
+                    .Take(McpLimit.Clamp(maxResults))
+                    .ToListAsync();
+                if (records.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {total} rows match; lower offset.";
 
                 var totalVolumeClause =
                     minTotalVolume > 0
@@ -451,10 +474,13 @@ public class ShortDataTools
                     r => RenderShortVolumeRow($"{r.CommonStock.Ticker} | {r.CommonStock.Name}", r)
                 );
 
-                return AppendNote(table, McpOutput.TruncationNote(records.Count, total));
+                return AppendNote(
+                    table,
+                    McpOutput.PagedTruncationNote(records.Count, total, offset)
+                );
             },
             "GetLargestShortVolume",
-            $"date: {date}, sortBy: {sortBy}, minTotalVolume: {minTotalVolume}"
+            $"date: {date}, sortBy: {sortBy}, minTotalVolume: {minTotalVolume}, offset: {offset}"
         );
     }
 
@@ -612,7 +638,11 @@ public class ShortDataTools
         [Description(
             "Optional stock ticker (e.g. GME): returns that one stock's score, factor breakdown, and rank within the scored universe instead of the board. The liquidity floors do not apply to a single-ticker lookup."
         )]
-            string ticker = null
+            string ticker = null,
+        [Description(
+            "Number of ranked results to skip before returning rows — pass the previous call's last rank to page past the maxResults cap (default: 0; ignored for a single-ticker lookup)"
+        )]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -656,6 +686,9 @@ public class ShortDataTools
                     return $"No scored stocks clear the requested liquidity floor (of {scores.Count} scored at settlement {settlementDate:yyyy-MM-dd}). Lower minMarketCap/minDollarVolume.";
 
                 var take = Math.Clamp(maxResults, 1, 200);
+                offset = McpLimit.ClampOffset(offset);
+                if (offset >= filtered.Count)
+                    return $"No results at offset {offset} - only {filtered.Count} scored stocks clear the filters; lower offset.";
                 var sb = new System.Text.StringBuilder();
                 sb.AppendLine(
                     $"# Highest short-squeeze scores — settlement {settlementDate:yyyy-MM-dd}"
@@ -671,12 +704,14 @@ public class ShortDataTools
                 sb.AppendLine(
                     "|---|--------|-------|-------------------|---------------|--------------------|------------------|-------------|---------------|-----------|------------|--------------|"
                 );
-                var shown = Math.Min(take, filtered.Count);
+                var shown = Math.Min(take, filtered.Count - offset);
                 sb.AppendNumberedRows(
-                    filtered.Take(take).ToList(),
+                    filtered.Skip(offset).Take(take).ToList(),
                     (rank, score) =>
                     {
-                        return $"| {rank} | {score.Ticker} | {score.Score.ToString("0", CultureInfo.InvariantCulture)} | "
+                        // Rank is the ABSOLUTE position in the filtered board, so page two
+                        // continues 26, 27, … instead of restarting at 1.
+                        return $"| {offset + rank} | {score.Ticker} | {score.Score.ToString("0", CultureInfo.InvariantCulture)} | "
                             + $"{score.ShortInterestPercentOfShares.ToString("P1", CultureInfo.InvariantCulture)} | "
                             + $"{score.DaysToCover?.ToString("0.0", CultureInfo.InvariantCulture) ?? "-"} | "
                             + $"{FormatSignedPercent(score.ShortVolumeShareTrend)} | "
@@ -687,16 +722,22 @@ public class ShortDataTools
                     }
                 );
 
-                if (shown < filtered.Count)
+                var pagedNote = McpOutput.PagedTruncationNote(
+                    shown,
+                    filtered.Count,
+                    offset,
+                    cap: 200
+                );
+                if (pagedNote.Length > 0)
                 {
                     sb.AppendLine();
-                    sb.AppendLine(McpOutput.TruncationNote(shown, filtered.Count));
+                    sb.AppendLine(pagedNote);
                 }
 
                 return sb.ToString();
             },
             "GetShortSqueezeScores",
-            $"minMarketCap: {minMarketCap}, minDollarVolume: {minDollarVolume}, maxResults: {maxResults}, ticker: {ticker}"
+            $"minMarketCap: {minMarketCap}, minDollarVolume: {minDollarVolume}, maxResults: {maxResults}, ticker: {ticker}, offset: {offset}"
         );
     }
 

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -376,7 +376,11 @@ public class InstitutionalHoldingsTools
         )]
             string reportDate = null,
         [Description("Maximum number of holdings to return (default: 20, clamped to 1-500)")]
-            int maxResults = 20
+            int maxResults = 20,
+        [Description(
+            "Number of ranked holding rows to skip before returning rows — pass the previous call's last row number to page past the maxResults cap (default: 0)"
+        )]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -414,6 +418,11 @@ public class InstitutionalHoldingsTools
                     .GroupBy(h => 1)
                     .Select(g => new
                     {
+                        // Rows and Positions differ: a stock held as shares AND as puts/calls
+                        // is one distinct position spread over several holding rows, and the
+                        // table below renders ROWS — quoting the distinct-stock count as its
+                        // denominator once produced "top 39 of 35".
+                        Rows = g.Count(),
                         Positions = g.Select(h => h.CommonStockId).Distinct().Count(),
                         Value = g.Sum(h => h.Value),
                         Unvalued = g.Where(h =>
@@ -425,6 +434,7 @@ public class InstitutionalHoldingsTools
                             .Count(),
                     })
                     .FirstOrDefaultAsync();
+                var totalRows = summary?.Rows ?? 0;
                 var totalPositions = summary?.Positions ?? 0;
                 var totalValue = summary?.Value ?? 0L;
                 var unvaluedPositions = summary?.Unvalued ?? 0;
@@ -439,11 +449,20 @@ public class InstitutionalHoldingsTools
                     .ThenByDescending(f => f.AccessionNumber)
                     .FirstOrDefaultAsync();
 
+                offset = McpLimit.ClampOffset(offset);
+                // Values tie (equal-sized lines, $0 unvalued rows), so the ordering ends on
+                // the row id — an offset over a partial order would silently repeat or skip
+                // rows between pages.
                 var holdings = await allHoldings
                     .OrderByDescending(h => h.Value)
+                    .ThenBy(h => h.CommonStockId)
+                    .ThenBy(h => h.Id)
+                    .Skip(offset)
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
+                if (holdings.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {totalRows} holding rows on file for {holder.Name} as of {FormatDate(targetDate)}; lower offset.";
                 if (holdings.Count == 0)
                     return $"No holdings found for {holder.Name} as of {FormatDate(targetDate)}.";
 
@@ -458,6 +477,8 @@ public class InstitutionalHoldingsTools
                     targetDate,
                     holdings,
                     splitsByStock,
+                    offset,
+                    totalRows,
                     totalPositions,
                     totalValue,
                     unvaluedPositions,
@@ -466,7 +487,7 @@ public class InstitutionalHoldingsTools
                 );
             },
             "GetInstitutionPortfolio",
-            $"institution: {institutionName}"
+            $"institution: {institutionName}, offset: {offset}"
         );
     }
 
@@ -475,6 +496,8 @@ public class InstitutionalHoldingsTools
         DateOnly targetDate,
         List<InstitutionalHolding> holdings,
         IReadOnlyDictionary<Guid, List<StockSplit>> splitsByStock,
+        int offset,
+        int totalRows,
         int totalPositions,
         long totalValue,
         int unvaluedPositions,
@@ -482,8 +505,13 @@ public class InstitutionalHoldingsTools
         string notes
     )
     {
+        // The table renders holding ROWS, so the coverage line counts rows — quoting the
+        // distinct-stock count as the denominator once produced "top 39 of 35" for a filer
+        // whose stocks appear as separate share and option rows.
         var subtitle =
-            $"Showing top {holdings.Count} of {McpFormat.WholeNumber(totalPositions)} tracked positions. "
+            $"Showing holding rows {offset + 1}-{offset + holdings.Count} of {McpFormat.WholeNumber(totalRows)}, "
+            + $"largest value first ({McpFormat.WholeNumber(totalPositions)} distinct tracked stocks — a stock "
+            + "held as shares and as options appears as separate rows). "
             + $"Tracked 13F value: ${FormatMillions(totalValue)}M";
 
         // The filer's own cover-page declaration, when captured, makes the coverage exact: the
@@ -546,7 +574,9 @@ public class InstitutionalHoldingsTools
                 var pct = Percentage.Of(h.Value, totalValue);
                 // The exact listing held: a GOOG position must not render as GOOGL.
                 var listedTicker = h.ListedTicker ?? h.CommonStock.Ticker;
-                return $"| {rank} | {listedTicker} | {h.CommonStock.Name} | "
+                // Rank is the ABSOLUTE position in the value-ranked rows, so page two
+                // continues 21, 22, … instead of restarting at 1.
+                return $"| {offset + rank} | {listedTicker} | {h.CommonStock.Name} | "
                     + $"{PositionType(h.OptionType)} | "
                     + $"{McpFormat.WholeNumber(shares)} | "
                     + $"{FormatMillions(h.Value)} | "
@@ -571,6 +601,13 @@ public class InstitutionalHoldingsTools
                 + "coverage — preferred shares, bonds, warrants, untracked share classes — so the "
                 + "filing's own declared total can exceed the figure above._"
         );
+
+        var pagedNote = McpOutput.PagedTruncationNote(holdings.Count, totalRows, offset);
+        if (pagedNote.Length > 0)
+        {
+            result.AppendLine();
+            result.AppendLine(pagedNote);
+        }
 
         return result.ToString();
     }

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -265,7 +265,11 @@ public class InsiderTradingTools
         [Description(
             "Maximum number of insiders to return (default: 30, max: 500; values outside 1-500 are clamped)"
         )]
-            int maxResults = 30
+            int maxResults = 30,
+        [Description(
+            "Number of ranked insiders to skip before returning rows — pass the previous call's shown count to page past the maxResults cap (default: 0)"
+        )]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -300,6 +304,10 @@ public class InsiderTradingTools
                 // adjusted holding so the ordering — and the top-N cut itself — compares
                 // like with like.
                 var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                offset = McpLimit.ClampOffset(offset);
+                // Adjusted holdings tie constantly (zero-share former insiders), so the
+                // ordering ends on stable keys — an offset over a partial order would
+                // silently repeat or skip insiders between pages.
                 var ranked = latestTransactions
                     .OrderByDescending(t =>
                         SplitAdjustment.AdjustShareCount(
@@ -308,9 +316,14 @@ public class InsiderTradingTools
                             splits
                         )
                     )
+                    .ThenBy(t => t.InsiderOwner.Name)
+                    .ThenBy(t => t.Id)
+                    .Skip(offset)
                     .Take(maxResults)
                     .ToList();
 
+                if (ranked.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {latestTransactions.Count} insiders on file; lower offset.";
                 if (ranked.Count == 0)
                     return $"No insider ownership data found for {stock.Ticker}.";
 
@@ -340,7 +353,11 @@ public class InsiderTradingTools
                     }
                 );
 
-                var truncation = McpOutput.TruncationNote(ranked.Count, latestTransactions.Count);
+                var truncation = McpOutput.PagedTruncationNote(
+                    ranked.Count,
+                    latestTransactions.Count,
+                    offset
+                );
                 if (truncation.Length > 0)
                 {
                     sb.AppendLine();
@@ -350,7 +367,7 @@ public class InsiderTradingTools
                 return sb.ToString();
             },
             "GetInsiderOwnership",
-            $"ticker: {ticker}"
+            $"ticker: {ticker}, offset: {offset}"
         );
     }
 
@@ -468,13 +485,18 @@ public class InsiderTradingTools
         [Description(
             "Maximum number of results (default: 10, max: 500; values outside 1-500 are clamped)"
         )]
-            int maxResults = 10
+            int maxResults = 10,
+        [Description(
+            "Number of matches to skip before returning rows — pass the previous call's shown count to page past the maxResults cap (default: 0)"
+        )]
+            int offset = 0
     )
     {
         return _runner.Execute(
             async () =>
             {
                 maxResults = McpLimit.Clamp(maxResults);
+                offset = McpLimit.ClampOffset(offset);
 
                 var matches = _ownerRepository.Search(query);
                 var total = await matches.CountAsync();
@@ -490,9 +512,12 @@ public class InsiderTradingTools
                     )
                     .ThenBy(o => o.Name)
                     .ThenBy(o => o.OwnerCik)
+                    .Skip(offset)
                     .Take(maxResults)
                     .ToListAsync();
 
+                if (insiders.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {total} insiders match; lower offset.";
                 if (insiders.Count == 0)
                     return $"No insiders found matching '{query}'. Names are matched as filed with the SEC (legal names, often 'LAST FIRST MIDDLE') and every word of the query must appear in the name - retry with the surname alone.";
 
@@ -541,7 +566,7 @@ public class InsiderTradingTools
                     }
                 );
 
-                var truncation = McpOutput.TruncationNote(insiders.Count, total);
+                var truncation = McpOutput.PagedTruncationNote(insiders.Count, total, offset);
                 if (truncation.Length > 0)
                 {
                     sb.AppendLine();
@@ -551,7 +576,7 @@ public class InsiderTradingTools
                 return sb.ToString();
             },
             "SearchInsiders",
-            $"query: {query}"
+            $"query: {query}, offset: {offset}"
         );
     }
 

--- a/src/Equibles.Mcp/Helpers/McpLimit.cs
+++ b/src/Equibles.Mcp/Helpers/McpLimit.cs
@@ -16,4 +16,13 @@ public static class McpLimit
     // ever affects an explicit non-positive request. The upper bound guards against resource
     // exhaustion from an oversized request.
     public static int Clamp(int maxResults) => Math.Clamp(maxResults, 1, MaxResults);
+
+    // Upper bound on a paging offset. Mirrors the REST host's MaxOffset: a deep offset makes
+    // the database skip-scan that many rows, so an unbounded value is a resource-exhaustion
+    // vector just like an unbounded cap.
+    public const int MaxOffset = 100_000;
+
+    // Clamps a client-supplied paging offset to [0, MaxOffset]. A negative offset would flow
+    // into .Skip(...) as a negative SQL OFFSET; zero (the default) means "from the top".
+    public static int ClampOffset(int offset) => Math.Clamp(offset, 0, MaxOffset);
 }

--- a/src/Equibles.Mcp/Helpers/McpOutput.cs
+++ b/src/Equibles.Mcp/Helpers/McpOutput.cs
@@ -6,11 +6,53 @@ public static class McpOutput
 {
     // Appended after a truncated result set so the model knows more rows exist and which
     // argument raises the cap. Returns the empty string when nothing was cut off, so callers
-    // can append it unconditionally.
-    public static string TruncationNote(int shown, int total, string argumentName = "maxResults") =>
-        shown >= total
-            ? string.Empty
-            : $"_Showing first {shown} of {total} results - raise {argumentName} to see more._";
+    // can append it unconditionally. When the shown count already sits AT the cap, "raise
+    // maxResults" is impossible advice (the argument is maxed), so the note states the cap
+    // and points at the tool's real continuation instead — callers whose tools have a
+    // narrower escape hatch (a date range, a filter) pass it via atCapAdvice.
+    public static string TruncationNote(
+        int shown,
+        int total,
+        string argumentName = "maxResults",
+        int cap = McpLimit.MaxResults,
+        string atCapAdvice = null
+    )
+    {
+        if (shown >= total)
+            return string.Empty;
+        if (shown < cap)
+            return $"_Showing first {shown} of {total} results - raise {argumentName} to see more._";
+        var advice = atCapAdvice ?? "narrow the request (filters or date range) to see more";
+        return $"_Showing first {shown} of {total} results - {argumentName} is at its cap of {cap}; {advice}._";
+    }
+
+    // Truncation note for tools that page with an offset argument. Names the absolute row
+    // range shown so the model can stitch pages, and always offers a continuation that is
+    // actually possible: raise the cap argument while below the cap, or continue at the next
+    // offset once at it. Empty when the full set (from offset 0) was shown, so callers can
+    // append it unconditionally.
+    public static string PagedTruncationNote(
+        int shown,
+        int total,
+        int offset,
+        string argumentName = "maxResults",
+        int cap = McpLimit.MaxResults
+    )
+    {
+        if (shown == 0)
+            return offset > 0
+                ? $"_No results at offset {offset} - only {total} results exist; lower offset._"
+                : string.Empty;
+
+        var first = offset + 1;
+        var last = offset + shown;
+        if (offset == 0 && last >= total)
+            return string.Empty;
+        if (last >= total)
+            return $"_Showing results {first}-{last} of {total} (the last page)._";
+        var raise = shown < cap ? $"raise {argumentName} (max {cap}) or " : "";
+        return $"_Showing results {first}-{last} of {total} - {raise}pass offset={last} to continue._";
+    }
 
     // Strict ISO yyyy-MM-dd parse in invariant culture. Rejects any other format so a typo or
     // locale-shaped date can't silently parse into a different day and shift the requested range.

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -360,7 +360,14 @@ public class FinancialFactsTools
         if (perPeriod.Count < totalPeriods)
         {
             result.AppendLine();
-            result.AppendLine(McpOutput.TruncationNote(perPeriod.Count, totalPeriods));
+            result.AppendLine(
+                McpOutput.TruncationNote(
+                    perPeriod.Count,
+                    totalPeriods,
+                    cap: MaxResultsCap,
+                    atCapAdvice: "narrow the period range with fromDate/toDate to see older periods"
+                )
+            );
         }
 
         return result.ToString();

--- a/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
@@ -76,6 +76,10 @@ public class FundDirectoryTools
 
                 var result = MarkdownTable.Start(
                     $"Registered funds matching '{query}', largest by net assets first (showing {matches.Count} of {totalCount}):",
+                    // Sweep-discovered series only have their tracked-stock positions stored,
+                    // so a bond fund's Holdings can read 0 beside real net assets — say so, or
+                    // the count reads as "this fund holds nothing".
+                    "_Holdings = stored holding rows on the fund's latest report. For the large multi-series trusts only positions in stocks this platform tracks are stored, so the count can be a small subset of (or zero within) the real portfolio; Net Assets is always the fund's own reported total._",
                     "| Fund | Profile id | Ticker | Type | Net Assets (USD) | Holdings | Latest Report |",
                     "|------|-----------|--------|------|------------------|----------|---------------|"
                 );

--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -61,10 +61,18 @@ public class NportTools
                     .Take(McpLimit.Clamp(maxResults))
                     .ToList();
 
+                // Sweep-discovered series (no CommonStock link) only have their TRACKED-stock
+                // positions stored, so their row count is a subset, not the portfolio — a bond
+                // fund would otherwise read "0 total holdings" beside billions in net assets.
+                var storedCountLabel =
+                    filing.CommonStockId == null
+                        ? $"{filing.Holdings.Count} tracked-stock holdings on record (only positions in stocks this platform tracks are stored for this fund — not its full portfolio)"
+                        : $"{filing.Holdings.Count} total holdings";
+
                 var result = MarkdownTable.Start(
                     $"Portfolio holdings for {fundName} ({ticker}) — "
                         + $"reported {filing.ReportPeriodDate:yyyy-MM-dd}, net assets ${FormatAmount(filing.NetAssets)}, "
-                        + $"{filing.Holdings.Count} total holdings, showing the largest {holdings.Count}:",
+                        + $"{storedCountLabel}, showing the largest {holdings.Count}:",
                     "| Holding | CUSIP | Balance | Units | Value (USD) | % Net Assets | Category | Country |",
                     "|---------|-------|---------|-------|-------------|--------------|----------|---------|"
                 );

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -778,11 +778,20 @@ public class StockPriceTools
         AppendNewestFirstRows(result, count, renderFrom, maxResults, formatRow);
 
         var available = count - renderFrom;
-        var note = McpOutput.TruncationNote(Math.Min(available, maxResults), available);
-        if (note.Length > 0)
+        var shown = Math.Min(available, maxResults);
+        if (shown < available)
         {
+            // These tables render newest-first, so name the kept end explicitly; and when
+            // the shown count already sits AT the cap, "raise maxResults" is impossible
+            // advice — the date range is this family's real continuation.
+            var advice =
+                shown >= McpLimit.MaxResults
+                    ? $"maxResults is at its cap of {McpLimit.MaxResults}; narrow the date range to see older rows"
+                    : "raise maxResults or narrow the date range to see older rows";
             result.AppendLine();
-            result.AppendLine(note);
+            result.AppendLine(
+                $"_Showing the newest {shown} of {available} records in the range - {advice}._"
+            );
         }
 
         if (footnote != null)

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -683,14 +683,19 @@ public class StockPriceTools
     }
 
     // Appended after tables that keep the NEWEST rows but render oldest-to-newest, where
-    // the shared "Showing first N" wording would point at the wrong end of the table.
+    // the shared "Showing first N" wording would point at the wrong end of the table. At the
+    // cap "raise maxResults" is impossible advice, so the note names the cap instead.
     private static void AppendNewestKeptTruncationNote(StringBuilder result, int shown, int total)
     {
         if (shown >= total)
             return;
+        var advice =
+            shown >= McpLimit.MaxResults
+                ? $"maxResults is at its cap of {McpLimit.MaxResults}; narrow the date range to see older rows"
+                : "raise maxResults or narrow the date range to see older rows";
         result.AppendLine();
         result.AppendLine(
-            $"_Showing the newest {shown} of {total} records in the range - raise maxResults or narrow the date range to see older rows._"
+            $"_Showing the newest {shown} of {total} records in the range - {advice}._"
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
@@ -233,6 +233,50 @@ public class CongressToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task GetMemberTrades_OffsetPaging_TiedDatesSplitCleanlyAcrossPages()
+    {
+        // Four trades tied on transaction AND filing date so only the Id tiebreak orders
+        // them — exactly where a partial order would repeat or skip rows between pages.
+        var stock = NvdaStock();
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<CongressMember>().Add(pelosi);
+        var markers = new[] { "Alpha Lot", "Bravo Lot", "Charlie Lot", "Delta Lot" };
+        DbContext
+            .Set<CongressionalTrade>()
+            .AddRange(
+                markers.Select(m =>
+                    TradeFor(pelosi, stock, new DateOnly(2026, 3, 15), assetName: m)
+                )
+            );
+        await DbContext.SaveChangesAsync();
+
+        var page1 = await Sut()
+            .GetMemberTrades(
+                "Nancy Pelosi",
+                startDate: "2026-01-01",
+                endDate: "2026-04-30",
+                maxResults: 2
+            );
+        var page2 = await Sut()
+            .GetMemberTrades(
+                "Nancy Pelosi",
+                startDate: "2026-01-01",
+                endDate: "2026-04-30",
+                maxResults: 2,
+                offset: 2
+            );
+
+        var onPage1 = markers.Where(m => page1.Contains(m)).ToList();
+        var onPage2 = markers.Where(m => page2.Contains(m)).ToList();
+        onPage1.Should().HaveCount(2);
+        onPage2.Should().HaveCount(2);
+        onPage1.Intersect(onPage2).Should().BeEmpty();
+        onPage1.Concat(onPage2).Should().BeEquivalentTo(markers);
+        page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
+    }
+
+    [Fact]
     public async Task GetMemberTrades_FiltersByDateRange()
     {
         var stock = NvdaStock();

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -672,7 +672,34 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
 
         var result = await Sut().SearchInsiders("Trunc", maxResults: 2);
 
-        result.Should().Contain("Showing first 2 of 3 results - raise maxResults to see more.");
+        result
+            .Should()
+            .Contain(
+                "Showing results 1-2 of 3 - raise maxResults (max 500) or pass offset=2 to continue."
+            );
+    }
+
+    [Fact]
+    public async Task SearchInsiders_OffsetPaging_TiedNamesSplitCleanlyAcrossPages()
+    {
+        // Four owners tied on the name sort key so only the CIK tiebreak orders them —
+        // exactly where a partial order would repeat or skip rows between offset pages.
+        var ciks = new[] { "0000555001", "0000555002", "0000555003", "0000555004" };
+        DbContext
+            .Set<InsiderOwner>()
+            .AddRange(ciks.Select(cik => CreateOwner(cik: cik, name: "Paged Insider")));
+        await DbContext.SaveChangesAsync();
+
+        var page1 = await Sut().SearchInsiders("Paged", maxResults: 2);
+        var page2 = await Sut().SearchInsiders("Paged", maxResults: 2, offset: 2);
+
+        var onPage1 = ciks.Where(c => page1.Contains(c)).ToList();
+        var onPage2 = ciks.Where(c => page2.Contains(c)).ToList();
+        onPage1.Should().HaveCount(2);
+        onPage2.Should().HaveCount(2);
+        onPage1.Intersect(onPage2).Should().BeEmpty();
+        onPage1.Concat(onPage2).Should().BeEquivalentTo(ciks);
+        page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
@@ -84,6 +84,56 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioTests : ParadeDbMc
         pennyIdx.Should().BeGreaterThan(appleIdx, "rank must be by Value descending, not Shares");
     }
 
+    [Fact]
+    public async Task GetInstitutionPortfolio_OffsetPaging_TiedValuesSplitCleanlyAcrossPages()
+    {
+        // Four rows tied on Value so only the stock-id/row-id tiebreaks order them —
+        // exactly where a partial order would repeat or skip rows between offset pages.
+        var holder = new InstitutionalHolder { Cik = "77", Name = "Paged Capital" };
+        DbContext.Add(holder);
+        var reportDate = new DateOnly(2024, 12, 31);
+        var tickers = new[] { "PGA", "PGB", "PGC", "PGD" };
+        foreach (var (ticker, index) in tickers.Select((t, i) => (t, i)))
+        {
+            var stock = new CommonStock
+            {
+                Ticker = ticker,
+                Name = $"{ticker} Corp",
+                Cik = $"000077000{index}",
+            };
+            DbContext.Add(stock);
+            DbContext.Add(MakeHolding(holder, stock, reportDate, shares: 1_000, value: 5_000_000));
+        }
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var page1 = await sut.GetInstitutionPortfolio("Paged Capital", maxResults: 2);
+        var page2 = await sut.GetInstitutionPortfolio("Paged Capital", maxResults: 2, offset: 2);
+
+        var onPage1 = tickers.Where(t => page1.Contains(t)).ToList();
+        var onPage2 = tickers.Where(t => page2.Contains(t)).ToList();
+        onPage1.Should().HaveCount(2);
+        onPage2.Should().HaveCount(2);
+        onPage1.Intersect(onPage2).Should().BeEmpty();
+        onPage1.Concat(onPage2).Should().BeEquivalentTo(tickers);
+        page2.Should().Contain("Showing holding rows 3-4 of 4");
+        page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
+    }
+
     private static InstitutionalHolding MakeHolding(
         InstitutionalHolder holder,
         CommonStock stock,

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioUnvaluedCountTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioUnvaluedCountTests.cs
@@ -60,7 +60,8 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioUnvaluedCountTests
         var output = await Sut().GetInstitutionPortfolio("Gotham");
 
         output.Should().Contain("3 tracked position(s) have no derivable value");
-        output.Should().Contain("of 5 tracked positions");
+        output.Should().Contain("Showing holding rows 1-5 of 5");
+        output.Should().Contain("(5 distinct tracked stocks");
     }
 
     private InstitutionalHoldingsTools Sut()

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -343,4 +343,53 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
         result.Should().Contain("MLP", "MLP common units are genuine operating equity");
         result.Should().NotContain("FXZ", "trust units are created/redeemed at NAV — no squeeze");
     }
+
+    [Fact]
+    public async Task GetShortSqueezeScores_OffsetPaging_TiedScoresSplitCleanlyAcrossPages()
+    {
+        // Four identical stocks score identically, so only the manager's ticker tiebreak
+        // orders the board — exactly where a partial order would repeat or skip rows
+        // between offset pages. Ranks must stay ABSOLUTE across pages.
+        var settlement = new DateOnly(2026, 4, 15);
+        foreach (
+            var (ticker, cik) in new[]
+            {
+                ("AAA", "0000000301"),
+                ("BBB", "0000000302"),
+                ("CCC", "0000000303"),
+                ("DDD", "0000000304"),
+            }
+        )
+        {
+            var stock = new CommonStock
+            {
+                Ticker = ticker,
+                Name = $"{ticker} Corp",
+                Cik = cik,
+                SharesOutStanding = 1_000_000,
+            };
+            DbContext.Set<CommonStock>().Add(stock);
+            DbContext
+                .Set<ShortInterest>()
+                .Add(
+                    new ShortInterest
+                    {
+                        CommonStockId = stock.Id,
+                        SettlementDate = settlement,
+                        CurrentShortPosition = 300_000,
+                        DaysToCover = 8m,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var page1 = await Sut().GetShortSqueezeScores(maxResults: 2);
+        var page2 = await Sut().GetShortSqueezeScores(maxResults: 2, offset: 2);
+
+        page1.Should().Contain("| 1 | AAA |").And.Contain("| 2 | BBB |");
+        page1.Should().NotContain("CCC").And.NotContain("DDD");
+        page2.Should().Contain("| 3 | CCC |").And.Contain("| 4 | DDD |");
+        page2.Should().NotContain("| 1 |").And.NotContain("AAA").And.NotContain("BBB");
+        page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
+    }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsLargestShortVolumeSortAndLegendTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsLargestShortVolumeSortAndLegendTests.cs
@@ -125,6 +125,34 @@ public class ShortDataToolsLargestShortVolumeSortAndLegendTests : ParadeDbMcpTes
 
         var result = await Sut().GetLargestShortVolume(maxResults: 1);
 
-        result.Should().Contain("Showing first 1 of 2 results");
+        result
+            .Should()
+            .Contain(
+                "Showing results 1-1 of 2 - raise maxResults (max 500) or pass offset=1 to continue."
+            );
+    }
+
+    [Fact]
+    public async Task LargestShortVolume_OffsetPaging_TiedRowsSplitCleanlyAcrossPages()
+    {
+        // Four rows tied on short volume so only the ticker tiebreak orders them —
+        // exactly where a partial order would repeat or skip rows between offset pages.
+        AddVolume(AddStock("AAA", "Alpha Corp"), 5_000_000, 10_000_000);
+        AddVolume(AddStock("BBB", "Bravo Corp"), 5_000_000, 10_000_000);
+        AddVolume(AddStock("CCC", "Chase Corp"), 5_000_000, 10_000_000);
+        AddVolume(AddStock("DDD", "Delta Corp"), 5_000_000, 10_000_000);
+        await DbContext.SaveChangesAsync();
+
+        var page1 = await Sut().GetLargestShortVolume(maxResults: 2);
+        var page2 = await Sut().GetLargestShortVolume(maxResults: 2, offset: 2);
+
+        var tickers = new[] { "AAA", "BBB", "CCC", "DDD" };
+        var onPage1 = tickers.Where(t => page1.Contains(t)).ToList();
+        var onPage2 = tickers.Where(t => page2.Contains(t)).ToList();
+        onPage1.Should().HaveCount(2);
+        onPage2.Should().HaveCount(2);
+        onPage1.Intersect(onPage2).Should().BeEmpty();
+        onPage1.Concat(onPage2).Should().BeEquivalentTo(tickers);
+        page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsSnapshotSentinelTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsSnapshotSentinelTests.cs
@@ -173,7 +173,11 @@ public class ShortDataToolsSnapshotSentinelTests : ParadeDbMcpTestBase
 
         var result = await Sut().GetShortInterestSnapshot(maxResults: 2);
 
-        result.Should().Contain("Showing first 2 of 3 results");
+        result
+            .Should()
+            .Contain(
+                "Showing results 1-2 of 3 - raise maxResults (max 500) or pass offset=2 to continue."
+            );
     }
 
     [Fact]
@@ -184,6 +188,30 @@ public class ShortDataToolsSnapshotSentinelTests : ParadeDbMcpTestBase
 
         var result = await Sut().GetShortInterestSnapshot();
 
-        result.Should().NotContain("Showing first");
+        result.Should().NotContain("Showing results");
+    }
+
+    [Fact]
+    public async Task Snapshot_OffsetPaging_TiedRowsSplitCleanlyAcrossPages()
+    {
+        // Four rows tied on every sort key so only the ticker tiebreak orders them —
+        // exactly where a partial order would repeat or skip rows between offset pages.
+        AddShortInterest(AddStock("AAA", "Alpha Corp"), 5.0m);
+        AddShortInterest(AddStock("BBB", "Bravo Corp"), 5.0m);
+        AddShortInterest(AddStock("CCC", "Chase Corp"), 5.0m);
+        AddShortInterest(AddStock("DDD", "Delta Corp"), 5.0m);
+        await DbContext.SaveChangesAsync();
+
+        var page1 = await Sut().GetShortInterestSnapshot(maxResults: 2);
+        var page2 = await Sut().GetShortInterestSnapshot(maxResults: 2, offset: 2);
+
+        var tickers = new[] { "AAA", "BBB", "CCC", "DDD" };
+        var onPage1 = tickers.Where(t => page1.Contains(t)).ToList();
+        var onPage2 = tickers.Where(t => page2.Contains(t)).ToList();
+        onPage1.Should().HaveCount(2);
+        onPage2.Should().HaveCount(2);
+        onPage1.Intersect(onPage2).Should().BeEmpty();
+        onPage1.Concat(onPage2).Should().BeEquivalentTo(tickers);
+        page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStrictArgsAndWarmupTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStrictArgsAndWarmupTests.cs
@@ -142,8 +142,8 @@ public class StockPriceToolsStrictArgsAndWarmupTests : ParadeDbMcpTestBase
     [Fact]
     public async Task GetOnBalanceVolume_MoreRowsThanMaxResults_AppendsTruncationNote()
     {
-        // Indicator tables render newest first, so the shared "Showing first N of M"
-        // wording is accurate there.
+        // Indicator tables keep the NEWEST rows, so the footer names that end of the
+        // table and offers the date range as the continuation.
         await SeedDailyCloses(new DateOnly(2026, 4, 1), 101m, 102m, 103m);
 
         var result = await Sut()
@@ -154,7 +154,11 @@ public class StockPriceToolsStrictArgsAndWarmupTests : ParadeDbMcpTestBase
                 maxResults: 2
             );
 
-        result.Should().Contain("Showing first 2 of 3 results");
+        result
+            .Should()
+            .Contain(
+                "Showing the newest 2 of 3 records in the range - raise maxResults or narrow the date range to see older rows."
+            );
     }
 
     // ── maxResults clamp on indicator tools ──────────────────────────────

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
@@ -61,7 +61,9 @@ public class InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarian
             targetDate,
             holdings,
             splitsByStock,
-            holdings.Count,
+            0, // offset
+            holdings.Count, // totalRows
+            holdings.Count, // totalPositions
             holdings.Sum(h => h.Value),
             0, // unvaluedPositions
             null,

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclosureTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclosureTests.cs
@@ -41,6 +41,8 @@ public class InstitutionalHoldingsToolsRenderInstitutionPortfolioUnvaluedDisclos
                     new DateOnly(2026, 3, 31),
                     holdings,
                     new Dictionary<Guid, List<StockSplit>>(),
+                    0,
+                    holdings.Count,
                     holdings.Count,
                     holdings.Sum(h => h.Value),
                     unvaluedPositions,

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipRankingTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipRankingTests.cs
@@ -206,7 +206,11 @@ public class InsiderTradingToolsOwnershipRankingTests
 
         output.Should().Contain("First Holder");
         output.Should().NotContain("Second Holder");
-        output.Should().Contain("Showing first 1 of 2 results - raise maxResults to see more.");
+        output
+            .Should()
+            .Contain(
+                "Showing results 1-1 of 2 - raise maxResults (max 500) or pass offset=1 to continue."
+            );
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipRankingTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipRankingTests.cs
@@ -214,6 +214,53 @@ public class InsiderTradingToolsOwnershipRankingTests
     }
 
     [Fact]
+    public async Task GetInsiderOwnership_OffsetPaging_TiedHoldingsSplitCleanlyAcrossPages()
+    {
+        // Four insiders tied on the adjusted holding so only the name/id tiebreaks order
+        // them — exactly where a partial order would repeat or skip rows between pages.
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        db.Add(stock);
+        var names = new[] { "Alpha Holder", "Bravo Holder", "Charlie Holder", "Delta Holder" };
+        foreach (var (name, index) in names.Select((n, i) => (n, i)))
+        {
+            var owner = new InsiderOwner
+            {
+                OwnerCik = $"000000010{index}",
+                Name = name,
+                IsDirector = true,
+            };
+            db.Add(owner);
+            db.Add(
+                NewTransaction(
+                    stock,
+                    owner,
+                    new DateOnly(2024, 6, 1),
+                    sharesOwnedAfter: 5_000,
+                    accessionNumber: $"acc-p-{index}"
+                )
+            );
+        }
+        await db.SaveChangesAsync();
+
+        var page1 = await Sut(db).GetInsiderOwnership("AAPL", maxResults: 2);
+        var page2 = await Sut(db).GetInsiderOwnership("AAPL", maxResults: 2, offset: 2);
+
+        var onPage1 = names.Where(n => page1.Contains(n)).ToList();
+        var onPage2 = names.Where(n => page2.Contains(n)).ToList();
+        onPage1.Should().HaveCount(2);
+        onPage2.Should().HaveCount(2);
+        onPage1.Intersect(onPage2).Should().BeEmpty();
+        onPage1.Concat(onPage2).Should().BeEquivalentTo(names);
+        page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
+    }
+
+    [Fact]
     public async Task GetInsiderOwnership_LowercaseTicker_EchoesCanonicalTicker()
     {
         await using var db = NewDb();

--- a/tests/Equibles.UnitTests/Mcp/McpLimitClampOffsetTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpLimitClampOffsetTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpLimitClampOffsetTests
+{
+    // Contract: a negative offset would flow into .Skip(...) as a negative SQL OFFSET; it
+    // clamps to 0 (the "from the top" default). int.MinValue must not overflow through.
+    [Theory]
+    [InlineData(int.MinValue, 0)]
+    [InlineData(-1, 0)]
+    [InlineData(0, 0)]
+    [InlineData(500, 500)]
+    [InlineData(McpLimit.MaxOffset, McpLimit.MaxOffset)]
+    public void ClampOffset_ClampsToValidRange(int input, int expected)
+    {
+        McpLimit.ClampOffset(input).Should().Be(expected);
+    }
+
+    // An unbounded offset is a resource-exhaustion vector (the database skip-scans that many
+    // rows), so it caps at MaxOffset like the REST host's paging.
+    [Fact]
+    public void ClampOffset_IntMaxValue_CapsAtMaxOffset()
+    {
+        McpLimit.ClampOffset(int.MaxValue).Should().Be(McpLimit.MaxOffset);
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/McpOutputTruncationNoteTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpOutputTruncationNoteTests.cs
@@ -1,0 +1,120 @@
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpOutputTruncationNoteTests
+{
+    // Contract: nothing was cut off → no note, so callers can append unconditionally.
+    [Theory]
+    [InlineData(10, 10)]
+    [InlineData(10, 5)]
+    [InlineData(0, 0)]
+    public void TruncationNote_NothingCut_ReturnsEmpty(int shown, int total)
+    {
+        McpOutput.TruncationNote(shown, total).Should().BeEmpty();
+    }
+
+    // Below the cap the note advises raising the cap argument — that advice is actionable.
+    [Fact]
+    public void TruncationNote_BelowCap_AdvisesRaisingArgument()
+    {
+        var note = McpOutput.TruncationNote(50, 200);
+
+        note.Should().Contain("Showing first 50 of 200");
+        note.Should().Contain("raise maxResults");
+    }
+
+    // Contract (#7056): at the cap "raise maxResults" is impossible advice — the argument is
+    // already maxed. The note must state the cap and point at a real continuation instead.
+    [Fact]
+    public void TruncationNote_AtCap_NeverAdvisesRaisingArgument()
+    {
+        var note = McpOutput.TruncationNote(McpLimit.MaxResults, 1200);
+
+        note.Should().NotContain("raise maxResults");
+        note.Should().Contain($"cap of {McpLimit.MaxResults}");
+    }
+
+    // Tools with a smaller cap (e.g. the squeeze board's 200) pass it explicitly, and can
+    // supply their own at-cap continuation advice.
+    [Fact]
+    public void TruncationNote_AtCustomCap_UsesSuppliedCapAndAdvice()
+    {
+        var note = McpOutput.TruncationNote(
+            200,
+            900,
+            cap: 200,
+            atCapAdvice: "tighten the liquidity floors"
+        );
+
+        note.Should().NotContain("raise maxResults");
+        note.Should().Contain("cap of 200");
+        note.Should().Contain("tighten the liquidity floors");
+    }
+
+    // Contract: the paged note names the ABSOLUTE row range so the model can stitch pages,
+    // and always offers a possible continuation — the next offset.
+    [Fact]
+    public void PagedTruncationNote_MidPages_NamesRangeAndNextOffset()
+    {
+        var note = McpOutput.PagedTruncationNote(50, 200, 50);
+
+        note.Should().Contain("Showing results 51-100 of 200");
+        note.Should().Contain("offset=100");
+    }
+
+    // Below the cap the paged note still offers raising the cap argument as the cheap path.
+    [Fact]
+    public void PagedTruncationNote_BelowCap_AlsoOffersRaisingArgument()
+    {
+        var note = McpOutput.PagedTruncationNote(50, 200, 0);
+
+        note.Should().Contain("raise maxResults");
+        note.Should().Contain("offset=50");
+    }
+
+    // At the cap the only continuation offered is the next offset — never "raise maxResults".
+    [Fact]
+    public void PagedTruncationNote_AtCap_OnlyOffersOffset()
+    {
+        var note = McpOutput.PagedTruncationNote(McpLimit.MaxResults, 1200, 0);
+
+        note.Should().NotContain("raise maxResults");
+        note.Should().Contain($"offset={McpLimit.MaxResults}");
+    }
+
+    // The full set from the top → no note; the last page → a closing range statement with no
+    // further continuation (offering one would send the caller to an empty page).
+    [Fact]
+    public void PagedTruncationNote_FullSetFromTop_ReturnsEmpty()
+    {
+        McpOutput.PagedTruncationNote(30, 30, 0).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PagedTruncationNote_LastPage_ClosesWithoutContinuation()
+    {
+        var note = McpOutput.PagedTruncationNote(20, 70, 50);
+
+        note.Should().Contain("51-70 of 70");
+        note.Should().NotContain("offset=70");
+        note.Should().NotContain("raise maxResults");
+    }
+
+    // An offset past the end must say so — an empty page must never read as "no data exists".
+    [Fact]
+    public void PagedTruncationNote_OffsetPastEnd_NamesTheOverrun()
+    {
+        var note = McpOutput.PagedTruncationNote(0, 40, 100);
+
+        note.Should().Contain("offset 100");
+        note.Should().Contain("only 40 results exist");
+    }
+
+    // Zero rows with no offset is the caller's genuine empty state — not this note's business.
+    [Fact]
+    public void PagedTruncationNote_EmptyWithoutOffset_ReturnsEmpty()
+    {
+        McpOutput.PagedTruncationNote(0, 0, 0).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

MCP tools that hit their row caps previously emitted a generic "Showing first N results — narrow your filters" footer even when the cap itself was the binding constraint, and several high-cardinality tools offered no way to reach rows past the cap at all. This change makes truncation honest and pageable:

- `McpOutput.TruncationNote` is now cap-aware: at the cap it names the cap and gives tool-specific advice (`atCapAdvice`) instead of a dead-end suggestion; below the cap it keeps the narrow-your-filters wording. A `PagedTruncationNote` variant renders offset-window footers ("Showing rows X–Y…").
- Offset paging (`McpLimit.ClampOffset`, 0–100,000) added to GetShortInterestSnapshot, GetLargestShortVolume, GetShortSqueezeScores, GetMemberTrades, GetInsiderOwnership, SearchInsiders and GetInstitutionPortfolio, each with a unique-key `ThenBy` tiebreak so pages are disjoint and stable.
- GetInstitutionPortfolio's footer no longer conflates holding rows with distinct tracked stocks; fund labels clarified.
- `ShortSqueezeScoreManager.Compute()` gained a final `ThenBy(Ticker)` tiebreak so a cache refresh mid-walk cannot reshuffle tied scores across pages.
- Cap-aware footers swept across every sub-500-cap tool (insider sentiment 200, executive changes 100, non-GAAP bridge 20, financial facts 200); the Yahoo/Cboe newest-kept footers now name their cap too.

## Code changes

- `Equibles.Mcp.Shared/McpOutput.cs`, `McpLimit.cs` — cap-aware `TruncationNote(…, cap, atCapAdvice)`, `PagedTruncationNote`, `ClampOffset`.
- Short data, insider trading, congress, holdings, financial facts, Yahoo, Cboe tool classes — offset params, tiebreaks, honest footers.
- `ShortSqueezeScoreManager` — deterministic tie ordering (universe cache key untouched).
- Integration + unit tests: page-composition tests over tied fixtures for every offset-gaining tool (disjoint, complete, absolute ranks), refreshed wording assertions.