### PR TITLE
fix(funds): expose complete NPORT coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,13 +317,13 @@ This self-hosted build exposes 64 tools over MCP. The hosted server at `https://
 
 - SearchInvestmentAdvisers — strict-first tokenized adviser-name search (Form ADV)
 - GetInvestmentAdviser — ADV profile by CRD
-- GetFundOperations — fund ops from N-CEN
-- GetFundHoldings — fund holdings from NPORT-P
+- GetFundOperations — fund ops from N-CEN with exact directory-identifier resolution
+- GetFundHoldings — NPORT-P holdings with full reported versus stored counts; trust-series rows identify their tracked-stock subset
 - GetFundsHoldingStock — funds holding a stock
 - GetExemptOfferings — private placements (Form D)
 - GetFailsToDeliver — SEC FTD data
 - SearchFunds — strict-first tokenized fund/registrant/ticker search with verified share-class aliases
-- GetFundProfile — fund profile + largest holdings
+- GetFundProfile — fund profile + largest stored holdings with explicit coverage counts
 
 **Fundamentals (XBRL)**
 

--- a/docs/guide/how-to-ask-about-fund-directory.md
+++ b/docs/guide/how-to-ask-about-fund-directory.md
@@ -15,21 +15,23 @@ Ask your assistant to search by fund name, registrant, or ticker:
 - "Search the fund directory for Vanguard."
 - "What fund has the ticker VOO?"
 
-The assistant calls `SearchFunds`, which first requires every query word anywhere across the fund name, registrant, or ticker; punctuation and word order need not mirror the SEC row. If that strict search has no rows, it broadens to any query word. Verified share-class aliases such as VOO and VFIAX resolve their SEC series. The table is largest by net assets first and shows the **profile id**, ticker when present, fund type, net assets, stored holding rows, and latest report date. No result means no match in the tracked Form NPORT-P directory, not that the fund does not exist.
+The assistant calls `SearchFunds`, which first requires every query word anywhere across the fund name, registrant, or ticker; punctuation and word order need not mirror the SEC row. If that strict search has no rows, it broadens to any query word. Verified share-class aliases such as VOO and VFIAX resolve their SEC series. The table is largest by net assets first and shows the **profile id**, ticker when present, fund type, net assets, stored rows, the fund's full reported investment-row count when available, and latest report date. Only multi-series trust rows limit the stored count to tracked-stock positions.
+
+No result is a coverage result, not evidence that the fund does not exist. Form NPORT-P covers registered management investment companies and ETFs organized as unit investment trusts; money market funds and small business investment companies do not file it. Operating companies and vehicles outside that filing regime are also out of scope. Fixed-income-only series can be absent because reports from multi-series trusts enter this tracked directory after at least one holding matches a tracked stock.
 
 The profile id is the key to the next step — note it for the fund you care about. The big fund families (iShares, Vanguard, Fidelity) run many series under one registrant and often have no single ticker, so searching by name or registrant is the way to reach them.
 
 ## View a fund's profile and holdings
 
-Ask for one fund's details, using either its profile id from the search or its ticker:
+Ask for one fund's details using its profile id, SEC series id, stored ticker, or a verified share-class alias from the search:
 
 - "Show me the profile for ishares-russell-2000-etf-s000002277."
 - "What are VOO's largest holdings?"
 - "How much does the Fidelity Contrafund hold, and in what?"
 
-The assistant calls the `GetFundProfile` tool and replies with the fund's registrant and series, its latest reporting period, net and total assets, and a table of its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value, share of net assets, and asset category, largest first.
+The assistant calls the `GetFundProfile` tool and replies with the fund's registrant and series, its latest reporting period, net and total assets, its full reported holding count when available, its stored holding count, and a table of its largest stored holdings — issuer name, CUSIP, position size, U.S.-dollar value, share of net assets, and asset category, largest first.
 
-For the large multi-series trusts, only positions in tracked stocks are stored, so the holdings table shows the fund's tracked-stock positions while the net-asset totals are the fund's real totals.
+For the large multi-series trusts, only positions whose CUSIPs match tracked stocks are stored. The reported count makes the omitted part explicit while the net-asset totals continue to describe the fund's full filing.
 
 ## What you should see
 

--- a/docs/guide/how-to-ask-about-fund-operations.md
+++ b/docs/guide/how-to-ask-about-fund-operations.md
@@ -9,16 +9,16 @@ Equibles ingests the SEC Form N-CEN annual reports that registered funds file an
 
 ## Ask about a fund's operations
 
-Name a fund by its ticker:
+Name a fund by its ticker or use an exact profile id, SEC series id, or verified alias from `SearchFunds`:
 
 - "Who is the custodian and auditor for SPY?"
 - "What service providers does VOO use?"
 - "Show me the operational filings for the Mexico Fund (MXF)."
 
-The assistant calls the `GetFundOperations` tool with the fund's ticker and returns up to 10 annual reports by default (ask for more or fewer), newest first.
+The assistant calls the `GetFundOperations` tool with that identifier and returns up to 10 annual reports by default (ask for more or fewer), newest first.
 
 ## What you should see
 
 For each N-CEN report, you see the fund's classification (for example N-1A open-end or N-2 closed-end), Investment Company Act file number, reporting period, and first/last-filing flags. The answer then separates the newest filing's named service providers from an exact filed-name timeline across the returned reports, so a changed or omitted adviser, custodian, transfer agent, administrator, auditor, or underwriter remains visible.
 
-If the reply comes back empty, the ticker may not belong to a registered fund — only mutual funds, ETFs, and closed-end funds file N-CEN, so an operating company returns no data — or its N-CEN may not have been imported yet. Try a large, well-known fund such as SPY to confirm the data is flowing.
+If the identifier resolves but the reply has no report, read the coverage note in the answer. N-CEN is filed at registrant level and this dataset currently ingests it through tracked issuer feeds, so a series inside an untracked multi-series trust can resolve while its registrant-level report remains unavailable. Operating companies are outside the N-CEN filing regime. Try a tracked listed fund such as MXF to confirm the data is flowing.

--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -68,17 +68,17 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 `NportTools`:
 
-- `GetFundHoldings` — portfolio holdings of a fund or ETF from its latest SEC Form NPORT-P monthly report: series, reporting period, net assets, and largest positions (issuer, CUSIP, position size, USD value, share of net assets, asset category). Only registered funds file NPORT-P.
+- `GetFundHoldings` — largest stored holdings of a fund or ETF from its latest SEC Form NPORT-P monthly report: series, reporting period, net assets, full reported holding count when available, stored holding count, and position details. For multi-series trusts the stored rows are only positions whose CUSIPs match tracked stocks; the reported count and net assets still describe the full filing. Accepts a profile id, SEC series id, stored ticker, or verified share-class alias from `SearchFunds`.
 - `GetFundsHoldingStock` — reverse lookup: the registered funds and ETFs holding a given stock, matched by CUSIP against each fund series' most recent NPORT-P report (so an exited position never shows as current). Returns registrant and series, reporting period, position size, USD value, share of the fund's net assets, and payoff profile (Long/Short), largest positions first.
 
 `FundDirectoryTools`:
 
-- `SearchFunds` — punctuation-independent all-token search of the tracked registered-fund directory by series, ticker, or registrant, with a sparse any-token fallback; verified share-class aliases such as VOO/VFIAX resolve their SEC series. Returns profile id, net assets, stored-holding count, and latest report date, largest first. An empty result means no match in this tracked directory, not that the fund does not exist.
-- `GetFundProfile` — one registered fund's profile and largest holdings from its latest NPORT-P report, addressed by a profile id from `SearchFunds` or the fund's own ticker.
+- `SearchFunds` — punctuation-independent all-token search of the tracked registered-fund directory by series, ticker, or registrant, with a sparse any-token fallback; verified share-class aliases such as VOO/VFIAX resolve their SEC series. Returns profile id, net assets, stored holding count, full reported count when available, and latest report date, largest first; only multi-series trust rows limit the stored count to tracked-stock positions. An empty result is a coverage result: NPORT-P covers registered management investment companies and ETFs organized as unit investment trusts, money market funds and small business investment companies do not file it, and fixed-income-only trust series can be absent because directory entry requires a tracked-stock match.
+- `GetFundProfile` — one registered fund's profile and largest stored holdings from its latest NPORT-P report, addressed by the same exact identifiers and verified aliases as `SearchFunds`; reports the full filed count beside the stored count.
 
 `NCenTools`:
 
-- `GetFundOperations` — operational data for a fund, ETF or closed-end fund from SEC Form N-CEN annual reports: registrant classification, Investment Company Act file number, reporting period, first/last-filing flags, the latest filing's named service providers, and an exact filed-name provider timeline across returned reports. Only registered funds file N-CEN.
+- `GetFundOperations` — operational data for a fund, ETF or closed-end fund from SEC Form N-CEN annual reports: registrant classification, Investment Company Act file number, reporting period, first/last-filing flags, the latest filing's named service providers, and an exact filed-name provider timeline. Uses the same exact fund identifiers and verified aliases as the directory. N-CEN is registrant-level and currently ingested through tracked issuer feeds, so a series in an untracked multi-series trust can resolve but still have no N-CEN report on record.
 
 `InvestmentAdviserTools`:
 

--- a/src/Equibles.Migrations/Migrations/20260810162249_AddNportReportedHoldingCounts.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260810162249_AddNportReportedHoldingCounts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260810162249_AddNportReportedHoldingCounts")]
+    partial class AddNportReportedHoldingCounts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260810162249_AddNportReportedHoldingCounts.cs
+++ b/src/Equibles.Migrations/Migrations/20260810162249_AddNportReportedHoldingCounts.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNportReportedHoldingCounts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ReportedHoldingCount",
+                table: "NportFiling",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReportedHoldingCount",
+                table: "FundSeries",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ReportedHoldingCount",
+                table: "NportFiling");
+
+            migrationBuilder.DropColumn(
+                name: "ReportedHoldingCount",
+                table: "FundSeries");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/FundSeries.cs
+++ b/src/Equibles.Sec.Data/Models/FundSeries.cs
@@ -90,6 +90,12 @@ public class FundSeries
     public int PositionCount { get; set; }
 
     /// <summary>
+    /// Investment rows reported on the latest NPORT-P before tracked-stock filtering. Null while
+    /// that filing is waiting for parser-version replay or could not be re-fetched from EDGAR.
+    /// </summary>
+    public int? ReportedHoldingCount { get; set; }
+
+    /// <summary>
     /// The N-CEN registration type of the fund (e.g. "N-1A" open-end/ETF, "N-2" closed-end), when
     /// an N-CEN filing is on record. Null for trusts and newly-launched funds with no N-CEN yet.
     /// </summary>

--- a/src/Equibles.Sec.Data/Models/NportFiling.cs
+++ b/src/Equibles.Sec.Data/Models/NportFiling.cs
@@ -33,9 +33,10 @@ public class NportFiling
     /// <summary>
     /// Current holdings-parsing algorithm version. Bump this whenever the NPORT-P parse changes so
     /// the reprocess worker re-derives every filing's <see cref="Holdings"/> from EDGAR. Version 1
-    /// is the first that reads the portfolio schedule from the correct <c>formData</c> element.
+    /// is the first that reads the portfolio schedule from the correct <c>formData</c> element;
+    /// version 2 also preserves the pre-filter <see cref="ReportedHoldingCount"/>.
     /// </summary>
-    public const int CurrentParserVersion = 1;
+    public const int CurrentParserVersion = 2;
 
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid Id { get; set; } = Guid.NewGuid();
@@ -99,6 +100,13 @@ public class NportFiling
 
     /// <summary>True when the registrant marked this as the series' final NPORT-P report.</summary>
     public bool IsFinalFiling { get; set; }
+
+    /// <summary>
+    /// Number of non-blank investment rows reported in the filing before the trust sweep narrows
+    /// <see cref="Holdings"/> to positions whose CUSIPs match tracked stocks. Null only while a
+    /// legacy filing is waiting for parser-version replay or could not be re-fetched from EDGAR.
+    /// </summary>
+    public int? ReportedHoldingCount { get; set; }
 
     /// <summary>The series' schedule of portfolio investments reported on the filing.</summary>
     public virtual List<NportHolding> Holdings { get; set; } = [];

--- a/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
@@ -78,6 +78,7 @@ public class FundSeriesRefreshService
                 NetAssets = f.NetAssets,
                 TotalAssets = f.TotalAssets,
                 PositionCount = f.Holdings.Count(),
+                ReportedHoldingCount = f.ReportedHoldingCount,
             })
             .ToListAsync(cancellationToken);
 
@@ -114,6 +115,7 @@ public class FundSeriesRefreshService
                             NetAssets = incoming.NetAssets,
                             TotalAssets = incoming.TotalAssets,
                             PositionCount = incoming.PositionCount,
+                            ReportedHoldingCount = incoming.ReportedHoldingCount,
                             FundType = incoming.FundType,
                             ComputedAt = incoming.ComputedAt,
                         }
@@ -251,6 +253,7 @@ public class FundSeriesRefreshService
             NetAssets = a.NetAssets,
             TotalAssets = a.TotalAssets,
             PositionCount = a.PositionCount,
+            ReportedHoldingCount = a.ReportedHoldingCount,
             FundType = fundType,
             ComputedAt = computedAt,
         };
@@ -314,5 +317,6 @@ public class FundSeriesRefreshService
         public decimal NetAssets { get; set; }
         public decimal TotalAssets { get; set; }
         public int PositionCount { get; set; }
+        public int? ReportedHoldingCount { get; set; }
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -108,6 +108,8 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
                 entity.Holdings.Add(holding);
         }
 
+        entity.ReportedHoldingCount = entity.Holdings.Count;
+
         return entity;
     }
 

--- a/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
@@ -257,6 +257,7 @@ public class NportFilingReprocessManager
         filing.TotalLiabilities = parsed.TotalLiabilities;
         filing.NetAssets = parsed.NetAssets;
         filing.IsFinalFiling = parsed.IsFinalFiling;
+        filing.ReportedHoldingCount = parsed.ReportedHoldingCount;
         filing.ParserVersion = NportFiling.CurrentParserVersion;
         filing.ReprocessAttempts = 0;
 

--- a/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
@@ -37,7 +37,7 @@ public class FundDirectoryTools
 
     [McpServerTool(Name = "SearchFunds", Title = "Search Funds and ETFs", ReadOnly = true)]
     [Description(
-        "Search the tracked SEC Form NPORT-P fund directory by fund name, ticker, or registrant. Search first requires every punctuation-independent query word anywhere across those fields, then broadens to any word only when no strict row matches. Verified share-class aliases such as VOO and VFIAX resolve to their SEC fund series even when N-PORT carries no class ticker. Returns profile id, ticker when present, registration type, net assets, stored holding count, and latest report date, largest funds first."
+        "Search the tracked SEC Form NPORT-P fund directory by fund name, ticker, or registrant. Search first requires every punctuation-independent query word anywhere across those fields, then broadens to any word only when no strict row matches. Verified share-class aliases such as VOO and VFIAX resolve to their SEC fund series even when N-PORT carries no class ticker. Returns profile id, ticker when present, registration type, net assets, stored holding count, the fund's full reported holding count when available, and latest report date, largest funds first. For multi-series trusts the stored count includes only positions whose CUSIPs match tracked stocks. Form NPORT-P covers registered management investment companies and ETFs organized as unit investment trusts; money market funds and small business investment companies do not file it. Fixed-income-only series can be absent because trust reports enter this tracked directory after a tracked-stock match."
     )]
     public Task<string> SearchFunds(
         [Description(
@@ -56,11 +56,12 @@ public class FundDirectoryTools
                 if (string.IsNullOrWhiteSpace(query))
                     return "Provide a fund name, ticker or registrant to search for.";
 
+                var safeQuery = MarkdownText(query);
                 var allMatches = _fundSeriesRepository.Search(query);
 
                 var totalCount = await allMatches.CountAsync();
                 if (totalCount == 0)
-                    return $"No match for '{query}' in the tracked Form NPORT-P fund directory. This does not assert that the fund does not exist or file with the SEC; try fewer words or list another identifier.";
+                    return $"No match for '{safeQuery}' in the tracked Form NPORT-P fund directory. Form NPORT-P covers registered management investment companies and ETFs organized as unit investment trusts; money market funds and small business investment companies do not file it. Operating companies, BDCs, unregistered private funds, and other filers outside that form are also out of scope; registered private-credit funds can be in scope. Fixed-income-only series can be absent because trust reports enter this directory after a tracked-stock match. This is a coverage result, not evidence that the fund does not exist; try fewer words or another identifier.";
 
                 var matches = await allMatches
                     .OrderByDescending(f => f.NetAssets)
@@ -68,19 +69,19 @@ public class FundDirectoryTools
                     .ToListAsync();
 
                 var result = MarkdownTable.Start(
-                    $"Registered funds matching '{query}', largest by net assets first (showing {matches.Count} of {totalCount}):",
+                    $"Registered funds matching '{safeQuery}', largest by net assets first (showing {matches.Count} of {totalCount}):",
                     // Sweep-discovered series only have their tracked-stock positions stored,
                     // so a bond fund's Holdings can read 0 beside real net assets — say so, or
                     // the count reads as "this fund holds nothing".
-                    "_Holdings = stored holding rows on the fund's latest report. For the large multi-series trusts only positions in stocks this platform tracks are stored, so the count can be a small subset of (or zero within) the real portfolio; Net Assets is always the fund's own reported total._",
-                    "| Fund | Profile id | Ticker | Type | Net Assets (USD) | Holdings | Latest Report |",
-                    "|------|-----------|--------|------|------------------|----------|---------------|"
+                    "_Stored = holding rows retained by this platform; for multi-series trusts that is only positions whose CUSIPs match tracked stocks. Reported = the full investment-row count in the fund's filing before that filter (`—` means parser replay is pending or EDGAR could not be re-fetched). Net Assets is always the fund's reported total._",
+                    "| Fund | Profile id | Ticker | Type | Net Assets (USD) | Stored | Reported | Latest Report |",
+                    "|------|-----------|--------|------|------------------|--------|----------|---------------|"
                 );
 
                 result.AppendRows(
                     matches,
                     f =>
-                        $"| {MarkdownTable.EscapeCell(f.SeriesName ?? f.RegistrantName, "-")} | {MarkdownTable.EscapeCell(f.Slug, "-")} | {MarkdownTable.EscapeCell(f.Ticker, "-")} | {MarkdownTable.EscapeCell(FundCodes.RegistrationType(f.FundType), "-")} | ${FormatAmount(f.NetAssets)} | {f.PositionCount} | {f.LatestReportPeriodDate:yyyy-MM-dd} |"
+                        $"| {MarkdownTable.EscapeCell(f.SeriesName ?? f.RegistrantName, "-")} | {MarkdownTable.EscapeCell(f.Slug, "-")} | {MarkdownTable.EscapeCell(f.Ticker, "-")} | {MarkdownTable.EscapeCell(FundCodes.RegistrationType(f.FundType), "-")} | ${FormatAmount(f.NetAssets)} | {f.PositionCount} | {FormatCount(f.ReportedHoldingCount)} | {f.LatestReportPeriodDate:yyyy-MM-dd} |"
                 );
 
                 TruncationNotes.Append(result, matches.Count, totalCount);
@@ -98,11 +99,11 @@ public class FundDirectoryTools
         ReadOnly = true
     )]
     [Description(
-        "Get a registered fund's profile and largest holdings from its most recent SEC Form NPORT-P report. Accepts a fund profile id from SearchFunds or a fund's own ticker. Returns the fund's registrant and series, reporting period, net and total assets, then its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value, share of net assets and asset category. Prefer this after SearchFunds: the profile id reaches the many fund series that have no ticker of their own; GetFundHoldings is the equivalent view, and GetFundsHoldingStock answers the inverse question (which funds own a stock). For the large multi-series trusts only positions in tracked stocks are stored, so the holdings shown are the fund's tracked-stock positions; the net-asset totals are the fund's real totals."
+        "Get a registered fund's profile and largest stored holdings from its most recent SEC Form NPORT-P report. Accepts a profile id, stored series ticker, SEC series id, or verified share-class alias from SearchFunds. Returns the fund's registrant and series, reporting period, net and total assets, full reported holding count when available, stored holding count, then its largest stored holdings — issuer name, CUSIP, position size, U.S.-dollar value, share of net assets and asset category. Prefer this after SearchFunds; GetFundHoldings is the equivalent view, and GetFundsHoldingStock answers the inverse question. For large multi-series trusts only positions in tracked stocks are stored; the reported count and asset totals still describe the fund's full filing."
     )]
     public Task<string> GetFundProfile(
         [Description(
-            "Fund profile id from SearchFunds (e.g., 'ishares-russell-2000-etf-s000004344') or a fund's own ticker (e.g., 'IWM'). Share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) do not resolve — find the fund by name via SearchFunds."
+            "Fund profile id, SEC series id, stored series ticker, or verified share-class alias from SearchFunds (e.g., 'ishares-russell-2000-etf-s000004344', 'S000004344', 'IWM', or 'VOO')."
         )]
             string fund,
         [Description("Maximum number of holdings to return, largest first (default: 20, max: 500)")]
@@ -115,18 +116,14 @@ public class FundDirectoryTools
                 if (string.IsNullOrWhiteSpace(fund))
                     return "Provide a fund profile id or ticker.";
 
-                var key = fund.Trim();
-                var lowerKey = key.ToLower();
+                var safeFund = MarkdownText(fund);
                 var series = await _fundSeriesRepository
-                    .GetAll()
-                    .Where(f =>
-                        f.Slug == key || (f.Ticker != null && f.Ticker.ToLower() == lowerKey)
-                    )
+                    .ResolveIdentifier(fund)
                     .OrderByDescending(f => f.NetAssets)
                     .FirstOrDefaultAsync();
 
                 if (series == null)
-                    return $"No registered fund found for '{fund}'. Use SearchFunds to find a fund's profile id — share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) do not resolve, so search by fund name.";
+                    return $"No registered fund found for '{safeFund}' in the tracked Form NPORT-P directory. Use SearchFunds to find a profile id. Form NPORT-P covers registered management investment companies and ETFs organized as unit investment trusts; money market funds and small business investment companies do not file it. Fixed-income-only series and vehicles outside that filing regime may be absent. This is a coverage result, not evidence that the fund does not exist.";
 
                 var latest = await _nportRepository
                     .GetSeriesReportsByPeriod(
@@ -140,7 +137,7 @@ public class FundDirectoryTools
                     .FirstOrDefaultAsync();
 
                 if (latest == null)
-                    return $"No Form NPORT-P report is on record for {series.SeriesName ?? series.RegistrantName}.";
+                    return $"No stored Form NPORT-P report is on record for {MarkdownText(series.SeriesName ?? series.RegistrantName)}. This is a dataset coverage result, not evidence that no SEC filing exists; the report may be outside the filing scope or absent from this ingestion, fetch, or replay state.";
 
                 var holdings = latest
                     .Holdings.OrderByDescending(h => h.ValueUsd)
@@ -148,12 +145,14 @@ public class FundDirectoryTools
                     .ToList();
 
                 var header =
-                    $"{series.SeriesName ?? series.RegistrantName}"
-                    + (series.Ticker != null ? $" ({series.Ticker})" : "")
-                    + $" — registrant {series.RegistrantName ?? "-"}, "
+                    $"{MarkdownText(series.SeriesName ?? series.RegistrantName)}"
+                    + (series.Ticker != null ? $" ({MarkdownText(series.Ticker)})" : "")
+                    + $" — registrant {MarkdownText(series.RegistrantName) ?? "-"}, "
                     + $"reported {latest.ReportPeriodDate:yyyy-MM-dd}, "
                     + $"net assets ${FormatAmount(latest.NetAssets)}, total assets ${FormatAmount(latest.TotalAssets)}, "
-                    + $"{latest.Holdings.Count} holdings on record, showing the largest {holdings.Count}:";
+                    + $"{FormatCount(latest.ReportedHoldingCount)} holdings reported, {latest.Holdings.Count} stored"
+                    + (latest.CommonStockId == null ? " tracked-stock holdings" : " holdings")
+                    + $", showing the largest {holdings.Count} stored rows:";
 
                 var result = MarkdownTable.Start(
                     header,
@@ -164,7 +163,7 @@ public class FundDirectoryTools
                 result.AppendRows(
                     holdings,
                     h =>
-                        $"| {h.Name ?? "-"} | {h.Cusip ?? "-"} | {FundCodes.Balance(h.Balance)} | {FundCodes.Unit(h.Units)} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {FundCodes.AssetCategory(h.AssetCategory)} | {h.InvestmentCountry ?? "-"} |"
+                        $"| {MarkdownText(h.Name) ?? "-"} | {MarkdownText(h.Cusip) ?? "-"} | {FundCodes.Balance(h.Balance)} | {MarkdownText(FundCodes.Unit(h.Units))} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {MarkdownText(FundCodes.AssetCategory(h.AssetCategory))} | {MarkdownText(h.InvestmentCountry) ?? "-"} |"
                 );
 
                 TruncationNotes.Append(result, holdings.Count, latest.Holdings.Count);
@@ -179,4 +178,9 @@ public class FundDirectoryTools
     private static string FormatAmount(decimal value) => McpFormat.Invariant(value, "N2");
 
     private static string FormatPercent(decimal value) => McpFormat.Invariant(value, "N2") + "%";
+
+    private static string FormatCount(int? value) => McpFormat.OrDash(value, "N0");
+
+    private static string MarkdownText(string value) =>
+        value == null ? null : MarkdownTable.EscapeCell(value).Trim();
 }

--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
@@ -19,17 +20,20 @@ public class NCenTools
 {
     private readonly NCenFilingRepository _nCenRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly FundSeriesRepository _fundSeriesRepository;
     private readonly McpToolRunner _runner;
 
     public NCenTools(
         NCenFilingRepository nCenRepository,
         CommonStockRepository commonStockRepository,
+        FundSeriesRepository fundSeriesRepository,
         ErrorManager errorManager,
         ILogger<NCenTools> logger
     )
     {
         _nCenRepository = nCenRepository;
         _commonStockRepository = commonStockRepository;
+        _fundSeriesRepository = fundSeriesRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -39,10 +43,13 @@ public class NCenTools
         ReadOnly = true
     )]
     [Description(
-        "Get operational data for a registered investment company from its SEC Form N-CEN annual reports. Resolves exchange-listed tickers only — ETFs, closed-end funds and unit investment trusts; an unlisted mutual-fund share-class ticker (e.g. VFIAX) will not resolve, so find that fund via SearchFunds/GetFundProfile instead. Each N-CEN shows the registrant's classification (e.g. N-1A open-end, N-2 closed-end, S-6 unit investment trust), Investment Company Act file number, reporting period, and whether it was the fund's first or last filing. The response shows the service providers named on the latest report and an exact filed-name history across the reports returned — investment advisers, sub-advisers, custodians, transfer agents, administrators, auditors and underwriters. Use this to see who runs and services a fund. Only registered funds file N-CEN; operating companies will return no data."
+        "Get operational data for a registered investment company from its SEC Form N-CEN annual reports. Accepts an exchange-listed ticker or an exact fund identifier from SearchFunds, including a profile id, SEC series id, stored series ticker, or verified share-class alias. Each N-CEN shows the registrant's classification, Investment Company Act file number, reporting period, first/last-filing flags, latest service providers, and an exact filed-name provider history. N-CEN is filed at registrant level; this dataset currently ingests it through tracked issuer feeds, so a series inside an untracked multi-series trust can resolve correctly but still have no N-CEN report on record. Only registered funds file N-CEN; operating companies return no data."
     )]
     public Task<string> GetFundOperations(
-        [Description("Fund or ETF ticker symbol (e.g., MXF, SPY)")] string ticker,
+        [Description(
+            "Fund or ETF ticker, profile id, SEC series id, or verified share-class alias (e.g., MXF, IVV, S000004344, VOO)"
+        )]
+            string ticker,
         [Description("Maximum number of annual reports to return (default: 10, max: 500)")]
             int maxResults = 10
     )
@@ -50,9 +57,36 @@ public class NCenTools
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
-                if (stockError != null)
-                    return stockError;
+                if (string.IsNullOrWhiteSpace(ticker))
+                    return "Provide a fund ticker or an exact identifier from SearchFunds.";
+
+                var safeTicker = MarkdownText(ticker);
+                var series = await _fundSeriesRepository
+                    .ResolveIdentifier(ticker)
+                    .OrderByDescending(f => f.NetAssets)
+                    .FirstOrDefaultAsync();
+                CommonStock stock = null;
+                if (series != null)
+                {
+                    if (series.CommonStockId == null)
+                    {
+                        return $"'{safeTicker}' resolves to {MarkdownText(series.SeriesName ?? series.RegistrantName)}"
+                            + (series.Ticker == null ? "" : $" ({MarkdownText(series.Ticker)})")
+                            + $", a series of {MarkdownText(series.RegistrantName) ?? "its registered-fund trust"}. Form N-CEN is filed at registrant level, but this dataset currently ingests N-CEN through tracked issuer feeds and has no registrant-level report on record for this untracked multi-series trust. This is a coverage result, not an identifier-resolution failure.";
+                    }
+
+                    stock = await _commonStockRepository
+                        .GetByIds([series.CommonStockId.Value])
+                        .FirstOrDefaultAsync();
+                    if (stock == null)
+                        return $"'{safeTicker}' resolves to {MarkdownText(series.SeriesName ?? series.RegistrantName)}, but its linked tracked issuer is no longer available; no Form N-CEN report can be selected. This is a coverage result, not evidence that the fund has no N-CEN filing.";
+                }
+                else
+                {
+                    (stock, _) = await _commonStockRepository.ResolveByTicker(ticker);
+                    if (stock == null)
+                        return $"No registered fund found for '{safeTicker}' in the tracked Form NPORT-P/N-CEN datasets. Use SearchFunds to find an exact profile id. Registered management investment companies and ETFs are in scope; vehicles outside those filing regimes may be absent, and fixed-income-only series can be missing from the tracked NPORT-P directory. This is a coverage result, not evidence that the fund does not exist.";
+                }
 
                 var filings = await _nCenRepository
                     .GetByStock(stock)
@@ -65,10 +99,10 @@ public class NCenTools
                     .ToListAsync();
 
                 if (filings.Count == 0)
-                    return $"No Form N-CEN annual reports found for {ticker}.";
+                    return $"No Form N-CEN annual reports found for {MarkdownText(series?.SeriesName ?? stock.Name)} ({MarkdownText(stock.Ticker)}). Form N-CEN is registrant-level and this dataset currently ingests it through tracked issuer feeds. This is a coverage result, not evidence that the fund has no N-CEN filing.";
 
                 var result = MarkdownTable.Start(
-                    $"Form N-CEN annual reports for {stock.Name} ({ticker}) — showing {filings.Count} most recent:",
+                    $"Form N-CEN annual reports for {MarkdownText(stock.Name)} ({safeTicker}) — showing {filings.Count} most recent:",
                     "| Filed | Period End | Type | File Number | Amendment | First Filing | Last Filing |",
                     "|-------|------------|------|-------------|-----------|--------------|-------------|"
                 );
@@ -76,7 +110,7 @@ public class NCenTools
                 result.AppendRows(
                     filings,
                     f =>
-                        $"| {f.FilingDate:yyyy-MM-dd} | {f.ReportEndingPeriod:yyyy-MM-dd} | {FundCodes.RegistrationType(f.InvestmentCompanyType)} | {f.InvestmentCompanyFileNumber ?? "-"} | {(f.IsAmendment ? "Yes" : "No")} | {(f.IsFirstFiling ? "Yes" : "No")} | {(f.IsLastFiling ? "Yes" : "No")} |"
+                        $"| {f.FilingDate:yyyy-MM-dd} | {f.ReportEndingPeriod:yyyy-MM-dd} | {MarkdownText(FundCodes.RegistrationType(f.InvestmentCompanyType))} | {MarkdownText(f.InvestmentCompanyFileNumber) ?? "-"} | {(f.IsAmendment ? "Yes" : "No")} | {(f.IsFirstFiling ? "Yes" : "No")} | {(f.IsLastFiling ? "Yes" : "No")} |"
                 );
 
                 AppendServiceProviders(result, filings[0]);

--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -38,11 +38,11 @@ public class NportTools
 
     [McpServerTool(Name = "GetFundHoldings", Title = "Fund Portfolio Holdings", ReadOnly = true)]
     [Description(
-        "Get the portfolio holdings of a registered investment company (mutual fund or ETF) from its most recent SEC Form NPORT-P monthly report. Accepts the fund's own ticker or a fund profile id from SearchFunds, so it also reaches the many fund series that have no ticker of their own. Returns the fund's series, reporting period and net assets, followed by its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value and share of net assets, with the asset category. Use SearchFunds to discover funds, GetFundProfile for the same view with the fund's registrant and total assets, and GetFundsHoldingStock for the inverse question (which funds own a stock). Only registered funds file NPORT-P; operating companies will return no data. Share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) do not resolve — find those funds by name via SearchFunds."
+        "Get the largest stored portfolio holdings of a registered investment company (mutual fund or ETF) from its most recent SEC Form NPORT-P monthly report. Accepts a fund ticker, profile id, SEC series id, or verified share-class alias from SearchFunds. Returns the fund's series, reporting period, net assets, full reported holding count when available, stored holding count, and largest stored holdings. For multi-series trusts only positions whose CUSIPs match tracked stocks are stored, so the stored rows can be a small subset of the reported portfolio; net assets and the reported count still describe the full filing. Use SearchFunds to discover funds, GetFundProfile for the same view with registrant and total assets, and GetFundsHoldingStock for the inverse question. Form NPORT-P covers registered management investment companies and ETFs organized as unit investment trusts; money market funds and small business investment companies do not file it."
     )]
     public Task<string> GetFundHoldings(
         [Description(
-            "Fund or ETF ticker symbol (e.g., SPY, IWM) or a fund profile id from SearchFunds (e.g., 'vanguard-500-index-fund-s000002839')"
+            "Fund or ETF ticker, profile id, SEC series id, or verified share-class alias from SearchFunds (e.g., SPY, 'vanguard-500-index-fund-s000002839', S000002839, or VOO)"
         )]
             string ticker,
         [Description("Maximum number of holdings to return, largest first (default: 20, max: 500)")]
@@ -61,18 +61,16 @@ public class NportTools
                     .Take(McpLimit.Clamp(maxResults))
                     .ToList();
 
-                // Sweep-discovered series (no CommonStock link) only have their TRACKED-stock
-                // positions stored, so their row count is a subset, not the portfolio — a bond
-                // fund would otherwise read "0 total holdings" beside billions in net assets.
                 var storedCountLabel =
                     filing.CommonStockId == null
-                        ? $"{filing.Holdings.Count} tracked-stock holdings on record (only positions in stocks this platform tracks are stored for this fund — not its full portfolio)"
-                        : $"{filing.Holdings.Count} total holdings";
+                        ? $"{filing.Holdings.Count} stored tracked-stock holdings"
+                        : $"{filing.Holdings.Count} stored holdings";
 
                 var result = MarkdownTable.Start(
-                    $"Portfolio holdings for {fundName} ({ticker}) — "
+                    $"Portfolio holdings for {MarkdownText(fundName)} ({MarkdownText(ticker)}) — "
                         + $"reported {filing.ReportPeriodDate:yyyy-MM-dd}, net assets ${FormatAmount(filing.NetAssets)}, "
-                        + $"{storedCountLabel}, showing the largest {holdings.Count}:",
+                        + $"{FormatCount(filing.ReportedHoldingCount)} holdings reported, {storedCountLabel}, "
+                        + $"showing the largest {holdings.Count} stored rows:",
                     "| Holding | CUSIP | Balance | Units | Value (USD) | % Net Assets | Category | Country |",
                     "|---------|-------|---------|-------|-------------|--------------|----------|---------|"
                 );
@@ -80,7 +78,7 @@ public class NportTools
                 result.AppendRows(
                     holdings,
                     h =>
-                        $"| {h.Name ?? "-"} | {h.Cusip ?? "-"} | {FundCodes.Balance(h.Balance)} | {FundCodes.Unit(h.Units)} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {FundCodes.AssetCategory(h.AssetCategory)} | {h.InvestmentCountry ?? "-"} |"
+                        $"| {MarkdownText(h.Name) ?? "-"} | {MarkdownText(h.Cusip) ?? "-"} | {FundCodes.Balance(h.Balance)} | {MarkdownText(FundCodes.Unit(h.Units))} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {MarkdownText(FundCodes.AssetCategory(h.AssetCategory))} | {MarkdownText(h.InvestmentCountry) ?? "-"} |"
                 );
 
                 TruncationNotes.Append(result, holdings.Count, filing.Holdings.Count);
@@ -98,12 +96,13 @@ public class NportTools
     private static readonly TimeSpan CurrentHolderRecencyFloor = TimeSpan.FromDays(548);
 
     /// <summary>
-    /// Resolves the identifier to the fund's most recent NPORT-P report: first as a tracked
-    /// stock's ticker, then — funds and share classes absent from the stock table — through the
-    /// fund directory by profile id (slug) or series-level ticker, the same lookup
-    /// <c>GetFundProfile</c> uses. The latest report is the one with the greatest report period
-    /// (filing date as tiebreaker), so a late-filed amendment of an older period never shadows
-    /// the newest period.
+    /// Resolves the identifier to the fund's most recent NPORT-P report through the same exact
+    /// fund-series tiers <c>SearchFunds</c> and <c>GetFundProfile</c> use. A canonical profile id,
+    /// SEC series id, stored series ticker, or verified share-class alias is authoritative and
+    /// keeps the filing query constrained to that series. Only identifiers absent from the fund
+    /// directory fall back to a tracked stock ticker. The latest report is the one with the
+    /// greatest report period (filing date as tiebreaker), so a late-filed amendment of an older
+    /// period never shadows the newest period.
     /// </summary>
     private async Task<(NportFiling Filing, string FundName, string Error)> ResolveLatestFiling(
         string identifier
@@ -111,6 +110,33 @@ public class NportTools
     {
         if (string.IsNullOrWhiteSpace(identifier))
             return (null, null, "Provide a fund ticker or a profile id from SearchFunds.");
+
+        var series = await _fundSeriesRepository
+            .ResolveIdentifier(identifier)
+            .OrderByDescending(f => f.NetAssets)
+            .FirstOrDefaultAsync();
+
+        if (series != null)
+        {
+            var latest = await _nportRepository
+                .GetSeriesReportsByPeriod(
+                    series.CommonStockId,
+                    series.RegistrantCik,
+                    series.SeriesId,
+                    DateOnly.MinValue
+                )
+                .Include(f => f.Holdings)
+                .OrderByDescending(f => f.ReportPeriodDate)
+                .FirstOrDefaultAsync();
+
+            return latest == null
+                ? (
+                    null,
+                    null,
+                    $"No stored Form NPORT-P report is on record for {MarkdownText(series.SeriesName ?? series.RegistrantName)}. This is a dataset coverage result, not evidence that no SEC filing exists; the report may be outside the filing scope or absent from this ingestion, fetch, or replay state."
+                )
+                : (latest, series.SeriesName ?? series.RegistrantName, null);
+        }
 
         var (stock, _) = await _commonStockRepository.ResolveByTicker(identifier);
         if (stock != null)
@@ -123,43 +149,19 @@ public class NportTools
                 .FirstOrDefaultAsync();
 
             return filing == null
-                ? (null, null, $"No Form NPORT-P portfolio reports found for {identifier}.")
+                ? (
+                    null,
+                    null,
+                    $"No stored Form NPORT-P portfolio report was found for {MarkdownText(identifier)}. This is a dataset coverage result, not evidence that no SEC filing exists; the report may be outside the filing scope or absent from this ingestion, fetch, or replay state."
+                )
                 : (filing, filing.SeriesName ?? stock.Name, null);
         }
 
-        var key = identifier.Trim();
-        var lowerKey = key.ToLower();
-        var series = await _fundSeriesRepository
-            .GetAll()
-            .Where(f => f.Slug == key || (f.Ticker != null && f.Ticker.ToLower() == lowerKey))
-            .OrderByDescending(f => f.NetAssets)
-            .FirstOrDefaultAsync();
-
-        if (series == null)
-            return (
-                null,
-                null,
-                $"No fund or ETF found for '{identifier}'. Use SearchFunds to find the fund and pass its profile id — share-class tickers of multi-class mutual funds (e.g. VOO, VFIAX) do not resolve, so search by fund name."
-            );
-
-        var latest = await _nportRepository
-            .GetSeriesReportsByPeriod(
-                series.CommonStockId,
-                series.RegistrantCik,
-                series.SeriesId,
-                DateOnly.MinValue
-            )
-            .Include(f => f.Holdings)
-            .OrderByDescending(f => f.ReportPeriodDate)
-            .FirstOrDefaultAsync();
-
-        return latest == null
-            ? (
-                null,
-                null,
-                $"No Form NPORT-P report is on record for {series.SeriesName ?? series.RegistrantName}."
-            )
-            : (latest, series.SeriesName ?? series.RegistrantName, null);
+        return (
+            null,
+            null,
+            $"No fund or ETF found for '{MarkdownText(identifier)}' in the tracked Form NPORT-P directory. Use SearchFunds to find a profile id. Form NPORT-P covers registered management investment companies and ETFs organized as unit investment trusts; money market funds and small business investment companies do not file it. Fixed-income-only series and vehicles outside that filing regime may be absent. This is a coverage result, not evidence that the fund does not exist."
+        );
     }
 
     [McpServerTool(Name = "GetFundsHoldingStock", Title = "Funds Holding a Stock", ReadOnly = true)]
@@ -183,10 +185,12 @@ public class NportTools
             {
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
-                    return stockError;
+                    return MarkdownText(stockError);
+
+                var safeTicker = MarkdownText(ticker);
 
                 if (string.IsNullOrEmpty(stock.Cusip))
-                    return $"No CUSIP is on record for {ticker}, so its fund ownership cannot be resolved from Form NPORT-P reports.";
+                    return $"No CUSIP is on record for {safeTicker}, so its fund ownership cannot be resolved from Form NPORT-P reports.";
 
                 var recencyFloor = DateOnly.FromDateTime(
                     DateTime.UtcNow - CurrentHolderRecencyFloor
@@ -229,8 +233,8 @@ public class NportTools
                 var totalCount = await currentPositions.CountAsync();
                 if (totalCount == 0)
                     return string.IsNullOrWhiteSpace(registrantOrSeries)
-                        ? $"No fund reports a position in {ticker} on its most recent Form NPORT-P."
-                        : $"No fund matching '{registrantOrSeries}' reports a position in {ticker} on its most recent Form NPORT-P.";
+                        ? $"No current position in {safeTicker} matched the ingested latest Form NPORT-P reports. This is a dataset coverage result, not evidence that no fund reports one."
+                        : $"No current position in {safeTicker} for a fund matching '{MarkdownText(registrantOrSeries)}' matched the ingested latest Form NPORT-P reports. This is a dataset coverage result, not evidence that no fund reports one.";
 
                 var positions = await currentPositions
                     .OrderByDescending(p => p.ValueUsd)
@@ -239,9 +243,9 @@ public class NportTools
 
                 var filterLabel = string.IsNullOrWhiteSpace(registrantOrSeries)
                     ? ""
-                    : $" matching '{registrantOrSeries.Trim()}'";
+                    : $" matching '{MarkdownText(registrantOrSeries)}'";
                 var result = MarkdownTable.Start(
-                    $"Funds holding {stock.Name} ({ticker}) on each series' most recent Form NPORT-P — "
+                    $"Funds holding {MarkdownText(stock.Name)} ({safeTicker}) on each series' most recent Form NPORT-P — "
                         + $"{totalCount} current fund positions{filterLabel}, showing the largest {positions.Count}. "
                         + "Report dates differ per series (each fund's own fiscal quarter):",
                     "| Registrant | Series | Report Date | Balance | Units | Value (USD) | % Net Assets | Long/Short |",
@@ -251,7 +255,7 @@ public class NportTools
                 result.AppendRows(
                     positions,
                     p =>
-                        $"| {p.RegistrantName ?? "-"} | {p.SeriesName ?? "-"} | {p.ReportPeriodDate:yyyy-MM-dd} | {FormatAmount(p.Balance)} | {FundCodes.Unit(p.Units)} | ${FormatAmount(p.ValueUsd)} | {FormatPercent(p.PercentValue)} | {p.PayoffProfile ?? "-"} |"
+                        $"| {MarkdownText(p.RegistrantName) ?? "-"} | {MarkdownText(p.SeriesName) ?? "-"} | {p.ReportPeriodDate:yyyy-MM-dd} | {FormatAmount(p.Balance)} | {MarkdownText(FundCodes.Unit(p.Units))} | ${FormatAmount(p.ValueUsd)} | {FormatPercent(p.PercentValue)} | {MarkdownText(p.PayoffProfile) ?? "-"} |"
                 );
 
                 return result.ToString();
@@ -264,4 +268,10 @@ public class NportTools
     private static string FormatAmount(decimal value) => McpFormat.Invariant(value, "N2");
 
     private static string FormatPercent(decimal value) => McpFormat.Invariant(value, "N2") + "%";
+
+    private static string FormatCount(int? value) =>
+        value.HasValue ? McpFormat.WholeNumber(value.Value) : "unavailable";
+
+    private static string MarkdownText(string value) =>
+        value == null ? null : MarkdownTable.EscapeCell(value).Trim();
 }

--- a/src/Equibles.Sec.Repositories/FundSeriesRepository.cs
+++ b/src/Equibles.Sec.Repositories/FundSeriesRepository.cs
@@ -69,6 +69,39 @@ public class FundSeriesRepository : BaseRepository<FundSeries>
             anyTokenMatches
         );
     }
+
+    /// <summary>
+    /// Resolves only a canonical profile id, SEC series id, stored series ticker, or verified
+    /// share-class alias. Unlike <see cref="Search"/>, this never treats a partial name match as
+    /// identity, so read tools can share the directory's authoritative resolution tiers without
+    /// silently choosing one row from an ambiguous discovery result.
+    /// </summary>
+    public IQueryable<FundSeries> ResolveIdentifier(string identifier)
+    {
+        if (string.IsNullOrWhiteSpace(identifier))
+            return GetAll().Where(_ => false);
+
+        var exact = identifier.Trim().ToLowerInvariant();
+        var exactIdentifier = GetAll()
+            .Where(f =>
+                f.SeriesId.ToLower() == exact
+                || (f.Ticker != null && f.Ticker.ToLower() == exact)
+                || f.Slug.ToLower() == exact
+            );
+        var aliasSeriesId = FundSeriesSearchAliases.ResolveSeriesId(identifier);
+        var verifiedAlias =
+            aliasSeriesId == null
+                ? GetAll().Where(_ => false)
+                : GetAll().Where(f => f.SeriesId == aliasSeriesId);
+        var empty = GetAll().Where(_ => false);
+
+        return SearchTerms.WithExclusiveResolutionTiers(
+            exactIdentifier,
+            verifiedAlias,
+            empty,
+            empty
+        );
+    }
 }
 
 internal static class FundSeriesSearchAliases

--- a/tests/Equibles.IntegrationTests/Mcp/FundDirectoryToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FundDirectoryToolsTests.cs
@@ -73,7 +73,9 @@ public class FundDirectoryToolsTests : IDisposable
         result
             .Should()
             .Contain("No match for 'Treasury' in the tracked Form NPORT-P fund directory");
-        result.Should().Contain("does not assert that the fund does not exist");
+        result.Should().Contain("Fixed-income-only series can be absent");
+        result.Should().Contain("money market funds and small business investment companies");
+        result.Should().Contain("coverage result, not evidence that the fund does not exist");
     }
 
     [Fact]
@@ -124,6 +126,18 @@ public class FundDirectoryToolsTests : IDisposable
     }
 
     [Fact]
+    public async Task SearchFunds_LabelsStoredAndReportedHoldingCountsSeparately()
+    {
+        SeedSeries("ACME BOND FUND", "S000001", reportedHoldingCount: 812);
+
+        var result = await _tools.SearchFunds("Acme");
+
+        result.Should().Contain("| Stored | Reported |");
+        result.Should().Contain("| 1 | 812 |");
+        result.Should().Contain("only positions whose CUSIPs match tracked stocks");
+    }
+
+    [Fact]
     public async Task GetFundProfile_GlossesUnitAndCategoryCodesAndDropsWholeShareDecimals()
     {
         var series = SeedSeries("ACME FUND", "S000001");
@@ -156,13 +170,69 @@ public class FundDirectoryToolsTests : IDisposable
     }
 
     [Fact]
-    public async Task GetFundProfile_UnknownFund_PointsAtSearchFundsAndNamesTheShareClassGap()
+    public async Task GetFundProfile_NoStoredReport_StatesDatasetCoverageBoundary()
     {
+        var series = SeedSeries("ACME FUND", "S000001");
+
+        var result = await _tools.GetFundProfile(series.Slug);
+
+        result.Should().Contain("No stored Form NPORT-P report is on record for ACME FUND");
+        result.Should().Contain("dataset coverage result, not evidence that no SEC filing exists");
+    }
+
+    [Fact]
+    public async Task GetFundProfile_FlattensAndEscapesFiledMarkdownBoundaries()
+    {
+        var series = SeedSeries("ACME FUND", "S000001");
+        series.SeriesName = "ACME\n# SYNTHETIC | FUND";
+        series.RegistrantName = "ACME\r\nTRUST | EXTRA";
+        var filing = MakeFiling(series, "acc-1", new DateOnly(2026, 5, 15));
+        var holding = MakeHolding("BIG\n# ROW | CO", 5_000_000m);
+        holding.Cusip = "12|34";
+        holding.Units = "N|S\nEXTRA";
+        holding.AssetCategory = "E|C\nEXTRA";
+        holding.InvestmentCountry = "U|S\nEXTRA";
+        filing.Holdings.Add(holding);
+        _dbContext.Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundProfile(series.Slug);
+
+        result.Should().Contain("ACME # SYNTHETIC \\| FUND");
+        result.Should().Contain("ACME  TRUST \\| EXTRA");
+        result.Should().Contain("BIG # ROW \\| CO");
+        result.Should().Contain("12\\|34");
+        result.Should().Contain("N\\|S EXTRA");
+        result.Should().Contain("E\\|C EXTRA");
+        result.Should().Contain("U\\|S EXTRA");
+        result.Should().NotContain("\n# SYNTHETIC");
+        result.Should().NotContain("\n# ROW");
+    }
+
+    [Fact]
+    public async Task GetFundProfile_VerifiedShareClassAlias_UsesDirectoryResolutionAndLabelsCoverage()
+    {
+        var series = SeedSeries("VANGUARD 500 INDEX FUND", "S000002839", reportedHoldingCount: 507);
+        var filing = MakeFiling(series, "acc-1", new DateOnly(2026, 5, 15));
+        filing.ReportedHoldingCount = 507;
+        filing.Holdings.Add(MakeHolding("TRACKED CO", 5_000_000m));
+        _dbContext.Set<NportFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
         var result = await _tools.GetFundProfile("VOO");
 
-        result.Should().Contain("No registered fund found for 'VOO'");
+        result.Should().Contain("VANGUARD 500 INDEX FUND");
+        result.Should().Contain("507 holdings reported, 1 stored tracked-stock holdings");
+    }
+
+    [Fact]
+    public async Task GetFundProfile_UnknownFund_PointsAtSearchFundsAndStatesScope()
+    {
+        var result = await _tools.GetFundProfile("NOTAFUND");
+
+        result.Should().Contain("No registered fund found for 'NOTAFUND'");
         result.Should().Contain("SearchFunds");
-        result.Should().Contain("share-class tickers");
+        result.Should().Contain("Fixed-income-only series");
     }
 
     private FundSeries SeedSeries(
@@ -170,7 +240,8 @@ public class FundDirectoryToolsTests : IDisposable
         string seriesId,
         decimal netAssets = 1_000_000m,
         string fundType = null,
-        string ticker = null
+        string ticker = null,
+        int? reportedHoldingCount = 12
     )
     {
         var series = new FundSeries
@@ -187,6 +258,7 @@ public class FundDirectoryToolsTests : IDisposable
             NetAssets = netAssets,
             TotalAssets = netAssets,
             PositionCount = 1,
+            ReportedHoldingCount = reportedHoldingCount,
             FundType = fundType,
         };
         _dbContext.Set<FundSeries>().Add(series);
@@ -211,6 +283,7 @@ public class FundDirectoryToolsTests : IDisposable
             TotalAssets = 1_200_000_000m,
             TotalLiabilities = 50_000_000m,
             NetAssets = 1_150_000_000m,
+            ReportedHoldingCount = series.ReportedHoldingCount,
         };
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolNewestFilingProvidersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolNewestFilingProvidersTests.cs
@@ -30,6 +30,7 @@ public class NCenFundOperationsToolNewestFilingProvidersTests : IDisposable
         _tools = new NCenTools(
             new NCenFilingRepository(_dbContext),
             new CommonStockRepository(_dbContext),
+            new FundSeriesRepository(_dbContext),
             errorManager: null,
             NullLogger<NCenTools>.Instance
         );

--- a/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolTests.cs
@@ -24,6 +24,7 @@ public class NCenFundOperationsToolTests : IDisposable
         _tools = new NCenTools(
             new NCenFilingRepository(_dbContext),
             new CommonStockRepository(_dbContext),
+            new FundSeriesRepository(_dbContext),
             errorManager: null,
             NullLogger<NCenTools>.Instance
         );
@@ -60,7 +61,8 @@ public class NCenFundOperationsToolTests : IDisposable
 
         var result = await _tools.GetFundOperations("MXF");
 
-        result.Should().Contain("No Form N-CEN annual reports found for MXF.");
+        result.Should().Contain("No Form N-CEN annual reports found for Mexico Fund Inc (MXF).");
+        result.Should().Contain("coverage result, not evidence that the fund has no N-CEN filing");
     }
 
     [Fact]
@@ -122,6 +124,110 @@ public class NCenFundOperationsToolTests : IDisposable
         var result = await _tools.GetFundOperations("MXF");
 
         result.Should().Contain("N-2 (closed-end fund)");
+    }
+
+    [Fact]
+    public async Task GetFundOperations_FlattensAndEscapesFiledTableCodes()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2025, 1, 15));
+        filing.InvestmentCompanyType = "N|2\n# TYPE";
+        filing.InvestmentCompanyFileNumber = "811|02409\n# FILE";
+        _dbContext.Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundOperations("MXF");
+
+        result.Should().Contain("N\\|2 # TYPE");
+        result.Should().Contain("811\\|02409 # FILE");
+        result.Should().NotContain("\n# TYPE");
+        result.Should().NotContain("\n# FILE");
+    }
+
+    [Fact]
+    public async Task GetFundOperations_SeriesTicker_ResolvesBeforeReportingRegistrantCoverageGap()
+    {
+        _dbContext.Add(
+            new FundSeries
+            {
+                IdentityKey = "rc:1100663:S000004310",
+                Slug = "ishares-core-sp-500-etf-s000004310",
+                RegistrantCik = "1100663",
+                SeriesId = "S000004310",
+                SeriesName = "ISHARES CORE S&P 500 ETF",
+                RegistrantName = "ISHARES TRUST",
+                Ticker = "IVV",
+                LatestReportPeriodDate = new DateOnly(2026, 3, 31),
+                LatestFilingDate = new DateOnly(2026, 5, 15),
+            }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundOperations("ivv");
+
+        result.Should().Contain("resolves to ISHARES CORE S&P 500 ETF (IVV)");
+        result.Should().Contain("coverage result, not an identifier-resolution failure");
+    }
+
+    [Fact]
+    public async Task GetFundOperations_VerifiedAliasWinsOverConflictingTrackedStockTicker()
+    {
+        var conflictingStock = SeedStock("VOO");
+        _dbContext.Add(MakeFiling(conflictingStock.Id, "wrong-series", new DateOnly(2026, 5, 16)));
+        _dbContext.Add(
+            new FundSeries
+            {
+                IdentityKey = "rc:0000102909:S000002839",
+                Slug = "vanguard-500-index-fund-s000002839",
+                RegistrantCik = "0000102909",
+                SeriesId = "S000002839",
+                SeriesName = "VANGUARD 500 INDEX FUND",
+                RegistrantName = "VANGUARD INDEX FUNDS",
+                LatestReportPeriodDate = new DateOnly(2026, 3, 31),
+                LatestFilingDate = new DateOnly(2026, 5, 15),
+            }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundOperations("VOO");
+
+        result.Should().Contain("resolves to VANGUARD 500 INDEX FUND");
+        result.Should().Contain("coverage result, not an identifier-resolution failure");
+        result.Should().NotContain("811-02409");
+    }
+
+    [Fact]
+    public async Task GetFundOperations_CoverageMessageFlattensFiledMarkdownBoundaries()
+    {
+        _dbContext.Add(
+            new FundSeries
+            {
+                IdentityKey = "rc:1100663:S000004310",
+                Slug = "unsafe-fund-s000004310",
+                RegistrantCik = "1100663",
+                SeriesId = "S000004310",
+                SeriesName = "ISHARES\n# SYNTHETIC | FUND",
+                RegistrantName = "ISHARES\r\nTRUST | EXTRA",
+                LatestReportPeriodDate = new DateOnly(2026, 3, 31),
+                LatestFilingDate = new DateOnly(2026, 5, 15),
+            }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundOperations("unsafe-fund-s000004310");
+
+        result.Should().Contain("ISHARES # SYNTHETIC \\| FUND");
+        result.Should().Contain("ISHARES  TRUST \\| EXTRA");
+        result.Should().NotContain("\n# SYNTHETIC");
+    }
+
+    [Fact]
+    public async Task GetFundOperations_UnknownIdentifierStatesDirectoryCoverageLimits()
+    {
+        var result = await _tools.GetFundOperations("UNKNOWN");
+
+        result.Should().Contain("fixed-income-only series");
+        result.Should().Contain("coverage result, not evidence that the fund does not exist");
     }
 
     private static NCenFiling MakeFiling(Guid stockId, string accession, DateOnly filingDate)

--- a/tests/Equibles.IntegrationTests/Mcp/NportFundHoldingsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportFundHoldingsToolTests.cs
@@ -61,7 +61,8 @@ public class NportFundHoldingsToolTests : IDisposable
 
         var result = await _tools.GetFundHoldings("VOO");
 
-        result.Should().Contain("No Form NPORT-P portfolio reports found for VOO.");
+        result.Should().Contain("No stored Form NPORT-P portfolio report was found for VOO.");
+        result.Should().Contain("dataset coverage result, not evidence that no SEC filing exists");
     }
 
     [Fact]
@@ -151,6 +152,33 @@ public class NportFundHoldingsToolTests : IDisposable
     }
 
     [Fact]
+    public async Task GetFundHoldings_FlattensAndEscapesFiledMarkdownBoundaries()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2025, 1, 31));
+        filing.SeriesName = "VANGUARD\n# SYNTHETIC | FUND";
+        var holding = MakeHolding("BIG\n# ROW | CO", 5_000_000m);
+        holding.Cusip = "12|34";
+        holding.Units = "N|S\nEXTRA";
+        holding.AssetCategory = "E|C\nEXTRA";
+        holding.InvestmentCountry = "U|S\nEXTRA";
+        filing.Holdings.Add(holding);
+        _dbContext.Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundHoldings("VOO");
+
+        result.Should().Contain("VANGUARD # SYNTHETIC \\| FUND");
+        result.Should().Contain("BIG # ROW \\| CO");
+        result.Should().Contain("12\\|34");
+        result.Should().Contain("N\\|S EXTRA");
+        result.Should().Contain("E\\|C EXTRA");
+        result.Should().Contain("U\\|S EXTRA");
+        result.Should().NotContain("\n# SYNTHETIC");
+        result.Should().NotContain("\n# ROW");
+    }
+
+    [Fact]
     public async Task GetFundHoldings_TickerlessTrustSeries_ResolvesThroughFundDirectorySlug()
     {
         SeedTrustSeries();
@@ -161,6 +189,17 @@ public class NportFundHoldingsToolTests : IDisposable
 
         result.Should().Contain("VANGUARD 500 INDEX FUND");
         result.Should().Contain("TRACKED CO");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_ResolvedSeriesWithoutStoredReport_StatesCoverageBoundary()
+    {
+        SeedTrustSeries();
+
+        var result = await _tools.GetFundHoldings("vanguard-500-index-fund-s000002839");
+
+        result.Should().Contain("No stored Form NPORT-P report is on record");
+        result.Should().Contain("dataset coverage result, not evidence that no SEC filing exists");
     }
 
     [Fact]
@@ -177,12 +216,49 @@ public class NportFundHoldingsToolTests : IDisposable
     }
 
     [Fact]
-    public async Task GetFundHoldings_UnknownIdentifier_PointsAtSearchFunds()
+    public async Task GetFundHoldings_VerifiedShareClassAlias_ResolvesAndLabelsReportedVersusStored()
     {
+        SeedTrustSeries();
+        _dbContext.Set<NportFiling>().Add(MakeTrustFiling("acc-1", new DateOnly(2026, 5, 15)));
+        await _dbContext.SaveChangesAsync();
+
         var result = await _tools.GetFundHoldings("VOO");
 
-        result.Should().Contain("No fund or ETF found for 'VOO'");
+        result.Should().Contain("VANGUARD 500 INDEX FUND");
+        result.Should().Contain("200 holdings reported, 1 stored tracked-stock holdings");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_VerifiedAliasWinsOverConflictingTrackedStockTicker()
+    {
+        var conflictingStock = SeedStock();
+        var conflictingFiling = MakeFiling(
+            conflictingStock.Id,
+            "wrong-series",
+            new DateOnly(2026, 5, 16)
+        );
+        conflictingFiling.Holdings.Add(MakeHolding("WRONG SERIES CO", 99_000_000m));
+        _dbContext.Add(conflictingFiling);
+        SeedTrustSeries();
+        _dbContext.Add(MakeTrustFiling("right-series", new DateOnly(2026, 5, 15)));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundHoldings("VOO");
+
+        result.Should().Contain("VANGUARD 500 INDEX FUND");
+        result.Should().Contain("TRACKED CO");
+        result.Should().NotContain("WRONG SERIES CO");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_UnknownIdentifier_PointsAtSearchFundsAndStatesScope()
+    {
+        var result = await _tools.GetFundHoldings("NOTAFUND");
+
+        result.Should().Contain("No fund or ETF found for 'NOTAFUND'");
         result.Should().Contain("SearchFunds");
+        result.Should().Contain("Fixed-income-only series");
+        result.Should().Contain("money market funds and small business investment companies");
     }
 
     private void SeedTrustSeries(string ticker = null)
@@ -204,6 +280,7 @@ public class NportFundHoldingsToolTests : IDisposable
                     NetAssets = 1_400_000_000_000m,
                     TotalAssets = 1_450_000_000_000m,
                     PositionCount = 1,
+                    ReportedHoldingCount = 200,
                 }
             );
         _dbContext.SaveChanges();
@@ -226,6 +303,7 @@ public class NportFundHoldingsToolTests : IDisposable
             TotalAssets = 1_450_000_000_000m,
             TotalLiabilities = 50_000_000_000m,
             NetAssets = 1_400_000_000_000m,
+            ReportedHoldingCount = 200,
         };
         filing.Holdings.Add(MakeHolding("TRACKED CO", 10_000_000m));
         return filing;

--- a/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
@@ -51,7 +51,8 @@ public class NportFundsHoldingStockToolTests : IDisposable
 
         var result = await _tools.GetFundsHoldingStock("AAPL");
 
-        result.Should().Contain("No fund reports a position in AAPL");
+        result.Should().Contain("No current position in AAPL matched the ingested latest");
+        result.Should().Contain("dataset coverage result, not evidence that no fund reports one");
     }
 
     [Fact]
@@ -91,7 +92,8 @@ public class NportFundsHoldingStockToolTests : IDisposable
 
         var result = await _tools.GetFundsHoldingStock("AAPL");
 
-        result.Should().Contain("No fund reports a position in AAPL");
+        result.Should().Contain("No current position in AAPL matched the ingested latest");
+        result.Should().Contain("dataset coverage result, not evidence that no fund reports one");
     }
 
     [Fact]
@@ -118,6 +120,48 @@ public class NportFundsHoldingStockToolTests : IDisposable
 
         result.Should().Contain("VANGUARD INDEX FUNDS");
         result.Should().Contain("1 current fund positions");
+    }
+
+    [Fact]
+    public async Task GetFundsHoldingStock_FlattensAndEscapesExternalMarkdownBoundaries()
+    {
+        var stock = SeedStock("AAPL", HeldCusip);
+        stock.Name = "APPLE\n# SYNTHETIC | INC";
+        var fund = SeedStock("VOO", cusip: null, cik: "0000036405");
+        var filing = MakeFiling(fund.Id, "acc-current", RecentFilingDate);
+        filing.RegistrantName = "VANGUARD\n# ROW | TRUST";
+        filing.SeriesName = "INDEX\r\nFUND | EXTRA";
+        var holding = MakeHolding(HeldCusip, 5_000_000m);
+        holding.Units = "N|S\nEXTRA";
+        holding.PayoffProfile = "Long\n# EXTRA | CELL";
+        filing.Holdings.Add(holding);
+        _dbContext.Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundsHoldingStock("AAPL");
+
+        result.Should().Contain("APPLE # SYNTHETIC \\| INC");
+        result.Should().Contain("VANGUARD # ROW \\| TRUST");
+        result.Should().Contain("INDEX  FUND \\| EXTRA");
+        result.Should().Contain("N\\|S EXTRA");
+        result.Should().Contain("Long # EXTRA \\| CELL");
+        result.Should().NotContain("\n# SYNTHETIC");
+        result.Should().NotContain("\n# ROW");
+    }
+
+    [Fact]
+    public async Task GetFundsHoldingStock_NoMatchFlattensAndEscapesCallerFilter()
+    {
+        SeedStock("AAPL", HeldCusip);
+
+        var result = await _tools.GetFundsHoldingStock(
+            "AAPL",
+            registrantOrSeries: "BAD\n# FILTER | VALUE"
+        );
+
+        result.Should().Contain("BAD # FILTER \\| VALUE");
+        result.Should().NotContain("\n# FILTER");
+        result.Should().Contain("dataset coverage result");
     }
 
     private CommonStock SeedStock(string ticker, string cusip, string cik = null)

--- a/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
@@ -15,8 +15,8 @@ namespace Equibles.IntegrationTests.Sec;
 /// Contract for <see cref="FundSeriesRefreshService"/>: after <c>RebuildAllAsync</c> the
 /// <see cref="FundSeries"/> directory holds one row per series taken from that series' latest NPORT
 /// report — tracked funds keyed by stock, sweep-discovered trusts keyed by registrant CIK + series
-/// id — with the report-header totals, the stored-holdings count, the N-CEN type when on record,
-/// and a unique route slug. Superseded reports never linger; rows the run doesn't touch are pruned.
+/// id — with the report-header totals, stored and reported holdings counts, the N-CEN type when on
+/// record, and a unique route slug. Superseded reports never linger; untouched rows are pruned.
 /// Exercised against ParadeDB because the service writes through FlexLabs <c>UpsertRange</c> and
 /// <c>ExecuteDeleteAsync</c>, neither of which the in-memory provider supports.
 /// </summary>
@@ -81,7 +81,8 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
             registrantName: "Gabelli Equity Trust",
             reportPeriod: new DateOnly(2025, 3, 31),
             netAssets: 1_000m,
-            totalAssets: 1_100m
+            totalAssets: 1_100m,
+            reportedHoldingCount: 2
         );
         AddHolding(trackedFiling, "037833100", 600m);
         AddHolding(trackedFiling, "594918104", 400m);
@@ -95,7 +96,8 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
             registrantName: "iShares Trust",
             reportPeriod: new DateOnly(2025, 3, 31),
             netAssets: 2_000m,
-            totalAssets: 2_050m
+            totalAssets: 2_050m,
+            reportedHoldingCount: 347
         );
         AddHolding(trustFiling, "037833100", 1_500m);
 
@@ -112,6 +114,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         tracked.NetAssets.Should().Be(1_000m);
         tracked.TotalAssets.Should().Be(1_100m);
         tracked.PositionCount.Should().Be(2);
+        tracked.ReportedHoldingCount.Should().Be(2);
         tracked.LatestReportPeriodDate.Should().Be(new DateOnly(2025, 3, 31));
 
         var trust = await read.Set<FundSeries>().SingleAsync(s => s.RegistrantCik == "0001100663");
@@ -121,6 +124,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         trust.Slug.Should().Be("ishares-russell-2000-etf-s000002277");
         trust.NetAssets.Should().Be(2_000m);
         trust.PositionCount.Should().Be(1, "only the tracked-CUSIP holding is stored for a trust");
+        trust.ReportedHoldingCount.Should().Be(347, "the full filing count survives filtering");
     }
 
     [Fact]
@@ -268,6 +272,47 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         rows[0].Slug.Should().Be("gabelli-equity-trust-gab");
     }
 
+    [Fact]
+    public async Task ResolveIdentifier_ExactTickerAndVerifiedAlias_TranslateOnPostgres()
+    {
+        await using var db = FreshContext();
+        db.AddRange(
+            new FundSeries
+            {
+                IdentityKey = "rc:1100663:S000004310",
+                Slug = "ishares-core-sp-500-etf-s000004310",
+                RegistrantCik = "1100663",
+                SeriesId = "S000004310",
+                SeriesName = "ISHARES CORE S&P 500 ETF",
+                RegistrantName = "ISHARES TRUST",
+                Ticker = "IVV",
+            },
+            new FundSeries
+            {
+                IdentityKey = "rc:0000102909:S000002839",
+                Slug = "vanguard-500-index-fund-s000002839",
+                RegistrantCik = "0000102909",
+                SeriesId = "S000002839",
+                SeriesName = "VANGUARD 500 INDEX FUND",
+                RegistrantName = "VANGUARD INDEX FUNDS",
+            }
+        );
+        await db.SaveChangesAsync();
+
+        var repository = new FundSeriesRepository(db);
+        var exact = await repository
+            .ResolveIdentifier("ivv")
+            .Select(f => f.SeriesName)
+            .ToListAsync();
+        var alias = await repository
+            .ResolveIdentifier("VOO")
+            .Select(f => f.SeriesName)
+            .ToListAsync();
+
+        exact.Should().ContainSingle().Which.Should().Be("ISHARES CORE S&P 500 ETF");
+        alias.Should().ContainSingle().Which.Should().Be("VANGUARD 500 INDEX FUND");
+    }
+
     private static async Task<CommonStock> SeedStock(
         EquiblesFinancialDbContext ctx,
         string ticker,
@@ -295,7 +340,8 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         string registrantName,
         DateOnly reportPeriod,
         decimal netAssets,
-        decimal totalAssets
+        decimal totalAssets,
+        int? reportedHoldingCount = null
     ) =>
         new()
         {
@@ -311,6 +357,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
             ReportPeriodEnd = reportPeriod.AddMonths(9),
             TotalAssets = totalAssets,
             NetAssets = netAssets,
+            ReportedHoldingCount = reportedHoldingCount,
         };
 
     private static void AddHolding(NportFiling filing, string cusip, decimal valueUsd) =>

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
@@ -40,6 +40,7 @@ public class NportFilingReprocessManagerTests
         reprocessed.ParserVersion.Should().Be(NportFiling.CurrentParserVersion);
         reprocessed.Holdings.Should().HaveCount(2);
         reprocessed.Holdings.Should().Contain(h => h.Name == "AT&T Inc" && h.Cusip == "00206R102");
+        reprocessed.ReportedHoldingCount.Should().Be(2);
         reprocessed.NetAssets.Should().Be(93591793.29m);
     }
 

--- a/tests/Equibles.IntegrationTests/Sec/NportRealtimeIngestionServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportRealtimeIngestionServiceTests.cs
@@ -61,6 +61,7 @@ public class NportRealtimeIngestionServiceTests
         stored.RegistrantName.Should().Be("VANGUARD INDEX FUNDS");
         // The bond is dropped; only the tracked-stock position is kept.
         stored.Holdings.Should().ContainSingle().Which.Cusip.Should().Be(AppleCusip);
+        stored.ReportedHoldingCount.Should().Be(2, "the pre-filter filing count stays visible");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- persist each NPORT-P filing's full pre-filter investment-row count beside stored holdings
- resolve exact fund series and verified share-class aliases consistently across fund MCP surfaces
- report honest NPORT/N-CEN coverage boundaries and escape external Markdown text
- add the nullable schema migration, parser replay bump, documentation, and adversarial PostgreSQL tests

Supports daniel3303/EquiblesCommercial#7065.

## Verification
- Release build passed
- OSS unit tests: 4,205 passed
- OSS integration tests: 2,472 passed
- CSharpier check passed
- git diff --check passed
- final independent review: clean