### PR TITLE
fix(corporate-actions): aggregate same-date dividend components

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
@@ -11,9 +11,9 @@ namespace Equibles.CorporateActions.BusinessLogic;
 // Upserts captured cash-dividend events into CashDividend. The manager locks and
 // revalidates the exact current primary listing before writing, so a company-sync
 // reorder cannot attach one security's action to another. Idempotent by (stock,
-// ExDate): a re-run with the same events writes nothing. A changed amount for an
-// existing ex-date is updated in place (Yahoo occasionally restates a dividend
-// after declaration).
+// ExDate): same-day cash components are summed into that one row, a re-run with
+// the same events writes nothing, and a changed total for an existing ex-date is
+// updated in place (providers occasionally restate a dividend after declaration).
 [Service]
 public class CashDividendCaptureManager
 {
@@ -39,6 +39,10 @@ public class CashDividendCaptureManager
         if (dividends == null || dividends.Count == 0)
             return 0;
 
+        var combinedDividends = CombineSameDateDividends(dividends);
+        if (combinedDividends.Count == 0)
+            return 0;
+
         await using var transaction = await _dividendRepository.CreateTransaction(
             IsolationLevel.ReadCommitted,
             cancellationToken
@@ -59,11 +63,8 @@ public class CashDividendCaptureManager
             .ToListAsync(cancellationToken);
         var changes = 0;
 
-        foreach (var dividend in dividends)
+        foreach (var dividend in combinedDividends)
         {
-            if (dividend.AmountPerShare <= 0)
-                continue;
-
             var match = existing.FirstOrDefault(d => d.ExDate == dividend.ExDate);
             if (match == null)
             {
@@ -92,5 +93,34 @@ public class CashDividendCaptureManager
 
         await transaction.CommitAsync(cancellationToken);
         return changes;
+    }
+
+    private static List<CapturedDividend> CombineSameDateDividends(
+        IReadOnlyCollection<CapturedDividend> dividends
+    ) =>
+        dividends
+            .Where(dividend => dividend.AmountPerShare > 0)
+            .GroupBy(dividend => dividend.ExDate)
+            .Select(CombineSameDateDividend)
+            .ToList();
+
+    private static CapturedDividend CombineSameDateDividend(
+        IGrouping<DateOnly, CapturedDividend> dividends
+    )
+    {
+        var sources = dividends.Select(dividend => dividend.Source).Distinct().ToList();
+        if (sources.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Cash dividends on {dividends.Key:yyyy-MM-dd} must come from one source per capture batch."
+            );
+        }
+
+        return new CapturedDividend
+        {
+            ExDate = dividends.Key,
+            AmountPerShare = dividends.Sum(dividend => dividend.AmountPerShare),
+            Source = sources[0],
+        };
     }
 }

--- a/tests/Equibles.UnitTests/CorporateActions/CashDividendCaptureManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CashDividendCaptureManagerTests.cs
@@ -14,7 +14,8 @@ namespace Equibles.UnitTests.CorporateActions;
 /// <summary>
 /// Pins the upsert contract of <see cref="CashDividendCaptureManager"/>, mirroring the split
 /// capture manager: the exact current primary is locked and revalidated, idempotent events write
-/// nothing, a restated amount updates in place, and a non-positive amount is dropped as unusable.
+/// nothing, same-date components are summed, a restated amount updates in place, and a
+/// non-positive amount is dropped as unusable.
 /// </summary>
 public class CashDividendCaptureManagerTests
 {
@@ -93,6 +94,48 @@ public class CashDividendCaptureManagerTests
 
         secondPass.Should().Be(0);
         (await new CashDividendRepository(db).GetByStock(stock.Id).CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Capture_MultipleCashComponentsOnSameExDate_StoresTheirTotalOnce()
+    {
+        await using var db = NewDb();
+        var stock = await AddStock(db);
+        var exDate = new DateOnly(2026, 8, 7);
+        var events = new[] { Dividend(exDate, 0.045m), Dividend(exDate, 0.775m) };
+
+        var changes = await NewManager(db).Capture(stock.Id, stock.Ticker, events);
+        var secondPass = await NewManager(db).Capture(stock.Id, stock.Ticker, events);
+
+        changes.Should().Be(1);
+        secondPass.Should().Be(0);
+        var stored = await new CashDividendRepository(db).GetByStock(stock.Id).SingleAsync();
+        stored.ExDate.Should().Be(exDate);
+        stored.AmountPerShare.Should().Be(0.82m);
+        stored.Source.Should().Be(CashDividendSource.Yahoo);
+    }
+
+    [Fact]
+    public async Task Capture_MixedSourcesOnSameExDate_ThrowsWithoutWriting()
+    {
+        await using var db = NewDb();
+        var stock = await AddStock(db);
+        var exDate = new DateOnly(2026, 8, 7);
+        var events = new[]
+        {
+            Dividend(exDate, 0.045m),
+            new CapturedDividend
+            {
+                ExDate = exDate,
+                AmountPerShare = 0.775m,
+                Source = CashDividendSource.External,
+            },
+        };
+
+        var capture = () => NewManager(db).Capture(stock.Id, stock.Ticker, events);
+
+        await capture.Should().ThrowAsync<InvalidOperationException>();
+        (await new CashDividendRepository(db).GetByStock(stock.Id).CountAsync()).Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- aggregate legitimate same-stock, same-ex-date cash-dividend components before the unique-row upsert
- keep reruns idempotent and preserve the sole provider source
- reject mixed-source same-date batches before opening a transaction or writing

## Verification
- dotnet build tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release
- dotnet vstest tests/Equibles.UnitTests/bin/Release/net10.0/Equibles.UnitTests.dll (4,214 passed)
- independent audit-only review: no findings

## Production evidence
- the existing parent lock still allowed duplicate-key failures when one provider batch contained two legitimate components for the same ex-date
- the current provider feed contains 138 such ticker/date groups, including regular plus special distributions