### PR TITLE
fix(prices): withhold day change across splits

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -235,7 +235,23 @@ public class StockPriceTools
 
                     var price = latestTwo[0];
                     var previous = latestTwo.Count > 1 ? latestTwo[1] : null;
-                    var previousClose = DayChangeBasis(price, previous);
+
+                    // Trailing 52-week close range, anchored on the row's own session so a
+                    // stock that stopped trading doesn't fabricate a fresh range. A completed
+                    // provider refresh cannot certify the basis of raw rows, so a captured split
+                    // inside the requested year moves the comparison start to that split date.
+                    var cutoff = price.Date.AddDays(-365);
+                    var comparableWindow = await LoadComparablePriceWindow(
+                        stock,
+                        priceTicker,
+                        cutoff,
+                        price.Date
+                    );
+                    var previousClose = DayChangeBasis(
+                        price,
+                        previous,
+                        comparableWindow.SplitBoundaryDate
+                    );
                     var changeCell = "—";
                     var changePctCell = "—";
                     if (previousClose != null)
@@ -251,22 +267,10 @@ public class StockPriceTools
                     else if (previous != null && !IsPriorSession(price, previous))
                     {
                         // Only a skipped session earns the footnote. A prior row with a
-                        // non-positive close is blanked too, and saying "no row for the session
-                        // before" about it would be wrong.
+                        // non-positive close or one before a split boundary is blanked too, and
+                        // saying "no row for the session before" about either would be wrong.
                         gapped = true;
                     }
-
-                    // Trailing 52-week close range, anchored on the row's own session so a
-                    // stock that stopped trading doesn't fabricate a fresh range. A completed
-                    // provider refresh cannot certify the basis of raw rows, so a captured split
-                    // inside the requested year moves the comparison start to that split date.
-                    var cutoff = price.Date.AddDays(-365);
-                    var comparableWindow = await LoadComparablePriceWindow(
-                        stock,
-                        priceTicker,
-                        cutoff,
-                        price.Date
-                    );
                     var range = await _priceRepository
                         .GetByStock(stock, priceTicker)
                         .Where(p => p.Date >= comparableWindow.Start && p.Close > 0)
@@ -294,7 +298,7 @@ public class StockPriceTools
                         range != null
                         && range.Oldest > cutoff.AddDays(BaselineSlackDays)
                         && !comparableWindow.IsSplitLimited;
-                    splitLimitedWindow |= range != null && comparableWindow.IsSplitLimited;
+                    splitLimitedWindow |= comparableWindow.IsSplitLimited;
 
                     rowDates.Add(price.Date);
                     result.AppendLine(
@@ -351,9 +355,10 @@ public class StockPriceTools
                     result.AppendLine();
                     result.AppendLine(
                         "Note: a 52-week value marked \\* can begin at the latest recorded split "
-                            + "inside the requested year. Earlier raw bars are withheld because "
-                            + "stored rows do not identify their split basis; the displayed bounds "
-                            + "compare only the post-split interval."
+                            + "inside the requested year. A Change of \"—\" can also mean its "
+                            + "previous session falls before that split. Earlier raw bars are "
+                            + "withheld because stored rows do not identify their split basis; "
+                            + "the displayed figures compare only the post-split interval."
                     );
                 }
 
@@ -897,8 +902,16 @@ public class StockPriceTools
     // So the basis is chosen by DATE, never by position: only the row dated the trading day
     // immediately before the latest one qualifies. Otherwise there is no day change to state,
     // and an absent percentage is honest where a wrong one is not.
-    private static decimal? DayChangeBasis(DailyStockPrice latest, DailyStockPrice previous) =>
-        IsPriorSession(latest, previous) && previous.Close > 0 ? previous.Close : null;
+    private static decimal? DayChangeBasis(
+        DailyStockPrice latest,
+        DailyStockPrice previous,
+        DateOnly? splitBoundaryDate
+    ) =>
+        IsPriorSession(latest, previous)
+        && previous.Close > 0
+        && (splitBoundaryDate == null || previous.Date >= splitBoundaryDate)
+            ? previous.Close
+            : null;
 
     // Whether the second-newest stored row is the session immediately before the newest one.
     // Shared with the caller so the "series skips a session" footnote and the decision to blank

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
@@ -242,6 +242,44 @@ public class StockPriceToolsTests : ParadeDbMcpTestBase
         result.Should().Contain("compare only the post-split interval");
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("AAPL")]
+    public async Task GetLatestPrices_LatestBarOnSplitDate_OmitsCrossBoundaryDayChange(
+        string priceSeriesTicker
+    )
+    {
+        var stock = AaplStock();
+        var splitDate = new DateOnly(2026, 8, 4);
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    PriceSeriesTicker = priceSeriesTicker,
+                    EffectiveDate = splitDate,
+                    Numerator = 1m,
+                    Denominator = 5m,
+                    Source = StockSplitSource.Yahoo,
+                }
+            );
+        DbContext
+            .Set<DailyStockPrice>()
+            .AddRange(
+                PriceFor(stock, new DateOnly(2026, 8, 3), close: 100m),
+                PriceFor(stock, splitDate, close: 20m)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLatestPrices("AAPL");
+
+        result.Should().Contain("| AAPL | 2026-08-04 | 20.00 | — | — |");
+        result.Should().Contain("previous session falls before that split");
+    }
+
     [Fact]
     public async Task GetLatestPrices_UnknownTickerInList_RendersNotFoundRow()
     {

--- a/tests/Equibles.UnitTests/Mcp/StockPriceToolsDayChangeBasisTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/StockPriceToolsDayChangeBasisTests.cs
@@ -28,7 +28,8 @@ public class StockPriceToolsDayChangeBasisTests
     private static decimal? Basis(
         DateOnly latestDate,
         DateOnly? previousDate,
-        decimal previousClose = 100m
+        decimal previousClose = 100m,
+        DateOnly? splitBoundaryDate = null
     )
     {
         var latest = new DailyStockPrice { Date = latestDate, Close = 110m };
@@ -36,7 +37,7 @@ public class StockPriceToolsDayChangeBasisTests
             previousDate == null
                 ? null
                 : new DailyStockPrice { Date = previousDate.Value, Close = previousClose };
-        return (decimal?)Method().Invoke(null, [latest, previous]);
+        return (decimal?)Method().Invoke(null, [latest, previous, splitBoundaryDate]);
     }
 
     [Fact]
@@ -114,6 +115,22 @@ public class StockPriceToolsDayChangeBasisTests
         // A duplicate bar is not a prior session; differencing it would state 0.00% as a day
         // change that was never measured.
         Basis(new DateOnly(2025, 3, 12), new DateOnly(2025, 3, 12)).Should().BeNull();
+    }
+
+    [Fact]
+    public void PriorSessionBeforeSplitBoundary_YieldsNoBasis()
+    {
+        var splitDate = new DateOnly(2026, 8, 4);
+
+        Basis(splitDate, new DateOnly(2026, 8, 3), splitBoundaryDate: splitDate).Should().BeNull();
+    }
+
+    [Fact]
+    public void PriorSessionOnSplitBoundary_RemainsComparable()
+    {
+        var splitDate = new DateOnly(2026, 8, 4);
+
+        Basis(new DateOnly(2026, 8, 5), splitDate, splitBoundaryDate: splitDate).Should().Be(100m);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- resolve the exact-series split window before calculating latest-price day change
- omit Change and Change % when the prior session is on the opposite side of the boundary
- explain split-caused omissions while preserving valid post-split and session-gap behavior

## Verification
- CSharpier: 3 files clean
- Release solution build: 0 errors
- OSS unit tests: 4,221 passed
- StockPriceTools PostgreSQL integration tests: 16 passed
- independent review: clean after the paired skill invariant was documented in Commercial