### PR TITLE
fix: bound stock 13F dates and preserve queue identity

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
+++ b/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
@@ -49,10 +49,10 @@ public class StockCombinedQuarterService
         CancellationToken cancellationToken = default
     )
     {
-        var dates = await _holdingRepository
-            .Get13FReportDatesByStock(stock)
-            .Take(2)
-            .ToListAsync(cancellationToken);
+        var dates = (await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(
+            stock,
+            cancellationToken
+        )).Take(2).ToList();
         if (dates.Count == 0)
             return null;
 

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -101,9 +101,8 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = await _holdingRepository
-                    .Get13FReportDatesByStock(stock)
-                    .ToListAsync();
+                var reportDates =
+                    await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(stock);
                 if (reportDates.Count == 0)
                     return $"No institutional holdings data available for {ticker}.";
 
@@ -270,10 +269,11 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = await _holdingRepository
-                    .Get13FReportDatesByStock(stock)
+                var reportDates = (
+                    await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(stock)
+                )
                     .Take(McpLimit.Clamp(maxPeriods))
-                    .ToListAsync();
+                    .ToList();
 
                 if (reportDates.Count == 0)
                     return $"No institutional holdings history available for {ticker}.";
@@ -724,9 +724,8 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = await _holdingRepository
-                    .Get13FReportDatesByStock(stock)
-                    .ToListAsync();
+                var reportDates =
+                    await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(stock);
                 if (reportDates.Count == 0)
                     return $"No institutional holdings data available for {ticker}.";
 

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -233,6 +233,55 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     public IQueryable<DateOnly> Get13FReportDatesByStock(CommonStock stock) =>
         Get13FHistoryByStock(stock).DistinctReportDatesDescending();
 
+    // Snapshot-backed twin for request paths. The live DISTINCT above scans every historical
+    // position for a heavily held stock; under ingest pressure that scan exhausted the 30-second
+    // command timeout on NVDA, MU and MPWR. StockQuarterlyActivity already materialises exactly
+    // one 13F row per (stock, quarter), so rows with current holders are the authoritative cheap
+    // date spine once present. Sold-out rows remain in the snapshot to describe the exit but cannot
+    // be offered as a holdings quarter because they intentionally have no current positions.
+    //
+    // The newest live holding is checked separately because aggregate refresh follows ingestion:
+    // during that short lag, prepend the new quarter instead of serving a stale selector. A stock
+    // with no snapshot rows falls back to the live query so a newly listed company never loses its
+    // prior quarters while the aggregate backfill catches up.
+    public async Task<List<DateOnly>> Get13FReportDatesByStockSnapshotBacked(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var latestLiveDate = await Get13FHistoryByStock(stock)
+            .OrderByDescending(h => h.ReportDate)
+            .Select(h => (DateOnly?)h.ReportDate)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (latestLiveDate is not { } latest)
+        {
+            return [];
+        }
+
+        var dates = await DbContext
+            .Set<StockQuarterlyActivity>()
+            .Where(s =>
+                s.CommonStockId == stock.Id
+                && s.CurrentFilerCount > 0
+                && s.ReportDate <= latest
+            )
+            .OrderByDescending(s => s.ReportDate)
+            .Select(s => s.ReportDate)
+            .ToListAsync(cancellationToken);
+
+        if (dates.Count == 0)
+        {
+            return await Get13FReportDatesByStock(stock).ToListAsync(cancellationToken);
+        }
+
+        if (latest > dates[0])
+        {
+            dates.Insert(0, latest);
+        }
+
+        return dates;
+    }
+
     // Latest dates first — see GetAvailableReportDates for the ordering contract.
     public IQueryable<DateOnly> GetReportDatesByHolder(InstitutionalHolder holder) =>
         GetHistoryByHolder(holder).DistinctReportDatesDescending();

--- a/src/Equibles.Messaging/Attributes/ConsumerAttribute.cs
+++ b/src/Equibles.Messaging/Attributes/ConsumerAttribute.cs
@@ -9,6 +9,12 @@ public class ConsumerAttribute : Attribute
 {
     public bool AllowMultiple { get; }
 
+    /// <summary>
+    /// Exact durable receive-endpoint name. Set this when a consumer moves namespaces or hosts so
+    /// the existing SQL transport queue remains the single canonical subscription.
+    /// </summary>
+    public string EndpointName { get; set; }
+
     public ConsumerAttribute(bool allowMultiple = false)
     {
         AllowMultiple = allowMultiple;

--- a/src/Equibles.Messaging/Equibles.Messaging.csproj
+++ b/src/Equibles.Messaging/Equibles.Messaging.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <InternalsVisibleTo Include="Equibles.IntegrationTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MassTransit" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" />
     <PackageReference Include="MassTransit.SqlTransport.PostgreSQL" />

--- a/src/Equibles.Messaging/Extensions/MessagingServiceCollectionExtensions.cs
+++ b/src/Equibles.Messaging/Extensions/MessagingServiceCollectionExtensions.cs
@@ -94,9 +94,11 @@ public static class MessagingServiceCollectionExtensions
                 x.AddConsumer(consumerType)
                     .Endpoint(e =>
                     {
-                        e.Name = attribute.AllowMultiple
-                            ? $"{mainAssemblyName}-{consumerType.Namespace}-{consumerType.Name}".ToLowerInvariant()
-                            : $"{consumerType.Namespace}-{consumerType.Name}".ToLowerInvariant();
+                        e.Name = ResolveConsumerEndpointName(
+                            consumerType,
+                            attribute,
+                            mainAssemblyName
+                        );
                     });
             }
 
@@ -128,6 +130,36 @@ public static class MessagingServiceCollectionExtensions
             {
                 options.ConnectionString = configuration.GetConnectionString("TransportConnection");
             });
+    }
+
+    internal static string ResolveConsumerEndpointName(
+        Type consumerType,
+        ConsumerAttribute attribute,
+        string mainAssemblyName
+    )
+    {
+        if (attribute.EndpointName != null)
+        {
+            if (string.IsNullOrWhiteSpace(attribute.EndpointName))
+            {
+                throw new InvalidOperationException(
+                    $"Consumer {consumerType.FullName} has an empty endpoint-name override."
+                );
+            }
+
+            if (attribute.AllowMultiple)
+            {
+                throw new InvalidOperationException(
+                    $"Consumer {consumerType.FullName} cannot combine a fixed endpoint name with AllowMultiple."
+                );
+            }
+
+            return attribute.EndpointName;
+        }
+
+        return attribute.AllowMultiple
+            ? $"{mainAssemblyName}-{consumerType.Namespace}-{consumerType.Name}".ToLowerInvariant()
+            : $"{consumerType.Namespace}-{consumerType.Name}".ToLowerInvariant();
     }
 
     private static bool IsSystemAssembly(Assembly assembly)

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -801,14 +801,15 @@ public class StockTabService
     // Report dates for the holdings tab, newest first, clamped to the sync
     // floor: quarters before it hold partial filings, so their dates must not
     // appear in the selector, the stats, or the combined view's quarter pair.
-    private Task<List<DateOnly>> LoadClampedReportDates(CommonStock stock)
+    private async Task<List<DateOnly>> LoadClampedReportDates(CommonStock stock)
     {
-        var datesQuery = _institutionalHoldingRepository.Get13FReportDatesByStock(stock);
+        IEnumerable<DateOnly> dates =
+            await _institutionalHoldingRepository.Get13FReportDatesByStockSnapshotBacked(stock);
         if (_minSyncDate is { } minDate)
         {
-            datesQuery = datesQuery.Where(d => d >= minDate);
+            dates = dates.Where(d => d >= minDate);
         }
-        return datesQuery.ToListAsync();
+        return dates.ToList();
     }
 
     // Mirrors the header-stat semantics per report date: Shares summed over every

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
@@ -78,6 +78,187 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
         dates.Should().Equal(q3, q2, q1);
     }
 
+    [Fact]
+    public async Task Get13FReportDatesByStockSnapshotBacked_ReturnsSnapshotDatesNewestFirst()
+    {
+        var stock = Stock("MSFT");
+        var holder = Holder("0000000005");
+        var q1 = new DateOnly(2024, 3, 31);
+        var q2 = new DateOnly(2024, 6, 30);
+
+        _dbContext.AddRange(stock, holder);
+        _dbContext.Set<StockQuarterlyActivity>().AddRange(
+            new StockQuarterlyActivity {
+                CommonStockId = stock.Id,
+                ReportDate = q1,
+                CurrentFilerCount = 1,
+            },
+            new StockQuarterlyActivity {
+                CommonStockId = stock.Id,
+                ReportDate = q2,
+                CurrentFilerCount = 1,
+            }
+        );
+        _dbContext.Set<InstitutionalHolding>().Add(
+            Holding(stock.Id, holder.Id, q2, FilingType.Form13F, "13F-Q2")
+        );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
+
+        dates.Should().Equal(q2, q1);
+    }
+
+    [Fact]
+    public async Task Get13FReportDatesByStockSnapshotBacked_PrependsNewestLiveQuarterDuringRefreshLag()
+    {
+        var stock = Stock("NVDA");
+        var holder = Holder("0000000002");
+        var snapshotQuarter = new DateOnly(2024, 6, 30);
+        var liveQuarter = new DateOnly(2024, 9, 30);
+
+        _dbContext.AddRange(stock, holder);
+        _dbContext.Set<StockQuarterlyActivity>().Add(
+            new StockQuarterlyActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = snapshotQuarter,
+                CurrentFilerCount = 1,
+            }
+        );
+        _dbContext.Set<InstitutionalHolding>().Add(
+            Holding(stock.Id, holder.Id, liveQuarter, FilingType.Form13F, "13F-LIVE")
+        );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
+
+        dates.Should().Equal(liveQuarter, snapshotQuarter);
+    }
+
+    [Fact]
+    public async Task Get13FReportDatesByStockSnapshotBacked_ExcludesSoldOutSnapshotQuarter()
+    {
+        var stock = Stock("EXIT");
+        var holder = Holder("0000000004");
+        var heldQuarter = new DateOnly(2024, 3, 31);
+        var soldOutQuarter = new DateOnly(2024, 6, 30);
+
+        _dbContext.AddRange(stock, holder);
+        _dbContext.Set<StockQuarterlyActivity>().AddRange(
+            new StockQuarterlyActivity {
+                CommonStockId = stock.Id,
+                ReportDate = heldQuarter,
+                CurrentFilerCount = 1,
+            },
+            new StockQuarterlyActivity {
+                CommonStockId = stock.Id,
+                ReportDate = soldOutQuarter,
+                CurrentFilerCount = 0,
+                PreviousFilerCount = 1,
+                SoldOutFilerCount = 1,
+            }
+        );
+        _dbContext.Set<InstitutionalHolding>().Add(
+            Holding(stock.Id, holder.Id, heldQuarter, FilingType.Form13F, "13F-HELD")
+        );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
+
+        dates.Should().Equal(heldQuarter);
+    }
+
+    [Fact]
+    public async Task Get13FReportDatesByStockSnapshotBacked_DropsSnapshotNewerThanLiveHistory()
+    {
+        var stock = Stock("STALE");
+        var holder = Holder("0000000006");
+        var q1 = new DateOnly(2024, 3, 31);
+        var liveQuarter = new DateOnly(2024, 6, 30);
+        var staleSnapshotQuarter = new DateOnly(2024, 9, 30);
+
+        _dbContext.AddRange(stock, holder);
+        _dbContext.Set<StockQuarterlyActivity>().AddRange(
+            new StockQuarterlyActivity {
+                CommonStockId = stock.Id,
+                ReportDate = q1,
+                CurrentFilerCount = 1,
+            },
+            new StockQuarterlyActivity {
+                CommonStockId = stock.Id,
+                ReportDate = staleSnapshotQuarter,
+                CurrentFilerCount = 1,
+            }
+        );
+        _dbContext.Set<InstitutionalHolding>().Add(
+            Holding(stock.Id, holder.Id, liveQuarter, FilingType.Form13F, "13F-LIVE-Q2")
+        );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
+
+        dates.Should().Equal(liveQuarter, q1);
+    }
+
+    [Fact]
+    public async Task Get13FReportDatesByStockSnapshotBacked_ReturnsEmptyWhenSnapshotHasNoLiveHoldings()
+    {
+        var stock = Stock("EMPTY");
+        _dbContext.Add(stock);
+        _dbContext.Set<StockQuarterlyActivity>().Add(
+            new StockQuarterlyActivity {
+                CommonStockId = stock.Id,
+                ReportDate = new DateOnly(2024, 9, 30),
+                CurrentFilerCount = 1,
+            }
+        );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
+
+        dates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Get13FReportDatesByStockSnapshotBacked_FallsBackToLive13FHistoryWithoutSnapshot()
+    {
+        var stock = Stock("MU");
+        var holder = Holder("0000000003");
+        var q1 = new DateOnly(2024, 3, 31);
+        var q2 = new DateOnly(2024, 6, 30);
+        var schedule13GDate = new DateOnly(2024, 8, 12);
+
+        _dbContext.AddRange(stock, holder);
+        _dbContext.Set<InstitutionalHolding>().AddRange(
+            Holding(stock.Id, holder.Id, q1, FilingType.Form13F, "13F-Q1"),
+            Holding(stock.Id, holder.Id, q2, FilingType.Form13F, "13F-Q2"),
+            Holding(stock.Id, holder.Id, schedule13GDate, FilingType.Schedule13G, "13G")
+        );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
+
+        dates.Should().Equal(q2, q1);
+    }
+
+    private static CommonStock Stock(string ticker) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = $"{ticker} Inc.",
+            Cik = Guid.NewGuid().ToString("N")[..10],
+        };
+
+    private static InstitutionalHolder Holder(string cik) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Cik = cik,
+            Name = $"Holder {cik}",
+        };
+
     private static InstitutionalHolding Holding(
         Guid stockId,
         Guid holderId,

--- a/tests/Equibles.IntegrationTests/Messaging/MessagingServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Messaging/MessagingServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Equibles.Holdings.HostedService.Consumers;
+using Equibles.Messaging.Attributes;
 using Equibles.Messaging.Extensions;
 using MassTransit;
 using Microsoft.Extensions.Configuration;
@@ -47,5 +48,40 @@ public class MessagingServiceCollectionExtensionsTests
                 d => d.ImplementationType == typeof(StockCusipChangedConsumer),
                 "the [Consumer] assembly scan auto-registered the real consumer"
             );
+    }
+
+    [Fact]
+    public void ResolveConsumerEndpointName_WithExplicitOverride_PreservesDurableQueueIdentity()
+    {
+        const string legacyEndpoint =
+            "equibles.web.portal.consumers-clientdailylimitreachedconsumer";
+        var attribute = new ConsumerAttribute { EndpointName = legacyEndpoint };
+
+        var endpoint = MessagingServiceCollectionExtensions.ResolveConsumerEndpointName(
+            typeof(StockCusipChangedConsumer),
+            attribute,
+            "replacement-host"
+        );
+
+        endpoint.Should().Be(legacyEndpoint);
+    }
+
+    [Fact]
+    public void ResolveConsumerEndpointName_WithFixedBroadcastEndpoint_RejectsAmbiguousIdentity()
+    {
+        var attribute = new ConsumerAttribute(allowMultiple: true)
+        {
+            EndpointName = "shared-endpoint",
+        };
+
+        var act = () => MessagingServiceCollectionExtensions.ResolveConsumerEndpointName(
+            typeof(StockCusipChangedConsumer),
+            attribute,
+            "worker"
+        );
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*cannot combine a fixed endpoint name with AllowMultiple*");
     }
 }


### PR DESCRIPTION
## Summary\n\n- Avoid per-stock 13F report-date timeouts by reading the materialized quarterly activity spine.\n- Preserve durable SQL queue identity when a consumer moves between application hosts.\n\n## Code changes\n\n- Add a snapshot-backed holdings date query with live-data fallback and refresh-lag handling.\n- Exclude sold-out and stale snapshot quarters.\n- Route holdings request surfaces through the bounded date query.\n- Add an explicit consumer endpoint-name override with invalid-configuration guards.\n- Add regression coverage for holdings date semantics and endpoint resolution.\n\n## Verification\n\n- Release integration-project build: 0 errors.\n- Focused holdings and messaging tests: 10 passed.