### PR TITLE
fix(finra): keep squeeze factors on comparable closes

### DIFF
--- a/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeDailyBar.cs
+++ b/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeDailyBar.cs
@@ -2,14 +2,8 @@ namespace Equibles.Finra.BusinessLogic.Models;
 
 /// <summary>
 /// One daily price bar of the minimal shape the squeeze price factors need.
-/// <see cref="AdjustedClose"/> is the split- and dividend-adjusted close (a
-/// comparable series across time); <see cref="Close"/> and <see cref="Volume"/>
-/// are the raw as-traded figures for the day, whose product is that day's
-/// dollar turnover on a self-consistent basis regardless of later splits.
+/// <see cref="Close"/> is the raw as-traded close inside one captured-split
+/// interval selected by the caller; its product with <see cref="Volume"/> is
+/// that day's dollar turnover on the same basis.
 /// </summary>
-public readonly record struct ShortSqueezeDailyBar(
-    DateOnly Date,
-    decimal AdjustedClose,
-    decimal Close,
-    long Volume
-);
+public readonly record struct ShortSqueezeDailyBar(DateOnly Date, decimal Close, long Volume);

--- a/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezePriceFactors.cs
+++ b/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezePriceFactors.cs
@@ -7,8 +7,9 @@ namespace Equibles.Finra.BusinessLogic.Models;
 public class ShortSqueezePriceFactors
 {
     /// <summary>
-    /// How far the latest adjusted close sits above (positive) or below (negative)
-    /// the trailing volume-weighted average price, as a fraction of that average.
+    /// How far the latest raw close sits above (positive) or below (negative) the
+    /// trailing volume-weighted average price within one comparable captured-split
+    /// interval, as a fraction of that average.
     /// A proxy for the aggregate paper loss of open short positions — the deeper
     /// the price trades above the level where recent volume changed hands, the
     /// more of the short base is underwater. Null when the price history is too

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezePriceFactorCalculator.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezePriceFactorCalculator.cs
@@ -82,13 +82,13 @@ public static class ShortSqueezePriceFactorCalculator
         var recentStart = bars.Count - RecentWindowBars;
         var baselineStart = recentStart - baselineCount;
 
-        var entryClose = bars[recentStart - 1].AdjustedClose;
+        var entryClose = bars[recentStart - 1].Close;
         if (entryClose <= 0)
         {
             return factors;
         }
 
-        var recentReturn = (double)(last.AdjustedClose / entryClose - 1);
+        var recentReturn = (double)(last.Close / entryClose - 1);
         if (recentReturn <= 0)
         {
             // Both catalysts require price moving AGAINST the shorts; a volume or
@@ -110,7 +110,7 @@ public static class ShortSqueezePriceFactorCalculator
     }
 
     /// <summary>
-    /// The latest close versus the volume-weighted average adjusted close over the
+    /// The latest close versus the volume-weighted average raw close over the
     /// trailing window (up to baseline + recent bars). Falls back to the simple
     /// mean when the window traded no volume at all.
     /// </summary>
@@ -131,13 +131,13 @@ public static class ShortSqueezePriceFactorCalculator
         decimal closeSum = 0;
         for (var i = windowStart; i < bars.Count; i++)
         {
-            priceVolumeSum += bars[i].AdjustedClose * bars[i].Volume;
+            priceVolumeSum += bars[i].Close * bars[i].Volume;
             volumeSum += bars[i].Volume;
-            closeSum += bars[i].AdjustedClose;
+            closeSum += bars[i].Close;
         }
 
         var vwap = volumeSum > 0 ? priceVolumeSum / volumeSum : closeSum / windowCount;
-        return vwap > 0 ? last.AdjustedClose / vwap - 1 : null;
+        return vwap > 0 ? last.Close / vwap - 1 : null;
     }
 
     /// <summary>
@@ -154,13 +154,13 @@ public static class ShortSqueezePriceFactorCalculator
         var returns = new List<double>(recentStart - baselineStart);
         for (var i = baselineStart + 1; i < recentStart; i++)
         {
-            var previous = bars[i - 1].AdjustedClose;
-            if (previous <= 0 || bars[i].AdjustedClose <= 0)
+            var previous = bars[i - 1].Close;
+            if (previous <= 0 || bars[i].Close <= 0)
             {
                 return 0;
             }
 
-            returns.Add((double)(bars[i].AdjustedClose / previous - 1));
+            returns.Add((double)(bars[i].Close / previous - 1));
         }
 
         if (returns.Count < 2)

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -279,7 +279,8 @@ public class ShortSqueezeScoreManager
 
         var scoredStockIds = stocks.Keys.ToList();
         var failsToDeliver = await LoadFailsToDeliver(scoredStockIds, cancellationToken);
-        var priceFactors = await LoadPriceFactors(scoredStockIds, cancellationToken);
+        var primaryTickers = stocks.ToDictionary(pair => pair.Key, pair => pair.Value.Ticker);
+        var priceFactors = await LoadPriceFactors(primaryTickers, splitsByStock, cancellationToken);
         var nearEarnings = await LoadStocksNearEarnings(scoredStockIds, cancellationToken);
 
         var scores = new List<ShortSqueezeScore>();
@@ -511,10 +512,12 @@ public class ShortSqueezeScoreManager
     /// no price factors instead of factors about the past.
     /// </summary>
     private async Task<Dictionary<Guid, ShortSqueezePriceFactors>> LoadPriceFactors(
-        List<Guid> stockIds,
+        IReadOnlyDictionary<Guid, string> primaryTickers,
+        IReadOnlyDictionary<Guid, IReadOnlyList<StockSplit>> splitsByStock,
         CancellationToken cancellationToken
     )
     {
+        var stockIds = primaryTickers.Keys.ToList();
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
         var cutoff = today.AddDays(-PriceHistoryCalendarDays);
         var bars = await _dailyStockPriceRepository
@@ -522,25 +525,42 @@ public class ShortSqueezeScoreManager
             .Select(p => new
             {
                 p.CommonStockId,
+                p.ListedTicker,
                 p.Date,
-                p.AdjustedClose,
                 p.Close,
                 p.Volume,
             })
             .ToListAsync(cancellationToken);
 
         var result = new Dictionary<Guid, ShortSqueezePriceFactors>();
-        if (bars.Count == 0)
+        var primaryBars = bars.Where(bar =>
+                primaryTickers.TryGetValue(bar.CommonStockId, out var ticker)
+                && string.Equals(bar.ListedTicker, ticker, StringComparison.OrdinalIgnoreCase)
+            )
+            .ToList();
+        if (primaryBars.Count == 0)
         {
             return result;
         }
 
-        var universeLatestDate = bars.Max(b => b.Date);
-        foreach (var group in bars.GroupBy(b => b.CommonStockId))
+        var universeLatestDate = primaryBars.Max(b => b.Date);
+        foreach (var group in primaryBars.GroupBy(b => b.CommonStockId))
         {
+            var ticker = primaryTickers[group.Key];
+            var latestDate = group.Max(bar => bar.Date);
+            var applicableSplits = PriceSeriesSplitScope.ForListing(
+                splitsByStock.GetValueOrDefault(group.Key) ?? [],
+                ticker,
+                ticker
+            );
+            var splitBoundary = applicableSplits
+                .Where(split => split.EffectiveDate <= latestDate)
+                .Select(split => (DateOnly?)split.EffectiveDate)
+                .Max();
             var series = group
+                .Where(bar => splitBoundary == null || bar.Date >= splitBoundary.Value)
                 .OrderBy(b => b.Date)
-                .Select(b => new ShortSqueezeDailyBar(b.Date, b.AdjustedClose, b.Close, b.Volume))
+                .Select(b => new ShortSqueezeDailyBar(b.Date, b.Close, b.Volume))
                 .ToList();
             result[group.Key] = ShortSqueezePriceFactorCalculator.Compute(
                 series,

--- a/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Finra.BusinessLogic;
@@ -367,6 +368,7 @@ public class ShortSqueezeScoreManagerTests : IDisposable
                     new DailyStockPrice
                     {
                         CommonStockId = stock.Id,
+                        ListedTicker = stock.Ticker,
                         Date = today.AddDays(i - 64),
                         Open = close,
                         High = close,
@@ -384,6 +386,147 @@ public class ShortSqueezeScoreManagerTests : IDisposable
 
         scores.Single().PriceAboveVwap.Should().NotBeNull();
         scores.Single().PriceAboveVwap.Should().BeGreaterThan(0.25m);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Compute_CapturedPrimarySplit_ClipsPriceFactorsToPostSplitRawCloses(
+        bool legacyNullAttribution
+    )
+    {
+        var stock = SeedStock("SPLIT", sharesOutstanding: 1_000_000);
+        SeedShortInterest(stock, shortPosition: 100_000, daysToCover: 2m);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var splitDate = today.AddDays(-4);
+        for (var i = 0; i < 65; i++)
+        {
+            var date = today.AddDays(i - 64);
+            var close = date < splitDate ? 100m : 10m;
+            _dbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        ListedTicker = stock.Ticker,
+                        Date = date,
+                        Open = close,
+                        High = close,
+                        Low = close,
+                        Close = close,
+                        // Deliberately plausible but uncertified: the score must neither use this
+                        // field nor retain the pre-split raw rows to meet its history minimum.
+                        AdjustedClose = 100m,
+                        Volume = 1_000,
+                    }
+                );
+        }
+
+        _dbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStockId = stock.Id,
+                    PriceSeriesTicker = legacyNullAttribution ? null : stock.Ticker,
+                    EffectiveDate = splitDate,
+                    Numerator = 10m,
+                    Denominator = 1m,
+                    Source = StockSplitSource.Yahoo,
+                }
+            );
+        await _dbContext.SaveChangesAsync();
+
+        var score = (await _manager.Compute()).Single();
+
+        score.PriceAboveVwap.Should().BeNull("only five comparable post-split bars exist");
+        score.HasPriceSpikeCatalyst.Should().BeFalse();
+        score.HasVolumeSurgeCatalyst.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Compute_FuturePrimarySplit_DoesNotClipCurrentPriceFactors()
+    {
+        var stock = SeedStock("FUTURE", sharesOutstanding: 1_000_000);
+        SeedShortInterest(stock, shortPosition: 100_000, daysToCover: 2m);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        for (var i = 0; i < 65; i++)
+        {
+            var close = i == 64 ? 130m : 100m;
+            _dbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        ListedTicker = stock.Ticker,
+                        Date = today.AddDays(i - 64),
+                        Open = close,
+                        High = close,
+                        Low = close,
+                        Close = close,
+                        AdjustedClose = 1m,
+                        Volume = 1_000,
+                    }
+                );
+        }
+
+        _dbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStockId = stock.Id,
+                    PriceSeriesTicker = stock.Ticker,
+                    EffectiveDate = today.AddDays(1),
+                    Numerator = 10m,
+                    Denominator = 1m,
+                    Source = StockSplitSource.Yahoo,
+                }
+            );
+        await _dbContext.SaveChangesAsync();
+
+        var score = (await _manager.Compute()).Single();
+
+        score.PriceAboveVwap.Should().NotBeNull("a split after the latest bar is not applicable");
+        score.PriceAboveVwap.Should().BeGreaterThan(0.25m);
+    }
+
+    [Fact]
+    public async Task Compute_SecondaryListingHistory_DoesNotSupplyPrimaryPriceFactors()
+    {
+        var stock = SeedStock("PRIMARY", sharesOutstanding: 1_000_000);
+        SeedShortInterest(stock, shortPosition: 100_000, daysToCover: 2m);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        for (var i = 0; i < 65; i++)
+        {
+            var close = i == 64 ? 130m : 100m;
+            _dbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        ListedTicker = "SECONDARY",
+                        Date = today.AddDays(i - 64),
+                        Open = close,
+                        High = close,
+                        Low = close,
+                        Close = close,
+                        AdjustedClose = close,
+                        Volume = 1_000,
+                    }
+                );
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        var score = (await _manager.Compute()).Single();
+
+        score.PriceAboveVwap.Should().BeNull();
+        score.HasPriceSpikeCatalyst.Should().BeFalse();
+        score.HasVolumeSurgeCatalyst.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezePriceFactorCalculatorCatalystTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezePriceFactorCalculatorCatalystTests.cs
@@ -89,17 +89,16 @@ public class ShortSqueezePriceFactorCalculatorCatalystTests
         for (var i = 0; i < baselineBars; i++)
         {
             var close = i % 2 == 0 ? 100m : 100.5m;
-            bars.Add(new ShortSqueezeDailyBar(end.AddDays(i - total + 1), close, close, 1_000));
+            bars.Add(new ShortSqueezeDailyBar(end.AddDays(i - total + 1), close, 1_000));
         }
 
-        var start = bars[^1].AdjustedClose;
+        var start = bars[^1].Close;
         for (var i = 0; i < 5; i++)
         {
             var close = start + (finalWeekClose - start) * (i + 1) / 5;
             bars.Add(
                 new ShortSqueezeDailyBar(
                     end.AddDays(baselineBars + i - total + 1),
-                    close,
                     close,
                     finalWeekVolume
                 )

--- a/tests/Equibles.UnitTests/Finra/ShortSqueezePriceFactorCalculatorVwapTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortSqueezePriceFactorCalculatorVwapTests.cs
@@ -94,8 +94,7 @@ public class ShortSqueezePriceFactorCalculatorVwapTests
         factors.HasVolumeSurgeCatalyst.Should().BeFalse();
     }
 
-    // Consecutive daily bars ending 2026-07-01; adjusted and raw close are equal so
-    // the tests read naturally.
+    // Consecutive daily bars ending 2026-07-01.
     private static List<ShortSqueezeDailyBar> Series(
         int count,
         Func<int, decimal> close,
@@ -105,12 +104,7 @@ public class ShortSqueezePriceFactorCalculatorVwapTests
         var end = new DateOnly(2026, 7, 1);
         return Enumerable
             .Range(0, count)
-            .Select(i => new ShortSqueezeDailyBar(
-                end.AddDays(i - count + 1),
-                close(i),
-                close(i),
-                volume(i)
-            ))
+            .Select(i => new ShortSqueezeDailyBar(end.AddDays(i - count + 1), close(i), volume(i)))
             .ToList();
     }
 }


### PR DESCRIPTION
Summary:
- compute short-squeeze return, VWAP-distance, volatility, and turnover from primary-listing raw closes
- clip price factors at the latest applicable captured split and withhold them when comparable history is insufficient
- exclude secondary listing history and future splits; cover exact and legacy-null primary attribution

Validation:
- Release solution build: 0 errors
- CSharpier: clean
- unit tests: 4,236 passed
- integration tests: 2,497 passed
- independent post-fix review: clean