### PR TITLE
fix(financial-facts): repair fiscal fact quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,8 @@ This self-hosted build exposes 64 tools over MCP. The hosted server at `https://
 
 **Fundamentals (XBRL)**
 
-- GetFinancialStatement — income/balance/cash-flow statement by period
-- GetFinancialFact — one concept over time
+- GetFinancialStatement — income/balance/cash-flow statement anchored to one period end, with each line's exact span
+- GetFinancialFact — one concept over time with exact spans and stale-alias coverage warnings
 - CompareFinancialFact — a concept across companies
 - GetRevenueBreakdown — revenue by segment/geography/product plus reported segment operating income and derived margin
 

--- a/docs/guide/how-to-ask-about-financial-statements.md
+++ b/docs/guide/how-to-ask-about-financial-statements.md
@@ -15,7 +15,7 @@ Name a company, a statement, and a period:
 - "What did Microsoft's balance sheet look like last fiscal year?"
 - "Pull NVDA's cash-flow statement for its latest annual period."
 
-The assistant calls the `GetFinancialStatement` tool and replies with the standard line items — revenue, net income, total assets, operating cash flow, and the rest — for the fiscal year and period you asked for, using the latest restated values.
+The assistant calls the `GetFinancialStatement` tool and replies with the standard line items — revenue, net income, total assets, operating cash flow, and the rest — for the fiscal year and period you asked for, using the latest restated values. Every line is anchored to one statement period end and includes its actual period start, so a discrete quarter and a fiscal-year-to-date flow remain visibly different.
 
 ## Follow one metric over time
 
@@ -24,7 +24,7 @@ To track a single concept across periods rather than a whole statement:
 - "How has Apple's revenue changed over the last several years?"
 - "Show me Tesla's diluted EPS history."
 
-The assistant uses `GetFinancialFact`, which returns a time series with one row per fiscal period. Common concepts include revenue, net income, diluted EPS, total assets, and operating cash flow.
+The assistant uses `GetFinancialFact`, which returns a time series with one row per fiscal period and the exact start/end span. Common concepts include revenue, net income, diluted EPS, total assets, and operating cash flow. If the alias ends more than roughly 18 months before the company's other structured facts, the result warns that the filer may have switched XBRL tags; an absent recent row is not treated as proof that the measure stopped.
 
 ## Compare companies side by side
 
@@ -36,7 +36,7 @@ The assistant calls `CompareFinancialFact`, returning one row per ticker for the
 
 ## What you should see
 
-A Markdown table (or several) with figures taken directly from the company's XBRL filings, labelled by fiscal year and period. Values are the latest restated numbers unless you ask for them as originally reported.
+A Markdown table (or several) with figures taken directly from the company's XBRL filings, labelled by fiscal year, fiscal period, period start, and period end. Values are the latest restated numbers unless you ask for them as originally reported. A canonical periodic report (10-K, 10-Q, 20-F, or 40-F) outranks a later proxy that repeats the same period's figure in rounded form.
 
 If a statement or metric is missing, the most likely reasons are that the scraper hasn't imported that company's XBRL facts yet, or the company doesn't tag that concept. For a breakdown of revenue by segment, geography, or product — which lives in dimensional facts rather than the standard statements — see [Ask your AI assistant for a company's revenue breakdown](how-to-ask-about-revenue-breakdown.md).
 

--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -89,12 +89,12 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 `FinancialFactsTools`:
 
-- `GetFinancialFact` — time series for one XBRL concept (e.g. `us-gaap:Revenues`) on one ticker.
+- `GetFinancialFact` — time series for one XBRL concept (e.g. `us-gaap:Revenues`) on one ticker, with the exact period start/end and a coverage warning when the alias materially trails the company's other structured facts.
 - `CompareFinancialFact` — same concept compared across multiple tickers.
 
 `FinancialStatementTools`:
 
-- `GetFinancialStatement` — full income statement / balance sheet / cash flow for a ticker + fiscal period.
+- `GetFinancialStatement` — full income statement / balance sheet / cash flow for a ticker + fiscal period, anchored to one actual period end with each line's exact start/end span.
 
 `RevenueBreakdownTools`:
 

--- a/src/Equibles.Migrations/Migrations/20260810050257_AddFinancialFactsImporterVersion.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260810050257_AddFinancialFactsImporterVersion.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260810050257_AddFinancialFactsImporterVersion")]
+    partial class AddFinancialFactsImporterVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260810050257_AddFinancialFactsImporterVersion.cs
+++ b/src/Equibles.Migrations/Migrations/20260810050257_AddFinancialFactsImporterVersion.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFinancialFactsImporterVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ImporterVersion",
+                table: "FinancialFactsSyncStatus",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ImporterVersion",
+                table: "FinancialFactsSyncStatus");
+        }
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/FinancialFactSourcePriority.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/FinancialFactSourcePriority.cs
@@ -1,0 +1,33 @@
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.Data;
+
+/// <summary>
+/// Ranks the source form for two facts that describe the same concept and actual period.
+/// Periodic reports carry the audited/reviewed statement value; a later proxy can repeat the
+/// same figure rounded for pay-versus-performance disclosure and must not restate it.
+/// </summary>
+public static class FinancialFactSourcePriority
+{
+    public static int Rank(DocumentType form)
+    {
+        if (
+            form == DocumentType.TenK
+            || form == DocumentType.TenKa
+            || form == DocumentType.TenQ
+            || form == DocumentType.TenQa
+            || form == DocumentType.TwentyF
+            || form == DocumentType.FortyF
+        )
+            return 0;
+
+        if (
+            form == DocumentType.EightK
+            || form == DocumentType.EightKa
+            || form == DocumentType.SixK
+        )
+            return 1;
+
+        return 2;
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactsSyncStatus.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactsSyncStatus.cs
@@ -26,6 +26,12 @@ public class FinancialFactsSyncStatus
     public DateOnly? LastFiledDateSeen { get; set; }
 
     /// <summary>
+    /// Version of the Company Facts import contract that last rebuilt this company's rows.
+    /// A lower value forces a full-history replay even when no newer filing exists.
+    /// </summary>
+    public int ImporterVersion { get; set; }
+
+    /// <summary>
     /// When the concept-metadata sweep (labels, descriptions, balance from the
     /// company's recent filings' MetaLinks) last ran for this company; null
     /// until the first run. A <see cref="LastFiledDateSeen"/> newer than this

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -41,8 +41,8 @@ public static class StatementLineFacts
     /// period-end instant alongside re-stated comparative instants. Prefer the
     /// span matching the period's granularity (instants span zero days and
     /// always qualify), then the candidate ending latest so a comparative
-    /// column never stands in for the current one, then the latest restatement
-    /// among same-ending candidates (#1546).
+    /// column never stands in for the current one, then a canonical periodic
+    /// source and the latest restatement among same-ending candidates (#1546).
     /// </summary>
     public static FinancialFact PickCurrentlyReported(
         IEnumerable<FinancialFact> facts,
@@ -65,7 +65,9 @@ public static class StatementLineFacts
 
         return candidates
             .OrderByDescending(f => f.PeriodEnd)
+            .ThenBy(f => FinancialFactSourcePriority.Rank(f.Form))
             .ThenByDescending(f => f.FiledDate)
+            .ThenByDescending(f => f.AccessionNumber)
             .First();
     }
 

--- a/src/Equibles.Sec.FinancialFacts.HostedService/FinancialFactsScraperWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/FinancialFactsScraperWorker.cs
@@ -54,6 +54,7 @@ public class FinancialFactsScraperWorker : BaseScraperWorker
     {
         List<Guid> allStockIds;
         Dictionary<Guid, DateTime> lastCheckedByStock;
+        Dictionary<Guid, int> importerVersionByStock;
         using (var scope = ScopeFactory.CreateScope())
         {
             var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
@@ -65,10 +66,24 @@ public class FinancialFactsScraperWorker : BaseScraperWorker
 
             var syncStatusRepo =
                 scope.ServiceProvider.GetRequiredService<FinancialFactsSyncStatusRepository>();
-            lastCheckedByStock = await syncStatusRepo
+            var syncStatuses = await syncStatusRepo
                 .GetAll()
                 .AsNoTracking()
-                .ToDictionaryAsync(s => s.CommonStockId, s => s.LastCheckedAt, stoppingToken);
+                .Select(s => new
+                {
+                    s.CommonStockId,
+                    s.LastCheckedAt,
+                    s.ImporterVersion,
+                })
+                .ToListAsync(stoppingToken);
+            lastCheckedByStock = syncStatuses.ToDictionary(
+                s => s.CommonStockId,
+                s => s.LastCheckedAt
+            );
+            importerVersionByStock = syncStatuses.ToDictionary(
+                s => s.CommonStockId,
+                s => s.ImporterVersion
+            );
         }
 
         if (allStockIds.Count == 0)
@@ -89,6 +104,7 @@ public class FinancialFactsScraperWorker : BaseScraperWorker
         var stockIds = SelectDueStocks(
             allStockIds,
             lastCheckedByStock,
+            importerVersionByStock,
             DateTime.UtcNow - _recheckInterval
         );
 
@@ -116,24 +132,31 @@ public class FinancialFactsScraperWorker : BaseScraperWorker
     }
 
     /// <summary>
-    /// Companies due for a facts check: never checked (no sync-status row) or
-    /// checked before the cutoff. Never-checked first, then stalest first, so
-    /// an interrupted sweep resumes as an ordered rolling walk (mirrors
-    /// <c>DocumentScraper.SelectDueCompanies</c>).
+    /// Companies due for a facts check: never checked (no sync-status row),
+    /// imported under an older contract version, or checked before the cutoff.
+    /// Never-checked first, then outdated imports, then ordinary stale rows so
+    /// a release repairs the corpus promptly without losing rolling-walk order.
     /// </summary>
     internal static List<Guid> SelectDueStocks(
         List<Guid> stockIds,
         Dictionary<Guid, DateTime> lastCheckedByStock,
+        Dictionary<Guid, int> importerVersionByStock,
         DateTime cutoff
     ) =>
         stockIds
             .Where(id =>
-                !lastCheckedByStock.TryGetValue(id, out var lastChecked) || lastChecked < cutoff
+                !lastCheckedByStock.TryGetValue(id, out var lastChecked)
+                || !importerVersionByStock.TryGetValue(id, out var importerVersion)
+                || importerVersion < FinancialFactsImportService.CurrentImporterVersion
+                || lastChecked < cutoff
             )
-            .OrderBy(id =>
-                lastCheckedByStock.TryGetValue(id, out var lastChecked)
-                    ? lastChecked
-                    : DateTime.MinValue
+            .OrderBy(id => lastCheckedByStock.ContainsKey(id) ? 1 : 0)
+            .ThenBy(id =>
+                importerVersionByStock.TryGetValue(id, out var importerVersion)
+                && importerVersion >= FinancialFactsImportService.CurrentImporterVersion
+                    ? 1
+                    : 0
             )
+            .ThenBy(id => lastCheckedByStock.GetValueOrDefault(id, DateTime.MinValue))
             .ToList();
 }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactImportQualityFilter.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactImportQualityFilter.cs
@@ -1,0 +1,186 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.HostedService.Services;
+
+/// <summary>
+/// Rejects Company Facts rows whose source is demonstrably lower-quality than another row for
+/// the same actual period. Rejected natural keys are also deleted during a versioned replay so a
+/// bad value already in the store cannot remain selectable.
+/// </summary>
+internal static class FinancialFactImportQualityFilter
+{
+    private const int MinAnnualDays = 350;
+    private const int MaxAnnualDays = 380;
+    private const int MinQuarterDays = 80;
+    private const int MaxQuarterDays = 100;
+    private const int MinimumQuarterCount = 3;
+    private const decimal ScaleMatchTolerance = 0.05m;
+    private const decimal MinimumScaledQuarterRatio = 0.1m;
+    private const decimal MaximumScaledQuarterRatio = 10m;
+
+    private static readonly decimal[] SuspectScaleFactors = [1_000m, 1_000_000m];
+
+    internal static FilterResult Apply(IReadOnlyCollection<FinancialFact> facts)
+    {
+        var rejected = new HashSet<FinancialFact>();
+
+        foreach (
+            var series in facts.GroupBy(f =>
+                (f.CommonStockId, f.FinancialConceptId, f.Unit, f.DimensionsKey)
+            )
+        )
+        {
+            var rows = series.ToList();
+            foreach (var candidate in rows.Where(IsAnnualDuration))
+            {
+                if (HasCorroboratedScaleError(candidate, rows))
+                    rejected.Add(candidate);
+            }
+        }
+
+        var scaleClean = facts.Where(f => !rejected.Contains(f)).ToList();
+        foreach (
+            var period in scaleClean.GroupBy(f =>
+                (
+                    f.CommonStockId,
+                    f.FinancialConceptId,
+                    f.Unit,
+                    f.PeriodType,
+                    f.PeriodStart,
+                    f.PeriodEnd,
+                    f.DimensionsKey
+                )
+            )
+        )
+        {
+            if (!period.Any(f => FinancialFactSourcePriority.Rank(f.Form) == 0))
+                continue;
+
+            foreach (var proxy in period.Where(f => f.Form == DocumentType.Def14A))
+                rejected.Add(proxy);
+        }
+
+        return new FilterResult(
+            facts.Where(f => !rejected.Contains(f)).ToList(),
+            facts.Where(rejected.Contains).ToList()
+        );
+    }
+
+    private static bool HasCorroboratedScaleError(
+        FinancialFact candidate,
+        IReadOnlyCollection<FinancialFact> series
+    )
+    {
+        if (!LooksLikeCurrency(candidate.Unit) || candidate.Value == 0)
+            return false;
+
+        var earlierAnnuals = series
+            .Where(f =>
+                f != candidate
+                && IsAnnualDuration(f)
+                && f.PeriodStart == candidate.PeriodStart
+                && f.PeriodEnd == candidate.PeriodEnd
+                && f.FiledDate < candidate.FiledDate
+                && f.AccessionNumber != candidate.AccessionNumber
+                && FinancialFactSourcePriority.Rank(f.Form) == 0
+                && f.Value != 0
+            )
+            .OrderByDescending(f => f.FiledDate)
+            .ThenByDescending(f => f.AccessionNumber)
+            .ToList();
+        if (earlierAnnuals.Count == 0)
+            return false;
+
+        var quarterRows = series
+            .Where(f =>
+                f.PeriodType == FactPeriodType.Duration
+                && f.PeriodStart >= candidate.PeriodStart
+                && f.PeriodEnd <= candidate.PeriodEnd
+                && SpanDays(f) >= MinQuarterDays
+                && SpanDays(f) <= MaxQuarterDays
+            )
+            .GroupBy(f => (f.PeriodStart, f.PeriodEnd))
+            .Select(g =>
+                g.OrderBy(f => FinancialFactSourcePriority.Rank(f.Form))
+                    .ThenByDescending(f => f.FiledDate)
+                    .ThenByDescending(f => f.AccessionNumber)
+                    .First()
+            )
+            .ToList();
+        if (quarterRows.Count < MinimumQuarterCount)
+            return false;
+
+        var quarterSum = SaturatingSum(quarterRows.Select(f => f.Value));
+        var quarterMagnitude = SaturatingSum(quarterRows.Select(f => Magnitude(f.Value)));
+        if (
+            quarterMagnitude == 0
+            || quarterSum == 0
+            || Math.Sign(quarterSum) != Math.Sign(candidate.Value)
+        )
+            return false;
+
+        foreach (var reference in earlierAnnuals)
+        {
+            if (Math.Sign(reference.Value) != Math.Sign(candidate.Value))
+                continue;
+
+            foreach (var scaleFactor in SuspectScaleFactors)
+            {
+                var scaledCandidate = candidate.Value / scaleFactor;
+                if (!ApproximatelyEqual(scaledCandidate, reference.Value))
+                    continue;
+
+                var scaledQuarterRatio = Magnitude(scaledCandidate) / quarterMagnitude;
+                if (
+                    scaledQuarterRatio >= MinimumScaledQuarterRatio
+                    && scaledQuarterRatio <= MaximumScaledQuarterRatio
+                )
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsAnnualDuration(FinancialFact fact) =>
+        fact.PeriodType == FactPeriodType.Duration
+        && SpanDays(fact) >= MinAnnualDays
+        && SpanDays(fact) <= MaxAnnualDays;
+
+    private static int SpanDays(FinancialFact fact) =>
+        fact.PeriodEnd.DayNumber - fact.PeriodStart.DayNumber;
+
+    private static bool LooksLikeCurrency(string unit) =>
+        unit is { Length: 3 } && unit.All(char.IsAsciiLetterUpper);
+
+    private static bool ApproximatelyEqual(decimal left, decimal right)
+    {
+        var denominator = Math.Max(Magnitude(left), Magnitude(right));
+        return denominator > 0 && Magnitude(left - right) / denominator <= ScaleMatchTolerance;
+    }
+
+    private static decimal Magnitude(decimal value) =>
+        value == decimal.MinValue ? decimal.MaxValue : Math.Abs(value);
+
+    private static decimal SaturatingSum(IEnumerable<decimal> values)
+    {
+        var result = 0m;
+        foreach (var value in values)
+        {
+            if (value > 0 && result > decimal.MaxValue - value)
+                return decimal.MaxValue;
+            if (value < 0 && result < decimal.MinValue - value)
+                return decimal.MinValue;
+            result += value;
+        }
+        return result;
+    }
+
+    internal sealed record FilterResult(
+        IReadOnlyList<FinancialFact> Accepted,
+        IReadOnlyList<FinancialFact> Rejected
+    );
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -32,6 +32,11 @@ public class FinancialFactsImportService
 {
     private const int InsertBatchSize = 1000;
 
+    // Bump whenever parsing, fiscal identity, or quality filtering changes existing rows. The
+    // per-company checkpoint forces a full Company Facts replay without racing the old worker
+    // during an additive migration rollout.
+    internal const int CurrentImporterVersion = 1;
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ISecEdgarClient _secEdgarClient;
     private readonly ILogger<FinancialFactsImportService> _logger;
@@ -108,8 +113,13 @@ public class FinancialFactsImportService
 
         var maxFiled = parsed.Max(p => p.Filed);
 
-        var lastSeen = await GetLastFiledSeen(stock, cancellationToken);
-        if (lastSeen.HasValue && lastSeen.Value >= maxFiled)
+        var syncStatus = await GetSyncStatus(stock, cancellationToken);
+        var lastSeen = syncStatus?.LastFiledDateSeen;
+        if (
+            syncStatus?.ImporterVersion >= CurrentImporterVersion
+            && lastSeen.HasValue
+            && lastSeen.Value >= maxFiled
+        )
         {
             // Nothing filed since the last successful sync — record the check
             // and skip the (expensive) re-upsert of the full history. Still re-source the share
@@ -214,10 +224,10 @@ public class FinancialFactsImportService
     )
     {
         var conceptIds = await ResolveConcepts(parsed, cancellationToken);
-        var documentIds = await LoadDocumentIdsByAccession(stock, cancellationToken);
+        var documents = await LoadDocumentsByAccession(stock, cancellationToken);
 
         var built = parsed
-            .Select(p => BuildFact(stock, p, conceptIds, documentIds))
+            .Select(p => BuildFact(stock, p, conceptIds, documents))
             .Where(f => f != null)
             .ToList();
 
@@ -234,7 +244,19 @@ public class FinancialFactsImportService
             );
         }
 
-        var facts = CollapseToNaturalKey(built);
+        var quality = FinancialFactImportQualityFilter.Apply(built);
+        if (quality.Rejected.Count > 0)
+        {
+            await DeleteRejectedFacts(stock, quality.Rejected, cancellationToken);
+            _logger.LogWarning(
+                "Rejected {Count} lower-quality Company Facts rows for {Ticker} (CIK {Cik})",
+                quality.Rejected.Count,
+                stock.Ticker,
+                stock.Cik
+            );
+        }
+
+        var facts = CollapseToNaturalKey(quality.Accepted.ToList());
 
         // SyncStatus is advanced only here, after a successful persist, so a
         // failure leaves the checkpoint un-advanced and the company is
@@ -427,7 +449,7 @@ public class FinancialFactsImportService
         return (pairs, concepts);
     }
 
-    private async Task<Dictionary<string, Guid>> LoadDocumentIdsByAccession(
+    private async Task<Dictionary<string, FilingDocumentContext>> LoadDocumentsByAccession(
         CommonStock stock,
         CancellationToken cancellationToken
     )
@@ -438,12 +460,22 @@ public class FinancialFactsImportService
         var rows = await documentRepository
             .GetByCompany(stock)
             .Where(d => d.AccessionNumber != null)
-            .Select(d => new { d.Id, d.AccessionNumber })
+            .Select(d => new
+            {
+                d.Id,
+                d.AccessionNumber,
+                d.ReportingForDate,
+                d.DocumentType,
+            })
             .ToListAsync(cancellationToken);
 
-        var map = new Dictionary<string, Guid>();
+        var map = new Dictionary<string, FilingDocumentContext>();
         foreach (var row in rows)
-            map[row.AccessionNumber] = row.Id;
+            map[row.AccessionNumber] = new FilingDocumentContext(
+                row.Id,
+                row.ReportingForDate,
+                row.DocumentType
+            );
         return map;
     }
 
@@ -451,24 +483,27 @@ public class FinancialFactsImportService
         CommonStock stock,
         ParsedFact p,
         Dictionary<(FactTaxonomy, string), Guid> conceptIds,
-        Dictionary<string, Guid> documentIds
+        Dictionary<string, FilingDocumentContext> documents
     )
     {
         if (!conceptIds.TryGetValue((p.Taxonomy, p.Tag), out var conceptId))
             return null;
 
+        documents.TryGetValue(p.Accession, out var document);
+        var fiscalIdentity = ValidateAgainstFilingDocumentPeriod(stock, p, document);
+
         return new FinancialFact
         {
             CommonStockId = stock.Id,
             FinancialConceptId = conceptId,
-            DocumentId = documentIds.TryGetValue(p.Accession, out var docId) ? docId : null,
+            DocumentId = document?.Id,
             Unit = p.Unit,
             PeriodType = p.PeriodType,
             PeriodStart = p.PeriodStart,
             PeriodEnd = p.PeriodEnd,
             Value = p.Value,
-            FiscalYear = p.FiscalYear,
-            FiscalPeriod = p.FiscalPeriod,
+            FiscalYear = fiscalIdentity.Year,
+            FiscalPeriod = fiscalIdentity.Period,
             // SEC emits many form strings outside the known DocumentTypes
             // (NT 10-K, S-1, 485BPOS, …); fold them into Other rather than
             // fabricating untracked DocumentType instances.
@@ -478,6 +513,46 @@ public class FinancialFactsImportService
             Frame = p.Frame,
         };
     }
+
+    // The Company Facts fy/fp fields identify the filing, and old importer rows can retain that
+    // high stamp. For the accession's own annual period, the stored SEC document supplies an
+    // independent period anchor. Re-resolve against that exact span; if company FYE metadata is
+    // unavailable or stale, a matching annual filing still establishes an FY ending in the
+    // document period's calendar year. Comparable prior-year facts in the same accession do not
+    // match ReportingForDate and continue through the ordinary date resolver.
+    private static (int Year, SecFiscalPeriod Period) ValidateAgainstFilingDocumentPeriod(
+        CommonStock stock,
+        ParsedFact fact,
+        FilingDocumentContext document
+    )
+    {
+        var original = (fact.FiscalYear, fact.FiscalPeriod);
+        if (
+            document == null
+            || fact.PeriodType != FactPeriodType.Duration
+            || fact.PeriodEnd != document.ReportingForDate
+            || fact.PeriodEnd.DayNumber - fact.PeriodStart.DayNumber is < 350 or > 380
+            || !IsAnnualPeriodicForm(document.DocumentType)
+        )
+            return original;
+
+        var resolved = FiscalPeriodResolver.Resolve(
+            fact.PeriodStart,
+            document.ReportingForDate,
+            stock.FiscalYearEndMonth,
+            stock.FiscalYearEndDay
+        );
+        if (resolved is { } validated && validated.Period == SecFiscalPeriod.FullYear)
+            return validated;
+
+        return (document.ReportingForDate.Year, SecFiscalPeriod.FullYear);
+    }
+
+    private static bool IsAnnualPeriodicForm(DocumentType form) =>
+        form == DocumentType.TenK
+        || form == DocumentType.TenKa
+        || form == DocumentType.TwentyF
+        || form == DocumentType.FortyF;
 
     // The CIK set one facts import reads: primary first, then every attached
     // secondary. Distinct because the subsidiary-attach path writes SEC's value
@@ -526,6 +601,10 @@ public class FinancialFactsImportService
                     new FinancialFact
                     {
                         Value = incoming.Value,
+                        PeriodType = incoming.PeriodType,
+                        FiscalYear = incoming.FiscalYear,
+                        FiscalPeriod = incoming.FiscalPeriod,
+                        Form = incoming.Form,
                         Frame = incoming.Frame,
                         FiledDate = incoming.FiledDate,
                         DocumentId = incoming.DocumentId,
@@ -534,15 +613,14 @@ public class FinancialFactsImportService
             .RunAsync();
     }
 
-    private async Task<DateOnly?> GetLastFiledSeen(
+    private async Task<FinancialFactsSyncStatus> GetSyncStatus(
         CommonStock stock,
         CancellationToken cancellationToken
     )
     {
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<FinancialFactsSyncStatusRepository>();
-        var status = await repo.GetByStock(stock).FirstOrDefaultAsync(cancellationToken);
-        return status?.LastFiledDateSeen;
+        return await repo.GetByStock(stock).FirstOrDefaultAsync(cancellationToken);
     }
 
     private async Task UpsertSyncStatus(
@@ -559,6 +637,7 @@ public class FinancialFactsImportService
             CommonStockId = stock.Id,
             LastCheckedAt = DateTime.UtcNow,
             LastFiledDateSeen = lastFiledSeen,
+            ImporterVersion = CurrentImporterVersion,
         };
 
         await dbContext
@@ -572,10 +651,51 @@ public class FinancialFactsImportService
                         LastCheckedAt = incoming.LastCheckedAt,
                         LastFiledDateSeen =
                             incoming.LastFiledDateSeen ?? existing.LastFiledDateSeen,
+                        ImporterVersion = incoming.ImporterVersion,
                     }
             )
             .RunAsync(cancellationToken);
     }
+
+    private async Task DeleteRejectedFacts(
+        CommonStock stock,
+        IReadOnlyCollection<FinancialFact> rejected,
+        CancellationToken cancellationToken
+    )
+    {
+        var keys = rejected.Select(NaturalKey).ToHashSet();
+        var accessions = rejected.Select(f => f.AccessionNumber).Distinct().ToList();
+        var conceptIds = rejected.Select(f => f.FinancialConceptId).Distinct().ToList();
+
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        var candidates = await dbContext
+            .Set<FinancialFact>()
+            .Where(f =>
+                f.CommonStockId == stock.Id
+                && f.DimensionsKey == ""
+                && accessions.Contains(f.AccessionNumber)
+                && conceptIds.Contains(f.FinancialConceptId)
+            )
+            .ToListAsync(cancellationToken);
+        var rows = candidates.Where(f => keys.Contains(NaturalKey(f))).ToList();
+        if (rows.Count == 0)
+            return;
+
+        dbContext.RemoveRange(rows);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static FactNaturalKey NaturalKey(FinancialFact fact) =>
+        new(
+            fact.CommonStockId,
+            fact.FinancialConceptId,
+            fact.Unit,
+            fact.PeriodStart,
+            fact.PeriodEnd,
+            fact.AccessionNumber,
+            fact.DimensionsKey
+        );
 
     private static bool TryMapTaxonomy(string key, out FactTaxonomy taxonomy)
     {
@@ -667,4 +787,20 @@ public class FinancialFactsImportService
         public string Accession { get; init; }
         public string Frame { get; init; }
     }
+
+    private sealed record FactNaturalKey(
+        Guid CommonStockId,
+        Guid FinancialConceptId,
+        string Unit,
+        DateOnly PeriodStart,
+        DateOnly PeriodEnd,
+        string AccessionNumber,
+        string DimensionsKey
+    );
+
+    internal sealed record FilingDocumentContext(
+        Guid Id,
+        DateOnly ReportingForDate,
+        DocumentType DocumentType
+    );
 }

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -11,6 +11,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Mcp.Helpers;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Statements;
@@ -27,6 +28,7 @@ public class FinancialFactsTools
 {
     private const int MaxResultsCap = 200;
     private const int MaxTickers = 25;
+    private const int MaxUnmarkedSeriesLagDays = 550;
 
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
@@ -53,8 +55,11 @@ public class FinancialFactsTools
             + "assets, operating cash flow) over time for a company, sourced from SEC "
             + "Company Facts (structured XBRL). Returns a time series, one row per fiscal "
             + "period, using the latest restated value unless asOriginallyReported is set. "
-            + "Fiscal years/quarters follow the company's own fiscal calendar. For a full "
-            + "statement use GetFinancialStatement; to compare peers use CompareFinancialFact."
+            + "Each row carries its actual period start/end; fiscal years/quarters follow the "
+            + "company's own fiscal calendar. Warns when the selected alias ends materially "
+            + "before the company's other structured facts, which can indicate an XBRL tag "
+            + "change. For a full statement use GetFinancialStatement; to compare peers use "
+            + "CompareFinancialFact."
     )]
     public Task<string> GetFinancialFact(
         [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -69,8 +74,8 @@ public class FinancialFactsTools
         [Description("Maximum periods to return, newest first (default 40, max 200)")]
             int maxResults = 40,
         [Description(
-            "When true, show the value as originally filed (earliest filing) instead of "
-                + "the latest restatement. Default false."
+            "When true, show the earliest canonical periodic filing instead of the latest "
+                + "restatement within that source priority. Default false."
         )]
             bool asOriginallyReported = false,
         [Description(
@@ -133,6 +138,16 @@ public class FinancialFactsTools
                     .GetConsolidatedByStock(stock)
                     .Where(f => conceptPriority.Keys.Contains(f.FinancialConceptId))
                     .ToListAsync();
+                var companyLatestPeriodEnd = await _financialFactRepository
+                    .GetConsolidatedByStock(stock)
+                    .MaxAsync(f => (DateOnly?)f.PeriodEnd);
+                var aliasLatestPeriodEnd =
+                    facts.Count == 0 ? (DateOnly?)null : facts.Max(f => f.PeriodEnd);
+                var coverageNote = BuildCoverageNote(
+                    stock.Ticker,
+                    aliasLatestPeriodEnd,
+                    companyLatestPeriodEnd
+                );
 
                 // Reported discrete fourth quarters hide under fp=FY — the same
                 // fiscal identity as the annual figure — so grouping by stamp
@@ -155,9 +170,10 @@ public class FinancialFactsTools
                 // One row per fiscal period. The alias may span several tags and
                 // a single period can carry facts under more than one of them
                 // (the ASC 606 transition year tags both Revenues and the new
-                // concept). Pick deterministically: the alias's primary tag
-                // wins, then the latest filing — or the earliest, when the
-                // caller wants the figure as originally reported. The picked
+                // concept). Pick deterministically: a canonical periodic source
+                // wins, then the alias's primary tag, then the latest filing — or
+                // the earliest within that source priority, when the caller wants
+                // the figure as originally reported. The picked
                 // rows are then deduped by actual reporting span, because a
                 // date window can degenerate a fiscal group to a comparative
                 // re-report of an earlier period (see DedupeByReportingSpan).
@@ -179,7 +195,8 @@ public class FinancialFactsTools
                     stock,
                     asOriginallyReported,
                     shown,
-                    perPeriod.Count
+                    perPeriod.Count,
+                    coverageNote
                 );
             },
             "GetFinancialFact",
@@ -311,9 +328,9 @@ public class FinancialFactsTools
                         .ToList();
                 }
 
-                // Same deterministic pick as GetFinancialFact: the alias's
-                // primary tag wins, then the latest filing, then accession as a
-                // stable tiebreak for same-day amendments (Postgres has no
+                // Same deterministic pick as GetFinancialFact: canonical periodic
+                // sources win before the alias's primary tag, then latest filing and
+                // accession provide stable amendment ordering (Postgres has no
                 // implicit row order).
                 var bestByStock = facts
                     .GroupBy(f => f.CommonStockId)
@@ -334,19 +351,20 @@ public class FinancialFactsTools
         CommonStock stock,
         bool asOriginallyReported,
         List<FinancialFact> perPeriod,
-        int totalPeriods
+        int totalPeriods,
+        string coverageNote
     )
     {
         var basis = asOriginallyReported ? "as originally reported" : "latest restated";
         var result = MarkdownTable.Start(
             $"{concept} for {stock.Ticker} ({FactMarkdown.Cell(stock.Name)}) — {basis}:",
-            "| Period End | FY | Period | Value | Unit | Form | Filed | Accession |",
-            "|-----------|---:|--------|------:|------|------|-------|-----------|"
+            "| Period Start | Period End | FY | Period | Value | Unit | Form | Filed | Accession |",
+            "|--------------|------------|---:|--------|------:|------|------|-------|-----------|"
         );
         result.AppendRows(
             perPeriod,
             f =>
-                $"| {f.PeriodEnd:yyyy-MM-dd} | {f.FiscalYear} | "
+                $"| {f.PeriodStart:yyyy-MM-dd} | {f.PeriodEnd:yyyy-MM-dd} | {f.FiscalYear} | "
                 + $"{f.FiscalPeriod.NameForHumans()} | "
                 + $"{FactMarkdown.Value(f.Value, f.Unit)} | "
                 + $"{FactMarkdown.Cell(f.Unit)} | "
@@ -370,7 +388,30 @@ public class FinancialFactsTools
             );
         }
 
+        if (coverageNote != null)
+            result.AppendLine($"\n_{coverageNote}_");
+
         return result.ToString();
+    }
+
+    internal static string BuildCoverageNote(
+        string ticker,
+        DateOnly? aliasLatestPeriodEnd,
+        DateOnly? companyLatestPeriodEnd
+    )
+    {
+        if (
+            aliasLatestPeriodEnd == null
+            || companyLatestPeriodEnd == null
+            || companyLatestPeriodEnd.Value.DayNumber - aliasLatestPeriodEnd.Value.DayNumber
+                <= MaxUnmarkedSeriesLagDays
+        )
+            return null;
+
+        return $"Coverage warning: this alias ends {aliasLatestPeriodEnd:yyyy-MM-dd}, while "
+            + $"other structured facts for {FactMarkdown.Cell(ticker)} reach "
+            + $"{companyLatestPeriodEnd:yyyy-MM-dd}. The filer may have changed XBRL tags; "
+            + "missing recent rows do not establish that the measure stopped.";
     }
 
     private static (
@@ -505,6 +546,7 @@ public class FinancialFactsTools
         // filed date — ignoring the period end surfaces a comparative column (#1546).
         var byPeriod = candidates
             .OrderByDescending(f => f.PeriodEnd)
+            .ThenBy(f => FinancialFactSourcePriority.Rank(f.Form))
             .ThenBy(f => conceptPriority[f.FinancialConceptId]);
         return asOriginallyReported
             ? byPeriod.ThenBy(f => f.FiledDate).ThenBy(f => f.AccessionNumber).First()

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -46,7 +46,9 @@ public class FinancialStatementTools
         "Get a company's income statement, balance sheet, or cash-flow statement for a "
             + "given fiscal year and period, sourced from SEC Company Facts (structured XBRL). "
             + "Returns the standard line items (e.g. revenue, net income, total assets, "
-            + "operating cash flow) with the latest-restated value for the period. "
+            + "operating cash flow) with the latest-restated value for one exact statement "
+            + "period end. Each row carries its actual period start/end so discrete-quarter "
+            + "and fiscal-year-to-date flow facts remain distinguishable. "
             + "Company-specific dimensional facts (e.g. product-segment revenue) are not "
             + "included — use GetRevenueBreakdown for segment/geographic revenue, and "
             + "GetFinancialFact or CompareFinancialFact for one line item across periods "
@@ -133,6 +135,18 @@ public class FinancialStatementTools
                     )
                     .ToListAsync();
 
+                if (facts.Count == 0)
+                    return $"No {statementType.NameForHumans().ToLowerInvariant()} line items "
+                        + $"were reported by {stock.Ticker} for FY{selectedYear} "
+                        + $"{selectedPeriod.NameForHumans()}.";
+
+                // A filing re-reports comparative spans under its own fiscal stamp, and a stale
+                // concept can retain an earlier end under the same (year, period). Anchor the
+                // statement to one actual period end before selecting line values so it cannot
+                // silently combine different balance dates or flow endpoints.
+                var statementPeriodEnd = facts.Max(f => f.PeriodEnd);
+                facts = facts.Where(f => f.PeriodEnd == statementPeriodEnd).ToList();
+
                 // A 10-Q tags each line under one fiscal (year, period) for both the
                 // discrete quarter and the fiscal year-to-date span, and re-reports prior
                 // comparative instants (the prior fiscal-year-end balance) under that same
@@ -176,8 +190,8 @@ public class FinancialStatementTools
             $"{statementType.NameForHumans()} for {stock.Ticker} "
                 + $"({FactMarkdown.Cell(stock.Name)}) — "
                 + $"FY{selectedYear} {selectedPeriod.NameForHumans()}:",
-            "| Line Item | Value | Unit | Period End | Form | Filed |",
-            "|-----------|------:|------|-----------|------|-------|"
+            "| Line Item | Value | Unit | Period Start | Period End | Form | Filed |",
+            "|-----------|------:|------|--------------|------------|------|-------|"
         );
 
         var rendered = 0;
@@ -200,6 +214,7 @@ public class FinancialStatementTools
                 $"| {FactMarkdown.Cell(line.Label)} | "
                     + $"{FactMarkdown.Value(fact.Value, fact.Unit)} | "
                     + $"{FactMarkdown.Cell(fact.Unit)} | "
+                    + $"{fact.PeriodStart:yyyy-MM-dd} | "
                     + $"{fact.PeriodEnd:yyyy-MM-dd} | "
                     + $"{FactMarkdown.Cell(fact.Form?.DisplayName)} | "
                     + $"{fact.FiledDate:yyyy-MM-dd} |"
@@ -219,6 +234,16 @@ public class FinancialStatementTools
         if (omitted > 0)
             result.AppendLine(
                 "\n_Line items the filer did not report for this period are omitted._"
+            );
+
+        if (
+            selectedPeriod != SecFiscalPeriod.FullYear
+            && statementType != FinancialStatementType.BalanceSheet
+        )
+            result.AppendLine(
+                "\n_Quarterly flow rows preserve the exact SEC-reported span. A period can "
+                    + "contain discrete-quarter and fiscal-year-to-date facts; use Period Start "
+                    + "and Period End to distinguish them._"
             );
 
         // Each line independently takes its latest restatement, so one

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsComparativeWindowLeakTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsComparativeWindowLeakTests.cs
@@ -142,11 +142,11 @@ public class FinancialFactsToolsComparativeWindowLeakTests : ParadeDbMcpTestBase
         // Exactly one row for period end 2025-01-26, labeled with ITS year.
         var occurrences = result.Split("| 2025-01-26 |").Length - 1;
         occurrences.Should().Be(1, "one reporting span is one row");
-        result.Should().Contain("| 2025-01-26 | 2025 |");
+        result.Should().Contain("| 2024-01-29 | 2025-01-26 | 2025 |");
         result
             .Should()
             .NotContain(
-                "| 2025-01-26 | 2026 |",
+                "| 2024-01-29 | 2025-01-26 | 2026 |",
                 "the comparative's re-stamp is not a period of its own"
             );
     }
@@ -158,8 +158,8 @@ public class FinancialFactsToolsComparativeWindowLeakTests : ParadeDbMcpTestBase
 
         var result = await Sut().GetFinancialFact("NVDA", "eps-diluted");
 
-        result.Should().Contain("| 2026-01-25 | 2026 |");
-        result.Should().Contain("| 2025-01-26 | 2025 |");
+        result.Should().Contain("| 2025-01-27 | 2026-01-25 | 2026 |");
+        result.Should().Contain("| 2024-01-29 | 2025-01-26 | 2025 |");
         (result.Split("| 2025-01-26 |").Length - 1).Should().Be(1);
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsTests.cs
@@ -155,8 +155,8 @@ public class FinancialFactsToolsTests : ParadeDbMcpTestBase
         var result = await Sut().GetFinancialFact("AAPL", "revenue");
 
         // Newest period first; the alias spans both tags.
-        result.Should().Contain("| 2023-12-31 | 2023 | FY | $400,000,000,000 |");
-        result.Should().Contain("| 2022-12-31 | 2022 | FY | $320,000,000,000 |");
+        result.Should().Contain("| 2023-01-01 | 2023-12-31 | 2023 | FY | $400,000,000,000 |");
+        result.Should().Contain("| 2022-01-01 | 2022-12-31 | 2022 | FY | $320,000,000,000 |");
         result.Should().NotContain("$300,000,000,000", "the latest restatement wins by default");
         var idx2023 = result.IndexOf("2023-12-31", StringComparison.Ordinal);
         var idx2022 = result.IndexOf("2022-12-31", StringComparison.Ordinal);
@@ -273,6 +273,77 @@ public class FinancialFactsToolsTests : ParadeDbMcpTestBase
                 "$999,000,000,000",
                 "the secondary tag must not win a same-period, same-filed tie"
             );
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_LaterProxyDuplicate_DoesNotOutrankPeriodicReport()
+    {
+        var stock = Apple();
+        DbContext.Set<CommonStock>().Add(stock);
+        var revenues = AddConcept("Revenues");
+        AddFact(
+            stock,
+            revenues,
+            2023,
+            SecFiscalPeriod.FullYear,
+            383_285_000_000m,
+            new DateOnly(2024, 2, 1),
+            DocumentType.TenK,
+            "ten-k"
+        );
+        AddFact(
+            stock,
+            revenues,
+            2023,
+            SecFiscalPeriod.FullYear,
+            383_000_000_000m,
+            new DateOnly(2024, 4, 1),
+            DocumentType.Def14A,
+            "proxy"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "revenue");
+
+        result.Should().Contain("$383,285,000,000");
+        result.Should().Contain("| 10-K |");
+        result.Should().NotContain("$383,000,000,000");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_AliasLagsCompanyCorpus_AppendsCoverageWarning()
+    {
+        var stock = Apple();
+        DbContext.Set<CommonStock>().Add(stock);
+        var revenues = AddConcept("Revenues");
+        var assets = AddConcept("Assets");
+        AddFact(
+            stock,
+            revenues,
+            2024,
+            SecFiscalPeriod.FullYear,
+            100_000_000m,
+            new DateOnly(2025, 2, 1),
+            DocumentType.TenK,
+            "revenue-2024"
+        );
+        AddFact(
+            stock,
+            assets,
+            2026,
+            SecFiscalPeriod.Q2,
+            500_000_000m,
+            new DateOnly(2026, 8, 1),
+            DocumentType.TenQ,
+            "assets-2026"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "revenue");
+
+        result.Should().Contain("Coverage warning: this alias ends 2024-12-31");
+        result.Should().Contain("other structured facts for AAPL reach 2026-12-31");
+        result.Should().Contain("may have changed XBRL tags");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
@@ -6,6 +6,7 @@ using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Mcp.Tools;
 using Equibles.Sec.FinancialFacts.Repositories;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -256,5 +257,146 @@ public class FinancialStatementToolsTests : ParadeDbMcpTestBase
         var result = await Sut().GetFinancialStatement("AAPL", statement: "income");
 
         result.Should().Contain("| EPS (Diluted) | $6.13 | USD/shares |");
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_QuarterlyFlows_ShowExactSpansAndDropEarlierEndpoint()
+    {
+        var stock = Apple();
+        var revenue = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenue",
+        };
+        var netIncome = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "NetIncomeLoss",
+            Label = "Net income",
+        };
+        var grossProfit = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "GrossProfit",
+            Label = "Gross profit",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<FinancialConcept>().AddRange(revenue, netIncome, grossProfit);
+
+        FinancialFact Fact(
+            FinancialConcept concept,
+            DateOnly start,
+            DateOnly end,
+            decimal value,
+            string accession
+        ) =>
+            new()
+            {
+                CommonStockId = stock.Id,
+                FinancialConceptId = concept.Id,
+                Unit = "USD",
+                PeriodType = FactPeriodType.Duration,
+                PeriodStart = start,
+                PeriodEnd = end,
+                Value = value,
+                FiscalYear = 2025,
+                FiscalPeriod = SecFiscalPeriod.Q2,
+                Form = DocumentType.TenQ,
+                FiledDate = new DateOnly(2025, 8, 1),
+                AccessionNumber = accession,
+            };
+
+        DbContext
+            .Set<FinancialFact>()
+            .AddRange(
+                Fact(
+                    revenue,
+                    new DateOnly(2025, 4, 1),
+                    new DateOnly(2025, 6, 30),
+                    25_000_000m,
+                    "revenue"
+                ),
+                Fact(
+                    netIncome,
+                    new DateOnly(2025, 1, 1),
+                    new DateOnly(2025, 6, 30),
+                    4_000_000m,
+                    "net-income-ytd"
+                ),
+                Fact(
+                    grossProfit,
+                    new DateOnly(2025, 1, 1),
+                    new DateOnly(2025, 3, 31),
+                    99_000_000m,
+                    "stale-end"
+                )
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetFinancialStatement("AAPL", statement: "income", year: 2025, period: "Q2");
+
+        result.Should().Contain("| Revenue | $25,000,000 | USD | 2025-04-01 | 2025-06-30 |");
+        result.Should().Contain("| Net Income | $4,000,000 | USD | 2025-01-01 | 2025-06-30 |");
+        result.Should().NotContain("$99,000,000");
+        result.Should().Contain("discrete-quarter and fiscal-year-to-date facts");
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_LaterProxyDuplicate_DoesNotOutrankTenK()
+    {
+        var stock = Apple();
+        var revenue = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenue",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<FinancialConcept>().Add(revenue);
+        await SeedRevenue(
+            stock,
+            revenue,
+            2023,
+            SecFiscalPeriod.FullYear,
+            383_285_000_000m,
+            "USD",
+            "ten-k"
+        );
+        var proxy = await DbContext
+            .Set<FinancialFact>()
+            .SingleAsync(f => f.AccessionNumber == "ten-k");
+        DbContext
+            .Set<FinancialFact>()
+            .Add(
+                new FinancialFact
+                {
+                    CommonStockId = proxy.CommonStockId,
+                    FinancialConceptId = proxy.FinancialConceptId,
+                    Unit = proxy.Unit,
+                    PeriodType = proxy.PeriodType,
+                    PeriodStart = proxy.PeriodStart,
+                    PeriodEnd = proxy.PeriodEnd,
+                    Value = 383_000_000_000m,
+                    FiscalYear = proxy.FiscalYear,
+                    FiscalPeriod = proxy.FiscalPeriod,
+                    Form = DocumentType.Def14A,
+                    FiledDate = proxy.FiledDate.AddMonths(2),
+                    AccessionNumber = "proxy",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetFinancialStatement("AAPL", statement: "income", year: 2023, period: "FY");
+
+        result.Should().Contain("$383,285,000,000");
+        result.Should().Contain("| 10-K |");
+        result.Should().NotContain("$383,000,000,000");
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportPeriodIdentityTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportPeriodIdentityTests.cs
@@ -4,6 +4,8 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models.Responses;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.HostedService.Services;
@@ -48,6 +50,10 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
 
     private IServiceScopeFactory CreateScopeFactory()
     {
+        var sharesProvider = Substitute.For<ISharesOutstandingProvider>();
+        sharesProvider
+            .GetCurrentSharesOutstanding(Arg.Any<CommonStock>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null));
         var scopeFactory = Substitute.For<IServiceScopeFactory>();
         scopeFactory
             .CreateScope()
@@ -61,6 +67,7 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
                 sp.GetService(typeof(FinancialFactsSyncStatusRepository))
                     .Returns(new FinancialFactsSyncStatusRepository(ctx));
                 sp.GetService(typeof(DocumentRepository)).Returns(new DocumentRepository(ctx));
+                sp.GetService(typeof(ISharesOutstandingProvider)).Returns(sharesProvider);
                 var scope = Substitute.For<IServiceScope>();
                 scope.ServiceProvider.Returns(sp);
                 return scope;
@@ -239,5 +246,394 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
 
         fact.FiscalYear.Should().Be(2023);
         fact.FiscalPeriod.Should().Be(SecFiscalPeriod.FullYear);
+    }
+
+    [Fact]
+    public async Task Import_OlderImporterVersion_ReplaysAndCorrectsExistingJnjFiscalYear()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "JNJ",
+            Name = "Johnson & Johnson",
+            Cik = "0000200406",
+            FiscalYearEndMonth = 1,
+            FiscalYearEndDay = 3,
+        };
+        var concept = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenue",
+        };
+        var filed = new DateOnly(2026, 2, 17);
+        var accession = "0000200406-26-000010";
+        var documentId = Guid.NewGuid();
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<FinancialConcept>().Add(concept);
+            var content = new Equibles.Media.Data.Models.File
+            {
+                Name = "jnj-10-k",
+                Extension = "txt",
+                ContentType = "text/plain",
+            };
+            seed.Set<Document>()
+                .Add(
+                    new Document
+                    {
+                        Id = documentId,
+                        CommonStock = stock,
+                        Content = content,
+                        DocumentType = DocumentType.TenK,
+                        ReportingDate = filed,
+                        ReportingForDate = new DateOnly(2025, 12, 28),
+                        AccessionNumber = accession,
+                    }
+                );
+            seed.Set<FinancialFact>()
+                .Add(
+                    new FinancialFact
+                    {
+                        CommonStockId = stock.Id,
+                        FinancialConceptId = concept.Id,
+                        Unit = "USD",
+                        PeriodType = FactPeriodType.Duration,
+                        PeriodStart = new DateOnly(2024, 12, 30),
+                        PeriodEnd = new DateOnly(2025, 12, 28),
+                        Value = 94_200_000_000m,
+                        FiscalYear = 2026,
+                        FiscalPeriod = SecFiscalPeriod.FullYear,
+                        Form = DocumentType.TenK,
+                        FiledDate = filed,
+                        AccessionNumber = accession,
+                    }
+                );
+            seed.Set<FinancialFactsSyncStatus>()
+                .Add(
+                    new FinancialFactsSyncStatus
+                    {
+                        CommonStockId = stock.Id,
+                        LastCheckedAt = DateTime.UtcNow,
+                        LastFiledDateSeen = filed,
+                        ImporterVersion = FinancialFactsImportService.CurrentImporterVersion - 1,
+                    }
+                );
+            await seed.SaveChangesAsync(CancellationToken.None);
+        }
+
+        var response = new CompanyFactsResponse
+        {
+            Cik = 200406,
+            EntityName = "Johnson & Johnson",
+            Facts = new()
+            {
+                ["us-gaap"] = new()
+                {
+                    ["Revenues"] = new CompanyFactConcept
+                    {
+                        Label = "Revenue",
+                        Units = new()
+                        {
+                            ["USD"] =
+                            [
+                                new CompanyFactValue
+                                {
+                                    Start = new DateOnly(2024, 12, 30),
+                                    End = new DateOnly(2025, 12, 28),
+                                    Val = 94_200_000_000m,
+                                    Accn = accession,
+                                    Fy = 2026,
+                                    Fp = "FY",
+                                    Form = "10-K",
+                                    Filed = filed,
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient.GetCompanyFacts(stock.Cik).Returns(response);
+        var sut = new FinancialFactsImportService(
+            CreateScopeFactory(),
+            secEdgarClient,
+            Substitute.For<ILogger<FinancialFactsImportService>>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+        await sut.Import(stock, CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        var fact = await verify
+            .Set<FinancialFact>()
+            .SingleAsync(f => f.CommonStockId == stock.Id, CancellationToken.None);
+        var status = await verify
+            .Set<FinancialFactsSyncStatus>()
+            .SingleAsync(s => s.CommonStockId == stock.Id, CancellationToken.None);
+        fact.FiscalYear.Should().Be(2025);
+        fact.FiscalPeriod.Should().Be(SecFiscalPeriod.FullYear);
+        fact.DocumentId.Should().Be(documentId);
+        status.ImporterVersion.Should().Be(FinancialFactsImportService.CurrentImporterVersion);
+    }
+
+    [Fact]
+    public async Task Import_AnnualDocumentPeriodCorrectsHighSecYearWithoutFyeMetadata()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "DOCP",
+            Name = "Document Period Corp.",
+            Cik = "0000999998",
+        };
+        var filed = new DateOnly(2026, 2, 17);
+        var periodEnd = new DateOnly(2025, 12, 28);
+        const string accession = "0000999998-26-000010";
+        var documentId = Guid.NewGuid();
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            var content = new Equibles.Media.Data.Models.File
+            {
+                Name = "annual-filing",
+                Extension = "txt",
+                ContentType = "text/plain",
+            };
+            seed.Set<Document>()
+                .Add(
+                    new Document
+                    {
+                        Id = documentId,
+                        CommonStock = stock,
+                        Content = content,
+                        DocumentType = DocumentType.TenK,
+                        ReportingDate = filed,
+                        ReportingForDate = periodEnd,
+                        AccessionNumber = accession,
+                    }
+                );
+            await seed.SaveChangesAsync(CancellationToken.None);
+        }
+
+        var response = new CompanyFactsResponse
+        {
+            Cik = 999998,
+            EntityName = stock.Name,
+            Facts = new()
+            {
+                ["us-gaap"] = new()
+                {
+                    ["Revenues"] = new CompanyFactConcept
+                    {
+                        Label = "Revenue",
+                        Units = new()
+                        {
+                            ["USD"] =
+                            [
+                                new CompanyFactValue
+                                {
+                                    Start = new DateOnly(2024, 12, 30),
+                                    End = periodEnd,
+                                    Val = 100_000_000m,
+                                    Accn = accession,
+                                    Fy = 2026,
+                                    Fp = "FY",
+                                    Form = "10-K",
+                                    Filed = filed,
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient.GetCompanyFacts(stock.Cik).Returns(response);
+        var sut = new FinancialFactsImportService(
+            CreateScopeFactory(),
+            secEdgarClient,
+            Substitute.For<ILogger<FinancialFactsImportService>>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+        await sut.Import(stock, CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        var fact = await verify
+            .Set<FinancialFact>()
+            .SingleAsync(f => f.CommonStockId == stock.Id, CancellationToken.None);
+        fact.FiscalYear.Should().Be(2025);
+        fact.FiscalPeriod.Should().Be(SecFiscalPeriod.FullYear);
+        fact.DocumentId.Should().Be(documentId);
+    }
+
+    [Fact]
+    public async Task Import_CorroboratedThousandScaleAmendment_RemovesPreviouslyStoredCorruptRow()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "DAWN",
+            Name = "Day One Biopharmaceuticals Inc.",
+            Cik = "0001845337",
+            FiscalYearEndMonth = 12,
+            FiscalYearEndDay = 31,
+        };
+        var concept = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "NetIncomeLoss",
+            Label = "Net loss",
+        };
+        var originalFiled = new DateOnly(2024, 3, 7);
+        var amendmentFiled = new DateOnly(2024, 5, 1);
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<FinancialConcept>().Add(concept);
+            seed.Set<FinancialFact>()
+                .Add(
+                    new FinancialFact
+                    {
+                        CommonStockId = stock.Id,
+                        FinancialConceptId = concept.Id,
+                        Unit = "USD",
+                        PeriodType = FactPeriodType.Duration,
+                        PeriodStart = new DateOnly(2023, 1, 1),
+                        PeriodEnd = new DateOnly(2023, 12, 31),
+                        Value = -107_322_000_000m,
+                        FiscalYear = 2023,
+                        FiscalPeriod = SecFiscalPeriod.FullYear,
+                        Form = DocumentType.TenKa,
+                        FiledDate = amendmentFiled,
+                        AccessionNumber = "dawn-amendment",
+                    }
+                );
+            seed.Set<FinancialFactsSyncStatus>()
+                .Add(
+                    new FinancialFactsSyncStatus
+                    {
+                        CommonStockId = stock.Id,
+                        LastCheckedAt = DateTime.UtcNow,
+                        LastFiledDateSeen = amendmentFiled,
+                        ImporterVersion = FinancialFactsImportService.CurrentImporterVersion - 1,
+                    }
+                );
+            await seed.SaveChangesAsync(CancellationToken.None);
+        }
+
+        CompanyFactValue Value(
+            DateOnly start,
+            DateOnly end,
+            decimal value,
+            string accession,
+            string form,
+            DateOnly filed
+        ) =>
+            new()
+            {
+                Start = start,
+                End = end,
+                Val = value,
+                Accn = accession,
+                Fy = 2023,
+                Fp = end == new DateOnly(2023, 12, 31) ? "FY" : "Q3",
+                Form = form,
+                Filed = filed,
+            };
+        var response = new CompanyFactsResponse
+        {
+            Cik = 1845337,
+            EntityName = stock.Name,
+            Facts = new()
+            {
+                ["us-gaap"] = new()
+                {
+                    ["NetIncomeLoss"] = new CompanyFactConcept
+                    {
+                        Label = "Net loss",
+                        Units = new()
+                        {
+                            ["USD"] =
+                            [
+                                Value(
+                                    new DateOnly(2023, 1, 1),
+                                    new DateOnly(2023, 12, 31),
+                                    -107_322_000m,
+                                    "dawn-original",
+                                    "10-K",
+                                    originalFiled
+                                ),
+                                Value(
+                                    new DateOnly(2023, 1, 1),
+                                    new DateOnly(2023, 12, 31),
+                                    -107_322_000_000m,
+                                    "dawn-amendment",
+                                    "10-K/A",
+                                    amendmentFiled
+                                ),
+                                Value(
+                                    new DateOnly(2023, 1, 1),
+                                    new DateOnly(2023, 3, 31),
+                                    -20_000_000m,
+                                    "dawn-q1",
+                                    "10-Q",
+                                    new DateOnly(2023, 5, 1)
+                                ),
+                                Value(
+                                    new DateOnly(2023, 4, 1),
+                                    new DateOnly(2023, 6, 30),
+                                    -30_000_000m,
+                                    "dawn-q2",
+                                    "10-Q",
+                                    new DateOnly(2023, 8, 1)
+                                ),
+                                Value(
+                                    new DateOnly(2023, 7, 1),
+                                    new DateOnly(2023, 9, 30),
+                                    -36_044_000m,
+                                    "dawn-q3",
+                                    "10-Q",
+                                    new DateOnly(2023, 11, 1)
+                                ),
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient.GetCompanyFacts(stock.Cik).Returns(response);
+        var sut = new FinancialFactsImportService(
+            CreateScopeFactory(),
+            secEdgarClient,
+            Substitute.For<ILogger<FinancialFactsImportService>>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+        await sut.Import(stock, CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        var facts = await verify
+            .Set<FinancialFact>()
+            .Where(f => f.CommonStockId == stock.Id)
+            .ToListAsync(CancellationToken.None);
+        facts.Should().Contain(f => f.Value == -107_322_000m);
+        facts.Should().NotContain(f => f.Value == -107_322_000_000m);
+        facts.Should().NotContain(f => f.AccessionNumber == "dawn-amendment");
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialFactImportQualityFilterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactImportQualityFilterTests.cs
@@ -1,0 +1,165 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactImportQualityFilterTests
+{
+    private static readonly Guid StockId = Guid.NewGuid();
+    private static readonly Guid ConceptId = Guid.NewGuid();
+
+    [Fact]
+    public void Apply_AmendmentExactlyOneThousandTimesPriorAnnualAndCorroboratedByQuarters_RejectsAmendment()
+    {
+        var original = Fact(
+            new DateOnly(2023, 1, 1),
+            new DateOnly(2023, 12, 31),
+            -107_322_000m,
+            DocumentType.TenK,
+            new DateOnly(2024, 3, 7),
+            "original"
+        );
+        var corruptAmendment = Fact(
+            original.PeriodStart,
+            original.PeriodEnd,
+            -107_322_000_000m,
+            DocumentType.TenKa,
+            new DateOnly(2024, 5, 1),
+            "amendment"
+        );
+        var quarters = new[]
+        {
+            Fact(
+                new DateOnly(2023, 1, 1),
+                new DateOnly(2023, 3, 31),
+                -20_000_000m,
+                DocumentType.TenQ,
+                new DateOnly(2023, 5, 1),
+                "q1"
+            ),
+            Fact(
+                new DateOnly(2023, 4, 1),
+                new DateOnly(2023, 6, 30),
+                -30_000_000m,
+                DocumentType.TenQ,
+                new DateOnly(2023, 8, 1),
+                "q2"
+            ),
+            Fact(
+                new DateOnly(2023, 7, 1),
+                new DateOnly(2023, 9, 30),
+                -36_044_000m,
+                DocumentType.TenQ,
+                new DateOnly(2023, 11, 1),
+                "q3"
+            ),
+        };
+
+        var result = FinancialFactImportQualityFilter.Apply(
+            new[] { original, corruptAmendment }.Concat(quarters).ToList()
+        );
+
+        result.Rejected.Should().ContainSingle().Which.Should().BeSameAs(corruptAmendment);
+        result.Accepted.Should().Contain(original);
+        result.Accepted.Should().Contain(quarters);
+    }
+
+    [Fact]
+    public void Apply_ScaledAnnualWithoutQuarterCorroboration_KeepsBothRows()
+    {
+        var original = Fact(
+            new DateOnly(2023, 1, 1),
+            new DateOnly(2023, 12, 31),
+            107_322_000m,
+            DocumentType.TenK,
+            new DateOnly(2024, 3, 7),
+            "original"
+        );
+        var later = Fact(
+            original.PeriodStart,
+            original.PeriodEnd,
+            107_322_000_000m,
+            DocumentType.TenKa,
+            new DateOnly(2024, 5, 1),
+            "amendment"
+        );
+
+        var result = FinancialFactImportQualityFilter.Apply([original, later]);
+
+        result.Rejected.Should().BeEmpty();
+        result.Accepted.Should().Equal(original, later);
+    }
+
+    [Fact]
+    public void Apply_ProxyDuplicateAndPeriodicFactShareActualPeriod_RejectsProxyOnly()
+    {
+        var tenK = Fact(
+            new DateOnly(2023, 1, 1),
+            new DateOnly(2023, 12, 31),
+            1_234_567_890m,
+            DocumentType.TenK,
+            new DateOnly(2024, 2, 1),
+            "ten-k"
+        );
+        var proxy = Fact(
+            tenK.PeriodStart,
+            tenK.PeriodEnd,
+            1_235_000_000m,
+            DocumentType.Def14A,
+            new DateOnly(2024, 4, 1),
+            "proxy"
+        );
+
+        var result = FinancialFactImportQualityFilter.Apply([tenK, proxy]);
+
+        result.Rejected.Should().ContainSingle().Which.Should().BeSameAs(proxy);
+        result.Accepted.Should().ContainSingle().Which.Should().BeSameAs(tenK);
+    }
+
+    [Fact]
+    public void Apply_ProxyOnlyPeriod_KeepsAvailableFact()
+    {
+        var proxy = Fact(
+            new DateOnly(2023, 1, 1),
+            new DateOnly(2023, 12, 31),
+            1_235_000_000m,
+            DocumentType.Def14A,
+            new DateOnly(2024, 4, 1),
+            "proxy"
+        );
+
+        var result = FinancialFactImportQualityFilter.Apply([proxy]);
+
+        result.Rejected.Should().BeEmpty();
+        result.Accepted.Should().ContainSingle().Which.Should().BeSameAs(proxy);
+    }
+
+    private static FinancialFact Fact(
+        DateOnly start,
+        DateOnly end,
+        decimal value,
+        DocumentType form,
+        DateOnly filed,
+        string accession
+    ) =>
+        new()
+        {
+            CommonStockId = StockId,
+            FinancialConceptId = ConceptId,
+            Unit = "USD",
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = start,
+            PeriodEnd = end,
+            Value = value,
+            FiscalYear = end.Year,
+            FiscalPeriod =
+                end.DayNumber - start.DayNumber >= 350
+                    ? SecFiscalPeriod.FullYear
+                    : SecFiscalPeriod.Q1,
+            Form = form,
+            FiledDate = filed,
+            AccessionNumber = accession,
+        };
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceBuildFactMissingConceptTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceBuildFactMissingConceptTests.cs
@@ -33,14 +33,14 @@ public class FinancialFactsImportServiceBuildFactMissingConceptTests
         {
             { (FactTaxonomy.UsGaap, "Revenues"), Guid.NewGuid() },
         };
-        var documentIds = new Dictionary<string, Guid>();
+        var documents = new Dictionary<string, FinancialFactsImportService.FilingDocumentContext>();
 
         var method = serviceType.GetMethod(
             "BuildFact",
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
-        var result = (FinancialFact)method.Invoke(null, [stock, parsed, conceptIds, documentIds]);
+        var result = (FinancialFact)method.Invoke(null, [stock, parsed, conceptIds, documents]);
 
         result.Should().BeNull();
     }

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceBuildFactMissingDocumentIdTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceBuildFactMissingDocumentIdTests.cs
@@ -10,16 +10,12 @@ public class FinancialFactsImportServiceBuildFactMissingDocumentIdTests
     [Fact]
     public void BuildFact_AccessionNotInDocumentIdsMap_DocumentIdIsNullNotGuidEmpty()
     {
-        // Contract (BuildFact line 359): `documentIds.TryGetValue(p.Accession, out
-        // var docId) ? docId : null`. A fact can be imported before its document
-        // is scraped — the accession won't yet be in the documentIds map. The
-        // ternary's miss arm produces a Guid? null. A refactor to the seemingly
-        // equivalent `documentIds.GetValueOrDefault(p.Accession)` would return
-        // `default(Guid) == Guid.Empty`, which assigns to the `Guid?` column as
-        // Guid.Empty (NOT null), corrupting FK references and the unique
+        // A fact can be imported before its document is scraped, so the accession
+        // will not yet be in the filing-document map. The miss arm must produce a
+        // Guid? null, never Guid.Empty, which would corrupt FK references and the unique
         // (CommonStockId,FinancialConceptId,...,AccessionNumber) index. Existing
         // BuildFact pins cover missing-concept and unknown-form arms; neither
-        // asserts on DocumentId. Pin: empty documentIds map → DocumentId null.
+        // asserts on DocumentId. Pin: empty document map → DocumentId null.
         var serviceType = typeof(FinancialFactsImportService);
         var parsedFactType = serviceType.GetNestedType("ParsedFact", BindingFlags.NonPublic);
         var parsedFact = Activator.CreateInstance(parsedFactType);
@@ -41,13 +37,13 @@ public class FinancialFactsImportServiceBuildFactMissingDocumentIdTests
         {
             [(FactTaxonomy.UsGaap, "Revenues")] = Guid.NewGuid(),
         };
-        var documentIds = new Dictionary<string, Guid>();
+        var documents = new Dictionary<string, FinancialFactsImportService.FilingDocumentContext>();
 
         var method = serviceType.GetMethod(
             "BuildFact",
             BindingFlags.NonPublic | BindingFlags.Static
         );
-        var fact = method!.Invoke(null, [stock, parsedFact, conceptIds, documentIds]);
+        var fact = method!.Invoke(null, [stock, parsedFact, conceptIds, documents]);
 
         var documentId = (Guid?)fact!.GetType().GetProperty("DocumentId")!.GetValue(fact);
         documentId.Should().BeNull();

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceBuildFactUnknownFormTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceBuildFactUnknownFormTests.cs
@@ -40,14 +40,14 @@ public class FinancialFactsImportServiceBuildFactUnknownFormTests
         {
             [(FactTaxonomy.UsGaap, "Revenues")] = conceptId,
         };
-        var documentIds = new Dictionary<string, Guid>();
+        var documents = new Dictionary<string, FinancialFactsImportService.FilingDocumentContext>();
 
         var method = serviceType.GetMethod(
             "BuildFact",
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
-        var fact = method.Invoke(null, [stock, parsedFact, conceptIds, documentIds]);
+        var fact = method.Invoke(null, [stock, parsedFact, conceptIds, documents]);
 
         var form = fact.GetType().GetProperty("Form").GetValue(fact);
         form.Should().Be(DocumentType.Other);

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsScraperWorkerSelectDueStocksTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsScraperWorkerSelectDueStocksTests.cs
@@ -1,4 +1,5 @@
 using Equibles.Sec.FinancialFacts.HostedService;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -26,6 +27,7 @@ public class FinancialFactsScraperWorkerSelectDueStocksTests
         var due = FinancialFactsScraperWorker.SelectDueStocks(
             [stale, neverChecked],
             new Dictionary<Guid, DateTime> { [stale] = Cutoff.AddHours(-1) },
+            CurrentVersions(stale),
             Cutoff
         );
 
@@ -42,6 +44,7 @@ public class FinancialFactsScraperWorkerSelectDueStocksTests
         var due = FinancialFactsScraperWorker.SelectDueStocks(
             [fresh],
             new Dictionary<Guid, DateTime> { [fresh] = Now.AddHours(-1) },
+            CurrentVersions(fresh),
             Cutoff
         );
 
@@ -64,6 +67,7 @@ public class FinancialFactsScraperWorkerSelectDueStocksTests
         var due = FinancialFactsScraperWorker.SelectDueStocks(
             [stale3h, stale9h, stale6h],
             stamps,
+            CurrentVersions(stale3h, stale9h, stale6h),
             Cutoff
         );
 
@@ -81,9 +85,37 @@ public class FinancialFactsScraperWorkerSelectDueStocksTests
         var due = FinancialFactsScraperWorker.SelectDueStocks(
             [atCutoff],
             new Dictionary<Guid, DateTime> { [atCutoff] = Cutoff },
+            CurrentVersions(atCutoff),
             Cutoff
         );
 
         due.Should().BeEmpty();
     }
+
+    [Fact]
+    public void OlderImporterVersionIsDueEvenWhenFresh()
+    {
+        var outdated = Guid.NewGuid();
+        var ordinaryStale = Guid.NewGuid();
+
+        var due = FinancialFactsScraperWorker.SelectDueStocks(
+            [ordinaryStale, outdated],
+            new Dictionary<Guid, DateTime>
+            {
+                [ordinaryStale] = Cutoff.AddHours(-2),
+                [outdated] = Now.AddMinutes(-1),
+            },
+            new Dictionary<Guid, int>
+            {
+                [ordinaryStale] = FinancialFactsImportService.CurrentImporterVersion,
+                [outdated] = FinancialFactsImportService.CurrentImporterVersion - 1,
+            },
+            Cutoff
+        );
+
+        due.Should().Equal(outdated, ordinaryStale);
+    }
+
+    private static Dictionary<Guid, int> CurrentVersions(params Guid[] ids) =>
+        ids.ToDictionary(id => id, _ => FinancialFactsImportService.CurrentImporterVersion);
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableLatestRestatedLabelTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableLatestRestatedLabelTests.cs
@@ -57,7 +57,7 @@ public class FinancialFactsToolsRenderFactHistoryTableLatestRestatedLabelTests
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
         var perPeriod = new List<FinancialFact>();
 
-        var result = (string)method.Invoke(null, ["Revenues", stock, false, perPeriod, 0]);
+        var result = (string)method.Invoke(null, ["Revenues", stock, false, perPeriod, 0, null]);
 
         result.Should().Contain("latest restated");
         result.Should().NotContain("as originally reported");

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableOriginallyReportedLabelTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableOriginallyReportedLabelTests.cs
@@ -41,7 +41,7 @@ public class FinancialFactsToolsRenderFactHistoryTableOriginallyReportedLabelTes
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
         var perPeriod = new List<FinancialFact>();
 
-        var result = (string)method.Invoke(null, ["Revenues", stock, true, perPeriod, 0]);
+        var result = (string)method.Invoke(null, ["Revenues", stock, true, perPeriod, 0, null]);
 
         result.Should().Contain("as originally reported");
         result.Should().NotContain("latest restated");

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableTruncationNoteTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableTruncationNoteTests.cs
@@ -39,7 +39,7 @@ public class FinancialFactsToolsRenderFactHistoryTableTruncationNoteTests
             })
             .ToList();
 
-        return (string)method.Invoke(null, ["revenue", stock, false, perPeriod, total]);
+        return (string)method.Invoke(null, ["revenue", stock, false, perPeriod, total, null]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- version Company Facts ingestion so existing rows replay, refresh derived fiscal identity, and validate annual rows against their accession document period
- quarantine only corroborated 1,000x/1,000,000x annual scale anomalies and remove lower-quality DEF 14A duplicates while retaining proxy-only data
- anchor statements to one actual period end, expose exact start/end spans, and warn when an alias materially trails the filer corpus
- add the additive importer-version migration, synchronized docs, and regression coverage

## Verification

- `dotnet csharpier check .`
- OSS unit suite: 4,179 passed
- OSS integration suite: 2,414 passed
- EF pending-model check: clean
- independent audit: clean

Related to daniel3303/EquiblesCommercial#7050. Keep the issue open until the commercial pin is deployed and the production replay is verified.