### PR TITLE
fix(holdings): revise thousands-scale filed publishes once prices arrive

### DIFF
--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -128,17 +128,19 @@ public class HoldingsScraperWorker : BaseScraperWorker
         if (failedDataSets.Count > 0)
             await RetryFailedDataSets(failedDataSets, minReportDate, stoppingToken);
 
+        // Revise mis-published filed values, heal abandoned zero-value rows (publish the filed
+        // figure) and reset implausible derivations for honest repricing. Bounded per cycle;
+        // self-terminating once the backlog drains. Runs BEFORE the pending recalculation so a
+        // row a repair phase resets is republished in the same cycle instead of serving $0 for a
+        // full SleepInterval.
+        await RepairAbandonedValues(stoppingToken);
+
         // Recalculate holdings that were imported without a Yahoo price available
         await RecalculatePendingValues(stoppingToken);
 
         // Withdraw the derived value from stored positions bigger than their issuer. Self-
         // terminating once the back catalogue is clean, so it costs one query per cycle after that.
         await RepairImpossiblePositions(stoppingToken);
-
-        // Heal abandoned zero-value rows (publish the filed figure) and reset implausible
-        // derivations for honest repricing. Bounded per cycle; self-terminating like the pass
-        // above once the backlog drains.
-        await RepairAbandonedValues(stoppingToken);
 
         // Restamp FilingType on filing rollup rows written before the column existed. Self-
         // terminating like the pass above.

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
@@ -1,4 +1,7 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
+using Equibles.Core.Contracts;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Data;
 using Equibles.Holdings.Data.Models;
 using Microsoft.EntityFrameworkCore;
@@ -6,13 +9,24 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.Holdings.HostedService.Services;
 
 /// <summary>
-/// Heals stored positions whose published value is a known lie: silent zeros the old retry ladder
-/// abandoned, and derivations inflated by a corrupt close.
+/// Heals stored positions whose published value is a known lie: filed figures published on a
+/// thousands basis, silent zeros the old retry ladder abandoned, and derivations inflated by a
+/// corrupt close.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Three populations, three phases:
+/// Four populations, four phases:
 /// <list type="number">
+/// <item><b>Mis-published filed values</b> — rows a valuation decision site published as
+/// <see cref="ValueSource.Filed"/> whose filed figure now looks thousands-scaled against an
+/// available close (<see cref="HoldingValueSanityGuard.FiledLooksThousandsScaled"/>). The decision
+/// is price-dependent, so it can be wrong in exactly one recoverable way: the price the decision
+/// needed was missing or different when it ran (a price series still backfilling, a guard shipped
+/// after the row was valued) and the row froze at the filer's thousands figure — 1,000× under
+/// water — with nothing ever re-examining a settled Filed row. One production window minted 22k+
+/// such rows on a single open quarter. The heal resets the row to pending so the recalculator
+/// republishes the derivation under the shared guard — never publishing in-phase, which would be
+/// a second implementation of the publish path free to drift from it.</item>
 /// <item><b>Stuck zeros</b> — rows the repricing lane gave up on before the filed-value fallback
 /// existed: <c>Value = 0</c>, not pending, not unavailable, with a perfectly good
 /// <see cref="InstitutionalHolding.FiledValue"/> sitting unused in the same row. At its worst this
@@ -23,7 +37,7 @@ namespace Equibles.Holdings.HostedService.Services;
 /// One corrupt price series manufactured $102.8T of phantom value this way across 263 holders.
 /// The heal resets them to pending so the recalculator re-derives them under its sanity guard
 /// (which routes them to the filed value when the series is still corrupt).</item>
-/// <item><b>Unmarked zeros</b> — the same abandoned population as phase 1 but with no filed
+/// <item><b>Unmarked zeros</b> — the same abandoned population as phase 2 but with no filed
 /// figure to publish. The ladder now stamps these <see cref="InstitutionalHolding.ValueUnavailable"/>
 /// on exhaustion, but rows abandoned before that change are indistinguishable from "position
 /// worth nothing", and every surface that discloses unvalued rows reads the flags. The heal
@@ -31,16 +45,56 @@ namespace Equibles.Holdings.HostedService.Services;
 /// </list>
 /// </para>
 /// <para>
+/// Phase 1 rules, each load-bearing:
+/// <list type="bullet">
+/// <item><b>Scope</b> is <c>ValueLastRetryAt == null</c> (with <c>Value == FiledValue</c> pinning
+/// "the row still serves the filed figure" — the flush upsert historically did not carry
+/// <see cref="ValueSource"/>, so a stale Filed label over a healthy derivation exists). The retry
+/// ladder stamps <c>ValueLastRetryAt</c> on every advance, so ladder-exhaust publishes are outside
+/// this phase by construction and remain the guard's documented accepted residual — a handful of
+/// rows in production, priced never or too late, not the multi-million abandoned-zero population
+/// (that one drained through phase 2 and carries a retry stamp anyway).</item>
+/// <item><b>The thousands signature is corroborated per accession, never per row.</b> Thousands
+/// reporting is a property of the filing's VALUE column: one in-band row alone can also be a
+/// legitimately-Filed depositary row (~3,200× basis) whose stored price basis error happens to
+/// land the recomputation inside the band — resetting that one would make the recalculator
+/// publish a derivation ~1,000× the filer's own figure, terminally. A reset therefore requires
+/// at least <see cref="MinCorroboratingRows"/> in-band rows making up at least
+/// <see cref="CorroborationFraction"/> of the accession's priced rows in the batch (the
+/// <c>Corrupt13FShareCountRepairer</c> pattern). Ambiguous in-band rows below that bar are
+/// stamped instead — they keep serving the filer's own figure, and the quarterly bulk re-import
+/// remains their healer.</item>
+/// <item><b>Only a POSITIVE usable close examines a row.</b> The stamp is the one irreversible
+/// decision in this lane (nothing but a re-import clears it), so it must never be taken on a
+/// garbage price: a stored zero close derives 0, which is out-of-band, and would retire a
+/// genuinely broken row forever. Zero/absent/implausible closes and unresolvable share-count
+/// bases defer the row unstamped to a later cycle — the same deferral gates the recalculator
+/// applies, so a reset row is always one it can republish.</item>
+/// <item><b>The scan advances a wrap-around frontier</b> so permanently deferred rows (a price
+/// series retired by the exact-listing cutover, an unresolvable secondary-listing split) cannot
+/// pin the bounded window to the head of the Id order. Examined/stamped/deferred counts are
+/// logged every non-empty cycle — a full window with a rising deferred count is the jam signal.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Phases are isolated: one phase dying (the un-indexed scans routinely time out under
+/// re-import load) must not starve the others, or a single slow predicate silently freezes every
+/// heal at once — which is exactly how the thousands-scale population sat untouched while the
+/// pass failed hourly on a later phase's timeout. Cancellation still propagates.
+/// </para>
+/// <para>
 /// Bounded per cycle and self-terminating: a healed row no longer matches its phase's candidate
-/// query. Phase 2 terminates because the recalculator guards the same number this phase tests —
-/// the effective per-share price (factor × close) — so a reset row either re-derives under the
-/// cap, falls back to the filed value, or exhausts the ladder into <c>ValueUnavailable</c>; it
-/// can never re-derive back above the cap and be reset again. Neither candidate predicate is
-/// index-served (the zero test isn't selective enough to earn one and the per-share comparison
-/// isn't sargable), so a drained backlog still costs two bounded sequential scans per daily
-/// cycle — accepted for a 24h cadence. Affected filing rollups and AUM quarters are re-derived
-/// through <see cref="HoldingsRollupRefresher"/> in the same pass — a healed position with a
-/// stale rollup would just move the lie one aggregate up.
+/// query (phase 1 drains through the reset or the <c>ValueLastRetryAt</c> stamp). Phase 1 cannot
+/// ping-pong with the recalculator because both consult the same prices, the same share-count
+/// factor and the same banded decision — a reset row either republishes as Derived (leaving the
+/// Filed population) or re-exhausts into a retry stamp this phase excludes. Phase 3 terminates
+/// because the recalculator guards the same number this phase tests — the effective per-share
+/// price (factor × close) — so a reset row can never re-derive back above the cap and be reset
+/// again. The candidate predicates are not index-served (none are selective enough to earn one),
+/// so a drained backlog still costs bounded sequential scans per daily cycle — accepted for a 24h
+/// cadence. Affected filing rollups and AUM quarters are re-derived through
+/// <see cref="HoldingsRollupRefresher"/> in the same pass — a healed position with a stale rollup
+/// would just move the lie one aggregate up.
 /// </para>
 /// </remarks>
 [Service]
@@ -52,38 +106,296 @@ public class HoldingValueFallbackRepairService
     // of rows in one scope.
     internal const int MaxRowsPerCycle = 50_000;
 
+    /// <summary>
+    /// Minimum in-band rows an accession must show in the batch before any of them is reset —
+    /// one or two can be coincidence (a depositary row behind a basis error), three sharing one
+    /// filing cannot reasonably be.
+    /// </summary>
+    internal const int MinCorroboratingRows = 3;
+
+    /// <summary>
+    /// Minimum share of an accession's priced batch rows that must be in-band for a reset — a
+    /// thousands-basis VALUE column marks (nearly) the whole filing, never a stray row of it.
+    /// </summary>
+    internal const decimal CorroborationFraction = 0.8m;
+
+    // Wrap-around frontier for the phase-1 scan. Ids are client-generated Guids, so OrderBy(Id)
+    // is an arbitrary but stable order; without the frontier, >MaxRowsPerCycle permanently
+    // deferred residents would pin the window to the head forever. Process restarts reset it to
+    // the head, which only costs re-examining already-stamped rows' predicate (they no longer
+    // match).
+    private static Guid _reviseFrontier = Guid.Empty;
+
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IStockPriceProvider _stockPriceProvider;
     private readonly ILogger<HoldingValueFallbackRepairService> _logger;
 
     public HoldingValueFallbackRepairService(
         IServiceScopeFactory scopeFactory,
+        IStockPriceProvider stockPriceProvider,
         ILogger<HoldingValueFallbackRepairService> logger
     )
     {
         _scopeFactory = scopeFactory;
+        _stockPriceProvider = stockPriceProvider;
         _logger = logger;
     }
 
     public async Task<int> Repair(CancellationToken cancellationToken)
     {
-        var healedZeros = await HealStuckZeros(cancellationToken);
-        var resetImplausible = await ResetImplausibleDerivations(cancellationToken);
-        var markedUnavailable = await MarkAbandonedZerosUnavailable(cancellationToken);
+        var revisedFiled = await RunPhase(
+            "revise-filed",
+            ReviseFiledPublishes,
+            cancellationToken
+        );
+        var healedZeros = await RunPhase("stuck-zeros", HealStuckZeros, cancellationToken);
+        var resetImplausible = await RunPhase(
+            "implausible-derivations",
+            ResetImplausibleDerivations,
+            cancellationToken
+        );
+        var markedUnavailable = await RunPhase(
+            "unmarked-zeros",
+            MarkAbandonedZerosUnavailable,
+            cancellationToken
+        );
 
-        if (healedZeros > 0 || resetImplausible > 0 || markedUnavailable > 0)
+        if (revisedFiled > 0 || healedZeros > 0 || resetImplausible > 0 || markedUnavailable > 0)
         {
             _logger.LogWarning(
-                "Value fallback repair: published the filed value on {HealedZeros} abandoned "
+                "Value fallback repair: reset {RevisedFiled} thousands-scale filed publish(es) "
+                    + "for honest repricing, published the filed value on {HealedZeros} abandoned "
                     + "zero-value position(s), reset {ResetImplausible} implausibly-derived "
                     + "position(s) for honest repricing, and marked {MarkedUnavailable} "
                     + "filed-value-less abandoned zero(s) as unavailable",
+                revisedFiled,
                 healedZeros,
                 resetImplausible,
                 markedUnavailable
             );
         }
 
-        return healedZeros + resetImplausible + markedUnavailable;
+        return revisedFiled + healedZeros + resetImplausible + markedUnavailable;
+    }
+
+    // One phase's failure must not starve the phases after it; only cancellation propagates.
+    private async Task<int> RunPhase(
+        string phase,
+        Func<CancellationToken, Task<int>> heal,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            return await heal(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Value fallback repair phase {Phase} failed; continuing with the remaining phases",
+                phase
+            );
+            return 0;
+        }
+    }
+
+    // Exposed for the Npgsql translation pin: Guid.CompareTo is the only way to express the
+    // frontier in LINQ (Guid has no comparison operators), and an untranslatable shape would
+    // pass every InMemory-backed test while faulting the phase at runtime.
+    internal static IQueryable<InstitutionalHolding> BuildReviseCandidateQuery(
+        EquiblesFinancialDbContext dbContext,
+        Guid frontier
+    ) =>
+        dbContext
+            .Set<InstitutionalHolding>()
+            .Include(h => h.ManagerEntries)
+            .Where(h =>
+                !h.ValuePending
+                && !h.ValueUnavailable
+                && h.ValueSource == ValueSource.Filed
+                && h.ValueLastRetryAt == null
+                && h.FiledValue != null
+                && h.FiledValue > 0
+                && h.Value == h.FiledValue
+                && h.Shares > 0
+                && h.Id.CompareTo(frontier) > 0
+            )
+            .OrderBy(h => h.Id)
+            .Take(MaxRowsPerCycle);
+
+    /// <summary>
+    /// Re-examines decision-site filed publishes against the prices available now, resetting to
+    /// pending those whose filed figure is on a corroborated thousands basis.
+    /// </summary>
+    private async Task<int> ReviseFiledPublishes(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        ExtendCommandTimeout(dbContext);
+
+        var rows = await BuildReviseCandidateQuery(dbContext, _reviseFrontier)
+            .ToListAsync(cancellationToken);
+
+        _reviseFrontier = rows.Count == MaxRowsPerCycle ? rows[^1].Id : Guid.Empty;
+
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        var pairs = rows.Select(h => (h.CommonStockId, h.ListedTicker, h.ReportDate))
+            .Distinct()
+            .ToList();
+        var prices = await _stockPriceProvider.GetClosingPrices(pairs, cancellationToken);
+
+        var stockIds = rows.Select(h => h.CommonStockId).Distinct().ToList();
+        var splitsByStock = (
+            await dbContext
+                .Set<StockSplit>()
+                .Where(s => stockIds.Contains(s.CommonStockId))
+                .ToListAsync(cancellationToken)
+        )
+            .GroupBy(s => s.CommonStockId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var tickerIdentities = await dbContext
+            .Set<CommonStock>()
+            .Where(cs => stockIds.Contains(cs.Id))
+            .Select(cs => new
+            {
+                cs.Id,
+                cs.Ticker,
+                cs.SecondaryTickers,
+            })
+            .ToListAsync(cancellationToken);
+        var primaryTickers = tickerIdentities.ToDictionary(cs => cs.Id, cs => cs.Ticker);
+        var secondaryTickers = tickerIdentities.ToDictionary(
+            cs => cs.Id,
+            cs => cs.SecondaryTickers ?? []
+        );
+
+        var deferred = 0;
+        var priced = new List<(InstitutionalHolding Holding, bool InBand)>();
+
+        foreach (var holding in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Only a POSITIVE plausible close examines a row: the stamp below is irreversible,
+            // and a zero/corrupt close derives an out-of-band figure that would retire a
+            // genuinely broken row forever. These are the recalculator's own deferral gates, so
+            // a reset row is always one it can republish.
+            if (
+                !prices.TryGetValue(
+                    (holding.CommonStockId, holding.ListedTicker, holding.ReportDate),
+                    out var closePrice
+                )
+                || closePrice <= 0
+                || HoldingValueSanityGuard.IsImplausibleClose(closePrice)
+            )
+            {
+                deferred++;
+                continue;
+            }
+
+            splitsByStock.TryGetValue(holding.CommonStockId, out var splits);
+            primaryTickers.TryGetValue(holding.CommonStockId, out var primaryTicker);
+            secondaryTickers.TryGetValue(holding.CommonStockId, out var listedSecondaries);
+            if (
+                !HoldingValueBasis.TryResolveShareCountFactor(
+                    holding.ReportDate,
+                    splits,
+                    holding.ListedTicker,
+                    primaryTicker,
+                    listedSecondaries,
+                    out var shareCountFactor
+                ) || HoldingValueSanityGuard.IsImplausibleClose(shareCountFactor * closePrice)
+            )
+            {
+                deferred++;
+                continue;
+            }
+
+            var derived = holding.Shares * shareCountFactor * closePrice;
+            priced.Add(
+                (
+                    holding,
+                    HoldingValueSanityGuard.FiledLooksThousandsScaled(
+                        derived,
+                        holding.Shares,
+                        holding.FiledValue
+                    )
+                )
+            );
+        }
+
+        var examinedAt = DateTime.UtcNow;
+        var resetRows = new List<InstitutionalHolding>();
+        var stamped = 0;
+
+        foreach (var filing in priced.GroupBy(p => p.Holding.AccessionNumber))
+        {
+            var pricedCount = filing.Count();
+            var inBandCount = filing.Count(p => p.InBand);
+            var corroborated =
+                inBandCount >= MinCorroboratingRows
+                && inBandCount >= CorroborationFraction * pricedCount;
+
+            foreach (var (holding, inBand) in filing)
+            {
+                if (corroborated && inBand)
+                {
+                    holding.Value = 0L;
+                    holding.ValuePending = true;
+                    holding.ValueRetryCount = 0;
+                    holding.ValueLastRetryAt = null;
+                    holding.ValueSource = ValueSource.Derived;
+                    foreach (var entry in holding.ManagerEntries)
+                    {
+                        entry.Value = 0L;
+                    }
+                    resetRows.Add(holding);
+                }
+                else
+                {
+                    // Examined under a usable price and either legitimately filed (depositary
+                    // basis, options premium) or in-band without corroboration: the stamp
+                    // retires it from this candidate set; a stamped ambiguous row keeps serving
+                    // the filer's own figure until a bulk re-import re-decides it.
+                    holding.ValueLastRetryAt = examinedAt;
+                    stamped++;
+                }
+            }
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        if (resetRows.Count > 0)
+        {
+            await HoldingsRollupRefresher.Refresh(
+                dbContext,
+                resetRows.Select(h => h.AccessionNumber).ToHashSet(),
+                resetRows.Select(h => h.ReportDate).ToHashSet(),
+                cancellationToken
+            );
+        }
+
+        // A full window with a rising deferred count is the jam signal; without these numbers
+        // "drained" and "jammed on permanent residents" read identically in the logs.
+        _logger.LogInformation(
+            "Filed-publish revision: examined {Examined} candidate(s), reset {Reset}, "
+                + "retired {Stamped}, deferred {Deferred} awaiting a usable price",
+            rows.Count,
+            resetRows.Count,
+            stamped,
+            deferred
+        );
+
+        return resetRows.Count;
     }
 
     /// <summary>
@@ -93,10 +405,7 @@ public class HoldingValueFallbackRepairService
     {
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
-        if (dbContext.Database.IsRelational())
-        {
-            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
-        }
+        ExtendCommandTimeout(dbContext);
 
         var rows = await dbContext
             .Set<InstitutionalHolding>()
@@ -143,10 +452,7 @@ public class HoldingValueFallbackRepairService
     {
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
-        if (dbContext.Database.IsRelational())
-        {
-            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
-        }
+        ExtendCommandTimeout(dbContext);
 
         // Decimal math server-side: 1M × a large share count overflows Int64, and the point of
         // the predicate is exactly the rows where Value is astronomically large. Filed-value rows
@@ -206,10 +512,7 @@ public class HoldingValueFallbackRepairService
     {
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
-        if (dbContext.Database.IsRelational())
-        {
-            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
-        }
+        ExtendCommandTimeout(dbContext);
 
         // Value stays 0, so no rollup or AUM figure moves — the stamp only makes the row
         // visible to every surface that discloses unvalued positions through the flags.
@@ -239,5 +542,13 @@ public class HoldingValueFallbackRepairService
 
         await dbContext.SaveChangesAsync(cancellationToken);
         return rows.Count;
+    }
+
+    private static void ExtendCommandTimeout(EquiblesFinancialDbContext dbContext)
+    {
+        if (dbContext.Database.IsRelational())
+        {
+            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+        }
     }
 }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueSanityGuard.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueSanityGuard.cs
@@ -76,7 +76,10 @@ internal static class HoldingValueSanityGuard
     /// otherwise land inside the band. Residual, accepted: rows this rule cannot see (a
     /// thousands filer whose price never arrives, published via the ladder-exhaust or
     /// stuck-zero filed fallbacks) still serve the thousands-scale figure — there is no scale
-    /// signal without a derivation to compare against.
+    /// signal without a derivation to compare against. Decision-site publishes are NOT part of
+    /// that residual: their price can arrive (or change) after the decision, so
+    /// <see cref="HoldingValueFallbackRepairService"/> re-examines them against current prices
+    /// and resets the ones this band identifies.
     /// </summary>
     internal static bool FiledLooksThousandsScaled(
         decimal derivedValue,

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1924,6 +1924,12 @@ public class HoldingsImportService
                         IsAmendment = incoming.IsAmendment,
                         ValuePending = incoming.ValuePending,
                         ValueUnavailable = incoming.ValueUnavailable,
+                        // The label must travel with the figure it describes: without it a
+                        // re-import that re-derives a previously Filed row keeps the stale Filed
+                        // label (shielding the new derivation from the implausible-derivation
+                        // reset), and one that publishes filed over a previously derived row
+                        // keeps Derived (exposing the filer's own figure to that same reset).
+                        ValueSource = incoming.ValueSource,
                     }
             )
             .RunAsync(cancellationToken);

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingValueFallbackRepairServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingValueFallbackRepairServiceTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.Contracts;
 using Equibles.CorporateActions.Data;
 using Equibles.Data;
 using Equibles.Holdings.Data;
@@ -32,6 +33,13 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
         ILogger<HoldingValueFallbackRepairService>
     >();
     private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    // The revise-filed phase consults this map exactly like the recalculator consults the
+    // provider: an absent pair means "price has not arrived", never zero.
+    private readonly Dictionary<
+        (Guid CommonStockId, string ListedTicker, DateOnly Date),
+        decimal
+    > _prices = [];
 
     public void Dispose()
     {
@@ -74,7 +82,18 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
         return scopeFactory;
     }
 
-    private HoldingValueFallbackRepairService CreateService() => new(CreateScopeFactory(), _logger);
+    private HoldingValueFallbackRepairService CreateService()
+    {
+        var priceProvider = Substitute.For<IStockPriceProvider>();
+        priceProvider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, string, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ => new Dictionary<(Guid, string, DateOnly), decimal>(_prices));
+
+        return new HoldingValueFallbackRepairService(CreateScopeFactory(), priceProvider, _logger);
+    }
 
     private async Task<InstitutionalHolding> SeedHolding(
         long value,
@@ -84,7 +103,8 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
         bool valueUnavailable = false,
         ValueSource valueSource = ValueSource.Derived,
         string accession = null,
-        int valueRetryCount = 0
+        int valueRetryCount = 0,
+        DateTime? valueLastRetryAt = null
     )
     {
         var seedContext = CreateSharedContext();
@@ -114,6 +134,7 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
             ValueUnavailable = valueUnavailable,
             ValueSource = valueSource,
             ValueRetryCount = valueRetryCount,
+            ValueLastRetryAt = valueLastRetryAt,
             ShareType = ShareType.Shares,
             InvestmentDiscretion = InvestmentDiscretion.Sole,
             AccessionNumber = accession ?? Guid.NewGuid().ToString()[..20],
@@ -145,7 +166,236 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
             .FirstAsync(h => h.Id == holdingId);
     }
 
-    // ── Phase 1: stuck zeros ───────────────────────────────────────────
+    private void PriceAt(InstitutionalHolding holding, decimal close) =>
+        _prices[(holding.CommonStockId, holding.ListedTicker, holding.ReportDate)] = close;
+
+    // The production signature (SG Americas / AAPL, 2026-06-30): the filer reports the VALUE
+    // column in thousands, the close arrived after the publish decision, and every row froze
+    // serving $6.7M for a $6.7B position — shares × close ÷ filed lands dead on 1,000×. The
+    // revision phase needs the signature corroborated across the accession, so most tests seed
+    // a filing of several such rows.
+    private async Task<List<InstitutionalHolding>> SeedThousandsFiling(
+        int count,
+        string accession = null
+    )
+    {
+        accession ??= Guid.NewGuid().ToString()[..20];
+        var holdings = new List<InstitutionalHolding>();
+        for (var i = 0; i < count; i++)
+        {
+            var holding = await SeedHolding(
+                value: 6_701_245L,
+                filedValue: 6_701_245L,
+                shares: 23_158_850,
+                valueSource: ValueSource.Filed,
+                accession: accession
+            );
+            PriceAt(holding, 289.36m);
+            holdings.Add(holding);
+        }
+        return holdings;
+    }
+
+    // ── Phase 1: mis-published thousands-scale filed values ────────────
+
+    [Fact]
+    public async Task Repair_CorroboratedThousandsScaleFiling_IsResetForRepricing()
+    {
+        var holdings = await SeedThousandsFiling(count: 3);
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(3);
+        foreach (var holding in holdings)
+        {
+            var updated = await Reload(holding.Id);
+            updated.ValuePending.Should().BeTrue("the recalculator republishes it under the guard");
+            updated.Value.Should().Be(0L);
+            updated.ValueSource.Should().Be(ValueSource.Derived);
+            updated.ValueRetryCount.Should().Be(0);
+            updated.ValueLastRetryAt.Should().BeNull();
+            updated.ManagerEntries.Single().Value.Should().Be(0L);
+        }
+    }
+
+    [Fact]
+    public async Task Repair_UncorroboratedInBandRow_IsStampedNotReset()
+    {
+        // One in-band row alone can also be a legitimately-Filed depositary row whose stored
+        // price basis error lands the recomputation inside the band — resetting it would make
+        // the recalculator publish ~1,000× the filer's own figure, terminally. Below the
+        // corroboration bar the row keeps the filer's figure and the bulk re-import stays its
+        // healer.
+        var holding = (await SeedThousandsFiling(count: 1)).Single();
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(0);
+        var updated = await Reload(holding.Id);
+        updated.Value.Should().Be(6_701_245L);
+        updated.ValueSource.Should().Be(ValueSource.Filed);
+        updated.ValueLastRetryAt.Should().NotBeNull("an examined ambiguous row must retire");
+    }
+
+    [Fact]
+    public async Task Repair_CorroboratedFiling_StampsItsOutOfBandRowInstead()
+    {
+        // Four in-band legs corroborate the filing; the fifth priced row is out of band (a
+        // depositary-basis publish, derived ~40× filed) and must keep the filer's figure.
+        var accession = "0001313360-26-000003";
+        await SeedThousandsFiling(count: 4, accession: accession);
+        var depositary = await SeedHolding(
+            value: 2_000_000L,
+            filedValue: 2_000_000L,
+            shares: 800_000,
+            valueSource: ValueSource.Filed,
+            accession: accession
+        );
+        PriceAt(depositary, 100m);
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(4);
+        var updated = await Reload(depositary.Id);
+        updated.Value.Should().Be(2_000_000L);
+        updated.ValueSource.Should().Be(ValueSource.Filed);
+        updated.ValuePending.Should().BeFalse();
+        updated.ValueLastRetryAt.Should().NotBeNull("an examined legitimate publish must retire");
+    }
+
+    [Fact]
+    public async Task Repair_FiledPublishWithoutPrice_StaysUnstampedForALaterCycle()
+    {
+        // No usable price yet (series still backfilling). The row must stay in the candidate
+        // set — stamping it would close the exact price-arrives-later race this phase exists
+        // to close.
+        var holding = await SeedHolding(
+            value: 6_701_245L,
+            filedValue: 6_701_245L,
+            shares: 23_158_850,
+            valueSource: ValueSource.Filed
+        );
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(0);
+        var updated = await Reload(holding.Id);
+        updated.Value.Should().Be(6_701_245L);
+        updated.ValueLastRetryAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Repair_FiledPublishWithZeroClose_StaysUnstampedForALaterCycle()
+    {
+        // A stored zero close derives 0 — out of band — and would retire a genuinely broken row
+        // forever if it were allowed to stamp. A non-positive close must defer, never examine.
+        var holdings = await SeedThousandsFiling(count: 3);
+        foreach (var holding in holdings)
+        {
+            PriceAt(holding, 0m);
+        }
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(0);
+        foreach (var holding in holdings)
+        {
+            var updated = await Reload(holding.Id);
+            updated.Value.Should().Be(6_701_245L);
+            updated.ValueLastRetryAt.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public async Task Repair_LadderExhaustFiledPublish_IsOutsideThisPhase()
+    {
+        // The retry ladder stamps ValueLastRetryAt on every advance, so an exhaust publish is
+        // outside this phase by construction — it is the guard's documented accepted residual.
+        var holding = await SeedHolding(
+            value: 6_701_245L,
+            filedValue: 6_701_245L,
+            shares: 23_158_850,
+            valueSource: ValueSource.Filed,
+            valueRetryCount: 4,
+            valueLastRetryAt: DateTime.UtcNow
+        );
+        PriceAt(holding, 289.36m);
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(0);
+        (await Reload(holding.Id)).Value.Should().Be(6_701_245L);
+    }
+
+    [Fact]
+    public async Task Repair_UnavailableFiledRow_IsNeverRevived()
+    {
+        // A multi-leg merge can leave ValueUnavailable and a Filed label on one row; the
+        // valuation was deliberately withheld (ImpossiblePositionGuard) and no phase may hand
+        // it back to the repricing lane.
+        var holding = await SeedHolding(
+            value: 6_701_245L,
+            filedValue: 6_701_245L,
+            shares: 23_158_850,
+            valueSource: ValueSource.Filed,
+            valueUnavailable: true
+        );
+        PriceAt(holding, 289.36m);
+
+        var repaired = await CreateService().Repair(CancellationToken.None);
+
+        repaired.Should().Be(0);
+        var updated = await Reload(holding.Id);
+        updated.ValuePending.Should().BeFalse();
+        updated.ValueLastRetryAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Repair_ThousandsScaleReset_RealignsTheFilingRollup()
+    {
+        var accession = "0001313360-26-000003";
+        var holdings = await SeedThousandsFiling(count: 3, accession: accession);
+
+        var seedContext = CreateSharedContext();
+        seedContext
+            .Set<InstitutionalFiling>()
+            .Add(
+                new InstitutionalFiling
+                {
+                    Id = Guid.NewGuid(),
+                    AccessionNumber = accession,
+                    InstitutionalHolderId = holdings[0].InstitutionalHolderId,
+                    FilingDate = holdings[0].FilingDate,
+                    ReportDate = holdings[0].ReportDate,
+                    PositionCount = 3,
+                    TotalValue = 3 * 6_701_245L,
+                }
+            );
+        await seedContext.SaveChangesAsync();
+
+        await CreateService().Repair(CancellationToken.None);
+
+        var verifyContext = CreateSharedContext();
+        var filing = await verifyContext
+            .Set<InstitutionalFiling>()
+            .FirstAsync(f => f.AccessionNumber == accession);
+        filing.TotalValue.Should().Be(0L, "the reset must not leave the thousands figure summed");
+    }
+
+    [Fact]
+    public async Task Repair_ThousandsScaleReset_SecondRunIsANoOp()
+    {
+        await SeedThousandsFiling(count: 3);
+
+        var service = CreateService();
+        var firstRun = await service.Repair(CancellationToken.None);
+        var secondRun = await service.Repair(CancellationToken.None);
+
+        firstRun.Should().Be(3);
+        secondRun.Should().Be(0, "a reset row is pending and outside every candidate set");
+    }
+
+    // ── Phase 2: stuck zeros ───────────────────────────────────────────
 
     [Fact]
     public async Task Repair_AbandonedZeroWithFiledValue_PublishesFiledValue()
@@ -199,7 +449,7 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
         updated.ValueUnavailable.Should().BeFalse();
     }
 
-    // ── Phase 3: abandoned zeros with no filed figure ──────────────────
+    // ── Phase 4: abandoned zeros with no filed figure ──────────────────
 
     [Fact]
     public async Task Repair_AbandonedZeroWithoutFiledValue_IsMarkedUnavailable()
@@ -223,7 +473,7 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
         updated.ValuePending.Should().BeFalse();
     }
 
-    // ── Phase 2: implausible derivations ───────────────────────────────
+    // ── Phase 3: implausible derivations ───────────────────────────────
 
     [Fact]
     public async Task Repair_ImplausibleImpliedPrice_ResetsRowForRepricing()

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueFallbackRepairServiceReviseQueryTranslationTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueFallbackRepairServiceReviseQueryTranslationTests.cs
@@ -1,0 +1,48 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.HostedService.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins that the filed-publish revision candidate query stays translatable by the Npgsql
+/// provider. The frontier is expressed as <c>Guid.CompareTo</c> (Guid has no comparison
+/// operators in LINQ), a shape the InMemory-backed integration tests would happily evaluate
+/// client-side — so without this pin an EF upgrade that stops translating it would pass every
+/// test and fault the repair phase at runtime instead.
+/// </summary>
+public class HoldingValueFallbackRepairServiceReviseQueryTranslationTests
+{
+    [Fact]
+    public void BuildReviseCandidateQuery_TranslatesToSql()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only")
+            .EnableServiceProviderCaching(false)
+            .Options;
+        using var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new HoldingsModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+
+        var query = HoldingValueFallbackRepairService.BuildReviseCandidateQuery(
+            ctx,
+            Guid.NewGuid()
+        );
+
+        // Throws InvalidOperationException ("could not be translated") when the shape stops
+        // translating; the assertions pin that the frontier comparison and the row cap stay in
+        // SQL rather than silently falling back to client evaluation.
+        var sql = query.ToQueryString();
+        sql.Should().Contain("LIMIT");
+        sql.Should().Contain(">");
+    }
+}


### PR DESCRIPTION
## Summary

13F rows published as `ValueSource.Filed` froze at the filer's thousands-basis figure — 1,000× under water — whenever the publish decision ran without the price it needed (exact-listing price series still backfilling) or before the banded thousands carve-out shipped (#4324). A production window (Aug 5–9) minted 22k+ such rows on the open 2026-06-30 quarter alone (SG Americas' entire book: implied $0.29/share AAPL), and nothing ever re-examined a settled Filed row: the v8 re-import heals bulk-dataset quarters, but realtime-swept open-quarter accessions have no re-import until the SEC's quarterly data set lands, and any future price-lags-decision race would freeze the same way.

## Code changes

- **`HoldingValueFallbackRepairService`** — new first phase `ReviseFiledPublishes`: re-tests decision-site filed publishes (rows the retry ladder never stamped, still serving `Value == FiledValue`) against current prices under the shared `HoldingValueSanityGuard` band. The thousands signature must corroborate across the accession (≥3 in-band rows, ≥80% of its priced rows — the `Corrupt13FShareCountRepairer` pattern) before any row resets to pending; the recalculator then republishes the derivation, so there is exactly one publish implementation. Legitimate/ambiguous publishes retire via a `ValueLastRetryAt` stamp; only a positive plausible close may examine a row (the stamp is irreversible); unpriced rows defer to a later cycle; a wrap-around frontier plus per-cycle examined/reset/retired/deferred logging keeps the bounded scan observable and jam-proof. Phases are now isolated (`RunPhase`) so one phase's statement timeout no longer starves the others — the pass had been failing hourly on a later phase's 57014.
- **`HoldingsScraperWorker`** — the repair pass now runs before `RecalculatePendingValues`, so a reset row republishes in the same cycle instead of serving $0 for a full `SleepInterval`.
- **`HoldingsImportService`** — the flush upsert now carries `ValueSource`, so a re-import that changes which figure a row publishes no longer leaves a stale label behind.
- **`HoldingValueSanityGuard`** — remarks narrowed: decision-site publishes are no longer part of the accepted residual.
- **Tests** — 9 integration tests over the new phase (corroborated reset incl. rollup realignment and idempotency, uncorroborated stamp, out-of-band stamp inside a corroborated filing, zero-close and no-price deferral, ladder-exhaust and unavailable-row exclusion) and an Npgsql `ToQueryString` pin for the Guid frontier comparison.

Build + full unit (4,248) and integration (2,527) suites green locally.