### PR TITLE
fix(sec): keep the NPORT-P reprocess ledger honest under timeouts and bad rows

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -124,22 +124,25 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
 
         var identifiers = El(element, "identifiers");
 
+        // Every bounded column is truncated to its MaxLength — a single malformed EDGAR line must
+        // surface as clipped text, not as a deterministic 22001 that fails the filing's insert on
+        // every reprocess attempt.
         return new NportHolding
         {
             Name = Truncate(name, 512),
             Title = Truncate(Clean(Val(element, "title")), 512),
-            Cusip = Clean(Val(element, "cusip")),
-            Isin = Clean(Attr(El(identifiers, "isin"), "value")),
-            Lei = Clean(Val(element, "lei")),
+            Cusip = Truncate(Clean(Val(element, "cusip")), 16),
+            Isin = Truncate(Clean(Attr(El(identifiers, "isin"), "value")), 32),
+            Lei = Truncate(Clean(Val(element, "lei")), 32),
             Balance = ParseDecimal(Val(element, "balance")),
-            Units = Clean(Val(element, "units")),
-            Currency = Clean(Val(element, "curCd")),
+            Units = Truncate(Clean(Val(element, "units")), 16),
+            Currency = Truncate(Clean(Val(element, "curCd")), 8),
             ValueUsd = valueUsd,
             PercentValue = ParseDecimal(Val(element, "pctVal")),
-            PayoffProfile = Clean(Val(element, "payoffProfile")),
-            AssetCategory = Clean(Val(element, "assetCat")),
-            IssuerCategory = ParseIssuerCategory(element),
-            InvestmentCountry = Clean(Val(element, "invCountry")),
+            PayoffProfile = Truncate(Clean(Val(element, "payoffProfile")), 16),
+            AssetCategory = Truncate(Clean(Val(element, "assetCat")), 16),
+            IssuerCategory = Truncate(ParseIssuerCategory(element), 16),
+            InvestmentCountry = Truncate(Clean(Val(element, "invCountry")), 8),
         };
     }
 

--- a/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
@@ -10,6 +10,7 @@ using Equibles.Sec.HostedService.Models;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace Equibles.Sec.HostedService.Services;
 
@@ -35,9 +36,10 @@ namespace Equibles.Sec.HostedService.Services;
 [Service]
 public class NportFilingReprocessManager
 {
-    // Cadence of the progress log line; each filing commits individually, so this is presentation
-    // only.
-    private const int ProgressLogInterval = 32;
+    // Page size of the id-only selection query and cadence of the progress log line. Each filing
+    // still loads, commits and releases individually — paging only avoids re-running the ordered
+    // selection (with its growing exclusion list) once per filing.
+    private const int BatchSize = 32;
 
     // After this many failed fetch/parse attempts a filing is advanced to the current version even
     // though its holdings were never re-derived, so a permanently-unfetchable filing (pulled
@@ -98,63 +100,100 @@ public class NportFilingReprocessManager
         var failedThisRun = new HashSet<Guid>();
         while (!cancellationToken.IsCancellationRequested)
         {
-            var filing = await _filingRepository
+            var page = await _filingRepository
                 .GetAll()
                 .Where(f => f.ParserVersion < NportFiling.CurrentParserVersion)
                 .Where(f => !failedThisRun.Contains(f.Id))
                 .OrderBy(f => f.FilingDate)
-                .Include(f => f.CommonStock)
-                .FirstOrDefaultAsync(cancellationToken);
+                .Select(f => f.Id)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken);
 
-            if (filing == null)
+            if (page.Count == 0)
                 break;
 
-            try
+            foreach (var filingId in page)
             {
-                result.HoldingsAdded += await ReprocessFiling(filing, cancellationToken);
-                result.Processed++;
-            }
-            catch (DbUpdateException ex)
-            {
-                // A concurrent ingest insert of the same filing or a similar conflict — the
-                // filing's replace rolled back; retry it next run without burning an attempt.
-                _logger.LogWarning(
-                    ex,
-                    "NPORT-P reprocess save failed for {AccessionNumber}; retrying next run",
-                    filing.AccessionNumber
-                );
-                failedThisRun.Add(filing.Id);
-                result.Failed++;
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                // One bad filing (e.g. a transient EDGAR 429/timeout) must not abort the run.
-                // Drop whatever partial graph the failure left tracked, then record the attempt
-                // on a freshly-loaded row; at the ceiling the filing is stamped current so it
-                // stops re-selecting itself forever.
-                _dbContext.ChangeTracker.Clear();
-                await RecordFailedAttempt(filing.Id, ex);
-                failedThisRun.Add(filing.Id);
-                result.Failed++;
-            }
-            finally
-            {
-                // Release the filing's tracked graph before selecting the next one.
-                _dbContext.ChangeTracker.Clear();
-            }
+                if (cancellationToken.IsCancellationRequested)
+                    break;
 
-            if ((result.Processed + result.Failed) % ProgressLogInterval == 0)
-                _logger.LogInformation(
-                    "NPORT-P reprocess: {Processed}/{Total} filings, holdings added={HoldingsAdded}, failed={Failed}",
-                    result.Processed,
-                    result.Total,
-                    result.HoldingsAdded,
-                    result.Failed
-                );
+                var filing = await _filingRepository
+                    .GetAll()
+                    .Include(f => f.CommonStock)
+                    .FirstOrDefaultAsync(f => f.Id == filingId, cancellationToken);
+
+                // Deleted (or already advanced) by a concurrent ingest since the page was taken.
+                if (filing == null || filing.ParserVersion >= NportFiling.CurrentParserVersion)
+                    continue;
+
+                try
+                {
+                    result.HoldingsAdded += await ReprocessFiling(filing, cancellationToken);
+                    result.Processed++;
+                }
+                catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+                {
+                    // A concurrent ingest inserted the same rows — the filing's replace rolled
+                    // back; retry it next run without burning an attempt.
+                    _logger.LogWarning(
+                        ex,
+                        "NPORT-P reprocess hit a concurrent-write conflict on {AccessionNumber}; retrying next run",
+                        filing.AccessionNumber
+                    );
+                    failedThisRun.Add(filing.Id);
+                    result.Failed++;
+                }
+                catch (Exception ex)
+                    when (ex is not OperationCanceledException
+                        || !cancellationToken.IsCancellationRequested
+                    )
+                {
+                    // One bad filing must not abort the run OR the attempt ledger. This arm also
+                    // owns EDGAR's per-request HttpClient timeout: it surfaces as
+                    // TaskCanceledException while our token stays uncancelled (the fetch takes no
+                    // token), and letting it escape would restart the run with a fresh
+                    // failedThisRun — the same slow filing re-selected first, forever, with no
+                    // attempt burned. Only a genuine shutdown (our token cancelled) propagates.
+                    // Drop whatever partial graph the failure left tracked, then record the
+                    // attempt on a freshly-loaded row; at the ceiling the filing is stamped
+                    // current so it stops re-selecting itself.
+                    _dbContext.ChangeTracker.Clear();
+                    await RecordFailedAttempt(filing.Id, ex, cancellationToken);
+                    failedThisRun.Add(filing.Id);
+                    result.Failed++;
+                }
+                finally
+                {
+                    // Release the filing's tracked graph before loading the next one.
+                    _dbContext.ChangeTracker.Clear();
+                }
+
+                if ((result.Processed + result.Failed) % BatchSize == 0)
+                    _logger.LogInformation(
+                        "NPORT-P reprocess: {Processed}/{Total} filings, holdings added={HoldingsAdded}, failed={Failed}",
+                        result.Processed,
+                        result.Total,
+                        result.HoldingsAdded,
+                        result.Failed
+                    );
+            }
         }
 
+        _logger.LogInformation(
+            "NPORT-P reprocess pass complete: {Processed}/{Total} filings, holdings added={HoldingsAdded}, failed={Failed}",
+            result.Processed,
+            result.Total,
+            result.HoldingsAdded,
+            result.Failed
+        );
         return result;
     }
+
+    // Only a unique violation is trusted as "another writer got there first" and retried without
+    // burning an attempt; every other database failure (e.g. a length or constraint violation) is
+    // deterministic for the filing and must count toward the ceiling.
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation };
 
     // Returns the number of holdings parsed onto the filing. Throws on any fetch/parse failure so
     // the caller can record the attempt and retry the filing on a later run. The EDGAR fetch and
@@ -237,10 +276,21 @@ public class NportFilingReprocessManager
         filing.ParserVersion = NportFiling.CurrentParserVersion;
         filing.ReprocessAttempts = 0;
 
-        // Replace the schedule without ever materializing the old rows: the set-based delete and
-        // the insert save commit together, so a failure rolls the filing back whole. The in-memory
-        // provider (tests) supports neither ExecuteDelete nor transactions; its fallback removes
-        // the tiny seeded schedule through the change tracker instead.
+        await ReplaceSchedule(filing, reparsedHoldings, cancellationToken);
+
+        return reparsedHoldings.Count;
+    }
+
+    // Replaces the stored schedule without ever materializing the old rows: the set-based delete
+    // and the insert save commit together, so a failure rolls the filing back whole. The in-memory
+    // provider (tests) supports neither ExecuteDelete nor transactions; its fallback removes the
+    // tiny seeded schedule through the change tracker instead.
+    private async Task ReplaceSchedule(
+        NportFiling filing,
+        List<NportHolding> reparsedHoldings,
+        CancellationToken cancellationToken
+    )
+    {
         if (_dbContext.Database.IsRelational())
         {
             await using var transaction = await _dbContext.Database.BeginTransactionAsync(
@@ -250,6 +300,8 @@ public class NportFilingReprocessManager
                 .Set<NportHolding>()
                 .Where(h => h.NportFilingId == filing.Id)
                 .ExecuteDeleteAsync(cancellationToken);
+            // The parser never sets the inverse NportFiling reference, so AddRange cannot reach
+            // (and mark Added) the untracked filing entity the parser built.
             _dbContext.Set<NportHolding>().AddRange(reparsedHoldings);
             await _filingRepository.SaveChanges();
             await transaction.CommitAsync(cancellationToken);
@@ -264,40 +316,61 @@ public class NportFilingReprocessManager
             _dbContext.Set<NportHolding>().AddRange(reparsedHoldings);
             await _filingRepository.SaveChanges();
         }
-
-        return reparsedHoldings.Count;
     }
 
     // Persists a failed attempt against a freshly-loaded filing row — the failed graph was just
     // dropped from the change tracker, so the stale instance must not be reused. At the attempt
     // ceiling the filing is advanced to the current version, keeping whatever holdings it already
-    // has, so it can't keep re-selecting itself.
-    private async Task RecordFailedAttempt(Guid filingId, Exception ex)
+    // has, so it can't keep re-selecting itself. Guarded so a failure while recording (row deleted
+    // concurrently, a save conflict) never aborts the run or masks the original exception.
+    private async Task RecordFailedAttempt(
+        Guid filingId,
+        Exception ex,
+        CancellationToken cancellationToken
+    )
     {
-        var filing = await _filingRepository.GetAll().FirstAsync(f => f.Id == filingId);
-
-        filing.ReprocessAttempts++;
-        if (filing.ReprocessAttempts >= MaxReprocessAttempts)
+        try
         {
-            filing.ParserVersion = NportFiling.CurrentParserVersion;
+            var filing = await _filingRepository
+                .GetAll()
+                .FirstOrDefaultAsync(f => f.Id == filingId, cancellationToken);
+            if (filing == null)
+                return;
+
+            filing.ReprocessAttempts++;
+            if (filing.ReprocessAttempts >= MaxReprocessAttempts)
+            {
+                filing.ParserVersion = NportFiling.CurrentParserVersion;
+                _logger.LogWarning(
+                    ex,
+                    "NPORT-P reprocess gave up on {AccessionNumber} after {Attempts} attempts; advancing it to the current version without re-deriving holdings",
+                    filing.AccessionNumber,
+                    filing.ReprocessAttempts
+                );
+            }
+            else
+            {
+                _logger.LogWarning(
+                    ex,
+                    "NPORT-P reprocess failed for {AccessionNumber} (attempt {Attempts}); retrying next run",
+                    filing.AccessionNumber,
+                    filing.ReprocessAttempts
+                );
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception recordEx)
+            when (recordEx is not OperationCanceledException
+                || !cancellationToken.IsCancellationRequested
+            )
+        {
             _logger.LogWarning(
-                ex,
-                "NPORT-P reprocess gave up on {AccessionNumber} after {Attempts} attempts; advancing it to the current version without re-deriving holdings",
-                filing.AccessionNumber,
-                filing.ReprocessAttempts
+                recordEx,
+                "NPORT-P reprocess could not record the failed attempt for filing {FilingId}",
+                filingId
             );
         }
-        else
-        {
-            _logger.LogWarning(
-                ex,
-                "NPORT-P reprocess failed for {AccessionNumber} (attempt {Attempts}); retrying next run",
-                filing.AccessionNumber,
-                filing.ReprocessAttempts
-            );
-        }
-
-        await _filingRepository.SaveChanges();
     }
 
     // The set of CUSIPs we track, loaded once per run and cached. Only consulted when a

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerRelationalTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerRelationalTests.cs
@@ -1,0 +1,159 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins the reprocess manager's RELATIONAL replace branch — the transaction + set-based
+/// ExecuteDelete that production runs — against real Postgres with lazy-loading proxies enabled,
+/// exactly the configuration whose Include/lazy-load of a six-figure schedule once OOM-killed the
+/// worker. The in-memory suite can only ever exercise the tracker-based fallback.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class NportFilingReprocessManagerRelationalTests : ParadeDbMcpTestBase
+{
+    public NportFilingReprocessManagerRelationalTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Run_FilingWithExistingHoldings_ReplacesScheduleThroughTheRelationalBranch()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BTEC",
+            Name = "Big Tech Index ETF",
+            Cik = "0001771146",
+        };
+        var filing = new NportFiling
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            AccessionNumber = "0001104659-26-000099",
+            FilingDate = new DateOnly(2026, 3, 30),
+            ReportPeriodDate = new DateOnly(2026, 2, 28),
+            ReportPeriodEnd = new DateOnly(2026, 2, 28),
+            ParserVersion = 1,
+        };
+        DbContext.Add(stock);
+        DbContext.Add(filing);
+        // A schedule left by the previous parser version — the relational branch must delete it
+        // set-based and land the reparsed rows in the same committed transaction.
+        DbContext.Add(
+            new NportHolding
+            {
+                Id = Guid.NewGuid(),
+                NportFilingId = filing.Id,
+                Name = "Stale Holding Corp",
+                Cusip = "STALE0001",
+                Balance = 1m,
+                ValueUsd = 1m,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var secClient = Substitute.For<ISecEdgarClient>();
+        secClient
+            .GetDocumentContent(filing.AccessionNumber, Arg.Any<string>())
+            .Returns(ValidNportSubmission);
+        var errorReporter = new ErrorReporter(
+            ServiceScopeSubstitute.Create(
+                (typeof(ErrorManager), new ErrorManager(new ErrorRepository(runCtx)))
+            ),
+            NullLogger<ErrorReporter>()
+        );
+        var manager = new NportFilingReprocessManager(
+            new NportFilingRepository(runCtx),
+            new CommonStockRepository(runCtx),
+            secClient,
+            runCtx,
+            errorReporter,
+            NullLogger<NportFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Processed.Should().Be(1);
+        result.HoldingsAdded.Should().Be(2);
+        result.Failed.Should().Be(0);
+
+        var reprocessed = await DbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        reprocessed.ParserVersion.Should().Be(NportFiling.CurrentParserVersion);
+        reprocessed.Holdings.Should().HaveCount(2);
+        reprocessed.Holdings.Should().NotContain(h => h.Name == "Stale Holding Corp");
+        reprocessed.Holdings.Should().Contain(h => h.Name == "Microsoft Corp");
+        reprocessed.ReportedHoldingCount.Should().Be(2);
+    }
+
+    // A trimmed NPORT-P submission with two holdings, laid out as real EDGAR filings are.
+    private const string ValidNportSubmission = """
+        <SEC-DOCUMENT>0001104659-26-000099.txt : 20260330
+        <DOCUMENT>
+        <TYPE>NPORT-P
+        <TEXT>
+        <XML>
+        <?xml version="1.0" encoding="UTF-8"?>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
+          <headerData>
+            <submissionType>NPORT-P</submissionType>
+          </headerData>
+          <formData>
+            <genInfo>
+              <regName>ETF Opportunities Trust</regName>
+              <seriesName>Big Tech Index ETF</seriesName>
+              <seriesId>S000087771</seriesId>
+              <repPdEnd>2026-08-31</repPdEnd>
+              <repPdDate>2026-02-28</repPdDate>
+              <isFinalFiling>N</isFinalFiling>
+            </genInfo>
+            <fundInfo>
+              <totAssets>287467294.33</totAssets>
+              <totLiabs>193875501.04</totLiabs>
+              <netAssets>93591793.29</netAssets>
+            </fundInfo>
+            <invstOrSecs>
+              <invstOrSec>
+                <name>AT&amp;T Inc</name>
+                <cusip>00206R102</cusip>
+                <balance>112500.00000000</balance>
+                <units>NS</units>
+                <curCd>USD</curCd>
+                <valUSD>1794375.00000000</valUSD>
+                <pctVal>1.92000000</pctVal>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+                <invCountry>US</invCountry>
+              </invstOrSec>
+              <invstOrSec>
+                <name>Microsoft Corp</name>
+                <cusip>594918104</cusip>
+                <balance>5000.00000000</balance>
+                <units>NS</units>
+                <curCd>USD</curCd>
+                <valUSD>2100000.00000000</valUSD>
+                <pctVal>2.24000000</pctVal>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+                <invCountry>US</invCountry>
+              </invstOrSec>
+            </invstOrSecs>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        </TEXT>
+        </DOCUMENT>
+        </SEC-DOCUMENT>
+        """;
+}

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
@@ -83,6 +83,32 @@ public class NportFilingReprocessManagerTests
     }
 
     [Fact]
+    public async Task Run_EdgarRequestTimeout_BurnsAnAttemptInsteadOfAbortingTheRun()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        var stock = SeedStock(dbContext);
+        SeedFiling(dbContext, stock, parserVersion: 0);
+        // The EDGAR client's HttpClient timeout surfaces as TaskCanceledException while the run's
+        // own token stays live — it must burn an attempt like any other fetch failure, not escape
+        // and abort the run (which would re-select the same slow filing first, forever).
+        secClient
+            .GetDocumentContent(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(
+                Task.FromException<string>(
+                    new TaskCanceledException("HttpClient.Timeout of 120 seconds elapsed")
+                )
+            );
+
+        var result = await manager.Run();
+
+        result.Processed.Should().Be(0);
+        result.Failed.Should().Be(1);
+        var filing = await dbContext.Set<NportFiling>().SingleAsync();
+        filing.ReprocessAttempts.Should().Be(1);
+        filing.ParserVersion.Should().Be(0);
+    }
+
+    [Fact]
     public async Task Run_FilingAlreadyAtCurrentVersion_IsLeftUntouched()
     {
         var (manager, dbContext, secClient) = CreateManagerWithDeps();


### PR DESCRIPTION
## Summary
Follow-up to #4358 hardening the per-filing reprocess loop. A post-merge review flagged two ways a poison filing dodges the `MaxReprocessAttempts` ceiling, and the first fired in production within an hour: EDGAR's 120-second HttpClient timeout surfaces as `TaskCanceledException` with the run's token still live, escaped the `is not OperationCanceledException` filter, and aborted the whole cycle without burning an attempt — a permanently slow filing would be re-selected first forever.

## Code changes
- `NportFilingReprocessManager`: the failure arm now swallows non-shutdown cancellations and burns an attempt (only a genuine stop propagates); the no-attempt exemption for `DbUpdateException` is scoped to Postgres unique violations (the concurrent-ingest race) so deterministic write failures count toward the ceiling; `RecordFailedAttempt` is guarded, null-safe and cancellable; the selection query pages 32 ids at a time instead of one ordered query per filing; an end-of-run summary always logs; the replace block is extracted to `ReplaceSchedule`.
- `NportFilingProcessor`: every bounded `NportHolding` column (Cusip, Isin, Lei, Units, Currency, PayoffProfile, AssetCategory, IssuerCategory, InvestmentCountry) is truncated to its MaxLength so one malformed EDGAR line degrades to clipped text instead of a filing that can never be written.
- Tests: an in-memory regression for the timeout-burns-an-attempt contract, and a ParadeDB-backed test that exercises the real transactional `ExecuteDelete` replace branch (the in-memory provider can only run the tracker fallback). Full integration suite green locally (2,518 tests).