### PR TITLE
fix(financial-facts): corroborate scaled facts across aliases

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactImportQualityFilter.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactImportQualityFilter.cs
@@ -2,6 +2,7 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Statements;
 
 namespace Equibles.Sec.FinancialFacts.HostedService.Services;
 
@@ -23,13 +24,22 @@ internal static class FinancialFactImportQualityFilter
 
     private static readonly decimal[] SuspectScaleFactors = [1_000m, 1_000_000m];
 
-    internal static FilterResult Apply(IReadOnlyCollection<FinancialFact> facts)
+    internal static FilterResult Apply(
+        IReadOnlyCollection<FinancialFact> facts,
+        IReadOnlyDictionary<(FactTaxonomy Taxonomy, string Tag), Guid> conceptIds
+    )
     {
         var rejected = new HashSet<FinancialFact>();
+        var aliasFamilies = BuildAliasFamilies(conceptIds);
 
         foreach (
             var series in facts.GroupBy(f =>
-                (f.CommonStockId, f.FinancialConceptId, f.Unit, f.DimensionsKey)
+                (
+                    f.CommonStockId,
+                    ConceptFamily(f.FinancialConceptId, aliasFamilies),
+                    f.Unit,
+                    f.DimensionsKey
+                )
             )
         )
         {
@@ -69,6 +79,66 @@ internal static class FinancialFactImportQualityFilter
         );
     }
 
+    private static IReadOnlyDictionary<Guid, Guid> BuildAliasFamilies(
+        IReadOnlyDictionary<(FactTaxonomy Taxonomy, string Tag), Guid> conceptIds
+    )
+    {
+        var neighbours = new Dictionary<Guid, HashSet<Guid>>();
+        foreach (var alias in FinancialConceptAliases.SupportedAliases)
+        {
+            if (!FinancialConceptAliases.TryResolve(alias, out var concepts))
+                continue;
+
+            var ids = concepts
+                .Select(c => conceptIds.GetValueOrDefault((c.Taxonomy, c.Tag)))
+                .Where(id => id != Guid.Empty)
+                .Distinct()
+                .ToList();
+            if (ids.Count < 2)
+                continue;
+
+            var first = ids[0];
+            foreach (var id in ids)
+            {
+                neighbours.TryAdd(id, []);
+                neighbours[id].Add(first);
+                neighbours[first].Add(id);
+            }
+        }
+
+        var familyByConcept = new Dictionary<Guid, Guid>();
+        foreach (var conceptId in neighbours.Keys)
+        {
+            if (familyByConcept.ContainsKey(conceptId))
+                continue;
+
+            var component = new List<Guid>();
+            var pending = new Stack<Guid>();
+            pending.Push(conceptId);
+            while (pending.TryPop(out var current))
+            {
+                if (familyByConcept.ContainsKey(current))
+                    continue;
+
+                familyByConcept[current] = Guid.Empty;
+                component.Add(current);
+                foreach (var neighbour in neighbours[current])
+                    pending.Push(neighbour);
+            }
+
+            var familyId = component.Min();
+            foreach (var member in component)
+                familyByConcept[member] = familyId;
+        }
+
+        return familyByConcept;
+    }
+
+    private static Guid ConceptFamily(
+        Guid conceptId,
+        IReadOnlyDictionary<Guid, Guid> aliasFamilies
+    ) => aliasFamilies.GetValueOrDefault(conceptId, conceptId);
+
     private static bool HasCorroboratedScaleError(
         FinancialFact candidate,
         IReadOnlyCollection<FinancialFact> series
@@ -88,8 +158,10 @@ internal static class FinancialFactImportQualityFilter
                 && FinancialFactSourcePriority.Rank(f.Form) == 0
                 && f.Value != 0
             )
-            .OrderByDescending(f => f.FiledDate)
+            .OrderBy(f => f.FinancialConceptId == candidate.FinancialConceptId ? 0 : 1)
+            .ThenByDescending(f => f.FiledDate)
             .ThenByDescending(f => f.AccessionNumber)
+            .ThenBy(f => f.FinancialConceptId)
             .ToList();
         if (earlierAnnuals.Count == 0)
             return false;
@@ -104,9 +176,11 @@ internal static class FinancialFactImportQualityFilter
             )
             .GroupBy(f => (f.PeriodStart, f.PeriodEnd))
             .Select(g =>
-                g.OrderBy(f => FinancialFactSourcePriority.Rank(f.Form))
+                g.OrderBy(f => f.FinancialConceptId == candidate.FinancialConceptId ? 0 : 1)
+                    .ThenBy(f => FinancialFactSourcePriority.Rank(f.Form))
                     .ThenByDescending(f => f.FiledDate)
                     .ThenByDescending(f => f.AccessionNumber)
+                    .ThenBy(f => f.FinancialConceptId)
                     .First()
             )
             .ToList();

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -35,7 +35,7 @@ public class FinancialFactsImportService
     // Bump whenever parsing, fiscal identity, or quality filtering changes existing rows. The
     // per-company checkpoint forces a full Company Facts replay without racing the old worker
     // during an additive migration rollout.
-    internal const int CurrentImporterVersion = 1;
+    internal const int CurrentImporterVersion = 2;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ISecEdgarClient _secEdgarClient;
@@ -244,7 +244,7 @@ public class FinancialFactsImportService
             );
         }
 
-        var quality = FinancialFactImportQualityFilter.Apply(built);
+        var quality = FinancialFactImportQualityFilter.Apply(built, conceptIds);
         if (quality.Rejected.Count > 0)
         {
             await DeleteRejectedFacts(stock, quality.Rejected, cancellationToken);

--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportPeriodIdentityTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportPeriodIdentityTests.cs
@@ -583,6 +583,16 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
                                     "10-K/A",
                                     amendmentFiled
                                 ),
+                            ],
+                        },
+                    },
+                    ["ProfitLoss"] = new CompanyFactConcept
+                    {
+                        Label = "Net loss including noncontrolling interests",
+                        Units = new()
+                        {
+                            ["USD"] =
+                            [
                                 Value(
                                     new DateOnly(2023, 1, 1),
                                     new DateOnly(2023, 3, 31),

--- a/tests/Equibles.UnitTests/Sec/FinancialFactImportQualityFilterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactImportQualityFilterTests.cs
@@ -9,6 +9,16 @@ public class FinancialFactImportQualityFilterTests
 {
     private static readonly Guid StockId = Guid.NewGuid();
     private static readonly Guid ConceptId = Guid.NewGuid();
+    private static readonly Guid ProfitLossConceptId = Guid.NewGuid();
+    private static readonly Guid OperatingIncomeConceptId = Guid.NewGuid();
+
+    private static readonly IReadOnlyDictionary<(FactTaxonomy, string), Guid> ConceptIds =
+        new Dictionary<(FactTaxonomy, string), Guid>
+        {
+            [(FactTaxonomy.UsGaap, "NetIncomeLoss")] = ConceptId,
+            [(FactTaxonomy.UsGaap, "ProfitLoss")] = ProfitLossConceptId,
+            [(FactTaxonomy.UsGaap, "OperatingIncomeLoss")] = OperatingIncomeConceptId,
+        };
 
     [Fact]
     public void Apply_AmendmentExactlyOneThousandTimesPriorAnnualAndCorroboratedByQuarters_RejectsAmendment()
@@ -58,7 +68,8 @@ public class FinancialFactImportQualityFilterTests
         };
 
         var result = FinancialFactImportQualityFilter.Apply(
-            new[] { original, corruptAmendment }.Concat(quarters).ToList()
+            new[] { original, corruptAmendment }.Concat(quarters).ToList(),
+            ConceptIds
         );
 
         result.Rejected.Should().ContainSingle().Which.Should().BeSameAs(corruptAmendment);
@@ -86,7 +97,7 @@ public class FinancialFactImportQualityFilterTests
             "amendment"
         );
 
-        var result = FinancialFactImportQualityFilter.Apply([original, later]);
+        var result = FinancialFactImportQualityFilter.Apply([original, later], ConceptIds);
 
         result.Rejected.Should().BeEmpty();
         result.Accepted.Should().Equal(original, later);
@@ -112,7 +123,7 @@ public class FinancialFactImportQualityFilterTests
             "proxy"
         );
 
-        var result = FinancialFactImportQualityFilter.Apply([tenK, proxy]);
+        var result = FinancialFactImportQualityFilter.Apply([tenK, proxy], ConceptIds);
 
         result.Rejected.Should().ContainSingle().Which.Should().BeSameAs(proxy);
         result.Accepted.Should().ContainSingle().Which.Should().BeSameAs(tenK);
@@ -130,10 +141,127 @@ public class FinancialFactImportQualityFilterTests
             "proxy"
         );
 
-        var result = FinancialFactImportQualityFilter.Apply([proxy]);
+        var result = FinancialFactImportQualityFilter.Apply([proxy], ConceptIds);
 
         result.Rejected.Should().BeEmpty();
         result.Accepted.Should().ContainSingle().Which.Should().BeSameAs(proxy);
+    }
+
+    [Fact]
+    public void Apply_AmendmentCorroboratedByAliasConceptQuarters_RejectsAmendment()
+    {
+        var original = Fact(
+            new DateOnly(2022, 1, 1),
+            new DateOnly(2022, 12, 31),
+            -142_181_000m,
+            DocumentType.TenK,
+            new DateOnly(2023, 3, 7),
+            "original"
+        );
+        var corruptAmendment = Fact(
+            original.PeriodStart,
+            original.PeriodEnd,
+            -142_181_000_000m,
+            DocumentType.TenKa,
+            new DateOnly(2026, 4, 17),
+            "amendment"
+        );
+        var aliasQuarters = new[]
+        {
+            Fact(
+                new DateOnly(2022, 1, 1),
+                new DateOnly(2022, 3, 31),
+                -35_000_000m,
+                DocumentType.TenQ,
+                new DateOnly(2022, 5, 1),
+                "q1",
+                ProfitLossConceptId
+            ),
+            Fact(
+                new DateOnly(2022, 4, 1),
+                new DateOnly(2022, 6, 30),
+                -45_000_000m,
+                DocumentType.TenQ,
+                new DateOnly(2022, 8, 1),
+                "q2",
+                ProfitLossConceptId
+            ),
+            Fact(
+                new DateOnly(2022, 7, 1),
+                new DateOnly(2022, 9, 30),
+                -40_000_000m,
+                DocumentType.TenQ,
+                new DateOnly(2022, 11, 1),
+                "q3",
+                ProfitLossConceptId
+            ),
+        };
+
+        var result = FinancialFactImportQualityFilter.Apply(
+            new[] { original, corruptAmendment }.Concat(aliasQuarters).ToList(),
+            ConceptIds
+        );
+
+        result.Rejected.Should().ContainSingle().Which.Should().BeSameAs(corruptAmendment);
+    }
+
+    [Fact]
+    public void Apply_AmendmentWithUnrelatedConceptQuarters_KeepsAmendment()
+    {
+        var original = Fact(
+            new DateOnly(2022, 1, 1),
+            new DateOnly(2022, 12, 31),
+            -142_181_000m,
+            DocumentType.TenK,
+            new DateOnly(2023, 3, 7),
+            "original"
+        );
+        var corruptAmendment = Fact(
+            original.PeriodStart,
+            original.PeriodEnd,
+            -142_181_000_000m,
+            DocumentType.TenKa,
+            new DateOnly(2026, 4, 17),
+            "amendment"
+        );
+        var unrelatedQuarters = new[]
+        {
+            Fact(
+                new DateOnly(2022, 1, 1),
+                new DateOnly(2022, 3, 31),
+                -35_000_000m,
+                DocumentType.TenQ,
+                new DateOnly(2022, 5, 1),
+                "q1",
+                OperatingIncomeConceptId
+            ),
+            Fact(
+                new DateOnly(2022, 4, 1),
+                new DateOnly(2022, 6, 30),
+                -45_000_000m,
+                DocumentType.TenQ,
+                new DateOnly(2022, 8, 1),
+                "q2",
+                OperatingIncomeConceptId
+            ),
+            Fact(
+                new DateOnly(2022, 7, 1),
+                new DateOnly(2022, 9, 30),
+                -40_000_000m,
+                DocumentType.TenQ,
+                new DateOnly(2022, 11, 1),
+                "q3",
+                OperatingIncomeConceptId
+            ),
+        };
+
+        var result = FinancialFactImportQualityFilter.Apply(
+            new[] { original, corruptAmendment }.Concat(unrelatedQuarters).ToList(),
+            ConceptIds
+        );
+
+        result.Rejected.Should().BeEmpty();
+        result.Accepted.Should().Contain(corruptAmendment);
     }
 
     private static FinancialFact Fact(
@@ -142,12 +270,13 @@ public class FinancialFactImportQualityFilterTests
         decimal value,
         DocumentType form,
         DateOnly filed,
-        string accession
+        string accession,
+        Guid? conceptId = null
     ) =>
         new()
         {
             CommonStockId = StockId,
-            FinancialConceptId = ConceptId,
+            FinancialConceptId = conceptId ?? ConceptId,
             Unit = "USD",
             PeriodType = FactPeriodType.Duration,
             PeriodStart = start,


### PR DESCRIPTION
## Summary
- group scale-corroboration series by authoritative financial-concept alias families
- keep proxy precedence exact-concept and fail closed for unrelated concepts
- bump the importer version so persisted corrupt amendment rows are deleted on replay

## Verification
- Equibles.UnitTests: 4190/4190
- Equibles.IntegrationTests: 2418/2418
- dotnet csharpier check .
- git diff --check
- independent audit-only review: clean

Commercial issue: daniel3303/EquiblesCommercial#7050