### PR TITLE
fix(insiders): total-order null CIK discovery

### DIFF
--- a/src/Equibles.InsiderTrading.Data/Extensions/InsiderTradingQueryOrderExtensions.cs
+++ b/src/Equibles.InsiderTrading.Data/Extensions/InsiderTradingQueryOrderExtensions.cs
@@ -35,6 +35,7 @@ public static class InsiderTradingQueryOrderExtensions
                 o.Transactions.Max(t => (DateOnly?)t.TransactionDate) ?? DateOnly.MinValue
             )
             .ThenBy(o => o.Name)
-            .ThenBy(o => o.OwnerCik);
+            .ThenBy(o => o.OwnerCik)
+            .ThenBy(o => o.Id);
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -1,10 +1,12 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Repositories;
+using Equibles.InsiderTrading.Data.Extensions;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Mcp.Tools;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Mcp;
@@ -740,6 +742,26 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
             .Should()
             .BeLessThan(page2.IndexOf(ciks[3], StringComparison.Ordinal));
         page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
+    }
+
+    [Fact]
+    public async Task OrderDiscoveryMatches_NullCikTie_EndsWithOwnerId()
+    {
+        var first = CreateOwner(cik: null, name: "Null CIK Insider");
+        first.Id = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var second = CreateOwner(cik: null, name: "Null CIK Insider");
+        second.Id = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        DbContext.Set<InsiderOwner>().AddRange(second, first);
+        await DbContext.SaveChangesAsync();
+
+        var orderedIds = await DbContext
+            .Set<InsiderOwner>()
+            .Where(o => o.Name == "Null CIK Insider")
+            .OrderDiscoveryMatches()
+            .Select(o => o.Id)
+            .ToListAsync();
+
+        orderedIds.Should().Equal(first.Id, second.Id);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- finish insider discovery ordering with owner ID after nullable CIK
- cover tied null-CIK rows against PostgreSQL

## Validation

- Release integration build
- focused integration checks: 2 passed
- formatting and whitespace checks passed