### PR TITLE
fix(holdings): restate closes across captured splits in the clone backtest

### DIFF
--- a/src/Equibles.CorporateActions.Data/ListingSplitScope.cs
+++ b/src/Equibles.CorporateActions.Data/ListingSplitScope.cs
@@ -1,0 +1,66 @@
+using Equibles.CorporateActions.Data.Models;
+
+namespace Equibles.CorporateActions.Data;
+
+/// <summary>
+/// One listing's captured splits, prepared for restating raw closes onto the current post-split
+/// basis. The price factor is Denominator/Numerator — the inverse of
+/// <see cref="SplitAdjustment.ShareCountFactor"/> — applied for every restatable split strictly
+/// after the close's date (a close ON the effective date already trades post-split, matching the
+/// share-side convention). A split whose ratio cannot be trusted (non-positive numerator or
+/// denominator) cannot restate anything across it, so it stays an exclusion boundary: closes
+/// before <see cref="UnusableBoundary"/> must be dropped (absent beats wrong).
+/// </summary>
+public sealed class ListingSplitScope
+{
+    public static readonly ListingSplitScope Empty = new([], null);
+
+    private readonly IReadOnlyList<StockSplit> _restatable;
+
+    private ListingSplitScope(IReadOnlyList<StockSplit> restatable, DateOnly? unusableBoundary)
+    {
+        _restatable = restatable;
+        UnusableBoundary = unusableBoundary;
+    }
+
+    /// <summary>Latest split with an unusable ratio; closes before it must be dropped.</summary>
+    public DateOnly? UnusableBoundary { get; }
+
+    public static ListingSplitScope Of(IEnumerable<StockSplit> scopedSplits)
+    {
+        if (scopedSplits == null)
+            return Empty;
+
+        List<StockSplit> restatable = null;
+        DateOnly? unusableBoundary = null;
+        foreach (var split in scopedSplits)
+        {
+            if (split.Numerator > 0 && split.Denominator > 0)
+            {
+                (restatable ??= []).Add(split);
+            }
+            else if (unusableBoundary == null || split.EffectiveDate > unusableBoundary)
+            {
+                unusableBoundary = split.EffectiveDate;
+            }
+        }
+        if (restatable == null && unusableBoundary == null)
+            return Empty;
+        return new ListingSplitScope((IReadOnlyList<StockSplit>)restatable ?? [], unusableBoundary);
+    }
+
+    /// <summary>
+    /// Restates a raw close observed on <paramref name="date"/> onto the current basis. A close
+    /// with no restatable split after it returns unchanged.
+    /// </summary>
+    public decimal RestateClose(decimal close, DateOnly date)
+    {
+        var factor = 1m;
+        foreach (var split in _restatable)
+        {
+            if (split.EffectiveDate > date)
+                factor *= split.Denominator / split.Numerator;
+        }
+        return factor == 1m ? close : close * factor;
+    }
+}

--- a/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
+++ b/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
@@ -13,9 +13,14 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.Holdings.BusinessLogic;
 
 /// <summary>
-/// Loads raw-close price-return series and runs the look-ahead-safe holdings backtests. Every
-/// exact listing is bounded at its latest captured split; the whole simulation begins at the
-/// latest such boundary so it never compares raw bars from opposite sides of a split.
+/// Loads raw-close price-return series and runs the look-ahead-safe holdings backtests. A
+/// captured split no longer truncates the window: closes before a listing's split are restated
+/// onto the current basis with the captured ratio (price factor = Denominator/Numerator, the
+/// inverse of the share factor), so returns span the boundary. Bounding every listing at its
+/// latest boundary — and flooring the WHOLE simulation at the latest boundary across the book —
+/// meant one recent split in any single holding collapsed a five-year request to weeks. Only a
+/// split with an unusable ratio still excludes that listing's pre-boundary closes (absent beats
+/// wrong), and then only that listing is affected.
 /// </summary>
 [Service]
 public class BacktestPriceLoader
@@ -101,22 +106,16 @@ public class BacktestPriceLoader
             )
             .ToListAsync(cancellationToken);
 
-        var boundaryByListing = new Dictionary<ListingKey, DateOnly?>();
-        var comparableFrom = from;
+        var splitScopeByListing = new Dictionary<ListingKey, ListingSplitScope>();
         foreach (var key in listingKeys)
         {
             var primaryTicker = primaryTickers.GetValueOrDefault(key.CommonStockId);
-            var boundary = PriceSeriesSplitScope
-                .ForListing(
-                    splits.Where(split => split.CommonStockId == key.CommonStockId),
-                    primaryTicker,
-                    key.ListedTicker
-                )
-                .Select(split => (DateOnly?)split.EffectiveDate)
-                .Max();
-            boundaryByListing[key] = boundary;
-            if (boundary is { } splitDate && splitDate > comparableFrom)
-                comparableFrom = splitDate;
+            var scoped = PriceSeriesSplitScope.ForListing(
+                splits.Where(split => split.CommonStockId == key.CommonStockId),
+                primaryTicker,
+                key.ListedTicker
+            );
+            splitScopeByListing[key] = ListingSplitScope.Of(scoped);
         }
 
         var requestedKeys = listingKeys.ToHashSet();
@@ -152,7 +151,10 @@ public class BacktestPriceLoader
             })
             .Where(row =>
                 requestedKeys.Contains(row.Key)
-                && (boundaryByListing[row.Key] == null || row.Date >= boundaryByListing[row.Key])
+                && (
+                    splitScopeByListing[row.Key].UnusableBoundary is not { } unusable
+                    || row.Date >= unusable
+                )
             )
             .GroupBy(row => row.Key)
             .ToDictionary(
@@ -160,7 +162,11 @@ public class BacktestPriceLoader
                 group =>
                     group
                         .OrderBy(row => row.Date)
-                        .Select(row => new PriceRow(row.Key.CommonStockId, row.Date, row.Close))
+                        .Select(row => new PriceRow(
+                            row.Key.CommonStockId,
+                            row.Date,
+                            splitScopeByListing[row.Key].RestateClose(row.Close, row.Date)
+                        ))
                         .ToArray()
             );
 
@@ -169,7 +175,7 @@ public class BacktestPriceLoader
 
         var usableFrom = ResolveUsableStart(
             snapshots,
-            comparableFrom,
+            from,
             to,
             pricesByListing,
             primaryTickers,
@@ -179,7 +185,7 @@ public class BacktestPriceLoader
         {
             return new BacktestResult
             {
-                StartDate = comparableFrom,
+                StartDate = from,
                 EndDate = to,
                 Reason = "no common comparable price date for the active portfolio and benchmark",
             };
@@ -275,10 +281,10 @@ public class BacktestPriceLoader
         return Expression.Lambda<Func<DailyStockPrice, bool>>(body, price);
     }
 
-    // A split can be effective on a weekend or holiday. Starting the calculator on that date while
-    // every pre-boundary close is excluded makes Rebalance silently skip a holding whose first
-    // comparable close arrives on the next session. Advance until the benchmark and every security
-    // in the then-active snapshot can be priced; repeat when that advance crosses a later rebalance.
+    // A listing's series can start late (new listing, or closes dropped behind an
+    // unusable-ratio split boundary), and a first usable close can land after a weekend or
+    // holiday. Advance until the benchmark and every security in the then-active snapshot can
+    // be priced; repeat when that advance crosses a later rebalance.
     private static DateOnly? ResolveUsableStart(
         IReadOnlyList<BacktestQuarterSnapshot> snapshots,
         DateOnly requestedFrom,

--- a/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/CloneBacktestTools.cs
@@ -44,7 +44,7 @@ public class CloneBacktestTools
         ReadOnly = true
     )]
     [Description(
-        "Backtest how cloning an institutional filer's reported 13F portfolio would have performed against a market benchmark, either over a trailing window (windowYears) or an explicit fromDate/toDate range. Reconstructs the filer's portfolio at each quarterly 13F snapshot, rebalances on the SEC filing lag (so the simulation uses only information available at the time), and values each exact listed security on raw closing prices. Returns price return (dividends excluded), annualized price return (CAGR), and max drawdown for both the cloned portfolio and the benchmark, plus the price-return alpha between them. A captured split can move the usable start date forward so raw bars from opposite sides are never compared. Use this to answer 'how would cloning fund X have performed against the market'."
+        "Backtest how cloning an institutional filer's reported 13F portfolio would have performed against a market benchmark, either over a trailing window (windowYears) or an explicit fromDate/toDate range. Reconstructs the filer's portfolio at each quarterly 13F snapshot, rebalances on the SEC filing lag (so the simulation uses only information available at the time), and values each exact listed security on raw closing prices. Returns price return (dividends excluded), annualized price return (CAGR), and max drawdown for both the cloned portfolio and the benchmark, plus the price-return alpha between them. Closes on opposite sides of a captured split are restated onto one basis with the captured ratio, so a split never shortens the window. Use this to answer 'how would cloning fund X have performed against the market'."
     )]
     public Task<string> GetFundCloneBacktest(
         [Description(
@@ -210,8 +210,8 @@ public class CloneBacktestTools
                 + $"{result.Points.Count} daily points simulated."
         );
         output.AppendLine(
-            "Raw closing prices are used, so dividends are excluded. A captured split can "
-                + "shorten the comparable window."
+            "Raw closing prices are used, so dividends are excluded; closes are restated "
+                + "across captured splits so a split never shortens the window."
         );
 
         // A clone is long-only, so a filer who expresses its thesis in options is only partly

--- a/tests/Equibles.IntegrationTests/Holdings/BacktestPriceLoaderSplitRestatementTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/BacktestPriceLoaderSplitRestatementTests.cs
@@ -1,0 +1,247 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Repositories.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+// The clone backtest used to bound every listing at its latest captured split and floor the
+// WHOLE simulation at the latest boundary across the book, so one recent split in any single
+// holding collapsed a five-year request to weeks while a headline alpha was still reported
+// (#4368). These tests pin the replacement: pre-split closes are restated onto the current
+// basis with the captured ratio, the requested window is honoured, and the split day itself
+// contributes no phantom return. An unusable ratio keeps the old exclusion for its own listing.
+public class BacktestPriceLoaderSplitRestatementTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly BacktestPriceLoader _loader;
+
+    private static readonly Guid StockId = Guid.NewGuid();
+    private static readonly Guid BenchmarkId = Guid.NewGuid();
+
+    public BacktestPriceLoaderSplitRestatementTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new CorporateActionsModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+        _loader = new BacktestPriceLoader(
+            new DailyStockPriceRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            new StockSplitRepository(_dbContext)
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // One snapshot holds only ACME; ACME trades flat at 500 pre-split and flat at 125 after a
+    // 4:1 split. Restated onto the post-split basis the series is a constant 125, so the
+    // simulation must span the whole window with a ~0% return — the old behavior either
+    // started at the split day or reported the -75% raw-close cliff.
+    [Fact]
+    public async Task RunBacktest_SpansACapturedSplit_WithNoPhantomReturn()
+    {
+        var (stock, benchmark) = await SeedStocks();
+        await SeedSplit(stock, new DateOnly(2026, 3, 10), numerator: 4, denominator: 1);
+        // Trading days around the split; 2026-03-10 itself trades post-split.
+        await SeedPrices(
+            stock,
+            "ACME",
+            (new DateOnly(2026, 3, 2), 500m),
+            (new DateOnly(2026, 3, 5), 500m),
+            (new DateOnly(2026, 3, 10), 125m),
+            (new DateOnly(2026, 3, 16), 125m),
+            (new DateOnly(2026, 3, 23), 125m)
+        );
+        await SeedPrices(
+            benchmark,
+            "SPY",
+            (new DateOnly(2026, 3, 2), 100m),
+            (new DateOnly(2026, 3, 5), 100m),
+            (new DateOnly(2026, 3, 10), 100m),
+            (new DateOnly(2026, 3, 16), 100m),
+            (new DateOnly(2026, 3, 23), 100m)
+        );
+
+        var result = await _loader.RunBacktest(
+            [Snapshot(new DateOnly(2026, 1, 15))],
+            benchmark,
+            "SPY",
+            from: new DateOnly(2026, 3, 2),
+            to: new DateOnly(2026, 3, 23)
+        );
+
+        Assert.NotNull(result);
+        Assert.Null(result.Reason);
+        Assert.Equal(new DateOnly(2026, 3, 2), result.StartDate);
+        Assert.Equal(0m, Math.Round(result.PortfolioSummary.TotalReturnPercent, 4));
+    }
+
+    // A reverse split (1:10) multiplies pre-split closes by 10 on the current basis: 10 → 100.
+    [Fact]
+    public async Task RunBacktest_RestatesAReverseSplitUpward()
+    {
+        var (stock, benchmark) = await SeedStocks();
+        await SeedSplit(stock, new DateOnly(2026, 3, 10), numerator: 1, denominator: 10);
+        await SeedPrices(
+            stock,
+            "ACME",
+            (new DateOnly(2026, 3, 2), 10m),
+            (new DateOnly(2026, 3, 10), 100m),
+            (new DateOnly(2026, 3, 16), 110m)
+        );
+        await SeedPrices(
+            benchmark,
+            "SPY",
+            (new DateOnly(2026, 3, 2), 100m),
+            (new DateOnly(2026, 3, 10), 100m),
+            (new DateOnly(2026, 3, 16), 100m)
+        );
+
+        var result = await _loader.RunBacktest(
+            [Snapshot(new DateOnly(2026, 1, 15))],
+            benchmark,
+            "SPY",
+            from: new DateOnly(2026, 3, 2),
+            to: new DateOnly(2026, 3, 16)
+        );
+
+        Assert.NotNull(result);
+        Assert.Null(result.Reason);
+        Assert.Equal(new DateOnly(2026, 3, 2), result.StartDate);
+        // 100 → 110 on the restated series = +10%.
+        Assert.Equal(10m, Math.Round(result.PortfolioSummary.TotalReturnPercent, 2));
+    }
+
+    // A split with an unusable ratio cannot restate anything across it, so its listing's
+    // pre-boundary closes are dropped and the simulation starts at the boundary — the old,
+    // honest fallback, scoped to the one listing.
+    [Fact]
+    public async Task RunBacktest_UnusableRatioSplit_StillExcludesPreBoundaryCloses()
+    {
+        var (stock, benchmark) = await SeedStocks();
+        await SeedSplit(stock, new DateOnly(2026, 3, 10), numerator: 0, denominator: 0);
+        await SeedPrices(
+            stock,
+            "ACME",
+            (new DateOnly(2026, 3, 2), 500m),
+            (new DateOnly(2026, 3, 10), 125m),
+            (new DateOnly(2026, 3, 16), 125m)
+        );
+        await SeedPrices(
+            benchmark,
+            "SPY",
+            (new DateOnly(2026, 3, 2), 100m),
+            (new DateOnly(2026, 3, 10), 100m),
+            (new DateOnly(2026, 3, 16), 100m)
+        );
+
+        var result = await _loader.RunBacktest(
+            [Snapshot(new DateOnly(2026, 1, 15))],
+            benchmark,
+            "SPY",
+            from: new DateOnly(2026, 3, 2),
+            to: new DateOnly(2026, 3, 16)
+        );
+
+        Assert.NotNull(result);
+        Assert.Null(result.Reason);
+        Assert.Equal(new DateOnly(2026, 3, 10), result.StartDate);
+        Assert.Equal(0m, Math.Round(result.PortfolioSummary.TotalReturnPercent, 4));
+    }
+
+    private BacktestQuarterSnapshot Snapshot(DateOnly reportDate) =>
+        new()
+        {
+            ReportDate = reportDate,
+            Positions =
+            [
+                new BacktestPosition
+                {
+                    CommonStockId = StockId,
+                    Shares = 100,
+                    Value = 50_000,
+                },
+            ],
+        };
+
+    private async Task<(CommonStock Stock, CommonStock Benchmark)> SeedStocks()
+    {
+        var stock = new CommonStock
+        {
+            Id = StockId,
+            Ticker = "ACME",
+            Name = "Acme Corp",
+        };
+        var benchmark = new CommonStock
+        {
+            Id = BenchmarkId,
+            Ticker = "SPY",
+            Name = "SPDR S&P 500",
+        };
+        _dbContext.Set<CommonStock>().AddRange(stock, benchmark);
+        await _dbContext.SaveChangesAsync();
+        return (stock, benchmark);
+    }
+
+    private async Task SeedSplit(
+        CommonStock stock,
+        DateOnly effectiveDate,
+        decimal numerator,
+        decimal denominator
+    )
+    {
+        _dbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStockId = stock.Id,
+                    EffectiveDate = effectiveDate,
+                    Numerator = numerator,
+                    Denominator = denominator,
+                    PriceSeriesTicker = stock.Ticker,
+                }
+            );
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private async Task SeedPrices(
+        CommonStock stock,
+        string listedTicker,
+        params (DateOnly Date, decimal Close)[] bars
+    )
+    {
+        foreach (var (date, close) in bars)
+        {
+            _dbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        ListedTicker = listedTicker,
+                        Date = date,
+                        Open = close,
+                        High = close,
+                        Low = close,
+                        Close = close,
+                        AdjustedClose = close,
+                        Volume = 1_000,
+                    }
+                );
+        }
+        await _dbContext.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary
The clone backtest bounded every listing at its latest captured split and floored the whole simulation at the latest boundary across the book — one recent split in any single holding collapsed a five-year request to weeks while a headline alpha was still reported (commercial audit finding, daniel3303/EquiblesCommercial#7174).

## Code changes
- New `ListingSplitScope` (CorporateActions.Data): per-listing restatable splits + unusable-ratio boundary; `RestateClose` applies the price factor Denominator/Numerator for splits strictly after the close's date (inverse of `SplitAdjustment.ShareCountFactor`, same strictly-after convention).
- `BacktestPriceLoader`: pre-split closes are restated onto the current basis instead of excluded; the whole-book `comparableFrom` floor is gone. A split with an unusable ratio still excludes that one listing's pre-boundary closes (absent beats wrong).
- `CloneBacktestTools` copy updated: a captured split no longer shortens the window.
- Integration tests: forward 4:1 span with no phantom return, reverse 1:10 restatement, unusable-ratio fallback.

Verified: OSS unit suite 4,285 green; integration suite 2,555 green (incl. the 3 new).