### PR TITLE
fix(mcp): render the fields the REST mirrors already returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Everything marked **Self-hosted** is scraped, stored, and served by this repo �
 | **Fund Filings** | SEC NPORT / N-CEN / Form D | ✅ | ✅ | Fund portfolio holdings, registered-fund operations (service providers), and exempt offerings (private placements) |
 | **Investment Advisers** | SEC Form ADV | ✅ | ✅ | SEC-registered advisers — assets under management, main office, employee count, fee structure |
 | **Insider Trading** | SEC Form 3/4/144 | ✅ | ✅ | Director, officer, and 10% owner transactions, plus proposed (Form 144) sales |
-| **Congressional Trading** | House/Senate disclosures | ✅ | ✅ | Stock trades by members of Congress |
+| **Congressional Trading** | House/Senate disclosures | ✅ | ✅ | Securities transactions by members of Congress, including the filed stock, option, bond, or other instrument |
 | **Short Data** | SEC / FINRA | ✅ | ✅ | Fails-to-deliver (SEC), daily short volume and short interest (FINRA) |
 | **Economic Indicators** | FRED (Federal Reserve) | ✅ | ✅ | Interest rates, inflation, employment, GDP, yield spreads, and more |
 | **Stock Prices** | Yahoo Finance | ✅ | ✅ | Daily OHLCV prices with technical indicators (SMA, RSI, MACD) |
@@ -330,7 +330,7 @@ This self-hosted build exposes 64 tools over MCP. The hosted server at `https://
 - GetFinancialStatement — income/balance/cash-flow statement by period
 - GetFinancialFact — one concept over time
 - CompareFinancialFact — a concept across companies
-- GetRevenueBreakdown — revenue by segment/geography/product
+- GetRevenueBreakdown — revenue by segment/geography/product plus reported segment operating income and derived margin
 
 **Economic data (FRED)**
 
@@ -372,7 +372,7 @@ This self-hosted build exposes 64 tools over MCP. The hosted server at `https://
 
 **Stock prices**
 
-- GetStockPrices — daily OHLCV (split-adjusted)
+- GetStockPrices — daily OHLCV plus the stored auxiliary adjusted close when it differs
 - GetLatestPrices — latest close/change/volume
 - GetStochasticOscillator — stochastic oscillator (%K/%D)
 - GetAverageTrueRange — average true range (ATR)

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -68,7 +68,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Ask your AI assistant about a company's insider trading](how-to-ask-about-insider-trading.md)
 - [Ask your AI assistant about proposed insider sales (Form 144)](how-to-ask-about-proposed-sales.md)
 - [View a member of Congress's trading profile](how-to-view-congress-member-trades.md)
-- [Ask your AI assistant about congressional stock trades](how-to-ask-about-congressional-trades.md)
+- [Ask your AI assistant about congressional securities transactions](how-to-ask-about-congressional-trades.md)
 - [Ask your AI assistant about a member of Congress's net worth](how-to-ask-about-congress-member-net-worth.md)
 - [Browse market-wide short data (most shorted and largest short volume)](how-to-browse-short-data.md)
 - [Ask your AI assistant about a stock's short data](how-to-ask-about-short-data.md)

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -25,7 +25,7 @@ Equibles scrapes several public and free-tier data sources automatically. Each s
 | **Yahoo Finance** | Historical stock prices (OHLCV) | Every 24 hours |
 | **FRED** | U.S. economic indicators (GDP, unemployment, CPI, …) | Every 24 hours (requires a [free API key](how-to-set-up-fred-api-key.md)) |
 | **FINRA** | Short-sale volume data | Every 24 hours (requires a [free API key](how-to-set-up-finra-api-key.md)) |
-| **U.S. Congress** | Congressional stock trades (House disclosures) | Every 12 hours |
+| **U.S. Congress** | Congressional securities transactions (House disclosures) | Every 12 hours |
 | **CBOE** | Options and volatility data | Every 24 hours |
 | **CFTC** | Commitments of Traders reports (futures positioning) | Every 24 hours |
 | **USAspending.gov** | Federal government contract awards won by public companies | Every 24 hours |

--- a/docs/guide/how-to-ask-about-congress-member-net-worth.md
+++ b/docs/guide/how-to-ask-about-congress-member-net-worth.md
@@ -29,5 +29,5 @@ A Markdown table in the assistant's reply, with one row per year. A missing year
 
 ## See also
 
-- [View a member of Congress's trading profile](how-to-view-congress-member-trades.md) — their reported stock trades, on the web portal.
+- [View a member of Congress's trading profile](how-to-view-congress-member-trades.md) — their reported securities transactions, on the web portal.
 - [Connect an AI assistant and ask your first question](tutorial-connect-ai-assistant.md)

--- a/docs/guide/how-to-ask-about-congressional-trades.md
+++ b/docs/guide/how-to-ask-about-congressional-trades.md
@@ -1,6 +1,6 @@
-# Ask your AI assistant about congressional stock trades
+# Ask your AI assistant about congressional securities transactions
 
-Equibles collects the periodic transaction reports that members of the U.S. House and Senate file when they buy or sell stock, and exposes them through the MCP server, so you can ask your AI assistant which members traded a stock, or what a particular member has been trading.
+Equibles collects the periodic transaction reports that members of the U.S. House and Senate file when they transact in securities, and exposes them through the MCP server. You can ask which members traded a company's stock, option, bond, or another reported instrument, or what a particular member has been trading.
 
 ## Before you start
 
@@ -14,20 +14,20 @@ Name a company and ask which members traded it:
 - "Which members of Congress have traded NVDA?"
 - "Has anyone in Congress bought or sold Apple recently?"
 
-The assistant calls the `GetCongressionalTrades` tool and replies with each trade in that ticker — the member, the transaction type (buy or sell), the date, and the disclosed amount. Because disclosure rules report a dollar range rather than an exact figure, amounts appear as bands.
+The assistant calls the `GetCongressionalTrades` tool and replies with each disclosed transaction tied to that ticker — the member, transaction type, filed Asset instrument, date, and disclosed amount. Because disclosure rules report a dollar range rather than an exact figure, amounts appear as bands.
 
 ## Ask what a member has been trading
 
 To follow one member instead of one stock:
 
 - "What has Nancy Pelosi been trading?"
-- "Show me Tommy Tuberville's recent stock trades."
+- "Show me Tommy Tuberville's recent securities transactions."
 
-The assistant uses `GetMemberTrades` for that member, listing each trade with its ticker, transaction type, and amount. If it needs to confirm the exact name first, it calls `SearchCongressMembers` to look the member up.
+The assistant uses `GetMemberTrades` for that member, listing each transaction with its ticker, filed Asset instrument, transaction type, and amount. If it needs to confirm the exact name first, it calls `SearchCongressMembers` to look the member up.
 
 ## What you should see
 
-A list of trades drawn straight from the official House and Senate filings, each tagged with the transaction and filing dates. Disclosures are filed after the trade — often weeks later — and amounts are ranges, so treat the figures as the bands Congress reports rather than exact values.
+A list of securities transactions drawn straight from the official House and Senate filings, each tagged with the filed Asset instrument plus transaction and filing dates. Disclosures are filed after the transaction — often weeks later — and amounts are ranges, so treat the figures as the bands Congress reports rather than exact values.
 
 If the reply says there's no data, either the member or company has no disclosed trades on record, or the scraper hasn't imported the latest filings yet.
 

--- a/docs/guide/how-to-ask-about-economic-indicators.md
+++ b/docs/guide/how-to-ask-about-economic-indicators.md
@@ -15,7 +15,7 @@ Name an indicator and ask for its history:
 - "Show me CPI inflation since 2020."
 - "How has the 10-year/2-year yield spread moved recently?"
 
-The assistant calls the `GetEconomicIndicator` tool and replies with the time series of observations. Common series include the fed funds rate, CPI, unemployment, GDP, the 10Y/2Y yield spread, and the 30-year mortgage rate. If it is unsure of the exact series, it uses `SearchEconomicIndicators` to look it up by name.
+The assistant calls the `GetEconomicIndicator` tool and replies with the time series of observations. Common series include the fed funds rate, CPI, unemployment, GDP, the 10Y/2Y yield spread, and the 30-year mortgage rate. If it is unsure of the exact series, it uses `SearchEconomicIndicators` to look it up by name. Each search result states the seasonal-adjustment basis, latest observation date, and exact UTC sync time; use those separately to judge comparability, publication recency, and pipeline freshness.
 
 ## Ask for a macro snapshot
 

--- a/docs/guide/how-to-ask-about-fund-operations.md
+++ b/docs/guide/how-to-ask-about-fund-operations.md
@@ -19,6 +19,6 @@ The assistant calls the `GetFundOperations` tool with the fund's ticker and retu
 
 ## What you should see
 
-For each N-CEN report, a summary of the fund's classification (for example N-1A open-end or N-2 closed-end), its Investment Company Act file number, the reporting period, and whether it was the fund's first or last filing — followed by the fund's named service providers: investment advisers and sub-advisers, custodians, transfer agents, administrators, auditors, and underwriters.
+For each N-CEN report, you see the fund's classification (for example N-1A open-end or N-2 closed-end), Investment Company Act file number, reporting period, and first/last-filing flags. The answer then separates the newest filing's named service providers from an exact filed-name timeline across the returned reports, so a changed or omitted adviser, custodian, transfer agent, administrator, auditor, or underwriter remains visible.
 
 If the reply comes back empty, the ticker may not belong to a registered fund — only mutual funds, ETFs, and closed-end funds file N-CEN, so an operating company returns no data — or its N-CEN may not have been imported yet. Try a large, well-known fund such as SPY to confirm the data is flowing.

--- a/docs/guide/how-to-ask-about-government-contracts.md
+++ b/docs/guide/how-to-ask-about-government-contracts.md
@@ -15,7 +15,7 @@ Ask your assistant about a specific ticker:
 - "Show me Boeing's government contract awards since 2024-01-01."
 - "How much has RTX been awarded recently, and by which agencies?"
 
-The assistant calls the `GetGovernmentContracts` tool and replies with a table of awards. Each row shows the action date, awarding agency, award type, dollar amount, award ID, and a short description, ordered largest first — useful for gauging how much a company relies on federal spending.
+The assistant calls the `GetGovernmentContracts` tool and replies with a table of awards. Each row shows the action date, recipient named by the government, awarding agency, award type, total value, outlays when reported, award ID, and a short description, ordered largest first — useful for gauging how much a company relies on federal spending.
 
 To narrow the window, mention dates ("between 2024-01-01 and 2024-12-31"). When you don't, the assistant defaults to the last year.
 

--- a/docs/guide/how-to-ask-about-insider-trading.md
+++ b/docs/guide/how-to-ask-about-insider-trading.md
@@ -30,7 +30,7 @@ A Form 144 is an affiliate's declared intent to sell, filed before the trade —
 
 - "Are there any proposed insider sales pending at NVDA?"
 
-The assistant calls `GetProposedSales` and returns each Form 144 notice — the seller and their relationship to the company, the shares and aggregate market value to be sold, the approximate sale date, and the broker.
+The assistant calls `GetProposedSales` and returns each Form 144 notice — the seller and their relationship to the company, the shares and aggregate market value to be sold, the sale as a percent of shares outstanding, the approximate sale date, the broker, and filed remarks such as a stated 10b5-1 plan.
 
 ## Look up a specific insider
 

--- a/docs/guide/how-to-ask-about-market-wide-13f-activity.md
+++ b/docs/guide/how-to-ask-about-market-wide-13f-activity.md
@@ -22,9 +22,11 @@ The assistant picks the `GetMarketWide13FActivity` tool and selects the matching
 
 A ranked table for the leaderboard you asked about:
 
-- **Top buys** — stocks with the largest increase in institutional holdings, ranked by change in market value.
-- **Top sells** — stocks with the largest decrease, ranked by the size of the sell-down.
+- **Top buys** — positive share changes ranked by change in stored quarter-end position value.
+- **Top sells** — negative share changes ranked by change in stored quarter-end position value.
 - **New positions** — stocks ranked by how many filers initiated a position this quarter.
 - **Sold-out positions** — stocks ranked by how many filers exited entirely.
+
+For top buys and sells, `Δ Value` includes the quarter's stock-price move on shares merely held; it is the ranking key, not a pure trading-flow measure. Read `Δ Shares` to identify the position change itself.
 
 If the reply is empty, only one quarter of 13F data has likely been imported so far — there's nothing to compare against yet. Let the worker keep running and try again once a second quarter has loaded.

--- a/docs/guide/how-to-ask-about-proposed-sales.md
+++ b/docs/guide/how-to-ask-about-proposed-sales.md
@@ -19,7 +19,7 @@ The assistant picks the `GetProposedSales` tool and returns the company's recent
 
 ## What you should see
 
-A table of recent Form 144 notices, each showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the approximate sale date, and the broker.
+A table of recent Form 144 notices, each showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the sale as a percent of shares outstanding, the approximate sale date, the broker, and filed remarks such as a stated 10b5-1 plan.
 
 Remember that a Form 144 is a *declaration of intent*, not a completed trade — the actual sale, if it happens, later appears as an executed [Form 4 insider transaction](how-to-ask-about-insider-trading.md).
 

--- a/docs/guide/how-to-ask-about-revenue-breakdown.md
+++ b/docs/guide/how-to-ask-about-revenue-breakdown.md
@@ -1,6 +1,6 @@
 # Ask your AI assistant for a company's revenue breakdown
 
-Equibles reads the dimensional XBRL facts a company tags in its own SEC filings and exposes them through the MCP server, so you can ask your AI assistant how a company's revenue splits by business segment, geography, and product or service. This breakdown is available to AI assistants only; the web portal shows a company's headline financial statements per stock, not the disaggregated revenue tables.
+Equibles reads the dimensional XBRL facts a company tags in its own SEC filings and exposes them through the MCP server, so you can ask your AI assistant how a company's revenue splits by business segment, geography, and product or service — and, when reported, how segment operating income and margins compare. This breakdown is available to AI assistants only; the web portal shows a company's headline financial statements per stock, not these disaggregated tables.
 
 ## Before you start
 
@@ -15,10 +15,10 @@ Name a company and ask how its revenue splits:
 - "How does Microsoft's revenue split across business segments over the last few years?"
 - "Show me NVDA's revenue by product and service."
 
-The assistant calls the `GetRevenueBreakdown` tool and replies with one table per axis the company actually reports — by segment, by geography, and by product and service. Each table lists annual fiscal years across the top and the company's own reported categories down the side, using the latest restated values. By default it covers the last 8 fiscal years; ask for fewer or more (up to 12) if you want a different window.
+The assistant calls the `GetRevenueBreakdown` tool and replies with one table per revenue axis the company actually reports — by segment, geography, and product or service. When the filer separately tags segment operating income, the answer also includes that table even if no dimensional revenue is present. Where income and positive revenue match by folded raw member QName for the exact period, a derived segment operating-margin table follows. By default it covers the last 8 annual fiscal years; ask for fewer or more (up to 12) if you want a different window.
 
 ## What you should see
 
-One or more Markdown tables in the assistant's reply, one per axis the company discloses. The figures are exactly as the company reported them — never estimated or allocated by Equibles — and annual only (quarterly slices are not included).
+One or more annual Markdown tables in the assistant's reply. Revenue and operating income are the latest restated figures exactly as the company reported them and are never estimated or allocated. Segment operating margin is explicitly labelled as the mechanical calculation `operating income ÷ revenue × 100`; unmatched cells stay blank.
 
 If a table is missing or the reply says there's no breakdown, the most likely reasons are that the company doesn't disaggregate revenue on that axis in its filings, or the scraper hasn't imported its XBRL facts yet. Companies vary widely in how much they break out: a large, diversified issuer (for example AAPL or MSFT) is the best place to confirm the data is flowing.

--- a/docs/guide/how-to-ask-about-stock-prices.md
+++ b/docs/guide/how-to-ask-about-stock-prices.md
@@ -20,7 +20,7 @@ For a single stock over a date range the assistant picks `GetStockPrices`; for t
 
 ## What you should see
 
-- **`GetStockPrices`** — a table of daily bars with one row per trading day: Date, Open, High, Low, Close, and Volume. Use it for charting, trend questions, or as the basis for the [technical indicators](how-to-ask-about-technical-indicators.md) Equibles computes on top of the same history.
+- **`GetStockPrices`** — a table of daily bars with one row per trading day: Date, Open, High, Low, Close, and Volume. When the stored auxiliary adjusted close differs, the table also includes `Adj Close`. It can be rewritten during full-history split reconciliation and is not guaranteed to be complete total return, so equality with or a difference from `Close` does not identify corporate actions. Use the bars for charting, trend questions, or as the basis for the [technical indicators](how-to-ask-about-technical-indicators.md) Equibles computes on top of the same history.
 - **`GetLatestPrices`** — the most recent closing price and volume for each ticker you named, ideal for a one-line portfolio or watchlist check.
 
 If the reply says there's no price data, the stock's prices probably haven't been imported yet — confirm the worker has run, then try a large, liquid ticker such as AAPL.

--- a/docs/guide/how-to-view-congress-member-trades.md
+++ b/docs/guide/how-to-view-congress-member-trades.md
@@ -1,6 +1,6 @@
 # View a member of Congress's trading profile
 
-This guide shows you how to open a member of Congress's profile and read their most recent reported stock trades.
+This guide shows you how to open a member of Congress's profile and read their most recent reported securities transactions.
 
 ## Find a member of Congress
 

--- a/docs/guide/tutorial-explore-stock.md
+++ b/docs/guide/tutorial-explore-stock.md
@@ -70,7 +70,7 @@ Click **Fund Holdings**. For registered funds, this tab lists the individual sec
 
 ## Congressional Trades
 
-Click **Congressional Trades**. Members of the U.S. House of Representatives are required to disclose their stock trades. This tab shows any reported purchases or sales of this stock by members of Congress, including the estimated transaction amount and the disclosure date.
+Click **Congressional Trades**. Members of the U.S. House of Representatives disclose securities transactions. This tab shows reported transactions tied to the company, including the filed Asset instrument (such as stock, option, or bond), estimated transaction amount, and disclosure date.
 
 ## You're done
 

--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -26,7 +26,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetInstitutionPortfolio` — full portfolio of one institution for a `ReportDate`.
 - `SearchInstitutions` — name-search returning matching `InstitutionalHolder` rows.
 - `GetTopBuyersSellers` — biggest absolute share additions and reductions for a ticker vs. the prior `ReportDate`; flags new and sold-out positions.
-- `GetMarketWide13FActivity` — market-wide leaderboard for a quarter, selected by `bucket`: `top-buys`, `top-sells`, `new-positions`, `sold-out-positions`.
+- `GetMarketWide13FActivity` — market-wide leaderboard for a quarter, selected by `bucket`: `top-buys`, `top-sells`, `new-positions`, `sold-out-positions`; Δ value includes the quarter's price move on held shares, so Δ shares is the position-change measure.
 - `GetInstitutionSummary` — portfolio header for one filer at a `ReportDate`: AUM, position count, top-10 / top-25 concentration, QoQ turnover, latest / prior dates.
 - `GetInstitutionSectorAllocation` — one filer's portfolio grouped by industry / sector for its latest 13F report; stocks lacking a classification collapse into an "Unclassified" row.
 - `GetInstitutionQuarterlyActivity` — one filer's position changes vs. the prior quarter, bucketed into Initiated / Increased / Reduced / Exited; optional `bucket` filter to a single bucket.
@@ -42,7 +42,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetInsiderTransactions` — recent transactions for a ticker, filterable by transaction code.
 - `GetInsiderOwnership` — current insider ownership summary for a ticker.
 - `SearchInsiders` — search insiders by name / company / role.
-- `GetProposedSales` — recent proposed insider sales for a ticker from SEC Form 144 notices: seller, relationship to the company, shares and aggregate market value to be sold, approximate sale date, and broker.
+- `GetProposedSales` — recent proposed insider sales for a ticker from SEC Form 144 notices: seller, relationship to the company, shares and aggregate market value to be sold, percent of shares outstanding, approximate sale date, broker, and filer remarks such as a stated 10b5-1 plan.
 
 ### `mcp.AddSec()` — SEC filings
 
@@ -78,7 +78,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 `NCenTools`:
 
-- `GetFundOperations` — operational data for a fund, ETF or closed-end fund from SEC Form N-CEN annual reports: registrant classification, Investment Company Act file number, reporting period, first/last-filing flags, and named service providers (advisers, sub-advisers, custodians, transfer agents, administrators, auditors, underwriters). Only registered funds file N-CEN.
+- `GetFundOperations` — operational data for a fund, ETF or closed-end fund from SEC Form N-CEN annual reports: registrant classification, Investment Company Act file number, reporting period, first/last-filing flags, the latest filing's named service providers, and an exact filed-name provider timeline across returned reports. Only registered funds file N-CEN.
 
 `InvestmentAdviserTools`:
 
@@ -98,14 +98,14 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 `RevenueBreakdownTools`:
 
-- `GetRevenueBreakdown` — revenue disaggregated by business segment, geography, and product/service from the dimensional XBRL facts the issuer tags in its own filings: annual fiscal years only, latest restated values, one table per axis the company reports; as-reported, never estimated.
+- `GetRevenueBreakdown` — revenue disaggregated by business segment, geography, and product/service from the dimensional XBRL facts the issuer tags in its own filings, plus reported segment operating income and a mechanically derived same-folded-member/exact-period operating-margin table: annual fiscal years only, latest restated source values, one table per axis the company reports; missing cells are never estimated.
 
 ### `mcp.AddCongress()` — congressional trading
 
 `CongressTools`:
 
-- `GetCongressionalTrades` — trades for a ticker across all members.
-- `GetMemberTrades` — trades by one member of Congress.
+- `GetCongressionalTrades` — disclosed securities transactions for a ticker across all members; the Asset column identifies stock, option, bond, or another filed instrument.
+- `GetMemberTrades` — disclosed securities transactions by one member of Congress, including the filed Asset instrument.
 - `SearchCongressMembers` — search members by name / chamber / position.
 - `GetMemberNetWorth` — a member's net-worth history from annual financial disclosures, reported as yearly min–max bands (electronic filings only).
 
@@ -113,9 +113,9 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 `FredTools`:
 
-- `GetEconomicIndicator` — observations for a FRED series (e.g. `DGS10`, `UNRATE`).
+- `GetEconomicIndicator` — observations for a FRED series (e.g. `DGS10`, `UNRATE`), with units, frequency, and seasonal-adjustment metadata.
 - `GetLatestEconomicData` — latest snapshot across the curated macro indicators.
-- `SearchEconomicIndicators` — keyword search across series titles / categories.
+- `SearchEconomicIndicators` — keyword search across series titles / categories; each result includes seasonal adjustment, latest observation date, and the exact UTC series-sync time.
 - `GetEconomicCalendar` — scheduled and recent US macro release dates (CPI, Employment Situation, GDP, …) and the FRED series each updates; defaults to the next 30 days.
 
 ### `mcp.AddStockPrices()` — Yahoo OHLCV + technical indicators
@@ -166,7 +166,7 @@ never substitutes `BRK-B`; dot share-class spelling such as `BRK.A` resolves to 
 
 `GovernmentContractsTools`:
 
-- `GetGovernmentContracts` — federal contract awards (USAspending.gov) won by one public company, with awarding agency, award amount, period dates, and description.
+- `GetGovernmentContracts` — federal contract awards (USAspending.gov) won by one public company, with the government-named recipient, awarding agency, total value, outlays when reported, period dates, and description.
 - `GetTopGovernmentContractors` — rank public companies by total federal contract dollars awarded over a date range.
 
 ### `mcp.AddFdaCatalysts()` — FDA advisory-committee meetings
@@ -198,5 +198,5 @@ never substitutes `BRK-B`; dot share-class spelling such as `BRK.A` resolves to 
 - Add the method to the existing `*Tools` class for that module (single tool class per module is the established pattern; only split when the surface grows past ~5 methods).
 - Apply `[McpServerTool(Name = "ToolName")]` + `[Description("…")]` on the method, `[Description("…")]` on every parameter.
 - Wrap the body in `McpToolExecutor.Execute(...)` so failures are logged + surfaced via `ErrorManager` instead of crashing the MCP request.
-- Return Markdown; keep tables compact (≤8 columns) so they render cleanly in chat clients.
+- Return Markdown; prefer ≤8 columns for chat readability, but retain required attribution or evidence fields when parity needs a wider table.
 - No host change required — `AssemblyMcpModule<TMarker>` discovers the new method via `WithToolsFromAssembly` on the next startup.

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -46,7 +46,7 @@ public class CongressTools
         ReadOnly = true
     )]
     [Description(
-        "Get congressional stock trades for a specific ticker (newest first, last year by default). Shows which members of Congress bought or sold shares, with transaction and filing dates; amounts are the disclosed ranges, not exact values. Use GetMemberTrades for one member's trades across all tickers."
+        "Get congressional securities transactions for a specific ticker (newest first, last year by default). Shows which members of Congress reported a purchase or sale, with transaction and filing dates; amounts are disclosed ranges, not exact values, and Asset identifies the filed instrument (such as stock, option, or bond). Use GetMemberTrades for one member's transactions across all tickers."
     )]
     public Task<string> GetCongressionalTrades(
         [Description("Stock ticker symbol (e.g., AAPL, MSFT, NVDA)")] string ticker,
@@ -115,7 +115,7 @@ public class CongressTools
 
     [McpServerTool(Name = "GetMemberTrades", Title = "Trades by Congress Member", ReadOnly = true)]
     [Description(
-        "Get a congress member's disclosed stock trades (newest first, last year by default). Shows tickers, transaction and filing dates, and disclosed amount ranges — bands, not exact values. Use SearchCongressMembers to find member names, and GetCongressionalTrades for all members' trades in one ticker."
+        "Get a congress member's disclosed securities transactions (newest first, last year by default). Shows tickers, transaction and filing dates, disclosed amount ranges, and the filed Asset identifying the instrument (such as stock, option, or bond). Use SearchCongressMembers to find member names, and GetCongressionalTrades for all members' transactions in one ticker."
     )]
     public Task<string> GetMemberTrades(
         [Description(
@@ -336,8 +336,7 @@ public class CongressTools
     // The asset as filed is free text and is the field that separates an option or bond trade from
     // a share trade, so an unescaped pipe would shift every later column and file Owner under
     // Asset — a classification error, not just a cosmetic one.
-    private static string EscapeCell(string value) =>
-        value == null ? "—" : value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
+    private static string EscapeCell(string value) => MarkdownTable.EscapeCell(value, "—");
 
     private static string FormatOwner(string ownerType) =>
         string.IsNullOrEmpty(ownerType)

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -93,14 +93,17 @@ public class CongressTools
                     trades,
                     $"No congressional trades found for {stock.Ticker} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
                     $"Congressional trades for {stock.Ticker} ({stock.Name}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
-                    "| Date | Filed | Member | Position | Type | Amount Range | Owner |",
-                    "|------|-------|--------|----------|------|-------------|-------|",
+                    "| Date | Filed | Member | Position | Type | Amount Range | Asset | Owner |",
+                    "|------|-------|--------|----------|------|-------------|-------|-------|",
                     t =>
                     {
                         var position = t.CongressMember.Position.NameForHumans();
                         var type = t.TransactionType.NameForHumans();
                         var amount = FormatAmountRange(t);
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {FormatOwner(t.OwnerType)} |";
+                        // The asset as filed is the ONLY thing separating an option or bond trade
+                        // from a stock trade — "Purchase" alone reads as a bullish share buy even
+                        // when the filing says it was a put.
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {t.AssetName} | {FormatOwner(t.OwnerType)} |";
                     }
                 );
                 return AppendTruncationNote(table, trades.Count, totalCount);

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -103,7 +103,7 @@ public class CongressTools
                         // The asset as filed is the ONLY thing separating an option or bond trade
                         // from a stock trade — "Purchase" alone reads as a bullish share buy even
                         // when the filing says it was a put.
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {t.AssetName} | {FormatOwner(t.OwnerType)} |";
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {EscapeCell(t.AssetName)} | {FormatOwner(t.OwnerType)} |";
                     }
                 );
                 return AppendTruncationNote(table, trades.Count, totalCount);
@@ -186,7 +186,7 @@ public class CongressTools
                     {
                         var type = t.TransactionType.NameForHumans();
                         var amount = FormatAmountRange(t);
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {FormatOwner(t.OwnerType)} |";
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {EscapeCell(t.AssetName)} | {FormatOwner(t.OwnerType)} |";
                     }
                 );
                 var note = McpOutput.PagedTruncationNote(trades.Count, totalCount, offset);
@@ -333,6 +333,12 @@ public class CongressTools
     // House PTRs disclose raw owner codes (SP/JT/DC) while Senate rows arrive spelled out;
     // render one vocabulary — the Senate labels — so a table never mixes "SP" and "Spouse".
     // The stored value is untouched: OwnerType is part of the trade upsert key.
+    // The asset as filed is free text and is the field that separates an option or bond trade from
+    // a share trade, so an unescaped pipe would shift every later column and file Owner under
+    // Asset — a classification error, not just a cosmetic one.
+    private static string EscapeCell(string value) =>
+        value == null ? "—" : value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
+
     private static string FormatOwner(string ownerType) =>
         string.IsNullOrEmpty(ownerType)
             ? "—"

--- a/src/Equibles.CorporateActions.BusinessLogic/StockSplitBackfillManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/StockSplitBackfillManager.cs
@@ -15,7 +15,7 @@ namespace Equibles.CorporateActions.BusinessLogic;
 // its rate limiter) and upserts the returned splits through the existing
 // idempotent capture path — safe to re-run. Newly captured splits carry a null
 // PriceAdjustmentAppliedTime, so the price sync's split reconciliation re-pulls
-// those stocks' fully-adjusted history on its next cycles without further work.
+// those stocks' full provider-served history on its next cycles without further work.
 [Service]
 public class StockSplitBackfillManager
 {

--- a/src/Equibles.CorporateActions.Data/SplitBasisResolver.cs
+++ b/src/Equibles.CorporateActions.Data/SplitBasisResolver.cs
@@ -3,32 +3,29 @@ using Equibles.CorporateActions.Data.Models;
 namespace Equibles.CorporateActions.Data;
 
 /// <summary>
-/// Resolves the split factor between a historical as-of date and the present price basis.
+/// Resolves the factor implied by captured splits between a historical as-of date and today.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Stored daily prices are rewritten onto TODAY'S post-split basis whenever a split's price
-/// reconciliation runs, while historical figures quoted as-of a date (a 13F share count, a
-/// Form 4 per-share price) stay on that date's basis. Any comparison or product across the two
-/// is off by exactly the product of the intervening split ratios. The factor returned here
-/// restates between them: an as-of share count × factor lands on the present count basis, and
-/// a present-basis close × factor lands back on the as-of per-share price basis.
+/// Historical figures quoted as-of a date (a 13F share count, a Form 4 per-share price) stay on
+/// that date's basis. The factor returned here restates those figures across captured splits: an
+/// as-of share count × factor lands on the present share-count basis.
 /// </para>
 /// <para>
-/// The restatement is only trustworthy while the stored series really is on today's basis.
-/// Between a split being captured and its price reconciliation running, the series mixes both
-/// bases; that window — and a split whose series attribution cannot be established — is
-/// reported as unresolvable (<c>false</c>) instead of guessed at.
+/// This resolver checks split attribution and whether reconciliation was stamped applied. It does
+/// not inspect price values and cannot prove a raw stored Close is on today's basis: Yahoo can
+/// serve either basis during a full-history replacement. Do not use a successful resolution as
+/// evidence for a universal raw-price basis. A pending or unattributed split is reported as
+/// unresolvable (<c>false</c>) instead of guessed at.
 /// </para>
 /// </remarks>
 public static class SplitBasisResolver
 {
     /// <summary>
-    /// Resolves the factor between figures quoted as-of <paramref name="asOfDate"/> and the
-    /// stored price series' present basis. Returns <c>false</c> when a split that would move
-    /// the figure has not had its price adjustment applied yet — the stored prices then
-    /// straddle two bases and no honest restatement exists; <paramref name="factor"/> is then
-    /// 1 and must not be used.
+    /// Resolves the factor between figures quoted as-of <paramref name="asOfDate"/> and today's
+    /// share-count basis. Returns <c>false</c> when a split that would move the figure has not had
+    /// its price reconciliation stamped applied; <paramref name="factor"/> is then 1 and must not
+    /// be used. A successful result does not prove the basis of raw stored price rows.
     /// <para>
     /// <paramref name="listedTicker"/> names the exact security; null means the filer's
     /// primary (<paramref name="primaryTicker"/>). A PRIMARY figure uses every split captured

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -283,9 +283,15 @@ public class FredTools
                     series,
                     $"No tracked series match '{query}'. Equibles tracks a curated ~40-series US macro set - FRED series outside it are not available. Try a category name (Inflation, Employment, InterestRates, ...) or an empty query to list all tracked series.",
                     title,
-                    "| Series ID | Title | Category | Frequency | Units |",
-                    "|-----------|-------|----------|-----------|-------|",
-                    s => $"| {s.SeriesId} | {s.Title} | {s.Category} | {s.Frequency} | {s.Units} |"
+                    // Seasonal adjustment decides whether two series are even comparable, and the
+                    // last-updated stamp is the only way to date a macro reading from search
+                    // alone — without it a caller cannot tell a live series from a retired one.
+                    "| Series ID | Title | Category | Frequency | Units | Seasonal Adj | Last Updated |",
+                    "|-----------|-------|----------|-----------|-------|--------------|--------------|",
+                    s =>
+                        $"| {s.SeriesId} | {s.Title} | {s.Category} | {s.Frequency} | {s.Units} "
+                        + $"| {(string.IsNullOrWhiteSpace(s.SeasonalAdjustment) ? "-" : s.SeasonalAdjustment)} "
+                        + $"| {(s.LastUpdated == null ? "-" : McpFormat.Invariant(s.LastUpdated.Value, "yyyy-MM-dd"))} |"
                 );
 
                 var truncation = McpOutput.TruncationNote(series.Count, total);

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -251,7 +251,7 @@ public class FredTools
         ReadOnly = true
     )]
     [Description(
-        "Search the curated set of ~40 US macro FRED series Equibles tracks (rates, inflation, employment, GDP, housing, market indicators) — not the full FRED catalog. Matches series ID, title, and category name: a category query like 'inflation' returns that whole category (CPI, PCE, PPI, breakevens), and an empty query lists every tracked series. Use this to discover what economic data is available before calling GetEconomicIndicator."
+        "Search the curated set of ~40 US macro FRED series Equibles tracks (rates, inflation, employment, GDP, housing, market indicators) — not the full FRED catalog. Matches series ID, title, and category name: a category query like 'inflation' returns that whole category (CPI, PCE, PPI, breakevens), and an empty query lists every tracked series. Results include seasonal adjustment, the latest observation date, and the UTC time Equibles last synced the series. Use this to discover what economic data is available before calling GetEconomicIndicator."
     )]
     public Task<string> SearchEconomicIndicators(
         [Description(
@@ -284,16 +284,16 @@ public class FredTools
                     $"No tracked series match '{query}'. Equibles tracks a curated ~40-series US macro set - FRED series outside it are not available. Try a category name (Inflation, Employment, InterestRates, ...) or an empty query to list all tracked series.",
                     title,
                     // Seasonal adjustment decides whether two series are even comparable. The
-                    // date column is ObservationEnd — the newest observation the series carries.
-                    // LastUpdated is deliberately NOT shown: it is our own sync clock (set to
-                    // UtcNow on every import cycle), so it is identical across every series and
-                    // says nothing about whether a series is still being published.
-                    "| Series ID | Title | Category | Frequency | Units | Seasonal Adj | Latest Observation |",
-                    "|-----------|-------|----------|-----------|-------|--------------|--------------------|",
+                    // ObservationEnd dates the newest data point; LastUpdated is the separate
+                    // Equibles import clock. Both REST fields are rendered with distinct labels
+                    // so a caller never mistakes ingestion freshness for publication recency.
+                    "| Series ID | Title | Category | Frequency | Units | Seasonal Adj | Latest Observation | Last Synced (UTC) |",
+                    "|-----------|-------|----------|-----------|-------|--------------|--------------------|-------------------|",
                     s =>
-                        $"| {s.SeriesId} | {s.Title} | {s.Category} | {s.Frequency} | {s.Units} "
-                        + $"| {(string.IsNullOrWhiteSpace(s.SeasonalAdjustment) ? "-" : s.SeasonalAdjustment)} "
-                        + $"| {(s.ObservationEnd == null ? "-" : McpFormat.Invariant(s.ObservationEnd.Value, "yyyy-MM-dd"))} |"
+                        $"| {MarkdownTable.EscapeCell(s.SeriesId, "-")} | {MarkdownTable.EscapeCell(s.Title, "-")} | {MarkdownTable.EscapeCell(s.Category.ToString(), "-")} | {MarkdownTable.EscapeCell(s.Frequency, "-")} | {MarkdownTable.EscapeCell(s.Units, "-")} "
+                        + $"| {MarkdownTable.EscapeCell(s.SeasonalAdjustment, "-")} "
+                        + $"| {(s.ObservationEnd == null ? "-" : McpFormat.Invariant(s.ObservationEnd.Value, "yyyy-MM-dd"))} "
+                        + $"| {McpFormat.OrDash(s.LastUpdated?.ToUniversalTime(), "O")} |"
                 );
 
                 var truncation = McpOutput.TruncationNote(series.Count, total);

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -283,15 +283,17 @@ public class FredTools
                     series,
                     $"No tracked series match '{query}'. Equibles tracks a curated ~40-series US macro set - FRED series outside it are not available. Try a category name (Inflation, Employment, InterestRates, ...) or an empty query to list all tracked series.",
                     title,
-                    // Seasonal adjustment decides whether two series are even comparable, and the
-                    // last-updated stamp is the only way to date a macro reading from search
-                    // alone — without it a caller cannot tell a live series from a retired one.
-                    "| Series ID | Title | Category | Frequency | Units | Seasonal Adj | Last Updated |",
-                    "|-----------|-------|----------|-----------|-------|--------------|--------------|",
+                    // Seasonal adjustment decides whether two series are even comparable. The
+                    // date column is ObservationEnd — the newest observation the series carries.
+                    // LastUpdated is deliberately NOT shown: it is our own sync clock (set to
+                    // UtcNow on every import cycle), so it is identical across every series and
+                    // says nothing about whether a series is still being published.
+                    "| Series ID | Title | Category | Frequency | Units | Seasonal Adj | Latest Observation |",
+                    "|-----------|-------|----------|-----------|-------|--------------|--------------------|",
                     s =>
                         $"| {s.SeriesId} | {s.Title} | {s.Category} | {s.Frequency} | {s.Units} "
                         + $"| {(string.IsNullOrWhiteSpace(s.SeasonalAdjustment) ? "-" : s.SeasonalAdjustment)} "
-                        + $"| {(s.LastUpdated == null ? "-" : McpFormat.Invariant(s.LastUpdated.Value, "yyyy-MM-dd"))} |"
+                        + $"| {(s.ObservationEnd == null ? "-" : McpFormat.Invariant(s.ObservationEnd.Value, "yyyy-MM-dd"))} |"
                 );
 
                 var truncation = McpOutput.TruncationNote(series.Count, total);

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -135,7 +135,7 @@ public class GovernmentContractsTools
                         + $"| {Escape(Shorten(c.Description, 80))} |"
                 );
 
-                return await AppendFooters(table, awards.Count, totalCount, end);
+                return await AppendFooters(table, awards.Count, totalCount, end, hasOutlays);
             },
             "GetGovernmentContracts",
             $"ticker: {ticker}"
@@ -211,7 +211,13 @@ public class GovernmentContractsTools
                         $"| {++rank} | {Escape(r.Ticker)} | {Escape(r.Name)} | {FormatUsd(r.Total)} | {r.Count} |"
                 );
 
-                return await AppendFooters(table, ranked.Count, totalCompanies, end);
+                return await AppendFooters(
+                    table,
+                    ranked.Count,
+                    totalCompanies,
+                    end,
+                    hasOutlays: false
+                );
             },
             "GetTopGovernmentContractors",
             $"range: {startDate}..{endDate}"
@@ -220,7 +226,13 @@ public class GovernmentContractsTools
 
     // Every result carries the dataset's coverage limits and its true recency, so a sparse
     // window reads as a data gap rather than as an absence of awards.
-    private async Task<string> AppendFooters(string table, int shown, int total, DateOnly rangeEnd)
+    private async Task<string> AppendFooters(
+        string table,
+        int shown,
+        int total,
+        DateOnly rangeEnd,
+        bool hasOutlays
+    )
     {
         var sb = new StringBuilder(table.TrimEnd('\n', '\r'));
         sb.AppendLine();
@@ -240,8 +252,13 @@ public class GovernmentContractsTools
 
         sb.AppendLine(
             "_Coverage: prime federal contract awards of $1M+ matched to listed companies; "
-                + "Total Value is obligated dollars plus unexercised option ceiling, not revenue received; "
-                + "Outlays, when reported, is what the government has actually disbursed so far. Recipient is the awarded "
+                + "Total Value is obligated dollars plus unexercised option ceiling, not revenue received"
+                + (
+                    hasOutlays
+                        ? "; Outlays is what the government has actually disbursed so far"
+                        : ""
+                )
+                + ". Recipient is the awarded "
                 + "entity as the government named it — a subsidiary's own name there is how an award reaches "
                 + "this company. "
                 + $"Latest ingested award action date: {Format(latestIngested)}._"

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -107,16 +107,31 @@ public class GovernmentContractsTools
                     : query.OrderByDescending(c => c.Amount);
                 var awards = await ordered.Take(maxResults).ToListAsync();
 
+                // USAspending reports outlays on only about a quarter of awards, so a permanent
+                // column would be mostly em-dashes; it renders when this answer actually carries
+                // the figure. Recipient is unconditional — it is the attribution evidence.
+                var hasOutlays = awards.Any(c => c.TotalOutlays != null);
+
                 var table = MarkdownTable.Render(
                     awards,
                     $"No federal contract awards found for {stock.Ticker} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
                     $"Federal contract awards for {stock.Ticker} ({stock.Name}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd} "
                         + $"— {totalCount} awards totaling {FormatUsd(totalValue)}:",
-                    "| Award Date | Recipient | Agency | Type | Total Value (obligated + ceiling) | Outlays | Period End | Award ID | Description |",
-                    "|------------|-----------|--------|------|-----------------------------------|---------|------------|----------|-------------|",
+                    hasOutlays
+                        ? "| Award Date | Recipient | Agency | Type | Total Value (obligated + ceiling) | Outlays | Period End | Award ID | Description |"
+                        : "| Award Date | Recipient | Agency | Type | Total Value (obligated + ceiling) | Period End | Award ID | Description |",
+                    hasOutlays
+                        ? "|------------|-----------|--------|------|-----------------------------------|---------|------------|----------|-------------|"
+                        : "|------------|-----------|--------|------|-----------------------------------|------------|----------|-------------|",
                     c =>
                         $"| {Format(c.ActionDate)} | {Escape(Shorten(c.RecipientName, 48))} | {Escape(c.AwardingAgency)} | {AwardTypeLabel(c.AwardType)} "
-                        + $"| {FormatUsd(c.Amount)} | {(c.TotalOutlays == null ? "—" : FormatUsd(c.TotalOutlays.Value))} | {Format(c.EndDate)} | {Escape(c.AwardId)} "
+                        + $"| {FormatUsd(c.Amount)} "
+                        + (
+                            hasOutlays
+                                ? $"| {(c.TotalOutlays == null ? "—" : FormatUsd(c.TotalOutlays.Value))} "
+                                : ""
+                        )
+                        + $"| {Format(c.EndDate)} | {Escape(c.AwardId)} "
                         + $"| {Escape(Shorten(c.Description, 80))} |"
                 );
 
@@ -226,7 +241,7 @@ public class GovernmentContractsTools
         sb.AppendLine(
             "_Coverage: prime federal contract awards of $1M+ matched to listed companies; "
                 + "Total Value is obligated dollars plus unexercised option ceiling, not revenue received; "
-                + "Outlays is what the government has actually disbursed so far. Recipient is the awarded "
+                + "Outlays, when reported, is what the government has actually disbursed so far. Recipient is the awarded "
                 + "entity as the government named it — a subsidiary's own name there is how an award reaches "
                 + "this company. "
                 + $"Latest ingested award action date: {Format(latestIngested)}._"

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -46,8 +46,9 @@ public class GovernmentContractsTools
     )]
     [Description(
         "Get federal government contract awards (from USAspending.gov) won by a specific public company. "
-            + "Shows the award (action) date, awarding agency, total value (obligated dollars plus "
-            + "unexercised ceiling — not revenue received), period-of-performance end date, and description. "
+            + "Shows the award (action) date, recipient named by the government, awarding agency, total value "
+            + "(obligated dollars plus unexercised ceiling — not revenue received), outlays when reported, "
+            + "period-of-performance end date, and description. "
             + "Coverage: only prime contract awards of $1M or more that resolve to a listed company are "
             + "included, so sums understate total federal revenue. Useful for gauging a company's reliance "
             + "on federal spending; use GetTopGovernmentContractors to rank companies market-wide."
@@ -124,7 +125,7 @@ public class GovernmentContractsTools
                         ? "|------------|-----------|--------|------|-----------------------------------|---------|------------|----------|-------------|"
                         : "|------------|-----------|--------|------|-----------------------------------|------------|----------|-------------|",
                     c =>
-                        $"| {Format(c.ActionDate)} | {Escape(Shorten(c.RecipientName, 48))} | {Escape(c.AwardingAgency)} | {AwardTypeLabel(c.AwardType)} "
+                        $"| {Format(c.ActionDate)} | {Escape(c.RecipientName)} | {Escape(c.AwardingAgency)} | {AwardTypeLabel(c.AwardType)} "
                         + $"| {FormatUsd(c.Amount)} "
                         + (
                             hasOutlays
@@ -135,7 +136,14 @@ public class GovernmentContractsTools
                         + $"| {Escape(Shorten(c.Description, 80))} |"
                 );
 
-                return await AppendFooters(table, awards.Count, totalCount, end, hasOutlays);
+                return await AppendFooters(
+                    table,
+                    awards.Count,
+                    totalCount,
+                    end,
+                    hasOutlays,
+                    hasRecipient: true
+                );
             },
             "GetGovernmentContracts",
             $"ticker: {ticker}"
@@ -216,7 +224,8 @@ public class GovernmentContractsTools
                     ranked.Count,
                     totalCompanies,
                     end,
-                    hasOutlays: false
+                    hasOutlays: false,
+                    hasRecipient: false
                 );
             },
             "GetTopGovernmentContractors",
@@ -231,7 +240,8 @@ public class GovernmentContractsTools
         int shown,
         int total,
         DateOnly rangeEnd,
-        bool hasOutlays
+        bool hasOutlays,
+        bool hasRecipient
     )
     {
         var sb = new StringBuilder(table.TrimEnd('\n', '\r'));
@@ -258,9 +268,11 @@ public class GovernmentContractsTools
                         ? "; Outlays is what the government has actually disbursed so far"
                         : ""
                 )
-                + ". Recipient is the awarded "
-                + "entity as the government named it — a subsidiary's own name there is how an award reaches "
-                + "this company. "
+                + (
+                    hasRecipient
+                        ? ". Recipient is the awarded entity as the government named it — a subsidiary's own name there is how an award reaches this company. "
+                        : ". "
+                )
                 + $"Latest ingested award action date: {Format(latestIngested)}._"
         );
 
@@ -375,11 +387,5 @@ public class GovernmentContractsTools
         return trimmed.TruncateToFit(maxLength) + "…";
     }
 
-    // Markdown cells can't contain a raw pipe or newline without breaking the table.
-    private static string Escape(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return "";
-        return value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
-    }
+    private static string Escape(string value) => MarkdownTable.EscapeCell(value);
 }

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -112,11 +112,11 @@ public class GovernmentContractsTools
                     $"No federal contract awards found for {stock.Ticker} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
                     $"Federal contract awards for {stock.Ticker} ({stock.Name}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd} "
                         + $"— {totalCount} awards totaling {FormatUsd(totalValue)}:",
-                    "| Award Date | Agency | Type | Total Value (obligated + ceiling) | Period End | Award ID | Description |",
-                    "|------------|--------|------|-----------------------------------|------------|----------|-------------|",
+                    "| Award Date | Recipient | Agency | Type | Total Value (obligated + ceiling) | Outlays | Period End | Award ID | Description |",
+                    "|------------|-----------|--------|------|-----------------------------------|---------|------------|----------|-------------|",
                     c =>
-                        $"| {Format(c.ActionDate)} | {Escape(c.AwardingAgency)} | {AwardTypeLabel(c.AwardType)} "
-                        + $"| {FormatUsd(c.Amount)} | {Format(c.EndDate)} | {Escape(c.AwardId)} "
+                        $"| {Format(c.ActionDate)} | {Escape(Shorten(c.RecipientName, 48))} | {Escape(c.AwardingAgency)} | {AwardTypeLabel(c.AwardType)} "
+                        + $"| {FormatUsd(c.Amount)} | {(c.TotalOutlays == null ? "—" : FormatUsd(c.TotalOutlays.Value))} | {Format(c.EndDate)} | {Escape(c.AwardId)} "
                         + $"| {Escape(Shorten(c.Description, 80))} |"
                 );
 
@@ -225,7 +225,10 @@ public class GovernmentContractsTools
 
         sb.AppendLine(
             "_Coverage: prime federal contract awards of $1M+ matched to listed companies; "
-                + "Total Value is obligated dollars plus unexercised option ceiling, not revenue received. "
+                + "Total Value is obligated dollars plus unexercised option ceiling, not revenue received; "
+                + "Outlays is what the government has actually disbursed so far. Recipient is the awarded "
+                + "entity as the government named it — a subsidiary's own name there is how an award reaches "
+                + "this company. "
                 + $"Latest ingested award action date: {Format(latestIngested)}._"
         );
 

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueBasis.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueBasis.cs
@@ -8,39 +8,30 @@ namespace Equibles.Holdings.HostedService.Services;
 /// </summary>
 /// <remarks>
 /// <para>
-/// A holding's <c>Value</c> is derived as shares × the period's closing price, but the two factors
-/// are quoted on different bases. The share count is <b>as filed</b>: it is whatever the issuer's
-/// shares were on the report date. The price is whatever <c>DailyStockPrice</c> holds <b>today</b>,
-/// and the split-price reconciliation deliberately rewrites a stock's whole stored history onto
-/// today's post-split basis whenever a split lands. Multiplying an as-filed count by a restated
-/// price is a units error, and it is off by exactly the split ratio: Scion's 633,959 BioAtla shares
-/// priced after that stock's 1:50 reverse split read as a $43.4M position against a filed $868,524.
-/// A forward split fails the same way in the other direction — NVDA's pre-10:1 counts against
-/// today's adjusted closes understate every 2023 position tenfold.
+/// A holding's <c>Value</c> is derived as shares × a stored period close. The share count is as
+/// filed, while the stored close has no basis metadata: Yahoo full-history reconciliation can
+/// serve either an adjusted or as-traded series. <see cref="SplitBasisResolver"/> therefore proves
+/// only the captured split factor and pending-marker state, not the close's actual basis.
 /// </para>
 /// <para>
-/// The fix is to restate the count onto the price's basis before multiplying, which is what
-/// <see cref="SplitAdjustment.ShareCountFactor"/> computes. The factor is returned rather than
-/// applied so the caller can fold it into the value product without rounding the share count to
-/// whole shares first — on a reverse split that rounding is the difference between reproducing the
-/// filed value exactly and missing it.
+/// This legacy helper returns that captured split factor so the caller can fold it into the value
+/// product without rounding the share count first. Applying it is not proof that the result matches
+/// the stored close's basis and can double-apply a split when the provider served as-traded history;
+/// the missing raw-price basis signal is tracked as a separate lane defect.
 /// </para>
 /// <para>
-/// The restatement is only valid while the stored prices really are on today's basis. Between a
-/// split being captured and its price reconciliation running, a stock's series is a mix of both
-/// bases, and adjusting the count then would double-apply the ratio. That window is reported as
-/// untrustworthy instead of guessed at: the caller leaves the row pending, and the repricing lane
-/// values it once the reconciliation has stamped the split.
+/// A pending captured split remains an explicit ambiguity: the caller leaves that row pending
+/// until reconciliation stamps the split. A completed stamp closes only that metadata window; it
+/// still does not identify the provider-served raw-price basis.
 /// </para>
 /// </remarks>
 internal static class HoldingValueBasis
 {
     /// <summary>
-    /// Resolves the factor that restates a share count reported as-of <paramref name="reportDate"/>
-    /// onto the basis the stored price series uses. Returns <c>false</c> when a split that would
-    /// move the count has not had its price adjustment applied yet, meaning the stored prices
-    /// straddle two bases and no honest value can be derived; <paramref name="shareCountFactor"/>
-    /// is then 1 and must not be used.
+    /// Resolves the captured share-count split factor since <paramref name="reportDate"/>. Returns
+    /// <c>false</c> when a relevant split is pending or cannot be attributed; this does not prove
+    /// which basis the stored raw close uses. <paramref name="shareCountFactor"/> is then 1 and
+    /// must not be used.
     /// <para>
     /// <paramref name="listedTicker"/> names the exact security being valued; null is the
     /// filer's primary (<paramref name="primaryTicker"/>). A PRIMARY position uses every split

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1167,8 +1167,17 @@ public class InstitutionalHoldingsTools
                 return $"| {rank} | {ticker} | {name} | {FormatSignedShares(r.DeltaShares)} | {FormatSignedMillions(r.DeltaValue)} |";
             }
         );
+        result.AppendLine();
+        result.AppendLine(DeltaValueCaveat);
         return result.ToString();
     }
+
+    // Δ Value is the change in reported market value, so it moves with the stock's own price on
+    // positions merely held through the quarter. Without this, the "most bought" stock reads as
+    // heavy accumulation when the share change was a rounding error and the price simply rose.
+    private const string DeltaValueCaveat =
+        "_Δ Value is the change in reported position value and includes the quarter's price move on "
+        + "held positions, not just net buying or selling — read Δ Shares for the position change itself._";
 
     private async Task<string> RenderMarketActivityChurn(
         string normalizedBucket,

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -770,7 +770,7 @@ public class InstitutionalHoldingsTools
                 // Restate each quarter's share counts onto today's split basis (the two
                 // quarters sit on different bases if a split fell between them) so Δ Shares
                 // and the Prior → New column reflect a real position change, not the split.
-                // Δ Value is a dollar figure and is split-invariant — left as reported.
+                // Δ Value is a dollar figure and is split-invariant — leave the stored value.
                 var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
                 var currentFactor = SplitAdjustment.ShareCountFactor(targetDate, splits);
                 var previousFactor = previousDate.HasValue
@@ -923,7 +923,7 @@ public class InstitutionalHoldingsTools
 
         result.AppendLine();
         result.AppendLine(
-            "_Δ Position Value is the change in reported market value and includes price movement — a seller can show a positive Δ when the stock rose during the quarter._"
+            "_Δ Position Value is the change in stored quarter-end position value and includes price movement — a seller can show a positive Δ when the stock rose during the quarter._"
         );
 
         return result.ToString();
@@ -963,7 +963,7 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Get the market-wide 13F leaderboards for a given quarter — which stocks were most bought, most sold, most initiated, or most exited across all 13F filers vs the prior quarter. The `bucket` argument selects one of: top-buys (Δ shares > 0 ranked by Δ value desc), top-sells (Δ shares < 0 ranked by Δ value asc), new-positions (stocks ranked by count of filers initiating a position), sold-out-positions (stocks ranked by count of filers exiting). Use this to answer 'what's the consensus 13F move this quarter?'"
+        "Get the market-wide 13F leaderboards for a given quarter — which stocks were most bought, most sold, most initiated, or most exited across all 13F filers vs the prior quarter. The `bucket` argument selects one of: top-buys (Δ shares > 0 ranked by Δ value desc), top-sells (Δ shares < 0 ranked by Δ value asc), new-positions (stocks ranked by count of filers initiating a position), sold-out-positions (stocks ranked by count of filers exiting). Δ Value is the change in stored quarter-end position value and includes the quarter's price move on held shares, so use Δ Shares to read the position change itself. Use this to answer 'what's the consensus 13F move this quarter?'"
     )]
     public Task<string> GetMarketWide13FActivity(
         [Description("Bucket: top-buys, top-sells, new-positions, or sold-out-positions")]
@@ -1172,11 +1172,11 @@ public class InstitutionalHoldingsTools
         return result.ToString();
     }
 
-    // Δ Value is the change in reported market value, so it moves with the stock's own price on
+    // Δ Value is the change in stored quarter-end position value, so it moves with the stock's own price on
     // positions merely held through the quarter. Without this, the "most bought" stock reads as
     // heavy accumulation when the share change was a rounding error and the price simply rose.
     private const string DeltaValueCaveat =
-        "_Δ Value is the change in reported position value and includes the quarter's price move on "
+        "_Δ Value is the change in stored quarter-end position value and includes the quarter's price move on "
         + "held positions, not just net buying or selling — read Δ Shares for the position change itself._";
 
     private async Task<string> RenderMarketActivityChurn(
@@ -1685,7 +1685,7 @@ public class InstitutionalHoldingsTools
         }
 
         result.AppendLine(
-            "_Δ Value is the change in reported market value and includes price movement, not just trading — it also drives the per-bucket ordering._"
+            "_Δ Value is the change in stored quarter-end position value and includes price movement, not just trading — it also drives the per-bucket ordering._"
         );
         return result.ToString();
     }

--- a/src/Equibles.Holdings.Repositories/Extensions/MarketWideActivityQueryExtensions.cs
+++ b/src/Equibles.Holdings.Repositories/Extensions/MarketWideActivityQueryExtensions.cs
@@ -15,42 +15,62 @@ public static class MarketWideActivityQueryExtensions
     ) =>
         source
             .Where(a => a.CurrentShares > a.PreviousShares)
-            .OrderByDescending(a => a.CurrentValue - a.PreviousValue);
+            .OrderByDescending(a => a.CurrentValue - a.PreviousValue)
+            .ThenBy(a => a.CommonStockId);
 
     public static IEnumerable<MarketWideStockActivity> TopBuyers(
         this IEnumerable<MarketWideStockActivity> source
     ) =>
         source
             .Where(a => a.CurrentShares > a.PreviousShares)
-            .OrderByDescending(a => a.CurrentValue - a.PreviousValue);
+            .OrderByDescending(a => a.CurrentValue - a.PreviousValue)
+            .ThenBy(a => a.CommonStockId);
 
     public static IQueryable<MarketWideStockActivity> TopSellers(
         this IQueryable<MarketWideStockActivity> source
     ) =>
         source
             .Where(a => a.CurrentShares < a.PreviousShares)
-            .OrderBy(a => a.CurrentValue - a.PreviousValue);
+            .OrderBy(a => a.CurrentValue - a.PreviousValue)
+            .ThenBy(a => a.CommonStockId);
 
     public static IEnumerable<MarketWideStockActivity> TopSellers(
         this IEnumerable<MarketWideStockActivity> source
     ) =>
         source
             .Where(a => a.CurrentShares < a.PreviousShares)
-            .OrderBy(a => a.CurrentValue - a.PreviousValue);
+            .OrderBy(a => a.CurrentValue - a.PreviousValue)
+            .ThenBy(a => a.CommonStockId);
 
     public static IQueryable<MarketWideStockChurn> NewPositions(
         this IQueryable<MarketWideStockChurn> source
-    ) => source.Where(c => c.NewFilerCount > 0).OrderByDescending(c => c.NewFilerCount);
+    ) =>
+        source
+            .Where(c => c.NewFilerCount > 0)
+            .OrderByDescending(c => c.NewFilerCount)
+            .ThenBy(c => c.CommonStockId);
 
     public static IEnumerable<MarketWideStockChurn> NewPositions(
         this IEnumerable<MarketWideStockChurn> source
-    ) => source.Where(c => c.NewFilerCount > 0).OrderByDescending(c => c.NewFilerCount);
+    ) =>
+        source
+            .Where(c => c.NewFilerCount > 0)
+            .OrderByDescending(c => c.NewFilerCount)
+            .ThenBy(c => c.CommonStockId);
 
     public static IQueryable<MarketWideStockChurn> SoldOutPositions(
         this IQueryable<MarketWideStockChurn> source
-    ) => source.Where(c => c.SoldOutFilerCount > 0).OrderByDescending(c => c.SoldOutFilerCount);
+    ) =>
+        source
+            .Where(c => c.SoldOutFilerCount > 0)
+            .OrderByDescending(c => c.SoldOutFilerCount)
+            .ThenBy(c => c.CommonStockId);
 
     public static IEnumerable<MarketWideStockChurn> SoldOutPositions(
         this IEnumerable<MarketWideStockChurn> source
-    ) => source.Where(c => c.SoldOutFilerCount > 0).OrderByDescending(c => c.SoldOutFilerCount);
+    ) =>
+        source
+            .Where(c => c.SoldOutFilerCount > 0)
+            .OrderByDescending(c => c.SoldOutFilerCount)
+            .ThenBy(c => c.CommonStockId);
 }

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderDailyBars.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderDailyBars.cs
@@ -6,9 +6,9 @@ namespace Equibles.InsiderTrading.BusinessLogic;
 
 /// <summary>
 /// Builds the <see cref="DailyBarContext"/> a price evaluation runs against: the stored bar
-/// plus the split factor between the transaction date and the series' present basis. One
-/// implementation for all three persisting call sites (ingest, backfill, reprocess) so they
-/// can never disagree on the basis rules.
+/// plus the captured split factor since the transaction date. The factor does not prove the
+/// provider-served raw bar's basis. One implementation serves all three persisting call sites
+/// (ingest, backfill, reprocess) so they use the same attribution and pending-marker rules.
 /// </summary>
 public static class InsiderDailyBars
 {

--- a/src/Equibles.InsiderTrading.BusinessLogic/Models/DailyBarContext.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Models/DailyBarContext.cs
@@ -5,12 +5,10 @@ namespace Equibles.InsiderTrading.BusinessLogic.Models;
 /// linking the two.
 /// </summary>
 /// <remarks>
-/// The stored series is rewritten onto TODAY'S post-split basis by the split reconciliation,
-/// while the filer's price is quoted on the TRANSACTION DATE's basis. The two differ by
-/// <see cref="SplitFactorToPresent"/>: <c>Close × SplitFactorToPresent</c> is the close
-/// restated onto the as-filed basis. Validation must accept a price plausible on EITHER basis
-/// — treating the stored close as unadjusted once "repaired" 15,822 correct pre-split prices
-/// into nonsense (AMZN's pre-20:1 $3,300.24 became $8.42).
+/// The stored raw series has no basis metadata, while the filer's price is quoted on the
+/// transaction-date basis. <see cref="SplitFactorToPresent"/> is the captured split product, not
+/// proof of the stored close's basis. Validation treats <c>Close × SplitFactorToPresent</c> as an
+/// alternate comparison candidate; the missing raw-price basis signal is a separate lane defect.
 /// </remarks>
 public class DailyBarContext
 {
@@ -24,16 +22,14 @@ public class DailyBarContext
     public decimal? High { get; set; }
 
     /// <summary>
-    /// Product of the split ratios between the transaction date and the stored series' present
-    /// basis; 1 when no split intervened. Multiplying a stored figure by this lands it on the
-    /// as-filed basis.
+    /// Product of captured split ratios since the transaction date; 1 when none intervened. It
+    /// does not establish the stored raw bar's basis.
     /// </summary>
     public decimal SplitFactorToPresent { get; set; } = 1m;
 
     /// <summary>
-    /// True when the factor could not be established (a captured split's price adjustment has
-    /// not run yet, or a split's series attribution is unknown) — the stored series straddles
-    /// two bases and no honest verdict exists, so evaluation stays pending.
+    /// True when the factor could not be established (a captured split's reconciliation has not
+    /// run yet, or a split's series attribution is unknown), so evaluation stays pending.
     /// </summary>
     public bool SplitBasisAmbiguous { get; set; }
 }

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -377,7 +377,7 @@ public class InsiderTradingTools
         ReadOnly = true
     )]
     [Description(
-        "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the proposed sale as a share of shares outstanding, the approximate sale date, and the broker. Results are the most recent notices first and a note flags when more exist than were returned; use fromDate/toDate to scope a period (heavy 10b5-1 filers can flood the recency window with small daily notices). Use this to anticipate upcoming insider selling before it shows up as an executed Form 4."
+        "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the proposed sale as a share of shares outstanding, the approximate sale date, the broker, and the filer's remarks (including any stated 10b5-1 plan). Results are the most recent notices first and a note flags when more exist than were returned; use fromDate/toDate to scope a period (heavy 10b5-1 filers can flood the recency window with small daily notices). Use this to anticipate upcoming insider selling before it shows up as an executed Form 4."
     )]
     public Task<string> GetProposedSales(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -449,9 +449,9 @@ public class InsiderTradingTools
                             f.ApproxSaleDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
                             ?? "-";
                         // Remarks is where a filer states the sale runs under a 10b5-1 plan, which
-                        // is the difference between pre-scheduled and discretionary selling. Kept
-                        // verbatim (clipped for width) — never re-worded into a plan/no-plan flag.
-                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {FormatPercentOfOutstanding(f.SharesToBeSold, f.SharesOutstanding)} | {approxSaleDate} | {f.BrokerName} | {ClipRemarks(f.Remarks)} |";
+                        // is the difference between pre-scheduled and discretionary selling. Keep
+                        // the complete filed text — a plan disclosure can occur at the end.
+                        return $"| {f.FilingDate:yyyy-MM-dd} | {MarkdownTable.EscapeCell(f.SellerName, "-")} | {MarkdownTable.EscapeCell(f.RelationshipToIssuer, "-")} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {FormatPercentOfOutstanding(f.SharesToBeSold, f.SharesOutstanding)} | {approxSaleDate} | {MarkdownTable.EscapeCell(f.BrokerName, "-")} | {MarkdownTable.EscapeCell(f.Remarks, "-")} |";
                     }
                 );
 
@@ -467,21 +467,6 @@ public class InsiderTradingTools
             "GetProposedSales",
             $"ticker: {ticker}"
         );
-    }
-
-    // Form 144 remarks are free text and occasionally run to a paragraph; the pipe would break the
-    // table row and the full prose is not worth a table cell, so it renders on one clipped line.
-    private const int MaxRemarksLength = 90;
-
-    private static string ClipRemarks(string remarks)
-    {
-        if (string.IsNullOrWhiteSpace(remarks))
-            return "-";
-
-        var flattened = remarks.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ").Trim();
-        return flattened.Length <= MaxRemarksLength
-            ? flattened
-            : flattened[..MaxRemarksLength] + "…";
     }
 
     // The standard Form 144 materiality signal: the proposed sale as a share of the notice's own

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -437,8 +437,8 @@ public class InsiderTradingTools
                 var result = MarkdownTable.Start(
                     $"Recent proposed sales (Form 144) for {stock.Name} ({stock.Ticker}):",
                     $"Showing {filings.Count} of {totalCount} most recent notices",
-                    "| Filed | Seller | Relationship | Shares | Market Value | % Outstanding | Approx. Sale Date | Broker |",
-                    "|-------|--------|--------------|--------|--------------|---------------|-------------------|--------|"
+                    "| Filed | Seller | Relationship | Shares | Market Value | % Outstanding | Approx. Sale Date | Broker | Remarks |",
+                    "|-------|--------|--------------|--------|--------------|---------------|-------------------|--------|---------|"
                 );
 
                 result.AppendRows(
@@ -448,7 +448,10 @@ public class InsiderTradingTools
                         var approxSaleDate =
                             f.ApproxSaleDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
                             ?? "-";
-                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {FormatPercentOfOutstanding(f.SharesToBeSold, f.SharesOutstanding)} | {approxSaleDate} | {f.BrokerName} |";
+                        // Remarks is where a filer states the sale runs under a 10b5-1 plan, which
+                        // is the difference between pre-scheduled and discretionary selling. Kept
+                        // verbatim (clipped for width) — never re-worded into a plan/no-plan flag.
+                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {FormatPercentOfOutstanding(f.SharesToBeSold, f.SharesOutstanding)} | {approxSaleDate} | {f.BrokerName} | {ClipRemarks(f.Remarks)} |";
                     }
                 );
 
@@ -464,6 +467,21 @@ public class InsiderTradingTools
             "GetProposedSales",
             $"ticker: {ticker}"
         );
+    }
+
+    // Form 144 remarks are free text and occasionally run to a paragraph; the pipe would break the
+    // table row and the full prose is not worth a table cell, so it renders on one clipped line.
+    private const int MaxRemarksLength = 90;
+
+    private static string ClipRemarks(string remarks)
+    {
+        if (string.IsNullOrWhiteSpace(remarks))
+            return "-";
+
+        var flattened = remarks.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ").Trim();
+        return flattened.Length <= MaxRemarksLength
+            ? flattened
+            : flattened[..MaxRemarksLength] + "…";
     }
 
     // The standard Form 144 materiality signal: the proposed sale as a share of the notice's own

--- a/src/Equibles.Mcp/Helpers/MarkdownTable.cs
+++ b/src/Equibles.Mcp/Helpers/MarkdownTable.cs
@@ -4,6 +4,21 @@ namespace Equibles.Mcp.Helpers;
 
 public static class MarkdownTable
 {
+    // A literal backslash immediately before an escaped pipe can reactivate the pipe under
+    // CommonMark's backslash rules. Double backslashes first, then escape pipes, so every pipe
+    // remains preceded by an odd-length escape run and cannot become a table delimiter.
+    public static string EscapeCell(string value, string emptyValue = "")
+    {
+        if (string.IsNullOrEmpty(value))
+            return emptyValue;
+
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("|", "\\|")
+            .Replace("\r", " ")
+            .Replace("\n", " ");
+    }
+
     public static StringBuilder Start(string title, string headerRow, string separatorRow)
     {
         var sb = new StringBuilder();

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactMarkdown.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactMarkdown.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Equibles.Mcp.Helpers;
 
 namespace Equibles.Sec.FinancialFacts.Mcp.Helpers;
 
@@ -13,8 +14,7 @@ public static class FactMarkdown
     /// Escapes the Markdown table delimiters so a value containing '|' or a
     /// newline (e.g. some ADR/fund names) can't break the table the LLM reads.
     /// </summary>
-    public static string Cell(string value) =>
-        value == null ? "" : value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
+    public static string Cell(string value) => MarkdownTable.EscapeCell(value);
 
     /// <summary>
     /// Strips control chars from untrusted args before they reach logs / the

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -82,7 +83,9 @@ public class RevenueBreakdownTools
     )]
     [Description(
         "Get a company's revenue disaggregated by business segment, geography and "
-            + "product/service, from the dimensional XBRL facts the issuer tags in its own "
+            + "product/service — plus operating income by segment when the issuer tags it, so "
+            + "segment profitability and margins are answerable — from the dimensional XBRL "
+            + "facts the issuer tags in its own "
             + "filings. Annual fiscal years only, latest restated values, one table per axis "
             + "the company reports; values are as-reported and never estimated. Rows within "
             + "one table can OVERLAP when the issuer tags several granularities on the same "
@@ -247,10 +250,106 @@ public class RevenueBreakdownTools
                     totals,
                     displayTotals
                 );
+                await AppendSegmentOperatingIncome(result, stock, years);
                 return result.ToString();
             },
             "GetRevenueBreakdown",
             $"ticker: {FactMarkdown.Clean(ticker)}"
+        );
+    }
+
+    // The profitability view of the segment cut: operating income tagged on the same
+    // business-segment axis. Unallocated corporate costs mean segments rarely add up to
+    // consolidated operating income, so this axis is rendered on its own reconciliation
+    // (its own consolidated totals) and never mixed into the revenue tables above.
+    private async Task AppendSegmentOperatingIncome(
+        StringBuilder result,
+        CommonStock stock,
+        int years
+    )
+    {
+        if (!FinancialConceptAliases.TryResolve("operating-income", out var conceptRefs))
+            return;
+
+        var taxonomies = conceptRefs.Select(r => r.Taxonomy).Distinct().ToList();
+        var tags = conceptRefs.Select(r => r.Tag).ToList();
+        var conceptIds = await _financialConceptRepository
+            .GetMatching(taxonomies, tags)
+            .Select(c => c.Id)
+            .ToListAsync();
+        if (conceptIds.Count == 0)
+            return;
+
+        var rows = await _financialFactRepository
+            .GetByStock(stock)
+            .Where(f =>
+                conceptIds.Contains(f.FinancialConceptId)
+                && f.PeriodType == FactPeriodType.Duration
+                && f.PeriodStart.AddDays(MinAnnualSpanDays) <= f.PeriodEnd
+                && f.DimensionsKey != ""
+                && f.Dimensions.Count(d => SegmentAxes.Contains(d.Axis)) == 1
+                && f.Dimensions.All(d =>
+                    SegmentAxes.Contains(d.Axis)
+                    || (d.Axis == ConsolidationItemsAxis && d.Member == OperatingSegmentsMember)
+                )
+            )
+            .Select(f => new DimensionalRevenueRow(
+                f.Dimensions.First(d => SegmentAxes.Contains(d.Axis)).Axis,
+                f.Dimensions.First(d => SegmentAxes.Contains(d.Axis)).Member,
+                f.PeriodEnd,
+                f.Value,
+                f.Unit,
+                f.FiledDate
+            ))
+            .ToListAsync();
+        if (rows.Count == 0)
+            return;
+
+        var consolidated = await _financialFactRepository
+            .GetConsolidatedByStock(stock)
+            .Where(f =>
+                conceptIds.Contains(f.FinancialConceptId)
+                && f.PeriodType == FactPeriodType.Duration
+                && f.PeriodStart.AddDays(MinAnnualSpanDays) <= f.PeriodEnd
+            )
+            .Select(f => new
+            {
+                f.PeriodEnd,
+                f.Unit,
+                f.FinancialConceptId,
+                f.Value,
+                f.FiledDate,
+            })
+            .ToListAsync();
+
+        var totals = consolidated
+            .GroupBy(f => (f.PeriodEnd, f.Unit))
+            .ToDictionary(
+                g => g.Key,
+                g =>
+                    (IReadOnlyList<decimal>)
+                        g.GroupBy(f => f.FinancialConceptId)
+                            .Select(c => c.OrderByDescending(f => f.FiledDate).First().Value)
+                            .ToList()
+            );
+        var displayTotals = consolidated
+            .GroupBy(f => (f.PeriodEnd, f.Unit))
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(f => f.FiledDate).First().Value);
+
+        AppendAxis(
+            result,
+            "Segment operating income",
+            rows,
+            SegmentAxes,
+            years,
+            totals,
+            displayTotals
+        );
+        result.AppendLine(
+            "_Segment operating income is tagged on the same business-segment axis as the revenue "
+                + "cut above; unallocated corporate costs mean the members need not add up to "
+                + "consolidated operating income. Divide a member here by the same member and "
+                + "period in the segment revenue table for that segment's operating margin._"
         );
     }
 

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -87,7 +87,9 @@ public class RevenueBreakdownTools
             + "segment profitability and margins are answerable — from the dimensional XBRL "
             + "facts the issuer tags in its own "
             + "filings. Annual fiscal years only, latest restated values, one table per axis "
-            + "the company reports; values are as-reported and never estimated. Rows within "
+            + "the company reports; source values are as-reported and never estimated, while "
+            + "segment operating margin is derived as operating income divided by revenue for "
+            + "the same folded raw member QName and exact period. Rows within "
             + "one table can OVERLAP when the issuer tags several granularities on the same "
             + "axis (a parent segment alongside its components), so never sum rows to derive "
             + "total revenue — use the consolidated total row each table carries. For "
@@ -109,8 +111,10 @@ public class RevenueBreakdownTools
                 if (stockError != null)
                     return stockError;
 
-                if (!FinancialConceptAliases.TryResolve("revenue", out var conceptRefs))
-                    return "No revenue concepts are configured.";
+                // Load the revenue and segment-income families independently. A fresh or
+                // restricted corpus can contain valid OperatingIncomeLoss segment facts before
+                // any revenue-alias concept row exists; that must not suppress the income table.
+                FinancialConceptAliases.TryResolve("revenue", out var conceptRefs);
 
                 var taxonomies = conceptRefs.Select(r => r.Taxonomy).Distinct().ToList();
                 var tags = conceptRefs.Select(r => r.Tag).ToList();
@@ -133,8 +137,6 @@ public class RevenueBreakdownTools
                     .Where(c => priorityByPair.ContainsKey((c.Taxonomy, c.Tag)))
                     .ToDictionary(c => c.Id, c => priorityByPair[(c.Taxonomy, c.Tag)]);
                 var conceptIds = priorityById.Keys.ToList();
-                if (conceptIds.Count == 0)
-                    return $"No revenue data has been ingested for {stock.Ticker}.";
 
                 // Annual revenue facts carrying exactly one dimension on a known axis.
                 // Cross-cut facts (e.g. segment × geography) are excluded — including
@@ -163,13 +165,10 @@ public class RevenueBreakdownTools
                         f.PeriodEnd,
                         f.Value,
                         f.Unit,
-                        f.FiledDate
+                        f.FiledDate,
+                        f.PeriodStart
                     ))
                     .ToListAsync();
-
-                if (rows.Count == 0)
-                    return $"{stock.Ticker} has no dimensional revenue tagging on record — "
-                        + "the issuer reports revenue as a consolidated total only.";
 
                 // Consolidated (no-dimension) total revenue — the figure each axis's members
                 // must add up to, used to detect a complete re-disaggregation so a member a
@@ -226,31 +225,60 @@ public class RevenueBreakdownTools
                     $"Revenue breakdown for {stock.Ticker} ({FactMarkdown.Cell(stock.Name)}) — "
                         + "annual fiscal years, latest restated values:"
                 );
-                result.AppendLine(
-                    "_Components are shown exactly as the issuer tags them: a renamed member "
-                        + "appears as a new row, so '—' gaps can reflect renames or "
-                        + "reclassifications rather than zero revenue._"
-                );
-                AppendAxis(result, "By segment", rows, SegmentAxes, years, totals, displayTotals);
-                AppendAxis(
+                if (rows.Count == 0)
+                {
+                    result.AppendLine(
+                        "_No dimensional revenue tagging is on record; segment profitability "
+                            + "below is shown only when the issuer separately tags it._"
+                    );
+                }
+                else
+                {
+                    result.AppendLine(
+                        "_Components are shown exactly as the issuer tags them: a renamed member "
+                            + "appears as a new row, so '—' gaps can reflect renames or "
+                            + "reclassifications rather than zero revenue._"
+                    );
+                    AppendAxis(
+                        result,
+                        "By segment",
+                        rows,
+                        SegmentAxes,
+                        years,
+                        totals,
+                        displayTotals
+                    );
+                    AppendAxis(
+                        result,
+                        "By geography",
+                        rows,
+                        GeographyAxes,
+                        years,
+                        totals,
+                        displayTotals
+                    );
+                    AppendAxis(
+                        result,
+                        "By product & service",
+                        rows,
+                        ProductAxes,
+                        years,
+                        totals,
+                        displayTotals
+                    );
+                }
+
+                var hasSegmentOperatingIncome = await AppendSegmentOperatingIncome(
                     result,
-                    "By geography",
-                    rows,
-                    GeographyAxes,
+                    stock,
                     years,
-                    totals,
-                    displayTotals
-                );
-                AppendAxis(
-                    result,
-                    "By product & service",
                     rows,
-                    ProductAxes,
-                    years,
-                    totals,
-                    displayTotals
+                    totals
                 );
-                await AppendSegmentOperatingIncome(result, stock, years);
+                if (rows.Count == 0 && !hasSegmentOperatingIncome)
+                    return $"{stock.Ticker} has no dimensional revenue or segment operating "
+                        + "income tagging on record.";
+
                 return result.ToString();
             },
             "GetRevenueBreakdown",
@@ -262,14 +290,16 @@ public class RevenueBreakdownTools
     // business-segment axis. Unallocated corporate costs mean segments rarely add up to
     // consolidated operating income, so this axis is rendered on its own reconciliation
     // (its own consolidated totals) and never mixed into the revenue tables above.
-    private async Task AppendSegmentOperatingIncome(
+    private async Task<bool> AppendSegmentOperatingIncome(
         StringBuilder result,
         CommonStock stock,
-        int years
+        int years,
+        List<DimensionalRevenueRow> revenueRows,
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> revenueTotals
     )
     {
         if (!FinancialConceptAliases.TryResolve("operating-income", out var conceptRefs))
-            return;
+            return false;
 
         var taxonomies = conceptRefs.Select(r => r.Taxonomy).Distinct().ToList();
         var tags = conceptRefs.Select(r => r.Tag).ToList();
@@ -278,7 +308,7 @@ public class RevenueBreakdownTools
             .Select(c => c.Id)
             .ToListAsync();
         if (conceptIds.Count == 0)
-            return;
+            return false;
 
         var rows = await _financialFactRepository
             .GetByStock(stock)
@@ -299,11 +329,12 @@ public class RevenueBreakdownTools
                 f.PeriodEnd,
                 f.Value,
                 f.Unit,
-                f.FiledDate
+                f.FiledDate,
+                f.PeriodStart
             ))
             .ToListAsync();
         if (rows.Count == 0)
-            return;
+            return false;
 
         var consolidated = await _financialFactRepository
             .GetConsolidatedByStock(stock)
@@ -336,6 +367,10 @@ public class RevenueBreakdownTools
             .GroupBy(f => (f.PeriodEnd, f.Unit))
             .ToDictionary(g => g.Key, g => g.OrderByDescending(f => f.FiledDate).First().Value);
 
+        var incomeSeries = BuildAxisSeries(rows, SegmentAxes, years, totals);
+        if (incomeSeries.Members.Count == 0)
+            return false;
+
         AppendAxis(
             result,
             "Segment operating income",
@@ -349,10 +384,23 @@ public class RevenueBreakdownTools
         );
         result.AppendLine(
             "_Segment operating income is tagged on the same business-segment axis as the revenue "
-                + "cut above; unallocated corporate costs mean the members need not add up to "
-                + "consolidated operating income. Divide a member here by the same member and "
-                + "period in the segment revenue table for that segment's operating margin._"
+                + "facts; unallocated corporate costs mean the members need not add up to "
+                + "consolidated operating income._"
         );
+
+        var revenueSeries = BuildAxisSeries(revenueRows, SegmentAxes, years, revenueTotals);
+        var marginSeries = BuildSegmentMarginSeries(revenueSeries, incomeSeries);
+        if (marginSeries.Members.Count > 0)
+        {
+            AppendSeriesTable(result, "Segment operating margin", marginSeries);
+            result.AppendLine(
+                "_Derived as segment operating income ÷ revenue × 100 only where the same folded "
+                    + "raw member QName and exact period match and revenue is positive; missing cells "
+                    + "are not estimated._"
+            );
+        }
+
+        return true;
     }
 
     // How far above the consolidated total a period's member sum must land before the
@@ -378,32 +426,12 @@ public class RevenueBreakdownTools
         bool checkOverlap = true
     )
     {
-        var (unit, periodEnds, members) = BuildAxisSeries(
-            rows,
-            axes,
-            maxYears,
-            totals,
-            reconcilesToTotal: checkOverlap
-        );
-        if (members.Count == 0)
+        var series = BuildAxisSeries(rows, axes, maxYears, totals);
+        if (series.Members.Count == 0)
             return;
 
-        result.AppendLine();
-        result.AppendLine($"**{title}** ({FactMarkdown.Cell(unit)}):");
-        result.AppendLine();
-        result.AppendLine(
-            "| Component | " + string.Join(" | ", periodEnds.Select(p => $"{p:yyyy-MM-dd}")) + " |"
-        );
-        result.AppendLine("|-----------|" + string.Concat(periodEnds.Select(_ => "---:|")));
-        foreach (var member in members)
-        {
-            var cells = member.Values.Select(v =>
-                v.HasValue ? FactMarkdown.Value(v.Value, unit) : "—"
-            );
-            result.AppendLine(
-                $"| {FactMarkdown.Cell(member.Label)} | " + string.Join(" | ", cells) + " |"
-            );
-        }
+        AppendSeriesTable(result, title, series);
+        var (unit, periodEnds, members) = series;
 
         // The consolidated figure the members must be read against — lets a
         // consumer compute revenue shares and spot overlapping rows without a
@@ -455,6 +483,28 @@ public class RevenueBreakdownTools
             );
     }
 
+    private static void AppendSeriesTable(StringBuilder result, string title, AxisSeries series)
+    {
+        result.AppendLine();
+        result.AppendLine($"**{title}** ({FactMarkdown.Cell(series.Unit)}):");
+        result.AppendLine();
+        result.AppendLine(
+            "| Component | "
+                + string.Join(" | ", series.PeriodEnds.Select(p => $"{p:yyyy-MM-dd}"))
+                + " |"
+        );
+        result.AppendLine("|-----------|" + string.Concat(series.PeriodEnds.Select(_ => "---:|")));
+        foreach (var member in series.Members)
+        {
+            var cells = member.Values.Select(v =>
+                v.HasValue ? FactMarkdown.Value(v.Value, series.Unit) : "—"
+            );
+            result.AppendLine(
+                $"| {FactMarkdown.Cell(member.Label)} | " + string.Join(" | ", cells) + " |"
+            );
+        }
+    }
+
     // Resolve the surviving (member, period) facts for one axis, one row per cell — all in a
     // single pinned unit. The default rule keeps the latest-filed fact per (member, period) —
     // correct for a restatement that re-reports a member with a new value. It is wrong when a
@@ -468,29 +518,6 @@ public class RevenueBreakdownTools
     // from older filings. Otherwise the latest filing only restated some members (a partial
     // amendment), so fall back to the latest-filed-per-member merge that carries un-amended
     // members forward.
-    // Completeness for an axis that cannot be reconciled arithmetically: the newest filing that
-    // reported the period defines which members still exist. A member absent from that filing was
-    // dropped by the issuer (a discontinued or renamed segment) and must not be carried forward
-    // from an older filing — the same defect ReconcileToTotal exists to prevent on the revenue
-    // axes, where the sum-to-total test can actually fire.
-    private static List<DimensionalRevenueRow> NewestRosterWins(
-        IEnumerable<DimensionalRevenueRow> axisRowsInUnit
-    )
-    {
-        var result = new List<DimensionalRevenueRow>();
-        foreach (var period in axisRowsInUnit.GroupBy(r => r.PeriodEnd))
-        {
-            var latestFiled = period.Max(r => r.FiledDate);
-            result.AddRange(
-                period
-                    .Where(r => r.FiledDate == latestFiled)
-                    .GroupBy(r => r.Member)
-                    .Select(g => g.First())
-            );
-        }
-        return result;
-    }
-
     private static List<DimensionalRevenueRow> ReconcileToTotal(
         IEnumerable<DimensionalRevenueRow> axisRowsInUnit,
         string unit,
@@ -770,42 +797,32 @@ public class RevenueBreakdownTools
         return (best ?? [], best != null);
     }
 
-    // Pivot one axis's rows into period-end columns (oldest first) × member rows. Filings
+    // Pivot one axis's rows into period-end columns (oldest first) × member rows. Each cell also
+    // retains its exact duration start so a downstream ratio cannot join same-end/different-span
+    // facts. Filings
     // re-report comparative prior years, so the latest-filed fact wins per (member,
     // period-end); the axis is pinned to the latest-filed fact's unit so a reporting-
     // currency change can't mix currencies in one series. ReconcileToTotal then runs on the
     // single-unit rows — when a later filing completely re-disaggregates a period, members it
     // dropped must not linger from an older filing.
-    internal static (
-        string Unit,
-        List<DateOnly> PeriodEnds,
-        List<(string Label, List<decimal?> Values)> Members
-    ) BuildAxisSeries(
+    internal static AxisSeries BuildAxisSeries(
         List<DimensionalRevenueRow> rows,
         string[] axes,
         int maxYears,
-        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals,
-        // Segment operating income does not reconcile to a consolidated total by construction —
-        // unallocated corporate costs sit outside the segments — so the arithmetic completeness
-        // test can never pass there and would silently degrade to the carry-forward merge that
-        // lets a discontinued segment linger forever. Those axes use the newest filing's member
-        // roster as authoritative instead.
-        bool reconcilesToTotal = true
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
     )
     {
         var axisRows = rows.Where(r => axes.Contains(r.Axis)).ToList();
         if (axisRows.Count == 0)
-            return (null, [], []);
+            return new AxisSeries(null, [], []);
 
         // Pin the unit first (latest-filed fact's unit) so the reconciliation sum and the
         // consolidated total are always in the same currency.
         var unit = axisRows.OrderByDescending(r => r.FiledDate).First().Unit;
         var inUnit = axisRows.Where(r => r.Unit == unit);
-        var current = reconcilesToTotal
-            ? ReconcileToTotal(inUnit, unit, totals)
-            : NewestRosterWins(inUnit);
+        var current = ReconcileToTotal(inUnit, unit, totals);
         if (current.Count == 0)
-            return (null, [], []);
+            return new AxisSeries(null, [], []);
 
         var periodEnds = current
             .Select(r => r.PeriodEnd)
@@ -816,24 +833,134 @@ public class RevenueBreakdownTools
             .ToList();
 
         var latest = periodEnds[^1];
+        // Fold before pivoting, not only when revenue and income are joined. An issuer can respell
+        // one member across filings (amd:DatacenterMember / amd:DataCenterMember); exact grouping
+        // would produce two half-series and make one side of a later margin join disappear. The
+        // latest-filed spelling fronts the merged series, and the latest-filed fact wins when two
+        // spellings survive for the same period.
         var members = current
-            .GroupBy(r => r.Member)
-            .Select(g => new { g.Key, ByPeriod = g.ToDictionary(r => r.PeriodEnd, r => r.Value) })
+            .GroupBy(r => FoldMemberQName(r.Member), StringComparer.Ordinal)
+            .Select(g => new
+            {
+                Key = g.OrderByDescending(r => r.FiledDate)
+                    .ThenByDescending(r => r.PeriodEnd)
+                    .First()
+                    .Member,
+                ByPeriod = g.GroupBy(r => r.PeriodEnd)
+                    .ToDictionary(
+                        pg => pg.Key,
+                        pg => pg.OrderByDescending(r => r.FiledDate).First()
+                    ),
+            })
             .Select(m => new
             {
                 m.Key,
-                Latest = m.ByPeriod.TryGetValue(latest, out var v) ? v : (decimal?)null,
+                Latest = m.ByPeriod.TryGetValue(latest, out var latestRow)
+                    ? latestRow.Value
+                    : (decimal?)null,
                 Values = periodEnds
-                    .Select(p => m.ByPeriod.TryGetValue(p, out var pv) ? pv : (decimal?)null)
+                    .Select(p =>
+                        m.ByPeriod.TryGetValue(p, out var row) ? row.Value : (decimal?)null
+                    )
+                    .ToList(),
+                PeriodStarts = periodEnds
+                    .Select(p =>
+                        m.ByPeriod.TryGetValue(p, out var row) ? row.PeriodStart : (DateOnly?)null
+                    )
                     .ToList(),
             })
             .Where(m => m.Values.Any(v => v.HasValue))
             .OrderByDescending(m => m.Latest ?? decimal.MinValue)
             .ThenBy(m => m.Key)
-            .Select(m => (Humanize(m.Key), m.Values))
+            .Select(m => new AxisMemberSeries(m.Key, Humanize(m.Key), m.Values, m.PeriodStarts))
             .ToList();
-        return (unit, periodEnds, members);
+        return new AxisSeries(unit, periodEnds, members);
     }
+
+    // REST parity for the derived margin axis: join the two independently selected axes by
+    // issuer member QName, exact duration, and unit, never by display label or row position. The fold is
+    // the corpus-backed XBRL identifier rule shared by the REST provider (case and underscores
+    // drift across filings); it retains the namespace prefix, so equal-looking labels from two
+    // different members cannot be combined.
+    internal static AxisSeries BuildSegmentMarginSeries(AxisSeries revenue, AxisSeries income)
+    {
+        if (
+            revenue.Members.Count == 0
+            || income.Members.Count == 0
+            || !string.Equals(revenue.Unit, income.Unit, StringComparison.Ordinal)
+        )
+            return new AxisSeries("%", [], []);
+
+        var incomeByMember = income
+            .Members.GroupBy(m => FoldMemberQName(m.Member), StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+        var incomePeriodIndex = income
+            .PeriodEnds.Select((periodEnd, index) => (periodEnd, index))
+            .ToDictionary(p => p.periodEnd, p => p.index);
+
+        var members = new List<AxisMemberSeries>();
+        var usedPeriods = new bool[revenue.PeriodEnds.Count];
+        foreach (var revenueMember in revenue.Members)
+        {
+            if (
+                !incomeByMember.TryGetValue(
+                    FoldMemberQName(revenueMember.Member),
+                    out var incomeMember
+                )
+            )
+                continue;
+
+            var values = new List<decimal?>();
+            var any = false;
+            for (var i = 0; i < revenue.PeriodEnds.Count; i++)
+            {
+                decimal? margin = null;
+                if (
+                    incomePeriodIndex.TryGetValue(revenue.PeriodEnds[i], out var incomeIndex)
+                    && revenueMember.PeriodStartAt(i) == incomeMember.PeriodStartAt(incomeIndex)
+                    && revenueMember.Values[i] is { } revenueValue
+                    && revenueValue > 0m
+                    && incomeMember.Values[incomeIndex] is { } incomeValue
+                )
+                {
+                    margin = incomeValue / revenueValue * 100m;
+                    any = true;
+                    usedPeriods[i] = true;
+                }
+                values.Add(margin);
+            }
+
+            if (any)
+            {
+                members.Add(
+                    new AxisMemberSeries(revenueMember.Member, revenueMember.Label, values)
+                );
+            }
+        }
+
+        if (members.Count == 0)
+            return new AxisSeries("%", [], []);
+
+        var keptIndexes = Enumerable
+            .Range(0, revenue.PeriodEnds.Count)
+            .Where(i => usedPeriods[i])
+            .ToList();
+        return new AxisSeries(
+            "%",
+            keptIndexes.Select(i => revenue.PeriodEnds[i]).ToList(),
+            members
+                .Select(m => new AxisMemberSeries(
+                    m.Member,
+                    m.Label,
+                    keptIndexes.Select(i => m.Values[i]).ToList(),
+                    keptIndexes.Select(i => m.PeriodStartAt(i)).ToList()
+                ))
+                .ToList()
+        );
+    }
+
+    private static string FoldMemberQName(string member) =>
+        member?.Replace("_", "").ToLowerInvariant();
 
     // Display label from the XBRL member QName: ISO country members get their English
     // name; everything else drops the Member suffix and spaces the PascalCase local name.
@@ -873,6 +1000,24 @@ public class RevenueBreakdownTools
         DateOnly PeriodEnd,
         decimal Value,
         string Unit,
-        DateOnly FiledDate
+        DateOnly FiledDate,
+        DateOnly? PeriodStart = null
+    );
+
+    internal sealed record AxisMemberSeries(
+        string Member,
+        string Label,
+        List<decimal?> Values,
+        List<DateOnly?> PeriodStarts = null
+    )
+    {
+        internal DateOnly? PeriodStartAt(int index) =>
+            PeriodStarts != null && index < PeriodStarts.Count ? PeriodStarts[index] : null;
+    }
+
+    internal sealed record AxisSeries(
+        string Unit,
+        List<DateOnly> PeriodEnds,
+        List<AxisMemberSeries> Members
     );
 }

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -343,7 +343,9 @@ public class RevenueBreakdownTools
             SegmentAxes,
             years,
             totals,
-            displayTotals
+            displayTotals,
+            totalLabel: "Total operating income (consolidated)",
+            checkOverlap: false
         );
         result.AppendLine(
             "_Segment operating income is tagged on the same business-segment axis as the revenue "
@@ -366,10 +368,23 @@ public class RevenueBreakdownTools
         string[] axes,
         int maxYears,
         IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals,
-        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), decimal> displayTotals
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), decimal> displayTotals,
+        // The total row is labelled per axis: printing an operating-income total under
+        // "Total revenue" would answer a revenue question with a profit figure.
+        string totalLabel = "Total revenue (consolidated)",
+        // The overlap warning below is a REVENUE rule — members that must add up to the
+        // consolidated total. Segment operating income is not expected to add up (unallocated
+        // corporate costs), so running it there fabricates a claim about the issuer's tagging.
+        bool checkOverlap = true
     )
     {
-        var (unit, periodEnds, members) = BuildAxisSeries(rows, axes, maxYears, totals);
+        var (unit, periodEnds, members) = BuildAxisSeries(
+            rows,
+            axes,
+            maxYears,
+            totals,
+            reconcilesToTotal: checkOverlap
+        );
         if (members.Count == 0)
             return;
 
@@ -401,9 +416,7 @@ public class RevenueBreakdownTools
             )
             .ToList();
         if (totalCells.Any(c => c != "—"))
-            result.AppendLine(
-                "| **Total revenue (consolidated)** | " + string.Join(" | ", totalCells) + " |"
-            );
+            result.AppendLine($"| **{totalLabel}** | " + string.Join(" | ", totalCells) + " |");
 
         // An issuer can tag a parent level alongside its components on the same
         // axis (AAPL's Product/Service next to iPhone/Mac/iPad; NVDA's Data
@@ -412,7 +425,7 @@ public class RevenueBreakdownTools
         // column sums to well over consolidated revenue — say so rather than
         // let a consumer double-count.
         var overlaps = false;
-        for (var i = 0; i < periodEnds.Count && !overlaps; i++)
+        for (var i = 0; i < periodEnds.Count && !overlaps && checkOverlap; i++)
         {
             if (!displayTotals.TryGetValue((periodEnds[i], unit), out var total) || total == 0m)
                 continue;
@@ -455,6 +468,29 @@ public class RevenueBreakdownTools
     // from older filings. Otherwise the latest filing only restated some members (a partial
     // amendment), so fall back to the latest-filed-per-member merge that carries un-amended
     // members forward.
+    // Completeness for an axis that cannot be reconciled arithmetically: the newest filing that
+    // reported the period defines which members still exist. A member absent from that filing was
+    // dropped by the issuer (a discontinued or renamed segment) and must not be carried forward
+    // from an older filing — the same defect ReconcileToTotal exists to prevent on the revenue
+    // axes, where the sum-to-total test can actually fire.
+    private static List<DimensionalRevenueRow> NewestRosterWins(
+        IEnumerable<DimensionalRevenueRow> axisRowsInUnit
+    )
+    {
+        var result = new List<DimensionalRevenueRow>();
+        foreach (var period in axisRowsInUnit.GroupBy(r => r.PeriodEnd))
+        {
+            var latestFiled = period.Max(r => r.FiledDate);
+            result.AddRange(
+                period
+                    .Where(r => r.FiledDate == latestFiled)
+                    .GroupBy(r => r.Member)
+                    .Select(g => g.First())
+            );
+        }
+        return result;
+    }
+
     private static List<DimensionalRevenueRow> ReconcileToTotal(
         IEnumerable<DimensionalRevenueRow> axisRowsInUnit,
         string unit,
@@ -748,7 +784,13 @@ public class RevenueBreakdownTools
         List<DimensionalRevenueRow> rows,
         string[] axes,
         int maxYears,
-        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals,
+        // Segment operating income does not reconcile to a consolidated total by construction —
+        // unallocated corporate costs sit outside the segments — so the arithmetic completeness
+        // test can never pass there and would silently degrade to the carry-forward merge that
+        // lets a discontinued segment linger forever. Those axes use the newest filing's member
+        // roster as authoritative instead.
+        bool reconcilesToTotal = true
     )
     {
         var axisRows = rows.Where(r => axes.Contains(r.Axis)).ToList();
@@ -758,7 +800,10 @@ public class RevenueBreakdownTools
         // Pin the unit first (latest-filed fact's unit) so the reconciliation sum and the
         // consolidated total are always in the same currency.
         var unit = axisRows.OrderByDescending(r => r.FiledDate).First().Unit;
-        var current = ReconcileToTotal(axisRows.Where(r => r.Unit == unit), unit, totals);
+        var inUnit = axisRows.Where(r => r.Unit == unit);
+        var current = reconcilesToTotal
+            ? ReconcileToTotal(inUnit, unit, totals)
+            : NewestRosterWins(inUnit);
         if (current.Count == 0)
             return (null, [], []);
 

--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -39,7 +39,7 @@ public class NCenTools
         ReadOnly = true
     )]
     [Description(
-        "Get operational data for a registered investment company from its SEC Form N-CEN annual reports. Resolves exchange-listed tickers only — ETFs, closed-end funds and unit investment trusts; an unlisted mutual-fund share-class ticker (e.g. VFIAX) will not resolve, so find that fund via SearchFunds/GetFundProfile instead. Each N-CEN shows the registrant's classification (e.g. N-1A open-end, N-2 closed-end, S-6 unit investment trust), Investment Company Act file number, reporting period, and whether it was the fund's first or last filing, followed by the service providers named on the most recent report only — investment advisers, sub-advisers, custodians, transfer agents, administrators, auditors and underwriters. Use this to see who runs and services a fund. Only registered funds file N-CEN; operating companies will return no data."
+        "Get operational data for a registered investment company from its SEC Form N-CEN annual reports. Resolves exchange-listed tickers only — ETFs, closed-end funds and unit investment trusts; an unlisted mutual-fund share-class ticker (e.g. VFIAX) will not resolve, so find that fund via SearchFunds/GetFundProfile instead. Each N-CEN shows the registrant's classification (e.g. N-1A open-end, N-2 closed-end, S-6 unit investment trust), Investment Company Act file number, reporting period, and whether it was the fund's first or last filing. The response shows the service providers named on the latest report and an exact filed-name history across the reports returned — investment advisers, sub-advisers, custodians, transfer agents, administrators, auditors and underwriters. Use this to see who runs and services a fund. Only registered funds file N-CEN; operating companies will return no data."
     )]
     public Task<string> GetFundOperations(
         [Description("Fund or ETF ticker symbol (e.g., MXF, SPY)")] string ticker,
@@ -58,6 +58,9 @@ public class NCenTools
                     .GetByStock(stock)
                     .Include(f => f.ServiceProviders)
                     .OrderByDescending(f => f.FilingDate)
+                    .ThenByDescending(f => f.IsAmendment)
+                    .ThenByDescending(f => f.AccessionNumber)
+                    .ThenByDescending(f => f.CreationTime)
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
@@ -77,7 +80,7 @@ public class NCenTools
                 );
 
                 AppendServiceProviders(result, filings[0]);
-                AppendServiceProviderChanges(result, filings);
+                AppendServiceProviderHistory(result, filings);
 
                 return result.ToString();
             },
@@ -111,15 +114,15 @@ public class NCenTools
         result.AppendRows(
             latest.ServiceProviders.OrderBy(p => p.ProviderType).ThenBy(p => p.Name),
             provider =>
-                $"| {provider.ProviderType.NameForHumans()} | {provider.Name} | {provider.Country ?? "-"} | {(provider.IsAffiliated ? "Yes" : "No")} |"
+                $"| {provider.ProviderType.NameForHumans()} | {MarkdownText(provider.Name)} | {MarkdownText(provider.Country) ?? "-"} | {(provider.IsAffiliated ? "Yes" : "No")} |"
         );
     }
 
-    // A changed auditor or custodian is the reason to read these reports at all, and it is
-    // invisible when only the newest report's providers are rendered. Repeating every report's
-    // full provider table would multiply the response for rows that are usually identical
-    // year over year, so only the transitions are listed — the diff IS the finding.
-    private static void AppendServiceProviderChanges(
+    // Historical provider rosters are the evidence needed to spot a changed auditor or custodian.
+    // Render the exact filed-name timeline and compress only consecutive IDENTICAL snapshots. An
+    // omitted role is an explicit "not reported" state, never a removal; punctuation differences
+    // stay visible rather than being heuristically collapsed into one provider identity.
+    private static void AppendServiceProviderHistory(
         System.Text.StringBuilder result,
         List<NCenFiling> filings
     )
@@ -127,77 +130,72 @@ public class NCenTools
         if (filings.Count < 2)
             return;
 
-        var oldestFirst = filings.OrderBy(f => f.FilingDate).ToList();
-        var changes = new List<string>();
-
+        var oldestFirst = filings
+            .OrderBy(f => f.FilingDate)
+            .ThenBy(f => f.IsAmendment)
+            .ThenBy(f => f.AccessionNumber)
+            .ThenBy(f => f.CreationTime)
+            .ToList();
+        var sameDateFilings = oldestFirst
+            .GroupBy(f => f.FilingDate)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToHashSet();
         var roles = oldestFirst
             .SelectMany(f => f.ServiceProviders.Select(p => p.ProviderType))
             .Distinct()
             .OrderBy(r => r.NameForHumans(), StringComparer.Ordinal);
 
+        result.AppendLine();
+        result.AppendLine(
+            $"Service-provider history across the {filings.Count} reports shown (exact filed names; consecutive identical snapshots compressed):"
+        );
+        result.AppendLine();
+
         foreach (var role in roles)
         {
-            for (var i = 1; i < oldestFirst.Count; i++)
+            string[] previous = null;
+            var timeline = new List<string>();
+            foreach (var filing in oldestFirst)
             {
-                var previous = NamesForRole(oldestFirst[i - 1], role);
-                var current = NamesForRole(oldestFirst[i], role);
-                // A role absent from a report is "not reported", not "dropped" — an N-CEN that
-                // omits the section would otherwise read as the fund firing its auditor.
-                if (previous.Length == 0 || current.Length == 0)
+                var current = NamesForRole(filing, role);
+                if (previous != null && previous.SequenceEqual(current, StringComparer.Ordinal))
                     continue;
-                if (
-                    ComparableNamesForRole(oldestFirst[i - 1], role)
-                    == ComparableNamesForRole(oldestFirst[i], role)
-                )
-                    continue;
-
-                changes.Add(
-                    $"- {role.NameForHumans()}: {previous} (filed {oldestFirst[i - 1].FilingDate:yyyy-MM-dd}) "
-                        + $"→ {current} (filed {oldestFirst[i].FilingDate:yyyy-MM-dd})"
+                timeline.Add(
+                    $"{TimelineLabel(filing, sameDateFilings.Contains(filing.FilingDate))}: "
+                        + (
+                            current.Length == 0
+                                ? "not reported"
+                                : string.Join(", ", current.Select(MarkdownText))
+                        )
                 );
+                previous = current;
             }
+            result.AppendLine($"- {role.NameForHumans()}: {string.Join("; ", timeline)}");
         }
-
-        result.AppendLine();
-        if (changes.Count == 0)
-        {
-            result.AppendLine(
-                $"No service-provider changes across the {filings.Count} reports shown."
-            );
-            return;
-        }
-
-        result.AppendLine($"Service-provider changes across the {filings.Count} reports shown:");
-        result.AppendLine();
-        foreach (var change in changes)
-            result.AppendLine(change);
     }
 
-    private static string NamesForRole(NCenFiling filing, NCenServiceProviderType role) =>
-        string.Join(
-            ", ",
-            filing
-                .ServiceProviders.Where(p => p.ProviderType == role)
-                .Select(p => p.Name)
-                .OrderBy(n => n, StringComparer.Ordinal)
-        );
+    private static string[] NamesForRole(NCenFiling filing, NCenServiceProviderType role) =>
+        filing
+            .ServiceProviders.Where(p => p.ProviderType == role)
+            .Select(p => p.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
 
-    // Filers re-punctuate and re-case the same firm between reports ("PricewaterhouseCoopers LLP"
-    // vs "PRICEWATERHOUSECOOPERS, LLP"). Comparing the raw strings reports those as a change of
-    // auditor, which is a false claim about the fund; the comparison runs on letters and digits
-    // only. Display still uses the filed spelling — this normalization never leaves the compare.
-    private static string ComparableNamesForRole(NCenFiling filing, NCenServiceProviderType role) =>
-        string.Join(
-            "|",
-            filing
-                .ServiceProviders.Where(p => p.ProviderType == role)
-                .Select(p => Squash(p.Name))
-                .Where(n => n.Length > 0)
-                .OrderBy(n => n, StringComparer.Ordinal)
-        );
+    private static string TimelineLabel(NCenFiling filing, bool disambiguate)
+    {
+        var date = filing.FilingDate.ToString("yyyy-MM-dd");
+        if (!disambiguate)
+            return date;
 
-    private static string Squash(string value) =>
-        value == null
-            ? ""
-            : new string(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
+        var kind = filing.IsAmendment ? "amendment" : "original";
+        var accession = MarkdownText(filing.AccessionNumber) ?? "accession unknown";
+        return $"{date} ({kind}; accession {accession})";
+    }
+
+    // SEC-filed text can carry pipes and line breaks. Flatten it before inserting it into a
+    // Markdown table or bullet so one provider cannot create a synthetic row or section.
+    private static string MarkdownText(string value) =>
+        value == null ? null : MarkdownTable.EscapeCell(value).Trim();
 }

--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -143,7 +143,12 @@ public class NCenTools
                 var current = NamesForRole(oldestFirst[i], role);
                 // A role absent from a report is "not reported", not "dropped" — an N-CEN that
                 // omits the section would otherwise read as the fund firing its auditor.
-                if (previous.Length == 0 || current.Length == 0 || previous == current)
+                if (previous.Length == 0 || current.Length == 0)
+                    continue;
+                if (
+                    ComparableNamesForRole(oldestFirst[i - 1], role)
+                    == ComparableNamesForRole(oldestFirst[i], role)
+                )
                     continue;
 
                 changes.Add(
@@ -176,4 +181,23 @@ public class NCenTools
                 .Select(p => p.Name)
                 .OrderBy(n => n, StringComparer.Ordinal)
         );
+
+    // Filers re-punctuate and re-case the same firm between reports ("PricewaterhouseCoopers LLP"
+    // vs "PRICEWATERHOUSECOOPERS, LLP"). Comparing the raw strings reports those as a change of
+    // auditor, which is a false claim about the fund; the comparison runs on letters and digits
+    // only. Display still uses the filed spelling — this normalization never leaves the compare.
+    private static string ComparableNamesForRole(NCenFiling filing, NCenServiceProviderType role) =>
+        string.Join(
+            "|",
+            filing
+                .ServiceProviders.Where(p => p.ProviderType == role)
+                .Select(p => Squash(p.Name))
+                .Where(n => n.Length > 0)
+                .OrderBy(n => n, StringComparer.Ordinal)
+        );
+
+    private static string Squash(string value) =>
+        value == null
+            ? ""
+            : new string(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
 }

--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -77,6 +77,7 @@ public class NCenTools
                 );
 
                 AppendServiceProviders(result, filings[0]);
+                AppendServiceProviderChanges(result, filings);
 
                 return result.ToString();
             },
@@ -113,4 +114,66 @@ public class NCenTools
                 $"| {provider.ProviderType.NameForHumans()} | {provider.Name} | {provider.Country ?? "-"} | {(provider.IsAffiliated ? "Yes" : "No")} |"
         );
     }
+
+    // A changed auditor or custodian is the reason to read these reports at all, and it is
+    // invisible when only the newest report's providers are rendered. Repeating every report's
+    // full provider table would multiply the response for rows that are usually identical
+    // year over year, so only the transitions are listed — the diff IS the finding.
+    private static void AppendServiceProviderChanges(
+        System.Text.StringBuilder result,
+        List<NCenFiling> filings
+    )
+    {
+        if (filings.Count < 2)
+            return;
+
+        var oldestFirst = filings.OrderBy(f => f.FilingDate).ToList();
+        var changes = new List<string>();
+
+        var roles = oldestFirst
+            .SelectMany(f => f.ServiceProviders.Select(p => p.ProviderType))
+            .Distinct()
+            .OrderBy(r => r.NameForHumans(), StringComparer.Ordinal);
+
+        foreach (var role in roles)
+        {
+            for (var i = 1; i < oldestFirst.Count; i++)
+            {
+                var previous = NamesForRole(oldestFirst[i - 1], role);
+                var current = NamesForRole(oldestFirst[i], role);
+                // A role absent from a report is "not reported", not "dropped" — an N-CEN that
+                // omits the section would otherwise read as the fund firing its auditor.
+                if (previous.Length == 0 || current.Length == 0 || previous == current)
+                    continue;
+
+                changes.Add(
+                    $"- {role.NameForHumans()}: {previous} (filed {oldestFirst[i - 1].FilingDate:yyyy-MM-dd}) "
+                        + $"→ {current} (filed {oldestFirst[i].FilingDate:yyyy-MM-dd})"
+                );
+            }
+        }
+
+        result.AppendLine();
+        if (changes.Count == 0)
+        {
+            result.AppendLine(
+                $"No service-provider changes across the {filings.Count} reports shown."
+            );
+            return;
+        }
+
+        result.AppendLine($"Service-provider changes across the {filings.Count} reports shown:");
+        result.AppendLine();
+        foreach (var change in changes)
+            result.AppendLine(change);
+    }
+
+    private static string NamesForRole(NCenFiling filing, NCenServiceProviderType role) =>
+        string.Join(
+            ", ",
+            filing
+                .ServiceProviders.Where(p => p.ProviderType == role)
+                .Select(p => p.Name)
+                .OrderBy(n => n, StringComparer.Ordinal)
+        );
 }

--- a/src/Equibles.Web/Views/Home/Index.cshtml
+++ b/src/Equibles.Web/Views/Home/Index.cshtml
@@ -43,7 +43,7 @@
         <a asp-controller="Search" asp-action="Index" asp-route-category="Congress" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">
             <div class="card-body">
                 <h2 class="card-title text-lg">Congressional Trades</h2>
-                <p class="text-sm text-base-content/70">Stock trades by members of Congress from House and Senate financial disclosures.</p>
+                <p class="text-sm text-base-content/70">Securities transactions by members of Congress from House and Senate financial disclosures.</p>
             </div>
         </a>
         <a asp-controller="Stocks" asp-action="Index" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -92,10 +92,10 @@ public class YahooPriceImportService
             includeEnrichment ? "on" : "off"
         );
 
-        // Before the forward-only incremental append: reconcile any stock whose stored history is
-        // on a pre-split basis. GetSyncStartDate only appends, so a split that landed after the
-        // last sync leaves the old rows on the wrong basis (a discontinuity in the series). Re-pull
-        // those stocks' full, fully-adjusted history and overwrite the stored rows (#2879).
+        // Before the forward-only incremental append: reconcile any stock whose captured split is
+        // still pending for its listed series. GetSyncStartDate only appends and cannot revisit the
+        // old rows, so re-pull the full provider-served history and overwrite them (#2879). The
+        // provider can serve that history on different bases; the pending marker does not prove one.
         await ReconcilePendingSplits(DateOnly.FromDateTime(DateTime.UtcNow), cancellationToken);
 
         // Crawl the recently-active stocks first, stalest-first within them, and the long-dormant
@@ -406,8 +406,8 @@ public class YahooPriceImportService
     }
 
     // Re-syncs the full price history of every exact listed series that has an unreconciled split,
-    // capped per cycle. Yahoo serves the whole history already split-adjusted, so the fix is to
-    // overwrite that series with a fresh pull rather than doing ratio arithmetic.
+    // capped per cycle. Yahoo's served basis can vary around recent splits, so copy the response
+    // exactly rather than guessing a ratio or labelling the replacement universally adjusted.
     private async Task ReconcilePendingSplits(DateOnly today, CancellationToken cancellationToken)
     {
         PendingSplitSelection selection;
@@ -424,7 +424,7 @@ public class YahooPriceImportService
             return;
 
         _logger.LogInformation(
-            "Re-syncing split-adjusted price history for {Count} listed series with pending splits",
+            "Re-syncing full price history for {Count} listed series with pending splits",
             selection.Series.Count
         );
         if (selection.Skipped > 0)
@@ -448,7 +448,7 @@ public class YahooPriceImportService
             {
                 _logger.LogWarning(
                     ex,
-                    "Failed to fetch split-adjusted history for {Ticker}; leaving its split(s) pending",
+                    "Failed to fetch full history for {Ticker}; leaving its split(s) pending",
                     series.ListedTicker
                 );
             }
@@ -462,7 +462,7 @@ public class YahooPriceImportService
             {
                 _logger.LogError(
                     ex,
-                    "Error reconciling split-adjusted history for {Ticker}",
+                    "Error reconciling full price history for {Ticker}",
                     series.ListedTicker
                 );
                 await _errorReporter.Report(
@@ -527,7 +527,7 @@ public class YahooPriceImportService
         );
     }
 
-    // Transactionally swaps a stock's stored rows in [floor, today] for the fresh fully-adjusted
+    // Transactionally swaps a stock's stored rows in [floor, today] for the fresh provider-served
     // series. Returns false without touching the stored rows when there is nothing usable to store
     // (all rows overflowed the numeric ceiling, or the parent CommonStock was removed) so a stock
     // is never left with an empty series.
@@ -748,7 +748,7 @@ public class YahooPriceImportService
             if (replaced)
             {
                 _logger.LogInformation(
-                    "Reconciled {Ticker}: replaced its split-adjusted listed price history",
+                    "Reconciled {Ticker}: replaced its full listed price history",
                     target.Ticker
                 );
                 await CaptureSplits(target, chartData.Splits, cancellationToken);

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -47,9 +47,11 @@ public class StockPriceTools
         "Get daily OHLCV (Open, High, Low, Close, Volume) price history for a stock. Useful for "
             + "technical analysis, charting, and price trend analysis. Prices are in USD and "
             + "restated to the current split basis. Close is the price as traded; an Adj Close "
-            + "column shows the stored split-adjusted close on the rows where it differs. That "
-            + "series is maintained for splits only, NOT for dividends, so it cannot be used to "
-            + "compute total return — treat both columns as price series."
+            + "column shows the stored adjusted close on the rows where it differs. Each stored "
+            + "row carries whatever adjustment the provider had applied when that row was "
+            + "written, and it is not restated when a later corporate action goes ex, so the "
+            + "adjustment basis is inconsistent across the series and it must not be used to "
+            + "compute total return."
     )]
     public Task<string> GetStockPrices(
         [Description(
@@ -98,12 +100,14 @@ public class StockPriceTools
                 if (records.Count == 0)
                     return $"No price data found for {priceTicker} in the specified date range.";
 
-                // AdjustedClose is the provider's STORED adjusted close, and our pipeline restates
-                // it only on a SPLIT rebase — dividends never rebase it, and the forward EOD lane
-                // writes AdjustedClose = Close. So a differing value proves a split rebase reached
-                // these rows; equality proves NOTHING about the world (a dividend payer's recent
-                // bars are equal). The column therefore renders when the stored rows differ, and
-                // every word around it speaks only about the stored rows shown.
+                // AdjustedClose is whatever the provider had adjusted for at the moment each row
+                // was written or last rebased; nothing restates a stored row when a LATER
+                // corporate action goes ex, and the forward EOD lane writes AdjustedClose = Close.
+                // Measured consequence: a dividend payer's differing bars stop on the last session
+                // before its newest ex-date, so one series straddles two bases (see issue #7088).
+                // A differing value therefore proves only that some adjustment reached that row,
+                // and equality proves NOTHING about the world. Render the column when the stored
+                // rows differ, and say only what the stored rows shown can support.
                 var hasAdjustment = records.Any(p => p.AdjustedClose != p.Close);
 
                 var result = hasAdjustment
@@ -131,8 +135,8 @@ public class StockPriceTools
                 result.AppendLine();
                 result.AppendLine(
                     hasAdjustment
-                        ? "_Close is the price as traded. Adj Close is the stored split-adjusted close: it is restated when a split is applied and is NOT maintained for dividends, so it does not give a total-return series — do not compute total return from it._"
-                        : "_Close is the price as traded. The stored split-adjusted close equals Close on every row shown. That series is restated only when a split rebase runs (dividends never restate it), so this says nothing about whether the company paid a dividend or split in this window._"
+                        ? "_Close is the price as traded. Adj Close is the stored adjusted close: each row carries whatever adjustment the provider had applied when that row was written, and a stored row is never restated when a later corporate action goes ex. The basis is therefore inconsistent across the series — do not compute total return from it._"
+                        : "_Close is the price as traded. The stored adjusted close equals Close on every row shown, and a stored row is never restated when a later corporate action goes ex, so this says nothing about whether the company paid a dividend or split in this window._"
                 );
 
                 return result.ToString();

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -46,9 +46,10 @@ public class StockPriceTools
     [Description(
         "Get daily OHLCV (Open, High, Low, Close, Volume) price history for a stock. Useful for "
             + "technical analysis, charting, and price trend analysis. Prices are in USD and "
-            + "restated to the current split basis. Close is as traded; an Adj Close column carries "
-            + "the split- and dividend-adjusted close whenever the window holds an adjustment, so a "
-            + "total-return series can be computed from it (Close alone understates a dividend payer)."
+            + "restated to the current split basis. Close is the price as traded; an Adj Close "
+            + "column shows the stored split-adjusted close on the rows where it differs. That "
+            + "series is maintained for splits only, NOT for dividends, so it cannot be used to "
+            + "compute total return — treat both columns as price series."
     )]
     public Task<string> GetStockPrices(
         [Description(
@@ -97,11 +98,12 @@ public class StockPriceTools
                 if (records.Count == 0)
                     return $"No price data found for {priceTicker} in the specified date range.";
 
-                // Close is as-traded; AdjustedClose carries the split AND dividend adjustment, so
-                // it is the only basis a total-return series can be built on. The column is worth
-                // its width only when the window actually holds an adjustment — for a stock that
-                // paid nothing and never split the two series are identical, and the footer says
-                // so rather than leaving a caller guessing whether the tool can answer at all.
+                // AdjustedClose is the provider's STORED adjusted close, and our pipeline restates
+                // it only on a SPLIT rebase — dividends never rebase it, and the forward EOD lane
+                // writes AdjustedClose = Close. So a differing value proves a split rebase reached
+                // these rows; equality proves NOTHING about the world (a dividend payer's recent
+                // bars are equal). The column therefore renders when the stored rows differ, and
+                // every word around it speaks only about the stored rows shown.
                 var hasAdjustment = records.Any(p => p.AdjustedClose != p.Close);
 
                 var result = hasAdjustment
@@ -129,8 +131,8 @@ public class StockPriceTools
                 result.AppendLine();
                 result.AppendLine(
                     hasAdjustment
-                        ? "_Close is as traded; Adj Close is adjusted for splits and dividends — compute total return from Adj Close, price return from Close._"
-                        : "_Close is as traded. The split- and dividend-adjusted close is identical across this window (no split or dividend), so total return equals price return here._"
+                        ? "_Close is the price as traded. Adj Close is the stored split-adjusted close: it is restated when a split is applied and is NOT maintained for dividends, so it does not give a total-return series — do not compute total return from it._"
+                        : "_Close is the price as traded. The stored split-adjusted close equals Close on every row shown. That series is restated only when a split rebase runs (dividends never restate it), so this says nothing about whether the company paid a dividend or split in this window._"
                 );
 
                 return result.ToString();

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -45,13 +45,12 @@ public class StockPriceTools
     [McpServerTool(Name = "GetStockPrices", Title = "Daily Price History", ReadOnly = true)]
     [Description(
         "Get daily OHLCV (Open, High, Low, Close, Volume) price history for a stock. Useful for "
-            + "technical analysis, charting, and price trend analysis. Prices are in USD and "
-            + "restated to the current split basis. Close is the price as traded; an Adj Close "
-            + "column shows the stored adjusted close on the rows where it differs. Each stored "
-            + "row carries whatever adjustment the provider had applied when that row was "
-            + "written, and it is not restated when a later corporate action goes ex, so the "
-            + "adjustment basis is inconsistent across the series and it must not be used to "
-            + "compute total return."
+            + "technical analysis, charting, and price trend analysis. Prices are in USD. An Adj "
+            + "Close column shows the stored adjusted close on the rows where it differs from "
+            + "Close. Adj Close is an auxiliary stored provider series that can be rewritten "
+            + "with the full history during split reconciliation and is not guaranteed to be "
+            + "complete total return. Neither equality with nor a difference from Close "
+            + "identifies which corporate actions it reflects."
     )]
     public Task<string> GetStockPrices(
         [Description(
@@ -100,14 +99,10 @@ public class StockPriceTools
                 if (records.Count == 0)
                     return $"No price data found for {priceTicker} in the specified date range.";
 
-                // AdjustedClose is whatever the provider had adjusted for at the moment each row
-                // was written or last rebased; nothing restates a stored row when a LATER
-                // corporate action goes ex, and the forward EOD lane writes AdjustedClose = Close.
-                // Measured consequence: a dividend payer's differing bars stop on the last session
-                // before its newest ex-date, so one series straddles two bases (see issue #7088).
-                // A differing value therefore proves only that some adjustment reached that row,
-                // and equality proves NOTHING about the world. Render the column when the stored
-                // rows differ, and say only what the stored rows shown can support.
+                // AdjustedClose is the provider's auxiliary series and is replaced with the full
+                // history during a split reconcile, but issue #7088 proves it is not a dependable
+                // total-return series. Render it when it differs without inferring a
+                // corporate-action cause or claiming a universal basis for Close.
                 var hasAdjustment = records.Any(p => p.AdjustedClose != p.Close);
 
                 var result = hasAdjustment
@@ -135,8 +130,8 @@ public class StockPriceTools
                 result.AppendLine();
                 result.AppendLine(
                     hasAdjustment
-                        ? "_Close is the price as traded. Adj Close is the stored adjusted close: each row carries whatever adjustment the provider had applied when that row was written, and a stored row is never restated when a later corporate action goes ex. The basis is therefore inconsistent across the series — do not compute total return from it._"
-                        : "_Close is the price as traded. The stored adjusted close equals Close on every row shown, and a stored row is never restated when a later corporate action goes ex, so this says nothing about whether the company paid a dividend or split in this window._"
+                        ? "_Adj Close is an auxiliary stored provider series. It can be rewritten with the full history during split reconciliation, is not guaranteed to be complete total return, and its difference from Close does not identify which corporate actions it reflects._"
+                        : "_The stored Adj Close equals Close on every row shown, but that equality does not prove the absence of a dividend or split. Adj Close can be rewritten with the full history during split reconciliation and is not guaranteed to be complete total return._"
                 );
 
                 return result.ToString();
@@ -158,8 +153,8 @@ public class StockPriceTools
             + "prior session while the fresh bar settles, so dates within one response can "
             + "differ — anchor on the Date column, never the wall clock. 52W High/Low are the "
             + "highest and lowest daily closes in the 365 days ending on the row's date "
-            + "(current split basis); Off High / Above Low are the close's percent distance "
-            + "from those bounds."
+            + "on the stored series; raw rows carry no split-basis metadata. Off High / Above "
+            + "Low are the close's percent distance from those bounds."
     )]
     public Task<string> GetLatestPrices(
         [Description(
@@ -250,8 +245,9 @@ public class StockPriceTools
                     }
 
                     // Trailing 52-week close range, anchored on the row's own session so a
-                    // stock that stopped trading doesn't fabricate a fresh range. Stored
-                    // closes are already on the current split basis, so raw closes compare.
+                    // stock that stopped trading doesn't fabricate a fresh range. This is the
+                    // extrema of the stored Close series; raw rows carry no basis metadata, so
+                    // do not attach a universal split-basis claim to the result.
                     var cutoff = price.Date.AddDays(-365);
                     var range = await _priceRepository
                         .GetByStock(stock, priceTicker)

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -46,7 +46,9 @@ public class StockPriceTools
     [Description(
         "Get daily OHLCV (Open, High, Low, Close, Volume) price history for a stock. Useful for "
             + "technical analysis, charting, and price trend analysis. Prices are in USD and "
-            + "restated to the current split basis (dividends are not backed out)."
+            + "restated to the current split basis. Close is as traded; an Adj Close column carries "
+            + "the split- and dividend-adjusted close whenever the window holds an adjustment, so a "
+            + "total-return series can be computed from it (Close alone understates a dividend payer)."
     )]
     public Task<string> GetStockPrices(
         [Description(
@@ -95,19 +97,41 @@ public class StockPriceTools
                 if (records.Count == 0)
                     return $"No price data found for {priceTicker} in the specified date range.";
 
-                var result = StartTable(
-                    $"Daily prices for {priceTicker} ({stock.Name}):",
-                    "| Date | Open | High | Low | Close | Volume |",
-                    "|------|------|------|-----|-------|--------|"
-                );
+                // Close is as-traded; AdjustedClose carries the split AND dividend adjustment, so
+                // it is the only basis a total-return series can be built on. The column is worth
+                // its width only when the window actually holds an adjustment — for a stock that
+                // paid nothing and never split the two series are identical, and the footer says
+                // so rather than leaving a caller guessing whether the tool can answer at all.
+                var hasAdjustment = records.Any(p => p.AdjustedClose != p.Close);
+
+                var result = hasAdjustment
+                    ? StartTable(
+                        $"Daily prices for {priceTicker} ({stock.Name}):",
+                        "| Date | Open | High | Low | Close | Adj Close | Volume |",
+                        "|------|------|------|-----|-------|-----------|--------|"
+                    )
+                    : StartTable(
+                        $"Daily prices for {priceTicker} ({stock.Name}):",
+                        "| Date | Open | High | Low | Close | Volume |",
+                        "|------|------|------|-----|-------|--------|"
+                    );
 
                 result.AppendRows(
                     records.OrderBy(p => p.Date),
                     p =>
-                        $"| {p.Date:yyyy-MM-dd} | {McpFormat.Price(p.Open)} | {McpFormat.Price(p.High)} | {McpFormat.Price(p.Low)} | {McpFormat.Price(p.Close)} | {McpFormat.WholeNumber(p.Volume)} |"
+                        hasAdjustment
+                            ? $"| {p.Date:yyyy-MM-dd} | {McpFormat.Price(p.Open)} | {McpFormat.Price(p.High)} | {McpFormat.Price(p.Low)} | {McpFormat.Price(p.Close)} | {McpFormat.Price(p.AdjustedClose)} | {McpFormat.WholeNumber(p.Volume)} |"
+                            : $"| {p.Date:yyyy-MM-dd} | {McpFormat.Price(p.Open)} | {McpFormat.Price(p.High)} | {McpFormat.Price(p.Low)} | {McpFormat.Price(p.Close)} | {McpFormat.WholeNumber(p.Volume)} |"
                 );
 
                 AppendNewestKeptTruncationNote(result, records.Count, total);
+
+                result.AppendLine();
+                result.AppendLine(
+                    hasAdjustment
+                        ? "_Close is as traded; Adj Close is adjusted for splits and dividends — compute total return from Adj Close, price return from Close._"
+                        : "_Close is as traded. The split- and dividend-adjusted close is identical across this window (no split or dividend), so total return equals price return here._"
+                );
 
                 return result.ToString();
             },

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+using System.Reflection;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Data.Models;
@@ -113,6 +115,38 @@ public class CongressToolsTests : ParadeDbMcpTestBase
         result.Should().Contain("Representative");
         result.Should().Contain("Purchase");
         result.Should().Contain("$1,000,001");
+    }
+
+    [Fact]
+    public async Task GetCongressionalTrades_OptionAsset_IsAttributedAsInstrumentAndTableSafe()
+    {
+        var stock = NvdaStock();
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<CongressMember>().Add(pelosi);
+        DbContext
+            .Set<CongressionalTrade>()
+            .Add(
+                TradeFor(
+                    pelosi,
+                    stock,
+                    new DateOnly(2026, 3, 15),
+                    assetName: "NVDA put option \\| $100 strike"
+                )
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetCongressionalTrades("NVDA", startDate: "2026-01-01", endDate: "2026-04-30");
+        var description = typeof(CongressTools)
+            .GetMethod(nameof(CongressTools.GetCongressionalTrades))!
+            .GetCustomAttribute<DescriptionAttribute>()!
+            .Description;
+
+        result.Should().Contain("NVDA put option \\\\\\| $100 strike");
+        description.Should().Contain("securities transactions");
+        description.Should().Contain("Asset identifies the filed instrument");
+        description.Should().NotContain("bought or sold shares");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
@@ -200,6 +200,86 @@ public class Form144ProposedSalesToolTests : IDisposable
         result.Should().Contain("| - |");
     }
 
+    [Fact]
+    public async Task GetProposedSales_RemarksPreserveCompleteUnicodeText()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1000);
+        filing.Remarks = new string('a', 89) + "😀 trailing text";
+        _dbContext.Set<Form144Filing>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        result.Should().Contain(new string('a', 89) + "😀 trailing text");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_RemarksPreserveCompleteEscapedPipeText()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1000);
+        filing.Remarks = new string('a', 89) + "|trailing text";
+        _dbContext.Set<Form144Filing>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        result.Should().Contain(new string('a', 89) + "\\|trailing text");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_RemarksPreserveLateRule10b5OneDisclosure()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1000);
+        filing.Remarks =
+            new string('a', 120) + " Sale will be made pursuant to a Rule 10b5-1 plan.";
+        _dbContext.Set<Form144Filing>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        result.Should().Contain("Sale will be made pursuant to a Rule 10b5-1 plan.");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_RemarksBackslashBeforePipe_KeepsPipeInsideCell()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1000);
+        filing.Remarks = "Sale under plan A\\|renewed";
+        _dbContext.Set<Form144Filing>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        result.Should().Contain("Sale under plan A\\\\\\|renewed");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_AllFiledTextCellsStayInsideTheirColumns()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(
+            stock.Id,
+            "acc",
+            new DateOnly(2026, 1, 5),
+            "SELLER\\|NAME\nSECOND",
+            1000
+        );
+        filing.RelationshipToIssuer = "Officer\\|Director\nAffiliate";
+        filing.BrokerName = "BROKER\\|DESK\nLLC";
+        _dbContext.Set<Form144Filing>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        result.Should().Contain("SELLER\\\\\\|NAME SECOND");
+        result.Should().Contain("Officer\\\\\\|Director Affiliate");
+        result.Should().Contain("BROKER\\\\\\|DESK LLC");
+    }
+
     private static Form144Filing MakeFiling(
         Guid stockId,
         string accession,

--- a/tests/Equibles.IntegrationTests/Mcp/FredToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FredToolsTests.cs
@@ -55,6 +55,10 @@ public class FredToolsTests : ParadeDbMcpTestBase
             Frequency = "Quarterly",
             Units = "Billions of Dollars",
             SeasonalAdjustment = "Seasonally Adjusted Annual Rate",
+            ObservationEnd = new DateOnly(2025, 4, 1),
+            LastUpdated = new DateTime(2025, 5, 2, 14, 30, 45, DateTimeKind.Utc).AddTicks(
+                1_234_560
+            ),
         };
 
         DbContext.Set<FredSeries>().AddRange(_fedFundsSeries, _cpiSeries, _gdpSeries);
@@ -527,6 +531,26 @@ public class FredToolsTests : ParadeDbMcpTestBase
 
         result.Should().Contain("| Series ID | Title | Category | Frequency | Units |");
         result.Should().Contain("|-----------|-------|----------|-----------|-------|");
+    }
+
+    [Fact]
+    public async Task SearchEconomicIndicators_RendersObservationAndSyncFreshnessSeparately()
+    {
+        var result = await Sut().SearchEconomicIndicators("GDP");
+
+        result.Should().Contain("| Latest Observation | Last Synced (UTC) |");
+        result.Should().Contain("| 2025-04-01 | 2025-05-02T14:30:45.1234560Z |");
+    }
+
+    [Fact]
+    public async Task SearchEconomicIndicators_EscapesExternalTableCells()
+    {
+        _gdpSeries.Title = "Gross\\|Domestic\r\nProduct";
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().SearchEconomicIndicators("GDP");
+
+        result.Should().Contain(@"Gross\\\|Domestic  Product");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
@@ -87,6 +87,9 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityTests : ParadeDbM
             .IndexOf("AAPL", StringComparison.Ordinal)
             .Should()
             .BeLessThan(output.IndexOf("MSFT", StringComparison.Ordinal));
+        output.Should().Contain("Δ Value is the change in stored quarter-end position value");
+        output.Should().Contain("includes the quarter's price move on held positions");
+        output.Should().Contain("read Δ Shares for the position change itself");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolNewestFilingProvidersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolNewestFilingProvidersTests.cs
@@ -11,11 +11,10 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Equibles.IntegrationTests.Mcp;
 
 /// <summary>
-/// Adversarial cover for <c>GetFundOperations</c>'s service-provider section, which the helper
-/// sources from the latest report only. When the newest filing reports no service providers, an
-/// explicit "names no service providers" note must render — and an older filing's providers must
-/// not leak in. Existing tests only seed providers on the newest filing, leaving both the
-/// empty-on-newest note and the newest-filing selection unexercised.
+/// Adversarial cover for <c>GetFundOperations</c>'s service-provider sections. The latest-report
+/// table must never borrow providers from an older report, while the history must preserve every
+/// exact filed-name state — including omitted roles, punctuation differences, and hostile
+/// Markdown text — without claiming that a heuristic identity match proves no change.
 /// </summary>
 public class NCenFundOperationsToolNewestFilingProvidersTests : IDisposable
 {
@@ -39,7 +38,7 @@ public class NCenFundOperationsToolNewestFilingProvidersTests : IDisposable
     public void Dispose() => _dbContext.Dispose();
 
     [Fact]
-    public async Task GetFundOperations_NewestFilingHasNoProviders_EmitsNoteWithoutLeakingOlderProviders()
+    public async Task GetFundOperations_NewestFilingHasNoProviders_SeparatesLatestSnapshotFromHistory()
     {
         var stock = new CommonStock
         {
@@ -67,13 +66,107 @@ public class NCenFundOperationsToolNewestFilingProvidersTests : IDisposable
 
         var result = await _tools.GetFundOperations("MXF");
 
-        // The section reflects only the latest report, which has no providers — so an explicit
-        // note renders instead of a silently missing section, and the older filing's provider
-        // must not leak in.
+        // The latest snapshot does not borrow an older provider, while the separately labelled
+        // history preserves the older filed state and the newest omission.
         result.Should().Contain("names no service providers");
         result.Should().Contain("2025-01-15");
         result.Should().NotContain("Service providers reported");
-        result.Should().NotContain("OLD ADVISER FIRM");
+        result.Should().Contain("Service-provider history");
+        result.Should().Contain("2023-01-05: OLD ADVISER FIRM; 2025-01-15: not reported");
+    }
+
+    [Fact]
+    public async Task GetFundOperations_HistoryPreservesOmissionsExactNamesAndMarkdownBoundaries()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "MXF",
+            Name = "Mexico Fund Inc",
+            Cik = "0000065433",
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+
+        var older = MakeFiling(stock.Id, "older", new DateOnly(2023, 1, 5));
+        older.ServiceProviders.Add(
+            new NCenServiceProvider
+            {
+                ProviderType = NCenServiceProviderType.PublicAccountant,
+                Name = "A-B\\|\nLLP",
+                Country = "U\\|\nS",
+            }
+        );
+        var newest = MakeFiling(stock.Id, "newest", new DateOnly(2025, 1, 15));
+        newest.ServiceProviders.Add(
+            new NCenServiceProvider
+            {
+                ProviderType = NCenServiceProviderType.PublicAccountant,
+                Name = "AB\\|LLP",
+                Country = "U\\|S",
+            }
+        );
+        _dbContext
+            .Set<NCenFiling>()
+            .AddRange(older, MakeFiling(stock.Id, "middle", new DateOnly(2024, 1, 10)), newest);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundOperations("MXF");
+
+        result.Should().Contain("| Independent Public Accountant | AB\\\\\\|LLP | U\\\\\\|S |");
+        result
+            .Should()
+            .Contain(
+                "2023-01-05: A-B\\\\\\| LLP; 2024-01-10: not reported; 2025-01-15: AB\\\\\\|LLP"
+            );
+        result.Should().NotContain("No service-provider changes");
+    }
+
+    [Fact]
+    public async Task GetFundOperations_SameDayAmendmentWinsAndHistoryIsDeterministic()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "MXF",
+            Name = "Mexico Fund Inc",
+            Cik = "0000065433",
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+
+        var filed = new DateOnly(2025, 1, 15);
+        var original = MakeFiling(stock.Id, "0000065433-25-000001", filed);
+        original.CreationTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        original.ServiceProviders.Add(
+            new NCenServiceProvider
+            {
+                ProviderType = NCenServiceProviderType.PublicAccountant,
+                Name = "ORIGINAL AUDITOR LLP",
+            }
+        );
+        var amendment = MakeFiling(stock.Id, "0000065433-25-000002", filed);
+        amendment.IsAmendment = true;
+        amendment.CreationTime = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        amendment.ServiceProviders.Add(
+            new NCenServiceProvider
+            {
+                ProviderType = NCenServiceProviderType.PublicAccountant,
+                Name = "AMENDED AUDITOR LLP",
+            }
+        );
+        _dbContext.Set<NCenFiling>().AddRange(original, amendment);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundOperations("MXF");
+        var latestSection = result[..result.IndexOf("Service-provider history")];
+
+        latestSection.Should().Contain("AMENDED AUDITOR LLP");
+        latestSection.Should().NotContain("ORIGINAL AUDITOR LLP");
+        result
+            .Should()
+            .Contain(
+                "2025-01-15 (original; accession 0000065433-25-000001): ORIGINAL AUDITOR LLP; "
+                    + "2025-01-15 (amendment; accession 0000065433-25-000002): AMENDED AUDITOR LLP"
+            );
     }
 
     private static NCenFiling MakeFiling(Guid stockId, string accession, DateOnly filingDate)

--- a/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsSegmentOperatingIncomeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsSegmentOperatingIncomeTests.cs
@@ -1,0 +1,269 @@
+using System.Security.Cryptography;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Repositories;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Segment operating income (#7058) is rendered from the same business-segment axis as segment
+/// revenue, but it obeys DIFFERENT rules, and getting that wrong states things about the issuer
+/// that are not true:
+/// <list type="bullet">
+/// <item>its total row is operating income, not revenue — the shared renderer's hardcoded
+/// "Total revenue (consolidated)" label would answer a revenue question with a profit figure;</item>
+/// <item>segments are NOT expected to add up to the consolidated figure (unallocated corporate
+/// costs sit outside them), so the revenue-shaped overlap warning would fire on a normal filing
+/// and fabricate a claim about the issuer's XBRL tagging;</item>
+/// <item>and because that same non-reconciliation makes the arithmetic completeness test
+/// unpassable, a discontinued segment must be dropped by the newest filing's roster instead, or
+/// it lingers forever and is summed into the table.</item>
+/// </list>
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class RevenueBreakdownToolsSegmentOperatingIncomeTests : ParadeDbMcpTestBase
+{
+    private const string SegmentAxis = "us-gaap:StatementBusinessSegmentsAxis";
+
+    public RevenueBreakdownToolsSegmentOperatingIncomeTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private RevenueBreakdownTools Sut() =>
+        new(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<RevenueBreakdownTools>()
+        );
+
+    [Fact]
+    public async Task GetRevenueBreakdown_SegmentOperatingIncome_LabelsItsOwnTotalAndSkipsTheRevenueOverlapWarning()
+    {
+        var stock = AddStock("AAPL");
+        var revenue = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
+        var operatingIncome = AddConcept("OperatingIncomeLoss");
+
+        // Consolidated revenue 416, segments sum to 416 — a clean revenue disaggregation.
+        AddFact(stock, revenue, 2024, 416_000_000_000m);
+        AddFact(
+            stock,
+            revenue,
+            2024,
+            250_000_000_000m,
+            (SegmentAxis, "aapl:AmericasSegmentMember")
+        );
+        AddFact(stock, revenue, 2024, 166_000_000_000m, (SegmentAxis, "aapl:EuropeSegmentMember"));
+
+        // Consolidated operating income 123, segments sum to 133 — a 8% overshoot that is NORMAL
+        // for this axis, not evidence of overlapping tagging.
+        AddFact(stock, operatingIncome, 2024, 123_000_000_000m);
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            85_000_000_000m,
+            (SegmentAxis, "aapl:AmericasSegmentMember")
+        );
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            48_000_000_000m,
+            (SegmentAxis, "aapl:EuropeSegmentMember")
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("AAPL");
+
+        result.Should().Contain("**Segment operating income**");
+        result.Should().Contain("Total operating income (consolidated)");
+        // The profit total must never be presented as revenue.
+        result.Should().NotContain("| **Total revenue (consolidated)** | $123,000,000,000");
+        // The revenue-shaped overlap claim must not be made about this axis.
+        var operatingIncomeSection = result[
+            result.IndexOf("**Segment operating income**", StringComparison.Ordinal)..
+        ];
+        operatingIncomeSection.Should().NotContain("Rows on this axis overlap");
+        operatingIncomeSection.Should().Contain("need not add up to consolidated operating income");
+
+        DumpForDocs(result);
+    }
+
+    [Fact]
+    public async Task GetRevenueBreakdown_SegmentOperatingIncome_DropsASegmentTheNewestFilingNoLongerReports()
+    {
+        // The completeness defect this pins: on an axis that cannot reconcile arithmetically, the
+        // old rule always fell back to a per-member carry-forward merge, so a segment the issuer
+        // discontinued (NVDA Singapore, AMD Japan/Europe in the code's own examples) survived from
+        // an older filing and was summed into every later period.
+        var stock = AddStock("NVDA");
+        var revenue = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
+        var operatingIncome = AddConcept("OperatingIncomeLoss");
+
+        // The tool answers off the revenue cut, so a filer tagging segment operating income also
+        // tags segment revenue; without it the whole response short-circuits before this axis.
+        AddFact(stock, revenue, 2024, 60_000_000_000m);
+        AddFact(stock, revenue, 2024, 35_000_000_000m, (SegmentAxis, "nvda:ComputeMember"));
+        AddFact(stock, revenue, 2024, 25_000_000_000m, (SegmentAxis, "nvda:GraphicsMember"));
+
+        AddFact(stock, operatingIncome, 2024, 30_000_000_000m);
+        // Older filing reports three segments including one later discontinued.
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            10_000_000_000m,
+            1,
+            [(SegmentAxis, "nvda:ComputeMember")]
+        );
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            8_000_000_000m,
+            1,
+            [(SegmentAxis, "nvda:GraphicsMember")]
+        );
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            2_000_000_000m,
+            1,
+            [(SegmentAxis, "nvda:SingaporeMember")]
+        );
+        // Newest filing restates the same period with the Singapore segment gone.
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            11_000_000_000m,
+            2,
+            [(SegmentAxis, "nvda:ComputeMember")]
+        );
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            9_000_000_000m,
+            2,
+            [(SegmentAxis, "nvda:GraphicsMember")]
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("NVDA");
+
+        result.Should().Contain("**Segment operating income**");
+        result.Should().NotContain("Singapore");
+        // The restated values from the newest filing are the ones shown.
+        result.Should().Contain("$11,000,000,000");
+    }
+
+    // Writes the real rendering so a docs example is copied from tool output rather than written
+    // by hand. Off unless explicitly requested, so the suite stays side-effect free in CI.
+    private static void DumpForDocs(string result)
+    {
+        if (Environment.GetEnvironmentVariable("EQUIBLES_DUMP_DOCS_EXAMPLE") != "1")
+            return;
+
+        File.WriteAllText(
+            Path.Combine(Path.GetTempPath(), "revenue-breakdown-docs-example.txt"),
+            result
+        );
+    }
+
+    private CommonStock AddStock(string ticker)
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = $"{ticker} Inc.",
+            Cik = "0000320193",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        return stock;
+    }
+
+    private FinancialConcept AddConcept(string tag)
+    {
+        var concept = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = tag,
+            Label = tag,
+        };
+        DbContext.Set<FinancialConcept>().Add(concept);
+        return concept;
+    }
+
+    private void AddFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        int fy,
+        decimal value,
+        params (string Axis, string Member)[] dimensions
+    ) => AddFact(stock, concept, fy, value, 1, dimensions);
+
+    private void AddFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        int fy,
+        decimal value,
+        int filedYearOffset,
+        (string Axis, string Member)[] dimensions
+    )
+    {
+        var fact = new FinancialFact
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Unit = "USD",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = new DateOnly(fy, 1, 1),
+            PeriodEnd = new DateOnly(fy, 12, 31),
+            Value = value,
+            FiscalYear = fy,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenK,
+            FiledDate = new DateOnly(fy + filedYearOffset, 2, 1),
+            AccessionNumber = $"acc-{Guid.NewGuid():N}"[..20],
+            DimensionsKey = DimensionsKeyOf(dimensions),
+        };
+        foreach (var (axis, member) in dimensions)
+            fact.Dimensions.Add(
+                new FinancialFactDimension
+                {
+                    FinancialFactId = fact.Id,
+                    Axis = axis,
+                    Member = member,
+                }
+            );
+        DbContext.Set<FinancialFact>().Add(fact);
+    }
+
+    private static string DimensionsKeyOf((string Axis, string Member)[] dimensions)
+    {
+        if (dimensions.Length == 0)
+            return "";
+        var canonical = string.Join(
+            "|",
+            dimensions
+                .OrderBy(d => d.Axis)
+                .ThenBy(d => d.Member)
+                .Select(d => $"{d.Axis}={d.Member}")
+        );
+        return Convert
+            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)))
+            .ToLowerInvariant();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsSegmentOperatingIncomeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RevenueBreakdownToolsSegmentOperatingIncomeTests.cs
@@ -21,9 +21,9 @@ namespace Equibles.IntegrationTests.Mcp;
 /// <item>segments are NOT expected to add up to the consolidated figure (unallocated corporate
 /// costs sit outside them), so the revenue-shaped overlap warning would fire on a normal filing
 /// and fabricate a claim about the issuer's XBRL tagging;</item>
-/// <item>and because that same non-reconciliation makes the arithmetic completeness test
-/// unpassable, a discontinued segment must be dropped by the newest filing's roster instead, or
-/// it lingers forever and is summed into the table.</item>
+/// <item>a partial amendment may restate only one member, so unchanged members must carry forward;
+/// a newest-filing roster is authoritative only when its members reconcile as a complete
+/// re-disaggregation.</item>
 /// </list>
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
@@ -83,6 +83,9 @@ public class RevenueBreakdownToolsSegmentOperatingIncomeTests : ParadeDbMcpTestB
         var result = await Sut().GetRevenueBreakdown("AAPL");
 
         result.Should().Contain("**Segment operating income**");
+        result.Should().Contain("**Segment operating margin** (%)");
+        result.Should().Contain("| Americas Segment | 34 |");
+        result.Should().Contain("same folded raw member QName and exact period match");
         result.Should().Contain("Total operating income (consolidated)");
         // The profit total must never be presented as revenue.
         result.Should().NotContain("| **Total revenue (consolidated)** | $123,000,000,000");
@@ -97,24 +100,61 @@ public class RevenueBreakdownToolsSegmentOperatingIncomeTests : ParadeDbMcpTestB
     }
 
     [Fact]
-    public async Task GetRevenueBreakdown_SegmentOperatingIncome_DropsASegmentTheNewestFilingNoLongerReports()
+    public async Task GetRevenueBreakdown_IncomeWithoutDimensionalRevenue_StillRendersIncome()
     {
-        // The completeness defect this pins: on an axis that cannot reconcile arithmetically, the
-        // old rule always fell back to a per-member carry-forward merge, so a segment the issuer
-        // discontinued (NVDA Singapore, AMD Japan/Europe in the code's own examples) survived from
-        // an older filing and was summed into every later period.
+        var stock = AddStock("SOLO");
+        var revenue = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
+        var operatingIncome = AddConcept("OperatingIncomeLoss");
+
+        AddFact(stock, revenue, 2024, 100_000_000m);
+        AddFact(stock, operatingIncome, 2024, 20_000_000m);
+        AddFact(stock, operatingIncome, 2024, 12_000_000m, (SegmentAxis, "solo:CoreMember"));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("SOLO");
+
+        result.Should().Contain("No dimensional revenue tagging is on record");
+        result.Should().Contain("**Segment operating income**");
+        result.Should().Contain("| Core | $12,000,000 |");
+        result.Should().NotContain("**Segment operating margin**");
+        result.Should().NotContain("has no dimensional revenue or segment operating income");
+    }
+
+    [Fact]
+    public async Task GetRevenueBreakdown_IncomeWithoutAnyRevenueConcept_StillRendersIncome()
+    {
+        var stock = AddStock("INCOMEONLY");
+        var operatingIncome = AddConcept("OperatingIncomeLoss");
+
+        AddFact(stock, operatingIncome, 2024, 20_000_000m);
+        AddFact(stock, operatingIncome, 2024, 12_000_000m, (SegmentAxis, "incomeonly:CoreMember"));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("INCOMEONLY");
+
+        result.Should().Contain("No dimensional revenue tagging is on record");
+        result.Should().Contain("**Segment operating income**");
+        result.Should().Contain("| Core | $12,000,000 |");
+        result.Should().NotContain("**Segment operating margin**");
+        result.Should().NotContain("has no dimensional revenue or segment operating income");
+    }
+
+    [Fact]
+    public async Task GetRevenueBreakdown_SegmentOperatingIncome_CarriesUnchangedMembersAcrossPartialAmendment()
+    {
+        // A partial amendment can restate one segment without repeating every unchanged member.
+        // Treating that one-row filing as the whole roster silently deletes valid segments.
         var stock = AddStock("NVDA");
         var revenue = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
         var operatingIncome = AddConcept("OperatingIncomeLoss");
 
-        // The tool answers off the revenue cut, so a filer tagging segment operating income also
-        // tags segment revenue; without it the whole response short-circuits before this axis.
+        // Seed matching segment revenue so this case also exercises the derived-margin path.
         AddFact(stock, revenue, 2024, 60_000_000_000m);
         AddFact(stock, revenue, 2024, 35_000_000_000m, (SegmentAxis, "nvda:ComputeMember"));
         AddFact(stock, revenue, 2024, 25_000_000_000m, (SegmentAxis, "nvda:GraphicsMember"));
 
         AddFact(stock, operatingIncome, 2024, 30_000_000_000m);
-        // Older filing reports three segments including one later discontinued.
+        // Original filing reports all three segments.
         AddFact(
             stock,
             operatingIncome,
@@ -139,7 +179,8 @@ public class RevenueBreakdownToolsSegmentOperatingIncomeTests : ParadeDbMcpTestB
             1,
             [(SegmentAxis, "nvda:SingaporeMember")]
         );
-        // Newest filing restates the same period with the Singapore segment gone.
+        // Amendment restates Compute alone. Its $11B cannot reconcile to the $30B consolidated
+        // figure, proving that this is not a complete re-disaggregation.
         AddFact(
             stock,
             operatingIncome,
@@ -148,22 +189,103 @@ public class RevenueBreakdownToolsSegmentOperatingIncomeTests : ParadeDbMcpTestB
             2,
             [(SegmentAxis, "nvda:ComputeMember")]
         );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("NVDA");
+
+        result.Should().Contain("**Segment operating income**");
+        result.Should().Contain("Singapore");
+        result.Should().Contain("$11,000,000,000");
+        result.Should().Contain("$8,000,000,000");
+        result.Should().Contain("$2,000,000,000");
+    }
+
+    [Fact]
+    public async Task GetRevenueBreakdown_SegmentOperatingIncome_DropsOldMemberAfterCompleteRedisaggregation()
+    {
+        var stock = AddStock("DROP");
+        var operatingIncome = AddConcept("OperatingIncomeLoss");
+
+        AddFact(stock, operatingIncome, 2024, 20_000_000_000m);
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            10_000_000_000m,
+            1,
+            [(SegmentAxis, "drop:ComputeMember")]
+        );
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            8_000_000_000m,
+            1,
+            [(SegmentAxis, "drop:GraphicsMember")]
+        );
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            2_000_000_000m,
+            1,
+            [(SegmentAxis, "drop:SingaporeMember")]
+        );
+        AddFact(
+            stock,
+            operatingIncome,
+            2024,
+            11_000_000_000m,
+            2,
+            [(SegmentAxis, "drop:ComputeMember")]
+        );
         AddFact(
             stock,
             operatingIncome,
             2024,
             9_000_000_000m,
             2,
-            [(SegmentAxis, "nvda:GraphicsMember")]
+            [(SegmentAxis, "drop:GraphicsMember")]
         );
         await DbContext.SaveChangesAsync();
 
-        var result = await Sut().GetRevenueBreakdown("NVDA");
+        var result = await Sut().GetRevenueBreakdown("DROP");
 
-        result.Should().Contain("**Segment operating income**");
-        result.Should().NotContain("Singapore");
-        // The restated values from the newest filing are the ones shown.
         result.Should().Contain("$11,000,000,000");
+        result.Should().Contain("$9,000,000,000");
+        result.Should().NotContain("Singapore");
+    }
+
+    [Fact]
+    public async Task GetRevenueBreakdown_MergesMemberQNameSpellingDriftAcrossYearsBeforeBuildingMargins()
+    {
+        var stock = AddStock("AMD");
+        var revenue = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
+        var operatingIncome = AddConcept("OperatingIncomeLoss");
+
+        AddFact(stock, revenue, 2023, 100m);
+        AddFact(stock, revenue, 2023, 60m, (SegmentAxis, "amd:DatacenterMember"));
+        AddFact(stock, revenue, 2023, 40m, (SegmentAxis, "amd:ClientMember"));
+        AddFact(stock, revenue, 2024, 200m);
+        AddFact(stock, revenue, 2024, 120m, (SegmentAxis, "amd:DataCenterMember"));
+        AddFact(stock, revenue, 2024, 80m, (SegmentAxis, "amd:ClientMember"));
+
+        AddFact(stock, operatingIncome, 2023, 25m);
+        AddFact(stock, operatingIncome, 2023, 15m, (SegmentAxis, "amd:DatacenterMember"));
+        AddFact(stock, operatingIncome, 2023, 10m, (SegmentAxis, "amd:ClientMember"));
+        AddFact(stock, operatingIncome, 2024, 50m);
+        AddFact(stock, operatingIncome, 2024, 30m, (SegmentAxis, "amd:DataCenterMember"));
+        AddFact(stock, operatingIncome, 2024, 20m, (SegmentAxis, "amd:ClientMember"));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetRevenueBreakdown("AMD");
+        var marginSection = result[
+            result.IndexOf("**Segment operating margin**", StringComparison.Ordinal)..
+        ];
+
+        marginSection.Should().Contain("| Component | 2023-12-31 | 2024-12-31 |");
+        marginSection.Should().Contain("| Data Center | 25 | 25 |");
+        marginSection.Should().NotContain("| Datacenter |");
     }
 
     // Writes the real rendering so a docs example is copied from tool output rather than written

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAdjustedCloseTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAdjustedCloseTests.cs
@@ -1,0 +1,97 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Mcp.Tools;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the adjusted-close rule on GetStockPrices (#7058). Close is as traded, so a dividend
+/// payer's price return understates its total return; without the adjusted series NO total-return
+/// figure is computable from this tool at all. The rule is that the column appears exactly when
+/// the window carries an adjustment, and that the output always states which basis it is on —
+/// silence would leave a caller unable to tell "no adjustment here" from "not supported".
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class StockPriceToolsAdjustedCloseTests : ParadeDbMcpTestBase
+{
+    public StockPriceToolsAdjustedCloseTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private StockPriceTools Sut() =>
+        new(
+            new DailyStockPriceRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<StockPriceTools>()
+        );
+
+    [Fact]
+    public async Task GetStockPrices_WhenTheWindowHoldsAnAdjustment_RendersTheAdjustedClose()
+    {
+        var stock = await SeedPrices(adjustedOffset: -3m);
+
+        var result = await Sut()
+            .GetStockPrices(stock.Ticker, startDate: "2025-01-06", endDate: "2025-01-20");
+
+        result.Should().Contain("| Date | Open | High | Low | Close | Adj Close | Volume |");
+        result.Should().Contain("97.00");
+        result.Should().Contain("adjusted for splits and dividends");
+    }
+
+    [Fact]
+    public async Task GetStockPrices_WhenNothingWasAdjusted_OmitsTheColumnAndSaysWhy()
+    {
+        // A stock that neither split nor paid a dividend has an identical adjusted series, so the
+        // column would repeat the close on every row. Dropping it silently would read as the tool
+        // being unable to answer total return, hence the explicit statement.
+        var stock = await SeedPrices(adjustedOffset: 0m);
+
+        var result = await Sut()
+            .GetStockPrices(stock.Ticker, startDate: "2025-01-06", endDate: "2025-01-20");
+
+        result.Should().Contain("| Date | Open | High | Low | Close | Volume |");
+        result.Should().NotContain("Adj Close");
+        result.Should().Contain("total return equals price return");
+    }
+
+    private async Task<CommonStock> SeedPrices(decimal adjustedOffset)
+    {
+        var stock = MakeStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+
+        var start = new DateOnly(2025, 1, 6);
+        for (var i = 0; i < 10; i++)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = start.AddDays(i),
+                        Open = 100m,
+                        High = 101m,
+                        Low = 99m,
+                        Close = 100m,
+                        AdjustedClose = 100m + adjustedOffset,
+                        Volume = 1_000,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+        return stock;
+    }
+
+    private static CommonStock MakeStock() =>
+        new()
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+        };
+}

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAdjustedCloseTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAdjustedCloseTests.cs
@@ -11,14 +11,10 @@ namespace Equibles.IntegrationTests.Mcp;
 /// <summary>
 /// Pins the adjusted-close rule on GetStockPrices (#7058).
 /// <para>
-/// The rule is about STORED ROWS, not about the world. A stored AdjustedClose carries whatever
-/// adjustment the provider had applied when that row was written, and nothing restates it when a
-/// LATER corporate action goes ex; the forward EOD lane also writes AdjustedClose = Close. So one
-/// series straddles bases — a dividend payer's older bars are discounted and its newer bars are
-/// not — and equality between the two columns proves nothing about the issuer. The tool must
-/// never infer an absence of corporate actions, must never offer the series as a total-return
-/// basis, and must never describe it as split-only: a caller told that would add dividends back
-/// itself and double-discount the pre-seam rows.
+/// AdjustedClose is an auxiliary stored provider series that can be rewritten with the full price
+/// history and is not guaranteed to be complete total return. Neither equality nor a difference
+/// identifies which corporate actions it reflects, and the tool makes no universal Close-basis
+/// claim.
 /// </para>
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
@@ -45,31 +41,31 @@ public class StockPriceToolsAdjustedCloseTests : ParadeDbMcpTestBase
 
         result.Should().Contain("| Date | Open | High | Low | Close | Adj Close | Volume |");
         result.Should().Contain("97.00");
-        result.Should().Contain("stored adjusted close");
-        result.Should().Contain("never restated when a later corporate action goes ex");
-        // Promising total return off an inconsistent basis is the error #7058 was filed about;
-        // calling the series split-only is the opposite error, because a caller who believed it
-        // would add dividends back and double-discount every pre-seam row.
-        result.Should().NotContain("total return from Adj Close");
+        result.Should().Contain("auxiliary stored provider series");
+        result.Should().Contain("rewritten with the full history during split reconciliation");
+        result.Should().Contain("not guaranteed to be complete total return");
+        result.Should().NotContain("compute total return from Adj Close");
         result.Should().NotContain("splits only");
         result.Should().NotContain("dividends never restate");
+        result.Should().NotContain("price as traded");
+        result.Should().NotContain("never restated");
     }
 
     [Fact]
     public async Task GetStockPrices_WhenNothingWasAdjusted_OmitsTheColumnAndSaysWhy()
     {
-        // A stock that neither split nor paid a dividend has an identical adjusted series, so the
-        // column would repeat the close on every row. Dropping it silently would read as the tool
-        // being unable to answer total return, hence the explicit statement.
+        // This stored window has an identical adjusted series, so the column would repeat Close
+        // on every row. The note must describe only that stored equality, not infer why it exists.
         var stock = await SeedPrices(adjustedOffset: 0m);
 
         var result = await Sut()
             .GetStockPrices(stock.Ticker, startDate: "2025-01-06", endDate: "2025-01-20");
 
         result.Should().Contain("| Date | Open | High | Low | Close | Volume |");
-        result.Should().NotContain("Adj Close");
+        result.Should().NotContain("| Date | Open | High | Low | Close | Adj Close | Volume |");
         // Says what is true of the stored rows, and nothing about whether the issuer acted.
         result.Should().Contain("equals Close on every row shown");
+        result.Should().Contain("rewritten with the full history during split reconciliation");
         result.Should().NotContain("no split or dividend");
         result.Should().NotContain("total return equals price return");
     }

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAdjustedCloseTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAdjustedCloseTests.cs
@@ -11,12 +11,14 @@ namespace Equibles.IntegrationTests.Mcp;
 /// <summary>
 /// Pins the adjusted-close rule on GetStockPrices (#7058).
 /// <para>
-/// The rule is about STORED ROWS, not about the world. Our AdjustedClose is restated only when a
-/// split rebase runs; dividends never rebase it and the forward EOD lane writes AdjustedClose =
-/// Close. So equality between the two columns proves only that no split rebase has touched these
-/// rows — a dividend payer's recent bars are equal while dividends were certainly paid. The tool
-/// must therefore never infer an absence of corporate actions, and must never offer the series as
-/// a total-return basis.
+/// The rule is about STORED ROWS, not about the world. A stored AdjustedClose carries whatever
+/// adjustment the provider had applied when that row was written, and nothing restates it when a
+/// LATER corporate action goes ex; the forward EOD lane also writes AdjustedClose = Close. So one
+/// series straddles bases — a dividend payer's older bars are discounted and its newer bars are
+/// not — and equality between the two columns proves nothing about the issuer. The tool must
+/// never infer an absence of corporate actions, must never offer the series as a total-return
+/// basis, and must never describe it as split-only: a caller told that would add dividends back
+/// itself and double-discount the pre-seam rows.
 /// </para>
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
@@ -43,11 +45,14 @@ public class StockPriceToolsAdjustedCloseTests : ParadeDbMcpTestBase
 
         result.Should().Contain("| Date | Open | High | Low | Close | Adj Close | Volume |");
         result.Should().Contain("97.00");
-        result.Should().Contain("split-adjusted");
-        // The series is split-only, so promising total return from it would be wrong in the
-        // understating direction — the very error #7058 was filed about.
+        result.Should().Contain("stored adjusted close");
+        result.Should().Contain("never restated when a later corporate action goes ex");
+        // Promising total return off an inconsistent basis is the error #7058 was filed about;
+        // calling the series split-only is the opposite error, because a caller who believed it
+        // would add dividends back and double-discount every pre-seam row.
         result.Should().NotContain("total return from Adj Close");
-        result.Should().Contain("NOT maintained for dividends");
+        result.Should().NotContain("splits only");
+        result.Should().NotContain("dividends never restate");
     }
 
     [Fact]
@@ -72,10 +77,11 @@ public class StockPriceToolsAdjustedCloseTests : ParadeDbMcpTestBase
     [Fact]
     public async Task GetStockPrices_ForADividendPayerWithNoStoredRebase_MakesNoCorporateActionClaim()
     {
-        // The production case that made the old wording a false statement: KO, JNJ, MSFT and PG
-        // all paid dividends recently, yet none has a single adj != close bar since 2026-05-01,
-        // because only a split rebase restates the stored series. The tool must not translate
-        // "our two stored columns match" into "the company paid nothing".
+        // The production case that made the old wording a false statement (issue #7088): each
+        // dividend payer's differing bars stop on the last session before its newest ex-date —
+        // KO 2026-06-12 vs ex-div 2026-06-15, PG 2026-07-23 vs 2026-07-24 — so the newest rows
+        // match while the company plainly paid. The tool must not translate "our two stored
+        // columns match" into "the company paid nothing".
         var stock = await SeedPrices(adjustedOffset: 0m);
 
         var result = await Sut()
@@ -88,6 +94,8 @@ public class StockPriceToolsAdjustedCloseTests : ParadeDbMcpTestBase
                 "no dividend",
                 "total return equals price return",
                 "adjusted for splits and dividends",
+                "splits only",
+                "not dividend-adjusted",
             }
         )
         {

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAdjustedCloseTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAdjustedCloseTests.cs
@@ -9,11 +9,15 @@ using Xunit;
 namespace Equibles.IntegrationTests.Mcp;
 
 /// <summary>
-/// Pins the adjusted-close rule on GetStockPrices (#7058). Close is as traded, so a dividend
-/// payer's price return understates its total return; without the adjusted series NO total-return
-/// figure is computable from this tool at all. The rule is that the column appears exactly when
-/// the window carries an adjustment, and that the output always states which basis it is on —
-/// silence would leave a caller unable to tell "no adjustment here" from "not supported".
+/// Pins the adjusted-close rule on GetStockPrices (#7058).
+/// <para>
+/// The rule is about STORED ROWS, not about the world. Our AdjustedClose is restated only when a
+/// split rebase runs; dividends never rebase it and the forward EOD lane writes AdjustedClose =
+/// Close. So equality between the two columns proves only that no split rebase has touched these
+/// rows — a dividend payer's recent bars are equal while dividends were certainly paid. The tool
+/// must therefore never infer an absence of corporate actions, and must never offer the series as
+/// a total-return basis.
+/// </para>
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class StockPriceToolsAdjustedCloseTests : ParadeDbMcpTestBase
@@ -39,7 +43,11 @@ public class StockPriceToolsAdjustedCloseTests : ParadeDbMcpTestBase
 
         result.Should().Contain("| Date | Open | High | Low | Close | Adj Close | Volume |");
         result.Should().Contain("97.00");
-        result.Should().Contain("adjusted for splits and dividends");
+        result.Should().Contain("split-adjusted");
+        // The series is split-only, so promising total return from it would be wrong in the
+        // understating direction — the very error #7058 was filed about.
+        result.Should().NotContain("total return from Adj Close");
+        result.Should().Contain("NOT maintained for dividends");
     }
 
     [Fact]
@@ -55,7 +63,36 @@ public class StockPriceToolsAdjustedCloseTests : ParadeDbMcpTestBase
 
         result.Should().Contain("| Date | Open | High | Low | Close | Volume |");
         result.Should().NotContain("Adj Close");
-        result.Should().Contain("total return equals price return");
+        // Says what is true of the stored rows, and nothing about whether the issuer acted.
+        result.Should().Contain("equals Close on every row shown");
+        result.Should().NotContain("no split or dividend");
+        result.Should().NotContain("total return equals price return");
+    }
+
+    [Fact]
+    public async Task GetStockPrices_ForADividendPayerWithNoStoredRebase_MakesNoCorporateActionClaim()
+    {
+        // The production case that made the old wording a false statement: KO, JNJ, MSFT and PG
+        // all paid dividends recently, yet none has a single adj != close bar since 2026-05-01,
+        // because only a split rebase restates the stored series. The tool must not translate
+        // "our two stored columns match" into "the company paid nothing".
+        var stock = await SeedPrices(adjustedOffset: 0m);
+
+        var result = await Sut()
+            .GetStockPrices(stock.Ticker, startDate: "2025-01-06", endDate: "2025-01-20");
+
+        foreach (
+            var forbidden in new[]
+            {
+                "no split or dividend",
+                "no dividend",
+                "total return equals price return",
+                "adjusted for splits and dividends",
+            }
+        )
+        {
+            result.Should().NotContain(forbidden);
+        }
     }
 
     private async Task<CommonStock> SeedPrices(decimal adjustedOffset)

--- a/tests/Equibles.UnitTests/CorporateActions/StockSplitBackfillManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/StockSplitBackfillManagerTests.cs
@@ -115,7 +115,7 @@ public class StockSplitBackfillManagerTests
         split.Source.Should().Be(StockSplitSource.Yahoo);
         split.PriceSeriesTicker.Should().Be("AAPL");
         // Null marks the exact listed series pending for the price sync's split reconciliation,
-        // which re-pulls the fully-adjusted history — the backfill itself never
+        // which re-pulls the full provider-served history — the backfill itself never
         // touches stored prices.
         split.PriceAdjustmentAppliedTime.Should().BeNull();
     }

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs
@@ -1,5 +1,16 @@
 using System.Reflection;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.GovernmentContracts.Data;
+using Equibles.GovernmentContracts.Data.Models;
 using Equibles.GovernmentContracts.Mcp.Tools;
+using Equibles.GovernmentContracts.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Equibles.UnitTests.GovernmentContracts;
 
@@ -32,6 +43,85 @@ public class GovernmentContractsToolsShortenSurrogateTests
         HasUnpairedSurrogate(result)
             .Should()
             .BeFalse("truncation must not split a surrogate pair into a lone surrogate");
+    }
+
+    [Fact]
+    public void Escape_BackslashBeforePipe_KeepsAwardCellInsideItsColumn()
+    {
+        var method = typeof(GovernmentContractsTools).GetMethod(
+            "Escape",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method!.Invoke(null, ["Subsidiary\\|Division"]);
+
+        result.Should().Be("Subsidiary\\\\\\|Division");
+    }
+
+    [Fact]
+    public async Task GetGovernmentContracts_RendersRecipientAndOutlaysWithSafeCells()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        await using var context = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new GovernmentContractsModuleConfiguration(),
+            }
+        );
+        context.Database.EnsureCreated();
+        var stock = new CommonStock
+        {
+            Ticker = "RTX",
+            Name = "RTX Corp",
+            Cik = "0000101829",
+        };
+        context.Add(stock);
+        context.Add(
+            new GovernmentContract
+            {
+                CommonStockId = stock.Id,
+                AwardUniqueKey = "award-1",
+                AwardId = "W58RGZ26C0001",
+                RecipientName =
+                    @"RTX Defense Holdings International Systems and\|Missiles Division LLC",
+                AwardType = GovernmentContractAwardType.DefinitiveContract,
+                AwardingAgency = "Department of Defense",
+                Amount = 1_500_000m,
+                TotalOutlays = 250_000m,
+                ActionDate = new DateOnly(2026, 6, 1),
+                EndDate = new DateOnly(2028, 6, 1),
+                Description = "Missile systems",
+            }
+        );
+        await context.SaveChangesAsync();
+        var tools = new GovernmentContractsTools(
+            new GovernmentContractRepository(context),
+            new CommonStockRepository(context),
+            new ErrorManager(null!),
+            NullLogger<GovernmentContractsTools>.Instance
+        );
+
+        var result = await tools.GetGovernmentContracts("RTX", "2026-01-01", "2026-12-31");
+
+        result.Should().Contain("| Award Date | Recipient | Agency |");
+        result.Should().Contain("| Outlays |");
+        result
+            .Should()
+            .Contain(@"RTX Defense Holdings International Systems and\\\|Missiles Division LLC");
+        result.Should().Contain("$250,000");
+
+        var ranking = await tools.GetTopGovernmentContractors("2026-01-01", "2026-12-31");
+        ranking
+            .Should()
+            .NotContain(
+                "Recipient is the awarded entity",
+                "the market-wide ranking has no Recipient column"
+            );
     }
 
     private static bool HasUnpairedSurrogate(string value)

--- a/tests/Equibles.UnitTests/Holdings/MarketWideActivityQueryExtensionsTieBreakTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/MarketWideActivityQueryExtensionsTieBreakTests.cs
@@ -1,0 +1,92 @@
+using Equibles.Holdings.Repositories.Extensions;
+using Equibles.Holdings.Repositories.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class MarketWideActivityQueryExtensionsTieBreakTests
+{
+    private static readonly Guid First = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly Guid Second = Guid.Parse("00000000-0000-0000-0000-000000000002");
+
+    [Fact]
+    public void EnumerableBuckets_BreakHeadlineMetricTiesByStockId()
+    {
+        AssertActivityOrder(ActivityRows().TopBuyers());
+        AssertActivityOrder(SellerRows().TopSellers());
+        AssertChurnOrder(ChurnRows().NewPositions());
+        AssertChurnOrder(ChurnRows().SoldOutPositions());
+    }
+
+    [Fact]
+    public void QueryableBuckets_BreakHeadlineMetricTiesByStockId()
+    {
+        AssertActivityOrder(ActivityRows().AsQueryable().TopBuyers());
+        AssertActivityOrder(SellerRows().AsQueryable().TopSellers());
+        AssertChurnOrder(ChurnRows().AsQueryable().NewPositions());
+        AssertChurnOrder(ChurnRows().AsQueryable().SoldOutPositions());
+    }
+
+    private static MarketWideStockActivity[] ActivityRows() =>
+        [
+            new()
+            {
+                CommonStockId = Second,
+                CurrentShares = 2,
+                PreviousShares = 1,
+                CurrentValue = 20,
+                PreviousValue = 10,
+            },
+            new()
+            {
+                CommonStockId = First,
+                CurrentShares = 2,
+                PreviousShares = 1,
+                CurrentValue = 20,
+                PreviousValue = 10,
+            },
+        ];
+
+    private static MarketWideStockActivity[] SellerRows() =>
+        [
+            new()
+            {
+                CommonStockId = Second,
+                CurrentShares = 1,
+                PreviousShares = 2,
+                CurrentValue = 10,
+                PreviousValue = 20,
+            },
+            new()
+            {
+                CommonStockId = First,
+                CurrentShares = 1,
+                PreviousShares = 2,
+                CurrentValue = 10,
+                PreviousValue = 20,
+            },
+        ];
+
+    private static MarketWideStockChurn[] ChurnRows() =>
+        [
+            new()
+            {
+                CommonStockId = Second,
+                NewFilerCount = 3,
+                SoldOutFilerCount = 4,
+            },
+            new()
+            {
+                CommonStockId = First,
+                NewFilerCount = 3,
+                SoldOutFilerCount = 4,
+            },
+        ];
+
+    private static void AssertActivityOrder(IEnumerable<MarketWideStockActivity> rows) =>
+        rows.Select(r => r.CommonStockId).Should().Equal(First, Second);
+
+    private static void AssertChurnOrder(IEnumerable<MarketWideStockChurn> rows) =>
+        rows.Select(r => r.CommonStockId).Should().Equal(First, Second);
+}

--- a/tests/Equibles.UnitTests/Mcp/MarkdownTableEscapeCellTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MarkdownTableEscapeCellTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class MarkdownTableEscapeCellTests
+{
+    [Fact]
+    public void EscapeCell_BackslashBeforePipe_KeepsPipeEscapedUnderCommonMarkRules()
+    {
+        var result = MarkdownTable.EscapeCell("A\\|B\r\nC");
+
+        result.Should().Be("A\\\\\\|B  C");
+    }
+
+    [Fact]
+    public void EscapeCell_Null_UsesRequestedEmptyValue()
+    {
+        MarkdownTable.EscapeCell(null, "—").Should().Be("—");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FactMarkdownCellEscapingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownCellEscapingTests.cs
@@ -21,4 +21,12 @@ public class FactMarkdownCellEscapingTests
 
         result.Should().Be("a\\|b c");
     }
+
+    [Fact]
+    public void Cell_BackslashBeforePipe_DoesNotReactivateTableDelimiter()
+    {
+        var result = FactMarkdown.Cell("a\\|b");
+
+        result.Should().Be("a\\\\\\|b");
+    }
 }

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsBuildSegmentMarginSeriesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsBuildSegmentMarginSeriesTests.cs
@@ -1,0 +1,97 @@
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class RevenueBreakdownToolsBuildSegmentMarginSeriesTests
+{
+    [Fact]
+    public void BuildSegmentMarginSeries_MatchesFoldedQNameAndPeriod_WithPositiveRevenueOnly()
+    {
+        var fy2023 = new DateOnly(2023, 12, 31);
+        var fy2024 = new DateOnly(2024, 12, 31);
+        var fy2025 = new DateOnly(2025, 12, 31);
+        var fy2023Start = new DateOnly(2023, 1, 1);
+        var fy2024Start = new DateOnly(2024, 1, 1);
+        var fy2025Start = new DateOnly(2025, 1, 1);
+        var revenue = new RevenueBreakdownTools.AxisSeries(
+            "USD",
+            [fy2023, fy2024],
+            [
+                new("acme:Cloud_Member", "Cloud", [100m, 200m], [fy2023Start, fy2024Start]),
+                new("sales:SharedMember", "Shared", [50m, 50m], [fy2023Start, fy2024Start]),
+                new("acme:ZeroMember", "Zero", [0m, 0m], [fy2023Start, fy2024Start]),
+            ]
+        );
+        var income = new RevenueBreakdownTools.AxisSeries(
+            "USD",
+            [fy2024, fy2025],
+            [
+                new("ACME:CloudMember", "Cloud", [50m, 999m], [fy2024Start, fy2025Start]),
+                new("profit:SharedMember", "Shared", [20m, 20m], [fy2024Start, fy2025Start]),
+                new("acme:ZeroMember", "Zero", [10m, 10m], [fy2024Start, fy2025Start]),
+            ]
+        );
+
+        var result = RevenueBreakdownTools.BuildSegmentMarginSeries(revenue, income);
+
+        result.Unit.Should().Be("%");
+        result
+            .PeriodEnds.Should()
+            .ContainSingle("only an exact shared period is computable")
+            .Which.Should()
+            .Be(fy2024);
+        result.Members.Should().ContainSingle();
+        result.Members[0].Member.Should().Be("acme:Cloud_Member");
+        result.Members[0].Values.Should().Equal(25m);
+        result
+            .Members.Should()
+            .NotContain(
+                m => m.Label == "Shared",
+                "equal display labels from different member QNames are not the same segment"
+            );
+        result
+            .Members.Should()
+            .NotContain(m => m.Label == "Zero", "non-positive revenue is never a denominator");
+    }
+
+    [Fact]
+    public void BuildSegmentMarginSeries_SameEndButDifferentDuration_DoesNotDivide()
+    {
+        var end = new DateOnly(2024, 12, 31);
+        var revenue = new RevenueBreakdownTools.AxisSeries(
+            "USD",
+            [end],
+            [new("acme:CloudMember", "Cloud", [200m], [new DateOnly(2024, 1, 1)])]
+        );
+        var income = new RevenueBreakdownTools.AxisSeries(
+            "USD",
+            [end],
+            [new("acme:CloudMember", "Cloud", [50m], [new DateOnly(2023, 10, 1)])]
+        );
+
+        var result = RevenueBreakdownTools.BuildSegmentMarginSeries(revenue, income);
+
+        result.Members.Should().BeEmpty("an exact period match includes both duration endpoints");
+    }
+
+    [Fact]
+    public void BuildSegmentMarginSeries_DifferentCurrencies_DoesNotDivide()
+    {
+        var end = new DateOnly(2024, 12, 31);
+        var start = new DateOnly(2024, 1, 1);
+        var revenue = new RevenueBreakdownTools.AxisSeries(
+            "USD",
+            [end],
+            [new("acme:CloudMember", "Cloud", [200m], [start])]
+        );
+        var income = new RevenueBreakdownTools.AxisSeries(
+            "EUR",
+            [end],
+            [new("acme:CloudMember", "Cloud", [50m], [start])]
+        );
+
+        var result = RevenueBreakdownTools.BuildSegmentMarginSeries(revenue, income);
+
+        result.Members.Should().BeEmpty("a ratio across different currencies is meaningless");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the OSS half of EquiblesCommercial #7058 by making MCP renderings preserve the evidence and fields already available in the shared stores.

- `GetStockPrices` renders `Adj Close` when it differs and describes it honestly as an auxiliary provider series. Neither equality with nor a difference from `Close` proves a dividend or split, and the stored series is not guaranteed to be complete total return.
- `GetRevenueBreakdown` renders segment operating income and derives segment operating margin only for the same folded raw member QName, exact start/end duration, and unit. Partial amendments carry unchanged members; a newest roster replaces history only when it reconciles as a complete re-disaggregation.
- Congressional trades render the filed asset instrument, including options and bonds.
- Form 144 renders complete escaped remarks, including late Rule 10b5-1 disclosures, plus safe filed-text cells.
- Government-contract rows preserve the full recipient legal name and conditionally render outlays.
- Fund operations render deterministic historical N-CEN provider changes, including same-day amendments.
- FRED search renders seasonal adjustment, latest observation date, and the exact Equibles sync timestamp.
- Market-wide 13F activity explains that delta value includes price movement, uses honest stored-value provenance, and applies stable cutoff tie-breaks.
- Shared Markdown escaping and public guides are synchronized with the final output contracts.

## Verification

- `dotnet build Equibles.sln -c Release --no-restore`
- `dotnet csharpier check .` (3,288 files)
- OSS unit tests: 4,174 passed
- Focused MCP integration tests: 94 passed
- Independent post-fix review: clean
