### PR TITLE
fix(yahoo): requeue prematurely stamped splits

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
@@ -290,7 +290,9 @@ public class CorporateActionPriceReconciliationManager
             .Where(split =>
                 split.CommonStockId == selectedSeries.CommonStockId
                 && split.PriceSeriesTicker == selectedSeries.ListedTicker
-                && split.PriceAdjustmentAppliedTime == null
+                // Keep the selection and stamping predicates identical so a legacy premature
+                // marker can be replaced with a post-effective marker after the provider fetch.
+                && !split.IsPriceAdjustmentApplied()
             )
             .Where(split =>
             {

--- a/src/Equibles.CorporateActions.Data/Models/StockSplit.cs
+++ b/src/Equibles.CorporateActions.Data/Models/StockSplit.cs
@@ -8,9 +8,9 @@ namespace Equibles.CorporateActions.Data.Models;
 /// An as-reported corporate-action stock split for a <see cref="CommonStock"/>.
 /// The ratio is expressed as <see cref="Numerator"/>:<see cref="Denominator"/>
 /// (e.g. 10:1 is a forward split, 1:12 is a reverse split).
-/// <see cref="PriceAdjustmentAppliedTime"/> is the idempotency marker for the
-/// price back-adjustment pass — a null value means historical prices have not
-/// yet been reconciled for this split.
+/// <see cref="PriceAdjustmentAppliedTime"/> is the idempotency marker for the price
+/// back-adjustment pass. The marker is applied only when its UTC date is after the effective
+/// date; null or older legacy markers remain pending.
 /// </summary>
 [Index(nameof(CommonStockId), nameof(EffectiveDate), IsUnique = true)]
 [Index(nameof(PriceAdjustmentAppliedTime))]
@@ -41,4 +41,14 @@ public class StockSplit
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 
     public DateTime? PriceAdjustmentAppliedTime { get; set; }
+
+    /// <summary>
+    /// True only when reconciliation ran on a UTC date after the effective date. Older workers
+    /// could stamp announced future splits before the provider history incorporated them.
+    /// </summary>
+    public bool IsPriceAdjustmentApplied()
+    {
+        return PriceAdjustmentAppliedTime != null
+            && DateOnly.FromDateTime(PriceAdjustmentAppliedTime.Value) > EffectiveDate;
+    }
 }

--- a/src/Equibles.CorporateActions.Data/SplitBasisResolver.cs
+++ b/src/Equibles.CorporateActions.Data/SplitBasisResolver.cs
@@ -100,7 +100,7 @@ public static class SplitBasisResolver
                 continue;
             }
 
-            if (split.PriceAdjustmentAppliedTime == null)
+            if (!split.IsPriceAdjustmentApplied())
             {
                 return false;
             }

--- a/src/Equibles.CorporateActions.Repositories/StockSplitRepository.cs
+++ b/src/Equibles.CorporateActions.Repositories/StockSplitRepository.cs
@@ -17,7 +17,14 @@ public class StockSplitRepository : BaseRepository<StockSplit>
 
     public IQueryable<StockSplit> GetPendingPriceAdjustment()
     {
-        return GetAll().Where(s => s.PriceAdjustmentAppliedTime == null);
+        // SQL-translatable mirror of StockSplit.IsPriceAdjustmentApplied: a marker written on or
+        // before the effective date came from the old worker, which could stamp a future split.
+        return GetAll()
+            .Where(split =>
+                split.PriceAdjustmentAppliedTime == null
+                || DateOnly.FromDateTime(split.PriceAdjustmentAppliedTime.Value)
+                    <= split.EffectiveDate
+            );
     }
 
     /// <summary>

--- a/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerSelectionTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerSelectionTests.cs
@@ -174,6 +174,66 @@ public class CorporateActionPriceReconciliationManagerSelectionTests
         series.Dividends.Should().ContainSingle();
     }
 
+    [Theory]
+    [InlineData(10)]
+    [InlineData(12)]
+    public async Task SelectPendingSeries_PrematurelyStampedSplit_RequeuesAfterEffectiveDate(
+        int appliedDay
+    )
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var effectiveDate = new DateOnly(2026, 8, 12);
+        db.Add(Stock(stockId));
+        var split = PendingSplit(stockId, effectiveDate);
+        split.PriceAdjustmentAppliedTime = new DateTime(
+            2026,
+            8,
+            appliedDay,
+            12,
+            0,
+            0,
+            DateTimeKind.Utc
+        );
+        db.Add(split);
+        await db.SaveChangesAsync();
+
+        var manager = NewManager(db);
+
+        (await manager.SelectPendingSeries(50, effectiveDate)).Series.Should().BeEmpty();
+        var selected = (await manager.SelectPendingSeries(50, effectiveDate.AddDays(1)))
+            .Series.Should()
+            .ContainSingle()
+            .Which;
+
+        var correctedAppliedTime = new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Utc);
+        (await manager.StampApplied(selected, correctedAppliedTime)).Should().Be(1);
+        split.PriceAdjustmentAppliedTime.Should().Be(correctedAppliedTime);
+        (await manager.SelectPendingSeries(50, effectiveDate.AddDays(1))).Series.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SplitPendingPredicate_TranslatesForNpgsql()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only")
+            .EnableServiceProviderCaching(false)
+            .Options;
+        using var db = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+
+        var sql = new StockSplitRepository(db).GetPendingPriceAdjustment().ToQueryString();
+
+        sql.Should().Contain("AT TIME ZONE 'UTC' AS date");
+        sql.Should().Contain("\"EffectiveDate\"");
+    }
+
     [Fact]
     public async Task SelectPendingSeries_IgnoresActionsWhoseAppliedSnapshotStillMatches()
     {

--- a/tests/Equibles.UnitTests/CorporateActions/SplitBasisResolverAppliedMarkerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/SplitBasisResolverAppliedMarkerTests.cs
@@ -1,0 +1,47 @@
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+
+namespace Equibles.UnitTests.CorporateActions;
+
+public class SplitBasisResolverAppliedMarkerTests
+{
+    [Theory]
+    [InlineData(10, false, 1)]
+    [InlineData(12, false, 1)]
+    [InlineData(13, true, 2)]
+    public void TryResolveFactor_RequiresPostEffectiveUtcMarker(
+        int appliedDay,
+        bool expectedResolved,
+        int expectedFactor
+    )
+    {
+        var split = new StockSplit
+        {
+            PriceSeriesTicker = "AAPL",
+            EffectiveDate = new DateOnly(2026, 8, 12),
+            Numerator = 2m,
+            Denominator = 1m,
+            PriceAdjustmentAppliedTime = new DateTime(
+                2026,
+                8,
+                appliedDay,
+                12,
+                0,
+                0,
+                DateTimeKind.Utc
+            ),
+        };
+
+        var resolved = SplitBasisResolver.TryResolveFactor(
+            new DateOnly(2026, 8, 1),
+            [split],
+            listedTicker: null,
+            primaryTicker: "AAPL",
+            secondaryTickers: [],
+            out var factor
+        );
+
+        resolved.Should().Be(expectedResolved);
+        factor.Should().Be(expectedFactor);
+    }
+}


### PR DESCRIPTION
## Summary
- repair the rolling-upgrade edge left by #4339 when an older worker stamped an announced split before its effective date
- keep price reconciliation and financial split-basis consumers on one post-effective marker contract

## Code changes
- requeue markers whose UTC date is on or before the split effective date, without selecting the action until the following settled day
- replace legacy markers after the full provider-history fetch and make holdings/insider calculations defer until that completes
- add before/on/after boundary coverage and pin the PostgreSQL translation

## Testing
- dotnet build Equibles.sln -c Release --no-restore
- 4,211 Equibles.UnitTests passed
- 2,456 Equibles.IntegrationTests passed
- CSharpier checked 3,303 files
- git diff --check