### PR TITLE
fix(holdings): unify institutional CIK spellings

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
@@ -143,11 +143,7 @@ public class HoldingValueFallbackRepairService
 
     public async Task<int> Repair(CancellationToken cancellationToken)
     {
-        var revisedFiled = await RunPhase(
-            "revise-filed",
-            ReviseFiledPublishes,
-            cancellationToken
-        );
+        var revisedFiled = await RunPhase("revise-filed", ReviseFiledPublishes, cancellationToken);
         var healedZeros = await RunPhase("stuck-zeros", HealStuckZeros, cancellationToken);
         var resetImplausible = await RunPhase(
             "implausible-derivations",

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.IO.Compression;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
@@ -863,7 +864,7 @@ public class HoldingsImportService
             .Distinct()
             .ToList();
 
-        var existingHolders = await holderRepo.GetByCiks(allCiks).ToListAsync(cancellationToken);
+        var existingHolders = await holderRepo.GetByCiks(allCiks, cancellationToken);
         foreach (var holder in existingHolders)
         {
             cikToHolderId[holder.Cik] = holder.Id;
@@ -880,25 +881,51 @@ public class HoldingsImportService
 
     // Refresh the confidential-treatment flag on holders we already track from
     // their latest filing's cover page; their identity columns stay as first seen.
-    // Keyed by CIK up front: a linear scan per holder is O(holders × submissions),
+    // Keyed by canonical CIK up front: a linear scan per holder is O(holders × submissions),
     // which a quarterly bulk data set (~8k of each) turns into tens of millions of
     // comparisons — and its first-match pick was import-order-arbitrary when a
     // filer has several submissions (multiple quarters) in one data set.
-    private void RefreshExistingHolderConfidentialTreatment(
+    internal void RefreshExistingHolderConfidentialTreatment(
         ImportContext context,
         List<InstitutionalHolder> existingHolders
     )
     {
-        var latestByCik = BuildLatestSubmissionByCik(context.Submissions.Values);
+        var latestByCanonicalCik = BuildLatestSubmissionByCanonicalCik(context.Submissions.Values);
 
         foreach (var holder in existingHolders)
         {
-            if (!latestByCik.TryGetValue(holder.Cik, out var submission))
+            var canonicalCik = CikNormalizer.Canonicalize(holder.Cik);
+            if (
+                canonicalCik == null
+                || !latestByCanonicalCik.TryGetValue(canonicalCik, out var submission)
+            )
                 continue;
             context.CoverPages.TryGetValue(submission.AccessionNumber, out var cp);
             if (cp != null)
                 holder.ConfidentialTreatmentRequested = IsYes(cp.ConfidentialTreatment);
         }
+    }
+
+    internal static Dictionary<string, SubmissionRow> BuildLatestSubmissionByCanonicalCik(
+        IEnumerable<SubmissionRow> submissions
+    )
+    {
+        var latestByCik = new Dictionary<string, SubmissionRow>(StringComparer.Ordinal);
+        foreach (var submission in submissions)
+        {
+            var canonicalCik = CikNormalizer.Canonicalize(submission.Cik);
+            if (canonicalCik == null)
+                continue;
+            if (
+                !latestByCik.TryGetValue(canonicalCik, out var current)
+                || CompareByFilingDateThenAccession(submission, current) > 0
+            )
+            {
+                latestByCik[canonicalCik] = submission;
+            }
+        }
+
+        return latestByCik;
     }
 
     // The most recently filed submission per CIK — same ordering contract as
@@ -942,14 +969,30 @@ public class HoldingsImportService
         Dictionary<string, Guid> cikToHolderId
     )
     {
-        var existingCiks = existingHolders
-            .Select(h => h.Cik)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var existingByCik = existingHolders.ToDictionary(
+            holder => holder.Cik,
+            StringComparer.Ordinal
+        );
 
         foreach (var submission in context.Submissions.Values)
         {
-            if (string.IsNullOrEmpty(submission.Cik) || existingCiks.Contains(submission.Cik))
+            if (string.IsNullOrEmpty(submission.Cik))
                 continue;
+
+            existingByCik.TryGetValue(submission.Cik, out var existingHolder);
+            if (existingHolder == null)
+            {
+                var alternateCik = InstitutionalHolderRepository.AlternateCikSpelling(
+                    submission.Cik
+                );
+                if (alternateCik != null)
+                    existingByCik.TryGetValue(alternateCik, out existingHolder);
+            }
+            if (existingHolder != null)
+            {
+                cikToHolderId[submission.Cik] = existingHolder.Id;
+                continue;
+            }
 
             context.CoverPages.TryGetValue(submission.AccessionNumber, out var coverPage);
 
@@ -970,7 +1013,8 @@ public class HoldingsImportService
 
             holderRepo.Add(holder);
             cikToHolderId[submission.Cik] = holder.Id;
-            existingCiks.Add(submission.Cik);
+            existingHolders.Add(holder);
+            existingByCik[holder.Cik] = holder;
         }
     }
 

--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -14,18 +14,76 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
     public async Task<InstitutionalHolder> GetByCik(string cik)
     {
         var validatedCik = CikNormalizer.Validate(cik);
-        return validatedCik == null
+        if (validatedCik == null)
+            return null;
+
+        var exact = await GetAll().FirstOrDefaultAsync(h => h.Cik == validatedCik);
+        if (exact != null)
+            return exact;
+
+        var alternateCik = AlternateCikSpelling(validatedCik);
+        return alternateCik == null
             ? null
-            : await GetAll().FirstOrDefaultAsync(h => h.Cik == validatedCik);
+            : await GetAll().FirstOrDefaultAsync(h => h.Cik == alternateCik);
     }
 
-    public IQueryable<InstitutionalHolder> GetByCiks(IEnumerable<string> ciks)
+    public async Task<List<InstitutionalHolder>> GetByCiks(
+        IEnumerable<string> ciks,
+        CancellationToken cancellationToken = default
+    )
     {
-        var rawCiks = ciks?.ToList() ?? [];
-        var validatedCiks = rawCiks.Select(CikNormalizer.Validate).ToList();
-        return validatedCiks.Any(cik => cik == null)
-            ? GetAll().Where(_ => false)
-            : GetAll().Where(h => validatedCiks.Contains(h.Cik));
+        var requestedCiks = (ciks ?? [])
+            .Select(CikNormalizer.Validate)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (requestedCiks.Count == 0 || requestedCiks.Any(cik => cik == null))
+            return [];
+
+        var candidateCiks = requestedCiks
+            .SelectMany(cik => new[] { cik, AlternateCikSpelling(cik) })
+            .Where(cik => cik != null)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        var candidates = await GetAll()
+            .Where(holder => candidateCiks.Contains(holder.Cik))
+            .ToListAsync(cancellationToken);
+        var byCik = candidates.ToDictionary(holder => holder.Cik, StringComparer.Ordinal);
+
+        var selected = new List<InstitutionalHolder>(requestedCiks.Count);
+        var selectedIds = new HashSet<Guid>();
+        foreach (var requestedCik in requestedCiks)
+        {
+            if (!byCik.TryGetValue(requestedCik, out var holder))
+            {
+                var alternateCik = AlternateCikSpelling(requestedCik);
+                if (alternateCik == null || !byCik.TryGetValue(alternateCik, out holder))
+                    continue;
+            }
+
+            if (selectedIds.Add(holder.Id))
+                selected.Add(holder);
+        }
+
+        return selected;
+    }
+
+    public static InstitutionalHolder MatchRequestedCik(
+        IReadOnlyList<InstitutionalHolder> holders,
+        string cik
+    )
+    {
+        var validatedCik = CikNormalizer.Validate(cik);
+        if (validatedCik == null)
+            return null;
+
+        var exact = holders.FirstOrDefault(holder => holder.Cik == validatedCik);
+        if (exact != null)
+            return exact;
+
+        var alternateCik = AlternateCikSpelling(validatedCik);
+        return alternateCik == null
+            ? null
+            : holders.FirstOrDefault(holder => holder.Cik == alternateCik);
     }
 
     public IQueryable<InstitutionalHolder> Search(string search)
@@ -388,7 +446,7 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
 
     // Both padded and unpadded CIK spellings exist in the holder table. Exact input wins;
     // this alternate is consulted only when the exact spelling has no row.
-    private static string AlternateCikSpelling(string exactCik)
+    public static string AlternateCikSpelling(string exactCik)
     {
         if (exactCik == null)
             return null;

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -464,13 +464,15 @@ public class ProfilesController : BaseController
         List<string> missingCikSink
     )
     {
+        var candidates = await _institutionalHolderRepository.GetByCiks(distinctCiks);
         var holders = new List<InstitutionalHolder>();
+        var seenHolderIds = new HashSet<Guid>();
         foreach (var cik in distinctCiks)
         {
-            var holder = await _institutionalHolderRepository.GetByCik(cik);
+            var holder = InstitutionalHolderRepository.MatchRequestedCik(candidates, cik);
             if (holder == null)
                 missingCikSink.Add(cik);
-            else
+            else if (seenHolderIds.Add(holder.Id))
                 holders.Add(holder);
         }
         return holders;
@@ -527,7 +529,15 @@ public class ProfilesController : BaseController
         if (validatedCiks.Any(c => c == null))
             return null;
 
-        return validatedCiks.Distinct(StringComparer.Ordinal).ToList();
+        var normalized = new List<string>(validatedCiks.Count);
+        var seenCanonicalCiks = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var cik in validatedCiks)
+        {
+            if (seenCanonicalCiks.Add(CikNormalizer.Canonicalize(cik)))
+                normalized.Add(cik);
+        }
+
+        return normalized;
     }
 
     // Resolves the picker chips for first render — preserves the order the user
@@ -538,17 +548,12 @@ public class ProfilesController : BaseController
         if (ciks.Count == 0)
             return [];
 
-        var byCik = (
-            await _institutionalHolderRepository
-                .GetByCiks(ciks)
-                .Select(h => new { h.Cik, h.Name })
-                .ToListAsync()
-        ).ToDictionary(x => x.Cik, x => x.Name, StringComparer.OrdinalIgnoreCase);
+        var holders = await _institutionalHolderRepository.GetByCiks(ciks);
 
         return ciks.Select(cik => new InstitutionPick
             {
                 Cik = cik,
-                Name = byCik.GetValueOrDefault(cik),
+                Name = InstitutionalHolderRepository.MatchRequestedCik(holders, cik)?.Name,
             })
             .ToList();
     }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCoverPageClampTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCoverPageClampTests.cs
@@ -84,4 +84,41 @@ public class HoldingsImportServiceCoverPageClampTests : IDisposable
                 "an over-length cover-page city must be clamped to the varchar(128) column or the batch flush aborts with 22001"
             );
     }
+
+    [Fact]
+    public void CreateMissingHolders_UnpaddedSubmissionReusesPaddedExistingHolder()
+    {
+        var service = new HoldingsImportService(
+            Substitute.For<IServiceScopeFactory>(),
+            NullLogger<HoldingsImportService>.Instance,
+            Options.Create(new WorkerOptions()),
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<IBus>()
+        );
+        var existing = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Cik = "0001067983",
+            Name = "Existing padded holder",
+        };
+        var context = new ImportContext
+        {
+            Submissions = new Dictionary<string, SubmissionRow>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ACC-ALTERNATE-CIK"] = new SubmissionRow
+                {
+                    AccessionNumber = "ACC-ALTERNATE-CIK",
+                    Cik = "1067983",
+                    FormType = "13F-HR",
+                },
+            },
+        };
+        var holderRepo = new InstitutionalHolderRepository(_dbContext);
+        var cikToHolderId = new Dictionary<string, Guid>();
+
+        service.CreateMissingHolders(context, [existing], holderRepo, cikToHolderId);
+
+        cikToHolderId.Should().Contain("1067983", existing.Id);
+        _dbContext.ChangeTracker.Entries<InstitutionalHolder>().Should().BeEmpty();
+    }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRepositoryTests.cs
@@ -115,7 +115,7 @@ public class InstitutionalHolderRepositoryTests : IDisposable
             );
         await _dbContext.SaveChangesAsync();
 
-        var result = await _repository.GetByCiks(["0001067983", "0001364742"]).ToListAsync();
+        var result = await _repository.GetByCiks(["0001067983", "0001364742"]);
 
         result.Should().HaveCount(2);
         result.Select(h => h.Name).Should().BeEquivalentTo("Berkshire Hathaway", "Vanguard Group");
@@ -127,7 +127,7 @@ public class InstitutionalHolderRepositoryTests : IDisposable
         _dbContext.Set<InstitutionalHolder>().Add(CreateHolder(cik: "0001067983"));
         await _dbContext.SaveChangesAsync();
 
-        var result = await _repository.GetByCiks(["9999999999", "8888888888"]).ToListAsync();
+        var result = await _repository.GetByCiks(["9999999999", "8888888888"]);
 
         result.Should().BeEmpty();
     }
@@ -138,7 +138,7 @@ public class InstitutionalHolderRepositoryTests : IDisposable
         _dbContext.Set<InstitutionalHolder>().Add(CreateHolder());
         await _dbContext.SaveChangesAsync();
 
-        var result = await _repository.GetByCiks([]).ToListAsync();
+        var result = await _repository.GetByCiks([]);
 
         result.Should().BeEmpty();
     }
@@ -154,7 +154,7 @@ public class InstitutionalHolderRepositoryTests : IDisposable
             );
         await _dbContext.SaveChangesAsync();
 
-        var result = await _repository.GetByCiks(["0001067983", "9999999999"]).ToListAsync();
+        var result = await _repository.GetByCiks(["0001067983", "9999999999"]);
 
         result.Should().ContainSingle().Which.Name.Should().Be("Berkshire Hathaway");
     }
@@ -165,7 +165,7 @@ public class InstitutionalHolderRepositoryTests : IDisposable
         _dbContext.Set<InstitutionalHolder>().Add(CreateHolder(cik: "0001067983"));
         await _dbContext.SaveChangesAsync();
 
-        var result = await _repository.GetByCiks(["0001067983", "0000000000"]).ToListAsync();
+        var result = await _repository.GetByCiks(["0001067983", "0000000000"]);
 
         result.Should().BeEmpty();
     }

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests.cs
@@ -592,6 +592,45 @@ public class InstitutionalHolderRepositorySearchNameOrCikLargestFirstTests : Par
     }
 
     [Fact]
+    public async Task GetByCik_UnpaddedInputFallsBackToPaddedStorage()
+    {
+        DbContext.Add(
+            new InstitutionalHolder { Cik = "0007654321", Name = "Padded Storage Holder" }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var holder = await new InstitutionalHolderRepository(verify).GetByCik("7654321");
+
+        holder.Should().NotBeNull();
+        holder.Cik.Should().Be("0007654321");
+    }
+
+    [Fact]
+    public async Task GetByCiks_UsesExactSpellingBeforePerRequestAlternateFallback()
+    {
+        DbContext.AddRange(
+            new InstitutionalHolder { Cik = "0008765432", Name = "Exact Padded Holder" },
+            new InstitutionalHolder { Cik = "8765432", Name = "Alternate Unpadded Holder" },
+            new InstitutionalHolder { Cik = "0007654320", Name = "Fallback Padded Holder" }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var holders = await new InstitutionalHolderRepository(verify).GetByCiks([
+            "0008765432",
+            "7654320",
+        ]);
+
+        holders
+            .Select(holder => holder.Name)
+            .Should()
+            .Equal("Exact Padded Holder", "Fallback Padded Holder");
+    }
+
+    [Fact]
     public async Task ResolveNameOrCik_PaddedOnlyStorageResolvesExactSpelling()
     {
         DbContext.Add(new InstitutionalHolder { Cik = "0009999999", Name = "Padded Only Holder" });

--- a/tests/Equibles.IntegrationTests/Web/ProfilesCombinedInstitutionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesCombinedInstitutionsTests.cs
@@ -31,6 +31,32 @@ public class ProfilesCombinedInstitutionsTests
     }
 
     [Fact]
+    public async Task GetCombined_AlternateSpellingsOfOneHolder_DoNotCountAsTwoFunds()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = Guid.NewGuid(),
+                    Cik = "0001067983",
+                    Name = "One Holder",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            "/Institutions/Combined?ciks=0001067983&ciks=1067983"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Pick at least 2 institutions");
+        html.Should().NotContain("data-testid=\"combined-summary\"");
+    }
+
+    [Fact]
     public async Task GetCombined_TooManyCiks_Returns400()
     {
         await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildLatestSubmissionByCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildLatestSubmissionByCikTests.cs
@@ -1,5 +1,12 @@
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Models;
 using Equibles.Holdings.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
 
 namespace Equibles.UnitTests.Holdings;
 
@@ -43,6 +50,65 @@ public class HoldingsImportServiceBuildLatestSubmissionByCikTests
         var result = HoldingsImportService.BuildLatestSubmissionByCik([noCik]);
 
         result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildLatestSubmissionByCanonicalCik_MixedSpellings_PicksLatestFiled()
+    {
+        var olderExact = Submission("0000000000-25-000021", "29-JAN-2025", "0001067983");
+        var latestAlternate = Submission("0000000000-25-000022", "14-FEB-2025", "1067983");
+
+        var result = HoldingsImportService.BuildLatestSubmissionByCanonicalCik([
+            olderExact,
+            latestAlternate,
+        ]);
+
+        result.Should().ContainSingle();
+        result["1067983"].Should().BeSameAs(latestAlternate);
+    }
+
+    [Fact]
+    public void RefreshExistingHolderConfidentialTreatment_MixedSpellings_UsesLatestFiledFlag()
+    {
+        var olderExact = Submission("0000000000-25-000023", "29-JAN-2025", "0001067983");
+        var latestAlternate = Submission("0000000000-25-000024", "14-FEB-2025", "1067983");
+        var context = new ImportContext
+        {
+            Submissions = new Dictionary<string, SubmissionRow>
+            {
+                [olderExact.AccessionNumber] = olderExact,
+                [latestAlternate.AccessionNumber] = latestAlternate,
+            },
+            CoverPages = new Dictionary<string, CoverPageRow>
+            {
+                [olderExact.AccessionNumber] = new()
+                {
+                    AccessionNumber = olderExact.AccessionNumber,
+                    ConfidentialTreatment = "N",
+                },
+                [latestAlternate.AccessionNumber] = new()
+                {
+                    AccessionNumber = latestAlternate.AccessionNumber,
+                    ConfidentialTreatment = "Y",
+                },
+            },
+        };
+        var holder = new InstitutionalHolder
+        {
+            Cik = olderExact.Cik,
+            ConfidentialTreatmentRequested = false,
+        };
+        var service = new HoldingsImportService(
+            Substitute.For<IServiceScopeFactory>(),
+            NullLogger<HoldingsImportService>.Instance,
+            Options.Create(new WorkerOptions()),
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<MassTransit.IBus>()
+        );
+
+        service.RefreshExistingHolderConfidentialTreatment(context, [holder]);
+
+        holder.ConfidentialTreatmentRequested.Should().BeTrue();
     }
 
     private static SubmissionRow Submission(string accession, string filingDate, string cik) =>

--- a/tests/Equibles.UnitTests/Web/ProfilesControllerNormalizeCiksTests.cs
+++ b/tests/Equibles.UnitTests/Web/ProfilesControllerNormalizeCiksTests.cs
@@ -46,4 +46,12 @@ public class ProfilesControllerNormalizeCiksTests
         result.Should().ContainSingle();
         result[0].Trim().Should().Be("1234567");
     }
+
+    [Fact]
+    public void NormalizeCiks_AlternatePaddingOfOneFiler_CollapsesToSingleEntry()
+    {
+        var result = Normalize(["0001067983", "1067983"]);
+
+        result.Should().Equal("0001067983");
+    }
 }


### PR DESCRIPTION
## Summary
- Resolve padded and unpadded CIK forms to one institutional holder.
- Preserve exact-spelling preference when both legacy rows exist.
- Reuse existing holders during bulk imports.
- Select the latest confidentiality flag across mixed spellings.
- Prevent one holder from counting twice in comparison pages.

## Validation
- OSS solution Release build passed with zero warnings and errors.
- 7 focused unit checks passed.
- 41 focused integration checks passed.
- Independent final review found no actionable issues.