### PR TITLE
fix(finra): resolve FINRA class-share symbol spellings in short-interest and weekly lanes

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/FinraClassShareSymbols.cs
+++ b/src/Equibles.Finra.HostedService/Services/FinraClassShareSymbols.cs
@@ -1,0 +1,87 @@
+namespace Equibles.Finra.HostedService.Services;
+
+/// <summary>
+/// FINRA spells one class share three different ways across its feeds: the daily short-volume
+/// files write <c>BRK/B</c> (normalized to a dash by the file parser), the weekly OTC
+/// transparency feed writes <c>BRK.B</c>, and the consolidated short-interest API writes the
+/// compressed <c>BRKB</c>. Stored tickers use the dash convention, so a raw map lookup silently
+/// dropped every class-share record in the two lanes that never normalized (#4369). This helper
+/// owns the deterministic spelling bridge in both directions. Casing is never folded here —
+/// FINRA symbol casing is identity (a lowercase suffix is a different security), so each caller
+/// passes the comparer its own ticker map uses.
+/// </summary>
+public static class FinraClassShareSymbols
+{
+    /// <summary>
+    /// The dotted class spelling onto the stored dash convention (<c>BRK.B</c> → <c>BRK-B</c>),
+    /// case-preserving. Symbols without a dot return unchanged.
+    /// </summary>
+    public static string DotToDash(string symbol) =>
+        symbol != null && symbol.Contains('.') ? symbol.Replace('.', '-') : symbol;
+
+    /// <summary>
+    /// Builds the supplemental compressed-spelling index for the consolidated short-interest
+    /// API: every stored dash ticker contributes its dash-removed spelling (<c>BRK-B</c> →
+    /// <c>BRKB</c>). A compressed spelling that is itself a stored ticker, or that two dash
+    /// tickers collide on, resolves to NOTHING — the identity is then ambiguous and absent
+    /// beats wrong.
+    /// </summary>
+    public static Dictionary<string, Guid> BuildCompressedIndex(
+        IReadOnlyDictionary<string, Guid> tickerMap,
+        StringComparer comparer
+    )
+    {
+        var index = new Dictionary<string, Guid>(comparer);
+        var ambiguous = new HashSet<string>(comparer);
+        foreach (var (ticker, stockId) in tickerMap)
+        {
+            if (!ticker.Contains('-'))
+                continue;
+            var compressed = ticker.Replace("-", "");
+            if (compressed.Length == 0 || tickerMap.ContainsKey(compressed))
+                continue;
+            if (!index.TryAdd(compressed, stockId))
+                ambiguous.Add(compressed);
+        }
+        foreach (var collision in ambiguous)
+            index.Remove(collision);
+        return index;
+    }
+
+    /// <summary>
+    /// Resolves a FINRA-spelled symbol to a stored stock: exact ticker first, then the dotted
+    /// spelling mapped onto the dash convention, then the compressed index.
+    /// </summary>
+    public static bool TryResolve(
+        IReadOnlyDictionary<string, Guid> tickerMap,
+        IReadOnlyDictionary<string, Guid> compressedIndex,
+        string symbol,
+        out Guid stockId
+    )
+    {
+        stockId = default;
+        if (string.IsNullOrEmpty(symbol))
+            return false;
+        if (tickerMap.TryGetValue(symbol, out stockId))
+            return true;
+        var dashed = DotToDash(symbol);
+        if (!ReferenceEquals(dashed, symbol) && tickerMap.TryGetValue(dashed, out stockId))
+            return true;
+        return compressedIndex.TryGetValue(symbol, out stockId);
+    }
+
+    /// <summary>
+    /// Every spelling FINRA may use for a stored ticker, for symbol-filtered API requests: the
+    /// stored dash form plus, for class shares, the compressed and dotted forms. Requesting all
+    /// three is harmless — unmatched filters return nothing and responses map back through
+    /// <see cref="TryResolve"/>.
+    /// </summary>
+    public static IEnumerable<string> RequestSpellings(string storedTicker)
+    {
+        yield return storedTicker;
+        if (storedTicker == null || !storedTicker.Contains('-'))
+            yield break;
+        yield return storedTicker.Replace("-", "");
+        yield return storedTicker.Replace('-', '.');
+    }
+}

--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
@@ -22,7 +22,10 @@ public class OffExchangeVolumeImportService
     // markers so every week still inside FINRA's rolling publication window (~1 year)
     // re-imports and the upsert replaces the corrupted totals; weeks that have aged out of the
     // window cannot be re-fetched and stay as stored.
-    private const string Dataset = "off-exchange-weekly-v2";
+    // v3: class-share symbol resolution (dot/compressed spellings onto stored dash tickers,
+    // #4369) — the bump re-imports every week FINRA still publishes so dual-class weeks fill
+    // in; weeks aged out of the ~1-year rolling window are unhealable and stay as stored.
+    private const string Dataset = "off-exchange-weekly-v3";
     private const int CorrectionLookbackWeeks = 8;
     private static readonly TimeSpan RecentPartitionRefreshInterval = TimeSpan.FromHours(24);
     private static readonly HashSet<string> CompletePublicationTiers = new(
@@ -107,10 +110,21 @@ public class OffExchangeVolumeImportService
             cancellationToken,
             StringComparer.Ordinal
         );
+        var compressedIndex = FinraClassShareSymbols.BuildCompressedIndex(
+            tickerMap,
+            StringComparer.Ordinal
+        );
         foreach (var week in weeks)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await ImportWeek(week, tickerMap, scopeKey, now.UtcDateTime, cancellationToken);
+            await ImportWeek(
+                week,
+                tickerMap,
+                compressedIndex,
+                scopeKey,
+                now.UtcDateTime,
+                cancellationToken
+            );
         }
     }
 
@@ -140,6 +154,7 @@ public class OffExchangeVolumeImportService
     private async Task ImportWeek(
         DateOnly weekStartDate,
         IReadOnlyDictionary<string, Guid> tickerMap,
+        IReadOnlyDictionary<string, Guid> compressedIndex,
         string scopeKey,
         DateTime importedAt,
         CancellationToken cancellationToken
@@ -164,7 +179,12 @@ public class OffExchangeVolumeImportService
                 return;
             }
 
-            var merged = OffExchangeVolumeMerger.Merge(records, tickerMap, weekStartDate);
+            var merged = OffExchangeVolumeMerger.Merge(
+                records,
+                tickerMap,
+                compressedIndex,
+                weekStartDate
+            );
             await UpsertWeek(merged.Values, weekStartDate, cancellationToken);
             await _partitionTracker.MarkImported(
                 Dataset,

--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeMerger.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeMerger.cs
@@ -11,15 +11,24 @@ internal static class OffExchangeVolumeMerger
     public static Dictionary<Guid, OffExchangeVolume> Merge(
         IEnumerable<OffExchangeWeeklyRecord> records,
         IReadOnlyDictionary<string, Guid> tickerMap,
+        IReadOnlyDictionary<string, Guid> compressedIndex,
         DateOnly weekStartDate
     )
     {
         var merged = new Dictionary<Guid, OffExchangeVolume>();
         foreach (var record in records)
         {
+            // The weekly feed spells class shares with a dot ("BRK.B"); resolution bridges
+            // FINRA's spellings onto the stored dash tickers so class-share weeks stop
+            // dropping silently (#4369). Casing stays Ordinal — a lowercase suffix is a
+            // different security.
             if (
-                string.IsNullOrEmpty(record.Symbol)
-                || !tickerMap.TryGetValue(record.Symbol, out var commonStockId)
+                !FinraClassShareSymbols.TryResolve(
+                    tickerMap,
+                    compressedIndex,
+                    record.Symbol,
+                    out var commonStockId
+                )
             )
             {
                 continue;

--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -60,6 +60,15 @@ public class ShortInterestImportService
 
         var trackedStockIds = tickerMap.Values.ToHashSet();
         var reverseMap = tickerMap.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+        // FINRA's consolidated short-interest API spells class shares compressed ("BRKB" for
+        // BRK-B), so a raw ticker lookup dropped every class-share record — whole issuers had
+        // zero rows across all history (#4369). The per-date missing-stock check below makes
+        // the heal automatic once resolution works: every stored date re-fetches its missing
+        // stocks on the next cycle.
+        var compressedIndex = FinraClassShareSymbols.BuildCompressedIndex(
+            tickerMap,
+            StringComparer.OrdinalIgnoreCase
+        );
 
         HashSet<DateOnly> knownDates;
         using (var scope = _scopeFactory.CreateScope())
@@ -144,6 +153,7 @@ public class ShortInterestImportService
             var imported = await ImportDate(
                 date,
                 tickerMap,
+                compressedIndex,
                 reverseMap,
                 trackedStockIds,
                 filteredFetchThreshold,
@@ -167,6 +177,7 @@ public class ShortInterestImportService
     private async Task<int> ImportDate(
         DateOnly date,
         Dictionary<string, Guid> tickerMap,
+        Dictionary<string, Guid> compressedIndex,
         Dictionary<Guid, string> reverseMap,
         HashSet<Guid> trackedStockIds,
         int filteredFetchThreshold,
@@ -204,20 +215,29 @@ public class ShortInterestImportService
             }
 
             var items = records
-                .Where(r =>
-                    !string.IsNullOrEmpty(r.Symbol)
-                    && tickerMap.TryGetValue(r.Symbol, out var stockId)
-                    && missingStockIds.Contains(stockId)
+                .Select(r =>
+                    (
+                        Record: r,
+                        StockId: FinraClassShareSymbols.TryResolve(
+                            tickerMap,
+                            compressedIndex,
+                            r.Symbol,
+                            out var stockId
+                        )
+                            ? (Guid?)stockId
+                            : null
+                    )
                 )
-                .Select(r => new ShortInterest
+                .Where(x => x.StockId is { } id && missingStockIds.Contains(id))
+                .Select(x => new ShortInterest
                 {
-                    CommonStockId = tickerMap[r.Symbol],
+                    CommonStockId = x.StockId.Value,
                     SettlementDate = date,
-                    CurrentShortPosition = r.CurrentShortPosition ?? 0,
-                    PreviousShortPosition = r.PreviousShortPosition ?? 0,
-                    ChangeInShortPosition = r.ChangeInShortPosition ?? 0,
-                    AverageDailyVolume = r.AverageDailyVolume,
-                    DaysToCover = r.DaysToCover,
+                    CurrentShortPosition = x.Record.CurrentShortPosition ?? 0,
+                    PreviousShortPosition = x.Record.PreviousShortPosition ?? 0,
+                    ChangeInShortPosition = x.Record.ChangeInShortPosition ?? 0,
+                    AverageDailyVolume = x.Record.AverageDailyVolume,
+                    DaysToCover = x.Record.DaysToCover,
                 });
 
             var inserted = await BatchPersister.Persist(
@@ -270,9 +290,14 @@ public class ShortInterestImportService
         if (useBulkFetch)
             return _finraClient.GetShortInterest(date);
 
+        // Request every spelling FINRA may use for a class share ("BRK-B" is "BRKB" in this
+        // API) — an unmatched filter returns nothing, and responses map back through the
+        // compressed index, so over-asking is harmless while under-asking silently returns
+        // zero rows for exactly the stocks being healed.
         var missingSymbols = missingStockIds
             .Where(id => reverseMap.ContainsKey(id))
-            .Select(id => reverseMap[id])
+            .SelectMany(id => FinraClassShareSymbols.RequestSpellings(reverseMap[id]))
+            .Distinct()
             .ToList();
         return _finraClient.GetShortInterest(date, missingSymbols);
     }

--- a/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
@@ -159,7 +159,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
 
         await _service.Import(CancellationToken.None);
 
-        _partitionRepo.GetPartition("off-exchange-weekly-v2", "all", week).Should().BeEmpty();
+        _partitionRepo.GetPartition("off-exchange-weekly-v3", "all", week).Should().BeEmpty();
         _volumeRepo.GetByWeek(week).Should().BeEmpty();
 
         await _service.Import(CancellationToken.None);
@@ -167,7 +167,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
         var row = _volumeRepo.GetByWeek(week).Single(v => v.CommonStockId == apple.Id);
         row.AtsVolume.Should().Be(5_000);
         row.NonAtsOtcVolume.Should().Be(3_000);
-        _partitionRepo.GetPartition("off-exchange-weekly-v2", "all", week).Should().ContainSingle();
+        _partitionRepo.GetPartition("off-exchange-weekly-v3", "all", week).Should().ContainSingle();
 
         _finraClient.ClearReceivedCalls();
         await _service.Import(CancellationToken.None);
@@ -222,7 +222,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
         row.NonAtsOtcVolume.Should().Be(4_000);
         row.NonAtsOtcTradeCount.Should().Be(40);
         _partitionRepo
-            .GetPartition("off-exchange-weekly-v2", "all", week)
+            .GetPartition("off-exchange-weekly-v3", "all", week)
             .Single()
             .ImportedAt.Should()
             .Be(previousImport);
@@ -233,7 +233,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
         _partitionRepo.Add(
             new FinraImportPartition
             {
-                Dataset = "off-exchange-weekly-v2",
+                Dataset = "off-exchange-weekly-v3",
                 PartitionDate = week,
                 ScopeKey = "all",
                 ImportedAt = importedAt ?? Now.UtcDateTime,

--- a/tests/Equibles.UnitTests/Finra/FinraClassShareSymbolsTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraClassShareSymbolsTests.cs
@@ -1,0 +1,126 @@
+using Equibles.Finra.HostedService.Services;
+using Equibles.Integrations.Finra.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+// FINRA spells one class share three ways across its feeds (daily files "BRK/B", weekly OTC
+// "BRK.B", consolidated short interest "BRKB") while stored tickers use the dash convention.
+// These pins guard the deterministic spelling bridge (#4369): resolution priority, the
+// ambiguity rules on the compressed index (absent beats wrong), case preservation, and the
+// outbound request spellings the symbol-filtered short-interest fetch depends on.
+public class FinraClassShareSymbolsTests
+{
+    [Fact]
+    public void DotToDash_MapsDottedClassSpellingCasePreserving()
+    {
+        FinraClassShareSymbols.DotToDash("BRK.B").Should().Be("BRK-B");
+        FinraClassShareSymbols.DotToDash("BF.B").Should().Be("BF-B");
+        FinraClassShareSymbols.DotToDash("TpC.A").Should().Be("TpC-A");
+        FinraClassShareSymbols.DotToDash("AAPL").Should().Be("AAPL");
+        FinraClassShareSymbols.DotToDash(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildCompressedIndex_IndexesDashTickers_AndDropsAmbiguity()
+    {
+        var brkB = Guid.NewGuid();
+        var realBfb = Guid.NewGuid();
+        var bfB = Guid.NewGuid();
+        var colliding1 = Guid.NewGuid();
+        var colliding2 = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            ["BRK-B"] = brkB,
+            // A real stored ticker that IS another ticker's compressed spelling: the class
+            // share must not shadow it, so no index entry is created.
+            ["BFB"] = realBfb,
+            ["BF-B"] = bfB,
+            // Two dash tickers compressing onto one spelling: both are dropped.
+            ["XY-Z"] = colliding1,
+            ["X-YZ"] = colliding2,
+        };
+
+        var index = FinraClassShareSymbols.BuildCompressedIndex(tickerMap, StringComparer.Ordinal);
+
+        index.Should().ContainKey("BRKB").WhoseValue.Should().Be(brkB);
+        index.Should().NotContainKey("BFB");
+        index.Should().NotContainKey("XYZ");
+    }
+
+    [Fact]
+    public void TryResolve_PrefersExactTicker_ThenDotted_ThenCompressed()
+    {
+        var exact = Guid.NewGuid();
+        var dashed = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            ["BRKB"] = exact,
+            ["BRK-B"] = dashed,
+        };
+        var index = FinraClassShareSymbols.BuildCompressedIndex(tickerMap, StringComparer.Ordinal);
+
+        // "BRKB" is a real stored ticker, so the compressed class spelling never shadows it.
+        FinraClassShareSymbols.TryResolve(tickerMap, index, "BRKB", out var id).Should().BeTrue();
+        id.Should().Be(exact);
+
+        FinraClassShareSymbols
+            .TryResolve(tickerMap, index, "BRK.B", out var dotted)
+            .Should()
+            .BeTrue();
+        dotted.Should().Be(dashed);
+
+        FinraClassShareSymbols.TryResolve(tickerMap, index, "MISSING", out _).Should().BeFalse();
+        FinraClassShareSymbols.TryResolve(tickerMap, index, null, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryResolve_CompressedSpelling_ResolvesWhenUnambiguous()
+    {
+        var bfB = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["BF-B"] = bfB };
+        var index = FinraClassShareSymbols.BuildCompressedIndex(tickerMap, StringComparer.Ordinal);
+
+        FinraClassShareSymbols.TryResolve(tickerMap, index, "BFB", out var id).Should().BeTrue();
+        id.Should().Be(bfB);
+    }
+
+    [Fact]
+    public void RequestSpellings_ClassShareYieldsAllThreeForms()
+    {
+        FinraClassShareSymbols.RequestSpellings("BRK-B").Should().Equal("BRK-B", "BRKB", "BRK.B");
+        FinraClassShareSymbols.RequestSpellings("AAPL").Should().Equal("AAPL");
+    }
+
+    // End-to-end through the weekly merger: a dotted class-share row lands on the dash-stored
+    // stock instead of dropping silently.
+    [Fact]
+    public void Merge_DottedClassShareSymbol_ResolvesToDashTicker()
+    {
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            ["BRK-B"] = stockId,
+        };
+        var index = FinraClassShareSymbols.BuildCompressedIndex(tickerMap, StringComparer.Ordinal);
+        var records = new List<OffExchangeWeeklyRecord>
+        {
+            new()
+            {
+                Symbol = "BRK.B",
+                SummaryTypeCode = "ATS_W_SMBL",
+                TotalWeeklyShareQuantity = 5_000,
+                TotalWeeklyTradeCount = 50,
+            },
+        };
+
+        var result = OffExchangeVolumeMerger.Merge(
+            records,
+            tickerMap,
+            index,
+            new DateOnly(2024, 3, 4)
+        );
+
+        result.Should().ContainSingle();
+        result[stockId].AtsVolume.Should().Be(5_000);
+    }
+}

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests.cs
@@ -31,7 +31,12 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests
             },
         };
 
-        var result = OffExchangeVolumeMerger.Merge(records, tickerMap, new Dictionary<string, Guid>(), new DateOnly(2024, 3, 4));
+        var result = OffExchangeVolumeMerger.Merge(
+            records,
+            tickerMap,
+            new Dictionary<string, Guid>(),
+            new DateOnly(2024, 3, 4)
+        );
 
         result.Should().ContainSingle();
         var merged = result[stockId];

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests.cs
@@ -31,7 +31,7 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests
             },
         };
 
-        var result = OffExchangeVolumeMerger.Merge(records, tickerMap, new DateOnly(2024, 3, 4));
+        var result = OffExchangeVolumeMerger.Merge(records, tickerMap, new Dictionary<string, Guid>(), new DateOnly(2024, 3, 4));
 
         result.Should().ContainSingle();
         var merged = result[stockId];

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTests.cs
@@ -40,7 +40,7 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTest
             },
         };
 
-        var result = OffExchangeVolumeMerger.Merge(records, tickerMap, new DateOnly(2024, 3, 4));
+        var result = OffExchangeVolumeMerger.Merge(records, tickerMap, new Dictionary<string, Guid>(), new DateOnly(2024, 3, 4));
 
         result.Should().HaveCount(1);
         var merged = result[stockId];

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTests.cs
@@ -40,7 +40,12 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTest
             },
         };
 
-        var result = OffExchangeVolumeMerger.Merge(records, tickerMap, new Dictionary<string, Guid>(), new DateOnly(2024, 3, 4));
+        var result = OffExchangeVolumeMerger.Merge(
+            records,
+            tickerMap,
+            new Dictionary<string, Guid>(),
+            new DateOnly(2024, 3, 4)
+        );
 
         result.Should().HaveCount(1);
         var merged = result[stockId];

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests.cs
@@ -28,7 +28,7 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests
             },
         };
 
-        var act = () => OffExchangeVolumeMerger.Merge(records, tickerMap, new DateOnly(2024, 3, 4));
+        var act = () => OffExchangeVolumeMerger.Merge(records, tickerMap, new Dictionary<string, Guid>(), new DateOnly(2024, 3, 4));
 
         var result = act.Should().NotThrow().Subject;
         result.Should().ContainKey(stockId);

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests.cs
@@ -28,7 +28,13 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests
             },
         };
 
-        var act = () => OffExchangeVolumeMerger.Merge(records, tickerMap, new Dictionary<string, Guid>(), new DateOnly(2024, 3, 4));
+        var act = () =>
+            OffExchangeVolumeMerger.Merge(
+                records,
+                tickerMap,
+                new Dictionary<string, Guid>(),
+                new DateOnly(2024, 3, 4)
+            );
 
         var result = act.Should().NotThrow().Subject;
         result.Should().ContainKey(stockId);

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests.cs
@@ -41,7 +41,12 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests
             },
         };
 
-        var result = OffExchangeVolumeMerger.Merge(records, tickerMap, new Dictionary<string, Guid>(), new DateOnly(2024, 3, 4));
+        var result = OffExchangeVolumeMerger.Merge(
+            records,
+            tickerMap,
+            new Dictionary<string, Guid>(),
+            new DateOnly(2024, 3, 4)
+        );
 
         result.Should().ContainSingle();
         result[trackedStockId].AtsVolume.Should().Be(1_000);

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests.cs
@@ -41,7 +41,7 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests
             },
         };
 
-        var result = OffExchangeVolumeMerger.Merge(records, tickerMap, new DateOnly(2024, 3, 4));
+        var result = OffExchangeVolumeMerger.Merge(records, tickerMap, new Dictionary<string, Guid>(), new DateOnly(2024, 3, 4));
 
         result.Should().ContainSingle();
         result[trackedStockId].AtsVolume.Should().Be(1_000);


### PR DESCRIPTION
## Summary
Whole issuers (BRK-A/B, BF-A/B) had zero rows in bi-monthly short interest and weekly off-exchange volume across all history while daily short volume covered them (commercial audit finding, daniel3303/EquiblesCommercial#7169). FINRA spells class shares differently per feed — consolidated short interest serves compressed `BRKB`, the weekly OTC transparency feed serves `BRK.B` — and both lanes did a raw ticker-map lookup against dash-stored tickers, silently dropping every record. Verified live against both FINRA feeds.

## Code changes
- New `FinraClassShareSymbols`: deterministic spelling bridge (exact → dotted-to-dash → compressed index) with ambiguity rules (a compressed spelling that is a real stored ticker or a collision resolves to nothing) and case preservation (FINRA casing is identity).
- `ShortInterestImportService`: resolves through the bridge; the symbol-filtered fetch requests all FINRA spellings so the per-date missing-stock check heals stored dates automatically — no dataset bump needed.
- `OffExchangeVolumeMerger`/`OffExchangeVolumeImportService`: resolve through the bridge; dataset key bumped to `off-exchange-weekly-v3` so every still-published week re-imports (~1-year reach, documented).
- Tests: spelling-bridge pins (priority, ambiguity, casing, request spellings), a dotted-symbol merge pin, and the backfill tests re-pinned to v3.

Verified: OSS unit suite 4,291 green; integration suite green after the v3 re-pin.