### PR TITLE
fix(prices): keep omitted dividends pending

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
@@ -154,18 +154,45 @@ public class CorporateActionPriceReconciliationManager
         PendingPriceReconciliationSeries selectedSeries,
         DateTime appliedTime,
         CancellationToken cancellationToken = default
-    ) => StampApplied(selectedSeries, [], DateOnly.MinValue, appliedTime, cancellationToken);
+    ) =>
+        StampAppliedCore(
+            selectedSeries,
+            [],
+            false,
+            DateOnly.MinValue,
+            appliedTime,
+            cancellationToken
+        );
 
     /// <summary>
-    /// Stamps unchanged selected actions plus dividends whose current state exactly matches the
+    /// Stamps unchanged selected splits plus dividends whose current state exactly matches the
     /// same provider response that supplied the replacement adjusted-price series.
     /// </summary>
-    public async Task<int> StampApplied(
+    public Task<int> StampApplied(
         PendingPriceReconciliationSeries selectedSeries,
         IReadOnlyCollection<CapturedDividend> priceSeriesDividends,
         DateOnly settledBefore,
         DateTime appliedTime,
         CancellationToken cancellationToken = default
+    )
+    {
+        return StampAppliedCore(
+            selectedSeries,
+            priceSeriesDividends,
+            true,
+            settledBefore,
+            appliedTime,
+            cancellationToken
+        );
+    }
+
+    private async Task<int> StampAppliedCore(
+        PendingPriceReconciliationSeries selectedSeries,
+        IReadOnlyCollection<CapturedDividend> priceSeriesDividends,
+        bool requirePriceSeriesDividendMatch,
+        DateOnly settledBefore,
+        DateTime appliedTime,
+        CancellationToken cancellationToken
     )
     {
         await using var transaction = await _stockRepository.CreateTransaction(
@@ -188,22 +215,15 @@ public class CorporateActionPriceReconciliationManager
             selectedSeries.ListedTicker,
             StringComparison.OrdinalIgnoreCase
         );
-        var unchangedDividends = await LoadUnchangedDividends(
-            selectedSeries,
-            isStillPrimary,
-            cancellationToken
-        );
-        var responseMatchedDividends = await LoadResponseMatchedDividends(
-            selectedSeries,
-            priceSeriesDividends,
-            settledBefore,
-            isStillPrimary,
-            cancellationToken
-        );
-        var dividendsToStamp = unchangedDividends
-            .Concat(responseMatchedDividends)
-            .DistinctBy(dividend => dividend.Id)
-            .ToList();
+        var dividendsToStamp = requirePriceSeriesDividendMatch
+            ? await LoadResponseMatchedDividends(
+                selectedSeries,
+                priceSeriesDividends,
+                settledBefore,
+                isStillPrimary,
+                cancellationToken
+            )
+            : await LoadUnchangedDividends(selectedSeries, isStillPrimary, cancellationToken);
         ApplyMarkers(unchangedSplits, dividendsToStamp, appliedTime);
 
         var stamped = unchangedSplits.Count + dividendsToStamp.Count;

--- a/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
@@ -272,6 +272,35 @@ public class CorporateActionPriceReconciliationManagerStampingTests
     }
 
     [Fact]
+    public async Task StampApplied_SelectedDividendOmittedFromPriceSeriesResponse_RemainsPending()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var exDate = new DateOnly(2024, 5, 9);
+        var split = PendingSplit(stockId, new DateOnly(2024, 6, 10));
+        var dividend = PendingDividend(stockId, exDate, 0.25m);
+        db.Add(Stock(stockId));
+        db.AddRange(split, dividend);
+        await db.SaveChangesAsync();
+
+        var manager = NewManager(db);
+        var selected = (await manager.SelectPendingSeries(50, SettledBefore)).Series.Single();
+        var appliedTime = new DateTime(2026, 8, 10, 12, 0, 0, DateTimeKind.Utc);
+
+        var stamped = await manager.StampApplied(selected, [], SettledBefore, appliedTime);
+
+        stamped.Should().Be(1);
+        split.PriceAdjustmentAppliedTime.Should().Be(appliedTime);
+        dividend.PriceAdjustmentAppliedAmountPerShare.Should().BeNull();
+        dividend.PriceAdjustmentAppliedTime.Should().BeNull();
+        (await manager.SelectPendingSeries(50, SettledBefore))
+            .Series.Should()
+            .ContainSingle()
+            .Which.Dividends.Should()
+            .ContainSingle(snapshot => snapshot.Id == dividend.Id);
+    }
+
+    [Fact]
     public async Task StampApplied_NewPriceSeriesDividendAfterSelection_StampsSameFetch()
     {
         await using var db = NewDb();


### PR DESCRIPTION
## Problem

A selected dividend could be marked reconciled after a full-history refresh even when that same response omitted the dividend.

## Fix

- Require an exact settled ex-date and amount match from the response before stamping a dividend.
- Preserve the legacy snapshot-only overload and unchanged split stamping.
- Cover the omitted-dividend case with a regression test.

## Verification

- Release solution build passed.
- 4,226 unit tests passed.
- 2,483 integration tests passed.
- Formatting and whitespace checks passed.