### PR TITLE
docs(mcp): state what the 52-week range is not

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -150,7 +150,10 @@ public class StockPriceTools
             + "prior session while the fresh bar settles, so dates within one response can "
             + "differ — anchor on the Date column, never the wall clock. 52W High/Low are the "
             + "highest and lowest daily closes in the 365 days ending on the row's date "
-            + "on the stored series; raw rows carry no split-basis metadata. Off High / Above "
+            + "on the stored series; raw rows carry no split-basis metadata. They are CLOSING "
+            + "extremes, never intraday highs and lows, and they are not dividend-adjusted, so "
+            + "a source quoting an intraday range reads higher and one quoting a "
+            + "dividend-adjusted range reads lower without either being wrong. Off High / Above "
             + "Low are the close's percent distance from those bounds."
     )]
     public Task<string> GetLatestPrices(


### PR DESCRIPTION
## Summary

`GetLatestPrices` describes the 52-week high and low as the highest and lowest daily closes in the 365 days ending on the row's date, and stops there. That says what the range **is** and never what it **is not**, so a caller comparing our figures against another provider cannot tell an ordinary basis difference from a defect.

Both bounds bite in practice, in opposite directions:

- a source quoting an **intraday** range reads **higher** than ours
- a source quoting a **dividend-adjusted** range reads **lower**

Naming them lets an agent resolve the discrepancy at call time instead of escalating it.

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — extends the `GetLatestPrices` description with the two missing facts and the direction each difference runs. Same shape as the existing one-session change note. Prose only; no behaviour, no computed value, and no output column changes.

## Verification

- `dotnet build src/Equibles.Yahoo.Mcp -c Release` — 0 errors.
- `dotnet csharpier check` clean on the changed file.
- No test pins this prose. The only 52-week assertion in the suite is the rendered table header in `StockPriceToolsGetLatestPricesMaxTickerBoundaryTests`, which this does not touch.