### PR TITLE
fix(prices): stamp dividends from reconciled response

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
@@ -95,7 +95,7 @@ public class CashDividendCaptureManager
         return changes;
     }
 
-    private static List<CapturedDividend> CombineSameDateDividends(
+    internal static List<CapturedDividend> CombineSameDateDividends(
         IReadOnlyCollection<CapturedDividend> dividends
     ) =>
         dividends

--- a/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
@@ -150,8 +150,20 @@ public class CorporateActionPriceReconciliationManager
     /// <summary>
     /// Stamps only selected actions whose source state is unchanged after the provider fetch.
     /// </summary>
+    public Task<int> StampApplied(
+        PendingPriceReconciliationSeries selectedSeries,
+        DateTime appliedTime,
+        CancellationToken cancellationToken = default
+    ) => StampApplied(selectedSeries, [], DateOnly.MinValue, appliedTime, cancellationToken);
+
+    /// <summary>
+    /// Stamps unchanged selected actions plus dividends whose current state exactly matches the
+    /// same provider response that supplied the replacement adjusted-price series.
+    /// </summary>
     public async Task<int> StampApplied(
         PendingPriceReconciliationSeries selectedSeries,
+        IReadOnlyCollection<CapturedDividend> priceSeriesDividends,
+        DateOnly settledBefore,
         DateTime appliedTime,
         CancellationToken cancellationToken = default
     )
@@ -171,18 +183,30 @@ public class CorporateActionPriceReconciliationManager
         }
 
         var unchangedSplits = await LoadUnchangedSplits(selectedSeries, cancellationToken);
+        var isStillPrimary = string.Equals(
+            stock.Ticker,
+            selectedSeries.ListedTicker,
+            StringComparison.OrdinalIgnoreCase
+        );
         var unchangedDividends = await LoadUnchangedDividends(
             selectedSeries,
-            string.Equals(
-                stock.Ticker,
-                selectedSeries.ListedTicker,
-                StringComparison.OrdinalIgnoreCase
-            ),
+            isStillPrimary,
             cancellationToken
         );
-        ApplyMarkers(unchangedSplits, unchangedDividends, appliedTime);
+        var responseMatchedDividends = await LoadResponseMatchedDividends(
+            selectedSeries,
+            priceSeriesDividends,
+            settledBefore,
+            isStillPrimary,
+            cancellationToken
+        );
+        var dividendsToStamp = unchangedDividends
+            .Concat(responseMatchedDividends)
+            .DistinctBy(dividend => dividend.Id)
+            .ToList();
+        ApplyMarkers(unchangedSplits, dividendsToStamp, appliedTime);
 
-        var stamped = unchangedSplits.Count + unchangedDividends.Count;
+        var stamped = unchangedSplits.Count + dividendsToStamp.Count;
         if (stamped > 0)
             await _stockRepository.SaveChanges();
 
@@ -336,6 +360,44 @@ public class CorporateActionPriceReconciliationManager
                     && dividend.AmountPerShare == selected.AmountPerShare
                     && dividend.Source == selected.Source;
             })
+            .ToList();
+    }
+
+    private async Task<List<CashDividend>> LoadResponseMatchedDividends(
+        PendingPriceReconciliationSeries selectedSeries,
+        IReadOnlyCollection<CapturedDividend> priceSeriesDividends,
+        DateOnly settledBefore,
+        bool isStillPrimary,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!isStillPrimary || priceSeriesDividends.Count == 0)
+            return [];
+
+        var expectedByDate = CashDividendCaptureManager
+            .CombineSameDateDividends(priceSeriesDividends)
+            .Where(dividend => dividend.ExDate < settledBefore)
+            .ToDictionary(dividend => dividend.ExDate, dividend => dividend.AmountPerShare);
+        if (expectedByDate.Count == 0)
+            return [];
+
+        var expectedDates = expectedByDate.Keys.ToList();
+        var candidateIds = await _dividendRepository
+            .GetByStock(selectedSeries.CommonStockId)
+            .Where(dividend => expectedDates.Contains(dividend.ExDate))
+            .Select(dividend => dividend.Id)
+            .ToListAsync(cancellationToken);
+        var locked = await _dividendRepository.GetForUpdate(candidateIds, cancellationToken);
+
+        return locked
+            .Where(dividend =>
+                dividend.PriceAdjustmentAppliedTime == null
+                || dividend.PriceAdjustmentAppliedAmountPerShare != dividend.AmountPerShare
+            )
+            .Where(dividend =>
+                expectedByDate.TryGetValue(dividend.ExDate, out var expectedAmount)
+                && dividend.AmountPerShare == expectedAmount
+            )
             .ToList();
     }
 

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -516,10 +516,15 @@ public class YahooPriceImportService
         if (!replaced)
             return;
 
-        // Capture actions carried by the full-history response before stamping the selected
-        // snapshot. Anything newly discovered here remains pending for one more reconciliation.
+        // Capture actions carried by the full-history response before stamping. Dividends that
+        // still exactly match this response can be marked from the same fetch; a concurrent
+        // restatement remains pending because the manager revalidates the locked current row.
         await CaptureSplits(target, chartData.Splits, cancellationToken);
-        await CaptureDividends(target, chartData.Dividends, cancellationToken);
+        var capturedDividends = await CaptureDividends(
+            target,
+            chartData.Dividends,
+            cancellationToken
+        );
 
         // A split changes the share base, so refresh the authoritative current share count +
         // market cap by refetch, not arithmetic (#2879). A dividend-only price reconciliation is
@@ -533,6 +538,8 @@ public class YahooPriceImportService
             scope.ServiceProvider.GetRequiredService<CorporateActionPriceReconciliationManager>();
         var stamped = await manager.StampApplied(
             selectedSeries,
+            capturedDividends,
+            today,
             DateTime.UtcNow,
             cancellationToken
         );
@@ -1254,14 +1261,14 @@ public class YahooPriceImportService
     // CashDividend via the CorporateActions capture manager. Mirrors
     // CaptureSplits: its own scope, and skipped when there are no dividends so
     // the common no-dividend path costs nothing.
-    private async Task CaptureDividends(
+    private async Task<IReadOnlyCollection<CapturedDividend>> CaptureDividends(
         PriceSeriesTarget target,
         IReadOnlyCollection<CashDividendEvent> dividends,
         CancellationToken cancellationToken
     )
     {
         if (dividends.Count == 0)
-            return;
+            return [];
 
         // Map Yahoo's dividend shape onto the source-neutral capture DTO at the
         // worker boundary, stamping Yahoo as the source, so the domain manager
@@ -1290,6 +1297,8 @@ public class YahooPriceImportService
                 target.Ticker,
                 target.CommonStockId
             );
+
+        return captured;
     }
 
     private async Task FlushPriceBatch(List<DailyStockPrice> batch)

--- a/tests/Equibles.IntegrationTests/CorporateActions/CorporateActionPriceReconciliationManagerResponseStampTests.cs
+++ b/tests/Equibles.IntegrationTests/CorporateActions/CorporateActionPriceReconciliationManagerResponseStampTests.cs
@@ -1,0 +1,97 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.BusinessLogic;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.CorporateActions;
+
+[Collection(ParadeDbCollection.Name)]
+public class CorporateActionPriceReconciliationManagerResponseStampTests : IAsyncLifetime
+{
+    private static readonly DateOnly SettledBefore = new(2026, 8, 10);
+    private readonly ParadeDbFixture _fixture;
+
+    public CorporateActionPriceReconciliationManagerResponseStampTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task StampApplied_RequestVariantDividendMatchingPriceResponse_StampsCurrentAmount()
+    {
+        var stockId = Guid.NewGuid();
+        var exDate = new DateOnly(2026, 7, 31);
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Add(new CommonStock { Id = stockId, Ticker = "GRTUF" });
+            seed.Add(
+                new CashDividend
+                {
+                    CommonStockId = stockId,
+                    ExDate = exDate,
+                    AmountPerShare = 0.21222556m,
+                    Source = CashDividendSource.Yahoo,
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        PendingPriceReconciliationSeries selected;
+        await using (var selection = _fixture.CreateDbContext())
+        {
+            selected = (
+                await NewManager(selection).SelectPendingSeries(50, SettledBefore)
+            ).Series.Single();
+        }
+
+        await using (var capture = _fixture.CreateDbContext())
+        {
+            var dividend = await capture.Set<CashDividend>().SingleAsync();
+            dividend.AmountPerShare = 0.21219057m;
+            await capture.SaveChangesAsync();
+        }
+
+        var appliedTime = new DateTime(2026, 8, 10, 12, 0, 0, DateTimeKind.Utc);
+        await using (var stamping = _fixture.CreateDbContext())
+        {
+            var stamped = await NewManager(stamping)
+                .StampApplied(
+                    selected,
+                    [
+                        new CapturedDividend
+                        {
+                            ExDate = exDate,
+                            AmountPerShare = 0.21219057m,
+                            Source = CashDividendSource.Yahoo,
+                        },
+                    ],
+                    SettledBefore,
+                    appliedTime
+                );
+
+            stamped.Should().Be(1);
+        }
+
+        await using var verification = _fixture.CreateDbContext();
+        var stored = await verification.Set<CashDividend>().SingleAsync();
+        stored.PriceAdjustmentAppliedAmountPerShare.Should().Be(0.21219057m);
+        stored.PriceAdjustmentAppliedTime.Should().Be(appliedTime);
+    }
+
+    private static CorporateActionPriceReconciliationManager NewManager(
+        Equibles.Data.EquiblesFinancialDbContext context
+    ) =>
+        new(
+            new StockSplitRepository(context),
+            new CashDividendRepository(context),
+            new CommonStockRepository(context),
+            new CorporateActionPriceReconciliationCursorRepository(context)
+        );
+}

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -418,7 +418,7 @@ public class YahooPriceImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Import_PendingDividend_ReplacesWholeSeriesWithProviderAdjustedCloses()
+    public async Task Import_RequestVariantPendingDividend_StampsSameProviderResponse()
     {
         var apple = CreateStock("AAPL", "Apple Inc.");
         await SeedStocks(apple);
@@ -464,7 +464,7 @@ public class YahooPriceImportServiceTests : IDisposable
                             Volume = 1_100_000,
                         },
                     ],
-                    Dividends = [new CashDividendEvent { Date = exDate, Amount = 0.27m }],
+                    Dividends = [new CashDividendEvent { Date = exDate, Amount = 0.2701m }],
                 }
             );
 
@@ -472,7 +472,8 @@ public class YahooPriceImportServiceTests : IDisposable
 
         var stored = _priceRepo.GetByStock(apple, "AAPL").OrderBy(price => price.Date).ToList();
         stored.Select(price => price.AdjustedClose).Should().Equal(99.73m, 105m);
-        dividend.PriceAdjustmentAppliedAmountPerShare.Should().Be(0.27m);
+        dividend.AmountPerShare.Should().Be(0.2701m);
+        dividend.PriceAdjustmentAppliedAmountPerShare.Should().Be(0.2701m);
         dividend.PriceAdjustmentAppliedTime.Should().NotBeNull();
         await _yahooClient
             .Received()

--- a/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
@@ -87,6 +87,14 @@ public class CorporateActionPriceReconciliationManagerStampingTests
             Source = CashDividendSource.Yahoo,
         };
 
+    private static CapturedDividend PriceSeriesDividend(DateOnly exDate, decimal amount) =>
+        new()
+        {
+            ExDate = exDate,
+            AmountPerShare = amount,
+            Source = CashDividendSource.Yahoo,
+        };
+
     [Fact]
     public async Task StampApplied_StampsSelectedSplitAndDividendSnapshots()
     {
@@ -198,6 +206,129 @@ public class CorporateActionPriceReconciliationManagerStampingTests
             .ContainSingle()
             .Which.Dividends.Should()
             .ContainSingle(snapshot => snapshot.AmountPerShare == 0.26m);
+    }
+
+    [Fact]
+    public async Task StampApplied_SelectedDividendRevisedToPriceSeriesAmount_StampsCurrentAmount()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var exDate = new DateOnly(2024, 5, 9);
+        db.Add(Stock(stockId));
+        var dividend = PendingDividend(stockId, exDate, 0.25m);
+        dividend.Source = CashDividendSource.External;
+        db.Add(dividend);
+        await db.SaveChangesAsync();
+
+        var manager = NewManager(db);
+        var selected = (await manager.SelectPendingSeries(50, SettledBefore)).Series.Single();
+        dividend.AmountPerShare = 0.26m;
+        await db.SaveChangesAsync();
+        var appliedTime = new DateTime(2026, 8, 10, 12, 0, 0, DateTimeKind.Utc);
+
+        var stamped = await manager.StampApplied(
+            selected,
+            [PriceSeriesDividend(exDate, 0.26m)],
+            SettledBefore,
+            appliedTime
+        );
+
+        stamped.Should().Be(1);
+        dividend.PriceAdjustmentAppliedAmountPerShare.Should().Be(0.26m);
+        dividend.PriceAdjustmentAppliedTime.Should().Be(appliedTime);
+        (await manager.SelectPendingSeries(50, SettledBefore)).Series.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StampApplied_CurrentDividendDoesNotMatchPriceSeries_RemainsPending()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var exDate = new DateOnly(2024, 5, 9);
+        db.Add(Stock(stockId));
+        var dividend = PendingDividend(stockId, exDate, 0.25m);
+        db.Add(dividend);
+        await db.SaveChangesAsync();
+
+        var manager = NewManager(db);
+        var selected = (await manager.SelectPendingSeries(50, SettledBefore)).Series.Single();
+        dividend.AmountPerShare = 0.27m;
+        await db.SaveChangesAsync();
+
+        var stamped = await manager.StampApplied(
+            selected,
+            [PriceSeriesDividend(exDate, 0.26m)],
+            SettledBefore,
+            DateTime.UtcNow
+        );
+
+        stamped.Should().Be(0);
+        dividend.PriceAdjustmentAppliedTime.Should().BeNull();
+        (await manager.SelectPendingSeries(50, SettledBefore))
+            .Series.Should()
+            .ContainSingle()
+            .Which.Dividends.Should()
+            .ContainSingle(snapshot => snapshot.AmountPerShare == 0.27m);
+    }
+
+    [Fact]
+    public async Task StampApplied_NewPriceSeriesDividendAfterSelection_StampsSameFetch()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var selectedExDate = new DateOnly(2024, 5, 9);
+        var discoveredExDate = new DateOnly(2025, 2, 7);
+        db.Add(Stock(stockId));
+        db.Add(PendingDividend(stockId, selectedExDate));
+        await db.SaveChangesAsync();
+
+        var manager = NewManager(db);
+        var selected = (await manager.SelectPendingSeries(50, SettledBefore)).Series.Single();
+        var discovered = PendingDividend(stockId, discoveredExDate, 0.26m);
+        db.Add(discovered);
+        await db.SaveChangesAsync();
+
+        var stamped = await manager.StampApplied(
+            selected,
+            [
+                PriceSeriesDividend(selectedExDate, 0.25m),
+                PriceSeriesDividend(discoveredExDate, 0.26m),
+            ],
+            SettledBefore,
+            DateTime.UtcNow
+        );
+
+        stamped.Should().Be(2);
+        discovered.PriceAdjustmentAppliedAmountPerShare.Should().Be(0.26m);
+        discovered.PriceAdjustmentAppliedTime.Should().NotBeNull();
+        (await manager.SelectPendingSeries(50, SettledBefore)).Series.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StampApplied_UnsettledPriceSeriesDividend_RemainsPending()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var selectedExDate = new DateOnly(2024, 5, 9);
+        db.Add(Stock(stockId));
+        db.Add(PendingDividend(stockId, selectedExDate));
+        await db.SaveChangesAsync();
+
+        var manager = NewManager(db);
+        var selected = (await manager.SelectPendingSeries(50, SettledBefore)).Series.Single();
+        var unsettled = PendingDividend(stockId, SettledBefore, 0.26m);
+        db.Add(unsettled);
+        await db.SaveChangesAsync();
+
+        var stamped = await manager.StampApplied(
+            selected,
+            [PriceSeriesDividend(selectedExDate, 0.25m), PriceSeriesDividend(SettledBefore, 0.26m)],
+            SettledBefore,
+            DateTime.UtcNow
+        );
+
+        stamped.Should().Be(1);
+        unsettled.PriceAdjustmentAppliedTime.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- stamp settled dividends from the exact full-history response that rebuilt AdjustedClose
- keep mismatched, unsettled, or concurrently changed rows pending
- cover request-variant historical amounts with unit and PostgreSQL integration regressions

## Validation

- Release solution build
- 4,225 unit tests
- 2,483 integration tests
- changed-file formatting and diff checks