### PR TITLE
fix(corporate-actions): revalidate dividend capture ownership

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -120,7 +120,8 @@ public class CommonStockRepository : BaseRepository<CommonStock>
     /// <summary>
     /// Loads and locks one stock until the caller's current transaction completes. Writers that
     /// key data by an authoritative listed ticker use this immediately before saving, so company
-    /// sync cannot change ticker ownership between validation and the write.
+    /// sync cannot change ticker ownership between validation and the write. An unchanged tracked
+    /// snapshot is refreshed after the lock; pending changes are rejected rather than discarded.
     /// </summary>
     public async Task<CommonStock> GetForUpdate(
         Guid commonStockId,
@@ -136,11 +137,30 @@ public class CommonStockRepository : BaseRepository<CommonStock>
         if (DbContext.Database.CurrentTransaction == null)
             throw new InvalidOperationException("GetForUpdate requires an active transaction.");
 
-        return await GetDbSet()
+        // A tracking raw-SQL query acquires the database lock but EF identity resolution returns
+        // an already-tracked instance without refreshing its values. Callers commonly preload a
+        // ticker snapshot before a provider fetch, so remember that state and reload only after
+        // FOR UPDATE has serialized us with a concurrent designation writer.
+        var trackedEntry = DbContext
+            .ChangeTracker.Entries<CommonStock>()
+            .FirstOrDefault(entry => entry.Entity.Id == commonStockId);
+        if (trackedEntry != null && trackedEntry.State != EntityState.Unchanged)
+        {
+            throw new InvalidOperationException(
+                $"GetForUpdate cannot refresh CommonStock {commonStockId} while its tracked state "
+                    + $"is {trackedEntry.State}; save, discard, or detach pending changes first."
+            );
+        }
+
+        var stock = await GetDbSet()
             .FromSqlInterpolated(
                 $"""SELECT * FROM "CommonStock" WHERE "Id" = {commonStockId} FOR UPDATE"""
             )
             .FirstOrDefaultAsync(cancellationToken);
+        if (stock != null && trackedEntry != null)
+            await DbContext.Entry(stock).ReloadAsync(cancellationToken);
+
+        return stock;
     }
 
     public IQueryable<string> GetAllTickers()

--- a/src/Equibles.CorporateActions.BusinessLogic/CashDividendBackfillManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CashDividendBackfillManager.cs
@@ -55,6 +55,6 @@ public class CashDividendBackfillManager
             })
             .ToList();
 
-        return await _captureManager.Capture(stock, captured);
+        return await _captureManager.Capture(stock.Id, stock.Ticker, captured, cancellationToken);
     }
 }

--- a/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
@@ -1,4 +1,6 @@
-using Equibles.CommonStocks.Data.Models;
+using System.Data;
+using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
@@ -6,29 +8,55 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.CorporateActions.BusinessLogic;
 
-// Upserts captured cash-dividend events into CashDividend. Idempotent by
-// (stock, ExDate): a re-run with the same events writes nothing. A changed
-// amount for an existing ex-date is updated in place (Yahoo occasionally
-// restates a dividend after declaration).
+// Upserts captured cash-dividend events into CashDividend. The manager locks and
+// revalidates the exact current primary listing before writing, so a company-sync
+// reorder cannot attach one security's action to another. Idempotent by (stock,
+// ExDate): a re-run with the same events writes nothing. A changed amount for an
+// existing ex-date is updated in place (Yahoo occasionally restates a dividend
+// after declaration).
 [Service]
 public class CashDividendCaptureManager
 {
     private readonly CashDividendRepository _dividendRepository;
+    private readonly CommonStockRepository _stockRepository;
 
-    public CashDividendCaptureManager(CashDividendRepository dividendRepository)
+    public CashDividendCaptureManager(
+        CashDividendRepository dividendRepository,
+        CommonStockRepository stockRepository
+    )
     {
         _dividendRepository = dividendRepository;
+        _stockRepository = stockRepository;
     }
 
     public async Task<int> Capture(
-        CommonStock stock,
-        IReadOnlyCollection<CapturedDividend> dividends
+        Guid commonStockId,
+        string listedTicker,
+        IReadOnlyCollection<CapturedDividend> dividends,
+        CancellationToken cancellationToken = default
     )
     {
         if (dividends == null || dividends.Count == 0)
             return 0;
 
-        var existing = await _dividendRepository.GetByStock(stock.Id).ToListAsync();
+        await using var transaction = await _dividendRepository.CreateTransaction(
+            IsolationLevel.ReadCommitted,
+            cancellationToken
+        );
+        var stock = await _stockRepository.GetForUpdate(commonStockId, cancellationToken);
+        var resolvedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, listedTicker);
+        if (
+            resolvedTicker == null
+            || !string.Equals(resolvedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return 0;
+        }
+
+        var existing = await _dividendRepository
+            .GetByStock(stock.Id)
+            .ToListAsync(cancellationToken);
         var changes = 0;
 
         foreach (var dividend in dividends)
@@ -62,6 +90,7 @@ public class CashDividendCaptureManager
         if (changes > 0)
             await _dividendRepository.SaveChanges();
 
+        await transaction.CommitAsync(cancellationToken);
         return changes;
     }
 }

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -1276,21 +1276,13 @@ public class YahooPriceImportService
             .ToList();
 
         using var scope = _scopeFactory.CreateScope();
-        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
-        await using var transaction = await stockRepo.CreateTransaction(
-            IsolationLevel.ReadCommitted,
+        var captureManager = scope.ServiceProvider.GetRequiredService<CashDividendCaptureManager>();
+        var count = await captureManager.Capture(
+            target.CommonStockId,
+            target.Ticker,
+            captured,
             cancellationToken
         );
-        var lockedSeries = await LockPriceSeries(stockRepo, target, cancellationToken);
-        if (lockedSeries is not { IsPrimary: true })
-        {
-            await transaction.RollbackAsync(cancellationToken);
-            return;
-        }
-
-        var captureManager = scope.ServiceProvider.GetRequiredService<CashDividendCaptureManager>();
-        var count = await captureManager.Capture(lockedSeries.Value.Stock, captured);
-        await transaction.CommitAsync(cancellationToken);
         if (count > 0)
             _logger.LogInformation(
                 "Captured {Count} cash dividend(s) for {Ticker} on {StockId}",

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryGetForUpdateTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryGetForUpdateTests.cs
@@ -1,0 +1,55 @@
+using System.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.CommonStocks;
+
+[Collection(ParadeDbCollection.Name)]
+public class CommonStockRepositoryGetForUpdateTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+
+    public CommonStockRepositoryGetForUpdateTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task GetForUpdate_ModifiedTrackedStock_ThrowsWithoutDiscardingChanges()
+    {
+        var stockId = Guid.NewGuid();
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple",
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        await using var context = _fixture.CreateDbContext();
+        var repository = new CommonStockRepository(context);
+        var tracked = await repository.GetByPrimaryTicker("AAPL");
+        tracked.Name = "Pending local name";
+        await using var transaction = await repository.CreateTransaction(
+            IsolationLevel.ReadCommitted
+        );
+
+        var action = async () => await repository.GetForUpdate(stockId);
+
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Modified*");
+        tracked.Name.Should().Be("Pending local name");
+        context.Entry(tracked).State.Should().Be(EntityState.Modified);
+        await transaction.RollbackAsync();
+    }
+}

--- a/tests/Equibles.IntegrationTests/CorporateActions/CashDividendCaptureManagerDesignationRaceTests.cs
+++ b/tests/Equibles.IntegrationTests/CorporateActions/CashDividendCaptureManagerDesignationRaceTests.cs
@@ -1,0 +1,82 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.BusinessLogic;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.CorporateActions;
+
+[Collection(ParadeDbCollection.Name)]
+public class CashDividendCaptureManagerDesignationRaceTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+
+    public CashDividendCaptureManagerDesignationRaceTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Capture_TrackedPrimaryChangedBeforeLock_UsesLockedDatabaseTicker()
+    {
+        var stockId = Guid.NewGuid();
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "GOOGL",
+                    SecondaryTickers = ["GOOG"],
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        await using var capture = _fixture.CreateDbContext();
+        var stockRepository = new CommonStockRepository(capture);
+        var staleStock = await stockRepository.GetByPrimaryTicker("GOOGL");
+        staleStock.Should().NotBeNull();
+
+        await using (var designation = _fixture.CreateDbContext())
+        {
+            var currentStock = await designation.Set<CommonStock>().SingleAsync();
+            currentStock.Ticker = "GOOG";
+            currentStock.SecondaryTickers = ["GOOGL"];
+            await designation.SaveChangesAsync();
+        }
+
+        // This context still holds the pre-fetch snapshot. The capture boundary must acquire the
+        // row lock and refresh it before deciding whether the observed ticker is still primary.
+        staleStock.Ticker.Should().Be("GOOGL");
+        var manager = new CashDividendCaptureManager(
+            new CashDividendRepository(capture),
+            stockRepository
+        );
+        var dividend = new CapturedDividend
+        {
+            ExDate = new DateOnly(2026, 8, 8),
+            AmountPerShare = 0.25m,
+            Source = CashDividendSource.External,
+        };
+
+        var staleWrite = await manager.Capture(stockId, "GOOGL", [dividend]);
+
+        staleWrite.Should().Be(0);
+        staleStock.Ticker.Should().Be("GOOG");
+        (await capture.Set<CashDividend>().ToListAsync()).Should().BeEmpty();
+
+        var currentWrite = await manager.Capture(stockId, "GOOG", [dividend]);
+
+        currentWrite.Should().Be(1);
+        await using var verify = _fixture.CreateDbContext();
+        var stored = await verify.Set<CashDividend>().SingleAsync();
+        stored.CommonStockId.Should().Be(stockId);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -80,7 +80,10 @@ public class YahooPriceImportServiceTests : IDisposable
                 typeof(StockSplitCaptureManager),
                 new StockSplitCaptureManager(_splitRepo, _stockRepo)
             ),
-            (typeof(CashDividendCaptureManager), new CashDividendCaptureManager(_dividendRepo))
+            (
+                typeof(CashDividendCaptureManager),
+                new CashDividendCaptureManager(_dividendRepo, _stockRepo)
+            )
         );
 
         var tickerMapService = new TickerMapService(scopeFactory);

--- a/tests/Equibles.UnitTests/CorporateActions/CashDividendBackfillManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CashDividendBackfillManagerTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.BusinessLogic;
 using Equibles.CorporateActions.Data;
 using Equibles.CorporateActions.Data.Models;
@@ -8,6 +9,7 @@ using Equibles.Data;
 using Equibles.Integrations.Yahoo.Contracts;
 using Equibles.Integrations.Yahoo.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using NSubstitute;
 
 namespace Equibles.UnitTests.CorporateActions;
@@ -25,6 +27,7 @@ public class CashDividendBackfillManagerTests
         var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .EnableServiceProviderCaching(false)
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
         var ctx = new EquiblesFinancialDbContext(
             options,
@@ -41,7 +44,22 @@ public class CashDividendBackfillManagerTests
     private static CashDividendBackfillManager NewManager(
         EquiblesFinancialDbContext db,
         IYahooFinanceClient yahooClient
-    ) => new(yahooClient, new CashDividendCaptureManager(new CashDividendRepository(db)));
+    ) =>
+        new(
+            yahooClient,
+            new CashDividendCaptureManager(
+                new CashDividendRepository(db),
+                new CommonStockRepository(db)
+            )
+        );
+
+    private static async Task<CommonStock> AddStock(EquiblesFinancialDbContext db)
+    {
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        db.Add(stock);
+        await db.SaveChangesAsync();
+        return stock;
+    }
 
     private static IYahooFinanceClient ClientReturning(params CashDividendEvent[] dividends)
     {
@@ -56,7 +74,7 @@ public class CashDividendBackfillManagerTests
     public async Task BackfillHistory_RequestsOneChartCoveringSinceThroughToday()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var stock = await AddStock(db);
         var since = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-730);
         var client = ClientReturning();
 
@@ -74,7 +92,7 @@ public class CashDividendBackfillManagerTests
     public async Task BackfillHistory_UpsertsReturnedDividendsAsYahooSourced()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var stock = await AddStock(db);
         var client = ClientReturning(
             new CashDividendEvent { Date = new DateOnly(2024, 2, 9), Amount = 0.24m },
             new CashDividendEvent { Date = new DateOnly(2024, 5, 9), Amount = 0.25m }
@@ -98,7 +116,7 @@ public class CashDividendBackfillManagerTests
     public async Task BackfillHistory_Rerun_IsIdempotentAndWritesNothing()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var stock = await AddStock(db);
         var client = ClientReturning(
             new CashDividendEvent { Date = new DateOnly(2024, 2, 9), Amount = 0.24m }
         );
@@ -116,7 +134,7 @@ public class CashDividendBackfillManagerTests
     public async Task BackfillHistory_NoDividendsInWindow_WritesNothingAndReturnsZero()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var stock = await AddStock(db);
 
         var captured = await NewManager(db, ClientReturning())
             .BackfillHistory(
@@ -133,7 +151,7 @@ public class CashDividendBackfillManagerTests
     public async Task BackfillHistory_AlreadyCancelled_ThrowsWithoutFetching()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var stock = await AddStock(db);
         var client = ClientReturning();
         using var cts = new CancellationTokenSource();
         cts.Cancel();

--- a/tests/Equibles.UnitTests/CorporateActions/CashDividendCaptureManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CashDividendCaptureManagerTests.cs
@@ -1,19 +1,20 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.BusinessLogic;
 using Equibles.CorporateActions.Data;
 using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Equibles.UnitTests.CorporateActions;
 
 /// <summary>
 /// Pins the upsert contract of <see cref="CashDividendCaptureManager"/>, mirroring the split
-/// capture manager: idempotent by (stock, ExDate) — a re-run with the same events writes nothing —
-/// a restated amount for an existing ex-date is updated in place, and a non-positive amount is
-/// dropped as unusable.
+/// capture manager: the exact current primary is locked and revalidated, idempotent events write
+/// nothing, a restated amount updates in place, and a non-positive amount is dropped as unusable.
 /// </summary>
 public class CashDividendCaptureManagerTests
 {
@@ -22,6 +23,7 @@ public class CashDividendCaptureManagerTests
         var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .EnableServiceProviderCaching(false)
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
         var ctx = new EquiblesFinancialDbContext(
             options,
@@ -33,6 +35,20 @@ public class CashDividendCaptureManagerTests
         );
         ctx.Database.EnsureCreated();
         return ctx;
+    }
+
+    private static CashDividendCaptureManager NewManager(EquiblesFinancialDbContext context) =>
+        new(new CashDividendRepository(context), new CommonStockRepository(context));
+
+    private static async Task<CommonStock> AddStock(
+        EquiblesFinancialDbContext context,
+        string ticker = "AAPL"
+    )
+    {
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = ticker };
+        context.Add(stock);
+        await context.SaveChangesAsync();
+        return stock;
     }
 
     private static CapturedDividend Dividend(DateOnly exDate, decimal amount) =>
@@ -47,11 +63,12 @@ public class CashDividendCaptureManagerTests
     public async Task Capture_NewDividends_InsertsOneRowPerExDate()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid() };
-        var manager = new CashDividendCaptureManager(new CashDividendRepository(db));
+        var stock = await AddStock(db);
+        var manager = NewManager(db);
 
         var changes = await manager.Capture(
-            stock,
+            stock.Id,
+            stock.Ticker,
             [Dividend(new DateOnly(2024, 2, 9), 0.24m), Dividend(new DateOnly(2024, 5, 9), 0.25m)]
         );
 
@@ -68,13 +85,11 @@ public class CashDividendCaptureManagerTests
     public async Task Capture_SameEventsRerun_IsIdempotentAndWritesNothing()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid() };
+        var stock = await AddStock(db);
         var events = new[] { Dividend(new DateOnly(2024, 2, 9), 0.24m) };
 
-        await new CashDividendCaptureManager(new CashDividendRepository(db)).Capture(stock, events);
-        var secondPass = await new CashDividendCaptureManager(
-            new CashDividendRepository(db)
-        ).Capture(stock, events);
+        await NewManager(db).Capture(stock.Id, stock.Ticker, events);
+        var secondPass = await NewManager(db).Capture(stock.Id, stock.Ticker, events);
 
         secondPass.Should().Be(0);
         (await new CashDividendRepository(db).GetByStock(stock.Id).CountAsync()).Should().Be(1);
@@ -84,21 +99,16 @@ public class CashDividendCaptureManagerTests
     public async Task Capture_RestatedAmountForExistingExDate_UpdatesInPlace()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid() };
+        var stock = await AddStock(db);
         var exDate = new DateOnly(2024, 2, 9);
 
-        await new CashDividendCaptureManager(new CashDividendRepository(db)).Capture(
-            stock,
-            [Dividend(exDate, 0.24m)]
-        );
+        await NewManager(db).Capture(stock.Id, stock.Ticker, [Dividend(exDate, 0.24m)]);
         var original = await db.Set<CashDividend>().SingleAsync();
         original.PriceAdjustmentAppliedAmountPerShare = original.AmountPerShare;
         original.PriceAdjustmentAppliedTime = DateTime.UtcNow;
         await db.SaveChangesAsync();
-        var changes = await new CashDividendCaptureManager(new CashDividendRepository(db)).Capture(
-            stock,
-            [Dividend(exDate, 0.26m)]
-        );
+        var changes = await NewManager(db)
+            .Capture(stock.Id, stock.Ticker, [Dividend(exDate, 0.26m)]);
 
         changes.Should().Be(1);
         var stored = await new CashDividendRepository(db).GetByStock(stock.Id).ToListAsync();
@@ -112,11 +122,12 @@ public class CashDividendCaptureManagerTests
     public async Task Capture_NonPositiveAmount_IsDropped()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid() };
-        var manager = new CashDividendCaptureManager(new CashDividendRepository(db));
+        var stock = await AddStock(db);
+        var manager = NewManager(db);
 
         var changes = await manager.Capture(
-            stock,
+            stock.Id,
+            stock.Ticker,
             [Dividend(new DateOnly(2024, 2, 9), 0m), Dividend(new DateOnly(2024, 5, 9), -0.1m)]
         );
 
@@ -125,13 +136,40 @@ public class CashDividendCaptureManagerTests
     }
 
     [Fact]
+    public async Task Capture_StalePrimaryTargetAfterReorder_DoesNotWriteIssuerAction()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "GOOG",
+            SecondaryTickers = ["GOOGL"],
+        };
+        db.Add(stock);
+        await db.SaveChangesAsync();
+
+        // The fetch originally saw GOOGL as primary. By the write boundary it is secondary, so
+        // the issuer-level dividend must be skipped rather than attached to GOOG's price series.
+        var staleWrite = await NewManager(db)
+            .Capture(stock.Id, "GOOGL", [Dividend(new DateOnly(2024, 2, 9), 0.24m)]);
+
+        staleWrite.Should().Be(0);
+        (await db.Set<CashDividend>().ToListAsync()).Should().BeEmpty();
+
+        var currentWrite = await NewManager(db)
+            .Capture(stock.Id, "GOOG", [Dividend(new DateOnly(2024, 2, 9), 0.24m)]);
+
+        currentWrite.Should().Be(1);
+        (await db.Set<CashDividend>().SingleAsync()).CommonStockId.Should().Be(stock.Id);
+    }
+
+    [Fact]
     public async Task Capture_NullOrEmpty_ReturnsZero()
     {
         await using var db = NewDb();
-        var stock = new CommonStock { Id = Guid.NewGuid() };
-        var manager = new CashDividendCaptureManager(new CashDividendRepository(db));
+        var manager = NewManager(db);
 
-        (await manager.Capture(stock, null)).Should().Be(0);
-        (await manager.Capture(stock, [])).Should().Be(0);
+        (await manager.Capture(Guid.NewGuid(), "AAPL", null)).Should().Be(0);
+        (await manager.Capture(Guid.NewGuid(), "AAPL", [])).Should().Be(0);
     }
 }


### PR DESCRIPTION
## Summary

- Close the final ownership race found while integrating adjusted-close corporate-action reconciliation.
- Prevent issuer-level dividends from being attached to a stale primary listing after a designation change.

## Code changes

- Make cash-dividend capture lock CommonStock and revalidate the observed exact ticker as the current primary.
- Refresh unchanged tracked snapshots only after FOR UPDATE, and reject pending tracked changes instead of discarding them.
- Route Yahoo incremental and historical capture through the same locked manager contract.
- Add PostgreSQL coverage for a two-context designation race and modified-state preservation.

## Testing

- dotnet build Equibles.sln -c Release
- 4,212 unit tests passed
- 2,458 PostgreSQL integration tests passed
- dotnet csharpier check . (3,305 files)
- git diff --check