### PR TITLE
fix(corporate-actions): preserve dividend source precedence

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CashDividendCaptureManager.cs
@@ -79,11 +79,21 @@ public class CashDividendCaptureManager
                 );
                 changes++;
             }
-            else if (match.AmountPerShare != dividend.AmountPerShare)
+            else if (CanSupersede(match.Source, dividend.Source))
             {
-                match.AmountPerShare = dividend.AmountPerShare;
-                match.PriceAdjustmentAppliedAmountPerShare = null;
-                match.PriceAdjustmentAppliedTime = null;
+                var amountChanged = match.AmountPerShare != dividend.AmountPerShare;
+                var sourceChanged = match.Source != dividend.Source;
+                if (!amountChanged && !sourceChanged)
+                    continue;
+
+                if (amountChanged)
+                {
+                    match.AmountPerShare = dividend.AmountPerShare;
+                    match.PriceAdjustmentAppliedAmountPerShare = null;
+                    match.PriceAdjustmentAppliedTime = null;
+                }
+
+                match.Source = dividend.Source;
                 changes++;
             }
         }
@@ -94,6 +104,24 @@ public class CashDividendCaptureManager
         await transaction.CommitAsync(cancellationToken);
         return changes;
     }
+
+    // Manual values are operator-owned. Yahoo supplies the adjusted price history, so its
+    // dividend amount must remain stable against a later generic external-reference refresh.
+    private static bool CanSupersede(
+        CashDividendSource currentSource,
+        CashDividendSource incomingSource
+    ) =>
+        incomingSource == currentSource
+        || SourcePriority(incomingSource) > SourcePriority(currentSource);
+
+    private static int SourcePriority(CashDividendSource source) =>
+        source switch
+        {
+            CashDividendSource.External => 0,
+            CashDividendSource.Yahoo => 1,
+            CashDividendSource.Manual => 2,
+            _ => int.MinValue,
+        };
 
     internal static List<CapturedDividend> CombineSameDateDividends(
         IReadOnlyCollection<CapturedDividend> dividends

--- a/tests/Equibles.IntegrationTests/CorporateActions/CorporateActionPriceReconciliationManagerResponseStampTests.cs
+++ b/tests/Equibles.IntegrationTests/CorporateActions/CorporateActionPriceReconciliationManagerResponseStampTests.cs
@@ -37,7 +37,7 @@ public class CorporateActionPriceReconciliationManagerResponseStampTests : IAsyn
                     CommonStockId = stockId,
                     ExDate = exDate,
                     AmountPerShare = 0.21222556m,
-                    Source = CashDividendSource.Yahoo,
+                    Source = CashDividendSource.External,
                 }
             );
             await seed.SaveChangesAsync();
@@ -53,9 +53,22 @@ public class CorporateActionPriceReconciliationManagerResponseStampTests : IAsyn
 
         await using (var capture = _fixture.CreateDbContext())
         {
-            var dividend = await capture.Set<CashDividend>().SingleAsync();
-            dividend.AmountPerShare = 0.21219057m;
-            await capture.SaveChangesAsync();
+            var changes = await new CashDividendCaptureManager(
+                new CashDividendRepository(capture),
+                new CommonStockRepository(capture)
+            ).Capture(
+                stockId,
+                "GRTUF",
+                [
+                    new CapturedDividend
+                    {
+                        ExDate = exDate,
+                        AmountPerShare = 0.21219057m,
+                        Source = CashDividendSource.Yahoo,
+                    },
+                ]
+            );
+            changes.Should().Be(1);
         }
 
         var appliedTime = new DateTime(2026, 8, 10, 12, 0, 0, DateTimeKind.Utc);
@@ -81,8 +94,32 @@ public class CorporateActionPriceReconciliationManagerResponseStampTests : IAsyn
 
         await using var verification = _fixture.CreateDbContext();
         var stored = await verification.Set<CashDividend>().SingleAsync();
+        stored.Source.Should().Be(CashDividendSource.Yahoo);
         stored.PriceAdjustmentAppliedAmountPerShare.Should().Be(0.21219057m);
         stored.PriceAdjustmentAppliedTime.Should().Be(appliedTime);
+
+        var externalReplay = await new CashDividendCaptureManager(
+            new CashDividendRepository(verification),
+            new CommonStockRepository(verification)
+        ).Capture(
+            stockId,
+            "GRTUF",
+            [
+                new CapturedDividend
+                {
+                    ExDate = exDate,
+                    AmountPerShare = 0.21222556m,
+                    Source = CashDividendSource.External,
+                },
+            ]
+        );
+        externalReplay.Should().Be(0);
+
+        var afterReplay = await verification.Set<CashDividend>().SingleAsync();
+        afterReplay.AmountPerShare.Should().Be(0.21219057m);
+        afterReplay.Source.Should().Be(CashDividendSource.Yahoo);
+        afterReplay.PriceAdjustmentAppliedAmountPerShare.Should().Be(0.21219057m);
+        afterReplay.PriceAdjustmentAppliedTime.Should().Be(appliedTime);
     }
 
     private static CorporateActionPriceReconciliationManager NewManager(

--- a/tests/Equibles.UnitTests/CorporateActions/CashDividendCaptureManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CashDividendCaptureManagerTests.cs
@@ -14,8 +14,8 @@ namespace Equibles.UnitTests.CorporateActions;
 /// <summary>
 /// Pins the upsert contract of <see cref="CashDividendCaptureManager"/>, mirroring the split
 /// capture manager: the exact current primary is locked and revalidated, idempotent events write
-/// nothing, same-date components are summed, a restated amount updates in place, and a
-/// non-positive amount is dropped as unusable.
+/// nothing, same-date components are summed, a higher-priority restatement updates in place,
+/// lower-priority sources cannot overwrite it, and a non-positive amount is dropped as unusable.
 /// </summary>
 public class CashDividendCaptureManagerTests
 {
@@ -52,12 +52,16 @@ public class CashDividendCaptureManagerTests
         return stock;
     }
 
-    private static CapturedDividend Dividend(DateOnly exDate, decimal amount) =>
+    private static CapturedDividend Dividend(
+        DateOnly exDate,
+        decimal amount,
+        CashDividendSource source = CashDividendSource.Yahoo
+    ) =>
         new()
         {
             ExDate = exDate,
             AmountPerShare = amount,
-            Source = CashDividendSource.Yahoo,
+            Source = source,
         };
 
     [Fact]
@@ -159,6 +163,119 @@ public class CashDividendCaptureManagerTests
         stored[0].AmountPerShare.Should().Be(0.26m);
         stored[0].PriceAdjustmentAppliedAmountPerShare.Should().BeNull();
         stored[0].PriceAdjustmentAppliedTime.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Capture_HigherPrioritySource_ReplacesAmountAndSource()
+    {
+        await using var db = NewDb();
+        var stock = await AddStock(db);
+        var exDate = new DateOnly(2024, 2, 9);
+
+        await NewManager(db)
+            .Capture(
+                stock.Id,
+                stock.Ticker,
+                [Dividend(exDate, 0.24m, CashDividendSource.External)]
+            );
+        var original = await db.Set<CashDividend>().SingleAsync();
+        original.PriceAdjustmentAppliedAmountPerShare = original.AmountPerShare;
+        original.PriceAdjustmentAppliedTime = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+
+        var changes = await NewManager(db)
+            .Capture(stock.Id, stock.Ticker, [Dividend(exDate, 0.26m)]);
+
+        changes.Should().Be(1);
+        var stored = await db.Set<CashDividend>().SingleAsync();
+        stored.AmountPerShare.Should().Be(0.26m);
+        stored.Source.Should().Be(CashDividendSource.Yahoo);
+        stored.PriceAdjustmentAppliedAmountPerShare.Should().BeNull();
+        stored.PriceAdjustmentAppliedTime.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Capture_LowerPrioritySource_DoesNotOverwriteAmountOrMarker()
+    {
+        await using var db = NewDb();
+        var stock = await AddStock(db);
+        var exDate = new DateOnly(2024, 2, 9);
+
+        await NewManager(db).Capture(stock.Id, stock.Ticker, [Dividend(exDate, 0.26m)]);
+        var original = await db.Set<CashDividend>().SingleAsync();
+        var appliedAt = DateTime.UtcNow;
+        original.PriceAdjustmentAppliedAmountPerShare = original.AmountPerShare;
+        original.PriceAdjustmentAppliedTime = appliedAt;
+        await db.SaveChangesAsync();
+
+        var changes = await NewManager(db)
+            .Capture(
+                stock.Id,
+                stock.Ticker,
+                [Dividend(exDate, 0.24m, CashDividendSource.External)]
+            );
+
+        changes.Should().Be(0);
+        var stored = await db.Set<CashDividend>().SingleAsync();
+        stored.AmountPerShare.Should().Be(0.26m);
+        stored.Source.Should().Be(CashDividendSource.Yahoo);
+        stored.PriceAdjustmentAppliedAmountPerShare.Should().Be(0.26m);
+        stored.PriceAdjustmentAppliedTime.Should().Be(appliedAt);
+    }
+
+    [Fact]
+    public async Task Capture_HigherPrioritySourceWithSameAmount_PromotesWithoutInvalidatingMarker()
+    {
+        await using var db = NewDb();
+        var stock = await AddStock(db);
+        var exDate = new DateOnly(2024, 2, 9);
+
+        await NewManager(db)
+            .Capture(
+                stock.Id,
+                stock.Ticker,
+                [Dividend(exDate, 0.26m, CashDividendSource.External)]
+            );
+        var original = await db.Set<CashDividend>().SingleAsync();
+        var appliedAt = DateTime.UtcNow;
+        original.PriceAdjustmentAppliedAmountPerShare = original.AmountPerShare;
+        original.PriceAdjustmentAppliedTime = appliedAt;
+        await db.SaveChangesAsync();
+
+        var changes = await NewManager(db)
+            .Capture(stock.Id, stock.Ticker, [Dividend(exDate, 0.26m)]);
+
+        changes.Should().Be(1);
+        var stored = await db.Set<CashDividend>().SingleAsync();
+        stored.Source.Should().Be(CashDividendSource.Yahoo);
+        stored.PriceAdjustmentAppliedAmountPerShare.Should().Be(0.26m);
+        stored.PriceAdjustmentAppliedTime.Should().Be(appliedAt);
+    }
+
+    [Fact]
+    public async Task Capture_AutomaticSources_DoNotOverwriteManualAmount()
+    {
+        await using var db = NewDb();
+        var stock = await AddStock(db);
+        var exDate = new DateOnly(2024, 2, 9);
+
+        await NewManager(db)
+            .Capture(stock.Id, stock.Ticker, [Dividend(exDate, 0.255m, CashDividendSource.Manual)]);
+
+        var yahooChanges = await NewManager(db)
+            .Capture(stock.Id, stock.Ticker, [Dividend(exDate, 0.26m)]);
+        var externalChanges = await NewManager(db)
+            .Capture(
+                stock.Id,
+                stock.Ticker,
+                [Dividend(exDate, 0.24m, CashDividendSource.External)]
+            );
+
+        yahooChanges.Should().Be(0);
+        externalChanges.Should().Be(0);
+        var stored = await db.Set<CashDividend>().SingleAsync();
+        stored.AmountPerShare.Should().Be(0.255m);
+        stored.Source.Should().Be(CashDividendSource.Manual);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Prevent a lower-priority dividend refresh from rewriting an amount already reconciled against adjusted price history.
- Preserve manual corrections and stop recurring refreshes from reopening completed adjustment markers.

## Code changes

- Enforce `Manual > Yahoo > External` precedence when an existing dividend is updated.
- Promote a higher-priority same-amount observation without clearing a valid marker.
- Clear applied fields only when an allowed update changes the amount.
- Cover the production replay sequence in unit and database-backed regression tests.

## Verification

- `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release` — 4,230 passed.
- Focused database-backed regression — 1 passed.
- CSharpier check and `git diff --check` — clean.
