### PR TITLE
fix(holdings): guard corpus boundary rankings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       ConnectionStrings__DefaultConnection: "Host=db;Database=equibles;Username=postgres;Password=postgres"
       McpApiKey: ${MCP_API_KEY:-}
       MinimumLogLevel: ${MINIMUM_LOG_LEVEL:-Warning}
+      Worker__MinSyncDate: ${Worker__MinSyncDate:-}
     depends_on:
       web:
         condition: service_healthy

--- a/src/Equibles.Holdings.BusinessLogic/HoldingsCorpusCoverage.cs
+++ b/src/Equibles.Holdings.BusinessLogic/HoldingsCorpusCoverage.cs
@@ -1,0 +1,85 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Core.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Holdings.BusinessLogic;
+
+/// <summary>
+/// Defines the first complete 13F report quarter implied by the ingest floor. Filings before
+/// that boundary are incidental and must not be ranked or used as a comparison baseline.
+/// </summary>
+[Service]
+public class HoldingsCorpusCoverage
+{
+    public static readonly DateOnly DefaultMinSyncDate = new(2020, 1, 1);
+
+    public static HoldingsCorpusCoverage Default { get; } = new(DefaultMinSyncDate);
+
+    public HoldingsCorpusCoverage(IOptions<WorkerOptions> workerOptions)
+        : this(
+            workerOptions.Value.MinSyncDate is { } configured
+                ? DateOnly.FromDateTime(configured)
+                : DefaultMinSyncDate
+        ) { }
+
+    internal HoldingsCorpusCoverage(DateOnly minSyncDate)
+    {
+        MinSyncDate = minSyncDate;
+        CoverageStartDate = FirstQuarterEndOnOrAfter(minSyncDate);
+    }
+
+    public DateOnly MinSyncDate { get; }
+
+    public DateOnly CoverageStartDate { get; }
+
+    public HoldingsCorpusStatus Evaluate(DateOnly reportDate, DateOnly? previousReportDate)
+    {
+        if (reportDate < CoverageStartDate)
+        {
+            return new HoldingsCorpusStatus(
+                CoverageStartDate,
+                IsWithinCoverage: false,
+                ComparisonAvailable: false,
+                $"Complete 13F coverage begins with {CoverageStartDate:yyyy-MM-dd}; "
+                    + $"{reportDate:yyyy-MM-dd} is outside the complete corpus."
+            );
+        }
+
+        if (previousReportDate is not { } previous || previous < CoverageStartDate)
+        {
+            var prior = previousReportDate is { } value
+                ? $"the prior {value:yyyy-MM-dd} report date predates"
+                : "there is no prior report date within";
+            return new HoldingsCorpusStatus(
+                CoverageStartDate,
+                IsWithinCoverage: true,
+                ComparisonAvailable: false,
+                $"Quarter-over-quarter comparison is unavailable because {prior} complete "
+                    + $"coverage, which begins {CoverageStartDate:yyyy-MM-dd}."
+            );
+        }
+
+        return new HoldingsCorpusStatus(
+            CoverageStartDate,
+            IsWithinCoverage: true,
+            ComparisonAvailable: true,
+            ComparisonUnavailableReason: null
+        );
+    }
+
+    public static DateOnly FirstQuarterEndOnOrAfter(DateOnly date)
+    {
+        var quarterEndMonth = ((date.Month - 1) / 3 + 1) * 3;
+        return new DateOnly(
+            date.Year,
+            quarterEndMonth,
+            DateTime.DaysInMonth(date.Year, quarterEndMonth)
+        );
+    }
+
+    public static DateOnly PreviousQuarterEnd(DateOnly quarterEnd)
+    {
+        var quarterStartMonth = ((quarterEnd.Month - 1) / 3) * 3 + 1;
+        return new DateOnly(quarterEnd.Year, quarterStartMonth, 1).AddDays(-1);
+    }
+}

--- a/src/Equibles.Holdings.BusinessLogic/HoldingsCorpusStatus.cs
+++ b/src/Equibles.Holdings.BusinessLogic/HoldingsCorpusStatus.cs
@@ -1,0 +1,8 @@
+namespace Equibles.Holdings.BusinessLogic;
+
+public sealed record HoldingsCorpusStatus(
+    DateOnly CoverageStartDate,
+    bool IsWithinCoverage,
+    bool ComparisonAvailable,
+    string ComparisonUnavailableReason
+);

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -57,6 +57,7 @@ public class InstitutionalHoldingsTools
     private readonly CommonStockRepository _commonStockRepository;
     private readonly StockSplitRepository _stockSplitRepository;
     private readonly StockCombinedQuarterService _combinedQuarterService;
+    private readonly HoldingsCorpusCoverage _corpusCoverage;
     private readonly McpToolRunner _runner;
 
     public InstitutionalHoldingsTools(
@@ -66,7 +67,8 @@ public class InstitutionalHoldingsTools
         StockSplitRepository stockSplitRepository,
         StockCombinedQuarterService combinedQuarterService,
         ErrorManager errorManager,
-        ILogger<InstitutionalHoldingsTools> logger
+        ILogger<InstitutionalHoldingsTools> logger,
+        HoldingsCorpusCoverage corpusCoverage = null
     )
     {
         _holdingRepository = holdingRepository;
@@ -74,6 +76,7 @@ public class InstitutionalHoldingsTools
         _commonStockRepository = commonStockRepository;
         _stockSplitRepository = stockSplitRepository;
         _combinedQuarterService = combinedQuarterService;
+        _corpusCoverage = corpusCoverage ?? HoldingsCorpusCoverage.Default;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -984,7 +987,7 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Get the market-wide 13F leaderboards for a given quarter — which stocks were most bought, most sold, most initiated, or most exited across all 13F filers vs the prior quarter. The `bucket` argument selects one of: top-buys (Δ shares > 0 ranked by Δ value desc), top-sells (Δ shares < 0 ranked by Δ value asc), new-positions (stocks ranked by count of filers initiating a position), sold-out-positions (stocks ranked by count of filers exiting). Δ Value is the change in stored quarter-end position value and includes the quarter's price move on held shares, so use Δ Shares to read the position change itself. Use this to answer 'what's the consensus 13F move this quarter?'"
+        "Get the market-wide 13F leaderboards for a given quarter — which stocks were most bought, most sold, most initiated, or most exited across all 13F filers vs the prior quarter. The `bucket` argument selects one of: top-buys (Δ shares > 0 ranked by Δ value desc), top-sells (Δ shares < 0 ranked by Δ value asc), new-positions (stocks ranked by count of filers initiating a position), sold-out-positions (stocks ranked by count of filers exiting). Δ Value is the change in stored quarter-end position value and includes the quarter's price move on held shares, so use Δ Shares to read the position change itself. The output publishes the first complete 13F report quarter and refuses comparisons that cross that corpus boundary. Use this to answer 'what's the consensus 13F move this quarter?'"
     )]
     public Task<string> GetMarketWide13FActivity(
         [Description("Bucket: top-buys, top-sells, new-positions, or sold-out-positions")]
@@ -1006,17 +1009,28 @@ public class InstitutionalHoldingsTools
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var (targetDate, previousDate, windowOpen, dateNote, error) =
+                var (targetDate, previousDate, windowOpen, dateNote, coverage, error) =
                     await ResolveMarketActivityDates(reportDate);
                 if (error != null)
                     return error;
+
+                if (!coverage.IsWithinCoverage || !coverage.ComparisonAvailable)
+                {
+                    return $"Market-wide 13F {normalizedBucket} for {FormatDate(targetDate)}\n"
+                        + $"_No ranking is available. {coverage.ComparisonUnavailableReason}_";
+                }
+
+                var comparisonDate = previousDate.Value;
 
                 // Headline + comparison subtitle.
                 var result = new StringBuilder();
                 result.AppendLine(
                     $"Market-wide 13F **{normalizedBucket}** for {FormatDate(targetDate)}"
                 );
-                result.AppendLine(PriorQuarterSubtitle(previousDate));
+                result.AppendLine(PriorQuarterSubtitle(comparisonDate));
+                result.AppendLine(
+                    $"Complete 13F coverage begins {FormatDate(coverage.CoverageStartDate)}"
+                );
                 if (dateNote != null)
                     result.AppendLine(dateNote);
                 if (windowOpen)
@@ -1031,7 +1045,7 @@ public class InstitutionalHoldingsTools
                     return await RenderMarketActivityMovers(
                         normalizedBucket,
                         targetDate,
-                        previousDate,
+                        comparisonDate,
                         windowOpen,
                         maxResults,
                         result
@@ -1042,7 +1056,7 @@ public class InstitutionalHoldingsTools
                     return await RenderMarketActivityChurn(
                         normalizedBucket,
                         targetDate,
-                        previousDate,
+                        comparisonDate,
                         windowOpen,
                         maxResults,
                         result
@@ -1056,9 +1070,10 @@ public class InstitutionalHoldingsTools
 
     private async Task<(
         DateOnly Target,
-        DateOnly Previous,
+        DateOnly? Previous,
         bool WindowOpen,
         string Note,
+        HoldingsCorpusStatus Coverage,
         string Error
     )> ResolveMarketActivityDates(string reportDate)
     {
@@ -1069,26 +1084,31 @@ public class InstitutionalHoldingsTools
         // 30s command timeout, so resolving off it cold timed out every first call.
         var reportDates = await _holdingRepository.Get13FAvailableReportDatesCached();
         if (reportDates.Count == 0)
-            return (default, default, false, null, "No 13F holdings data available.");
+            return (default, null, false, null, null, "No 13F holdings data available.");
 
         var (targetDate, note, error) = ResolveReportDateStrict(reportDate, reportDates);
         if (error != null)
-            return (default, default, false, null, error);
+            return (default, null, false, null, null, error);
 
         var targetIndex = IndexOfDate(reportDates, targetDate);
         if (targetIndex >= reportDates.Count - 1)
-            return (
-                default,
-                default,
-                false,
-                null,
-                $"No prior quarter to compare against for {FormatDate(targetDate)}."
-            );
+        {
+            var coverageWithoutPrior = _corpusCoverage.Evaluate(targetDate, null);
+            return (targetDate, null, false, note, coverageWithoutPrior, null);
+        }
 
         // While the newest quarter's filing window is open its leaderboards must use the
         // combined queries, or every fund that has not filed yet reads as a mass seller.
+        var previousDate = reportDates[targetIndex + 1];
         var windowOpen = targetIndex == 0 && CombinedQuarterHelper.IsFilingWindowOpen(targetDate);
-        return (targetDate, reportDates[targetIndex + 1], windowOpen, note, null);
+        return (
+            targetDate,
+            previousDate,
+            windowOpen,
+            note,
+            _corpusCoverage.Evaluate(targetDate, previousDate),
+            null
+        );
     }
 
     private static int IndexOfDate(IReadOnlyList<DateOnly> dates, DateOnly target)
@@ -1243,7 +1263,7 @@ public class InstitutionalHoldingsTools
 
     [McpServerTool(Name = "GetMostHeldStocks", Title = "Most Widely Held Stocks", ReadOnly = true)]
     [Description(
-        "Get the cross-sectional ranking of stocks by institutional 13F breadth for a given quarter. Returns the stocks ranked by number of 13F filers reporting them as a holding (default), by quarter-over-quarter change in filer count (warming names — 'filersDelta' — or cooling names — 'filersDeltaAsc'), or by total reported dollar value. Includes Δ filers vs the prior quarter, total value, Δ value, and the stock's share of the 13F universe. Only currently-held stocks rank; fully-sold-out names live in GetMarketWide13FActivity's sold-out-positions bucket. While the newest quarter's filing window is open, funds that have not filed yet are carried at their prior-quarter positions (noted in the output). Use this to answer 'which stocks are most owned by institutions right now, and is breadth expanding or contracting?'"
+        "Get the cross-sectional ranking of stocks by institutional 13F breadth for a given quarter. Returns the stocks ranked by number of 13F filers reporting them as a holding (default), by quarter-over-quarter change in filer count (warming names — 'filersDelta' — or cooling names — 'filersDeltaAsc'), or by total reported dollar value. Includes Δ filers vs the prior quarter, total value, Δ value, and the stock's share of the 13F universe. The output publishes the first complete 13F report quarter; earlier rankings are unavailable, and boundary-quarter deltas are withheld. Only currently-held stocks rank; fully-sold-out names live in GetMarketWide13FActivity's sold-out-positions bucket. While the newest quarter's filing window is open, funds that have not filed yet are carried at their prior-quarter positions (noted in the output). Use this to answer 'which stocks are most owned by institutions right now, and is breadth expanding or contracting?'"
     )]
     public Task<string> GetMostHeldStocks(
         [Description(
@@ -1269,17 +1289,34 @@ public class InstitutionalHoldingsTools
                         string.Join(", ", ValidMostHeldSorts)
                     );
 
-                var (targetDate, previousDate, windowOpen, dateNote, error) =
+                var (targetDate, previousDate, windowOpen, dateNote, coverage, error) =
                     await ResolveMarketActivityDates(reportDate);
                 if (error != null)
                     return error;
+
+                if (!coverage.IsWithinCoverage)
+                {
+                    return $"Most-held 13F ranking for {FormatDate(targetDate)} is unavailable. "
+                        + coverage.ComparisonUnavailableReason;
+                }
+
+                var deltaSort = normalizedSort is "filersdelta" or "filersdeltaasc";
+                if (deltaSort && !coverage.ComparisonAvailable)
+                {
+                    return $"Sort '{normalizedSort}' is unavailable for {FormatDate(targetDate)}. "
+                        + coverage.ComparisonUnavailableReason
+                        + " Use 'filers' or 'value' for the current-quarter ranking.";
+                }
+
+                var queryPreviousDate =
+                    previousDate ?? HoldingsCorpusCoverage.PreviousQuarterEnd(targetDate);
 
                 // Combined while the window is open — the as-filed ranking would order the
                 // whole market by which funds happened to file early. Snapshot-first like
                 // the movers/churn buckets; GetMostHeld's CurrentFilerCount > 0 filter and
                 // the sort run in memory over the ~6k mapped rows.
                 var ranking = (
-                    await LoadMarketActivity(targetDate, previousDate, windowOpen)
+                    await LoadMarketActivity(targetDate, queryPreviousDate, windowOpen)
                 ).Where(a => a.CurrentFilerCount > 0);
                 ranking = normalizedSort switch
                 {
@@ -1300,11 +1337,11 @@ public class InstitutionalHoldingsTools
                 if (rows.Count == 0)
                     return $"No stocks were held by 13F filers as of {FormatDate(targetDate)}.";
 
-                var universeFilers = await (
+                var universeFilers = await _holdingRepository.Get13FUniverseFilerCount(
+                    targetDate,
+                    queryPreviousDate,
                     windowOpen
-                        ? _holdingRepository.GetUniqueFilerIdsCombined(targetDate, previousDate)
-                        : _holdingRepository.GetUniqueFilerIds(targetDate)
-                ).CountAsync();
+                );
                 var stocks = await LoadStocksByIds(rows.Select(r => r.CommonStockId).ToList());
 
                 var table = RenderMostHeldStocksTable(
@@ -1312,11 +1349,16 @@ public class InstitutionalHoldingsTools
                     previousDate,
                     normalizedSort,
                     universeFilers,
+                    coverage.ComparisonAvailable,
                     rows,
                     stocks
                 );
                 var trailingNotes = JoinNotes(
                     dateNote,
+                    $"Coverage: complete 13F data begins {FormatDate(coverage.CoverageStartDate)}.",
+                    coverage.ComparisonAvailable
+                        ? null
+                        : $"Note: {coverage.ComparisonUnavailableReason} Delta columns are shown as —.",
                     windowOpen
                         ? $"Note: the {FormatDate(targetDate)} filing window is still open — "
                             + "funds that have not filed yet carry their prior-quarter positions."
@@ -1331,17 +1373,22 @@ public class InstitutionalHoldingsTools
 
     private static string RenderMostHeldStocksTable(
         DateOnly targetDate,
-        DateOnly previousDate,
+        DateOnly? previousDate,
         string sort,
         int universeFilers,
+        bool comparisonAvailable,
         List<MarketWideStockActivity> rows,
         IDictionary<Guid, CommonStock> stocks
     )
     {
         var result = new StringBuilder();
         result.AppendLine($"Most-held 13F stocks as of {FormatDate(targetDate)}");
+        var comparisonNote =
+            comparisonAvailable && previousDate.HasValue
+                ? PriorQuarterSubtitle(previousDate.Value)
+                : "No prior report quarter is available within complete coverage";
         result.AppendLine(
-            $"{PriorQuarterSubtitle(previousDate)} · {McpFormat.WholeNumber(universeFilers)} filers in the 13F universe"
+            $"{comparisonNote} · {McpFormat.WholeNumber(universeFilers)} filers in the 13F universe"
         );
         result.AppendLine($"Sorted by: {sort}");
         result.AppendLine();
@@ -1353,8 +1400,11 @@ public class InstitutionalHoldingsTools
             {
                 var (ticker, name) = ResolveStockCells(stocks, r.CommonStockId);
                 var pct = Percentage.Of(r.CurrentFilerCount, universeFilers);
-                var deltaFilers = r.CurrentFilerCount - r.PreviousFilerCount;
-                return $"| {rank} | {ticker} | {name} | {McpFormat.WholeNumber(r.CurrentFilerCount)} | {FormatSignedShares(deltaFilers)} | {FormatMillions(r.CurrentValue)} | {FormatSignedMillions(r.DeltaValue)} | {FormatPercent(pct)}% |";
+                var deltaFilers = comparisonAvailable
+                    ? FormatSignedShares(r.CurrentFilerCount - r.PreviousFilerCount)
+                    : "—";
+                var deltaValue = comparisonAvailable ? FormatSignedMillions(r.DeltaValue) : "—";
+                return $"| {rank} | {ticker} | {name} | {McpFormat.WholeNumber(r.CurrentFilerCount)} | {deltaFilers} | {FormatMillions(r.CurrentValue)} | {deltaValue} | {FormatPercent(pct)}% |";
             }
         );
         return result.ToString();

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -337,6 +337,33 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             .Distinct();
     }
 
+    // Snapshot-first denominator for public most-held rankings. Closed-quarter AUM snapshots
+    // already materialise the exact 13F filer universe, avoiding a corpus-wide DISTINCT that
+    // measured tens of seconds and could hit the command timeout. Missing, dirty, and zero-valued
+    // stubs fall back to the exact count until their snapshot rebuild completes. An open filing
+    // window still needs the combined universe because non-filers are carried forward.
+    public async Task<int> Get13FUniverseFilerCount(
+        DateOnly current,
+        DateOnly previous,
+        bool combined,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (!combined)
+        {
+            var snapshot = await DbContext
+                .Set<AumQuarterlySnapshot>()
+                .AsNoTracking()
+                .Where(s => s.ReportDate == current)
+                .Select(s => new { s.FilerCount, s.DirtyAt })
+                .SingleOrDefaultAsync(cancellationToken);
+            if (snapshot is { DirtyAt: null, FilerCount: > 0 })
+                return snapshot.FilerCount;
+        }
+
+        return await GetUniqueFilerIds(current, previous, combined).CountAsync(cancellationToken);
+    }
+
     // Earliest 13F quarter each of the given holders appears on — the "is this the
     // filer's first 13F?" test behind the new-filer annotation on the buyers/sellers
     // table. A brand-new filer entity (often a CIK migration of an existing manager)

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -87,6 +87,9 @@ public partial class Program
         builder.Services.Configure<Equibles.Media.BusinessLogic.Configuration.FileStorageOptions>(
             builder.Configuration.GetSection("FileStorage")
         );
+        builder.Services.Configure<Equibles.Core.Configuration.WorkerOptions>(
+            builder.Configuration.GetSection("Worker")
+        );
 
         builder.Services.AddEquiblesMcp(mcp =>
         {

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryMostHeldTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryMostHeldTests.cs
@@ -191,6 +191,67 @@ public class InstitutionalHoldingRepositoryMostHeldTests : IAsyncLifetime
         priorCount.Should().Be(1);
     }
 
+    [Fact]
+    public async Task Get13FUniverseFilerCount_ClosedQuarter_UsesMaterializedSnapshot()
+    {
+        await using var seed = FreshContext();
+        seed.Add(new AumQuarterlySnapshot { ReportDate = Current, FilerCount = 5_320 });
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var count = await sut.Get13FUniverseFilerCount(Current, Prior, combined: false);
+
+        count.Should().Be(5_320);
+    }
+
+    [Fact]
+    public async Task Get13FUniverseFilerCount_MissingSnapshot_FallsBackToExactDistinctCount()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "AAPL");
+        var h1 = await SeedHolder(seed, "h1");
+        var h2 = await SeedHolder(seed, "h2");
+        seed.Add(MakeHolding(stock, h1, Current, shares: 100, value: 100_000));
+        seed.Add(MakeHolding(stock, h2, Current, shares: 100, value: 100_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var count = await sut.Get13FUniverseFilerCount(Current, Prior, combined: false);
+
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Get13FUniverseFilerCount_DirtyZeroStub_FallsBackToExactDistinctCount()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "MSFT");
+        var h1 = await SeedHolder(seed, "dirty-h1");
+        var h2 = await SeedHolder(seed, "dirty-h2");
+        seed.Add(MakeHolding(stock, h1, Current, shares: 100, value: 100_000));
+        seed.Add(MakeHolding(stock, h2, Current, shares: 100, value: 100_000));
+        seed.Add(
+            new AumQuarterlySnapshot
+            {
+                ReportDate = Current,
+                FilerCount = 0,
+                DirtyAt = DateTime.UtcNow,
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var count = await sut.Get13FUniverseFilerCount(Current, Prior, combined: false);
+
+        count.Should().Be(2);
+    }
+
     private static async Task<CommonStock> SeedStock(
         Equibles.Data.EquiblesFinancialDbContext ctx,
         string ticker

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsCorpusBoundaryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsCorpusBoundaryTests.cs
@@ -1,0 +1,135 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsCorpusBoundaryTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsCorpusBoundaryTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetMostHeldStocks_FirstCoveredQuarter_HidesFabricatedDeltas()
+    {
+        var prior = new DateOnly(2019, 12, 31);
+        var current = new DateOnly(2020, 3, 31);
+        var stock = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft",
+            Cik = "C1",
+        };
+        var sparse = new InstitutionalHolder { Cik = "H1", Name = "Sparse filer" };
+        var currentOnly = new InstitutionalHolder { Cik = "H2", Name = "Current filer" };
+        DbContext.AddRange(stock, sparse, currentOnly);
+        DbContext.Add(MakeHolding(stock, sparse, prior, 1, 1));
+        DbContext.Add(MakeHolding(stock, sparse, current, 100, 100_000));
+        DbContext.Add(MakeHolding(stock, currentOnly, current, 200, 200_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var read = Fixture.CreateDbContext();
+        var output = await NewSut(read).GetMostHeldStocks("2020-03-31");
+
+        output.Should().Contain("MSFT");
+        output.Should().Contain("No prior report quarter is available within complete coverage");
+        output.Should().NotContain("Prior quarter: 2019-12-31");
+        output.Should().Contain("Delta columns are shown as —");
+        output.Should().NotContain("| +1 | 0.3 | +0.3 |");
+    }
+
+    [Fact]
+    public async Task GetMarketWide13FActivity_FirstCoveredQuarter_ReturnsNoComparisonRanking()
+    {
+        var prior = new DateOnly(2019, 12, 31);
+        var current = new DateOnly(2020, 3, 31);
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "C1",
+        };
+        var filer = new InstitutionalHolder { Cik = "H1", Name = "Filer" };
+        DbContext.AddRange(stock, filer);
+        DbContext.Add(MakeHolding(stock, filer, prior, 1, 1));
+        DbContext.Add(MakeHolding(stock, filer, current, 10_000, 10_000_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var read = Fixture.CreateDbContext();
+        var output = await NewSut(read).GetMarketWide13FActivity("top-buys", "2020-03-31");
+
+        output.Should().Contain("No ranking is available");
+        output.Should().Contain("complete coverage, which begins 2020-03-31");
+        output.Should().NotContain("AAPL");
+    }
+
+    [Fact]
+    public async Task GetMostHeldStocks_TargetBeforeCoverage_RejectsSparseRanking()
+    {
+        var prior = new DateOnly(2019, 9, 30);
+        var current = new DateOnly(2019, 12, 31);
+        var stock = new CommonStock
+        {
+            Ticker = "ARE",
+            Name = "Alexandria",
+            Cik = "C1",
+        };
+        var filer = new InstitutionalHolder { Cik = "H1", Name = "Filer" };
+        DbContext.AddRange(stock, filer);
+        DbContext.Add(MakeHolding(stock, filer, prior, 1, 0));
+        DbContext.Add(MakeHolding(stock, filer, current, 1, 0));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var read = Fixture.CreateDbContext();
+        var output = await NewSut(read).GetMostHeldStocks("2019-12-31");
+
+        output.Should().Contain("ranking for 2019-12-31 is unavailable");
+        output.Should().Contain("Complete 13F coverage begins with 2020-03-31");
+        output.Should().NotContain("ARE |");
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesFinancialDbContext dbContext) =>
+        new(
+            new InstitutionalHoldingRepository(dbContext),
+            new InstitutionalHolderRepository(dbContext),
+            new CommonStockRepository(dbContext),
+            new StockSplitRepository(dbContext),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(dbContext),
+                new StockSplitRepository(dbContext)
+            ),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{stock.Ticker}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterTests.cs
@@ -12,15 +12,9 @@ using NSubstitute;
 namespace Equibles.IntegrationTests.Mcp;
 
 /// <summary>
-/// Pins the "No prior quarter to compare against" arm of
-/// <c>ResolveMarketActivityDates</c> — the shared helper used by every
-/// market-activity MCP tool (GetMarketWide13FActivity, GetMostHeldStocks).
-/// When the database has exactly one report date, the helper must surface
-/// a user-friendly error rather than silently picking the same date for
-/// both `targetDate` and `previousDate` (which would dump a meaningless
-/// zero-delta table). A regression that removed the
-/// `targetIndex >= reportDates.Count - 1` guard would either index out of
-/// range (current crash) or, worse, produce phantom zero-delta output.
+/// Pins the clean-corpus boundary where the first covered report quarter is
+/// also the oldest available row. Current-quarter breadth remains valid, but
+/// no prior row exists and comparison columns must stay unavailable.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterTests
@@ -32,7 +26,7 @@ public class InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterT
         : base(fixture) { }
 
     [Fact]
-    public async Task GetMostHeldStocks_OnlyOneReportDateExists_ReturnsNoPriorQuarterError()
+    public async Task GetMostHeldStocks_OnlyCoveredReportDateExists_ServesRankingWithoutDeltas()
     {
         var current = new DateOnly(2024, 12, 31);
         var aapl = new CommonStock
@@ -63,8 +57,11 @@ public class InstitutionalHoldingsToolsResolveMarketActivityDatesNoPriorQuarterT
 
         var output = await sut.GetMostHeldStocks();
 
-        output.Should().Contain("No prior quarter to compare against");
-        output.Should().Contain("2024-12-31");
+        output.Should().Contain("Most-held 13F stocks as of 2024-12-31");
+        output.Should().Contain("AAPL");
+        output.Should().Contain("No prior report quarter is available within complete coverage");
+        output.Should().Contain("Delta columns are shown as —");
+        output.Should().NotContain("No prior quarter to compare against");
     }
 
     private static InstitutionalHolding MakeHolding(

--- a/tests/Equibles.UnitTests/Holdings/HoldingsCorpusCoverageTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsCorpusCoverageTests.cs
@@ -1,0 +1,75 @@
+using Equibles.Holdings.BusinessLogic;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsCorpusCoverageTests
+{
+    [Theory]
+    [InlineData("2020-01-01", "2020-03-31")]
+    [InlineData("2020-03-31", "2020-03-31")]
+    [InlineData("2020-04-01", "2020-06-30")]
+    [InlineData("2020-12-15", "2020-12-31")]
+    public void FirstQuarterEndOnOrAfter_MapsIngestFloorToCompleteReportQuarter(
+        string floor,
+        string expected
+    )
+    {
+        HoldingsCorpusCoverage
+            .FirstQuarterEndOnOrAfter(DateOnly.Parse(floor))
+            .Should()
+            .Be(DateOnly.Parse(expected));
+    }
+
+    [Theory]
+    [InlineData("2020-03-31", "2019-12-31")]
+    [InlineData("2020-06-30", "2020-03-31")]
+    [InlineData("2020-09-30", "2020-06-30")]
+    [InlineData("2020-12-31", "2020-09-30")]
+    public void PreviousQuarterEnd_ReturnsTheActualCalendarQuarterEnd(
+        string current,
+        string expected
+    )
+    {
+        HoldingsCorpusCoverage
+            .PreviousQuarterEnd(DateOnly.Parse(current))
+            .Should()
+            .Be(DateOnly.Parse(expected));
+    }
+
+    [Fact]
+    public void Evaluate_TargetBeforeCoverage_FlagsIncompleteRanking()
+    {
+        var sut = new HoldingsCorpusCoverage(new DateOnly(2020, 1, 1));
+
+        var status = sut.Evaluate(new DateOnly(2019, 12, 31), new DateOnly(2019, 9, 30));
+
+        status.CoverageStartDate.Should().Be(new DateOnly(2020, 3, 31));
+        status.IsWithinCoverage.Should().BeFalse();
+        status.ComparisonAvailable.Should().BeFalse();
+        status.ComparisonUnavailableReason.Should().Contain("outside the complete corpus");
+    }
+
+    [Fact]
+    public void Evaluate_FirstCoveredQuarter_NullsComparisonAgainstSparsePrior()
+    {
+        var sut = new HoldingsCorpusCoverage(new DateOnly(2020, 1, 1));
+
+        var status = sut.Evaluate(new DateOnly(2020, 3, 31), new DateOnly(2019, 12, 31));
+
+        status.IsWithinCoverage.Should().BeTrue();
+        status.ComparisonAvailable.Should().BeFalse();
+        status.ComparisonUnavailableReason.Should().Contain("prior 2019-12-31");
+    }
+
+    [Fact]
+    public void Evaluate_TwoCoveredQuarters_AllowsComparison()
+    {
+        var sut = new HoldingsCorpusCoverage(new DateOnly(2020, 1, 1));
+
+        var status = sut.Evaluate(new DateOnly(2020, 6, 30), new DateOnly(2020, 3, 31));
+
+        status.IsWithinCoverage.Should().BeTrue();
+        status.ComparisonAvailable.Should().BeTrue();
+        status.ComparisonUnavailableReason.Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderMostHeldStocksTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderMostHeldStocksTableCultureInvarianceTests.cs
@@ -39,7 +39,7 @@ public class InstitutionalHoldingsToolsRenderMostHeldStocksTableCultureInvarianc
             },
         };
         var stocks = new Dictionary<Guid, CommonStock>();
-        object[] args = [targetDate, previousDate, "filers", 1_234, rows, stocks];
+        object[] args = [targetDate, previousDate, "filers", 1_234, true, rows, stocks];
 
         var original = CultureInfo.CurrentCulture;
         string invariantOutput;


### PR DESCRIPTION
## Summary

- derive complete 13F coverage from the configured import start
- publish first-covered-quarter rankings without invalid quarter-over-quarter deltas
- reject pre-coverage dates and use an exact filer-count fallback for incomplete snapshots

## Verification

- Release builds passed for the integration and unit test projects
- 12 focused integration checks passed
- 12 focused unit checks passed
- formatting and diff checks passed
- independent review found no correctness or release blocker