### PR TITLE
fix(prices): enforce traded and current listing data

### DIFF
--- a/src/Equibles.CommonStocks.Data/Helpers/CikNormalizer.cs
+++ b/src/Equibles.CommonStocks.Data/Helpers/CikNormalizer.cs
@@ -1,0 +1,24 @@
+namespace Equibles.CommonStocks.Data.Helpers;
+
+public static class CikNormalizer
+{
+    public const int MaxLength = 16;
+
+    // Validates a caller/provider CIK while preserving its stored zero-padding.
+    public static string Validate(string cik)
+    {
+        if (string.IsNullOrWhiteSpace(cik))
+            return null;
+
+        var digits = cik.Trim();
+        return
+            digits.Length <= MaxLength
+            && digits.Any(character => character != '0')
+            && digits.All(char.IsAsciiDigit)
+            ? digits
+            : null;
+    }
+
+    // Canonical identity form for comparing differently padded authoritative CIKs.
+    public static string Canonicalize(string cik) => Validate(cik)?.TrimStart('0');
+}

--- a/src/Equibles.CommonStocks.Data/Helpers/CommonStockListingSyncLock.cs
+++ b/src/Equibles.CommonStocks.Data/Helpers/CommonStockListingSyncLock.cs
@@ -1,0 +1,31 @@
+namespace Equibles.CommonStocks.Data.Helpers;
+
+/// <summary>
+/// Serializes the worker's independent SEC-company and external-reference writers while they
+/// reconcile <c>SecondaryTickers</c>. Both writers run in the one worker process; without this
+/// gate, either can save a list computed before the other's authoritative subset changed.
+/// </summary>
+public static class CommonStockListingSyncLock
+{
+    private static readonly SemaphoreSlim Gate = new(1, 1);
+
+    public static async Task<IDisposable> Acquire(CancellationToken cancellationToken = default)
+    {
+        await Gate.WaitAsync(cancellationToken);
+        return new Releaser();
+    }
+
+    private sealed class Releaser : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            Gate.Release();
+        }
+    }
+}

--- a/src/Equibles.CommonStocks.Data/Helpers/SecondaryTickerPolicy.cs
+++ b/src/Equibles.CommonStocks.Data/Helpers/SecondaryTickerPolicy.cs
@@ -33,6 +33,9 @@ public static class SecondaryTickerPolicy
             return null;
 
         var requested = TickerNormalizer.Normalize(requestedTicker);
+        if (requested == null)
+            return null;
+
         var candidates = requested.Contains('.')
             ? new[] { requested, requested.Replace('.', '-') }
             : new[] { requested };

--- a/src/Equibles.CommonStocks.Data/Helpers/TickerNormalizer.cs
+++ b/src/Equibles.CommonStocks.Data/Helpers/TickerNormalizer.cs
@@ -2,7 +2,42 @@ namespace Equibles.CommonStocks.Data.Helpers;
 
 public static class TickerNormalizer
 {
-    // Canonical ticker form for case-insensitive lookups. Upper-cases with the invariant
-    // culture so a host's locale (e.g. Turkish dotless-i) can't fork the mapping.
-    public static string Normalize(string ticker) => ticker.Trim().ToUpperInvariant();
+    public const int MaxListedLength = 32;
+    public const int MaxPrimaryLength = 16;
+
+    // Canonical ticker form for case-insensitive lookups. Invalid or oversized symbols fail
+    // closed so request-facing resolvers never query arbitrary text as a security identifier.
+    public static string Normalize(string ticker) => NormalizeListed(ticker);
+
+    /// <summary>
+    /// Canonical exact-listing symbol accepted from authoritative directories. Every symbol is
+    /// bounded to the database/API contract and contains only ASCII letters, digits, dots, and
+    /// dashes with at least one alphanumeric character.
+    /// </summary>
+    public static string NormalizeListed(string ticker)
+    {
+        if (string.IsNullOrWhiteSpace(ticker))
+            return null;
+
+        var trimmed = ticker.Trim();
+        if (
+            trimmed.Length > MaxListedLength
+            || !trimmed.Any(character => char.IsAsciiLetterOrDigit(character))
+            || trimmed.Any(character =>
+                !char.IsAsciiLetterOrDigit(character) && character != '-' && character != '.'
+            )
+        )
+            return null;
+
+        return trimmed.ToUpperInvariant();
+    }
+
+    public static string NormalizeDashListed(string ticker) =>
+        NormalizeListed(ticker)?.Replace('.', '-');
+
+    public static string NormalizePrimary(string ticker)
+    {
+        var normalized = NormalizeListed(ticker);
+        return normalized?.Length <= MaxPrimaryLength ? normalized : null;
+    }
 }

--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -61,6 +61,29 @@ public class CommonStock
         set;
     } = [];
 
+    /// <summary>
+    /// Active listed symbols established by an authoritative reference directory outside the
+    /// SEC company-ticker feed. The SEC sync folds these into <see cref="SecondaryTickers"/>
+    /// without owning or deleting them, so exchange-traded fund series survive its hourly
+    /// refresh while every existing ticker resolver continues to use one materialized list.
+    /// </summary>
+    public List<string> ReferenceTickers
+    {
+        get => field ?? [];
+        set;
+    } = [];
+
+    /// <summary>
+    /// Exact listed symbols whose full Yahoo history has been committed atomically. A reference
+    /// symbol absent from this set is still a grouped-daily bootstrap and must retry the deep
+    /// history fetch even after more forward bars arrive.
+    /// </summary>
+    public List<string> PriceHistoryBackfilledTickers
+    {
+        get => field ?? [];
+        set;
+    } = [];
+
     public List<string> SecondaryCiks
     {
         get => field ?? [];

--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -11,8 +11,42 @@ public static class CommonStockRepositoryExtensions
         string ticker
     )
     {
-        var stock = await repository.GetByTicker(TickerNormalizer.Normalize(ticker));
+        var normalized = TickerNormalizer.Normalize(ticker);
+        if (normalized == null)
+            return (null, $"Stock '{ticker}' not found.");
+
+        var stock = await repository.GetByTicker(normalized);
         return stock == null ? (null, $"Stock '{ticker}' not found.") : (stock, null);
+    }
+
+    // SEC CIKs appear padded and unpadded, while a surviving filer can also own a predecessor's
+    // CIK through SecondaryCiks. Resolve the canonical identity across both fields and fail closed
+    // when corrupted ownership maps the same CIK to more than one CommonStock.
+    public static async Task<CommonStock> GetByCikTolerant(
+        this CommonStockRepository repository,
+        string cik,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var validated = CikNormalizer.Validate(cik);
+        var canonical = CikNormalizer.Canonicalize(validated);
+        if (canonical == null)
+            return null;
+
+        var padded = canonical.PadLeft(10, '0');
+        var matches = await repository
+            .GetAll()
+            .Where(stock =>
+                stock.Cik == validated
+                || stock.Cik == canonical
+                || stock.Cik == padded
+                || stock.SecondaryCiks.Contains(validated)
+                || stock.SecondaryCiks.Contains(canonical)
+                || stock.SecondaryCiks.Contains(padded)
+            )
+            .Take(2)
+            .ToListAsync(cancellationToken);
+        return matches.Count == 1 ? matches[0] : null;
     }
 
     // Returns the subset of the given ids whose CommonStock still exists. Importers

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -521,7 +521,7 @@ public class ShortSqueezeScoreManager
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
         var cutoff = today.AddDays(-PriceHistoryCalendarDays);
         var bars = await _dailyStockPriceRepository
-            .GetByStocks(stockIds, cutoff, today)
+            .GetTradedByStocks(stockIds, cutoff, today)
             .Select(p => new
             {
                 p.CommonStockId,

--- a/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
+++ b/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
@@ -128,7 +128,10 @@ public class BacktestPriceLoader
                     .GetAllSeries()
                     .Where(ListingPredicate(listingBatch))
                     .Where(price =>
-                        price.Date >= priceWindowFrom && price.Date <= to && price.Close > 0
+                        price.Date >= priceWindowFrom
+                        && price.Date <= to
+                        && price.Close > 0
+                        && price.Volume > 0
                     )
                     .Select(price => new LoadedPriceRow
                     {

--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -64,7 +64,10 @@ public class FundScoringManager
         string benchmarkTicker = DefaultBenchmark
     )
     {
-        benchmarkTicker = TickerNormalizer.Normalize(benchmarkTicker);
+        benchmarkTicker = TickerNormalizer.NormalizeDashListed(benchmarkTicker);
+
+        if (benchmarkTicker == null)
+            return null;
 
         var benchmarkStock = await _stockRepository.GetByTicker(benchmarkTicker);
         if (benchmarkStock == null)

--- a/src/Equibles.Holdings.BusinessLogic/HoldingsCloneBacktestProvider.cs
+++ b/src/Equibles.Holdings.BusinessLogic/HoldingsCloneBacktestProvider.cs
@@ -53,17 +53,30 @@ public class HoldingsCloneBacktestProvider
         string benchmark
     )
     {
+        var validatedCik = CikNormalizer.Validate(cik);
+        var normalizedBenchmark = string.IsNullOrWhiteSpace(benchmark)
+            ? DefaultBenchmark
+            : TickerNormalizer.NormalizeDashListed(benchmark);
         var outcome = new CloneBacktestOutcome
         {
-            Cik = cik,
-            Benchmark = string.IsNullOrWhiteSpace(benchmark)
-                ? DefaultBenchmark
-                : TickerNormalizer.Normalize(benchmark),
+            Cik = validatedCik ?? cik,
+            Benchmark = normalizedBenchmark,
             RequestedFrom = from,
             RequestedTo = to,
         };
 
-        var holder = await _holderRepository.GetByCik(cik);
+        if (validatedCik == null)
+        {
+            outcome.HolderNotFound = true;
+            return outcome;
+        }
+        if (normalizedBenchmark == null)
+        {
+            outcome.BenchmarkNotFound = true;
+            return outcome;
+        }
+
+        var holder = await _holderRepository.GetByCik(validatedCik);
         if (holder == null)
         {
             outcome.HolderNotFound = true;

--- a/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
@@ -64,7 +64,7 @@ public class SmartMoneyIndexManager
     )
     {
         topFunds = Math.Max(1, topFunds);
-        benchmarkTicker = TickerNormalizer.Normalize(benchmarkTicker);
+        benchmarkTicker = TickerNormalizer.NormalizeDashListed(benchmarkTicker);
 
         var result = new SmartMoneyIndexResult
         {
@@ -75,6 +75,12 @@ public class SmartMoneyIndexManager
             BenchmarkTicker = benchmarkTicker,
             AsOf = asOf,
         };
+
+        if (benchmarkTicker == null)
+        {
+            result.Reason = "Benchmark ticker is invalid.";
+            return result;
+        }
 
         var benchmarkStock = await _stockRepository.GetByTicker(benchmarkTicker);
         if (benchmarkStock == null)

--- a/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
+++ b/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
@@ -139,6 +139,11 @@ public class FundScoringWorker : BackgroundService
             .ToListAsync(cancellationToken);
 
         var benchmark = TickerNormalizer.Normalize(BenchmarkTicker);
+        if (benchmark == null)
+            throw new InvalidOperationException(
+                "The configured fund-scoring benchmark is invalid."
+            );
+
         var scoreStates = await dbContext
             .Set<FundScore>()
             .Where(s => s.WindowYears == WindowYears && s.BenchmarkTicker == benchmark)

--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.Data;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories.Models;
@@ -12,12 +13,19 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
 
     public async Task<InstitutionalHolder> GetByCik(string cik)
     {
-        return await GetAll().FirstOrDefaultAsync(h => h.Cik == cik);
+        var validatedCik = CikNormalizer.Validate(cik);
+        return validatedCik == null
+            ? null
+            : await GetAll().FirstOrDefaultAsync(h => h.Cik == validatedCik);
     }
 
     public IQueryable<InstitutionalHolder> GetByCiks(IEnumerable<string> ciks)
     {
-        return GetAll().Where(h => ciks.Contains(h.Cik));
+        var rawCiks = ciks?.ToList() ?? [];
+        var validatedCiks = rawCiks.Select(CikNormalizer.Validate).ToList();
+        return validatedCiks.Any(cik => cik == null)
+            ? GetAll().Where(_ => false)
+            : GetAll().Where(h => validatedCiks.Contains(h.Cik));
     }
 
     public IQueryable<InstitutionalHolder> Search(string search)
@@ -53,18 +61,22 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
     {
         var nameMatches = SearchNameTokens(search, requireAll: true);
         var exactCik = NormalizeExactCikQuery(search);
-        var primaryCikPrefix = $"{EscapeLikePattern(exactCik ?? search ?? string.Empty)}%";
-        var alternateCik = AlternateCikSpelling(exactCik);
-        var alternateCikPrefix =
-            alternateCik == null ? null : $"{EscapeLikePattern(alternateCik)}%";
-        var identityMatches = GetAll()
-            .Where(h =>
-                EF.Functions.ILike(h.Cik, primaryCikPrefix, LikePattern.EscapeChar)
-                || (
-                    alternateCikPrefix != null
-                    && EF.Functions.ILike(h.Cik, alternateCikPrefix, LikePattern.EscapeChar)
-                )
-            );
+        var identityMatches = GetAll().Where(_ => false);
+        if (exactCik != null)
+        {
+            var primaryCikPrefix = $"{EscapeLikePattern(exactCik)}%";
+            var alternateCik = AlternateCikSpelling(exactCik);
+            var alternateCikPrefix =
+                alternateCik == null ? null : $"{EscapeLikePattern(alternateCik)}%";
+            identityMatches = GetAll()
+                .Where(h =>
+                    EF.Functions.ILike(h.Cik, primaryCikPrefix, LikePattern.EscapeChar)
+                    || (
+                        alternateCikPrefix != null
+                        && EF.Functions.ILike(h.Cik, alternateCikPrefix, LikePattern.EscapeChar)
+                    )
+                );
+        }
 
         var strict = nameMatches.Concat(identityMatches);
         var aliasCik = InstitutionalHolderSearchAliases.ResolveCik(search);
@@ -372,13 +384,7 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
         };
     }
 
-    private static string NormalizeExactCikQuery(string search)
-    {
-        var trimmed = search?.Trim();
-        if (string.IsNullOrEmpty(trimmed) || !trimmed.All(char.IsAsciiDigit))
-            return null;
-        return trimmed;
-    }
+    private static string NormalizeExactCikQuery(string search) => CikNormalizer.Validate(search);
 
     // Both padded and unpadded CIK spellings exist in the holder table. Exact input wins;
     // this alternate is consulted only when the exact spelling has no row.

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -475,7 +475,9 @@ public class InsiderFilingReprocessManager
 
         var prices = await _dailyStockPriceRepository
             .GetAll()
-            .Where(p => p.CommonStockId == stockId && p.Date >= minDate && p.Date <= maxDate)
+            .Where(p =>
+                p.CommonStockId == stockId && p.Date >= minDate && p.Date <= maxDate && p.Volume > 0
+            )
             .Select(p => new
             {
                 p.Date,

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
@@ -213,7 +213,10 @@ public class InsiderTransactionPriceBackfillManager
         var rawPrices = await _dailyStockPriceRepository
             .GetAll()
             .Where(p =>
-                stockIds.Contains(p.CommonStockId) && p.Date >= minDate && p.Date <= maxDate
+                stockIds.Contains(p.CommonStockId)
+                && p.Date >= minDate
+                && p.Date <= maxDate
+                && p.Volume > 0
             )
             .Select(p => new
             {

--- a/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.Data;
 using Equibles.InsiderTrading.Data.Models;
 using Microsoft.EntityFrameworkCore;
@@ -12,12 +13,19 @@ public class InsiderOwnerRepository : BaseRepository<InsiderOwner>
 
     public async Task<InsiderOwner> GetByOwnerCik(string ownerCik)
     {
-        return await GetAll().FirstOrDefaultAsync(o => o.OwnerCik == ownerCik);
+        var validatedCik = CikNormalizer.Validate(ownerCik);
+        return validatedCik == null
+            ? null
+            : await GetAll().FirstOrDefaultAsync(o => o.OwnerCik == validatedCik);
     }
 
     public IQueryable<InsiderOwner> GetByOwnerCiks(IEnumerable<string> ownerCiks)
     {
-        return GetAll().Where(o => ownerCiks.Contains(o.OwnerCik));
+        var rawCiks = ownerCiks?.ToList() ?? [];
+        var validatedCiks = rawCiks.Select(CikNormalizer.Validate).ToList();
+        return validatedCiks.Any(cik => cik == null)
+            ? GetAll().Where(_ => false)
+            : GetAll().Where(o => validatedCiks.Contains(o.OwnerCik));
     }
 
     public IQueryable<InsiderOwner> Search(string search)

--- a/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
@@ -70,6 +70,9 @@ public class ChartSplit
 
 public class ChartMeta
 {
+    [JsonProperty("firstTradeDate")]
+    public long? FirstTradeDate { get; set; }
+
     // Exchange UTC offset in seconds. Yahoo stamps daily-bar timestamps in the
     // exchange's local time; this is how a UTC epoch maps back to the trading
     // day. Defaults to 0 when absent (UTC).

--- a/src/Equibles.Integrations.Yahoo/Models/YahooChartData.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/YahooChartData.cs
@@ -5,6 +5,7 @@ namespace Equibles.Integrations.Yahoo.Models;
 // callers get all three without a second HTTP round-trip.
 public class YahooChartData
 {
+    public DateOnly? FirstTradeDate { get; set; }
     public List<HistoricalPrice> Prices { get; set; } = [];
     public List<StockSplitEvent> Splits { get; set; } = [];
     public List<CashDividendEvent> Dividends { get; set; } = [];

--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -91,6 +91,9 @@ public class YahooFinanceClient : IYahooFinanceClient
 
         return new YahooChartData
         {
+            FirstTradeDate = result.Meta?.FirstTradeDate is > 0
+                ? FromUnixTimestamp(result.Meta.FirstTradeDate.Value + offsetSeconds)
+                : null,
             Prices = BuildPrices(result, ticker, offsetSeconds, startDate, endDate),
             Splits = BuildSplits(result.Events?.Splits, offsetSeconds, startDate, endDate),
             Dividends = BuildDividends(result.Events?.Dividends, offsetSeconds, startDate, endDate),

--- a/src/Equibles.Mcp/Equibles.Mcp.csproj
+++ b/src/Equibles.Mcp/Equibles.Mcp.csproj
@@ -9,4 +9,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Equibles.Mcp/McpToolExecutor.cs
+++ b/src/Equibles.Mcp/McpToolExecutor.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Equibles.CommonStocks.Data.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Equibles.Mcp;
@@ -34,7 +35,8 @@ public static class McpToolExecutor
 
     public static string StockNotFound(string ticker) => $"Stock '{ticker}' not found.";
 
-    public static string NormalizeTicker(string ticker) => ticker.Trim().ToUpperInvariant();
+    public static string NormalizeTicker(string ticker) =>
+        TickerNormalizer.NormalizeDashListed(ticker);
 
     public static async Task<string> Execute(
         Func<Task<string>> action,

--- a/src/Equibles.Migrations/Migrations/20260811175947_AddReferenceTickers.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260811175947_AddReferenceTickers.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811175947_AddReferenceTickers")]
+    partial class AddReferenceTickers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260811175947_AddReferenceTickers.cs
+++ b/src/Equibles.Migrations/Migrations/20260811175947_AddReferenceTickers.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReferenceTickers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<string>>(
+                name: "PriceHistoryBackfilledTickers",
+                table: "CommonStock",
+                type: "text[]",
+                nullable: true);
+
+            migrationBuilder.AddColumn<List<string>>(
+                name: "ReferenceTickers",
+                table: "CommonStock",
+                type: "text[]",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PriceHistoryBackfilledTickers",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "ReferenceTickers",
+                table: "CommonStock");
+        }
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
@@ -262,19 +263,22 @@ public class FinancialFactsTools
                 if (string.IsNullOrWhiteSpace(tickers))
                     return "At least one ticker is required.";
 
-                var requested = tickers
-                    .Split(
-                        ',',
-                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
-                    )
-                    .Select(t => t.ToUpperInvariant())
-                    .Distinct()
-                    .ToList();
-
-                if (requested.Count == 0)
+                var segments = tickers.Split(',').Select(ticker => ticker.Trim()).ToList();
+                if (segments.All(string.IsNullOrWhiteSpace))
                     return "At least one ticker is required.";
-                if (requested.Count > MaxTickers)
-                    return $"Too many tickers ({requested.Count}). The maximum is {MaxTickers}.";
+                if (segments.Count > MaxTickers)
+                    return $"Too many tickers ({segments.Count}). The maximum is {MaxTickers}.";
+
+                var requested = new List<string>();
+                var seenTickers = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var segment in segments)
+                {
+                    var normalizedTicker = TickerNormalizer.NormalizeDashListed(segment);
+                    if (normalizedTicker == null)
+                        return $"Invalid ticker '{segment}'. Use 1-32 ASCII letters, digits, dots, or dashes.";
+                    if (seenTickers.Add(normalizedTicker))
+                        requested.Add(normalizedTicker);
+                }
 
                 var conceptPriority = await ResolveConceptPriority(conceptRefs);
                 if (conceptPriority.Count == 0)

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Configuration;
@@ -78,12 +79,24 @@ public class CompanySyncService : ICompanySyncService
                 );
             }
 
+            using var listingSync = await CommonStockListingSyncLock.Acquire();
             using var scope = _serviceScopeFactory.CreateScope();
             var state = await BuildSyncState(secCompanies, scope);
 
             foreach (var secCompany in secCompanies)
             {
-                if (state.SecondaryCikToParent.TryGetValue(secCompany.Cik, out var parent))
+                var canonicalCik = CikNormalizer.Canonicalize(secCompany.Cik);
+                if (canonicalCik == null)
+                {
+                    _logger.LogWarning(
+                        "Company {CompanyName} has an invalid CIK {Cik}, skipping",
+                        secCompany.Name,
+                        secCompany.Cik
+                    );
+                    continue;
+                }
+
+                if (state.SecondaryCikToParent.TryGetValue(canonicalCik, out var parent))
                 {
                     _logger.LogDebug(
                         "Skipping subsidiary CIK {Cik} ({Name}) — already attached to parent {ParentTicker} (CIK: {ParentCik})",
@@ -95,7 +108,14 @@ public class CompanySyncService : ICompanySyncService
                     continue;
                 }
 
-                var primaryTicker = secCompany.Tickers.FirstOrDefault();
+                var normalizedTickers = secCompany
+                    .Tickers.Select(TickerNormalizer.NormalizeListed)
+                    .Where(ticker => ticker != null)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                var primaryTicker = normalizedTickers.FirstOrDefault(ticker =>
+                    ticker.Length <= TickerNormalizer.MaxPrimaryLength
+                );
                 if (string.IsNullOrEmpty(primaryTicker))
                 {
                     _logger.LogWarning(
@@ -106,9 +126,13 @@ public class CompanySyncService : ICompanySyncService
                     continue;
                 }
 
-                var secondaryTickers = secCompany.Tickers.Skip(1).ToList();
+                var secondaryTickers = normalizedTickers
+                    .Where(ticker =>
+                        !string.Equals(ticker, primaryTicker, StringComparison.OrdinalIgnoreCase)
+                    )
+                    .ToList();
 
-                if (state.ExistingCiks.Contains(secCompany.Cik))
+                if (state.ExistingCiks.Contains(canonicalCik))
                 {
                     await UpdateExistingStock(secCompany, primaryTicker, secondaryTickers, state);
                 }
@@ -146,15 +170,23 @@ public class CompanySyncService : ICompanySyncService
             scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var commonStockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
-        var secCiks = secCompanies.Select(c => c.Cik).ToHashSet();
+        var secCiks = secCompanies
+            .Select(company => CikNormalizer.Canonicalize(company.Cik))
+            .Where(cik => cik != null)
+            .ToHashSet(StringComparer.Ordinal);
 
         // Load every existing stock so we can detect subsidiaries already attached
         // as SecondaryCiks on prior syncs. We can't filter by SEC CIKs alone because
         // the subsidiary's CIK won't match any incoming primary CIK — it lives only
         // inside another stock's SecondaryCiks list.
         var allExistingStocks = await commonStockRepository.GetAll().ToListAsync();
-        var existingStocks = allExistingStocks.Where(cs => secCiks.Contains(cs.Cik)).ToList();
-        var existingCiks = existingStocks.Select(cs => cs.Cik).ToHashSet();
+        var existingStocks = allExistingStocks
+            .Where(stock => secCiks.Contains(CikNormalizer.Canonicalize(stock.Cik)))
+            .ToList();
+        var existingCiks = existingStocks
+            .Select(stock => CikNormalizer.Canonicalize(stock.Cik))
+            .Where(cik => cik != null)
+            .ToHashSet(StringComparer.Ordinal);
 
         // Build the ticker → stock lookup over every row so ReplaceObsoleteStock can find
         // a ticker holder whose own CIK dropped out of SEC's feed but who still owns the
@@ -197,8 +229,16 @@ public class CompanySyncService : ICompanySyncService
         StockSyncState state
     )
     {
-        var existingStock = state.ExistingStocks.First(cs => cs.Cik == secCompany.Cik);
+        var canonicalCik = CikNormalizer.Canonicalize(secCompany.Cik);
+        var existingStock = state.ExistingStocks.First(stock =>
+            CikNormalizer.Canonicalize(stock.Cik) == canonicalCik
+        );
         var normalizedName = NormalizeCompanyName(secCompany.Name);
+        var combinedSecondaryTickers = MergeSecondaryTickers(
+            primaryTicker,
+            secondaryTickers,
+            existingStock.ReferenceTickers
+        );
         // Empty string counts as missing: the SEC metadata website field is blank for most
         // companies, and rows that captured that blank must stay eligible for a refill —
         // but only re-ask EDGAR once per recheck interval, not once per 15s cycle.
@@ -208,7 +248,7 @@ public class CompanySyncService : ICompanySyncService
         var needsUpdate =
             existingStock.Ticker != primaryTicker
             || existingStock.Name != normalizedName
-            || !(existingStock.SecondaryTickers ?? []).SequenceEqual(secondaryTickers)
+            || !(existingStock.SecondaryTickers ?? []).SequenceEqual(combinedSecondaryTickers)
             || missingWebsite;
 
         if (!needsUpdate)
@@ -230,7 +270,7 @@ public class CompanySyncService : ICompanySyncService
 
             existingStock.Ticker = primaryTicker;
             existingStock.Name = normalizedName;
-            existingStock.SecondaryTickers = secondaryTickers;
+            existingStock.SecondaryTickers = combinedSecondaryTickers;
 
             if (
                 existingStock.Ticker == oldTicker
@@ -252,6 +292,8 @@ public class CompanySyncService : ICompanySyncService
             {
                 state.ExistingPrimaryTickers.Remove(oldTicker);
                 state.ExistingPrimaryTickers.Add(primaryTicker);
+                state.PrimaryTickerToStock.Remove(oldTicker);
+                state.PrimaryTickerToStock[primaryTicker] = existingStock;
             }
 
             _logger.LogDebug(
@@ -328,8 +370,22 @@ public class CompanySyncService : ICompanySyncService
         // unreachable. PrimaryTickerToStock exists for exactly this (see its
         // construction comment) and is what ReplaceObsoleteStock uses.
         state.PrimaryTickerToStock.TryGetValue(primaryTicker, out var tickerHolder);
-        if (tickerHolder != null && !state.SecCiks.Contains(tickerHolder.Cik))
+        if (
+            tickerHolder != null
+            && !state.SecCiks.Contains(CikNormalizer.Canonicalize(tickerHolder.Cik))
+        )
         {
+            if (HasReferenceCoverage(tickerHolder))
+            {
+                _logger.LogWarning(
+                    "Cannot assign SEC ticker {Ticker} to CIK {IncomingCik}: its incumbent CIK {IncumbentCik} has active reference-directory coverage; preserving the incumbent and its price history",
+                    primaryTicker,
+                    secCompany.Cik,
+                    tickerHolder.Cik
+                );
+                return false;
+            }
+
             try
             {
                 await DeleteAndUntrack(tickerHolder, state);
@@ -378,7 +434,10 @@ public class CompanySyncService : ICompanySyncService
         // own CIK dropped out of the feed.
         state.PrimaryTickerToStock.TryGetValue(primaryTicker, out var obsoleteStock);
 
-        if (obsoleteStock != null && state.SecCiks.Contains(obsoleteStock.Cik))
+        if (
+            obsoleteStock != null
+            && state.SecCiks.Contains(CikNormalizer.Canonicalize(obsoleteStock.Cik))
+        )
         {
             // Both CIKs are active in SEC's feed — this is the legitimate parent/subsidiary
             // case (e.g. ATAI Life Sciences + AtaiBeckley sharing ATAI). Resolve which one
@@ -395,6 +454,17 @@ public class CompanySyncService : ICompanySyncService
                 secCompany.Name,
                 secCompany.Cik,
                 primaryTicker
+            );
+            return;
+        }
+
+        if (HasReferenceCoverage(obsoleteStock))
+        {
+            _logger.LogWarning(
+                "Cannot replace ticker {Ticker} with SEC CIK {IncomingCik}: incumbent CIK {IncumbentCik} has active reference-directory coverage; preserving the incumbent and its price history",
+                primaryTicker,
+                secCompany.Cik,
+                obsoleteStock.Cik
             );
             return;
         }
@@ -565,7 +635,15 @@ public class CompanySyncService : ICompanySyncService
         StockSyncState state
     )
     {
-        if (incumbent.SecondaryCiks.Contains(incoming.Cik))
+        var canonicalIncomingCik = CikNormalizer.Canonicalize(incoming.Cik);
+        if (canonicalIncomingCik == null)
+            return;
+
+        if (
+            incumbent.SecondaryCiks.Any(cik =>
+                CikNormalizer.Canonicalize(cik) == canonicalIncomingCik
+            )
+        )
             return;
 
         incumbent.SecondaryCiks = [.. incumbent.SecondaryCiks, incoming.Cik];
@@ -573,7 +651,7 @@ public class CompanySyncService : ICompanySyncService
         // uniqueness validation against the incumbent's own Ticker/CIK, which is
         // an unnecessary round-trip for a SecondaryCiks-only mutation.
         await state.CommonStockRepository.SaveChanges();
-        state.SecondaryCikToParent[incoming.Cik] = incumbent;
+        state.SecondaryCikToParent[canonicalIncomingCik] = incumbent;
 
         // Same signal the operator attach publishes (root bus, after the commit):
         // without it the financial-facts checkpoint is never reset, so the newly
@@ -710,15 +788,19 @@ public class CompanySyncService : ICompanySyncService
         {
             foreach (var subCik in stock.SecondaryCiks)
             {
-                if (!secondaryCikToParent.TryAdd(subCik, stock))
+                var canonicalCik = CikNormalizer.Canonicalize(subCik);
+                if (canonicalCik == null)
+                    continue;
+
+                if (!secondaryCikToParent.TryAdd(canonicalCik, stock))
                 {
                     _logger.LogWarning(
                         "Subsidiary CIK {Cik} is attached to multiple parents ({ExistingParent} and {DuplicateParent}); "
                             + "keeping {ExistingParent}. Manual cleanup required.",
                         subCik,
-                        secondaryCikToParent[subCik].Ticker,
+                        secondaryCikToParent[canonicalCik].Ticker,
                         stock.Ticker,
-                        secondaryCikToParent[subCik].Ticker
+                        secondaryCikToParent[canonicalCik].Ticker
                     );
                 }
             }
@@ -781,6 +863,29 @@ public class CompanySyncService : ICompanySyncService
             }
         );
 
+    internal static List<string> MergeSecondaryTickers(
+        string primaryTicker,
+        IEnumerable<string> secTickers,
+        IEnumerable<string> referenceTickers
+    )
+    {
+        return (secTickers ?? [])
+            .Concat(referenceTickers ?? [])
+            .Select(TickerNormalizer.NormalizeListed)
+            .Where(ticker => ticker != null)
+            .Where(ticker =>
+                !string.Equals(ticker, primaryTicker, StringComparison.OrdinalIgnoreCase)
+            )
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(ticker => ticker, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static bool HasReferenceCoverage(CommonStock stock) =>
+        (stock.ReferenceTickers ?? []).Any(ticker =>
+            TickerNormalizer.NormalizeListed(ticker) != null
+        );
+
     private static void AddAndTrack(
         CommonStock newStock,
         string cik,
@@ -788,9 +893,12 @@ public class CompanySyncService : ICompanySyncService
         StockSyncState state
     )
     {
-        state.ExistingCiks.Add(cik);
+        var canonicalCik = CikNormalizer.Canonicalize(cik);
+        if (canonicalCik != null)
+            state.ExistingCiks.Add(canonicalCik);
         state.ExistingPrimaryTickers.Add(primaryTicker);
         state.ExistingStocks.Add(newStock);
+        state.PrimaryTickerToStock[primaryTicker] = newStock;
     }
 
     private static async Task DeleteAndUntrack(CommonStock stock, StockSyncState state)
@@ -833,9 +941,16 @@ public class CompanySyncService : ICompanySyncService
             await state.CommonStockRepository.SaveChanges();
         }
 
-        state.ExistingCiks.Remove(stock.Cik);
+        var canonicalCik = CikNormalizer.Canonicalize(stock.Cik);
+        if (canonicalCik != null)
+            state.ExistingCiks.Remove(canonicalCik);
         state.ExistingPrimaryTickers.Remove(stock.Ticker);
         state.ExistingStocks.Remove(stock);
+        if (
+            state.PrimaryTickerToStock.TryGetValue(stock.Ticker, out var mapped)
+            && mapped.Id == stock.Id
+        )
+            state.PrimaryTickerToStock.Remove(stock.Ticker);
     }
 
     private Task ReportError(string operation, Exception ex, string context) =>

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -790,7 +790,12 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         var prices = await dailyStockPriceRepository
             .GetAll()
-            .Where(p => p.CommonStockId == companyId && p.Date >= minDate && p.Date <= maxDate)
+            .Where(p =>
+                p.CommonStockId == companyId
+                && p.Date >= minDate
+                && p.Date <= maxDate
+                && p.Volume > 0
+            )
             .Select(p => new
             {
                 p.Date,

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -19,6 +20,8 @@ namespace Equibles.Sec.Mcp.Tools;
 [McpServerToolType]
 public class RagSearchTools
 {
+    private const int MaxExcludedTickers = 25;
+
     // Attribute descriptions are compile-time constants, so they cannot enumerate types
     // registered at host startup (DocumentType.Register). They name the built-in filing
     // values plus the most useful registered example, and the strict rejection below
@@ -95,6 +98,9 @@ public class RagSearchTools
                 if (!TryParseDocumentTypes(documentType, out var parsedTypes, out var typeError))
                     return typeError;
 
+                if (!TryParseTickers(excludeTickers, out var parsedTickers, out var tickerError))
+                    return tickerError;
+
                 maxResults = McpLimit.Clamp(maxResults);
                 var chunks = await _ragManager.SearchRelevantChunks(
                     query,
@@ -102,7 +108,7 @@ public class RagSearchTools
                     parsedTypes,
                     ToDateOnly(startDate),
                     ToDateOnly(endDate),
-                    ParseTickers(excludeTickers),
+                    parsedTickers,
                     Math.Max(maxResultsPerCompany, 0),
                     // BM25 ANDs every query token, so one non-matching word in a wordy
                     // natural-language query hides fully indexed filings; top up with
@@ -155,9 +161,11 @@ public class RagSearchTools
                 // An unknown ticker must not fall through to a search that is guaranteed
                 // empty: "No relevant financial documents found." would read as "this
                 // company's filings say nothing about the topic".
-                var stock = await _commonStockRepository.GetByTicker(
-                    McpToolExecutor.NormalizeTicker(ticker)
-                );
+                var normalizedTicker = McpToolExecutor.NormalizeTicker(ticker);
+                if (normalizedTicker == null)
+                    return McpToolExecutor.StockNotFound(ticker);
+
+                var stock = await _commonStockRepository.GetByTicker(normalizedTicker);
                 if (stock == null)
                     return McpToolExecutor.StockNotFound(ticker);
 
@@ -291,9 +299,11 @@ public class RagSearchTools
                         return UnknownDocumentType(documentType);
                 }
 
-                var stock = await _commonStockRepository.GetByTicker(
-                    McpToolExecutor.NormalizeTicker(ticker)
-                );
+                var normalizedTicker = McpToolExecutor.NormalizeTicker(ticker);
+                if (normalizedTicker == null)
+                    return McpToolExecutor.StockNotFound(ticker);
+
+                var stock = await _commonStockRepository.GetByTicker(normalizedTicker);
                 if (stock == null)
                     return McpToolExecutor.StockNotFound(ticker);
 
@@ -420,17 +430,42 @@ public class RagSearchTools
                 )
         );
 
-    // Comma-separated tickers for the exclusion filter; null when nothing usable.
-    private static IReadOnlyCollection<string> ParseTickers(string tickers)
+    // Comma-separated tickers for the exclusion filter; null when omitted.
+    private static bool TryParseTickers(
+        string tickers,
+        out IReadOnlyCollection<string> parsed,
+        out string error
+    )
     {
+        parsed = null;
+        error = null;
         if (string.IsNullOrWhiteSpace(tickers))
-            return null;
+            return true;
 
-        var parsed = tickers
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        return parsed.Count > 0 ? parsed : null;
+        var segments = tickers.Split(',').Select(ticker => ticker.Trim()).ToList();
+        if (segments.Count > MaxExcludedTickers)
+        {
+            error = $"Maximum {MaxExcludedTickers} excluded tickers per request.";
+            return false;
+        }
+
+        var normalized = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var segment in segments)
+        {
+            var ticker = TickerNormalizer.NormalizeDashListed(segment);
+            if (ticker == null)
+            {
+                error =
+                    $"Invalid excluded ticker '{segment}'. Use 1-32 ASCII letters, digits, dots, or dashes.";
+                return false;
+            }
+            if (seen.Add(ticker))
+                normalized.Add(ticker);
+        }
+
+        parsed = normalized;
+        return true;
     }
 
     // A contradictory window (start after end) must error instead of returning the generic

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -38,10 +38,11 @@ public class HoldingsExportController : BaseController
     [HttpGet("~/holdings/export/holders")]
     public async Task<IActionResult> Holders(string ticker, DateOnly? date)
     {
-        if (string.IsNullOrWhiteSpace(ticker))
+        var normalizedTicker = TickerNormalizer.NormalizeDashListed(ticker);
+        if (normalizedTicker == null)
             return NotFound();
 
-        var stock = await _stockRepository.GetByTicker(TickerNormalizer.Normalize(ticker));
+        var stock = await _stockRepository.GetByTicker(normalizedTicker);
         if (stock == null)
             return NotFound();
 
@@ -102,10 +103,11 @@ public class HoldingsExportController : BaseController
     [HttpGet("~/holdings/export/institution")]
     public async Task<IActionResult> Institution(string cik, DateOnly? date)
     {
-        if (string.IsNullOrWhiteSpace(cik))
+        var validatedCik = CikNormalizer.Validate(cik);
+        if (validatedCik == null)
             return NotFound();
 
-        var holder = await _holderRepository.GetByCik(cik);
+        var holder = await _holderRepository.GetByCik(validatedCik);
         if (holder == null)
             return NotFound();
 

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.Congress.Repositories;
 using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
@@ -60,7 +61,11 @@ public class ProfilesController : BaseController
     [HttpGet("~/institutions/{cik}")]
     public async Task<IActionResult> Institution(string cik, DateOnly? activityDate = null)
     {
-        var holder = await _institutionalHolderRepository.GetByCik(cik);
+        var validatedCik = CikNormalizer.Validate(cik);
+        if (validatedCik == null)
+            return NotFound();
+
+        var holder = await _institutionalHolderRepository.GetByCik(validatedCik);
         if (holder == null)
             return NotFound();
 
@@ -227,6 +232,10 @@ public class ProfilesController : BaseController
     )
     {
         var distinctCiks = NormalizeCiks(ciks);
+        if (distinctCiks == null)
+            return BadRequest(
+                "Every CIK must contain only ASCII digits and be at most 16 characters."
+            );
         if (distinctCiks.Count > InstitutionCompareViewModel.MaxCiks)
             return BadRequest(
                 $"At most {InstitutionCompareViewModel.MaxCiks} CIKs may be compared."
@@ -260,6 +269,10 @@ public class ProfilesController : BaseController
             .SelectMany(c => c.Split([',', ' '], StringSplitOptions.RemoveEmptyEntries))
             .ToArray();
         var distinctCiks = NormalizeCiks(splitCiks);
+        if (distinctCiks == null)
+            return BadRequest(
+                "Every CIK must contain only ASCII digits and be at most 16 characters."
+            );
         if (distinctCiks.Count > InstitutionOverlapMatrixViewModel.MaxCiks)
             return BadRequest(
                 $"At most {InstitutionOverlapMatrixViewModel.MaxCiks} CIKs may be compared."
@@ -288,6 +301,10 @@ public class ProfilesController : BaseController
     )
     {
         var distinctCiks = NormalizeCiks(ciks);
+        if (distinctCiks == null)
+            return BadRequest(
+                "Every CIK must contain only ASCII digits and be at most 16 characters."
+            );
         if (distinctCiks.Count > InstitutionCombinedViewModel.MaxCiks)
             return BadRequest(
                 $"At most {InstitutionCombinedViewModel.MaxCiks} CIKs may be combined."
@@ -328,7 +345,11 @@ public class ProfilesController : BaseController
     [HttpGet("~/insiders/{ownerCik}")]
     public async Task<IActionResult> Insider(string ownerCik)
     {
-        var owner = await _insiderOwnerRepository.GetByOwnerCik(ownerCik);
+        var validatedCik = CikNormalizer.Validate(ownerCik);
+        if (validatedCik == null)
+            return NotFound();
+
+        var owner = await _insiderOwnerRepository.GetByOwnerCik(validatedCik);
         if (owner == null)
             return NotFound();
 
@@ -499,18 +520,19 @@ public class ProfilesController : BaseController
     private static DateOnly ResolveSelectedDate(DateOnly? requested, List<DateOnly> available) =>
         available.ResolveSelectedDateOrFirst(requested);
 
-    private static List<string> NormalizeCiks(string[] ciks) =>
-        (ciks ?? [])
-            .Where(c => !string.IsNullOrWhiteSpace(c))
-            .Select(c => c.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
+    private static List<string> NormalizeCiks(string[] ciks)
+    {
+        var rawCiks = (ciks ?? []).Where(c => !string.IsNullOrWhiteSpace(c)).ToList();
+        var validatedCiks = rawCiks.Select(CikNormalizer.Validate).ToList();
+        if (validatedCiks.Any(c => c == null))
+            return null;
+
+        return validatedCiks.Distinct(StringComparer.Ordinal).ToList();
+    }
 
     // Resolves the picker chips for first render — preserves the order the user
-    // submitted CIKs in, and leaves Name == null for CIKs that aren't in the DB so
-    // the view can flag them as missing. Case-insensitive comparer matches
-    // NormalizeCiks above; otherwise a lowercase `?ciks=cik123` in the URL would
-    // miss the row stored as "CIK123" and render as "(name unknown)".
+    // submitted valid numeric CIKs in, and leaves Name == null for CIKs that aren't
+    // in the DB so the view can flag them as missing.
     private async Task<List<InstitutionPick>> ResolvePicks(List<string> ciks)
     {
         if (ciks.Count == 0)

--- a/src/Equibles.Web/Controllers/SearchController.cs
+++ b/src/Equibles.Web/Controllers/SearchController.cs
@@ -58,10 +58,11 @@ public class SearchController : BaseController
     // secondary. Returns null for company-name or partial queries so they fall through to search.
     private async Task<Equibles.CommonStocks.Data.Models.CommonStock> ResolveExactTicker(string q)
     {
-        if (string.IsNullOrWhiteSpace(q))
+        var normalizedTicker = TickerNormalizer.NormalizeListed(q);
+        if (normalizedTicker == null)
             return null;
 
-        return await _commonStockRepository.GetByTicker(TickerNormalizer.Normalize(q));
+        return await _commonStockRepository.GetByTicker(normalizedTicker);
     }
 
     // Results-only fragment for instant (as-you-type) search. instant-search.js fetches this

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -287,6 +287,9 @@ public class StocksController : BaseController
     private async Task<Equibles.CommonStocks.Data.Models.CommonStock> LoadStock(string ticker)
     {
         var normalizedTicker = TickerNormalizer.Normalize(ticker);
+        if (normalizedTicker == null)
+            return null;
+
         var stock = await _commonStockRepository.GetByTicker(normalizedTicker);
         if (stock != null || !normalizedTicker.Contains('.'))
             return stock;
@@ -318,11 +321,15 @@ public class StocksController : BaseController
     [HttpGet("~/stocks/{ticker}/documents/{id:guid}")]
     public async Task<IActionResult> ShowDocument(string ticker, Guid id)
     {
+        var normalizedTicker = TickerNormalizer.NormalizeDashListed(ticker);
+        if (normalizedTicker == null)
+            return NotFound();
+
         var document = await _documentRepository.GetWithContent(id);
         if (document == null)
             return NotFound();
 
-        if (!string.Equals(document.CommonStock.Ticker, ticker, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(document.CommonStock.Ticker, normalizedTicker, StringComparison.Ordinal))
         {
             return NotFound();
         }
@@ -339,27 +346,32 @@ public class StocksController : BaseController
         {
             Document = document,
             Content = content,
-            Ticker = ticker.ToUpperInvariant(),
+            Ticker = normalizedTicker,
         };
 
-        ViewData["Title"] = $"{document.DocumentType.DisplayName} - {ticker.ToUpperInvariant()}";
+        ViewData["Title"] = $"{document.DocumentType.DisplayName} - {normalizedTicker}";
         return View(viewModel);
     }
 
     [HttpGet("~/stocks/{ticker}/holders/{cik}")]
     public async Task<IActionResult> ShowHolder(string ticker, string cik)
     {
-        var stock = await _commonStockRepository.GetByTicker(TickerNormalizer.Normalize(ticker));
+        var normalizedTicker = TickerNormalizer.NormalizeDashListed(ticker);
+        var validatedCik = CikNormalizer.Validate(cik);
+        if (normalizedTicker == null || validatedCik == null)
+            return NotFound();
+
+        var stock = await _commonStockRepository.GetByTicker(normalizedTicker);
         if (stock == null)
             return NotFound();
 
-        var holder = await _institutionalHolderRepository.GetByCik(cik);
+        var holder = await _institutionalHolderRepository.GetByCik(validatedCik);
         if (holder == null)
             return NotFound();
 
         var viewModel = await _stockTabService.LoadHolderDetail(stock, holder);
 
-        ViewData["Title"] = $"{holder.Name} - {ticker.ToUpperInvariant()}";
+        ViewData["Title"] = $"{holder.Name} - {normalizedTicker}";
         return View(viewModel);
     }
 }

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -429,7 +429,7 @@ public class StockTabService
     public async Task<PriceTabViewModel> LoadPriceTab(CommonStock stock, string listedTicker)
     {
         var resolvedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, listedTicker);
-        var priceQuery = _dailyStockPriceRepository.GetByStock(stock, resolvedTicker);
+        var priceQuery = _dailyStockPriceRepository.GetTradedByStock(stock, resolvedTicker);
         if (_minSyncDate is { } minDate)
         {
             // Clamp the indicators too: derived series (SMA, RSI, MACD) over
@@ -499,7 +499,7 @@ public class StockTabService
 
         var latestDate = stockPrices[^1].Date;
         var benchmarkPrices = await _dailyStockPriceRepository
-            .GetByStock(benchmark, latestDate.AddDays(-BenchmarkLookbackDays), latestDate)
+            .GetTradedByStock(benchmark, latestDate.AddDays(-BenchmarkLookbackDays), latestDate)
             .OrderBy(p => p.Date)
             .ToListAsync();
 
@@ -715,7 +715,7 @@ public class StockTabService
         var resolvedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, listedTicker);
 
         var recentPrices = await _dailyStockPriceRepository
-            .GetByStock(stock, resolvedTicker)
+            .GetTradedByStock(stock, resolvedTicker)
             .OrderByDescending(p => p.Date)
             .Take(252)
             .ToListAsync();

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -25,7 +25,12 @@ namespace Equibles.Yahoo.HostedService.Services;
 
 internal readonly record struct PriceSeriesKey(Guid CommonStockId, string ListedTicker);
 
-internal readonly record struct PriceSeriesTarget(string Ticker, Guid CommonStockId, bool IsPrimary)
+internal readonly record struct PriceSeriesTarget(
+    string Ticker,
+    Guid CommonStockId,
+    bool IsPrimary,
+    bool RequiresFullHistory = false
+)
 {
     public PriceSeriesKey Key => new(CommonStockId, Ticker);
 }
@@ -35,6 +40,7 @@ internal readonly record struct LockedPriceSeries(CommonStock Stock, bool IsPrim
 [Service]
 public class YahooPriceImportService
 {
+    private const double MinimumReferenceHistoryCoverageShare = 0.90;
     private const int InsertBatchSize = 500;
     private const decimal MaxPriceValue = 99_999_999_999_999.9999m; // numeric(18,4) ceiling
 
@@ -144,6 +150,8 @@ public class YahooPriceImportService
                 stock.Id,
                 stock.Ticker,
                 stock.SecondaryTickers,
+                stock.ReferenceTickers,
+                stock.PriceHistoryBackfilledTickers,
             })
             .ToListAsync(cancellationToken);
 
@@ -153,18 +161,47 @@ public class YahooPriceImportService
             if (string.IsNullOrWhiteSpace(stock.Ticker))
                 continue;
 
-            var primaryTicker = TickerNormalizer.Normalize(stock.Ticker);
-            targets.Add(new PriceSeriesTarget(primaryTicker, stock.Id, IsPrimary: true));
+            var primaryTicker = TickerNormalizer.NormalizePrimary(stock.Ticker);
+            if (primaryTicker == null)
+                continue;
+
+            var referenceTickers = (stock.ReferenceTickers ?? [])
+                .Select(TickerNormalizer.NormalizeListed)
+                .Where(ticker => ticker != null)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var backfilledTickers = (stock.PriceHistoryBackfilledTickers ?? [])
+                .Select(TickerNormalizer.NormalizeListed)
+                .Where(ticker => ticker != null)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            targets.Add(
+                new PriceSeriesTarget(
+                    primaryTicker,
+                    stock.Id,
+                    IsPrimary: true,
+                    RequiresFullHistory: referenceTickers.Contains(primaryTicker)
+                        && !backfilledTickers.Contains(primaryTicker)
+                )
+            );
 
             foreach (
                 var secondaryTicker in (stock.SecondaryTickers ?? [])
+                    .Concat(stock.ReferenceTickers ?? [])
                     .Where(ticker => !string.IsNullOrWhiteSpace(ticker))
-                    .Select(TickerNormalizer.Normalize)
-                    .Where(ticker => ticker != primaryTicker)
-                    .Distinct(StringComparer.Ordinal)
+                    .Select(TickerNormalizer.NormalizeListed)
+                    .Where(ticker => ticker != null && ticker != primaryTicker)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
             )
             {
-                targets.Add(new PriceSeriesTarget(secondaryTicker, stock.Id, IsPrimary: false));
+                targets.Add(
+                    new PriceSeriesTarget(
+                        secondaryTicker,
+                        stock.Id,
+                        IsPrimary: false,
+                        RequiresFullHistory: referenceTickers.Contains(secondaryTicker)
+                            && !backfilledTickers.Contains(secondaryTicker)
+                    )
+                );
             }
         }
 
@@ -618,7 +655,8 @@ public class YahooPriceImportService
         );
         try
         {
-            if (await LockPriceSeries(stockRepo, target, cancellationToken) == null)
+            var lockedSeries = await LockPriceSeries(stockRepo, target, cancellationToken);
+            if (lockedSeries == null)
             {
                 await transaction.RollbackAsync(cancellationToken);
                 return false;
@@ -641,6 +679,18 @@ public class YahooPriceImportService
             {
                 repo.AddRange(batch);
                 await repo.SaveChanges();
+            }
+
+            if (target.RequiresFullHistory)
+            {
+                lockedSeries.Value.Stock.PriceHistoryBackfilledTickers = lockedSeries
+                    .Value.Stock.PriceHistoryBackfilledTickers.Append(target.Ticker)
+                    .Select(TickerNormalizer.NormalizeListed)
+                    .Where(ticker => ticker != null)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(ticker => ticker, StringComparer.Ordinal)
+                    .ToList();
+                await stockRepo.SaveChanges();
             }
 
             await transaction.CommitAsync(cancellationToken);
@@ -743,6 +793,39 @@ public class YahooPriceImportService
         // HTTP.
         var chartData = await _yahooClient.GetChart(target.Ticker, startDate, today);
 
+        if (target.RequiresFullHistory)
+        {
+            if (!IsCompleteReferenceHistory(chartData, PriceHistoryFloor(), today))
+            {
+                _logger.LogWarning(
+                    "Yahoo returned incomplete full history for reference listing {Ticker}; keeping its grouped bootstrap rows pending",
+                    target.Ticker
+                );
+                return new TickerImportResult(Fetched: true, Inserted: 0);
+            }
+
+            var replaced = await ReplaceStoredPrices(
+                target,
+                PriceHistoryFloor(),
+                today,
+                chartData.Prices,
+                cancellationToken
+            );
+            if (replaced)
+            {
+                _logger.LogInformation(
+                    "Replaced grouped bootstrap rows with full Yahoo history for reference listing {Ticker}",
+                    target.Ticker
+                );
+                await CaptureSplits(target, chartData.Splits, cancellationToken);
+                await CaptureDividends(target, chartData.Dividends, cancellationToken);
+            }
+            return new TickerImportResult(
+                Fetched: true,
+                Inserted: replaced ? chartData.Prices.Count : 0
+            );
+        }
+
         // Every exact listing needs a full-history rebase when its chart reports a split: Yahoo
         // retroactively adjusts old bars while the ordinary importer only appends. Doing this for
         // both the snapshotted primary and secondaries makes a concurrent designation change
@@ -794,6 +877,46 @@ public class YahooPriceImportService
         _workerOptions.MinSyncDate.HasValue
             ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
             : new DateOnly(2020, 1, 1);
+
+    private static bool IsCompleteReferenceHistory(
+        YahooChartData chartData,
+        DateOnly floor,
+        DateOnly today
+    )
+    {
+        var storableDates = chartData
+            .Prices.Where(price => !HasOverflowPrice(price))
+            .Where(price => !IsInvalidOhlc(price))
+            .Where(price => IsSettledDailyBar(price.Date, today))
+            .Select(price => price.Date)
+            .ToList();
+        if (storableDates.Count == 0)
+            return false;
+
+        var firstTradeDate = chartData.FirstTradeDate ?? floor;
+        var expectedFirst = firstTradeDate > floor ? firstTradeDate : floor;
+        while (!UsMarketCalendar.IsTradingDay(expectedFirst))
+            expectedFirst = expectedFirst.AddDays(1);
+        if (expectedFirst >= today)
+            return false;
+
+        var expectedLast = UsMarketCalendar.PreviousTradingDay(today);
+        if (storableDates.Min() > expectedFirst || storableDates.Max() < expectedLast)
+            return false;
+
+        var expectedSessions = 0;
+        for (var date = expectedFirst; date <= expectedLast; date = date.AddDays(1))
+        {
+            if (UsMarketCalendar.IsTradingDay(date))
+                expectedSessions++;
+        }
+        var coveredSessions = storableDates
+            .Where(date => date >= expectedFirst && date <= expectedLast)
+            .Distinct()
+            .Count();
+        return coveredSessions
+            >= (int)Math.Ceiling(expectedSessions * MinimumReferenceHistoryCoverageShare);
+    }
 
     private async Task<int> PersistPrices(
         PriceSeriesTarget target,
@@ -1450,7 +1573,7 @@ public class YahooPriceImportService
         {
             var priceRepo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
             currentPrice = await priceRepo
-                .GetByStock(stock)
+                .GetTradedByStock(stock)
                 .OrderByDescending(p => p.Date)
                 .Select(p => (decimal?)p.Close)
                 .FirstOrDefaultAsync(cancellationToken);
@@ -1697,6 +1820,9 @@ public class YahooPriceImportService
         CancellationToken cancellationToken
     )
     {
+        if (target.RequiresFullHistory)
+            return PriceHistoryFloor();
+
         var forwardOnly = await GetSyncStartDate(target, cancellationToken);
 
         // The heal only ever RIDES a fetch the forward-only date already demands — it must never

--- a/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
@@ -62,6 +62,7 @@ public class YahooStockPriceProvider : IStockPriceProvider
                     )
                     && p.Date >= minDate
                     && p.Date <= date
+                    && p.Volume > 0
                 )
                 .Select(p => new
                 {

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -56,7 +56,8 @@ public class StockPriceTools
             + "differs from Close. Captured corporate-action changes trigger a full-history "
             + "refresh of the exact listed series, but the stored rows do not certify which split "
             + "basis the provider returned. Do not treat reconciliation status alone as proof that "
-            + "a window is a consistent total-return series."
+            + "a window is a consistent total-return series. Zero-volume carry-forward candles are "
+            + "excluded because they do not establish a traded market price."
     )]
     public Task<string> GetStockPrices(
         [Description(
@@ -94,7 +95,7 @@ public class StockPriceTools
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var rangeQuery = _priceRepository.GetByStock(stock, priceTicker, start, end);
+                var rangeQuery = _priceRepository.GetTradedByStock(stock, priceTicker, start, end);
                 var total = await rangeQuery.CountAsync();
 
                 var records = await rangeQuery
@@ -153,7 +154,8 @@ public class StockPriceTools
             + "or watchlist. The change columns are a ONE-SESSION move: they are shown only "
             + "when the stored series holds the trading day immediately before the date on the "
             + "row, and are \"—\" otherwise, so a change is never a multi-session move in "
-            + "disguise. Each row is that ticker's newest SETTLED daily bar and the Date column "
+            + "disguise. Each row is that ticker's newest TRADED, SETTLED daily bar; zero-volume "
+            + "carry-forward candles are excluded. The Date column "
             + "names its session: for a few hours after a US close some tickers still show the "
             + "prior session while the fresh bar settles, so dates within one response can "
             + "differ — anchor on the Date column, never the wall clock. 52W High/Low are the "
@@ -175,19 +177,25 @@ public class StockPriceTools
         return _runner.Execute(
             async () =>
             {
-                var tickerList = tickers
-                    .Split(
-                        ',',
-                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
-                    )
-                    .Select(t => t.ToUpperInvariant())
-                    .Distinct()
-                    .ToList();
-
-                if (tickerList.Count == 0)
+                if (string.IsNullOrWhiteSpace(tickers))
                     return "No tickers provided.";
-                if (tickerList.Count > 25)
+
+                var segments = tickers.Split(',').Select(ticker => ticker.Trim()).ToList();
+                if (segments.All(string.IsNullOrWhiteSpace))
+                    return "No tickers provided.";
+                if (segments.Count > 25)
                     return "Maximum 25 tickers per request. Please split into multiple calls.";
+
+                var tickerList = new List<string>();
+                var seenTickers = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var segment in segments)
+                {
+                    var normalizedTicker = TickerNormalizer.NormalizeDashListed(segment);
+                    if (normalizedTicker == null)
+                        return $"Invalid ticker '{segment}'. Use 1-32 ASCII letters, digits, dots, or dashes.";
+                    if (seenTickers.Add(normalizedTicker))
+                        tickerList.Add(normalizedTicker);
+                }
 
                 var result = StartTable(
                     "Latest prices:",
@@ -226,7 +234,7 @@ public class StockPriceTools
                     // Newest two bars in one query: the latest row plus the prior close
                     // needed for the day-over-day change columns.
                     var latestTwo = await _priceRepository
-                        .GetByStock(stock, priceTicker)
+                        .GetTradedByStock(stock, priceTicker)
                         .OrderByDescending(p => p.Date)
                         .Take(2)
                         .ToListAsync();
@@ -320,7 +328,7 @@ public class StockPriceTools
                         gapped = true;
                     }
                     var range = await _priceRepository
-                        .GetByStock(stock, priceTicker)
+                        .GetTradedByStock(stock, priceTicker)
                         .Where(p => p.Date >= comparableWindow.Start && p.Close > 0)
                         .GroupBy(p => 1)
                         .Select(g => new
@@ -835,7 +843,7 @@ public class StockPriceTools
             return (stock, priceTicker, null, 0, rangeError);
 
         var records = await _priceRepository
-            .GetByStock(stock, priceTicker, start, end)
+            .GetTradedByStock(stock, priceTicker, start, end)
             .OrderBy(p => p.Date)
             .ToListAsync();
 
@@ -855,7 +863,7 @@ public class StockPriceTools
         if (warmupBars > 0)
         {
             var warmup = await _priceRepository
-                .GetByStock(stock, priceTicker)
+                .GetTradedByStock(stock, priceTicker)
                 .Where(p => p.Date < start)
                 .OrderByDescending(p => p.Date)
                 .Take(warmupBars)

--- a/src/Equibles.Yahoo.Repositories/DailyStockPriceRepository.cs
+++ b/src/Equibles.Yahoo.Repositories/DailyStockPriceRepository.cs
@@ -67,6 +67,49 @@ public class DailyStockPriceRepository : BaseRepository<DailyStockPrice>
         return GetByStock(stock, ticker).Where(p => p.Date >= startDate && p.Date <= endDate);
     }
 
+    /// <summary>
+    /// Exact-listing rows backed by at least one reported trade. Upstream daily feeds can emit
+    /// zero-volume carry-forward candles for a dormant symbol; customer-facing price surfaces
+    /// must not present those synthetic rows as a newly settled market price.
+    /// </summary>
+    public IQueryable<DailyStockPrice> GetTradedByStock(CommonStock stock, string ticker)
+    {
+        return GetByStock(stock, ticker).Where(p => p.Volume > 0);
+    }
+
+    public IQueryable<DailyStockPrice> GetTradedByStock(CommonStock stock)
+    {
+        return GetByStock(stock).Where(p => p.Volume > 0);
+    }
+
+    public IQueryable<DailyStockPrice> GetTradedByStock(
+        CommonStock stock,
+        string ticker,
+        DateOnly startDate,
+        DateOnly endDate
+    )
+    {
+        return GetTradedByStock(stock, ticker).Where(p => p.Date >= startDate && p.Date <= endDate);
+    }
+
+    public IQueryable<DailyStockPrice> GetTradedByStock(
+        CommonStock stock,
+        DateOnly startDate,
+        DateOnly endDate
+    )
+    {
+        return GetTradedByStock(stock).Where(p => p.Date >= startDate && p.Date <= endDate);
+    }
+
+    public IQueryable<DailyStockPrice> GetTradedByStocks(
+        IEnumerable<Guid> stockIds,
+        DateOnly startDate,
+        DateOnly endDate
+    )
+    {
+        return GetByStocks(stockIds, startDate, endDate).Where(p => p.Volume > 0);
+    }
+
     public IQueryable<DailyStockPrice> GetByStocks(
         IEnumerable<Guid> stockIds,
         DateOnly startDate,

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryExtensionsResolveByTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryExtensionsResolveByTickerTests.cs
@@ -46,4 +46,65 @@ public class CommonStockRepositoryExtensionsResolveByTickerTests : IDisposable
         stock.Ticker.Should().Be("AAPL");
         error.Should().BeNull();
     }
+
+    [Fact]
+    public async Task GetByCikTolerant_UnpaddedInputResolvesPaddedPrimaryCik()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+        };
+        _dbContext.Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var resolved = await _repository.GetByCikTolerant("320193");
+
+        resolved.Should().BeSameAs(stock);
+    }
+
+    [Fact]
+    public async Task GetByCikTolerant_PaddedInputResolvesUnpaddedSecondaryCik()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "SURV",
+            Name = "Surviving filer",
+            Cik = "10",
+            SecondaryCiks = ["320193"],
+        };
+        _dbContext.Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var resolved = await _repository.GetByCikTolerant("0000320193");
+
+        resolved.Should().BeSameAs(stock);
+    }
+
+    [Fact]
+    public async Task GetByCikTolerant_CanonicalCollisionFailsClosed()
+    {
+        _dbContext.AddRange(
+            new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = "PAD",
+                Name = "Padded",
+                Cik = "0000320193",
+            },
+            new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = "PLAIN",
+                Name = "Plain",
+                Cik = "320193",
+            }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        (await _repository.GetByCikTolerant("0000320193")).Should().BeNull();
+    }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/FundScoringManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/FundScoringManagerTests.cs
@@ -392,6 +392,7 @@ public class FundScoringManagerTests : IDisposable
                     Low = close,
                     Close = close,
                     AdjustedClose = adjustedClose ?? close,
+                    Volume = 1_000,
                 }
             );
     }

--- a/tests/Equibles.IntegrationTests/Holdings/FundScoringWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/FundScoringWorkerTests.cs
@@ -205,6 +205,7 @@ public class FundScoringWorkerTests : IDisposable
                     Low = close,
                     Close = close,
                     AdjustedClose = close,
+                    Volume = 1_000,
                 }
             );
     }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRepositoryTests.cs
@@ -154,9 +154,20 @@ public class InstitutionalHolderRepositoryTests : IDisposable
             );
         await _dbContext.SaveChangesAsync();
 
-        var result = await _repository.GetByCiks(["0001067983", "0000000000"]).ToListAsync();
+        var result = await _repository.GetByCiks(["0001067983", "9999999999"]).ToListAsync();
 
         result.Should().ContainSingle().Which.Name.Should().Be("Berkshire Hathaway");
+    }
+
+    [Fact]
+    public async Task GetByCiks_InvalidMember_RejectsTheWholeBatch()
+    {
+        _dbContext.Set<InstitutionalHolder>().Add(CreateHolder(cik: "0001067983"));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetByCiks(["0001067983", "0000000000"]).ToListAsync();
+
+        result.Should().BeEmpty();
     }
 
     // ── Search ──────────────────────────────────────────────────────────

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests.cs
@@ -626,4 +626,36 @@ public class InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests : Par
         resolution.Selected.Should().BeNull();
         resolution.Candidates.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task ResolveNameOrCik_InvalidCikSpellings_DoNotResolveIdentifierRows()
+    {
+        var invalidCiks = new[] { "12345678901234567", "１２３", "0000" };
+        DbContext.AddRange(
+            invalidCiks
+                .Skip(1)
+                .Select(
+                    (cik, index) =>
+                        new InstitutionalHolder
+                        {
+                            Cik = cik,
+                            Name = $"Invalid identifier row {index}",
+                        }
+                )
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var repository = new InstitutionalHolderRepository(verify);
+        foreach (var invalidCik in invalidCiks)
+        {
+            var resolution = await repository.ResolveNameOrCik(invalidCik);
+            var discovery = await repository.SearchNameOrCik(invalidCik).ToListAsync();
+
+            resolution.Selected.Should().BeNull();
+            resolution.Candidates.Should().BeEmpty();
+            discovery.Should().BeEmpty();
+        }
+    }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs
@@ -266,6 +266,7 @@ public class SmartMoneyIndexManagerTests : IDisposable
                     Low = close,
                     Close = close,
                     AdjustedClose = close,
+                    Volume = 1_000,
                 }
             );
     }

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRefusedRepairTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRefusedRepairTests.cs
@@ -108,6 +108,7 @@ public class InsiderFilingReprocessManagerRefusedRepairTests : ParadeDbMcpTestBa
                 CommonStockId = stock.Id,
                 Date = date,
                 Close = 50m,
+                Volume = 1_000,
             }
         );
         DbContext.Add(stale);

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRepairTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRepairTests.cs
@@ -109,6 +109,7 @@ public class InsiderFilingReprocessManagerRepairTests : ParadeDbMcpTestBase
                 CommonStockId = stock.Id,
                 Date = date,
                 Close = 50m,
+                Volume = 1_000,
             }
         );
         DbContext.Add(stale);

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerFetchClosesWeekendFallbackTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerFetchClosesWeekendFallbackTests.cs
@@ -66,6 +66,7 @@ public class InsiderTransactionPriceBackfillManagerFetchClosesWeekendFallbackTes
                     ListedTicker = "WKND",
                     Date = thursday,
                     Close = 48m,
+                    Volume = 1_000,
                 },
                 new DailyStockPrice
                 {
@@ -73,6 +74,7 @@ public class InsiderTransactionPriceBackfillManagerFetchClosesWeekendFallbackTes
                     ListedTicker = "WKND",
                     Date = friday,
                     Close = 50m,
+                    Volume = 1_000,
                 }
             );
         await _dbContext.SaveChangesAsync(CancellationToken.None);

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerRunTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerRunTests.cs
@@ -58,6 +58,7 @@ public class InsiderTransactionPriceBackfillManagerRunTests : ParadeDbMcpTestBas
                 CommonStockId = stock.Id,
                 Date = date,
                 Close = 50m,
+                Volume = 1_000,
             }
         );
         DbContext.Add(implausible);
@@ -142,6 +143,7 @@ public class InsiderTransactionPriceBackfillManagerRunTests : ParadeDbMcpTestBas
                 CommonStockId = priced.Id,
                 Date = date,
                 Close = 50m,
+                Volume = 1_000,
             }
         );
         DbContext.Add(unrepairable);

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsCompareToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsCompareToolsTests.cs
@@ -111,6 +111,26 @@ public class FinancialFactsCompareToolsTests : ParadeDbMcpTestBase
         result.Should().Contain("Too many tickers (30). The maximum is 25.");
     }
 
+    [Theory]
+    [InlineData("ſPY")]
+    [InlineData("AAPL/../../x")]
+    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567")]
+    [InlineData("AAPL,,MSFT")]
+    public async Task CompareFinancialFact_InvalidBatchFailsBeforeRepositoryAccess(string tickers)
+    {
+        var sut = new FinancialFactsTools(
+            new FinancialFactRepository(null),
+            new FinancialConceptRepository(null),
+            new CommonStockRepository(null),
+            new Equibles.Errors.BusinessLogic.ErrorManager(null),
+            NullLogger<FinancialFactsTools>()
+        );
+
+        var result = await sut.CompareFinancialFact(tickers, "revenue", 2023);
+
+        result.Should().Contain("Invalid ticker");
+    }
+
     [Fact]
     public async Task CompareFinancialFact_PeerSet_RendersRowsLatestRestatedAndListsSkipped()
     {

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
@@ -106,6 +106,26 @@ public class StockPriceToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task GetStockPrices_ExcludesZeroVolumeCarryForwardRows()
+    {
+        var stock = AaplStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<DailyStockPrice>()
+            .AddRange(
+                PriceFor(stock, new DateOnly(2026, 4, 1), close: 175.50m),
+                PriceFor(stock, new DateOnly(2026, 4, 2), close: 175.50m, volume: 0)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetStockPrices("AAPL", startDate: "2026-04-01", endDate: "2026-04-30");
+
+        result.Should().Contain("2026-04-01");
+        result.Should().NotContain("2026-04-02");
+    }
+
+    [Fact]
     public async Task GetStockPrices_MaxResultsLimitsRows()
     {
         var stock = AaplStock();
@@ -167,6 +187,26 @@ public class StockPriceToolsTests : ParadeDbMcpTestBase
         result.Should().Be("No tickers provided.");
     }
 
+    [Theory]
+    [InlineData("ſPY")]
+    [InlineData("AAPL/../../x")]
+    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567")]
+    [InlineData("AAPL,,MSFT")]
+    public async Task GetLatestPrices_InvalidBatchFailsBeforeRepositoryAccess(string tickers)
+    {
+        var sut = new StockPriceTools(
+            new DailyStockPriceRepository(null),
+            new CommonStockRepository(null),
+            new Equibles.CorporateActions.Repositories.StockSplitRepository(null),
+            new Equibles.Errors.BusinessLogic.ErrorManager(null),
+            NullLogger<StockPriceTools>()
+        );
+
+        var result = await sut.GetLatestPrices(tickers);
+
+        result.Should().Contain("Invalid ticker");
+    }
+
     [Fact]
     public async Task GetLatestPrices_KnownTickers_ReturnsLatestRow()
     {
@@ -199,6 +239,25 @@ public class StockPriceToolsTests : ParadeDbMcpTestBase
                 "| MSFT | 2026-04-05 | 425.75 | — | — | 22,000,000 | 425.75\\* | 425.75\\* | 0.00% | 0.00% |"
             );
         result.Should().NotContain("| AAPL | 2026-04-01");
+    }
+
+    [Fact]
+    public async Task GetLatestPrices_ExcludesZeroVolumeCarryForwardFromLatestAndRange()
+    {
+        var stock = AaplStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<DailyStockPrice>()
+            .AddRange(
+                PriceFor(stock, new DateOnly(2026, 4, 1), close: 175.50m),
+                PriceFor(stock, new DateOnly(2026, 4, 2), close: 999.00m, volume: 0)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLatestPrices("AAPL");
+
+        result.Should().Contain("| AAPL | 2026-04-01 | 175.50 |");
+        result.Should().NotContain("999.00");
     }
 
     [Theory]

--- a/tests/Equibles.IntegrationTests/Migrations/RepairChunkReportingDatesMigrationTests.cs
+++ b/tests/Equibles.IntegrationTests/Migrations/RepairChunkReportingDatesMigrationTests.cs
@@ -23,7 +23,6 @@ public class RepairChunkReportingDatesMigrationTests : ParadeDbMcpTestBase
     public async Task Up_ReplacesAStaleChunkCacheWithItsDocumentReportingDate()
     {
         var migrator = DbContext.Database.GetService<IMigrator>();
-        await migrator.MigrateAsync(PreviousMigration);
 
         try
         {
@@ -64,6 +63,12 @@ public class RepairChunkReportingDatesMigrationTests : ParadeDbMcpTestBase
             };
             DbContext.Add(chunk);
             await DbContext.SaveChangesAsync();
+            DbContext.ChangeTracker.Clear();
+
+            // Seed through the current EF model first, then recreate the historical schema.
+            // Future additive columns must not make this migration-transition test write through
+            // a model that is newer than the database it deliberately downgraded.
+            await migrator.MigrateAsync(PreviousMigration);
 
             await migrator.MigrateAsync(RepairMigration);
             DbContext.ChangeTracker.Clear();
@@ -75,7 +80,7 @@ public class RepairChunkReportingDatesMigrationTests : ParadeDbMcpTestBase
         }
         finally
         {
-            await migrator.MigrateAsync(RepairMigration);
+            await migrator.MigrateAsync();
         }
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCaseMismatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCaseMismatchTests.cs
@@ -97,7 +97,7 @@ public class CompanySyncServiceReplaceObsoleteCaseMismatchTests : ParadeDbMcpTes
             .Should()
             .ContainSingle("the obsolete holder must be replaced, not kept alongside a duplicate");
         stocks[0].Cik.Should().Be("0000000111");
-        stocks[0].Ticker.Should().Be("reused");
+        stocks[0].Ticker.Should().Be("REUSED", "listed tickers are persisted canonically");
         stocks[0].Name.Should().Be("Acquirer Inc.");
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
@@ -118,4 +118,79 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
             .Should()
             .BeEmpty("the authorized parent cascade removes the obsolete listing's exact rows");
     }
+
+    [Fact]
+    public async Task SyncCompaniesFromSecApi_TickerHeldByReferenceOwner_PreservesOwnerAndHistory()
+    {
+        var referenceOwner = new CommonStock
+        {
+            Cik = "0000000999",
+            Ticker = "REUSED",
+            Name = "Reference-owned ETF",
+            ReferenceTickers = ["REUSED"],
+        };
+        var exactPriceId = Guid.NewGuid();
+        DbContext.AddRange(
+            referenceOwner,
+            new DailyStockPrice
+            {
+                Id = exactPriceId,
+                CommonStockId = referenceOwner.Id,
+                ListedTicker = "REUSED",
+                Date = new DateOnly(2026, 8, 3),
+                Open = 10m,
+                High = 11m,
+                Low = 9m,
+                Close = 10m,
+                AdjustedClose = 10m,
+                Volume = 1_000,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient
+            .GetActiveCompanies()
+            .Returns([
+                new CompanyInfo
+                {
+                    Cik = "0000000111",
+                    Name = "Incoming SEC Company",
+                    Tickers = ["REUSED"],
+                    EntityType = "operating",
+                },
+            ]);
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
+            (
+                typeof(CommonStockManager),
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
+            ),
+            (typeof(EquiblesFinancialDbContext), DbContext)
+        );
+        var sut = new CompanySyncService(
+            scopeFactory,
+            secEdgarClient,
+            Options.Create(new WorkerOptions { TickersToSync = [] }),
+            Substitute.For<ILogger<CompanySyncService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Substitute.For<IBus>()
+        );
+
+        await sut.SyncCompaniesFromSecApi();
+
+        await using var verify = Fixture.CreateDbContext();
+        var stock = await verify.Set<CommonStock>().AsNoTracking().SingleAsync();
+        stock.Id.Should().Be(referenceOwner.Id);
+        stock.Cik.Should().Be("0000000999");
+        stock.ReferenceTickers.Should().Equal("REUSED");
+        (await verify.Set<DailyStockPrice>().AsNoTracking().SingleAsync())
+            .Id.Should()
+            .Be(exactPriceId);
+    }
 }

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
@@ -41,7 +41,8 @@ public class CompanySyncServiceUpdateExistingTests : ParadeDbMcpTestBase
             Cik = "0001067983",
             Ticker = "OLD",
             Name = "Old Name Inc.",
-            SecondaryTickers = ["X.A"],
+            SecondaryTickers = ["X.A", "FUND-X"],
+            ReferenceTickers = ["FUND-X"],
             Description = "Pre-sync description",
         };
         DbContext.Add(existing);
@@ -95,6 +96,127 @@ public class CompanySyncServiceUpdateExistingTests : ParadeDbMcpTestBase
         stocks[0].Id.Should().Be(existing.Id);
         stocks[0].Ticker.Should().Be("BRK.A");
         stocks[0].Name.Should().Be("Berkshire Hathaway Inc.");
-        stocks[0].SecondaryTickers.Should().Equal("BRK.B");
+        stocks[0].ReferenceTickers.Should().Equal("FUND-X");
+        stocks[0].SecondaryTickers.Should().Equal("BRK.B", "FUND-X");
+    }
+
+    [Fact]
+    public async Task SyncCompaniesFromSecApi_EquivalentCikSpellingPreservesReferenceOwner()
+    {
+        var existing = new CommonStock
+        {
+            Cik = "0000036405",
+            Ticker = "VOO",
+            Name = "Vanguard S&P 500 ETF",
+            SecondaryTickers = ["VOO"],
+            ReferenceTickers = ["VOO"],
+        };
+        DbContext.Add(existing);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient
+            .GetActiveCompanies()
+            .Returns([
+                new CompanyInfo
+                {
+                    Cik = "36405",
+                    Name = "Vanguard S&P 500 ETF",
+                    Tickers = ["VOO"],
+                    EntityType = "operating",
+                },
+            ]);
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
+            (
+                typeof(CommonStockManager),
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
+            ),
+            (typeof(EquiblesFinancialDbContext), DbContext)
+        );
+        var sut = new CompanySyncService(
+            scopeFactory,
+            secEdgarClient,
+            Options.Create(new WorkerOptions { TickersToSync = [] }),
+            Substitute.For<ILogger<CompanySyncService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Substitute.For<IBus>()
+        );
+
+        await sut.SyncCompaniesFromSecApi();
+
+        await using var verify = Fixture.CreateDbContext();
+        var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
+        stocks.Should().ContainSingle();
+        stocks[0].Id.Should().Be(existing.Id);
+        stocks[0].Cik.Should().Be("0000036405");
+        stocks[0].ReferenceTickers.Should().Equal("VOO");
+    }
+
+    [Fact]
+    public async Task SyncCompaniesFromSecApi_RenameCollidesWithReferenceOwner_PreservesBothRows()
+    {
+        var referenceOwner = new CommonStock
+        {
+            Cik = "999",
+            Ticker = "REUSED",
+            Name = "Reference-owned ETF",
+            ReferenceTickers = ["REUSED"],
+        };
+        var incoming = new CommonStock
+        {
+            Cik = "111",
+            Ticker = "OLD",
+            Name = "Incoming SEC company",
+        };
+        DbContext.AddRange(referenceOwner, incoming);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient
+            .GetActiveCompanies()
+            .Returns([
+                new CompanyInfo
+                {
+                    Cik = "111",
+                    Name = "Incoming SEC company",
+                    Tickers = ["REUSED"],
+                    EntityType = "operating",
+                },
+            ]);
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
+            (
+                typeof(CommonStockManager),
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
+            ),
+            (typeof(EquiblesFinancialDbContext), DbContext)
+        );
+        var sut = new CompanySyncService(
+            scopeFactory,
+            secEdgarClient,
+            Options.Create(new WorkerOptions { TickersToSync = [] }),
+            Substitute.For<ILogger<CompanySyncService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Substitute.For<IBus>()
+        );
+
+        await sut.SyncCompaniesFromSecApi();
+
+        await using var verify = Fixture.CreateDbContext();
+        var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
+        stocks.Should().HaveCount(2);
+        stocks.Single(stock => stock.Id == referenceOwner.Id).Ticker.Should().Be("REUSED");
+        stocks.Single(stock => stock.Id == incoming.Id).Ticker.Should().Be("OLD");
     }
 }

--- a/tests/Equibles.IntegrationTests/Web/ProfilesCombinedInstitutionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesCombinedInstitutionsTests.cs
@@ -154,14 +154,15 @@ public class ProfilesCombinedInstitutionsTests
             await Task.CompletedTask;
         });
 
+        const string missingCik = "9999999999";
         var response = await _fixture.Client.GetAsync(
-            $"/Institutions/Combined?ciks={cikA}&ciks=does-not-exist"
+            $"/Institutions/Combined?ciks={cikA}&ciks={missingCik}"
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();
         html.Should().Contain("Could not resolve CIKs");
-        html.Should().Contain("does-not-exist");
+        html.Should().Contain(missingCik);
     }
 
     private static InstitutionalHolding MakeHolding(

--- a/tests/Equibles.IntegrationTests/Web/ProfilesCompareInstitutionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesCompareInstitutionsTests.cs
@@ -127,14 +127,15 @@ public class ProfilesCompareInstitutionsTests
         });
 
         // Fund A exists, Fund B does not.
+        const string missingCik = "9999999999";
         var response = await _fixture.Client.GetAsync(
-            $"/Institutions/Compare?ciks={fundACik}&ciks=does-not-exist"
+            $"/Institutions/Compare?ciks={fundACik}&ciks={missingCik}"
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();
         html.Should().Contain("Could not resolve CIKs");
-        html.Should().Contain("does-not-exist");
+        html.Should().Contain(missingCik);
     }
 
     private static InstitutionalHolding MakeHolding(

--- a/tests/Equibles.IntegrationTests/Web/SmartMoneyIndexViewTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/SmartMoneyIndexViewTests.cs
@@ -130,6 +130,7 @@ public class SmartMoneyIndexViewTests
             Low = close,
             Close = close,
             AdjustedClose = close,
+            Volume = 1_000,
         };
 
     private static InstitutionalHolding MakeHolding(Guid stockId, Guid holderId) =>

--- a/tests/Equibles.IntegrationTests/Yahoo/DailyStockPriceRepositoryGetByStocksTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/DailyStockPriceRepositoryGetByStocksTests.cs
@@ -63,12 +63,41 @@ public class DailyStockPriceRepositoryGetByStocksTests : IDisposable
         result.Select(p => p.Date).Should().BeEquivalentTo([start, end]);
     }
 
-    private static DailyStockPrice Price(Guid stockId, string listedTicker, DateOnly date) =>
+    [Fact]
+    public async Task GetTradedByStocks_ExcludesCarryForwardAndInvalidVolumeRows()
+    {
+        var stockId = Guid.NewGuid();
+        var start = new DateOnly(2026, 8, 7);
+        var end = new DateOnly(2026, 8, 11);
+        _dbContext.Set<CommonStock>().Add(new CommonStock { Id = stockId, Ticker = "THIN" });
+        _dbContext
+            .Set<DailyStockPrice>()
+            .AddRange(
+                Price(stockId, "THIN", start, 10),
+                Price(stockId, "THIN", start.AddDays(1), 0),
+                Price(stockId, "THIN", end, -1)
+            );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var result = await _repository
+            .GetTradedByStocks([stockId], start, end)
+            .ToListAsync(CancellationToken.None);
+
+        result.Should().ContainSingle().Which.Date.Should().Be(start);
+    }
+
+    private static DailyStockPrice Price(
+        Guid stockId,
+        string listedTicker,
+        DateOnly date,
+        long volume = 100
+    ) =>
         new()
         {
             CommonStockId = stockId,
             ListedTicker = listedTicker,
             Date = date,
             Close = 100m,
+            Volume = volume,
         };
 }

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Calendars;
 using Equibles.Core.Configuration;
 using Equibles.CorporateActions.BusinessLogic;
 using Equibles.CorporateActions.Data.Models;
@@ -210,6 +211,93 @@ public class YahooPriceImportServiceTests : IDisposable
         prices.Should().HaveCount(3);
         prices.Should().AllSatisfy(p => p.CommonStockId.Should().Be(apple.Id));
         prices.Select(p => p.Close).Should().BeEquivalentTo([180m, 182m, 185m]);
+    }
+
+    [Fact]
+    public async Task Import_ReferenceSeriesWithTwoGroupedRows_RetriesShortResponseThenCommitsFullHistory()
+    {
+        _workerOptions.MinSyncDate = new DateTime(2020, 1, 1);
+        var stock = CreateStock("OWNER", "Reference Owner");
+        stock.SecondaryTickers = ["REF"];
+        stock.ReferenceTickers = ["REF"];
+        await SeedStocks(stock);
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var latestSettled = UsMarketCalendar.PreviousTradingDay(today);
+        var priorSettled = UsMarketCalendar.PreviousTradingDay(latestSettled);
+        var firstBootstrap = CreatePrice(stock, priorSettled, 100m, "REF");
+        var secondBootstrap = CreatePrice(stock, latestSettled, 101m, "REF");
+        await SeedPrices(firstBootstrap, secondBootstrap);
+
+        var requestedStarts = new List<DateOnly>();
+        var floor = new DateOnly(2020, 1, 1);
+        var firstExpectedSession = new DateOnly(2020, 1, 2);
+        var completeHistory = Enumerable
+            .Range(0, latestSettled.DayNumber - floor.DayNumber + 1)
+            .Select(offset => floor.AddDays(offset))
+            .Where(UsMarketCalendar.IsTradingDay)
+            .Select(
+                (date, index) =>
+                    new HistoricalPrice
+                    {
+                        Date = date,
+                        Open = 20m + index,
+                        High = 22m + index,
+                        Low = 19m + index,
+                        Close = 21m + index,
+                        AdjustedClose = 21m + index,
+                        Volume = 500_000,
+                    }
+            )
+            .ToList();
+        _yahooClient
+            .GetChart("REF", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(
+                call =>
+                {
+                    requestedStarts.Add(call.ArgAt<DateOnly>(1));
+                    return CreateChartData((firstExpectedSession, 20m), (latestSettled, 102m));
+                },
+                call =>
+                {
+                    requestedStarts.Add(call.ArgAt<DateOnly>(1));
+                    return new YahooChartData { Prices = completeHistory };
+                }
+            );
+        _yahooClient
+            .GetChart("OWNER", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new YahooChartData());
+
+        await _service.Import(CancellationToken.None);
+
+        requestedStarts.Should().Equal(floor);
+        _priceRepo.GetAllSeries().Should().Contain(price => price.Id == firstBootstrap.Id);
+        _priceRepo.GetAllSeries().Should().Contain(price => price.Id == secondBootstrap.Id);
+        _stockRepo
+            .GetAll()
+            .Single(stockRow => stockRow.Id == stock.Id)
+            .PriceHistoryBackfilledTickers.Should()
+            .BeEmpty();
+
+        await _service.Import(CancellationToken.None);
+
+        requestedStarts.Should().Equal(floor, floor);
+        var stored = _priceRepo
+            .GetAllSeries()
+            .Where(price => price.CommonStockId == stock.Id && price.ListedTicker == "REF")
+            .OrderBy(price => price.Date)
+            .ToList();
+        stored
+            .Select(price => price.Date)
+            .Should()
+            .Equal(completeHistory.Select(price => price.Date));
+        stored.Should().NotContain(price => price.Id == firstBootstrap.Id);
+        stored.Should().NotContain(price => price.Id == secondBootstrap.Id);
+        _stockRepo
+            .GetAll()
+            .Single(stockRow => stockRow.Id == stock.Id)
+            .PriceHistoryBackfilledTickers.Should()
+            .Equal("REF");
     }
 
     [Fact]
@@ -1013,6 +1101,29 @@ public class YahooPriceImportServiceTests : IDisposable
 
         var updated = _stockRepo.GetAll().Single(s => s.Ticker == "CEF");
         updated.SharesOutStanding.Should().Be(50_000_000);
+        updated.MarketCapitalization.Should().Be(50_000_000d * 40d);
+    }
+
+    [Fact]
+    public async Task Import_MarketCapFallback_UsesLatestTradedClose()
+    {
+        var stock = CreateStock("TRD", "Traded Close Co.");
+        await SeedStocks(stock);
+        var traded = CreatePrice(stock, new DateOnly(2024, 1, 2), close: 40m);
+        var carryForward = CreatePrice(stock, new DateOnly(2024, 1, 3), close: 90m);
+        carryForward.Volume = 0;
+        await SeedPrices(traded, carryForward);
+
+        _sharesProvider.GetCurrentSharesOutstanding(stock).Returns(50_000_000L);
+        _sharesProvider.IsForeignPrivateIssuer(stock).Returns(false);
+        _yahooClient
+            .GetChart("TRD", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(new YahooChartData());
+        _yahooClient.GetKeyStatistics("TRD").Returns((KeyStatistics)null);
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "TRD");
         updated.MarketCapitalization.Should().Be(50_000_000d * 40d);
     }
 

--- a/tests/Equibles.UnitTests/CommonStocks/CikNormalizerTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CikNormalizerTests.cs
@@ -1,0 +1,30 @@
+using Equibles.CommonStocks.Data.Helpers;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class CikNormalizerTests
+{
+    [Theory]
+    [InlineData(" 0000036405 ", "0000036405", "36405")]
+    [InlineData("10", "10", "10")]
+    public void ValidAsciiCik_PreservesLookupSpellingAndCanonicalizesIdentity(
+        string input,
+        string validated,
+        string canonical
+    )
+    {
+        CikNormalizer.Validate(input).Should().Be(validated);
+        CikNormalizer.Canonicalize(input).Should().Be(canonical);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("not-a-cik")]
+    [InlineData("١٢٣")]
+    [InlineData("12345678901234567")]
+    public void InvalidCik_FailsClosed(string input)
+    {
+        CikNormalizer.Validate(input).Should().BeNull();
+        CikNormalizer.Canonicalize(input).Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockListingSyncLockTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockListingSyncLockTests.cs
@@ -1,0 +1,26 @@
+using Equibles.CommonStocks.Data.Helpers;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class CommonStockListingSyncLockTests
+{
+    [Fact]
+    public async Task Acquire_HoldsTheSecondWriterUntilTheFirstReleases()
+    {
+        var first = await CommonStockListingSyncLock.Acquire();
+        try
+        {
+            var secondTask = CommonStockListingSyncLock.Acquire();
+            await Task.Yield();
+
+            secondTask.IsCompleted.Should().BeFalse();
+
+            first.Dispose();
+            using var second = await secondTask.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            first.Dispose();
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/TickerNormalizerNormalizeCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/TickerNormalizerNormalizeCultureInvarianceTests.cs
@@ -27,4 +27,23 @@ public class TickerNormalizerNormalizeCultureInvarianceTests
             CultureInfo.CurrentCulture = original;
         }
     }
+
+    [Theory]
+    [InlineData("brk.b", "BRK.B")]
+    [InlineData(" BRK-B ", "BRK-B")]
+    public void NormalizeListed_AcceptsBoundedExchangeSpelling(string ticker, string expected)
+    {
+        TickerNormalizer.NormalizeListed(ticker).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("@@@")]
+    [InlineData("AAPL/../../x")]
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
+    [InlineData("ſPY")]
+    public void NormalizeListed_RejectsMalformedOrOversizedSymbols(string ticker)
+    {
+        TickerNormalizer.NormalizeListed(ticker).Should().BeNull();
+        TickerNormalizer.Normalize(ticker).Should().BeNull();
+    }
 }

--- a/tests/Equibles.UnitTests/Mcp/McpToolExecutorNormalizeTickerTurkishCultureTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpToolExecutorNormalizeTickerTurkishCultureTests.cs
@@ -40,4 +40,13 @@ public class McpToolExecutorNormalizeTickerTurkishCultureTests
             CultureInfo.CurrentCulture = original;
         }
     }
+
+    [Theory]
+    [InlineData("ſPY")]
+    [InlineData("AAPL/../../x")]
+    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567")]
+    public void NormalizeTicker_InvalidOriginalText_ReturnsNull(string ticker)
+    {
+        McpToolExecutor.NormalizeTicker(ticker).Should().BeNull();
+    }
 }

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentDuplicateTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentDuplicateTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
@@ -52,7 +53,7 @@ public class CompanySyncServiceBuildSecondaryCikToParentDuplicateTests
                     [new List<CommonStock> { apple, microsoft }]
                 );
 
-        result["0000999999"].Should().BeSameAs(apple);
+        result[CikNormalizer.Canonicalize("0000999999")].Should().BeSameAs(apple);
     }
 
     private static CompanySyncService CreateService()

--- a/tests/Equibles.UnitTests/Sec/RagSearchToolsExcludedTickerValidationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagSearchToolsExcludedTickerValidationTests.cs
@@ -1,0 +1,41 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Sec.Mcp.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Sec;
+
+public class RagSearchToolsExcludedTickerValidationTests
+{
+    private static RagSearchTools Tool() =>
+        new(
+            null,
+            null,
+            null,
+            null,
+            null,
+            new ErrorManager(null),
+            NullLogger<RagSearchTools>.Instance
+        );
+
+    [Theory]
+    [InlineData("ſPY")]
+    [InlineData("AAPL/../../x")]
+    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567")]
+    [InlineData("AAPL,,MSFT")]
+    public async Task SearchDocuments_InvalidExcludedTickerFailsBeforeSearch(string tickers)
+    {
+        var result = await Tool().SearchDocuments("revenue", excludeTickers: tickers);
+
+        result.Should().Contain("Invalid excluded ticker");
+    }
+
+    [Fact]
+    public async Task SearchDocuments_TooManyExcludedTickersFailsBeforeSearch()
+    {
+        var tickers = string.Join(',', Enumerable.Range(1, 26).Select(index => $"T{index}"));
+
+        var result = await Tool().SearchDocuments("revenue", excludeTickers: tickers);
+
+        result.Should().Contain("Maximum 25 excluded tickers");
+    }
+}

--- a/tests/Equibles.UnitTests/Web/HoldingsExportControllerCikBoundaryValidationTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsExportControllerCikBoundaryValidationTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsExportControllerCikBoundaryValidationTests
+{
+    private static HoldingsExportController Controller()
+    {
+        var constructor = typeof(HoldingsExportController).GetConstructors().Single();
+        return (HoldingsExportController)
+            constructor.Invoke(constructor.GetParameters().Select(_ => (object)null).ToArray());
+    }
+
+    [Theory]
+    [InlineData("ſ234")]
+    [InlineData("١٢٣")]
+    [InlineData("12345678901234567")]
+    [InlineData("0000")]
+    public async Task InstitutionRejectsInvalidCikBeforeRepositoryAccess(string cik)
+    {
+        (await Controller().Institution(cik, null)).Should().BeOfType<NotFoundResult>();
+    }
+}

--- a/tests/Equibles.UnitTests/Web/ProfilesControllerNormalizeCiksCaseInsensitiveTests.cs
+++ b/tests/Equibles.UnitTests/Web/ProfilesControllerNormalizeCiksCaseInsensitiveTests.cs
@@ -3,39 +3,22 @@ using Equibles.Web.Controllers;
 
 namespace Equibles.UnitTests.Web;
 
-/// <summary>
-/// Adversarial Lane A. <c>NormalizeCiks</c> dedups with
-/// <c>StringComparer.OrdinalIgnoreCase</c> — the inline comment two lines
-/// below the helper makes the case-insensitivity load-bearing: "Case-
-/// insensitive comparer matches NormalizeCiks above; otherwise a lowercase
-/// <c>?ciks=cik123</c> in the URL would miss the row stored as
-/// <c>CIK123</c>." The sibling <c>WhitespacePaddedDuplicate</c> test only
-/// pins trim-then-dedup; a refactor that swapped the comparer to
-/// <c>StringComparer.Ordinal</c> (or dropped the explicit comparer
-/// altogether, defaulting to ordinal value-equality on <c>Distinct</c>)
-/// would still pass that test but would admit the same logical CIK twice
-/// into the <c>WHERE Cik IN (…)</c> on the comparison/overlap views,
-/// double-counting holdings in the join.
-/// </summary>
-public class ProfilesControllerNormalizeCiksCaseInsensitiveTests
+public class ProfilesControllerNormalizeCiksValidationTests
 {
     private static readonly MethodInfo NormalizeMethod = typeof(ProfilesController).GetMethod(
         "NormalizeCiks",
         BindingFlags.NonPublic | BindingFlags.Static
     );
 
-    [Fact]
-    public void NormalizeCiks_DuplicatesDifferingOnlyInLetterCase_CollapseToOneEntry()
+    [Theory]
+    [InlineData("12345678901234567")]
+    [InlineData("１２３")]
+    [InlineData("123x")]
+    [InlineData("0000")]
+    public void NormalizeCiks_InvalidMember_RejectsWholeBatch(string invalidCik)
     {
-        // Three inputs that are byte-distinct but logically the same CIK
-        // once compared case-insensitively. Exactly one survivor is required.
-        var result =
-            (List<string>)NormalizeMethod.Invoke(null, [new[] { "CIK123", "cik123", "CiK123" }]);
+        var result = (List<string>)NormalizeMethod.Invoke(null, [new[] { "1234567", invalidCik }]);
 
-        result
-            .Should()
-            .ContainSingle(
-                "OrdinalIgnoreCase Distinct must collapse case-variant CIK duplicates so the holdings IN-clause doesn't join the same filer twice"
-            );
+        result.Should().BeNull();
     }
 }

--- a/tests/Equibles.UnitTests/Web/StocksControllerTickerBoundaryValidationTests.cs
+++ b/tests/Equibles.UnitTests/Web/StocksControllerTickerBoundaryValidationTests.cs
@@ -1,0 +1,37 @@
+using Equibles.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Equibles.UnitTests.Web;
+
+public class StocksControllerTickerBoundaryValidationTests
+{
+    private static StocksController Controller()
+    {
+        var constructor = typeof(StocksController).GetConstructors().Single();
+        return (StocksController)
+            constructor.Invoke(constructor.GetParameters().Select(_ => (object)null).ToArray());
+    }
+
+    [Theory]
+    [InlineData("ſPY")]
+    [InlineData("AAPL/../../x")]
+    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567")]
+    public async Task DocumentAndHolderRoutesRejectInvalidTickerBeforeDataAccess(string ticker)
+    {
+        var controller = Controller();
+
+        (await controller.ShowDocument(ticker, Guid.NewGuid())).Should().BeOfType<NotFoundResult>();
+        (await controller.ShowHolder(ticker, "1234")).Should().BeOfType<NotFoundResult>();
+    }
+
+    [Theory]
+    [InlineData("ſ234")]
+    [InlineData("12345678901234567")]
+    [InlineData("0000")]
+    public async Task HolderRouteRejectsInvalidCikBeforeDataAccess(string cik)
+    {
+        var controller = Controller();
+
+        (await controller.ShowHolder("AAPL", cik)).Should().BeOfType<NotFoundResult>();
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooSplitParsingTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooSplitParsingTests.cs
@@ -18,7 +18,7 @@ public class YahooSplitParsingTests
           "chart": {
             "result": [
               {
-                "meta": { "gmtoffset": 0, "exchangeTimezoneName": "UTC" },
+                "meta": { "firstTradeDate": 1609459200, "gmtoffset": 0, "exchangeTimezoneName": "UTC" },
                 "timestamp": [1719532800, 1719792000],
                 "events": {
                   "splits": {
@@ -56,6 +56,7 @@ public class YahooSplitParsingTests
 
         var chart = await client.GetChart("NVDA", WindowStart, WindowEnd);
 
+        chart.FirstTradeDate.Should().Be(new DateOnly(2021, 1, 1));
         chart.Splits.Should().HaveCount(2);
 
         var forward = chart.Splits.Single(s => s.Date == new DateOnly(2021, 7, 20));


### PR DESCRIPTION
## Summary\n\n- Exclude non-traded daily rows from public and derived price calculations.\n- Validate ticker and CIK boundaries before data access.\n- Preserve authoritative exchange-traded-product references across SEC synchronization.\n- Retry exact-listing history bootstrap until verified deep coverage is stored.\n- Add the two additive CommonStock array columns and regression coverage.\n\n## Validation\n\n- 4,281 unit tests passed.\n- 2,539 integration tests passed.\n- Release builds passed.\n- The migration model matches the snapshot.