### PR TITLE
chore: format recently merged holdings and messaging files

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
+++ b/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
@@ -49,10 +49,14 @@ public class StockCombinedQuarterService
         CancellationToken cancellationToken = default
     )
     {
-        var dates = (await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(
-            stock,
-            cancellationToken
-        )).Take(2).ToList();
+        var dates = (
+            await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(
+                stock,
+                cancellationToken
+            )
+        )
+            .Take(2)
+            .ToList();
         if (dates.Count == 0)
             return null;
 

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -101,8 +101,9 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates =
-                    await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(stock);
+                var reportDates = await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(
+                    stock
+                );
                 if (reportDates.Count == 0)
                     return $"No institutional holdings data available for {ticker}.";
 
@@ -724,8 +725,9 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates =
-                    await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(stock);
+                var reportDates = await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(
+                    stock
+                );
                 if (reportDates.Count == 0)
                     return $"No institutional holdings data available for {ticker}.";
 

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -261,9 +261,7 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         var dates = await DbContext
             .Set<StockQuarterlyActivity>()
             .Where(s =>
-                s.CommonStockId == stock.Id
-                && s.CurrentFilerCount > 0
-                && s.ReportDate <= latest
+                s.CommonStockId == stock.Id && s.CurrentFilerCount > 0 && s.ReportDate <= latest
             )
             .OrderByDescending(s => s.ReportDate)
             .Select(s => s.ReportDate)

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
@@ -87,21 +87,25 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
         var q2 = new DateOnly(2024, 6, 30);
 
         _dbContext.AddRange(stock, holder);
-        _dbContext.Set<StockQuarterlyActivity>().AddRange(
-            new StockQuarterlyActivity {
-                CommonStockId = stock.Id,
-                ReportDate = q1,
-                CurrentFilerCount = 1,
-            },
-            new StockQuarterlyActivity {
-                CommonStockId = stock.Id,
-                ReportDate = q2,
-                CurrentFilerCount = 1,
-            }
-        );
-        _dbContext.Set<InstitutionalHolding>().Add(
-            Holding(stock.Id, holder.Id, q2, FilingType.Form13F, "13F-Q2")
-        );
+        _dbContext
+            .Set<StockQuarterlyActivity>()
+            .AddRange(
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = q1,
+                    CurrentFilerCount = 1,
+                },
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = q2,
+                    CurrentFilerCount = 1,
+                }
+            );
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(Holding(stock.Id, holder.Id, q2, FilingType.Form13F, "13F-Q2"));
         await _dbContext.SaveChangesAsync(CancellationToken.None);
 
         var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
@@ -118,17 +122,19 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
         var liveQuarter = new DateOnly(2024, 9, 30);
 
         _dbContext.AddRange(stock, holder);
-        _dbContext.Set<StockQuarterlyActivity>().Add(
-            new StockQuarterlyActivity
-            {
-                CommonStockId = stock.Id,
-                ReportDate = snapshotQuarter,
-                CurrentFilerCount = 1,
-            }
-        );
-        _dbContext.Set<InstitutionalHolding>().Add(
-            Holding(stock.Id, holder.Id, liveQuarter, FilingType.Form13F, "13F-LIVE")
-        );
+        _dbContext
+            .Set<StockQuarterlyActivity>()
+            .Add(
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = snapshotQuarter,
+                    CurrentFilerCount = 1,
+                }
+            );
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(Holding(stock.Id, holder.Id, liveQuarter, FilingType.Form13F, "13F-LIVE"));
         await _dbContext.SaveChangesAsync(CancellationToken.None);
 
         var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
@@ -145,23 +151,27 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
         var soldOutQuarter = new DateOnly(2024, 6, 30);
 
         _dbContext.AddRange(stock, holder);
-        _dbContext.Set<StockQuarterlyActivity>().AddRange(
-            new StockQuarterlyActivity {
-                CommonStockId = stock.Id,
-                ReportDate = heldQuarter,
-                CurrentFilerCount = 1,
-            },
-            new StockQuarterlyActivity {
-                CommonStockId = stock.Id,
-                ReportDate = soldOutQuarter,
-                CurrentFilerCount = 0,
-                PreviousFilerCount = 1,
-                SoldOutFilerCount = 1,
-            }
-        );
-        _dbContext.Set<InstitutionalHolding>().Add(
-            Holding(stock.Id, holder.Id, heldQuarter, FilingType.Form13F, "13F-HELD")
-        );
+        _dbContext
+            .Set<StockQuarterlyActivity>()
+            .AddRange(
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = heldQuarter,
+                    CurrentFilerCount = 1,
+                },
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = soldOutQuarter,
+                    CurrentFilerCount = 0,
+                    PreviousFilerCount = 1,
+                    SoldOutFilerCount = 1,
+                }
+            );
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(Holding(stock.Id, holder.Id, heldQuarter, FilingType.Form13F, "13F-HELD"));
         await _dbContext.SaveChangesAsync(CancellationToken.None);
 
         var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
@@ -179,21 +189,25 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
         var staleSnapshotQuarter = new DateOnly(2024, 9, 30);
 
         _dbContext.AddRange(stock, holder);
-        _dbContext.Set<StockQuarterlyActivity>().AddRange(
-            new StockQuarterlyActivity {
-                CommonStockId = stock.Id,
-                ReportDate = q1,
-                CurrentFilerCount = 1,
-            },
-            new StockQuarterlyActivity {
-                CommonStockId = stock.Id,
-                ReportDate = staleSnapshotQuarter,
-                CurrentFilerCount = 1,
-            }
-        );
-        _dbContext.Set<InstitutionalHolding>().Add(
-            Holding(stock.Id, holder.Id, liveQuarter, FilingType.Form13F, "13F-LIVE-Q2")
-        );
+        _dbContext
+            .Set<StockQuarterlyActivity>()
+            .AddRange(
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = q1,
+                    CurrentFilerCount = 1,
+                },
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = staleSnapshotQuarter,
+                    CurrentFilerCount = 1,
+                }
+            );
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(Holding(stock.Id, holder.Id, liveQuarter, FilingType.Form13F, "13F-LIVE-Q2"));
         await _dbContext.SaveChangesAsync(CancellationToken.None);
 
         var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
@@ -206,13 +220,16 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
     {
         var stock = Stock("EMPTY");
         _dbContext.Add(stock);
-        _dbContext.Set<StockQuarterlyActivity>().Add(
-            new StockQuarterlyActivity {
-                CommonStockId = stock.Id,
-                ReportDate = new DateOnly(2024, 9, 30),
-                CurrentFilerCount = 1,
-            }
-        );
+        _dbContext
+            .Set<StockQuarterlyActivity>()
+            .Add(
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = new DateOnly(2024, 9, 30),
+                    CurrentFilerCount = 1,
+                }
+            );
         await _dbContext.SaveChangesAsync(CancellationToken.None);
 
         var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);
@@ -230,11 +247,13 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
         var schedule13GDate = new DateOnly(2024, 8, 12);
 
         _dbContext.AddRange(stock, holder);
-        _dbContext.Set<InstitutionalHolding>().AddRange(
-            Holding(stock.Id, holder.Id, q1, FilingType.Form13F, "13F-Q1"),
-            Holding(stock.Id, holder.Id, q2, FilingType.Form13F, "13F-Q2"),
-            Holding(stock.Id, holder.Id, schedule13GDate, FilingType.Schedule13G, "13G")
-        );
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .AddRange(
+                Holding(stock.Id, holder.Id, q1, FilingType.Form13F, "13F-Q1"),
+                Holding(stock.Id, holder.Id, q2, FilingType.Form13F, "13F-Q2"),
+                Holding(stock.Id, holder.Id, schedule13GDate, FilingType.Schedule13G, "13G")
+            );
         await _dbContext.SaveChangesAsync(CancellationToken.None);
 
         var dates = await _repository.Get13FReportDatesByStockSnapshotBacked(stock);

--- a/tests/Equibles.IntegrationTests/Messaging/MessagingServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Messaging/MessagingServiceCollectionExtensionsTests.cs
@@ -74,11 +74,12 @@ public class MessagingServiceCollectionExtensionsTests
             EndpointName = "shared-endpoint",
         };
 
-        var act = () => MessagingServiceCollectionExtensions.ResolveConsumerEndpointName(
-            typeof(StockCusipChangedConsumer),
-            attribute,
-            "worker"
-        );
+        var act = () =>
+            MessagingServiceCollectionExtensions.ResolveConsumerEndpointName(
+                typeof(StockCusipChangedConsumer),
+                attribute,
+                "worker"
+            );
 
         act.Should()
             .Throw<InvalidOperationException>()


### PR DESCRIPTION
## Summary
`dotnet csharpier check .` fails on main since the last holdings merges left five files unformatted, so the lint gate is red for every open PR.

## Code changes
Formatting only — `dotnet csharpier format .` across the tree; five files change, no behavior.