### PR TITLE
fix(mcp): show the resolved CIK on the institution summary

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1399,6 +1399,9 @@ public class InstitutionalHoldingsTools
         result.AppendLine();
         result.AppendLine("| Metric | Value |");
         result.AppendLine("|--------|-------|");
+        // The CIK is how a caller chains this fund into every other institution route, and
+        // a name-resolved lookup has no other way to learn it.
+        result.AppendLine($"| CIK | {holder.Cik} |");
         result.AppendLine($"| Reported AUM | ${McpFormat.WholeNumber(summary.ReportedAum)} |");
         result.AppendLine($"| # Positions | {McpFormat.WholeNumber(summary.PositionCount)} |");
         result.AppendLine(


### PR DESCRIPTION
## Summary

`GetInstitutionSummary` accepts a fund name and resolves it to a filer, but never printed the resolved CIK — so a name-resolved fund could not be chained into any other route that keys on CIK. The REST mirror already returns it.

## Code changes

- `InstitutionTools.RenderInstitutionSummary` — adds a `CIK` row to the summary table, unpadded, matching the REST `cik` field.