### PR TITLE
fix(data): stabilize ordering for tied public rows

### DIFF
--- a/src/Equibles.Congress.Data/Extensions/CongressionalTradeQueryOrderExtensions.cs
+++ b/src/Equibles.Congress.Data/Extensions/CongressionalTradeQueryOrderExtensions.cs
@@ -1,0 +1,16 @@
+using Equibles.Congress.Data.Models;
+
+namespace Equibles.Congress.Data.Extensions;
+
+public static class CongressionalTradeQueryOrderExtensions
+{
+    public static IOrderedQueryable<CongressionalTrade> OrderNewestFirst(
+        this IQueryable<CongressionalTrade> query
+    )
+    {
+        return query
+            .OrderByDescending(t => t.TransactionDate)
+            .ThenByDescending(t => t.FilingDate)
+            .ThenBy(t => t.Id);
+    }
+}

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Congress.Data.Extensions;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.Repositories;
 using Equibles.Core.Extensions;
@@ -85,7 +86,7 @@ public class CongressTools
 
                 var trades = await query
                     .Include(t => t.CongressMember)
-                    .OrderByDescending(t => t.TransactionDate)
+                    .OrderNewestFirst()
                     .Take(maxResults)
                     .ToListAsync();
 
@@ -162,14 +163,9 @@ public class CongressTools
                 offset = McpLimit.ClampOffset(offset);
                 var totalCount = await query.CountAsync();
 
-                // Same-day trades tie constantly, so the ordering ends on the row id — an
-                // offset over a partial order would silently repeat or skip trades between
-                // pages.
                 var trades = await query
                     .Include(t => t.CommonStock)
-                    .OrderByDescending(t => t.TransactionDate)
-                    .ThenByDescending(t => t.FilingDate)
-                    .ThenBy(t => t.Id)
+                    .OrderNewestFirst()
                     .Skip(offset)
                     .Take(maxResults)
                     .ToListAsync();

--- a/src/Equibles.InsiderTrading.Data/Extensions/InsiderTradingQueryOrderExtensions.cs
+++ b/src/Equibles.InsiderTrading.Data/Extensions/InsiderTradingQueryOrderExtensions.cs
@@ -1,0 +1,40 @@
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.InsiderTrading.Data.Extensions;
+
+public static class InsiderTradingQueryOrderExtensions
+{
+    public static IOrderedQueryable<InsiderTransaction> OrderNewestFirst(
+        this IQueryable<InsiderTransaction> query
+    )
+    {
+        return query
+            .OrderByDescending(t => t.TransactionDate)
+            .ThenByDescending(t => t.FilingDate)
+            .ThenBy(t => t.AccessionNumber)
+            .ThenBy(t => t.TransactionOrder)
+            .ThenBy(t => t.Id);
+    }
+
+    public static IOrderedQueryable<Form144Filing> OrderNewestFirst(
+        this IQueryable<Form144Filing> query
+    )
+    {
+        return query
+            .OrderByDescending(f => f.FilingDate)
+            .ThenBy(f => f.AccessionNumber)
+            .ThenBy(f => f.Id);
+    }
+
+    public static IOrderedQueryable<InsiderOwner> OrderDiscoveryMatches(
+        this IQueryable<InsiderOwner> query
+    )
+    {
+        return query
+            .OrderByDescending(o =>
+                o.Transactions.Max(t => (DateOnly?)t.TransactionDate) ?? DateOnly.MinValue
+            )
+            .ThenBy(o => o.Name)
+            .ThenBy(o => o.OwnerCik);
+    }
+}

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -176,10 +176,7 @@ public class InsiderTradingTools
                 }
 
                 var total = await query.CountAsync();
-                var transactions = await query
-                    .OrderByDescending(t => t.TransactionDate)
-                    .Take(maxResults)
-                    .ToListAsync();
+                var transactions = await query.OrderNewestFirst().Take(maxResults).ToListAsync();
 
                 if (transactions.Count == 0)
                     return filtered
@@ -288,14 +285,13 @@ public class InsiderTradingTools
                 // ranking: each row sits on its own split basis, and cutting on the raw
                 // counts would under-rank insiders whose last filing predates a large split
                 // (pre-split counts are smaller until restated).
+                var newestByStock = byStock.OrderNewestFirst();
                 var latestTransactions = await _transactionRepository
                     .GetByStockWithOwner(stock)
                     .Where(t =>
                         t.Id
-                        == byStock
+                        == newestByStock
                             .Where(t2 => t2.InsiderOwnerId == t.InsiderOwnerId)
-                            .OrderByDescending(t2 => t2.TransactionDate)
-                            .ThenByDescending(t2 => t2.FilingDate)
                             .Select(t2 => t2.Id)
                             .First()
                     )
@@ -426,7 +422,7 @@ public class InsiderTradingTools
                     return $"No Form 144 proposed sales found for {stock.Ticker}.";
 
                 var filings = await query
-                    .OrderByDescending(f => f.FilingDate)
+                    .OrderNewestFirst()
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
@@ -505,17 +501,8 @@ public class InsiderTradingTools
                 var matches = _ownerRepository.Search(query);
                 var total = await matches.CountAsync();
 
-                // Deterministic order: most recently active filers first (the insider the
-                // caller wants is far more likely among them than in an arbitrary
-                // Postgres-chosen subset of, say, 557 Smiths), then name/CIK as stable
-                // tie-breakers. The coalesce keeps never-filed owners last — Postgres
-                // sorts NULLs first on a DESC order.
                 var insiders = await matches
-                    .OrderByDescending(o =>
-                        o.Transactions.Max(t => (DateOnly?)t.TransactionDate) ?? DateOnly.MinValue
-                    )
-                    .ThenBy(o => o.Name)
-                    .ThenBy(o => o.OwnerCik)
+                    .OrderDiscoveryMatches()
                     .Skip(offset)
                     .Take(maxResults)
                     .ToListAsync();
@@ -530,14 +517,13 @@ public class InsiderTradingTools
                 // tools are keyed on.
                 var ownerIds = insiders.Select(i => i.Id).ToList();
                 var byOwners = _transactionRepository.GetByOwnerIds(ownerIds);
+                var newestByOwners = byOwners.OrderNewestFirst();
                 var latestByOwner = (
                     await byOwners
                         .Where(t =>
                             t.Id
-                            == byOwners
+                            == newestByOwners
                                 .Where(t2 => t2.InsiderOwnerId == t.InsiderOwnerId)
-                                .OrderByDescending(t2 => t2.TransactionDate)
-                                .ThenByDescending(t2 => t2.FilingDate)
                                 .Select(t2 => t2.Id)
                                 .First()
                         )

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
@@ -215,6 +215,39 @@ public class CongressToolsTests : ParadeDbMcpTestBase
         result.IndexOf("2026-03-15").Should().BeLessThan(result.IndexOf("2026-01-10"));
     }
 
+    [Fact]
+    public async Task GetCongressionalTrades_TiedDates_UseRowIdentityBeforeTheLimit()
+    {
+        var stock = NvdaStock();
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<CongressMember>().Add(pelosi);
+        var day = new DateOnly(2026, 3, 15);
+        var alpha = TradeFor(pelosi, stock, day, assetName: "Alpha Lot");
+        var bravo = TradeFor(pelosi, stock, day, assetName: "Bravo Lot");
+        var charlie = TradeFor(pelosi, stock, day, assetName: "Charlie Lot");
+        var delta = TradeFor(pelosi, stock, day, assetName: "Delta Lot");
+        alpha.Id = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        bravo.Id = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        charlie.Id = Guid.Parse("00000000-0000-0000-0000-000000000003");
+        delta.Id = Guid.Parse("00000000-0000-0000-0000-000000000004");
+        DbContext.Set<CongressionalTrade>().AddRange(delta, charlie, bravo, alpha);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetCongressionalTrades(
+                "NVDA",
+                startDate: "2026-01-01",
+                endDate: "2026-04-30",
+                maxResults: 2
+            );
+
+        result.Should().Contain("Alpha Lot");
+        result.Should().Contain("Bravo Lot");
+        result.Should().NotContain("Charlie Lot");
+        result.Should().NotContain("Delta Lot");
+    }
+
     // ── GetMemberTrades ──────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
@@ -96,6 +96,29 @@ public class Form144ProposedSalesToolTests : IDisposable
     }
 
     [Fact]
+    public async Task GetProposedSales_TiedDates_UseAccessionBeforeTheLimit()
+    {
+        var stock = SeedStock();
+        var day = new DateOnly(2026, 5, 27);
+        _dbContext
+            .Set<Form144Filing>()
+            .AddRange(
+                MakeFiling(stock.Id, "0004", day, "DELTA SELLER", 400),
+                MakeFiling(stock.Id, "0003", day, "CHARLIE SELLER", 300),
+                MakeFiling(stock.Id, "0002", day, "BRAVO SELLER", 200),
+                MakeFiling(stock.Id, "0001", day, "ALPHA SELLER", 100)
+            );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL", maxResults: 2);
+
+        result.Should().Contain("ALPHA SELLER");
+        result.Should().Contain("BRAVO SELLER");
+        result.Should().NotContain("CHARLIE SELLER");
+        result.Should().NotContain("DELTA SELLER");
+    }
+
+    [Fact]
     public async Task GetProposedSales_RespectsMaxResults()
     {
         var stock = SeedStock();

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -216,6 +216,39 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task GetInsiderTransactions_TiedDates_UseFilingIdentityBeforeTheLimit()
+    {
+        var stock = CreateStock("TIE", "Tie Corp.");
+        var alpha = CreateOwner("0001111101", "Alpha Insider");
+        var bravo = CreateOwner("0001111102", "Bravo Insider");
+        var charlie = CreateOwner("0001111103", "Charlie Insider");
+        var delta = CreateOwner("0001111104", "Delta Insider");
+        await SeedStock(stock);
+        await SeedOwner(alpha);
+        await SeedOwner(bravo);
+        await SeedOwner(charlie);
+        await SeedOwner(delta);
+
+        var day = new DateOnly(2026, 4, 23);
+        DbContext
+            .Set<InsiderTransaction>()
+            .AddRange(
+                CreateTransaction(stock, delta, day, day, accessionNumber: "0001-26-000004"),
+                CreateTransaction(stock, charlie, day, day, accessionNumber: "0001-26-000003"),
+                CreateTransaction(stock, bravo, day, day, accessionNumber: "0001-26-000002"),
+                CreateTransaction(stock, alpha, day, day, accessionNumber: "0001-26-000001")
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetInsiderTransactions("TIE", maxResults: 2);
+
+        result.Should().Contain("Alpha Insider");
+        result.Should().Contain("Bravo Insider");
+        result.Should().NotContain("Charlie Insider");
+        result.Should().NotContain("Delta Insider");
+    }
+
+    [Fact]
     public async Task GetInsiderTransactions_RespectsMaxResults()
     {
         var stock = CreateStock("AAPL", "Apple Inc.");
@@ -685,9 +718,10 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
         // Four owners tied on the name sort key so only the CIK tiebreak orders them —
         // exactly where a partial order would repeat or skip rows between offset pages.
         var ciks = new[] { "0000555001", "0000555002", "0000555003", "0000555004" };
+        var insertionOrder = new[] { ciks[3], ciks[1], ciks[0], ciks[2] };
         DbContext
             .Set<InsiderOwner>()
-            .AddRange(ciks.Select(cik => CreateOwner(cik: cik, name: "Paged Insider")));
+            .AddRange(insertionOrder.Select(cik => CreateOwner(cik: cik, name: "Paged Insider")));
         await DbContext.SaveChangesAsync();
 
         var page1 = await Sut().SearchInsiders("Paged", maxResults: 2);
@@ -695,10 +729,16 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
 
         var onPage1 = ciks.Where(c => page1.Contains(c)).ToList();
         var onPage2 = ciks.Where(c => page2.Contains(c)).ToList();
-        onPage1.Should().HaveCount(2);
-        onPage2.Should().HaveCount(2);
-        onPage1.Intersect(onPage2).Should().BeEmpty();
-        onPage1.Concat(onPage2).Should().BeEquivalentTo(ciks);
+        onPage1.Should().Equal(ciks[0], ciks[1]);
+        onPage2.Should().Equal(ciks[2], ciks[3]);
+        page1
+            .IndexOf(ciks[0], StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(page1.IndexOf(ciks[1], StringComparison.Ordinal));
+        page2
+            .IndexOf(ciks[2], StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(page2.IndexOf(ciks[3], StringComparison.Ordinal));
         page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
     }
 


### PR DESCRIPTION
## Summary
- centralize total ordering for insider transactions, proposed sales, insider discovery, and congressional trades
- apply stable keys before limits and offset paging
- preserve query translation for correlated latest-row reads
- pin tied-date limits and exact CIK page boundaries

## Verification
- Release integration build succeeded
- 73 related integration tests passed
- independent review found no remaining issues