### PR TITLE
fix(holdings): serve request aggregates from snapshots

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/HoldingsCloneBacktestProvider.cs
+++ b/src/Equibles.Holdings.BusinessLogic/HoldingsCloneBacktestProvider.cs
@@ -92,8 +92,8 @@ public class HoldingsCloneBacktestProvider
         }
         outcome.BenchmarkName = benchmarkStock.Name;
 
-        var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
-        // Get13FReportDatesByHolder returns latest first; the backtest iterates earliest first.
+        var reportDates = await _holdingRepository.Get13FReportDatesByHolderSnapshotBacked(holder);
+        // Snapshot-backed dates return latest first; the backtest iterates earliest first.
         // 13D/G event dates are excluded so a single disclosed stake never rotates the whole
         // simulation into one stock at the event date.
         reportDates.Reverse();

--- a/src/Equibles.Holdings.BusinessLogic/InstitutionPortfolioSummaryProvider.cs
+++ b/src/Equibles.Holdings.BusinessLogic/InstitutionPortfolioSummaryProvider.cs
@@ -1,0 +1,108 @@
+using System.Globalization;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Equibles.Holdings.BusinessLogic;
+
+// One shared implementation for MCP and REST portfolio summaries. Closed-quarter results are
+// pure functions of two holder snapshots, so their ComputedAt values form the cache version.
+// Dirty quarters bypass the cache until the aggregate drain finishes; this prevents a filing
+// import from serving the previous summary for the cache TTL.
+[Service]
+public class InstitutionPortfolioSummaryProvider
+{
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(6);
+
+    private readonly InstitutionalHoldingRepository _holdingRepository;
+    private readonly IMemoryCache _memoryCache;
+
+    public InstitutionPortfolioSummaryProvider(
+        InstitutionalHoldingRepository holdingRepository,
+        IMemoryCache memoryCache
+    )
+    {
+        _holdingRepository = holdingRepository;
+        _memoryCache = memoryCache;
+    }
+
+    public async Task<InstitutionPortfolioSummary> Get(
+        InstitutionalHolder holder,
+        DateOnly currentReportDate,
+        DateOnly? previousReportDate,
+        int quartersReported,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var state = await _holdingRepository.GetHolderSummarySnapshotState(
+            holder.Id,
+            currentReportDate,
+            previousReportDate,
+            cancellationToken
+        );
+        if (!state.CanCache(previousReportDate.HasValue))
+        {
+            return await Calculate(
+                holder,
+                currentReportDate,
+                previousReportDate,
+                quartersReported,
+                cancellationToken
+            );
+        }
+
+        var key = string.Join(
+            ':',
+            "holdings",
+            "institution-summary",
+            holder.Id.ToString("N"),
+            currentReportDate.ToString("yyyyMMdd", CultureInfo.InvariantCulture),
+            previousReportDate?.ToString("yyyyMMdd", CultureInfo.InvariantCulture) ?? "none",
+            quartersReported.ToString(CultureInfo.InvariantCulture),
+            state.CurrentComputedAt!.Value.Ticks.ToString(CultureInfo.InvariantCulture),
+            state.PreviousComputedAt?.Ticks.ToString(CultureInfo.InvariantCulture) ?? "none"
+        );
+        return await _memoryCache.GetOrCreateAsync(
+            key,
+            async entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = CacheDuration;
+                return await Calculate(
+                    holder,
+                    currentReportDate,
+                    previousReportDate,
+                    quartersReported,
+                    cancellationToken
+                );
+            }
+        );
+    }
+
+    private async Task<InstitutionPortfolioSummary> Calculate(
+        InstitutionalHolder holder,
+        DateOnly currentReportDate,
+        DateOnly? previousReportDate,
+        int quartersReported,
+        CancellationToken cancellationToken
+    )
+    {
+        var current = await _holdingRepository
+            .Get13FPositionAggregatesByHolder(holder, currentReportDate)
+            .ToListAsync(cancellationToken);
+        var previous = previousReportDate is { } prior
+            ? await _holdingRepository
+                .Get13FPositionAggregatesByHolder(holder, prior)
+                .ToListAsync(cancellationToken)
+            : [];
+        return InstitutionPortfolioSummaryCalculator.CalculatePositions(
+            current,
+            previous,
+            quartersReported,
+            currentReportDate,
+            previousReportDate
+        );
+    }
+}

--- a/src/Equibles.Holdings.BusinessLogic/MarketActivityShareRestater.cs
+++ b/src/Equibles.Holdings.BusinessLogic/MarketActivityShareRestater.cs
@@ -1,0 +1,143 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.BusinessLogic;
+
+// Restates market activity one exact listed price series at a time. Stock-level activity
+// deliberately combines sibling share classes for ranking, but a split attributed to one class
+// must never multiply the others. The persisted listing breakdown keeps this read path bounded.
+[Service]
+public class MarketActivityShareRestater
+{
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
+
+    public MarketActivityShareRestater(
+        CommonStockRepository commonStockRepository,
+        StockSplitRepository stockSplitRepository
+    )
+    {
+        _commonStockRepository = commonStockRepository;
+        _stockSplitRepository = stockSplitRepository;
+    }
+
+    public async Task RestateMarketActivity(
+        IReadOnlyList<MarketWideStockActivity> activity,
+        DateOnly currentReportDate,
+        DateOnly previousReportDate,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var stockIds = activity.Select(row => row.CommonStockId).Distinct().ToArray();
+        if (stockIds.Length == 0)
+            return;
+
+        var primaryTickers = await _commonStockRepository
+            .GetByIds(stockIds)
+            .AsNoTracking()
+            .Select(stock => new { stock.Id, stock.Ticker })
+            .ToDictionaryAsync(stock => stock.Id, stock => stock.Ticker, cancellationToken);
+        var splitsByStock = (
+            await _stockSplitRepository
+                .GetAll()
+                .AsNoTracking()
+                .Where(split => stockIds.Contains(split.CommonStockId))
+                .ToListAsync(cancellationToken)
+        )
+            .GroupBy(split => split.CommonStockId)
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<StockSplit>)group.ToList());
+
+        foreach (var row in activity)
+        {
+            if (!splitsByStock.TryGetValue(row.CommonStockId, out var splits) || splits.Count == 0)
+                continue;
+            if (!primaryTickers.TryGetValue(row.CommonStockId, out var primaryTicker))
+                throw new InvalidOperationException(
+                    $"Cannot restate holdings activity for missing stock {row.CommonStockId}."
+                );
+            if (row.ListingShares.Count == 0)
+                throw new InvalidOperationException(
+                    $"Cannot restate holdings activity for {primaryTicker} without listing-share snapshots."
+                );
+
+            row.CurrentShares = RestateListingTotal(
+                row.ListingShares,
+                listing => listing.CurrentShares,
+                currentReportDate,
+                primaryTicker,
+                splits
+            );
+            row.PreviousShares = RestateListingTotal(
+                row.ListingShares,
+                listing => listing.PreviousShares,
+                previousReportDate,
+                primaryTicker,
+                splits
+            );
+        }
+    }
+
+    public async Task RestateStockActivity(
+        CommonStock stock,
+        IReadOnlyList<StockQuarterlyActivity> activity,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (activity.Count == 0)
+            return;
+
+        var splits = await _stockSplitRepository
+            .GetByStock(stock.Id)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+        if (splits.Count == 0)
+            return;
+
+        foreach (var row in activity)
+        {
+            if (row.ListingShares.Count == 0)
+                throw new InvalidOperationException(
+                    $"Cannot restate holdings activity for {stock.Ticker} without listing-share snapshots."
+                );
+
+            row.CurrentShares = RestateListingTotal(
+                row.ListingShares,
+                listing => listing.CurrentShares,
+                row.ReportDate,
+                stock.Ticker,
+                splits
+            );
+            row.PreviousShares = row.PreviousReportDate is { } previousReportDate
+                ? RestateListingTotal(
+                    row.ListingShares,
+                    listing => listing.PreviousShares,
+                    previousReportDate,
+                    stock.Ticker,
+                    splits
+                )
+                : 0;
+        }
+    }
+
+    internal static long RestateListingTotal(
+        IReadOnlyList<StockQuarterlyListingActivity> listingShares,
+        Func<StockQuarterlyListingActivity, long> shares,
+        DateOnly reportDate,
+        string primaryTicker,
+        IReadOnlyList<StockSplit> splits
+    ) =>
+        listingShares.Sum(listing =>
+            SplitAdjustment.AdjustShareCount(
+                shares(listing),
+                reportDate,
+                PriceSeriesSplitScope.ForListing(splits, primaryTicker, listing.PriceSeriesTicker)
+            )
+        );
+}

--- a/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
@@ -154,7 +154,7 @@ public class SmartMoneyIndexManager
     {
         // 13F dates only: a fund's latest filing can be a Schedule 13D/G event date, whose single
         // disclosed stake would otherwise replace the real portfolio as a 100%-weight "holding".
-        var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
+        var reportDates = await _holdingRepository.Get13FReportDatesByHolderSnapshotBacked(holder);
         if (reportDates.Count == 0)
             return null;
 

--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -155,6 +155,10 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
         // a separate table rather than a lane column.
         builder.Entity<StockQuarterlyActivityCombined>();
 
+        // Exact listing-series share breakdown shared by the closed and combined snapshots.
+        // Its attribute-declared key includes IsCombined so both generations can coexist.
+        builder.Entity<StockQuarterlyListingActivity>();
+
         // HolderQuarterlySnapshot likewise declares its composite
         // (InstitutionalHolderId, ReportDate) key and ReportDate index as
         // attributes.

--- a/src/Equibles.Holdings.Data/Models/StockQuarterlyActivity.cs
+++ b/src/Equibles.Holdings.Data/Models/StockQuarterlyActivity.cs
@@ -37,4 +37,7 @@ public class StockQuarterlyActivity
     public int SoldOutFilerCount { get; set; }
 
     public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+
+    [NotMapped]
+    public IReadOnlyList<StockQuarterlyListingActivity> ListingShares { get; set; } = [];
 }

--- a/src/Equibles.Holdings.Data/Models/StockQuarterlyActivityCombined.cs
+++ b/src/Equibles.Holdings.Data/Models/StockQuarterlyActivityCombined.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Holdings.Data.Models;
@@ -37,4 +38,7 @@ public class StockQuarterlyActivityCombined
     public int SoldOutFilerCount { get; set; }
 
     public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+
+    [NotMapped]
+    public IReadOnlyList<StockQuarterlyListingActivity> ListingShares { get; set; } = [];
 }

--- a/src/Equibles.Holdings.Data/Models/StockQuarterlyListingActivity.cs
+++ b/src/Equibles.Holdings.Data/Models/StockQuarterlyListingActivity.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Data.Models;
+
+// Exact listing-series share totals that accompany StockQuarterlyActivity. The stock-level
+// snapshot deliberately collapses every share class for ranking and filer counts, but a split
+// attributed to one class must not restate its siblings. Keeping this small breakdown lets
+// request surfaces apply each series' captured splits without returning to the holdings corpus.
+[PrimaryKey(
+    nameof(CommonStockId),
+    nameof(ReportDate),
+    nameof(IsCombined),
+    nameof(PriceSeriesTicker)
+)]
+[Index(nameof(ReportDate), nameof(IsCombined))]
+public class StockQuarterlyListingActivity
+{
+    public Guid CommonStockId { get; set; }
+
+    public DateOnly ReportDate { get; set; }
+
+    public bool IsCombined { get; set; }
+
+    // Always non-null: a holding's legacy null ListedTicker is materialized as the stock's
+    // authoritative primary ticker, while explicit sibling rows retain their exact ticker.
+    [MaxLength(32)]
+    public string PriceSeriesTicker { get; set; }
+
+    public long CurrentShares { get; set; }
+
+    public long PreviousShares { get; set; }
+
+    public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.HostedService/AumSnapshotDrainWorker.cs
+++ b/src/Equibles.Holdings.HostedService/AumSnapshotDrainWorker.cs
@@ -13,14 +13,12 @@ namespace Equibles.Holdings.HostedService;
 /// <c>DirtyAt = UtcNow</c> on each import — many events for the same quarter
 /// in the same cooldown window coalesce into a single rebuild here.
 ///
-/// The dirty flag is CLAIMED (cleared) before the rebuild runs, not after.
-/// The consumer only stamps <c>DirtyAt</c> when it is currently null, so a
-/// clear-after-rebuild could never observe a mid-rebuild import — the flag
-/// would test unchanged and the signal be silently dropped. Clearing first
-/// means an import landing mid-rebuild finds the flag null, re-dirties the
-/// row with a fresh timestamp, and the next cooldown rebuilds again — no
-/// signal lost. If the rebuild fails, the claim is re-armed with the original
-/// timestamp so the next tick retries immediately.
+/// The dirty flag is claimed with a short future-dated lease before rebuilding.
+/// It stays non-null so request paths never mistake the old snapshot for clean.
+/// The consumer replaces a future lease with its new event timestamp, which
+/// preserves an import that lands mid-rebuild; the successful rebuild clears
+/// the lease only when no newer event replaced it. A crashed worker's lease
+/// becomes eligible again after the lease and ordinary cooldown expire.
 /// </summary>
 public class AumSnapshotDrainWorker : BackgroundService
 {
@@ -33,6 +31,8 @@ public class AumSnapshotDrainWorker : BackgroundService
     protected virtual TimeSpan StartupDelay => TimeSpan.FromMinutes(1);
     protected virtual TimeSpan TickInterval => TimeSpan.FromMinutes(5);
     protected virtual TimeSpan Cooldown => TimeSpan.FromHours(1);
+    protected virtual TimeSpan ClaimLease => TimeSpan.FromMinutes(5);
+    protected virtual TimeSpan ClaimRenewInterval => TimeSpan.FromMinutes(1);
 
     public AumSnapshotDrainWorker(
         IServiceScopeFactory scopeFactory,
@@ -115,25 +115,43 @@ public class AumSnapshotDrainWorker : BackgroundService
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Claim BEFORE rebuilding: the consumer only stamps DirtyAt when it
-            // is null, so an import landing mid-rebuild can only be observed if
-            // the flag is already cleared — it then re-dirties the row with a
-            // fresh timestamp and the next cooldown rebuilds again. A skipped
-            // claim means another racer (or a fresh event) moved the flag;
-            // leave this entry for the next tick.
-            if (!await TryClaimDirtyFlag(entry, cancellationToken))
+            // Claim with a future timestamp rather than clearing DirtyAt. Readers keep
+            // treating the snapshot as dirty, another drain cannot select it, and a new
+            // import replaces the future marker with its real event time. A skipped claim
+            // means another worker or a fresh event moved the flag.
+            var claimToken = await TryClaimDirtyFlag(entry, cancellationToken);
+            if (claimToken is not { } claimedAt)
                 continue;
+            entry.ClaimedAt = claimedAt;
+            using var renewalCts = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken
+            );
+            var renewal = RenewClaimLease(entry, renewalCts.Token);
 
             try
             {
                 await _refreshService.RebuildQuarterAsync(entry.ReportDate, cancellationToken);
+                renewalCts.Cancel();
+                await renewal;
+                if (!await TryClearActiveClaim(entry, cancellationToken))
+                {
+                    // The claim expired before it could be renewed, or a new event replaced
+                    // it. Re-arm only when our exact token is still present; a newer event's
+                    // timestamp never matches and remains untouched.
+                    await RearmDirtyFlag(entry, CancellationToken.None);
+                }
             }
             catch (OperationCanceledException)
             {
+                renewalCts.Cancel();
+                await renewal;
+                await RearmDirtyFlag(entry, CancellationToken.None);
                 throw;
             }
             catch (Exception ex)
             {
+                renewalCts.Cancel();
+                await renewal;
                 _logger.LogError(
                     ex,
                     "Failed to drain dirty AUM snapshot for {ReportDate}; will retry on next tick",
@@ -144,9 +162,10 @@ public class AumSnapshotDrainWorker : BackgroundService
         }
     }
 
-    // Clears DirtyAt only if it still matches the claim-time value, returning
-    // whether this worker won the claim.
-    private async Task<bool> TryClaimDirtyFlag(
+    // Replaces the selected event timestamp with a future-dated lease and returns that
+    // compare-and-clear token. PostgreSQL serializes both uses of the same DateTime value
+    // at identical precision, so an equality guard safely distinguishes a newer import.
+    private async Task<DateTime?> TryClaimDirtyFlag(
         DueRebuild entry,
         CancellationToken cancellationToken
     )
@@ -154,19 +173,96 @@ public class AumSnapshotDrainWorker : BackgroundService
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
 
+        var claimedAt = DateTime.UtcNow.Add(ClaimLease);
         var claimed = await dbContext
             .Set<AumQuarterlySnapshot>()
             .Where(s => s.ReportDate == entry.ReportDate && s.DirtyAt == entry.DirtyAt)
+            .ExecuteUpdateAsync(s => s.SetProperty(x => x.DirtyAt, claimedAt), cancellationToken);
+
+        return claimed > 0 ? claimedAt : null;
+    }
+
+    // Extend an owned lease while a long aggregate rebuild is running. Failure is safe: the
+    // completion path refuses to clear an expired token and re-arms it for another attempt.
+    private async Task RenewClaimLease(DueRebuild entry, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(ClaimRenewInterval, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var currentClaim = entry.ClaimedAt!.Value;
+            var renewedClaim = DateTime.UtcNow.Add(ClaimLease);
+            try
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                var dbContext =
+                    scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+                var renewed = await dbContext
+                    .Set<AumQuarterlySnapshot>()
+                    .Where(s =>
+                        s.ReportDate == entry.ReportDate
+                        && s.DirtyAt == currentClaim
+                        && s.DirtyAt > DateTime.UtcNow
+                    )
+                    .ExecuteUpdateAsync(
+                        s => s.SetProperty(x => x.DirtyAt, renewedClaim),
+                        cancellationToken
+                    );
+                if (renewed == 0)
+                    return;
+                entry.ClaimedAt = renewedClaim;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to renew AUM snapshot claim for {ReportDate}; completion will preserve the dirty flag",
+                    entry.ReportDate
+                );
+                return;
+            }
+        }
+    }
+
+    // A successful rebuild clears only its own still-active lease. Npgsql translates
+    // DateTime.UtcNow to database now(), so expiry and compare-and-clear are one atomic UPDATE.
+    // An import during the rebuild replaces the future marker with a real event timestamp; an
+    // expired marker is also refused because stampers can no longer identify it as a lease.
+    private async Task<bool> TryClearActiveClaim(
+        DueRebuild entry,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+
+        var cleared = await dbContext
+            .Set<AumQuarterlySnapshot>()
+            .Where(s =>
+                s.ReportDate == entry.ReportDate
+                && s.DirtyAt == entry.ClaimedAt
+                && s.DirtyAt > DateTime.UtcNow
+            )
             .ExecuteUpdateAsync(
                 s => s.SetProperty(x => x.DirtyAt, (DateTime?)null),
                 cancellationToken
             );
-
-        return claimed > 0;
+        return cleared > 0;
     }
 
-    // Restores the original claim timestamp after a failed rebuild — unless an
-    // import already re-dirtied the row (a fresh timestamp supersedes ours).
+    // Restores the original event timestamp after a failed rebuild — unless an import
+    // already replaced the lease with a fresh timestamp that supersedes ours.
     // The restored value is already past the cooldown, so the retry is immediate.
     private async Task RearmDirtyFlag(DueRebuild entry, CancellationToken cancellationToken)
     {
@@ -177,7 +273,7 @@ public class AumSnapshotDrainWorker : BackgroundService
 
             await dbContext
                 .Set<AumQuarterlySnapshot>()
-                .Where(s => s.ReportDate == entry.ReportDate && s.DirtyAt == null)
+                .Where(s => s.ReportDate == entry.ReportDate && s.DirtyAt == entry.ClaimedAt)
                 .ExecuteUpdateAsync(
                     s => s.SetProperty(x => x.DirtyAt, entry.DirtyAt),
                     cancellationToken
@@ -199,5 +295,6 @@ public class AumSnapshotDrainWorker : BackgroundService
     {
         public DateOnly ReportDate { get; set; }
         public DateTime DirtyAt { get; set; }
+        public DateTime? ClaimedAt { get; set; }
     }
 }

--- a/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
+++ b/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
@@ -141,9 +141,9 @@ public class AumSnapshotRebuildWorker : BackgroundService
         var snapshotQuarters = await dbContext
             .Set<AumQuarterlySnapshot>()
             .CountAsync(cancellationToken);
-        // RebuildQuarter also materialises StockQuarterlyActivity and
-        // HolderQuarterlySnapshot, so a quarter isn't fully covered until all
-        // three snapshots exist for it — otherwise a newly-added snapshot
+        // RebuildQuarter also materialises stock, exact-listing and holder activity, so a
+        // quarter isn't fully covered until every snapshot family exists for it. Otherwise a
+        // newly-added snapshot
         // table would never backfill once AUM is complete.
         var activityQuarters = await dbContext
             .Set<StockQuarterlyActivity>()
@@ -155,19 +155,27 @@ public class AumSnapshotRebuildWorker : BackgroundService
             .Select(s => s.ReportDate)
             .Distinct()
             .CountAsync(cancellationToken);
+        var listingQuarters = await dbContext
+            .Set<StockQuarterlyListingActivity>()
+            .Where(s => !s.IsCombined)
+            .Select(s => s.ReportDate)
+            .Distinct()
+            .CountAsync(cancellationToken);
         if (
             snapshotQuarters >= form13FQuarters
             && activityQuarters >= form13FQuarters
             && holderQuarters >= form13FQuarters
+            && listingQuarters >= form13FQuarters
         )
         {
             return;
         }
 
         _logger.LogInformation(
-            "Holdings snapshot coverage incomplete (AUM {Snapshots}, activity {Activity}, holder {HolderQuarters} of {Form13FQuarters} 13F quarters) — running backfill with {Timeout}s command timeout",
+            "Holdings snapshot coverage incomplete (AUM {Snapshots}, activity {Activity}, listing {ListingQuarters}, holder {HolderQuarters} of {Form13FQuarters} 13F quarters) — running backfill with {Timeout}s command timeout",
             snapshotQuarters,
             activityQuarters,
+            listingQuarters,
             holderQuarters,
             form13FQuarters,
             BackfillCommandTimeout.TotalSeconds

--- a/src/Equibles.Holdings.HostedService/Consumers/Filings13FImportedConsumer.cs
+++ b/src/Equibles.Holdings.HostedService/Consumers/Filings13FImportedConsumer.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.Holdings.HostedService.Consumers;
 
 /// <summary>
-/// Marks the AUM snapshot for the affected ReportDate dirty so
+/// Marks the AUM snapshot for the affected ReportDate and its following 13F quarter dirty so
 /// <see cref="AumSnapshotDrainWorker"/> rebuilds it after the cooldown
 /// elapses. The expensive multi-distinct rebuild used to run inline here —
 /// during 13F filing-season burst windows (Feb / May / Aug / Nov) hundreds
@@ -21,10 +21,11 @@ namespace Equibles.Holdings.HostedService.Consumers;
 /// (FlexLabs UpsertRange). For a brand-new quarter that has no snapshot row
 /// yet, the row is inserted with <c>DirtyAt = UtcNow</c> and zero aggregates —
 /// the dashboard sees an empty quarter for at most one drain cooldown until
-/// the rebuild lands. For an existing row, <c>DirtyAt</c> is set only when
-/// currently null (preserving the first event's timestamp so the drain
-/// schedules the rebuild from the start of the burst, not the latest event);
-/// aggregate columns are untouched. Doing both branches atomically removes
+/// the rebuild lands. For an existing row, the first ordinary event timestamp
+/// is preserved so a filing burst cannot postpone the rebuild indefinitely.
+/// A future-dated drain claim is replaced by the incoming event timestamp, so
+/// an import during a rebuild stays scheduled for a follow-up refresh. Aggregate
+/// columns are untouched. Doing both branches atomically removes
 /// the consumer→AnyAsync→Rebuild TOCTOU race between parallel consumers.
 /// </summary>
 [Consumer]
@@ -50,38 +51,69 @@ public class Filings13FImportedConsumer : IConsumer<Filings13FImported>
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
 
-        var now = DateTime.UtcNow;
-        var stub = new AumQuarterlySnapshot
-        {
-            ReportDate = reportDate,
-            TotalValue = 0L,
-            FilerCount = 0,
-            PositionCount = 0,
-            StockCount = 0,
-            FilingCount = 0,
-            // ComputedAt = DateTime.UtcNow by C# default, but the row is a
-            // stub: the drain worker overwrites every column on rebuild.
-            ComputedAt = now,
-            DirtyAt = now,
-        };
+        var nextReportDate = await dbContext
+            .Set<AumQuarterlySnapshot>()
+            .Where(snapshot => snapshot.ReportDate > reportDate)
+            .OrderBy(snapshot => snapshot.ReportDate)
+            .Select(snapshot => (DateOnly?)snapshot.ReportDate)
+            .FirstOrDefaultAsync(cancellationToken);
 
-        // Single atomic statement: INSERT new stub OR set DirtyAt only when
-        // currently null. WhenMatched assignments overwrite only the listed
-        // columns, so aggregate values and ComputedAt on an existing row are
-        // untouched (rebuilds, not the consumer, set those).
+        var now = DateTime.UtcNow;
+        var dirtySnapshots = new List<AumQuarterlySnapshot>
+        {
+            new()
+            {
+                ReportDate = reportDate,
+                TotalValue = 0L,
+                FilerCount = 0,
+                PositionCount = 0,
+                StockCount = 0,
+                FilingCount = 0,
+                // ComputedAt = DateTime.UtcNow by C# default, but the row is a
+                // stub: the drain worker overwrites every column on rebuild.
+                ComputedAt = now,
+                DirtyAt = now,
+            },
+        };
+        if (nextReportDate is { } following)
+        {
+            // StockQuarterlyActivity for a quarter embeds its prior-quarter columns. A late
+            // amendment therefore invalidates both the amended quarter and its immediate
+            // successor; marking the successor here prevents a permanently stale comparison.
+            dirtySnapshots.Add(
+                new AumQuarterlySnapshot
+                {
+                    ReportDate = following,
+                    ComputedAt = now,
+                    DirtyAt = now,
+                }
+            );
+        }
+
+        // Single atomic statement: INSERT a stub or retain the first ordinary event time.
+        // A future DirtyAt is the drain's active claim lease; replace it so an import
+        // during the rebuild cannot be cleared with that lease. Aggregate values and
+        // ComputedAt on an existing row stay untouched.
         await dbContext
             .Set<AumQuarterlySnapshot>()
-            .UpsertRange(stub)
+            .UpsertRange(dirtySnapshots)
             .On(s => s.ReportDate)
             .WhenMatched(
                 (existing, incoming) =>
-                    new AumQuarterlySnapshot { DirtyAt = existing.DirtyAt ?? incoming.DirtyAt }
+                    new AumQuarterlySnapshot
+                    {
+                        DirtyAt =
+                            existing.DirtyAt == null || existing.DirtyAt > incoming.DirtyAt
+                                ? incoming.DirtyAt
+                                : existing.DirtyAt,
+                    }
             )
             .RunAsync(cancellationToken);
 
         _logger.LogInformation(
-            "Marked AUM snapshot dirty for {ReportDate} ({FilingCount} filing(s))",
+            "Marked AUM snapshots dirty for {ReportDate} and {FollowingReportDate} ({FilingCount} filing(s))",
             reportDate,
+            nextReportDate,
             context.Message.FilingCount
         );
     }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -207,12 +207,39 @@ public class HoldingsAggregateRefreshService
             dbContext.Database.SetCommandTimeout(commandTimeout.Value);
         }
 
-        await UpsertAumSnapshot(dbContext, reportDate, cancellationToken);
-        await UpsertSectorSnapshots(dbContext, reportDate, cancellationToken);
-        await UpsertStockActivitySnapshots(dbContext, reportDate, cancellationToken);
-        await UpsertHolderSnapshots(dbContext, reportDate, cancellationToken);
-        await RefreshCombinedLane(dbContext, reportDate, cancellationToken);
+        async Task PublishSnapshotGeneration()
+        {
+            await UpsertAumSnapshot(dbContext, reportDate, cancellationToken);
+            await UpsertSectorSnapshots(dbContext, reportDate, cancellationToken);
+            await UpsertStockActivitySnapshots(dbContext, reportDate, cancellationToken);
+            await UpsertHolderSnapshots(dbContext, reportDate, cancellationToken);
+            await BeforeCombinedLaneRefresh(reportDate, cancellationToken);
+            await RefreshCombinedLane(dbContext, reportDate, cancellationToken);
+        }
+
+        if (!dbContext.Database.IsRelational())
+        {
+            await PublishSnapshotGeneration();
+            return;
+        }
+
+        // Activity rows and the holder-union denominator are one published generation.
+        // Without this transaction, readers can observe the new combined activity between
+        // statements while HolderQuarterlySnapshot still represents the prior rebuild.
+        await using var transaction = await dbContext.Database.BeginTransactionAsync(
+            cancellationToken
+        );
+        await PublishSnapshotGeneration();
+        await transaction.CommitAsync(cancellationToken);
     }
+
+    // Test seam for observing the generation between the holder and combined calculations. The
+    // relational transaction must keep every write invisible until the latter finishes and the
+    // whole generation commits.
+    protected virtual Task BeforeCombinedLaneRefresh(
+        DateOnly reportDate,
+        CancellationToken cancellationToken
+    ) => Task.CompletedTask;
 
     // Maintains the open filing window's combined-lane snapshot
     // (StockQuarterlyActivityCombined). While the newest quarter's 45-day window is
@@ -248,6 +275,10 @@ public class HoldingsAggregateRefreshService
             await dbContext
                 .Set<StockQuarterlyActivityCombined>()
                 .ExecuteDeleteAsync(cancellationToken);
+            await dbContext
+                .Set<StockQuarterlyListingActivity>()
+                .Where(row => row.IsCombined)
+                .ExecuteDeleteAsync(cancellationToken);
             return;
         }
 
@@ -262,6 +293,13 @@ public class HoldingsAggregateRefreshService
             // First quarter on record: there is nothing to carry forward, so the
             // combined view degenerates to the plain snapshot — leave the lane empty
             // and let consumers fall back.
+            await dbContext
+                .Set<StockQuarterlyActivityCombined>()
+                .ExecuteDeleteAsync(cancellationToken);
+            await dbContext
+                .Set<StockQuarterlyListingActivity>()
+                .Where(row => row.IsCombined)
+                .ExecuteDeleteAsync(cancellationToken);
             return;
         }
 
@@ -288,6 +326,50 @@ public class HoldingsAggregateRefreshService
                 .ToListAsync(cancellationToken)
         ).ToDictionary(c => c.CommonStockId);
 
+        var combinedListingShares = await repository
+            .GetCombinedQuarter(latest, previous)
+            .Join(
+                dbContext.Set<CommonStock>(),
+                holding => holding.CommonStockId,
+                stock => stock.Id,
+                (holding, stock) => new { Holding = holding, stock.Ticker }
+            )
+            .GroupBy(row => new
+            {
+                row.Holding.CommonStockId,
+                PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
+            })
+            .Select(group => new
+            {
+                group.Key.CommonStockId,
+                group.Key.PriceSeriesTicker,
+                Shares = group.Sum(row => row.Holding.Shares),
+            })
+            .ToListAsync(cancellationToken);
+        var previousListingShares = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(holding =>
+                holding.ReportDate == previous && holding.FilingType == FilingType.Form13F
+            )
+            .Join(
+                dbContext.Set<CommonStock>(),
+                holding => holding.CommonStockId,
+                stock => stock.Id,
+                (holding, stock) => new { Holding = holding, stock.Ticker }
+            )
+            .GroupBy(row => new
+            {
+                row.Holding.CommonStockId,
+                PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
+            })
+            .Select(group => new
+            {
+                group.Key.CommonStockId,
+                group.Key.PriceSeriesTicker,
+                Shares = group.Sum(row => row.Holding.Shares),
+            })
+            .ToListAsync(cancellationToken);
+
         var computedAt = DateTime.UtcNow;
         var rows = activity
             .Select(a =>
@@ -308,6 +390,27 @@ public class HoldingsAggregateRefreshService
                     SoldOutFilerCount = c?.SoldOutFilerCount ?? 0,
                     ComputedAt = computedAt,
                 };
+            })
+            .ToList();
+        var currentListingLookup = combinedListingShares.ToDictionary(
+            row => (row.CommonStockId, row.PriceSeriesTicker),
+            row => row.Shares
+        );
+        var previousListingLookup = previousListingShares.ToDictionary(
+            row => (row.CommonStockId, row.PriceSeriesTicker),
+            row => row.Shares
+        );
+        var listingRows = currentListingLookup
+            .Keys.Union(previousListingLookup.Keys)
+            .Select(key => new StockQuarterlyListingActivity
+            {
+                CommonStockId = key.CommonStockId,
+                ReportDate = latest,
+                IsCombined = true,
+                PriceSeriesTicker = key.PriceSeriesTicker,
+                CurrentShares = currentListingLookup.GetValueOrDefault(key),
+                PreviousShares = previousListingLookup.GetValueOrDefault(key),
+                ComputedAt = computedAt,
             })
             .ToList();
 
@@ -344,6 +447,18 @@ public class HoldingsAggregateRefreshService
             .Set<StockQuarterlyActivityCombined>()
             .Where(s => s.ReportDate != latest || !currentStockIds.Contains(s.CommonStockId))
             .ExecuteDeleteAsync(cancellationToken);
+
+        await dbContext
+            .Set<StockQuarterlyListingActivity>()
+            .Where(row => row.IsCombined && row.ReportDate != latest)
+            .ExecuteDeleteAsync(cancellationToken);
+        await ReplaceListingActivitySnapshots(
+            dbContext,
+            latest,
+            isCombined: true,
+            listingRows,
+            cancellationToken
+        );
     }
 
     // Per-(holder, quarter) AUM aggregates for the institutions browse ranking
@@ -632,6 +747,36 @@ public class HoldingsAggregateRefreshService
             })
             .ToListAsync(cancellationToken);
 
+        var listingActivity = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h =>
+                (h.ReportDate == reportDate || h.ReportDate == previousReportDate)
+                && h.FilingType == FilingType.Form13F
+            )
+            .Join(
+                dbContext.Set<CommonStock>(),
+                holding => holding.CommonStockId,
+                stock => stock.Id,
+                (holding, stock) => new { Holding = holding, stock.Ticker }
+            )
+            .GroupBy(row => new
+            {
+                row.Holding.CommonStockId,
+                PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
+            })
+            .Select(group => new
+            {
+                group.Key.CommonStockId,
+                group.Key.PriceSeriesTicker,
+                CurrentShares = group.Sum(row =>
+                    row.Holding.ReportDate == reportDate ? row.Holding.Shares : 0L
+                ),
+                PreviousShares = group.Sum(row =>
+                    row.Holding.ReportDate == previousReportDate ? row.Holding.Shares : 0L
+                ),
+            })
+            .ToListAsync(cancellationToken);
+
         var churn = (
             await BuildChurnQuery(dbContext, reportDate, previousReportDate)
                 .ToListAsync(cancellationToken)
@@ -692,6 +837,63 @@ public class HoldingsAggregateRefreshService
             .Set<StockQuarterlyActivity>()
             .Where(s => s.ReportDate == reportDate && !currentStockIds.Contains(s.CommonStockId))
             .ExecuteDeleteAsync(cancellationToken);
+
+        await ReplaceListingActivitySnapshots(
+            dbContext,
+            reportDate,
+            isCombined: false,
+            listingActivity
+                .Select(row => new StockQuarterlyListingActivity
+                {
+                    CommonStockId = row.CommonStockId,
+                    ReportDate = reportDate,
+                    IsCombined = false,
+                    PriceSeriesTicker = row.PriceSeriesTicker,
+                    CurrentShares = row.CurrentShares,
+                    PreviousShares = row.PreviousShares,
+                    ComputedAt = computedAt,
+                })
+                .ToList(),
+            cancellationToken
+        );
+    }
+
+    private static async Task ReplaceListingActivitySnapshots(
+        EquiblesFinancialDbContext dbContext,
+        DateOnly reportDate,
+        bool isCombined,
+        List<StockQuarterlyListingActivity> rows,
+        CancellationToken cancellationToken
+    )
+    {
+        await dbContext
+            .Set<StockQuarterlyListingActivity>()
+            .Where(row => row.ReportDate == reportDate && row.IsCombined == isCombined)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        if (rows.Count == 0)
+            return;
+
+        await dbContext
+            .Set<StockQuarterlyListingActivity>()
+            .UpsertRange(rows)
+            .On(row => new
+            {
+                row.CommonStockId,
+                row.ReportDate,
+                row.IsCombined,
+                row.PriceSeriesTicker,
+            })
+            .WhenMatched(
+                (_, incoming) =>
+                    new StockQuarterlyListingActivity
+                    {
+                        CurrentShares = incoming.CurrentShares,
+                        PreviousShares = incoming.PreviousShares,
+                        ComputedAt = incoming.ComputedAt,
+                    }
+            )
+            .RunAsync(cancellationToken);
     }
 
     // Per-stock churn: the same numbers GetQuarterlyNewSoldOutPositions defines ("new" =

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsRollupRefresher.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsRollupRefresher.cs
@@ -19,8 +19,8 @@ namespace Equibles.Holdings.HostedService.Services;
 /// </para>
 /// <para>
 /// Idempotent and re-entrant: re-summing an already-correct filing writes nothing, and the dirty
-/// stamp is an insert-or-set-when-null upsert (the same statement
-/// <c>Filings13FImportedConsumer</c> uses), so concurrent stampers converge.
+/// stamp is an atomic insert-or-preserve-first-event upsert (the same lease-aware
+/// semantics <c>Filings13FImportedConsumer</c> uses), so concurrent stampers converge.
 /// </para>
 /// </remarks>
 internal static class HoldingsRollupRefresher
@@ -98,7 +98,9 @@ internal static class HoldingsRollupRefresher
     }
 
     /// <summary>
-    /// Stamps the quarters' AUM snapshots dirty so the drain worker rebuilds them.
+    /// Stamps the quarters' AUM snapshots and their immediate successors dirty so the drain
+    /// worker rebuilds both the changed current values and the successor comparisons that embed
+    /// them as prior-quarter values.
     /// </summary>
     internal static async Task MarkAumSnapshotsDirty(
         EquiblesFinancialDbContext dbContext,
@@ -106,10 +108,28 @@ internal static class HoldingsRollupRefresher
         CancellationToken cancellationToken
     )
     {
-        var quarters = reportDates.Distinct().ToList();
-        if (quarters.Count == 0)
+        var changedQuarters = reportDates.Distinct().ToList();
+        if (changedQuarters.Count == 0)
         {
             return;
+        }
+
+        // The snapshot table is one bounded row per 13F quarter. Resolve the immediate successor
+        // from that spine once, then stamp the union so a repaired prior-quarter value cannot
+        // leave StockQuarterlyActivity's embedded comparison permanently stale.
+        var snapshotDates = await dbContext
+            .Set<AumQuarterlySnapshot>()
+            .OrderBy(snapshot => snapshot.ReportDate)
+            .Select(snapshot => snapshot.ReportDate)
+            .ToListAsync(cancellationToken);
+        var quarters = changedQuarters.ToHashSet();
+        foreach (var changed in changedQuarters)
+        {
+            var successor = snapshotDates.FirstOrDefault(date => date > changed);
+            if (successor != default)
+            {
+                quarters.Add(successor);
+            }
         }
 
         var now = DateTime.UtcNow;
@@ -141,7 +161,10 @@ internal static class HoldingsRollupRefresher
             {
                 if (existingByDate.TryGetValue(stub.ReportDate, out var existing))
                 {
-                    existing.DirtyAt ??= now;
+                    if (existing.DirtyAt == null || existing.DirtyAt > now)
+                    {
+                        existing.DirtyAt = now;
+                    }
                 }
                 else
                 {
@@ -158,7 +181,13 @@ internal static class HoldingsRollupRefresher
             .On(s => s.ReportDate)
             .WhenMatched(
                 (existing, incoming) =>
-                    new AumQuarterlySnapshot { DirtyAt = existing.DirtyAt ?? incoming.DirtyAt }
+                    new AumQuarterlySnapshot
+                    {
+                        DirtyAt =
+                            existing.DirtyAt == null || existing.DirtyAt > incoming.DirtyAt
+                                ? incoming.DirtyAt
+                                : existing.DirtyAt,
+                    }
             )
             .RunAsync(cancellationToken);
     }

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -18,8 +18,10 @@ using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Extensions;
 using Equibles.Holdings.Repositories.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Extensions;
 using Equibles.Mcp.Helpers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -28,6 +30,8 @@ namespace Equibles.Holdings.Mcp.Tools;
 [McpServerToolType]
 public class InstitutionalHoldingsTools
 {
+    private static readonly TimeSpan MarketActivityCacheDuration = TimeSpan.FromMinutes(30);
+
     private static readonly string[] ValidActivityBuckets =
     [
         "top-buys",
@@ -58,6 +62,9 @@ public class InstitutionalHoldingsTools
     private readonly StockSplitRepository _stockSplitRepository;
     private readonly StockCombinedQuarterService _combinedQuarterService;
     private readonly HoldingsCorpusCoverage _corpusCoverage;
+    private readonly IMemoryCache _memoryCache;
+    private readonly MarketActivityShareRestater _marketActivityShareRestater;
+    private readonly InstitutionPortfolioSummaryProvider _summaryProvider;
     private readonly McpToolRunner _runner;
 
     public InstitutionalHoldingsTools(
@@ -68,7 +75,10 @@ public class InstitutionalHoldingsTools
         StockCombinedQuarterService combinedQuarterService,
         ErrorManager errorManager,
         ILogger<InstitutionalHoldingsTools> logger,
-        HoldingsCorpusCoverage corpusCoverage = null
+        HoldingsCorpusCoverage corpusCoverage = null,
+        IMemoryCache memoryCache = null,
+        InstitutionPortfolioSummaryProvider summaryProvider = null,
+        MarketActivityShareRestater marketActivityShareRestater = null
     )
     {
         _holdingRepository = holdingRepository;
@@ -77,6 +87,13 @@ public class InstitutionalHoldingsTools
         _stockSplitRepository = stockSplitRepository;
         _combinedQuarterService = combinedQuarterService;
         _corpusCoverage = corpusCoverage ?? HoldingsCorpusCoverage.Default;
+        _memoryCache = memoryCache ?? new MemoryCache(new MemoryCacheOptions());
+        _marketActivityShareRestater =
+            marketActivityShareRestater
+            ?? new MarketActivityShareRestater(_commonStockRepository, _stockSplitRepository);
+        _summaryProvider =
+            summaryProvider
+            ?? new InstitutionPortfolioSummaryProvider(_holdingRepository, _memoryCache);
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -121,44 +138,63 @@ public class InstitutionalHoldingsTools
                 var presentCombined =
                     anchor is { IsCombined: true } && targetDate == anchor.ReportDate;
                 var allHoldings = presentCombined
-                    ? _holdingRepository.GetCombinedQuarterByStock(
+                    ? _holdingRepository.GetCombinedQuarterByStockWithHolder(
                         stock,
                         anchor.ReportDate,
                         anchor.PreviousReportDate.Value
                     )
-                    : _holdingRepository.Get13FByStock(stock, targetDate);
-                var totalInstitutions = await allHoldings
-                    .Select(h => h.InstitutionalHolderId)
-                    .Distinct()
-                    .CountAsync();
-                var totalSharesAll = await allHoldings.SumAsync(h => h.Shares);
-                var totalValueAll = await allHoldings.SumAsync(h => h.Value);
-
-                maxResults = McpLimit.Clamp(maxResults);
-
+                    : _holdingRepository.Get13FByStockWithHolder(stock, targetDate);
+                // Materialise one compact projection. Exact-listing split factors can change
+                // both rank and denominator, so a separate raw aggregate/page query would scan
+                // the combined-quarter view twice and could rank a sibling class incorrectly.
                 var holdings = await allHoldings
-                    .OrderByDescending(h => h.Shares)
-                    .Take(maxResults)
+                    .AsNoTracking()
+                    .Select(h => new TopHolderRow
+                    {
+                        Id = h.Id,
+                        InstitutionalHolderId = h.InstitutionalHolderId,
+                        InstitutionName = h.InstitutionalHolder.Name,
+                        Shares = h.Shares,
+                        Value = h.Value,
+                        ListedTicker = h.ListedTicker,
+                        OptionType = h.OptionType,
+                    })
                     .ToListAsync();
-
                 if (holdings.Count == 0)
                     return $"No institutional holdings found for {ticker} as of {FormatDate(targetDate)}.";
 
-                // All rows share the target report date, so a single factor restates every
-                // share count onto today's basis (matching the web). The % of Total is a
-                // same-date ratio and is split-invariant (the factor cancels top and bottom).
                 var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
-                var shareFactor = SplitAdjustment.ShareCountFactor(targetDate, splits);
+                foreach (var holding in holdings)
+                {
+                    var listing = holding.ListedTicker ?? stock.Ticker;
+                    holding.Shares = SplitAdjustment.AdjustShareCount(
+                        holding.Shares,
+                        targetDate,
+                        PriceSeriesSplitScope.ForListing(splits, stock.Ticker, listing)
+                    );
+                }
 
-                return RenderTopHoldersTable(
+                var totalInstitutions = holdings
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count();
+                var totalShares = holdings.Sum(h => h.Shares);
+                var totalValue = holdings.Sum(h => h.Value);
+                maxResults = McpLimit.Clamp(maxResults);
+                holdings = holdings
+                    .OrderByDescending(h => h.Shares)
+                    .ThenBy(h => h.Id)
+                    .Take(maxResults)
+                    .ToList();
+
+                return RenderAdjustedTopHoldersTable(
                     stock,
                     ticker,
                     targetDate,
                     totalInstitutions,
-                    totalSharesAll,
-                    totalValueAll,
+                    totalShares,
+                    totalValue,
                     holdings,
-                    shareFactor,
                     JoinNotes(
                         dateNote,
                         presentCombined ? CombinedViewNote(targetDate, anchor) : null
@@ -186,6 +222,9 @@ public class InstitutionalHoldingsTools
         + $"after quarter end). Combined view: funds that have not filed yet carry their "
         + $"{FormatDate(anchor.PreviousReportDate.Value)} positions.";
 
+    // Stable pure rendering seam retained for the culture/date/zero-denominator contracts.
+    // The request path above uses exact-listing adjusted rows because sibling classes can
+    // have different split factors; this adapter preserves the former single-factor shape.
     private static string RenderTopHoldersTable(
         CommonStock stock,
         string ticker,
@@ -199,9 +238,44 @@ public class InstitutionalHoldingsTools
     )
     {
         var adjustedTotalShares = SplitAdjustment.AdjustShareCount(totalSharesAll, shareFactor);
+        var adjustedRows = holdings
+            .Select(h => new TopHolderRow
+            {
+                Id = h.Id,
+                InstitutionalHolderId = h.InstitutionalHolderId,
+                InstitutionName = h.InstitutionalHolder?.Name ?? "Unknown",
+                Shares = SplitAdjustment.AdjustShareCount(h.Shares, shareFactor),
+                Value = h.Value,
+                ListedTicker = h.ListedTicker,
+                OptionType = h.OptionType,
+            })
+            .ToList();
+        return RenderAdjustedTopHoldersTable(
+            stock,
+            ticker,
+            targetDate,
+            totalInstitutions,
+            adjustedTotalShares,
+            totalValueAll,
+            adjustedRows,
+            combinedNote
+        );
+    }
+
+    private static string RenderAdjustedTopHoldersTable(
+        CommonStock stock,
+        string ticker,
+        DateOnly targetDate,
+        int totalInstitutions,
+        long totalSharesAll,
+        long totalValueAll,
+        List<TopHolderRow> holdings,
+        string combinedNote
+    )
+    {
         var subtitle =
             $"Showing {holdings.Count} of {totalInstitutions} institutions. Total: "
-            + $"{McpFormat.WholeNumber(adjustedTotalShares)} shares, "
+            + $"{McpFormat.WholeNumber(totalSharesAll)} shares, "
             + $"${FormatMillions(totalValueAll)}M value";
         if (combinedNote != null)
             subtitle = $"{subtitle}\n{combinedNote}";
@@ -216,19 +290,16 @@ public class InstitutionalHoldingsTools
             holdings,
             (rank, h) =>
             {
-                // Ratio computed from raw shares (split-invariant); only the displayed
-                // absolute share count is restated onto today's basis.
                 var pct = Percentage.Of(h.Shares, totalSharesAll);
-                var adjustedShares = SplitAdjustment.AdjustShareCount(h.Shares, shareFactor);
                 // A sibling-class row is a DIFFERENT security of the same issuer; the class
                 // qualifies the type in place so single-class stocks pay no extra column.
                 var positionType =
                     h.ListedTicker == null
                         ? PositionType(h.OptionType)
                         : $"{PositionType(h.OptionType)} ({h.ListedTicker})";
-                return $"| {rank} | {h.InstitutionalHolder.Name} | "
+                return $"| {rank} | {h.InstitutionName} | "
                     + $"{positionType} | "
-                    + $"{McpFormat.WholeNumber(adjustedShares)} | "
+                    + $"{McpFormat.WholeNumber(h.Shares)} | "
                     + $"{FormatMillions(h.Value)} | "
                     + $"{McpFormat.Invariant(pct, "F2")}% |";
             }
@@ -245,6 +316,17 @@ public class InstitutionalHoldingsTools
         );
 
         return result.ToString();
+    }
+
+    private sealed class TopHolderRow
+    {
+        public Guid Id { get; set; }
+        public Guid InstitutionalHolderId { get; set; }
+        public string InstitutionName { get; set; }
+        public long Shares { get; set; }
+        public long Value { get; set; }
+        public string ListedTicker { get; set; }
+        public OptionType? OptionType { get; set; }
     }
 
     [McpServerTool(
@@ -396,9 +478,9 @@ public class InstitutionalHoldingsTools
                 if (holderError != null)
                     return holderError;
 
-                var reportDates = await _holdingRepository
-                    .Get13FReportDatesByHolder(holder)
-                    .ToListAsync();
+                var reportDates = await _holdingRepository.Get13FReportDatesByHolderSnapshotBacked(
+                    holder
+                );
                 if (reportDates.Count == 0)
                     return $"No holdings data for {holder.Name}.";
 
@@ -739,37 +821,9 @@ public class InstitutionalHoldingsTools
                     return dateError;
 
                 var previousDate = GetPriorReportDate(reportDates, targetDate);
-
-                var currentHoldings = await _holdingRepository
-                    .Get13FByStockWithHolder(stock, targetDate)
+                var activity = await _holdingRepository
+                    .Get13FHolderActivityByStock(stock, targetDate, previousDate)
                     .ToListAsync();
-                var previousHoldings = previousDate.HasValue
-                    ? await _holdingRepository
-                        .Get13FByStockWithHolder(stock, previousDate.Value)
-                        .ToListAsync()
-                    : [];
-
-                // Aggregate by holder (one holder may file multiple 13F rows per quarter).
-                // TODO(#1008): the same aggregation/grouping logic lives in
-                // Equibles.Web.Services.HoldingsPositionGrouper. Consolidate into a shared
-                // Equibles.Holdings.BusinessLogic project once one exists.
-                static Dictionary<Guid, HolderAggregate> AggregateByHolder(
-                    List<InstitutionalHolding> holdings
-                ) =>
-                    holdings
-                        .GroupBy(h => h.InstitutionalHolderId)
-                        .ToDictionary(
-                            g => g.Key,
-                            g => new HolderAggregate
-                            {
-                                Name = g.First().InstitutionalHolder?.Name ?? "Unknown",
-                                Shares = g.Sum(h => h.Shares),
-                                Value = g.Sum(h => h.Value),
-                            }
-                        );
-
-                var currentByHolder = AggregateByHolder(currentHoldings);
-                var previousByHolder = AggregateByHolder(previousHoldings);
 
                 // A previous holder with no current row only PROVES an exit when it filed a
                 // 13F for the target quarter elsewhere. While the filing window is open the
@@ -785,9 +839,14 @@ public class InstitutionalHoldingsTools
                 HashSet<Guid> filedPreviousHolders = null;
                 if (previousDate.HasValue)
                 {
+                    var priorHolderIds = activity
+                        .Where(row => row.PreviousPositionCount > 0)
+                        .Select(row => row.InstitutionalHolderId)
+                        .Distinct()
+                        .ToList();
                     filedPreviousHolders = (
                         await _holdingRepository
-                            .GetFiledHolderIdsAmong(targetDate, previousByHolder.Keys.ToList())
+                            .GetFiledHolderIdsAmong(targetDate, priorHolderIds)
                             .ToListAsync()
                     ).ToHashSet();
                 }
@@ -797,38 +856,42 @@ public class InstitutionalHoldingsTools
                 // and the Prior → New column reflect a real position change, not the split.
                 // Δ Value is a dollar figure and is split-invariant — leave the stored value.
                 var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
-                var currentFactor = SplitAdjustment.ShareCountFactor(targetDate, splits);
-                var previousFactor = previousDate.HasValue
-                    ? SplitAdjustment.ShareCountFactor(previousDate.Value, splits)
-                    : 1m;
-
-                var allHolderIds = currentByHolder
-                    .Keys.Union(previousByHolder.Keys)
-                    .Where(id =>
-                        filedPreviousHolders == null
-                        || currentByHolder.ContainsKey(id)
-                        || filedPreviousHolders.Contains(id)
+                long AdjustShares(long shares, DateOnly asOf, string listedTicker)
+                {
+                    var exactTicker = listedTicker ?? stock.Ticker;
+                    var scoped = PriceSeriesSplitScope.ForListing(
+                        splits,
+                        stock.Ticker,
+                        exactTicker
                     );
-                var movers = allHolderIds
-                    .Select(id =>
+                    return SplitAdjustment.AdjustShareCount(shares, asOf, scoped);
+                }
+
+                var movers = activity
+                    .GroupBy(row => row.InstitutionalHolderId)
+                    .Where(g =>
+                        filedPreviousHolders == null
+                        || g.Any(row => row.CurrentPositionCount > 0)
+                        || filedPreviousHolders.Contains(g.Key)
+                    )
+                    .Select(g =>
                     {
-                        currentByHolder.TryGetValue(id, out var c);
-                        previousByHolder.TryGetValue(id, out var p);
-                        var currentShares = SplitAdjustment.AdjustShareCount(
-                            c?.Shares ?? 0,
-                            currentFactor
+                        var currentShares = g.Sum(row =>
+                            AdjustShares(row.CurrentShares, targetDate, row.ListedTicker)
                         );
-                        var previousShares = SplitAdjustment.AdjustShareCount(
-                            p?.Shares ?? 0,
-                            previousFactor
+                        var previousShares = g.Sum(row =>
+                            AdjustShares(
+                                row.PreviousShares,
+                                previousDate ?? targetDate,
+                                row.ListedTicker
+                            )
                         );
                         return (
-                            Id: id,
-                            Name: c?.Name ?? p?.Name ?? "Unknown",
+                            Id: g.Key,
                             CurrentShares: currentShares,
                             PreviousShares: previousShares,
                             DeltaShares: currentShares - previousShares,
-                            DeltaValue: (c?.Value ?? 0) - (p?.Value ?? 0)
+                            DeltaValue: g.Sum(row => row.CurrentValue - row.PreviousValue)
                         );
                     })
                     .ToList();
@@ -846,6 +909,19 @@ public class InstitutionalHoldingsTools
 
                 if (topBuyers.Count == 0 && topSellers.Count == 0)
                     return $"No quarter-over-quarter movement found for {stock.Name} ({ticker}) as of {FormatDate(targetDate)}.";
+
+                var topHolderIds = topBuyers
+                    .Select(m => m.Id)
+                    .Concat(topSellers.Select(m => m.Id))
+                    .Distinct()
+                    .ToList();
+                var holderNames = await _holderRepository
+                    .GetAll()
+                    .Where(h => topHolderIds.Contains(h.Id))
+                    .Select(h => new { h.Id, h.Name })
+                    .ToDictionaryAsync(h => h.Id, h => h.Name);
+                string HolderName(Guid id) =>
+                    holderNames.TryGetValue(id, out var name) ? name : "Unknown";
 
                 // Flag first-time filers among whole-position buyers: a filer whose FIRST 13F
                 // is the target quarter shows its entire book as "new positions", which is
@@ -871,8 +947,8 @@ public class InstitutionalHoldingsTools
                     .Select(m =>
                         (
                             firstTimeFilerIds.Contains(m.Id)
-                                ? $"{m.Name} (first 13F this quarter)"
-                                : m.Name,
+                                ? $"{HolderName(m.Id)} (first 13F this quarter)"
+                                : HolderName(m.Id),
                             m.CurrentShares,
                             m.PreviousShares,
                             m.DeltaShares,
@@ -882,7 +958,13 @@ public class InstitutionalHoldingsTools
                     .ToList();
                 var sellerRows = topSellers
                     .Select(m =>
-                        (m.Name, m.CurrentShares, m.PreviousShares, m.DeltaShares, m.DeltaValue)
+                        (
+                            HolderName(m.Id),
+                            m.CurrentShares,
+                            m.PreviousShares,
+                            m.DeltaShares,
+                            m.DeltaValue
+                        )
                     )
                     .ToList();
 
@@ -1135,18 +1217,24 @@ public class InstitutionalHoldingsTools
         bool windowOpen
     )
     {
-        var snapshot = windowOpen
-            ? (await _holdingRepository.GetStockActivitySnapshotsCombined(targetDate).ToListAsync())
-                .Select(s => s.ToActivity())
-                .ToList()
-            : (await _holdingRepository.GetStockActivitySnapshots(targetDate).ToListAsync())
-                .Select(s => s.ToActivity())
-                .ToList();
-        if (snapshot.Count > 0)
-            return snapshot;
-        return await _holdingRepository
-            .GetQuarterlyActivity(targetDate, previousDate, windowOpen)
-            .ToListAsync();
+        var cached = await GetMarketAggregateCached(
+            "activity",
+            targetDate,
+            previousDate,
+            windowOpen,
+            async () =>
+            {
+                return await _holdingRepository.GetMarketActivitySnapshotBacked(
+                    targetDate,
+                    previousDate,
+                    windowOpen
+                );
+            }
+        );
+
+        // Split restatement mutates the returned rows. Keep the cached source pristine so a
+        // second request cannot compound the adjustment applied by the first request.
+        return cached.Select(CloneActivity).ToList();
     }
 
     // Churn twin of LoadMarketActivity — same lanes, same empty-snapshot fallback.
@@ -1156,19 +1244,127 @@ public class InstitutionalHoldingsTools
         bool windowOpen
     )
     {
-        var snapshot = windowOpen
-            ? (await _holdingRepository.GetStockActivitySnapshotsCombined(targetDate).ToListAsync())
-                .Select(s => s.ToChurn())
-                .ToList()
-            : (await _holdingRepository.GetStockActivitySnapshots(targetDate).ToListAsync())
-                .Select(s => s.ToChurn())
-                .ToList();
-        if (snapshot.Count > 0)
-            return snapshot;
-        return await _holdingRepository
-            .GetQuarterlyNewSoldOutPositions(targetDate, previousDate, windowOpen)
-            .ToListAsync();
+        var cached = await GetMarketAggregateCached(
+            "churn",
+            targetDate,
+            previousDate,
+            windowOpen,
+            async () =>
+            {
+                var snapshot = windowOpen
+                    ? (
+                        await _holdingRepository
+                            .GetStockActivitySnapshotsCombined(targetDate)
+                            .AsNoTracking()
+                            .ToListAsync()
+                    )
+                        .Select(s => s.ToChurn())
+                        .ToList()
+                    : (
+                        await _holdingRepository
+                            .GetStockActivitySnapshots(targetDate)
+                            .AsNoTracking()
+                            .ToListAsync()
+                    )
+                        .Select(s => s.ToChurn())
+                        .ToList();
+                if (snapshot.Count > 0)
+                    return snapshot;
+                return await _holdingRepository
+                    .GetQuarterlyNewSoldOutPositions(targetDate, previousDate, windowOpen)
+                    .ToListAsync();
+            }
+        );
+
+        return cached.Select(CloneChurn).ToList();
     }
+
+    // Only resolved 13F quarter dates reach this key builder, so the process-wide lock set grows
+    // by a bounded handful of keys per calendar quarter rather than by arbitrary request input.
+    private static string MarketActivityCacheKey(
+        string source,
+        DateOnly targetDate,
+        DateOnly previousDate,
+        bool windowOpen
+    ) =>
+        $"holdings:{source}:{(windowOpen ? "combined" : "closed")}:"
+        + $"{targetDate.ToString("O", CultureInfo.InvariantCulture)}:"
+        + previousDate.ToString("O", CultureInfo.InvariantCulture);
+
+    private sealed record VersionedMarketCacheEntry<T>(DateTime Version, T Value);
+
+    private async Task<T> GetMarketAggregateCached<T>(
+        string source,
+        DateOnly targetDate,
+        DateOnly previousDate,
+        bool windowOpen,
+        Func<Task<T>> factory
+    )
+    {
+        var key = MarketActivityCacheKey(source, targetDate, previousDate, windowOpen);
+        var state = await _holdingRepository.GetMarketActivitySnapshotState(
+            targetDate,
+            previousDate,
+            windowOpen
+        );
+        if (!state.CanCache)
+        {
+            _memoryCache.Remove(key);
+            // A dirty quarter bypasses the process cache, but still reads the bounded snapshot.
+            // Falling back to the holdings corpus here would put the 7-30s aggregates back on
+            // every request for the drain's one-hour ingest cooldown. Each snapshot loader falls
+            // back to live rows only when its materialized table is genuinely empty.
+            return await factory();
+        }
+
+        var version = state.ComputedAt!.Value;
+        if (
+            _memoryCache.TryGetValue(key, out VersionedMarketCacheEntry<T> existing)
+            && existing.Version == version
+        )
+            return existing.Value;
+
+        _memoryCache.Remove(key);
+        var cached = await _memoryCache.GetOrCreateSafeAsync(
+            key,
+            MarketActivityCacheDuration,
+            async () => new VersionedMarketCacheEntry<T>(version, await factory())
+        );
+        var latestState = await _holdingRepository.GetMarketActivitySnapshotState(
+            targetDate,
+            previousDate,
+            windowOpen
+        );
+        if (latestState.CanCache && latestState.ComputedAt == cached.Version)
+            return cached.Value;
+
+        // A refresh can land between the first version read and the single-flight factory.
+        // Re-read the version after the factory so that newly built stale entries are evicted
+        // before this caller can observe them.
+        _memoryCache.Remove(key);
+        return await factory();
+    }
+
+    private static MarketWideStockActivity CloneActivity(MarketWideStockActivity activity) =>
+        new()
+        {
+            CommonStockId = activity.CommonStockId,
+            CurrentShares = activity.CurrentShares,
+            PreviousShares = activity.PreviousShares,
+            CurrentValue = activity.CurrentValue,
+            PreviousValue = activity.PreviousValue,
+            CurrentFilerCount = activity.CurrentFilerCount,
+            PreviousFilerCount = activity.PreviousFilerCount,
+            ListingShares = activity.ListingShares.ToList(),
+        };
+
+    private static MarketWideStockChurn CloneChurn(MarketWideStockChurn churn) =>
+        new()
+        {
+            CommonStockId = churn.CommonStockId,
+            NewFilerCount = churn.NewFilerCount,
+            SoldOutFilerCount = churn.SoldOutFilerCount,
+        };
 
     private async Task<string> RenderMarketActivityMovers(
         string normalizedBucket,
@@ -1187,7 +1383,11 @@ public class InstitutionalHoldingsTools
         // While the filing window is open the combined variant carries non-filers forward at a
         // zero delta, so only real reported moves rank.
         var activity = await LoadMarketActivity(targetDate, previousDate, windowOpen);
-        await RestateActivitySharesToTodaysBasis(activity, targetDate, previousDate);
+        await _marketActivityShareRestater.RestateMarketActivity(
+            activity,
+            targetDate,
+            previousDate
+        );
 
         var movers = activity.Where(a => a.CurrentShares != a.PreviousShares);
         var rows =
@@ -1338,10 +1538,17 @@ public class InstitutionalHoldingsTools
                 if (rows.Count == 0)
                     return $"No stocks were held by 13F filers as of {FormatDate(targetDate)}.";
 
-                var universeFilers = await _holdingRepository.Get13FUniverseFilerCount(
+                var universeFilers = await GetMarketAggregateCached(
+                    "universe-filers",
                     targetDate,
                     queryPreviousDate,
-                    windowOpen
+                    windowOpen,
+                    () =>
+                        _holdingRepository.Get13FUniverseFilerCount(
+                            targetDate,
+                            queryPreviousDate,
+                            windowOpen
+                        )
                 );
                 var stocks = await LoadStocksByIds(rows.Select(r => r.CommonStockId).ToList());
 
@@ -1439,21 +1646,11 @@ public class InstitutionalHoldingsTools
                     return error;
 
                 var previousDate = GetPriorReportDate(reportDates, targetDate);
-
-                var currentHoldings = await _holdingRepository
-                    .Get13FByHolder(holder, targetDate)
-                    .ToListAsync();
-                var previousHoldings = previousDate.HasValue
-                    ? await _holdingRepository
-                        .Get13FByHolder(holder, previousDate.Value)
-                        .ToListAsync()
-                    : [];
-                var summary = InstitutionPortfolioSummaryCalculator.Calculate(
-                    currentHoldings,
-                    previousHoldings,
-                    reportDates.Count,
+                var summary = await _summaryProvider.Get(
+                    holder,
                     targetDate,
-                    previousDate
+                    previousDate,
+                    reportDates.Count
                 );
 
                 return RenderInstitutionSummary(holder, targetDate, previousDate, summary, notes);
@@ -1664,9 +1861,9 @@ public class InstitutionalHoldingsTools
                 if (holderError != null)
                     return holderError;
 
-                var reportDates = await _holdingRepository
-                    .Get13FReportDatesByHolder(holder)
-                    .ToListAsync();
+                var reportDates = await _holdingRepository.Get13FReportDatesByHolderSnapshotBacked(
+                    holder
+                );
                 if (reportDates.Count < 2)
                     return $"{holder.Name} has fewer than two reported quarters — no diff available.";
 
@@ -1887,7 +2084,7 @@ public class InstitutionalHoldingsTools
     {
         var perHolder = new List<List<DateOnly>>(holders.Count);
         foreach (var holder in holders)
-            perHolder.Add(await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync());
+            perHolder.Add(await _holdingRepository.Get13FReportDatesByHolderSnapshotBacked(holder));
 
         return perHolder
             .Skip(1)
@@ -2190,33 +2387,6 @@ public class InstitutionalHoldingsTools
         Guid stockId
     ) => splitsByStock.TryGetValue(stockId, out var splits) ? splits : [];
 
-    // Restates each activity row's current/previous share counts onto today's split basis
-    // (current at the target quarter, previous at the prior quarter) from each row's own
-    // stock's splits. These rows are query projections, not tracked entities, so mutating them
-    // in place is safe; Δ Shares recomputes from the restated counts.
-    private async Task RestateActivitySharesToTodaysBasis(
-        IReadOnlyList<MarketWideStockActivity> activity,
-        DateOnly currentDate,
-        DateOnly previousDate
-    )
-    {
-        var splitsByStock = await LoadSplitsByStock(activity.Select(a => a.CommonStockId));
-        foreach (var a in activity)
-        {
-            var splits = SplitsFor(splitsByStock, a.CommonStockId);
-            a.CurrentShares = SplitAdjustment.AdjustShareCount(
-                a.CurrentShares,
-                currentDate,
-                splits
-            );
-            a.PreviousShares = SplitAdjustment.AdjustShareCount(
-                a.PreviousShares,
-                previousDate,
-                splits
-            );
-        }
-    }
-
     // Restates the quarterly-activity diff onto today's split basis, then re-classifies the
     // movement buckets from the restated counts. A zero side is preserved by restatement, so
     // Initiated/Exited stay put; only Increased/Reduced/Unchanged can flip.
@@ -2316,7 +2486,7 @@ public class InstitutionalHoldingsTools
         if (holderError != null)
             return (null, null, default, null, holderError);
 
-        var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
+        var reportDates = await _holdingRepository.Get13FReportDatesByHolderSnapshotBacked(holder);
         if (reportDates.Count == 0)
             return (holder, null, default, null, $"No 13F holdings reported by {holder.Name}.");
 
@@ -2396,13 +2566,6 @@ public class InstitutionalHoldingsTools
         if (index < 0 || index >= reportDates.Count - 1)
             return null;
         return reportDates[index + 1];
-    }
-
-    private class HolderAggregate
-    {
-        public string Name { get; set; }
-        public long Shares { get; set; }
-        public long Value { get; set; }
     }
 
     // Thin forwarder so existing reflection-based normalization tests still find the method.

--- a/src/Equibles.Holdings.Repositories/Extensions/StockActivitySnapshotMapping.cs
+++ b/src/Equibles.Holdings.Repositories/Extensions/StockActivitySnapshotMapping.cs
@@ -20,6 +20,7 @@ public static class StockActivitySnapshotMapping
             PreviousValue = s.PreviousValue,
             CurrentFilerCount = s.CurrentFilerCount,
             PreviousFilerCount = s.PreviousFilerCount,
+            ListingShares = s.ListingShares,
         };
 
     public static MarketWideStockChurn ToChurn(this StockQuarterlyActivity s) =>
@@ -40,6 +41,7 @@ public static class StockActivitySnapshotMapping
             PreviousValue = s.PreviousValue,
             CurrentFilerCount = s.CurrentFilerCount,
             PreviousFilerCount = s.PreviousFilerCount,
+            ListingShares = s.ListingShares,
         };
 
     public static MarketWideStockChurn ToChurn(this StockQuarterlyActivityCombined s) =>

--- a/src/Equibles.Holdings.Repositories/InstitutionPortfolioSummaryCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionPortfolioSummaryCalculator.cs
@@ -13,6 +13,41 @@ public static class InstitutionPortfolioSummaryCalculator
         DateOnly? previousReportDate
     )
     {
+        var current = currentQuarterHoldings
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new InstitutionPortfolioPosition
+            {
+                CommonStockId = g.Key,
+                Shares = g.Sum(h => h.Shares),
+                Value = g.Sum(h => h.Value),
+            })
+            .ToList();
+        var previous = previousQuarterHoldings
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new InstitutionPortfolioPosition
+            {
+                CommonStockId = g.Key,
+                Shares = g.Sum(h => h.Shares),
+                Value = g.Sum(h => h.Value),
+            })
+            .ToList();
+        return CalculatePositions(
+            current,
+            previous,
+            quartersReported,
+            latestReportDate,
+            previousReportDate
+        );
+    }
+
+    public static InstitutionPortfolioSummary CalculatePositions(
+        IReadOnlyList<InstitutionPortfolioPosition> currentQuarterPositions,
+        IReadOnlyList<InstitutionPortfolioPosition> previousQuarterPositions,
+        int quartersReported,
+        DateOnly? latestReportDate,
+        DateOnly? previousReportDate
+    )
+    {
         var summary = new InstitutionPortfolioSummary
         {
             QuartersReported = quartersReported,
@@ -20,21 +55,16 @@ public static class InstitutionPortfolioSummaryCalculator
             PreviousReportDate = previousReportDate,
         };
 
-        if (currentQuarterHoldings.Count == 0)
+        if (currentQuarterPositions.Count == 0)
             return summary;
 
-        // Aggregate per stock — a filer may report a stock across multiple rows when
-        // multiple managers share discretion; only the aggregated per-stock figures
-        // are meaningful for AUM / concentration / turnover.
-        var byStock = currentQuarterHoldings
-            .GroupBy(h => h.CommonStockId)
-            .Select(g => new { Shares = g.Sum(h => h.Shares), Value = g.Sum(h => h.Value) })
+        summary.ReportedAum = currentQuarterPositions.Sum(p => p.Value);
+        summary.PositionCount = currentQuarterPositions.Count;
+
+        var valuesDesc = currentQuarterPositions
+            .OrderByDescending(p => p.Value)
+            .Select(p => p.Value)
             .ToList();
-
-        summary.ReportedAum = byStock.Sum(p => p.Value);
-        summary.PositionCount = byStock.Count;
-
-        var valuesDesc = byStock.OrderByDescending(p => p.Value).Select(p => p.Value).ToList();
         if (summary.ReportedAum > 0)
         {
             summary.Top10ConcentrationPercent =
@@ -43,11 +73,11 @@ public static class InstitutionPortfolioSummaryCalculator
                 (double)valuesDesc.Take(25).Sum() / summary.ReportedAum * 100.0;
         }
 
-        if (previousQuarterHoldings.Count > 0 && summary.ReportedAum > 0)
+        if (previousQuarterPositions.Count > 0 && summary.ReportedAum > 0)
         {
             summary.QoQTurnoverPercent = ComputeQoQTurnoverPercent(
-                currentQuarterHoldings,
-                previousQuarterHoldings,
+                currentQuarterPositions,
+                previousQuarterPositions,
                 summary.ReportedAum
             );
         }
@@ -56,23 +86,19 @@ public static class InstitutionPortfolioSummaryCalculator
     }
 
     private static double ComputeQoQTurnoverPercent(
-        IReadOnlyList<InstitutionalHolding> currentQuarterHoldings,
-        IReadOnlyList<InstitutionalHolding> previousQuarterHoldings,
+        IReadOnlyList<InstitutionPortfolioPosition> currentQuarterPositions,
+        IReadOnlyList<InstitutionPortfolioPosition> previousQuarterPositions,
         long reportedAum
     )
     {
         // Current-quarter price proxy = Value / Shares per stock. For each stock that
         // appears in either quarter, |Δ shares × current price proxy| is the absolute
         // dollar movement; the canonical turnover formula then divides by 2 × AUM.
-        var currentByStock = currentQuarterHoldings
-            .GroupBy(h => h.CommonStockId)
-            .ToDictionary(
-                g => g.Key,
-                g => new { Shares = g.Sum(h => h.Shares), Value = g.Sum(h => h.Value) }
-            );
-        var previousByStock = previousQuarterHoldings
-            .GroupBy(h => h.CommonStockId)
-            .ToDictionary(g => g.Key, g => g.Sum(h => h.Shares));
+        var currentByStock = currentQuarterPositions.ToDictionary(p => p.CommonStockId);
+        var previousByStock = previousQuarterPositions.ToDictionary(
+            p => p.CommonStockId,
+            p => p.Shares
+        );
 
         var allStockIds = currentByStock.Keys.Union(previousByStock.Keys);
         decimal turnoverDollars = 0m;

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -55,6 +55,46 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return Get13FByStock(stock, reportDate).Include(h => h.InstitutionalHolder);
     }
 
+    // Lightweight two-quarter holder/listing projection for the per-stock movers surface. The prior
+    // implementation materialised every holding entity and holder navigation from both quarters
+    // before grouping in memory; popular stocks turned that into thousands of wide rows per call.
+    public IQueryable<HolderStockActivity> Get13FHolderActivityByStock(
+        CommonStock stock,
+        DateOnly currentReportDate,
+        DateOnly? previousReportDate
+    )
+    {
+        return GetAll()
+            .Where(Is13F)
+            .Where(h => h.CommonStockId == stock.Id)
+            .Where(h =>
+                h.ReportDate == currentReportDate
+                || (previousReportDate.HasValue && h.ReportDate == previousReportDate.Value)
+            )
+            .GroupBy(h => new { h.InstitutionalHolderId, h.ListedTicker })
+            .Select(g => new HolderStockActivity
+            {
+                InstitutionalHolderId = g.Key.InstitutionalHolderId,
+                ListedTicker = g.Key.ListedTicker,
+                CurrentShares = g.Sum(h => h.ReportDate == currentReportDate ? h.Shares : 0L),
+                PreviousShares = g.Sum(h =>
+                    previousReportDate.HasValue && h.ReportDate == previousReportDate.Value
+                        ? h.Shares
+                        : 0L
+                ),
+                CurrentValue = g.Sum(h => h.ReportDate == currentReportDate ? h.Value : 0L),
+                PreviousValue = g.Sum(h =>
+                    previousReportDate.HasValue && h.ReportDate == previousReportDate.Value
+                        ? h.Value
+                        : 0L
+                ),
+                CurrentPositionCount = g.Count(h => h.ReportDate == currentReportDate),
+                PreviousPositionCount = g.Count(h =>
+                    previousReportDate.HasValue && h.ReportDate == previousReportDate.Value
+                ),
+            });
+    }
+
     public IQueryable<InstitutionalHolding> GetByHolder(
         InstitutionalHolder holder,
         DateOnly reportDate
@@ -94,6 +134,24 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     )
     {
         return Get13FByHolder(holder, reportDate).Include(h => h.CommonStock);
+    }
+
+    // Minimal per-stock projection for portfolio-summary maths. Loading thousands of full
+    // tracked holding entities for two quarters made a cold summary proportional to the raw
+    // filing row count even though concentration and turnover only use these three fields.
+    public IQueryable<InstitutionPortfolioPosition> Get13FPositionAggregatesByHolder(
+        InstitutionalHolder holder,
+        DateOnly reportDate
+    )
+    {
+        return Get13FByHolder(holder, reportDate)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new InstitutionPortfolioPosition
+            {
+                CommonStockId = g.Key,
+                Shares = g.Sum(h => h.Shares),
+                Value = g.Sum(h => h.Value),
+            });
     }
 
     public IQueryable<InstitutionalHolding> GetLatestByStock(CommonStock stock)
@@ -154,15 +212,11 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     public IQueryable<DateOnly> Get13FAvailableReportDates() =>
         GetAll().Where(Is13F).DistinctReportDatesDescending();
 
-    // The DISTINCT behind Get13FAvailableReportDates scans the whole holdings index (~32M
-    // entries) to produce fewer than a hundred quarter-end dates and measures ~28s warm —
-    // right at the 30s command timeout, so every surface that resolves its comparison
-    // window off the live list (market-wide MCP leaderboards, the activity / export /
-    // screener pages) fails on a cold cache. The list gains at most one date per filing
-    // day, so a short-lived process-wide cache removes the scan from every request except
-    // the first after boot / expiry. Keyed by connection string so parallel databases
-    // (test fixtures) never see each other's lists; a null connection string (e.g. the
-    // EF InMemory provider) bypasses the cache entirely.
+    // The live DISTINCT behind Get13FAvailableReportDates scans the whole holdings index
+    // (~34M rows) to produce fewer than a hundred quarter ends and measures ~28s warm. The
+    // worker-maintained AumQuarterlySnapshot table is the bounded one-row-per-quarter date spine
+    // for request paths; the process cache below is retained only for a fresh/unbackfilled
+    // database whose snapshot table is still empty.
     private static readonly TimeSpan ReportDatesCacheTtl = TimeSpan.FromHours(1);
     private static readonly object ReportDatesCacheLock = new();
     private static readonly Dictionary<
@@ -186,6 +240,29 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         CancellationToken cancellationToken = default
     )
     {
+        var latestLiveDate = await GetAll()
+            .Where(Is13F)
+            .OrderByDescending(h => h.ReportDate)
+            .Select(h => (DateOnly?)h.ReportDate)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (latestLiveDate is not { } latest)
+            return [];
+
+        var snapshotDates = await DbContext
+            .Set<AumQuarterlySnapshot>()
+            .Where(s => s.ReportDate <= latest)
+            .Select(s => s.ReportDate)
+            .OrderByDescending(date => date)
+            .ToListAsync(cancellationToken);
+        if (snapshotDates.Count > 0)
+        {
+            // Aggregate refresh follows ingestion. Keep the just-opened quarter selectable
+            // during that short lag without falling back to the corpus-wide DISTINCT.
+            if (latest > snapshotDates[0])
+                snapshotDates.Insert(0, latest);
+            return snapshotDates;
+        }
+
         // GetConnectionString throws on non-relational providers (the EF InMemory tests),
         // which also want no cross-instance caching — so they bypass the cache entirely.
         var cacheKey = DbContext.Database.IsRelational()
@@ -203,11 +280,8 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             }
         }
 
-        // The DISTINCT scan behind this list measures ~28s warm and can cross Npgsql's
-        // default 30s command timeout cold — verified in production: the first
-        // market-activity request after a container recreate (or a cache-TTL expiry)
-        // 500s here before any aggregate even runs. Same headroom as the market-wide
-        // aggregates, so a cold resolve becomes a slow success instead of a failure.
+        // Fresh databases have no aggregate spine yet. Preserve the exact live fallback with
+        // extra timeout headroom until the first snapshot rebuild completes.
         ExtendCommandTimeoutForMarketWideAggregates();
         var dates = await Get13FAvailableReportDates().ToListAsync(cancellationToken);
 
@@ -289,6 +363,162 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     public IQueryable<DateOnly> Get13FReportDatesByHolder(InstitutionalHolder holder) =>
         Get13FHistoryByHolder(holder).DistinctReportDatesDescending();
 
+    // Request-path twin of Get13FReportDatesByHolder. A large filer can carry thousands of
+    // positions per quarter, so DISTINCT over its full history turns a one-row-per-quarter
+    // lookup into a multi-second cold scan. HolderQuarterlySnapshot is maintained in the same
+    // dirty-quarter transaction as the market aggregates. The newest live row bounds stale
+    // snapshots and is prepended while the refresh worker trails ingestion.
+    public async Task<List<DateOnly>> Get13FReportDatesByHolderSnapshotBacked(
+        InstitutionalHolder holder,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var latestLiveDate = await Get13FHistoryByHolder(holder)
+            .OrderByDescending(h => h.ReportDate)
+            .Select(h => (DateOnly?)h.ReportDate)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (latestLiveDate is not { } latest)
+            return [];
+
+        var dates = await DbContext
+            .Set<HolderQuarterlySnapshot>()
+            .Where(s => s.InstitutionalHolderId == holder.Id && s.ReportDate <= latest)
+            .OrderByDescending(s => s.ReportDate)
+            .Select(s => s.ReportDate)
+            .ToListAsync(cancellationToken);
+        if (dates.Count == 0)
+            return await Get13FReportDatesByHolder(holder).ToListAsync(cancellationToken);
+
+        if (latest > dates[0])
+            dates.Insert(0, latest);
+        return dates;
+    }
+
+    public IQueryable<HolderQuarterlySnapshot> GetHolderQuarterlySnapshots(
+        InstitutionalHolder holder
+    ) => DbContext.Set<HolderQuarterlySnapshot>().Where(s => s.InstitutionalHolderId == holder.Id);
+
+    // Snapshot-first holder trend source. A holder with no materialized rows can exist on a
+    // fresh database or during the first aggregate refresh, so only that missing holder falls
+    // back to a holder-scoped GROUP BY. Existing snapshot slices remain authoritative while
+    // dirty and never trigger the expensive live path.
+    public async Task<List<HolderQuarterlySnapshot>> GetHolderQuarterlySnapshotsSnapshotBacked(
+        IReadOnlyCollection<Guid> holderIds,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (holderIds.Count == 0)
+            return [];
+
+        var snapshots = await DbContext
+            .Set<HolderQuarterlySnapshot>()
+            .AsNoTracking()
+            .Where(s => holderIds.Contains(s.InstitutionalHolderId))
+            .ToListAsync(cancellationToken);
+        var coveredHolderIds = snapshots.Select(s => s.InstitutionalHolderId).ToHashSet();
+        var missingHolderIds = holderIds.Where(id => !coveredHolderIds.Contains(id)).ToList();
+        if (missingHolderIds.Count == 0)
+            return snapshots;
+
+        var live = await GetAll()
+            .Where(Is13F)
+            .Where(h => missingHolderIds.Contains(h.InstitutionalHolderId))
+            .GroupBy(h => new { h.InstitutionalHolderId, h.ReportDate })
+            .Select(g => new
+            {
+                g.Key.InstitutionalHolderId,
+                g.Key.ReportDate,
+                FilingDate = g.Max(h => h.FilingDate),
+                Aum = g.Sum(h => h.Value),
+                PositionCount = g.Count(),
+                StockCount = g.Select(h => h.CommonStockId).Distinct().Count(),
+            })
+            .ToListAsync(cancellationToken);
+        snapshots.AddRange(
+            live.Select(row => new HolderQuarterlySnapshot
+            {
+                InstitutionalHolderId = row.InstitutionalHolderId,
+                ReportDate = row.ReportDate,
+                FilingDate = row.FilingDate,
+                Aum = row.Aum,
+                PositionCount = row.PositionCount,
+                StockCount = row.StockCount,
+            })
+        );
+        return snapshots;
+    }
+
+    public Task<List<HolderQuarterlySnapshot>> GetHolderQuarterlySnapshotsSnapshotBacked(
+        InstitutionalHolder holder,
+        CancellationToken cancellationToken = default
+    ) => GetHolderQuarterlySnapshotsSnapshotBacked([holder.Id], cancellationToken);
+
+    // Version stamp for process-local market-aggregate caches. DirtyAt is set in the import
+    // transaction and cleared only after every quarter snapshot has rebuilt, so callers bypass
+    // the process cache during the ingest-to-refresh gap while still serving the bounded existing
+    // snapshot. ComputedAt changes on every completed rebuild and invalidates the fixed cache key
+    // without an inter-process signal.
+    public async Task<HoldingsSnapshotState> GetMarketActivitySnapshotState(
+        DateOnly reportDate,
+        DateOnly previousReportDate,
+        bool combined,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var dates = new[] { reportDate, previousReportDate };
+        var dirty = await DbContext
+            .Set<AumQuarterlySnapshot>()
+            .AnyAsync(s => dates.Contains(s.ReportDate) && s.DirtyAt != null, cancellationToken);
+        var computedAt = combined
+            ? await DbContext
+                .Set<StockQuarterlyActivityCombined>()
+                .Where(s => s.ReportDate == reportDate)
+                .Select(s => (DateTime?)s.ComputedAt)
+                .MaxAsync(cancellationToken)
+            : await DbContext
+                .Set<StockQuarterlyActivity>()
+                .Where(s => s.ReportDate == reportDate)
+                .Select(s => (DateTime?)s.ComputedAt)
+                .MaxAsync(cancellationToken);
+        return new HoldingsSnapshotState(dirty, computedAt);
+    }
+
+    // Per-holder counterpart used by InstitutionPortfolioSummaryProvider. Both quarter stamps
+    // participate because turnover reads current and prior positions; a rebuild of either side
+    // must produce a new cache identity.
+    public async Task<HolderSummarySnapshotState> GetHolderSummarySnapshotState(
+        Guid holderId,
+        DateOnly currentReportDate,
+        DateOnly? previousReportDate,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var dates = previousReportDate is { } previous
+            ? new[] { currentReportDate, previous }
+            : new[] { currentReportDate };
+        var dirty = await DbContext
+            .Set<AumQuarterlySnapshot>()
+            .AnyAsync(s => dates.Contains(s.ReportDate) && s.DirtyAt != null, cancellationToken);
+        var versions = await DbContext
+            .Set<HolderQuarterlySnapshot>()
+            .Where(s => s.InstitutionalHolderId == holderId && dates.Contains(s.ReportDate))
+            .Select(s => new { s.ReportDate, s.ComputedAt })
+            .ToListAsync(cancellationToken);
+        return new HolderSummarySnapshotState(
+            dirty,
+            versions
+                .Where(s => s.ReportDate == currentReportDate)
+                .Select(s => (DateTime?)s.ComputedAt)
+                .SingleOrDefault(),
+            previousReportDate is { } prior
+                ? versions
+                    .Where(s => s.ReportDate == prior)
+                    .Select(s => (DateTime?)s.ComputedAt)
+                    .SingleOrDefault()
+                : null
+        );
+    }
+
     public IQueryable<InstitutionalHolding> GetByAccessionNumber(string accessionNumber)
     {
         return GetAll().Where(h => h.AccessionNumber == accessionNumber);
@@ -299,12 +529,11 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     // and the churn / combined forms add correlated NOT-EXISTS probes — which sits
     // exactly at Npgsql's default 30s command timeout, so a cache miss intermittently
     // dies mid-stream with "Timeout during reading attempt". Closed quarters read the
-    // StockQuarterlyActivity snapshot instead, but the open filing window has no
-    // materialised view yet, so its combined lane must run these live. Raising the
-    // scope's timeout when such a query is composed gives that lane headroom; the
-    // DbContext is scoped, so the raise lives and dies with the current request / tool
-    // call, and an already-higher caller value (e.g. the snapshot rebuild worker's) is
-    // kept.
+    // StockQuarterlyActivity snapshots instead. These live queries remain only as the
+    // fresh-database fallback while the matching closed or combined snapshot is empty.
+    // Raising the scope's timeout when such a fallback is composed gives it headroom;
+    // the DbContext is scoped, so the raise lives and dies with the current request, and
+    // an already-higher caller value (e.g. the snapshot rebuild worker's) is kept.
     private static readonly TimeSpan MarketWideAggregateCommandTimeout = TimeSpan.FromSeconds(120);
 
     private void ExtendCommandTimeoutForMarketWideAggregates()
@@ -386,9 +615,11 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
 
     // Snapshot-first denominator for public most-held rankings. Closed-quarter AUM snapshots
     // already materialise the exact 13F filer universe, avoiding a corpus-wide DISTINCT that
-    // measured tens of seconds and could hit the command timeout. Missing, dirty, and zero-valued
-    // stubs fall back to the exact count until their snapshot rebuild completes. An open filing
-    // window still needs the combined universe because non-filers are carried forward.
+    // measured tens of seconds and could hit the command timeout. A positive dirty snapshot is
+    // served uncached until its rebuild lands; only a missing/zero stub falls back to the exact
+    // count. During an open filing window, the matching combined activity snapshot proves that
+    // the bounded holder-quarter slices are available; their distinct union is the exact
+    // carry-forward universe. Only a genuinely empty snapshot falls back to the live corpus.
     public async Task<int> Get13FUniverseFilerCount(
         DateOnly current,
         DateOnly previous,
@@ -396,16 +627,33 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         CancellationToken cancellationToken = default
     )
     {
-        if (!combined)
+        if (combined)
+        {
+            var hasCombinedSnapshot = await DbContext
+                .Set<StockQuarterlyActivityCombined>()
+                .AsNoTracking()
+                .AnyAsync(s => s.ReportDate == current, cancellationToken);
+            if (hasCombinedSnapshot)
+            {
+                return await DbContext
+                    .Set<HolderQuarterlySnapshot>()
+                    .AsNoTracking()
+                    .Where(s => s.ReportDate == current || s.ReportDate == previous)
+                    .Select(s => s.InstitutionalHolderId)
+                    .Distinct()
+                    .CountAsync(cancellationToken);
+            }
+        }
+        else
         {
             var snapshot = await DbContext
                 .Set<AumQuarterlySnapshot>()
                 .AsNoTracking()
                 .Where(s => s.ReportDate == current)
-                .Select(s => new { s.FilerCount, s.DirtyAt })
+                .Select(s => (int?)s.FilerCount)
                 .SingleOrDefaultAsync(cancellationToken);
-            if (snapshot is { DirtyAt: null, FilerCount: > 0 })
-                return snapshot.FilerCount;
+            if (snapshot is > 0)
+                return snapshot.Value;
         }
 
         return await GetUniqueFilerIds(current, previous, combined).CountAsync(cancellationToken);
@@ -478,6 +726,199 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     public IQueryable<StockQuarterlyActivity> GetStockActivitySnapshots(DateOnly reportDate) =>
         DbContext.Set<StockQuarterlyActivity>().Where(s => s.ReportDate == reportDate);
 
+    public IQueryable<StockQuarterlyActivity> GetStockActivitySnapshotsByStock(CommonStock stock) =>
+        DbContext.Set<StockQuarterlyActivity>().Where(s => s.CommonStockId == stock.Id);
+
+    // Snapshot-first stock trend source. The newest live row bounds stale snapshot history and
+    // is appended while refresh lags; the stock-scoped live GROUP BY remains bootstrap-only.
+    public async Task<List<StockQuarterlyActivity>> GetStockActivitySnapshotsByStockSnapshotBacked(
+        CommonStock stock,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var latestLiveDate = await Get13FHistoryByStock(stock)
+            .OrderByDescending(h => h.ReportDate)
+            .Select(h => (DateOnly?)h.ReportDate)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (latestLiveDate is not { } latest)
+        {
+            return [];
+        }
+
+        var snapshots = await GetStockActivitySnapshotsByStock(stock)
+            .Where(s => s.ReportDate <= latest)
+            .AsNoTracking()
+            .OrderBy(s => s.ReportDate)
+            .ToListAsync(cancellationToken);
+        if (snapshots.Count == 0)
+            return await GetLiveStockActivity(stock, cancellationToken);
+
+        var snapshotDates = snapshots.Select(row => row.ReportDate).ToArray();
+        var listingRows = await DbContext
+            .Set<StockQuarterlyListingActivity>()
+            .AsNoTracking()
+            .Where(row =>
+                row.CommonStockId == stock.Id
+                && !row.IsCombined
+                && snapshotDates.Contains(row.ReportDate)
+            )
+            .ToListAsync(cancellationToken);
+        var listingByDate = listingRows
+            .GroupBy(row => row.ReportDate)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<StockQuarterlyListingActivity>)group.ToList()
+            );
+        if (
+            snapshots.Any(row =>
+                !listingByDate.TryGetValue(row.ReportDate, out var listings)
+                || listings.Any(listing => listing.ComputedAt != row.ComputedAt)
+            )
+        )
+            return await GetLiveStockActivity(stock, cancellationToken);
+
+        foreach (var snapshot in snapshots)
+            snapshot.ListingShares = listingByDate[snapshot.ReportDate];
+        if (latest > snapshots[^1].ReportDate)
+        {
+            snapshots.Add(await GetLiveStockActivityPoint(stock, latest, cancellationToken));
+        }
+        return snapshots;
+    }
+
+    // Refresh-lag fallback for one just-opened quarter. Its comparison is bounded to that
+    // quarter and the immediately preceding live quarter instead of regrouping the stock's
+    // entire filing history whenever the aggregate worker trails ingestion.
+    private async Task<StockQuarterlyActivity> GetLiveStockActivityPoint(
+        CommonStock stock,
+        DateOnly currentReportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        var previousReportDate = await Get13FHistoryByStock(stock)
+            .Where(holding => holding.ReportDate < currentReportDate)
+            .OrderByDescending(holding => holding.ReportDate)
+            .Select(holding => (DateOnly?)holding.ReportDate)
+            .FirstOrDefaultAsync(cancellationToken);
+        var activity = await Get13FHolderActivityByStock(
+                stock,
+                currentReportDate,
+                previousReportDate
+            )
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+        var currentHolders = activity
+            .Where(row => row.CurrentPositionCount > 0)
+            .Select(row => row.InstitutionalHolderId)
+            .ToHashSet();
+        var previousHolders = activity
+            .Where(row => row.PreviousPositionCount > 0)
+            .Select(row => row.InstitutionalHolderId)
+            .ToHashSet();
+        var listingShares = activity
+            .GroupBy(row => row.ListedTicker ?? stock.Ticker)
+            .Select(group => new StockQuarterlyListingActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = currentReportDate,
+                IsCombined = false,
+                PriceSeriesTicker = group.Key,
+                CurrentShares = group.Sum(row => row.CurrentShares),
+                PreviousShares = group.Sum(row => row.PreviousShares),
+            })
+            .ToList();
+        return new StockQuarterlyActivity
+        {
+            CommonStockId = stock.Id,
+            ReportDate = currentReportDate,
+            PreviousReportDate = previousReportDate,
+            CurrentShares = activity.Sum(row => row.CurrentShares),
+            PreviousShares = activity.Sum(row => row.PreviousShares),
+            CurrentValue = activity.Sum(row => row.CurrentValue),
+            PreviousValue = activity.Sum(row => row.PreviousValue),
+            CurrentFilerCount = currentHolders.Count,
+            PreviousFilerCount = previousHolders.Count,
+            NewFilerCount = currentHolders.Except(previousHolders).Count(),
+            SoldOutFilerCount = previousHolders.Except(currentHolders).Count(),
+            ListingShares = listingShares,
+        };
+    }
+
+    private async Task<List<StockQuarterlyActivity>> GetLiveStockActivity(
+        CommonStock stock,
+        CancellationToken cancellationToken
+    )
+    {
+        var aggregates = await Get13FHistoryByStock(stock)
+            .GroupBy(holding => holding.ReportDate)
+            .Select(group => new
+            {
+                ReportDate = group.Key,
+                Shares = group.Sum(holding => holding.Shares),
+                Value = group.Sum(holding => holding.Value),
+                FilerCount = group
+                    .Select(holding => holding.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+            })
+            .OrderBy(row => row.ReportDate)
+            .ToListAsync(cancellationToken);
+        var exact = await Get13FHistoryByStock(stock)
+            .GroupBy(holding => new { holding.ReportDate, holding.ListedTicker })
+            .Select(group => new
+            {
+                group.Key.ReportDate,
+                PriceSeriesTicker = group.Key.ListedTicker ?? stock.Ticker,
+                Shares = group.Sum(holding => holding.Shares),
+            })
+            .ToListAsync(cancellationToken);
+        var exactByDate = exact
+            .GroupBy(row => row.ReportDate)
+            .ToDictionary(
+                group => group.Key,
+                group => group.ToDictionary(row => row.PriceSeriesTicker, row => row.Shares)
+            );
+
+        var result = new List<StockQuarterlyActivity>(aggregates.Count);
+        for (var index = 0; index < aggregates.Count; index++)
+        {
+            var current = aggregates[index];
+            var previous = index > 0 ? aggregates[index - 1] : null;
+            var currentSeries = exactByDate[current.ReportDate];
+            var previousSeries = previous is null
+                ? new Dictionary<string, long>()
+                : exactByDate[previous.ReportDate];
+            var listingShares = currentSeries
+                .Keys.Union(previousSeries.Keys)
+                .Select(ticker => new StockQuarterlyListingActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = current.ReportDate,
+                    IsCombined = false,
+                    PriceSeriesTicker = ticker,
+                    CurrentShares = currentSeries.GetValueOrDefault(ticker),
+                    PreviousShares = previousSeries.GetValueOrDefault(ticker),
+                })
+                .ToList();
+            result.Add(
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = current.ReportDate,
+                    PreviousReportDate = previous?.ReportDate,
+                    CurrentShares = current.Shares,
+                    PreviousShares = previous?.Shares ?? 0,
+                    CurrentValue = current.Value,
+                    PreviousValue = previous?.Value ?? 0,
+                    CurrentFilerCount = current.FilerCount,
+                    PreviousFilerCount = previous?.FilerCount ?? 0,
+                    ListingShares = listingShares,
+                }
+            );
+        }
+        return result;
+    }
+
     // Combined-lane twin for the open filing window: the same per-stock figures with
     // non-filers carried forward at their prior-quarter positions, materialised by
     // HoldingsAggregateRefreshService while the window is open and deleted when it
@@ -487,6 +928,232 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     public IQueryable<StockQuarterlyActivityCombined> GetStockActivitySnapshotsCombined(
         DateOnly reportDate
     ) => DbContext.Set<StockQuarterlyActivityCombined>().Where(s => s.ReportDate == reportDate);
+
+    public IQueryable<StockQuarterlyListingActivity> GetStockListingActivitySnapshots(
+        DateOnly reportDate,
+        bool combined
+    ) =>
+        DbContext
+            .Set<StockQuarterlyListingActivity>()
+            .Where(row => row.ReportDate == reportDate && row.IsCombined == combined);
+
+    // Loads one complete materialized market generation. Listing-share rows are part of the
+    // snapshot contract: an older deployment can leave the new breakdown table empty while the
+    // stock-level rows already exist, in which case callers must use the exact live fallback
+    // until the one-time backfill publishes both tables atomically.
+    public async Task<List<MarketWideStockActivity>> GetMarketActivitySnapshots(
+        DateOnly reportDate,
+        bool combined,
+        CancellationToken cancellationToken = default
+    )
+    {
+        List<MarketWideStockActivity> activity;
+        Dictionary<Guid, DateTime> versions;
+        if (combined)
+        {
+            var rows = await GetStockActivitySnapshotsCombined(reportDate)
+                .AsNoTracking()
+                .ToListAsync(cancellationToken);
+            activity = rows.Select(row => row.ToActivity()).ToList();
+            versions = rows.ToDictionary(row => row.CommonStockId, row => row.ComputedAt);
+        }
+        else
+        {
+            var rows = await GetStockActivitySnapshots(reportDate)
+                .AsNoTracking()
+                .ToListAsync(cancellationToken);
+            activity = rows.Select(row => row.ToActivity()).ToList();
+            versions = rows.ToDictionary(row => row.CommonStockId, row => row.ComputedAt);
+        }
+        if (activity.Count == 0)
+            return [];
+
+        var listingRows = await GetStockListingActivitySnapshots(reportDate, combined)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+        var byStock = listingRows
+            .GroupBy(row => row.CommonStockId)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<StockQuarterlyListingActivity>)group.ToList()
+            );
+        if (
+            activity.Any(row =>
+                !byStock.TryGetValue(row.CommonStockId, out var listings)
+                || listings.Any(listing => listing.ComputedAt != versions[row.CommonStockId])
+            )
+        )
+            return [];
+
+        foreach (var row in activity)
+            row.ListingShares = byStock[row.CommonStockId];
+        return activity;
+    }
+
+    // Snapshot-first complete market activity. Both the stock aggregate and exact-listing
+    // breakdown are read under one repeatable snapshot; if either materialized slice is absent
+    // (fresh database or additive-migration backfill), the same transaction supplies the bounded
+    // two-quarter live fallback without mixing concurrent filing imports between statements.
+    public async Task<List<MarketWideStockActivity>> GetMarketActivitySnapshotBacked(
+        DateOnly current,
+        DateOnly previous,
+        bool combined,
+        CancellationToken cancellationToken = default
+    )
+    {
+        async Task<List<MarketWideStockActivity>> Load()
+        {
+            var snapshot = await GetMarketActivitySnapshots(current, combined, cancellationToken);
+            if (snapshot.Count > 0)
+                return snapshot;
+
+            var activity = await GetQuarterlyActivity(current, previous, combined)
+                .ToListAsync(cancellationToken);
+            var listings = await GetLiveListingShareActivity(
+                current,
+                previous,
+                combined,
+                activity.Select(row => row.CommonStockId).ToArray(),
+                cancellationToken
+            );
+            var byStock = listings
+                .GroupBy(row => row.CommonStockId)
+                .ToDictionary(
+                    group => group.Key,
+                    group => (IReadOnlyList<StockQuarterlyListingActivity>)group.ToList()
+                );
+            if (activity.Any(row => !byStock.ContainsKey(row.CommonStockId)))
+                return [];
+            foreach (var row in activity)
+                row.ListingShares = byStock[row.CommonStockId];
+            return activity;
+        }
+
+        if (!DbContext.Database.IsRelational() || DbContext.Database.CurrentTransaction != null)
+            return await Load();
+
+        await using var transaction = await DbContext.Database.BeginTransactionAsync(
+            System.Data.IsolationLevel.RepeatableRead,
+            cancellationToken
+        );
+        var result = await Load();
+        await transaction.CommitAsync(cancellationToken);
+        return result;
+    }
+
+    // Exact listing grain for the rare live fallback while a snapshot generation is absent.
+    // The query remains bounded to the requested quarter pair; normal request traffic reads the
+    // much smaller StockQuarterlyListingActivity table instead.
+    public async Task<List<StockQuarterlyListingActivity>> GetLiveListingShareActivity(
+        DateOnly current,
+        DateOnly previous,
+        bool combined,
+        IReadOnlyCollection<Guid> commonStockIds,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (commonStockIds.Count == 0)
+            return [];
+
+        if (!combined)
+        {
+            return await GetAll()
+                .Where(Is13F)
+                .Where(holding =>
+                    commonStockIds.Contains(holding.CommonStockId)
+                    && (holding.ReportDate == current || holding.ReportDate == previous)
+                )
+                .Join(
+                    DbContext.Set<CommonStock>(),
+                    holding => holding.CommonStockId,
+                    stock => stock.Id,
+                    (holding, stock) => new { Holding = holding, stock.Ticker }
+                )
+                .GroupBy(row => new
+                {
+                    row.Holding.CommonStockId,
+                    PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
+                })
+                .Select(group => new StockQuarterlyListingActivity
+                {
+                    CommonStockId = group.Key.CommonStockId,
+                    ReportDate = current,
+                    IsCombined = false,
+                    PriceSeriesTicker = group.Key.PriceSeriesTicker,
+                    CurrentShares = group.Sum(row =>
+                        row.Holding.ReportDate == current ? row.Holding.Shares : 0L
+                    ),
+                    PreviousShares = group.Sum(row =>
+                        row.Holding.ReportDate == previous ? row.Holding.Shares : 0L
+                    ),
+                })
+                .ToListAsync(cancellationToken);
+        }
+
+        var currentRows = await GetCombinedQuarter(current, previous)
+            .Where(holding => commonStockIds.Contains(holding.CommonStockId))
+            .Join(
+                DbContext.Set<CommonStock>(),
+                holding => holding.CommonStockId,
+                stock => stock.Id,
+                (holding, stock) => new { Holding = holding, stock.Ticker }
+            )
+            .GroupBy(row => new
+            {
+                row.Holding.CommonStockId,
+                PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
+            })
+            .Select(group => new
+            {
+                group.Key.CommonStockId,
+                group.Key.PriceSeriesTicker,
+                Shares = group.Sum(row => row.Holding.Shares),
+            })
+            .ToListAsync(cancellationToken);
+        var previousRows = await GetAll()
+            .Where(Is13F)
+            .Where(holding =>
+                commonStockIds.Contains(holding.CommonStockId) && holding.ReportDate == previous
+            )
+            .Join(
+                DbContext.Set<CommonStock>(),
+                holding => holding.CommonStockId,
+                stock => stock.Id,
+                (holding, stock) => new { Holding = holding, stock.Ticker }
+            )
+            .GroupBy(row => new
+            {
+                row.Holding.CommonStockId,
+                PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
+            })
+            .Select(group => new
+            {
+                group.Key.CommonStockId,
+                group.Key.PriceSeriesTicker,
+                Shares = group.Sum(row => row.Holding.Shares),
+            })
+            .ToListAsync(cancellationToken);
+        var currentLookup = currentRows.ToDictionary(
+            row => (row.CommonStockId, row.PriceSeriesTicker),
+            row => row.Shares
+        );
+        var previousLookup = previousRows.ToDictionary(
+            row => (row.CommonStockId, row.PriceSeriesTicker),
+            row => row.Shares
+        );
+        return currentLookup
+            .Keys.Union(previousLookup.Keys)
+            .Select(key => new StockQuarterlyListingActivity
+            {
+                CommonStockId = key.CommonStockId,
+                ReportDate = current,
+                IsCombined = true,
+                PriceSeriesTicker = key.PriceSeriesTicker,
+                CurrentShares = currentLookup.GetValueOrDefault(key),
+                PreviousShares = previousLookup.GetValueOrDefault(key),
+            })
+            .ToList();
+    }
 
     // Double-down report: per-(holder, stock) positions where the share-count
     // increase from the prior quarter exceeds a given percentage threshold,
@@ -941,11 +1608,13 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
 
     public IQueryable<Guid> GetUniqueFilerIdsCombined(DateOnly current, DateOnly previous)
     {
-        // Full-quarter DISTINCT over the combined view (incl. its NOT-EXISTS probe) —
-        // the one market-wide aggregate not built on BothQuarters, so it opts into the
-        // extended timeout itself.
-        ExtendCommandTimeoutForMarketWideAggregates();
-        return GetCombinedQuarter(current, previous)
+        // The distinct filer universe of the combined view is exactly the union of
+        // current- and previous-quarter 13F filers. Applying the per-row carry-forward
+        // NOT-EXISTS predicate before DISTINCT does not change that set, but it turns a
+        // sub-second indexed union into a corpus-wide correlated scan at production scale.
+        return GetAll()
+            .Where(Is13F)
+            .Where(h => h.ReportDate == current || h.ReportDate == previous)
             .Select(h => h.InstitutionalHolderId)
             .Distinct();
     }

--- a/src/Equibles.Holdings.Repositories/Models/HolderStockActivity.cs
+++ b/src/Equibles.Holdings.Repositories/Models/HolderStockActivity.cs
@@ -1,0 +1,25 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public sealed class HolderStockActivity
+{
+    public Guid InstitutionalHolderId { get; set; }
+
+    // Null identifies the issuer's primary listing. Sibling-listing rows stay separate until
+    // read-time split restatement; combining them here would apply the primary split factor to
+    // a class whose own price series has a different split history.
+    public string ListedTicker { get; set; }
+
+    public long CurrentShares { get; set; }
+
+    public long PreviousShares { get; set; }
+
+    public long CurrentValue { get; set; }
+
+    public long PreviousValue { get; set; }
+
+    // Row presence cannot be inferred from the aggregate share count: a filed zero-share row
+    // still proves that the holder reported in the current quarter.
+    public int CurrentPositionCount { get; set; }
+
+    public int PreviousPositionCount { get; set; }
+}

--- a/src/Equibles.Holdings.Repositories/Models/HoldingsSnapshotState.cs
+++ b/src/Equibles.Holdings.Repositories/Models/HoldingsSnapshotState.cs
@@ -1,0 +1,18 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public sealed record HoldingsSnapshotState(bool IsDirty, DateTime? ComputedAt)
+{
+    public bool CanCache => !IsDirty && ComputedAt.HasValue;
+}
+
+public sealed record HolderSummarySnapshotState(
+    bool IsDirty,
+    DateTime? CurrentComputedAt,
+    DateTime? PreviousComputedAt
+)
+{
+    public bool CanCache(bool hasPreviousQuarter) =>
+        !IsDirty
+        && CurrentComputedAt.HasValue
+        && (!hasPreviousQuarter || PreviousComputedAt.HasValue);
+}

--- a/src/Equibles.Holdings.Repositories/Models/InstitutionPortfolioPosition.cs
+++ b/src/Equibles.Holdings.Repositories/Models/InstitutionPortfolioPosition.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public sealed class InstitutionPortfolioPosition
+{
+    public Guid CommonStockId { get; set; }
+
+    public long Shares { get; set; }
+
+    public long Value { get; set; }
+}

--- a/src/Equibles.Holdings.Repositories/Models/MarketWideStockActivity.cs
+++ b/src/Equibles.Holdings.Repositories/Models/MarketWideStockActivity.cs
@@ -1,3 +1,5 @@
+using Equibles.Holdings.Data.Models;
+
 namespace Equibles.Holdings.Repositories.Models;
 
 public class MarketWideStockActivity
@@ -9,6 +11,8 @@ public class MarketWideStockActivity
     public long PreviousValue { get; set; }
     public int CurrentFilerCount { get; set; }
     public int PreviousFilerCount { get; set; }
+
+    public IReadOnlyList<StockQuarterlyListingActivity> ListingShares { get; set; } = [];
 
     public long DeltaShares => CurrentShares - PreviousShares;
     public long DeltaValue => CurrentValue - PreviousValue;

--- a/src/Equibles.Mcp/Extensions/MemoryCacheExtensions.cs
+++ b/src/Equibles.Mcp/Extensions/MemoryCacheExtensions.cs
@@ -14,9 +14,9 @@ public static class MemoryCacheExtensions
     // abandon the wait with its own request; cancelling never aborts the in-flight
     // factory, which keeps running for whoever owns the lock.
     //
-    // Keys must come from a bounded, program-controlled set (compile-time
-    // constants) — never per-request input: lock entries are kept for the process
-    // lifetime, so an unbounded key space grows the table forever.
+    // Keys must come from a bounded, program-controlled set (compile-time constants or
+    // resolved quarter dates) — never raw request input: lock entries are kept for the
+    // process lifetime, so an unbounded key space grows the table forever.
     public static async Task<T> GetOrCreateSafeAsync<T>(
         this IMemoryCache cache,
         string key,

--- a/src/Equibles.Migrations/Migrations/20260812004248_AddStockQuarterlyListingActivity.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260812004248_AddStockQuarterlyListingActivity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260812004248_AddStockQuarterlyListingActivity")]
+    partial class AddStockQuarterlyListingActivity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260812004248_AddStockQuarterlyListingActivity.cs
+++ b/src/Equibles.Migrations/Migrations/20260812004248_AddStockQuarterlyListingActivity.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStockQuarterlyListingActivity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StockQuarterlyListingActivity",
+                columns: table => new
+                {
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    IsCombined = table.Column<bool>(type: "boolean", nullable: false),
+                    PriceSeriesTicker = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CurrentShares = table.Column<long>(type: "bigint", nullable: false),
+                    PreviousShares = table.Column<long>(type: "bigint", nullable: false),
+                    ComputedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StockQuarterlyListingActivity", x => new { x.CommonStockId, x.ReportDate, x.IsCombined, x.PriceSeriesTicker });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockQuarterlyListingActivity_ReportDate_IsCombined",
+                table: "StockQuarterlyListingActivity",
+                columns: new[] { "ReportDate", "IsCombined" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StockQuarterlyListingActivity");
+        }
+    }
+}

--- a/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
@@ -63,6 +63,7 @@ public class HybridChunkSearcher
     // still lets the degrade succeed while bounding what one search can pin a database
     // connection for — the pair can never burn more than one full budget plus this.
     private const int DegradedPassTimeoutSeconds = 3;
+    private const int TickerScopedPassTimeoutSeconds = 3;
 
     public async Task<List<Chunk>> Search(
         string query,
@@ -113,6 +114,7 @@ public class HybridChunkSearcher
 
         List<Chunk> bm25;
         ChunkSearchTimeoutException bm25Timeout = null;
+        var companyFallbackAnswered = false;
         try
         {
             bm25 = await _chunkRepository.HybridSearch(
@@ -124,6 +126,7 @@ public class HybridChunkSearcher
                 documentTypes,
                 startDate,
                 endDate,
+                commandTimeoutSeconds: ticker != null ? TickerScopedPassTimeoutSeconds : null,
                 cancellationToken: cancellationToken
             );
         }
@@ -138,6 +141,40 @@ public class HybridChunkSearcher
             _logger.LogWarning(exception, "Conjunctive BM25 pass timed out; degrading");
             bm25 = [];
             bm25Timeout = exception;
+
+            if (ticker != null)
+            {
+                try
+                {
+                    bm25 = await _chunkRepository.HybridSearchCompanyFallback(
+                        query,
+                        bm25Limit,
+                        ticker,
+                        documentId,
+                        documentTypes,
+                        startDate,
+                        endDate,
+                        cancellationToken
+                    );
+                    if (bm25.Count > 0)
+                    {
+                        companyFallbackAnswered = true;
+                        bm25Timeout = null;
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception fallbackException)
+                    when (!cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning(
+                        fallbackException,
+                        "Company-local full-text fallback failed; continuing search degradation"
+                    );
+                }
+            }
         }
 
         // Opt-in recall fallback: BM25 ANDs every query token, so a wordy natural-language
@@ -145,7 +182,7 @@ public class HybridChunkSearcher
         // excludes every on-point chunk. When the conjunctive pass can't fill the request,
         // top up from a disjunctive (any-token) pass — conjunctive hits keep their rank and
         // the broader hits only append after them, so precise matches never lose position.
-        if (disjunctiveFallback && bm25.Count < maxResults)
+        if (!companyFallbackAnswered && disjunctiveFallback && bm25.Count < maxResults)
         {
             try
             {
@@ -192,6 +229,16 @@ public class HybridChunkSearcher
             if (results.Count == 0 && bm25Timeout != null)
                 ExceptionDispatchInfo.Capture(bm25Timeout).Throw();
             return results;
+        }
+
+        // The company-local fallback already returned proven full-text matches from a bounded
+        // ticker slice. Return them immediately instead of spending another statement budget on
+        // the index or semantic arms that just failed under the same load.
+        if (companyFallbackAnswered)
+        {
+            return ApplyPoolControls(bm25, excludeTickers, documentTypes, maxResultsPerCompany)
+                .Take(maxResults)
+                .ToList();
         }
 
         // With only the pool re-rank available, an empty BM25 pool leaves the semantic arm

--- a/src/Equibles.Sec.Repositories/ChunkRepository.cs
+++ b/src/Equibles.Sec.Repositories/ChunkRepository.cs
@@ -16,6 +16,7 @@ public class ChunkRepository : BaseRepository<Chunk>
     // happily runs the chunk search for minutes after the aggregator has
     // already returned Empty, pinning the Npgsql connection (issue #1026).
     private const int HybridSearchCommandTimeoutSeconds = 5;
+    private const int CompanyFallbackCommandTimeoutSeconds = 3;
 
     public ChunkRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
@@ -152,6 +153,84 @@ public class ChunkRepository : BaseRepository<Chunk>
         {
             DbContext.Database.SetCommandTimeout(originalTimeout);
         }
+    }
+
+    // Bounded degrade for a ticker-scoped search whose ParadeDB pass timed out. The ticker btree
+    // narrows this PostgreSQL full-text scan to one company's chunks before Content is parsed, so
+    // a cold or contended BM25 index can still return proven matches instead of a 500. This is not
+    // used for corpus-wide search: generating tsvectors over the whole Chunk table would recreate
+    // the same unbounded work the fallback is meant to avoid.
+    public virtual async Task<List<Chunk>> HybridSearchCompanyFallback(
+        string searchText,
+        int maxResults,
+        string ticker,
+        Guid? documentId = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
+        DateOnly? startDate = null,
+        DateOnly? endDate = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var originalTimeout = DbContext.Database.GetCommandTimeout();
+        DbContext.Database.SetCommandTimeout(CompanyFallbackCommandTimeoutSeconds);
+        try
+        {
+            return await BuildCompanyFallbackQuery(
+                    searchText,
+                    maxResults,
+                    ticker,
+                    documentId,
+                    documentTypes,
+                    startDate,
+                    endDate
+                )
+                .ToListAsync(cancellationToken);
+        }
+        finally
+        {
+            DbContext.Database.SetCommandTimeout(originalTimeout);
+        }
+    }
+
+    internal IQueryable<Chunk> BuildCompanyFallbackQuery(
+        string searchText,
+        int maxResults,
+        string ticker,
+        Guid? documentId = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
+        DateOnly? startDate = null,
+        DateOnly? endDate = null
+    )
+    {
+        var normalizedTicker = ticker.ToUpperInvariant();
+        var query = DbContext
+            .Set<Chunk>()
+            .Where(c => c.Ticker == normalizedTicker)
+            .Where(c =>
+                EF.Functions.ToTsVector("english", c.Content)
+                    .Matches(EF.Functions.WebSearchToTsQuery("english", searchText))
+            );
+
+        if (documentId.HasValue)
+            query = query.Where(c => c.DocumentId == documentId.Value);
+
+        if (documentTypes is { Count: > 0 })
+        {
+            var types = documentTypes.ToList();
+            query = query.Where(c => types.Contains(c.DocumentType));
+        }
+
+        // Match the primary search path's filing-date source of truth; the denormalized chunk
+        // date can trail a corrected parent document date.
+        if (startDate is { } windowStart)
+            query = query.Where(c => c.Document.ReportingDate >= windowStart);
+        if (endDate is { } windowEnd)
+            query = query.Where(c => c.Document.ReportingDate <= windowEnd);
+
+        return query
+            .OrderByDescending(c => c.Document.ReportingDate)
+            .ThenBy(c => c.StartPosition)
+            .Take(maxResults);
     }
 
     // How far past the statement budget an elapsed run may land and still be attributed to

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -289,33 +289,37 @@ public class HoldingsActivityController : BaseController
         var selectedDate = viewModel.SelectedDate;
         var priorForRepo = viewModel.PreviousDate ?? selectedDate;
 
-        var rankingQuery = _holdingRepository.GetMostHeld(
+        var (activityRows, _) = await LoadActivityAndChurn(
+            selectedDate,
+            priorForRepo,
+            viewModel.IsCombinedSelected
+        );
+        var ranking = activityRows.Where(a => a.CurrentFilerCount > 0).ToList();
+
+        viewModel.TotalRows = ranking.Count;
+        viewModel.TotalUniverseFilers = await _holdingRepository.Get13FUniverseFilerCount(
             selectedDate,
             priorForRepo,
             viewModel.IsCombinedSelected
         );
 
-        viewModel.TotalRows = await rankingQuery.CountAsync();
-        viewModel.TotalUniverseFilers = await _holdingRepository
-            .GetUniqueFilerIds(selectedDate, priorForRepo, viewModel.IsCombinedSelected)
-            .CountAsync();
-
-        var orderedQuery = normalizedSort switch
+        var ordered = normalizedSort switch
         {
-            HoldingsMostHeldViewModel.SortFilersDelta => rankingQuery
+            HoldingsMostHeldViewModel.SortFilersDelta => ranking
                 .OrderByDescending(a => a.CurrentFilerCount - a.PreviousFilerCount)
                 .ThenByDescending(a => a.CurrentFilerCount),
-            HoldingsMostHeldViewModel.SortValue => rankingQuery
+            HoldingsMostHeldViewModel.SortValue => ranking
                 .OrderByDescending(a => a.CurrentValue)
                 .ThenByDescending(a => a.CurrentFilerCount),
-            _ => rankingQuery
+            _ => ranking
                 .OrderByDescending(a => a.CurrentFilerCount)
                 .ThenByDescending(a => a.CurrentValue),
         };
 
-        var pageRows = await orderedQuery
-            .Page(viewModel.Page, HoldingsMostHeldViewModel.PageSize)
-            .ToListAsync();
+        var pageRows = ordered
+            .Skip((viewModel.Page - 1) * HoldingsMostHeldViewModel.PageSize)
+            .Take(HoldingsMostHeldViewModel.PageSize)
+            .ToList();
 
         var stockIds = pageRows.Select(r => r.CommonStockId).ToList();
         var stocks = await LoadStockLabels(stockIds);
@@ -393,66 +397,28 @@ public class HoldingsActivityController : BaseController
         var selectedDate = viewModel.SelectedDate;
         var previousDate = viewModel.PreviousDate.Value;
 
-        var totalFilers = await _holdingRepository
-            .GetUniqueFilerIds(selectedDate, previousDate, viewModel.IsCombinedSelected)
-            .CountAsync();
+        var totalFilers = await _holdingRepository.Get13FUniverseFilerCount(
+            selectedDate,
+            previousDate,
+            viewModel.IsCombinedSelected
+        );
         viewModel.TotalUniverseFilers = totalFilers;
 
-        List<HeatMapPoint> points;
-        if (viewModel.IsCombinedSelected)
-        {
-            // The combined view (still-open quarter + prior-quarter carry-forward for
-            // non-filers) reads its materialised lane, kept fresh by the same drain
-            // that maintains the plain snapshot. Live derivation remains only as the
-            // fallback for an empty lane — the window just opened and the first
-            // combined rebuild has not drained yet.
-            var combinedSnapshot = await _holdingRepository
-                .GetStockActivitySnapshotsCombined(selectedDate)
-                .Where(a => a.CurrentFilerCount >= MinHeatMapFilers)
-                .ToListAsync();
-
-            List<MarketWideStockActivity> activity;
-            Dictionary<Guid, MarketWideStockChurn> churnLookup;
-            if (combinedSnapshot.Count > 0)
+        var (allActivity, churnRows) = await LoadActivityAndChurn(
+            selectedDate,
+            previousDate,
+            viewModel.IsCombinedSelected
+        );
+        var activity = allActivity.Where(a => a.CurrentFilerCount >= MinHeatMapFilers).ToList();
+        var churnLookup = churnRows.ToDictionary(c => c.CommonStockId);
+        var stocks = await LoadStockLabels(activity.Select(a => a.CommonStockId).ToList());
+        var points = activity
+            .Select(a =>
             {
-                activity = combinedSnapshot.Select(s => s.ToActivity()).ToList();
-                churnLookup = combinedSnapshot.ToDictionary(s => s.CommonStockId, s => s.ToChurn());
-            }
-            else
-            {
-                activity = await _holdingRepository
-                    .GetQuarterlyActivity(selectedDate, previousDate, combined: true)
-                    .Where(a => a.CurrentFilerCount >= MinHeatMapFilers)
-                    .ToListAsync();
-                churnLookup = (
-                    await _holdingRepository
-                        .GetQuarterlyNewSoldOutPositions(selectedDate, previousDate, combined: true)
-                        .ToListAsync()
-                ).ToDictionary(c => c.CommonStockId);
-            }
-
-            var stocks = await LoadStockLabels(activity.Select(a => a.CommonStockId).ToList());
-            points = activity
-                .Select(a =>
-                {
-                    churnLookup.TryGetValue(a.CommonStockId, out var churn);
-                    return BuildHeatMapPoint(a, churn, totalFilers, stocks);
-                })
-                .ToList();
-        }
-        else
-        {
-            // Single-quarter view reads the pre-aggregated StockQuarterlyActivity
-            // snapshot — filer counts and new/sold-out churn are already
-            // materialised, so this avoids the ~30s two-quarter live scan (#1262).
-            var activity = await _holdingRepository
-                .GetStockActivitySnapshots(selectedDate)
-                .Where(a => a.CurrentFilerCount >= MinHeatMapFilers)
-                .ToListAsync();
-
-            var stocks = await LoadStockLabels(activity.Select(a => a.CommonStockId).ToList());
-            points = activity.Select(a => BuildHeatMapPoint(a, totalFilers, stocks)).ToList();
-        }
+                churnLookup.TryGetValue(a.CommonStockId, out var churn);
+                return BuildHeatMapPoint(a, churn, totalFilers, stocks);
+            })
+            .ToList();
 
         viewModel.Points = points
             .OrderByDescending(p => p.ConvictionScore)

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Extensions;
+using Equibles.Holdings.Repositories.Models;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.Extensions;
 using Equibles.Web.Services;
@@ -111,7 +112,7 @@ public class HoldingsExportController : BaseController
         if (holder == null)
             return NotFound();
 
-        var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
+        var reportDates = await _holdingRepository.Get13FReportDatesByHolderSnapshotBacked(holder);
         if (reportDates.Count == 0)
             return NotFound();
 
@@ -178,19 +179,21 @@ public class HoldingsExportController : BaseController
         var selectedDate = reportDates.ResolveSelectedDateOrFirst(date);
         if (reportDates.PreviousFrom(selectedDate) is not { } previousDate)
             return NotFound();
+        var windowOpen =
+            selectedDate == reportDates[0]
+            && CombinedQuarterHelper.IsFilingWindowOpen(selectedDate);
 
         // Per-stock buy/sell movers (CSV has no row cap — analysts expect the full set).
-        var activity = await _holdingRepository
-            .GetQuarterlyActivity(selectedDate, previousDate)
-            .Where(a => a.CurrentShares != a.PreviousShares)
-            .ToListAsync();
+        var (activityRows, churnRows) = await LoadActivityAndChurn(
+            selectedDate,
+            previousDate,
+            windowOpen
+        );
+        var activity = activityRows.Where(a => a.CurrentShares != a.PreviousShares).ToList();
         var topBuys = activity.TopBuyers().ToList();
         var topSells = activity.TopSellers().ToList();
 
-        var churn = await _holdingRepository
-            .GetQuarterlyNewSoldOutPositions(selectedDate, previousDate)
-            .Where(c => c.NewFilerCount > 0 || c.SoldOutFilerCount > 0)
-            .ToListAsync();
+        var churn = churnRows.Where(c => c.NewFilerCount > 0 || c.SoldOutFilerCount > 0).ToList();
         var newPositions = churn.NewPositions().ToList();
         var soldOut = churn.SoldOutPositions().ToList();
 
@@ -232,6 +235,50 @@ public class HoldingsExportController : BaseController
 
         var csv = CsvExportService.BuildCsv(headers, rows);
         return CsvFile(csv, $"13F-activity-{selectedDate:yyyy-MM-dd}.csv");
+    }
+
+    private async Task<(
+        List<MarketWideStockActivity> Activity,
+        List<MarketWideStockChurn> Churn
+    )> LoadActivityAndChurn(DateOnly selectedDate, DateOnly previousDate, bool combined)
+    {
+        if (combined)
+        {
+            var lane = await _holdingRepository
+                .GetStockActivitySnapshotsCombined(selectedDate)
+                .AsNoTracking()
+                .ToListAsync();
+            if (lane.Count > 0)
+            {
+                return (
+                    lane.Select(s => s.ToActivity()).ToList(),
+                    lane.Select(s => s.ToChurn()).ToList()
+                );
+            }
+        }
+        else
+        {
+            var snapshots = await _holdingRepository
+                .GetStockActivitySnapshots(selectedDate)
+                .AsNoTracking()
+                .ToListAsync();
+            if (snapshots.Count > 0)
+            {
+                return (
+                    snapshots.Select(s => s.ToActivity()).ToList(),
+                    snapshots.Select(s => s.ToChurn()).ToList()
+                );
+            }
+        }
+
+        return (
+            await _holdingRepository
+                .GetQuarterlyActivity(selectedDate, previousDate, combined)
+                .ToListAsync(),
+            await _holdingRepository
+                .GetQuarterlyNewSoldOutPositions(selectedDate, previousDate, combined)
+                .ToListAsync()
+        );
     }
 
     private FileContentResult CsvFile(string csv, string filename)

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -34,6 +34,7 @@ public class ProfilesController : BaseController
     private readonly CongressMemberRepository _congressMemberRepository;
     private readonly CongressionalTradeRepository _congressionalTradeRepository;
     private readonly HoldingsBacktestService _holdingsBacktestService;
+    private readonly InstitutionPortfolioSummaryProvider _institutionPortfolioSummaryProvider;
 
     public ProfilesController(
         InstitutionalHolderRepository institutionalHolderRepository,
@@ -44,6 +45,7 @@ public class ProfilesController : BaseController
         CongressMemberRepository congressMemberRepository,
         CongressionalTradeRepository congressionalTradeRepository,
         HoldingsBacktestService holdingsBacktestService,
+        InstitutionPortfolioSummaryProvider institutionPortfolioSummaryProvider,
         ILogger<ProfilesController> logger
     )
         : base(logger)
@@ -56,6 +58,7 @@ public class ProfilesController : BaseController
         _congressMemberRepository = congressMemberRepository;
         _congressionalTradeRepository = congressionalTradeRepository;
         _holdingsBacktestService = holdingsBacktestService;
+        _institutionPortfolioSummaryProvider = institutionPortfolioSummaryProvider;
     }
 
     [HttpGet("~/institutions/{cik}")]
@@ -84,9 +87,8 @@ public class ProfilesController : BaseController
 
         // Header strip + industry allocation — pulled with extra per-quarter
         // materializations so the existing recent-rows list keeps its top-50 shape.
-        var distinctDates = await _institutionalHoldingRepository
-            .Get13FReportDatesByHolder(holder)
-            .ToListAsync();
+        var distinctDates =
+            await _institutionalHoldingRepository.Get13FReportDatesByHolderSnapshotBacked(holder);
         var (summary, industryAllocation) = await BuildSummaryAndAllocation(holder, distinctDates);
         var (quarterlyActivity, activityResolved, activityPrior) = await BuildQuarterlyActivity(
             holder,
@@ -197,30 +199,20 @@ public class ProfilesController : BaseController
 
         var latest = distinctReportDates[0];
         var previous = distinctReportDates.Count > 1 ? distinctReportDates[1] : (DateOnly?)null;
-        // Current quarter loaded twice — shallow for the summary calculator and again with
-        // the Industry navigation for the allocation calculator. Kept separate so the
-        // summary path doesn't pay the Industry join cost.
-        var currentHoldings = await _institutionalHoldingRepository
-            .GetByHolder(holder, latest)
-            .ToListAsync();
+        var summary = await _institutionPortfolioSummaryProvider.Get(
+            holder,
+            latest,
+            previous,
+            distinctReportDates.Count
+        );
+
+        // Industry allocation still needs the stock/industry navigation, but the summary above
+        // reads grouped scalar projections and no longer materializes current + prior holdings.
         var currentHoldingsWithIndustry = await _institutionalHoldingRepository
-            .GetByHolder(holder, latest)
+            .Get13FByHolder(holder, latest)
             .Include(h => h.CommonStock)
                 .ThenInclude(s => s.Industry)
             .ToListAsync();
-        var previousHoldings = previous.HasValue
-            ? await _institutionalHoldingRepository
-                .GetByHolder(holder, previous.Value)
-                .ToListAsync()
-            : [];
-
-        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
-            currentHoldings,
-            previousHoldings,
-            distinctReportDates.Count,
-            latest,
-            previous
-        );
         var allocation = IndustryAllocationCalculator.Calculate(currentHoldingsWithIndustry);
         return (summary, allocation);
     }
@@ -486,9 +478,10 @@ public class ProfilesController : BaseController
         var perHolderDates = new List<List<DateOnly>>();
         foreach (var holder in holders)
         {
-            var dates = await _institutionalHoldingRepository
-                .Get13FReportDatesByHolder(holder)
-                .ToListAsync();
+            var dates =
+                await _institutionalHoldingRepository.Get13FReportDatesByHolderSnapshotBacked(
+                    holder
+                );
             perHolderDates.Add(dates);
         }
         return perHolderDates

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -8,6 +8,7 @@ using Equibles.Core.Configuration;
 using Equibles.Core.Extensions;
 using Equibles.Data.Extensions;
 using Equibles.Finra.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Data.Extensions;
@@ -46,6 +47,7 @@ public class StockTabService
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly MarketActivityShareRestater _marketActivityShareRestater;
 
     // Data before the configured sync floor is partial — the scrapers only
     // backfill from it — so historical series clamp to it rather than render
@@ -77,7 +79,8 @@ public class StockTabService
         FinancialFactRepository financialFactRepository,
         FinancialConceptRepository financialConceptRepository,
         CommonStockRepository commonStockRepository,
-        IOptions<WorkerOptions> workerOptions = null
+        IOptions<WorkerOptions> workerOptions = null,
+        MarketActivityShareRestater marketActivityShareRestater = null
     )
     {
         _minSyncDate = workerOptions?.Value.MinSyncDate is { } floor
@@ -99,6 +102,7 @@ public class StockTabService
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
         _commonStockRepository = commonStockRepository;
+        _marketActivityShareRestater = marketActivityShareRestater;
     }
 
     // Whether the holdings tab should OPEN in the combined view: the newest quarter's filing
@@ -817,30 +821,29 @@ public class StockTabService
     // latest point matches the stats shown for the latest quarter.
     private async Task<List<OwnershipTrendPoint>> LoadOwnershipTrend(CommonStock stock)
     {
-        var holdingsQuery = _institutionalHoldingRepository.Get13FHistoryByStock(stock);
+        var snapshotActivity =
+            await _institutionalHoldingRepository.GetStockActivitySnapshotsByStockSnapshotBacked(
+                stock
+            );
+        if (_marketActivityShareRestater != null)
+            await _marketActivityShareRestater.RestateStockActivity(stock, snapshotActivity);
+        IEnumerable<StockQuarterlyActivity> activity = snapshotActivity;
         if (_minSyncDate is { } trendFloor)
         {
-            holdingsQuery = holdingsQuery.Where(h => h.ReportDate >= trendFloor);
+            activity = activity.Where(a => a.ReportDate >= trendFloor);
         }
-        var points = await holdingsQuery
-            .GroupBy(h => h.ReportDate)
-            .Select(g => new
+        var points = activity
+            .Where(a => a.CurrentFilerCount > 0)
+            .OrderBy(a => a.ReportDate)
+            .Select(a => new OwnershipTrendPoint
             {
-                ReportDate = g.Key,
-                TotalShares = g.Sum(h => h.Shares),
-                HolderCount = g.Select(h => h.InstitutionalHolderId).Distinct().Count(),
-            })
-            .OrderBy(p => p.ReportDate)
-            .ToListAsync();
-
-        return points
-            .Select(p => new OwnershipTrendPoint
-            {
-                ReportDate = p.ReportDate,
-                TotalShares = p.TotalShares,
-                HolderCount = p.HolderCount,
+                ReportDate = a.ReportDate,
+                TotalShares = a.CurrentShares,
+                HolderCount = a.CurrentFilerCount,
             })
             .ToList();
+
+        return points;
     }
 
     // Narrow the Sold-Out filter to only holders who were in the previous

--- a/tests/Equibles.IntegrationTests/Holdings/AumSnapshotDrainWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/AumSnapshotDrainWorkerTests.cs
@@ -186,6 +186,17 @@ public class AumSnapshotDrainWorkerTests : IAsyncLifetime
             onRebuild: async ct =>
             {
                 await using var mutate = FreshContext();
+                var activeClaim = await mutate
+                    .Set<AumQuarterlySnapshot>()
+                    .Where(s => s.ReportDate == Q4)
+                    .Select(s => s.DirtyAt)
+                    .SingleAsync(ct);
+                activeClaim
+                    .Should()
+                    .NotBeNull("request paths must see the snapshot as dirty during rebuild")
+                    .And.Subject.As<DateTime?>()
+                    .Value.Should()
+                    .BeAfter(DateTime.UtcNow, "the drain owns a recoverable future-dated lease");
                 await mutate
                     .Set<AumQuarterlySnapshot>()
                     .Where(s => s.ReportDate == Q4)
@@ -212,6 +223,132 @@ public class AumSnapshotDrainWorkerTests : IAsyncLifetime
                 TimeSpan.FromSeconds(1),
                 "drain saw DirtyAt changed and skipped clear"
             );
+    }
+
+    [Fact]
+    public async Task DrainOnce_LongRebuildRenewsClaimAndClearsDirtyAt()
+    {
+        var dirtyAt = DateTime.UtcNow.AddHours(-2);
+        await using (var seed = FreshContext())
+        {
+            seed.Add(new AumQuarterlySnapshot { ReportDate = Q4, DirtyAt = dirtyAt });
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = BuildScopeFactory();
+        var worker = new TestableDrainWorker(
+            scopeFactory,
+            new DelayedRefreshService(
+                scopeFactory,
+                NullLogger<HoldingsAggregateRefreshService>.Instance,
+                TimeSpan.FromMilliseconds(180)
+            ),
+            NullLogger<AumSnapshotDrainWorker>.Instance,
+            cooldown: TimeSpan.Zero,
+            claimLease: TimeSpan.FromMilliseconds(80),
+            claimRenewInterval: TimeSpan.FromMilliseconds(15)
+        );
+
+        await worker.DrainOnce(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var snapshot = await read.Set<AumQuarterlySnapshot>().SingleAsync();
+        snapshot.DirtyAt.Should().BeNull("the renewed lease remained active through completion");
+    }
+
+    [Fact]
+    public async Task DrainOnce_ExpiredUnrenewedClaimIsRearmedInsteadOfCleared()
+    {
+        var dirtyAt = DateTime.UtcNow.AddHours(-2);
+        await using (var seed = FreshContext())
+        {
+            seed.Add(new AumQuarterlySnapshot { ReportDate = Q4, DirtyAt = dirtyAt });
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = BuildScopeFactory();
+        var worker = new TestableDrainWorker(
+            scopeFactory,
+            new DelayedRefreshService(
+                scopeFactory,
+                NullLogger<HoldingsAggregateRefreshService>.Instance,
+                TimeSpan.FromMilliseconds(80)
+            ),
+            NullLogger<AumSnapshotDrainWorker>.Instance,
+            cooldown: TimeSpan.Zero,
+            claimLease: TimeSpan.FromMilliseconds(20),
+            claimRenewInterval: TimeSpan.FromSeconds(5)
+        );
+
+        await worker.DrainOnce(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var snapshot = await read.Set<AumQuarterlySnapshot>().SingleAsync();
+        snapshot
+            .DirtyAt.Should()
+            .NotBeNull("an expired claim is never cleared")
+            .And.Subject.As<DateTime?>()
+            .Value.Should()
+            .BeCloseTo(dirtyAt, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task DrainOnce_LateRenewalCannotResurrectExpiredClaimAfterEvent()
+    {
+        await SeedHoldings();
+        var dirtyAt = DateTime.UtcNow.AddHours(-2);
+        await using (var seed = FreshContext())
+        {
+            seed.Add(new AumQuarterlySnapshot { ReportDate = Q4, DirtyAt = dirtyAt });
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = BuildScopeFactory();
+        var racingRefresh = new RacingRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance,
+            onRebuild: async ct =>
+            {
+                // Let the lease expire, then simulate the consumer's keep-the-first-event
+                // expression. An expired marker sorts before the new event and therefore stays
+                // in place; the drain must not resurrect it when the delayed renewal runs.
+                await Task.Delay(TimeSpan.FromMilliseconds(130), ct);
+                var incoming = DateTime.UtcNow;
+                await using var mutate = FreshContext();
+                await mutate
+                    .Set<AumQuarterlySnapshot>()
+                    .Where(s => s.ReportDate == Q4)
+                    .ExecuteUpdateAsync(
+                        s =>
+                            s.SetProperty(
+                                x => x.DirtyAt,
+                                x =>
+                                    x.DirtyAt == null || x.DirtyAt > incoming ? incoming : x.DirtyAt
+                            ),
+                        ct
+                    );
+                await Task.Delay(TimeSpan.FromMilliseconds(150), ct);
+            }
+        );
+        var worker = new TestableDrainWorker(
+            scopeFactory,
+            racingRefresh,
+            NullLogger<AumSnapshotDrainWorker>.Instance,
+            cooldown: TimeSpan.Zero,
+            claimLease: TimeSpan.FromMilliseconds(100),
+            claimRenewInterval: TimeSpan.FromMilliseconds(200)
+        );
+
+        await worker.DrainOnce(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var snapshot = await read.Set<AumQuarterlySnapshot>().SingleAsync();
+        snapshot
+            .DirtyAt.Should()
+            .NotBeNull("an expired claim can only be rearmed, never renewed and cleared")
+            .And.Subject.As<DateTime?>()
+            .Value.Should()
+            .BeCloseTo(dirtyAt, TimeSpan.FromSeconds(1));
     }
 
     [Fact]
@@ -258,21 +395,50 @@ public class AumSnapshotDrainWorkerTests : IAsyncLifetime
     private sealed class TestableDrainWorker : AumSnapshotDrainWorker
     {
         private readonly TimeSpan _cooldown;
+        private readonly TimeSpan? _claimLease;
+        private readonly TimeSpan? _claimRenewInterval;
 
         public TestableDrainWorker(
             IServiceScopeFactory scopeFactory,
             HoldingsAggregateRefreshService refreshService,
             ILogger<AumSnapshotDrainWorker> logger,
-            TimeSpan cooldown
+            TimeSpan cooldown,
+            TimeSpan? claimLease = null,
+            TimeSpan? claimRenewInterval = null
         )
             : base(scopeFactory, refreshService, logger)
         {
             _cooldown = cooldown;
+            _claimLease = claimLease;
+            _claimRenewInterval = claimRenewInterval;
         }
 
         protected override TimeSpan StartupDelay => TimeSpan.Zero;
         protected override TimeSpan TickInterval => TimeSpan.FromMilliseconds(1);
         protected override TimeSpan Cooldown => _cooldown;
+        protected override TimeSpan ClaimLease => _claimLease ?? base.ClaimLease;
+        protected override TimeSpan ClaimRenewInterval =>
+            _claimRenewInterval ?? base.ClaimRenewInterval;
+    }
+
+    private sealed class DelayedRefreshService : HoldingsAggregateRefreshService
+    {
+        private readonly TimeSpan _delay;
+
+        public DelayedRefreshService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<HoldingsAggregateRefreshService> logger,
+            TimeSpan delay
+        )
+            : base(scopeFactory, logger)
+        {
+            _delay = delay;
+        }
+
+        public override Task RebuildQuarterAsync(
+            DateOnly reportDate,
+            CancellationToken cancellationToken
+        ) => Task.Delay(_delay, cancellationToken);
     }
 
     /// <summary>

--- a/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
@@ -257,6 +257,15 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
                         CurrentFilerCount = 1,
                     }
                 );
+                seed.Add(
+                    new StockQuarterlyListingActivity
+                    {
+                        CommonStockId = aapl.Id,
+                        ReportDate = quarter,
+                        PriceSeriesTicker = aapl.Ticker,
+                        CurrentShares = 1_000,
+                    }
+                );
             }
             await seed.SaveChangesAsync();
         }
@@ -285,6 +294,92 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
         holderQuarters
             .Should()
             .Equal(quarters, "the backfill covers every quarter, not just the safety-net window");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ListingSnapshotsMissing_BackfillsBeyondSafetyNetWindow()
+    {
+        var quarters = Enumerable
+            .Range(0, 5)
+            .Select(i => new DateOnly(2023, 12, 31).AddMonths(3 * i))
+            .ToList();
+        CommonStock stock;
+        await using (var seed = FreshContext())
+        {
+            var sector = new Sector { Name = "Technology" };
+            seed.Add(sector);
+            await seed.SaveChangesAsync();
+            var industry = new Industry { Name = "Software", SectorId = sector.Id };
+            seed.Add(industry);
+            await seed.SaveChangesAsync();
+            stock = new CommonStock
+            {
+                Ticker = "AAPL",
+                Name = "Apple",
+                Cik = "C0000320193",
+                IndustryId = industry.Id,
+            };
+            var holder = new InstitutionalHolder { Cik = "H001", Name = "Holder H001" };
+            seed.AddRange(stock, holder);
+            await seed.SaveChangesAsync();
+            foreach (var quarter in quarters)
+            {
+                seed.Add(MakeHolding(stock, holder, quarter, 100_000, $"acc-{quarter}"));
+                seed.AddRange(
+                    new AumQuarterlySnapshot
+                    {
+                        ReportDate = quarter,
+                        TotalValue = 100_000,
+                        FilerCount = 1,
+                        PositionCount = 1,
+                        StockCount = 1,
+                        FilingCount = 1,
+                    },
+                    new StockQuarterlyActivity
+                    {
+                        CommonStockId = stock.Id,
+                        ReportDate = quarter,
+                        CurrentShares = 1_000,
+                        CurrentValue = 100_000,
+                        CurrentFilerCount = 1,
+                    },
+                    new HolderQuarterlySnapshot
+                    {
+                        InstitutionalHolderId = holder.Id,
+                        ReportDate = quarter,
+                        FilingDate = quarter.AddDays(45),
+                        Aum = 100_000,
+                        PositionCount = 1,
+                        StockCount = 1,
+                    }
+                );
+            }
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = ScopeFactory();
+        var refreshService = new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+        var worker = new InstantTickWorker(scopeFactory, refreshService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await worker.StartAsync(cts.Token);
+        await WaitForSnapshots(async ctx =>
+            await ctx.Set<StockQuarterlyListingActivity>()
+                .CountAsync(row => row.CommonStockId == stock.Id && !row.IsCombined)
+            >= quarters.Count
+        );
+        await worker.StopAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var listingQuarters = await read.Set<StockQuarterlyListingActivity>()
+            .Where(row => row.CommonStockId == stock.Id && !row.IsCombined)
+            .Select(row => row.ReportDate)
+            .OrderBy(date => date)
+            .ToListAsync();
+        listingQuarters.Should().Equal(quarters);
     }
 
     [Fact]
@@ -357,6 +452,15 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
                         Aum = 100_000,
                         PositionCount = 1,
                         StockCount = 1,
+                    }
+                );
+                seed.Add(
+                    new StockQuarterlyListingActivity
+                    {
+                        CommonStockId = aapl.Id,
+                        ReportDate = quarter,
+                        PriceSeriesTicker = aapl.Ticker,
+                        CurrentShares = 1_000,
                     }
                 );
             }

--- a/tests/Equibles.IntegrationTests/Holdings/Filings13FImportedConsumerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filings13FImportedConsumerTests.cs
@@ -12,7 +12,7 @@ namespace Equibles.IntegrationTests.Holdings;
 
 /// <summary>
 /// Contract for <see cref="Filings13FImportedConsumer"/>: marks the AUM
-/// snapshot for the affected quarter dirty in a single atomic upsert. Brand-new
+/// snapshot for the affected quarter and its following quarter dirty in one atomic upsert. Brand-new
 /// quarters land as a stub row with <c>DirtyAt</c> set; the drain worker fills
 /// in the aggregates on its next cooldown-expired tick.
 /// </summary>
@@ -146,5 +146,55 @@ public class Filings13FImportedConsumerTests : IAsyncLifetime
         var aum = await read.Set<AumQuarterlySnapshot>().SingleAsync(s => s.ReportDate == Q4);
         aum.DirtyAt.Should().NotBeNull();
         aum.DirtyAt!.Value.Should().BeCloseTo(firstEventAt, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task Consume_ActiveDrainClaim_ReplacesLeaseWithEventTimestamp()
+    {
+        var activeLease = DateTime.UtcNow.AddMinutes(5);
+        await using (var seed = FreshContext())
+        {
+            seed.Add(
+                new AumQuarterlySnapshot
+                {
+                    ReportDate = Q4,
+                    TotalValue = 1L,
+                    DirtyAt = activeLease,
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var before = DateTime.UtcNow;
+        await BuildConsumer().Consume(Context(new Filings13FImported(Q4, FilingCount: 1)));
+        var after = DateTime.UtcNow;
+
+        await using var read = FreshContext();
+        var aum = await read.Set<AumQuarterlySnapshot>().SingleAsync(s => s.ReportDate == Q4);
+        aum.DirtyAt.Should().NotBeNull();
+        aum.DirtyAt!.Value.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public async Task Consume_HistoricalQuarterAlsoDirtiesFollowingComparisonSnapshot()
+    {
+        var amended = new DateOnly(2024, 9, 30);
+        await using (var seed = FreshContext())
+        {
+            seed.AddRange(
+                new AumQuarterlySnapshot { ReportDate = amended },
+                new AumQuarterlySnapshot { ReportDate = Q4 }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        await BuildConsumer().Consume(Context(new Filings13FImported(amended, FilingCount: 1)));
+
+        await using var read = FreshContext();
+        var snapshots = await read.Set<AumQuarterlySnapshot>()
+            .OrderBy(snapshot => snapshot.ReportDate)
+            .ToListAsync();
+        snapshots.Should().HaveCount(2);
+        snapshots.Should().OnlyContain(snapshot => snapshot.DirtyAt != null);
     }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceCombinedLaneTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceCombinedLaneTests.cs
@@ -116,6 +116,16 @@ public class HoldingsAggregateRefreshServiceCombinedLaneTests : IAsyncLifetime
         row.NewFilerCount.Should().Be(1, "only C initiated");
         row.SoldOutFilerCount.Should()
             .Be(1, "D filed this quarter without AAPL — a proven exit; B is assumed to hold");
+        var listing = await read.Set<StockQuarterlyListingActivity>()
+            .SingleAsync(snapshot =>
+                snapshot.CommonStockId == aapl.Id
+                && snapshot.ReportDate == OpenCur
+                && snapshot.IsCombined
+            );
+        listing.PriceSeriesTicker.Should().Be("AAPL");
+        listing.CurrentShares.Should().Be(2_000);
+        listing.PreviousShares.Should().Be(1_600);
+        listing.ComputedAt.Should().Be(row.ComputedAt);
     }
 
     [Fact]
@@ -189,6 +199,71 @@ public class HoldingsAggregateRefreshServiceCombinedLaneTests : IAsyncLifetime
         rows.Should().ContainSingle(r => r.CommonStockId == aapl.Id);
     }
 
+    [Fact]
+    public async Task RebuildQuarterAsync_PublishesHolderAndCombinedSnapshotsAtomically()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var stock = await SeedStock(seed, "AAPL", industry);
+        var holderA = await SeedHolder(seed, "H001");
+        var holderB = await SeedHolder(seed, "H002");
+        seed.AddRange(
+            MakeHolding(stock, holderA, OpenPrev, 100_000, "acc-a-prev"),
+            MakeHolding(stock, holderA, OpenCur, 120_000, "acc-a-cur")
+        );
+        await seed.SaveChangesAsync();
+        await BuildService().RebuildQuarterAsync(OpenCur, CancellationToken.None);
+
+        await using (var import = FreshContext())
+        {
+            import.Add(MakeHolding(stock, holderB, OpenCur, 30_000, "acc-b-cur"));
+            await import.SaveChangesAsync();
+        }
+
+        var blocking = BuildBlockingService();
+        var rebuild = blocking.RebuildQuarterAsync(OpenCur, CancellationToken.None);
+        await blocking.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        try
+        {
+            await using var during = FreshContext();
+            var visibleHolders = await during
+                .Set<HolderQuarterlySnapshot>()
+                .CountAsync(row => row.ReportDate == OpenCur);
+            var visibleActivity = await during
+                .Set<StockQuarterlyActivityCombined>()
+                .SingleAsync(row => row.CommonStockId == stock.Id && row.ReportDate == OpenCur);
+
+            visibleHolders.Should().Be(1, "the new holder generation is still uncommitted");
+            visibleActivity
+                .CurrentFilerCount.Should()
+                .Be(1, "the old activity generation remains visible");
+        }
+        finally
+        {
+            blocking.Release.TrySetResult(true);
+        }
+        await rebuild;
+
+        await using var after = FreshContext();
+        (await after.Set<HolderQuarterlySnapshot>().CountAsync(row => row.ReportDate == OpenCur))
+            .Should()
+            .Be(2);
+        (
+            await after
+                .Set<StockQuarterlyActivityCombined>()
+                .SingleAsync(row => row.CommonStockId == stock.Id && row.ReportDate == OpenCur)
+        )
+            .CurrentFilerCount.Should()
+            .Be(2);
+    }
+
+    private BlockingRefreshService BuildBlockingService()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(_ => CreateScopeFromFixture());
+        return new BlockingRefreshService(scopeFactory);
+    }
+
     private static async Task<Guid> SeedTaxonomy(Equibles.Data.EquiblesFinancialDbContext ctx)
     {
         var sector = new Sector { Name = "Technology" };
@@ -254,4 +329,25 @@ public class HoldingsAggregateRefreshServiceCombinedLaneTests : IAsyncLifetime
                     ..9
                 ],
         };
+
+    private sealed class BlockingRefreshService : HoldingsAggregateRefreshService
+    {
+        public BlockingRefreshService(IServiceScopeFactory scopeFactory)
+            : base(scopeFactory, NullLogger<HoldingsAggregateRefreshService>.Instance) { }
+
+        public TaskCompletionSource<bool> Entered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override async Task BeforeCombinedLaneRefresh(
+            DateOnly reportDate,
+            CancellationToken cancellationToken
+        )
+        {
+            Entered.TrySetResult(true);
+            await Release.Task.WaitAsync(cancellationToken);
+        }
+    }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceStockActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceStockActivityTests.cs
@@ -126,6 +126,45 @@ public class HoldingsAggregateRefreshServiceStockActivityTests : IAsyncLifetime
         row.SoldOutFilerCount.Should().Be(0, "no 13F filer left between the quarters");
     }
 
+    [Fact]
+    public async Task RebuildQuarterAsync_PreservesExactListingShareBreakdown()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var stock = await SeedStock(seed, "ACME", industry);
+        var holder = await SeedHolder(seed, "H001");
+        seed.AddRange(
+            MakeHolding(stock, holder, QPrev, 10_000, "primary-prev"),
+            MakeHolding(stock, holder, QPrev, 1_000, "sibling-prev", listedTicker: "ACME.B"),
+            MakeHolding(stock, holder, QCur, 12_000, "primary-cur"),
+            MakeHolding(stock, holder, QCur, 2_000, "sibling-cur", listedTicker: "ACME.B")
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(QCur, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var rows = await read.Set<StockQuarterlyListingActivity>()
+            .Where(row => row.CommonStockId == stock.Id && row.ReportDate == QCur)
+            .OrderBy(row => row.PriceSeriesTicker)
+            .ToListAsync();
+
+        rows.Should().HaveCount(2);
+        rows.Should()
+            .ContainSingle(row =>
+                row.PriceSeriesTicker == "ACME"
+                && row.CurrentShares == 120
+                && row.PreviousShares == 100
+            );
+        rows.Should()
+            .ContainSingle(row =>
+                row.PriceSeriesTicker == "ACME.B"
+                && row.CurrentShares == 20
+                && row.PreviousShares == 10
+            );
+        rows.Should().OnlyContain(row => !row.IsCombined);
+    }
+
     private static async Task<Guid> SeedTaxonomy(Equibles.Data.EquiblesFinancialDbContext ctx)
     {
         var sector = new Sector { Name = "Technology" };
@@ -172,7 +211,8 @@ public class HoldingsAggregateRefreshServiceStockActivityTests : IAsyncLifetime
         DateOnly reportDate,
         long value,
         string accession,
-        FilingType filingType = FilingType.Form13F
+        FilingType filingType = FilingType.Form13F,
+        string listedTicker = null
     ) =>
         new()
         {
@@ -186,6 +226,7 @@ public class HoldingsAggregateRefreshServiceStockActivityTests : IAsyncLifetime
             InvestmentDiscretion = InvestmentDiscretion.Sole,
             AccessionNumber = accession,
             FilingType = filingType,
+            ListedTicker = listedTicker,
             // CUSIP column is varchar(9); a deterministic per-accession value keeps
             // the holding-row unique key disambiguated across the seeds.
             Cusip =

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRollupRefresherTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRollupRefresherTests.cs
@@ -1,0 +1,85 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsRollupRefresherTests : IAsyncLifetime
+{
+    private static readonly DateOnly Prior = new(2024, 9, 30);
+    private static readonly DateOnly Current = new(2024, 12, 31);
+
+    private readonly ParadeDbFixture _fixture;
+
+    public HoldingsRollupRefresherTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task MarkAumSnapshotsDirty_ReplacesClaimAndDirtiesSuccessor()
+    {
+        var activeClaim = DateTime.UtcNow.AddMinutes(5);
+        await using (var seed = FreshContext())
+        {
+            seed.AddRange(
+                new AumQuarterlySnapshot { ReportDate = Prior, DirtyAt = activeClaim },
+                new AumQuarterlySnapshot { ReportDate = Current }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var before = DateTime.UtcNow;
+        await using (var write = FreshContext())
+        {
+            await HoldingsRollupRefresher.MarkAumSnapshotsDirty(
+                write,
+                [Prior],
+                CancellationToken.None
+            );
+        }
+        var after = DateTime.UtcNow;
+
+        await using var read = FreshContext();
+        var snapshots = await read.Set<AumQuarterlySnapshot>()
+            .OrderBy(snapshot => snapshot.ReportDate)
+            .ToListAsync();
+        snapshots.Should().HaveCount(2);
+        snapshots.Should().OnlyContain(snapshot => snapshot.DirtyAt != null);
+        snapshots.Should().OnlyContain(snapshot => snapshot.DirtyAt >= before);
+        snapshots.Should().OnlyContain(snapshot => snapshot.DirtyAt <= after);
+    }
+
+    [Fact]
+    public async Task MarkAumSnapshotsDirty_PreservesFirstOrdinaryEventTimestamp()
+    {
+        var firstEvent = DateTime.UtcNow.AddMinutes(-10);
+        await using (var seed = FreshContext())
+        {
+            seed.Add(new AumQuarterlySnapshot { ReportDate = Prior, DirtyAt = firstEvent });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var write = FreshContext())
+        {
+            await HoldingsRollupRefresher.MarkAumSnapshotsDirty(
+                write,
+                [Prior],
+                CancellationToken.None
+            );
+        }
+
+        await using var read = FreshContext();
+        var snapshot = await read.Set<AumQuarterlySnapshot>().SingleAsync();
+        snapshot.DirtyAt.Should().BeCloseTo(firstEvent, TimeSpan.FromMilliseconds(1));
+    }
+
+    private EquiblesFinancialDbContext FreshContext() => _fixture.CreateDbContext();
+}

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionPortfolioSummaryProviderCacheTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionPortfolioSummaryProviderCacheTests.cs
@@ -1,0 +1,175 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class InstitutionPortfolioSummaryProviderCacheTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly MemoryCache _cache = new(new MemoryCacheOptions());
+
+    public InstitutionPortfolioSummaryProviderCacheTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new HoldingsModuleConfiguration(),
+            new CorporateActionsModuleConfiguration()
+        );
+    }
+
+    public void Dispose()
+    {
+        _cache.Dispose();
+        _dbContext.Dispose();
+    }
+
+    [Fact]
+    public async Task Get_DirtyIngestBypassesCachedSummaryUntilSnapshotRefresh()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Cik = "0000000001",
+            Name = "Test Holder",
+        };
+        var previous = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var currentHolding = Holding(stock.Id, holder.Id, current, 100, "CURRENT");
+
+        _dbContext.AddRange(stock, holder, currentHolding);
+        _dbContext.Add(Holding(stock.Id, holder.Id, previous, 50, "PREVIOUS"));
+        _dbContext.AddRange(
+            Snapshot(holder.Id, previous, new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            Snapshot(holder.Id, current, new DateTime(2025, 1, 2, 0, 0, 0, DateTimeKind.Utc)),
+            new AumQuarterlySnapshot { ReportDate = previous },
+            new AumQuarterlySnapshot { ReportDate = current }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var provider = new InstitutionPortfolioSummaryProvider(
+            new InstitutionalHoldingRepository(_dbContext),
+            _cache
+        );
+        var first = await provider.Get(holder, current, previous, quartersReported: 2);
+        first.ReportedAum.Should().Be(100);
+
+        currentHolding.Value = 200;
+        _dbContext.Set<AumQuarterlySnapshot>().Find(current).DirtyAt = DateTime.UtcNow;
+        await _dbContext.SaveChangesAsync();
+
+        var duringDirtyWindow = await provider.Get(holder, current, previous, quartersReported: 2);
+        duringDirtyWindow.ReportedAum.Should().Be(200);
+
+        currentHolding.Value = 300;
+        await _dbContext.SaveChangesAsync();
+        var secondDirtyRead = await provider.Get(holder, current, previous, quartersReported: 2);
+        secondDirtyRead.ReportedAum.Should().Be(300);
+    }
+
+    [Fact]
+    public async Task Get_CleanSnapshotVersionInvalidatesCachedSummary()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Cik = "0000000002",
+            Name = "Versioned Holder",
+        };
+        var previous = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var currentHolding = Holding(stock.Id, holder.Id, current, 100, "CURRENT-VERSIONED");
+        var currentSnapshot = Snapshot(
+            holder.Id,
+            current,
+            new DateTime(2025, 1, 2, 0, 0, 0, DateTimeKind.Utc)
+        );
+
+        _dbContext.AddRange(stock, holder, currentHolding);
+        _dbContext.Add(Holding(stock.Id, holder.Id, previous, 50, "PREVIOUS-VERSIONED"));
+        _dbContext.AddRange(
+            Snapshot(holder.Id, previous, new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            currentSnapshot,
+            new AumQuarterlySnapshot { ReportDate = previous },
+            new AumQuarterlySnapshot { ReportDate = current }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var provider = new InstitutionPortfolioSummaryProvider(
+            new InstitutionalHoldingRepository(_dbContext),
+            _cache
+        );
+        var first = await provider.Get(holder, current, previous, quartersReported: 2);
+        first.ReportedAum.Should().Be(100);
+
+        currentHolding.Value = 200;
+        await _dbContext.SaveChangesAsync();
+
+        var cached = await provider.Get(holder, current, previous, quartersReported: 2);
+        cached.ReportedAum.Should().Be(100);
+
+        currentSnapshot.ComputedAt = currentSnapshot.ComputedAt.AddMinutes(1);
+        await _dbContext.SaveChangesAsync();
+
+        var refreshed = await provider.Get(holder, current, previous, quartersReported: 2);
+        refreshed.ReportedAum.Should().Be(200);
+    }
+
+    private static InstitutionalHolding Holding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long value,
+        string accession
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            FilingType = FilingType.Form13F,
+            Shares = value,
+            Value = value,
+            AccessionNumber = accession,
+        };
+
+    private static HolderQuarterlySnapshot Snapshot(
+        Guid holderId,
+        DateOnly reportDate,
+        DateTime computedAt
+    ) =>
+        new()
+        {
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Aum = 100,
+            PositionCount = 1,
+            StockCount = 1,
+            ComputedAt = computedAt,
+        };
+}

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
@@ -79,6 +79,28 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
     }
 
     [Fact]
+    public async Task Get13FAvailableReportDatesCached_UsesSnapshotSpineAndPrependsRefreshLag()
+    {
+        var stock = Stock("GLOBAL");
+        var holder = Holder("0000000010");
+        var snapshotted = new DateOnly(2024, 6, 30);
+        var live = new DateOnly(2024, 9, 30);
+
+        _dbContext.AddRange(stock, holder);
+        _dbContext
+            .Set<AumQuarterlySnapshot>()
+            .Add(new AumQuarterlySnapshot { ReportDate = snapshotted, FilerCount = 1 });
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(Holding(stock.Id, holder.Id, live, FilingType.Form13F, "13F-LIVE"));
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.Get13FAvailableReportDatesCached();
+
+        dates.Should().Equal(live, snapshotted);
+    }
+
+    [Fact]
     public async Task Get13FReportDatesByStockSnapshotBacked_ReturnsSnapshotDatesNewestFirst()
     {
         var stock = Stock("MSFT");
@@ -261,6 +283,192 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
         dates.Should().Equal(q2, q1);
     }
 
+    [Fact]
+    public async Task Get13FReportDatesByHolderSnapshotBacked_UsesOnlyThatHolderAndPrependsLive()
+    {
+        var stock = Stock("HOLDER");
+        var holder = Holder("0000000011");
+        var other = Holder("0000000012");
+        var snapshotted = new DateOnly(2024, 6, 30);
+        var live = new DateOnly(2024, 9, 30);
+
+        _dbContext.AddRange(stock, holder, other);
+        _dbContext
+            .Set<HolderQuarterlySnapshot>()
+            .AddRange(
+                Snapshot(holder.Id, snapshotted),
+                Snapshot(other.Id, new DateOnly(2024, 12, 31))
+            );
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(Holding(stock.Id, holder.Id, live, FilingType.Form13F, "13F-HOLDER-LIVE"));
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.Get13FReportDatesByHolderSnapshotBacked(holder);
+
+        dates.Should().Equal(live, snapshotted);
+    }
+
+    [Fact]
+    public async Task Get13FReportDatesByHolderSnapshotBacked_FallsBackWithoutSnapshot()
+    {
+        var stock = Stock("FALLBACK");
+        var holder = Holder("0000000013");
+        var q1 = new DateOnly(2024, 3, 31);
+        var q2 = new DateOnly(2024, 6, 30);
+
+        _dbContext.AddRange(stock, holder);
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .AddRange(
+                Holding(stock.Id, holder.Id, q1, FilingType.Form13F, "13F-H-Q1"),
+                Holding(stock.Id, holder.Id, q2, FilingType.Form13F, "13F-H-Q2")
+            );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.Get13FReportDatesByHolderSnapshotBacked(holder);
+
+        dates.Should().Equal(q2, q1);
+    }
+
+    [Fact]
+    public async Task GetStockActivitySnapshotsByStockSnapshotBacked_FallsBackToStockScoped13F()
+    {
+        var stock = Stock("TREND");
+        var first = Holder("0000000014");
+        var second = Holder("0000000015");
+        var quarter = new DateOnly(2024, 6, 30);
+        _dbContext.AddRange(stock, first, second);
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .AddRange(
+                Holding(stock.Id, first.Id, quarter, FilingType.Form13F, "13F-A"),
+                Holding(stock.Id, second.Id, quarter, FilingType.Form13F, "13F-B"),
+                Holding(stock.Id, second.Id, quarter, FilingType.Schedule13G, "13G-B")
+            );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var rows = await _repository.GetStockActivitySnapshotsByStockSnapshotBacked(stock);
+
+        var row = rows.Should().ContainSingle().Which;
+        row.ReportDate.Should().Be(quarter);
+        row.CurrentShares.Should().Be(200);
+        row.CurrentValue.Should().Be(2000);
+        row.CurrentFilerCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetStockActivitySnapshotsByStockSnapshotBacked_BoundsStaleRowsAndAppendsRefreshLag()
+    {
+        var stock = Stock("TREND-LAG");
+        var first = Holder("0000000018");
+        var second = Holder("0000000019");
+        var older = new DateOnly(2024, 3, 31);
+        var snapshotted = new DateOnly(2024, 6, 30);
+        var latest = new DateOnly(2024, 9, 30);
+        var staleFuture = new DateOnly(2024, 12, 31);
+        var computedAt = DateTime.UtcNow;
+        _dbContext.AddRange(stock, first, second);
+        _dbContext
+            .Set<StockQuarterlyActivity>()
+            .AddRange(
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = snapshotted,
+                    CurrentShares = 100,
+                    CurrentValue = 1000,
+                    CurrentFilerCount = 1,
+                    ComputedAt = computedAt,
+                },
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = staleFuture,
+                    CurrentShares = 999,
+                    CurrentValue = 9999,
+                    CurrentFilerCount = 9,
+                    ComputedAt = computedAt,
+                }
+            );
+        _dbContext
+            .Set<StockQuarterlyListingActivity>()
+            .Add(
+                new StockQuarterlyListingActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = snapshotted,
+                    PriceSeriesTicker = stock.Ticker,
+                    CurrentShares = 100,
+                    ComputedAt = computedAt,
+                }
+            );
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .AddRange(
+                Holding(stock.Id, first.Id, older, FilingType.Form13F, "13F-LAG-OLD"),
+                Holding(stock.Id, first.Id, snapshotted, FilingType.Form13F, "13F-LAG-PRIOR"),
+                Holding(stock.Id, first.Id, latest, FilingType.Form13F, "13F-LAG-A"),
+                Holding(stock.Id, second.Id, latest, FilingType.Form13F, "13F-LAG-B")
+            );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var rows = await _repository.GetStockActivitySnapshotsByStockSnapshotBacked(stock);
+
+        rows.Select(row => row.ReportDate).Should().Equal(snapshotted, latest);
+        var newest = rows[^1];
+        newest.CurrentShares.Should().Be(200);
+        newest.PreviousReportDate.Should().Be(snapshotted);
+        newest.PreviousShares.Should().Be(100);
+        newest.CurrentValue.Should().Be(2000);
+        newest.PreviousValue.Should().Be(1000);
+        newest.CurrentFilerCount.Should().Be(2);
+        newest.PreviousFilerCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetHolderQuarterlySnapshotsSnapshotBacked_FallsBackOnlyForMissingHolder()
+    {
+        var stock = Stock("FUNDS");
+        var snapshotted = Holder("0000000016");
+        var missing = Holder("0000000017");
+        var quarter = new DateOnly(2024, 6, 30);
+        _dbContext.AddRange(stock, snapshotted, missing);
+        _dbContext
+            .Set<HolderQuarterlySnapshot>()
+            .Add(
+                new HolderQuarterlySnapshot
+                {
+                    InstitutionalHolderId = snapshotted.Id,
+                    ReportDate = quarter,
+                    FilingDate = quarter.AddDays(45),
+                    Aum = 123,
+                    PositionCount = 1,
+                    StockCount = 1,
+                }
+            );
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .AddRange(
+                Holding(stock.Id, snapshotted.Id, quarter, FilingType.Form13F, "13F-SNAPSHOT"),
+                Holding(stock.Id, missing.Id, quarter, FilingType.Form13F, "13F-MISSING"),
+                Holding(stock.Id, missing.Id, quarter, FilingType.Schedule13D, "13D-MISSING")
+            );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var rows = await _repository.GetHolderQuarterlySnapshotsSnapshotBacked([
+            snapshotted.Id,
+            missing.Id,
+        ]);
+
+        rows.Should().HaveCount(2);
+        rows.Single(row => row.InstitutionalHolderId == snapshotted.Id).Aum.Should().Be(123);
+        var fallback = rows.Single(row => row.InstitutionalHolderId == missing.Id);
+        fallback.Aum.Should().Be(1000);
+        fallback.PositionCount.Should().Be(1);
+        fallback.StockCount.Should().Be(1);
+    }
+
     private static CommonStock Stock(string ticker) =>
         new()
         {
@@ -296,5 +504,16 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
             Shares = 100,
             Value = 1000,
             AccessionNumber = accession,
+        };
+
+    private static HolderQuarterlySnapshot Snapshot(Guid holderId, DateOnly reportDate) =>
+        new()
+        {
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Aum = 1000,
+            PositionCount = 1,
+            StockCount = 1,
         };
 }

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryMostHeldTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryMostHeldTests.cs
@@ -207,6 +207,28 @@ public class InstitutionalHoldingRepositoryMostHeldTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Get13FUniverseFilerCount_DirtyPositiveSnapshot_UsesMaterializedValue()
+    {
+        await using var seed = FreshContext();
+        seed.Add(
+            new AumQuarterlySnapshot
+            {
+                ReportDate = Current,
+                FilerCount = 5_320,
+                DirtyAt = DateTime.UtcNow,
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var count = await sut.Get13FUniverseFilerCount(Current, Prior, combined: false);
+
+        count.Should().Be(5_320, "dirty request paths still use the bounded snapshot");
+    }
+
+    [Fact]
     public async Task Get13FUniverseFilerCount_MissingSnapshot_FallsBackToExactDistinctCount()
     {
         await using var seed = FreshContext();
@@ -250,6 +272,124 @@ public class InstitutionalHoldingRepositoryMostHeldTests : IAsyncLifetime
         var count = await sut.Get13FUniverseFilerCount(Current, Prior, combined: false);
 
         count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Get13FUniverseFilerCount_CombinedDirtyWindowUsesMaterializedHolderUnion()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "AAPL");
+        var currentFiler = await SeedHolder(seed, "current-filer");
+        var carryForwardFiler = await SeedHolder(seed, "carry-filer");
+        var newlyImportedFiler = await SeedHolder(seed, "new-filer");
+        seed.AddRange(
+            MakeHolding(stock, currentFiler, Current, shares: 100, value: 100_000),
+            MakeHolding(stock, carryForwardFiler, Prior, shares: 100, value: 100_000),
+            MakeHolding(stock, newlyImportedFiler, Current, shares: 100, value: 100_000),
+            new HolderQuarterlySnapshot
+            {
+                InstitutionalHolderId = currentFiler.Id,
+                ReportDate = Current,
+                FilingDate = Current.AddDays(45),
+                Aum = 100_000,
+                PositionCount = 1,
+                StockCount = 1,
+            },
+            new HolderQuarterlySnapshot
+            {
+                InstitutionalHolderId = carryForwardFiler.Id,
+                ReportDate = Prior,
+                FilingDate = Prior.AddDays(45),
+                Aum = 100_000,
+                PositionCount = 1,
+                StockCount = 1,
+            },
+            new StockQuarterlyActivityCombined
+            {
+                CommonStockId = stock.Id,
+                ReportDate = Current,
+                PreviousReportDate = Prior,
+                CurrentShares = 200,
+                PreviousShares = 100,
+                CurrentValue = 200_000,
+                PreviousValue = 100_000,
+                CurrentFilerCount = 2,
+                PreviousFilerCount = 1,
+            },
+            new AumQuarterlySnapshot
+            {
+                ReportDate = Current,
+                FilerCount = 2,
+                DirtyAt = DateTime.UtcNow,
+            },
+            new AumQuarterlySnapshot { ReportDate = Prior, FilerCount = 1 }
+        );
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var count = await sut.Get13FUniverseFilerCount(Current, Prior, combined: true);
+
+        count
+            .Should()
+            .Be(
+                2,
+                "dirty requests must keep the activity and denominator on the same bounded snapshot"
+            );
+    }
+
+    [Fact]
+    public async Task Get13FUniverseFilerCount_MissingCombinedSnapshotFallsBackToExactUnion()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "MSFT");
+        var bothQuarters = await SeedHolder(seed, "both-quarters");
+        var priorOnly = await SeedHolder(seed, "prior-only");
+        seed.AddRange(
+            MakeHolding(stock, bothQuarters, Current, shares: 100, value: 100_000),
+            MakeHolding(stock, bothQuarters, Prior, shares: 100, value: 100_000),
+            MakeHolding(stock, priorOnly, Prior, shares: 100, value: 100_000)
+        );
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var count = await sut.Get13FUniverseFilerCount(Current, Prior, combined: true);
+
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Get13FUniverseFilerCount_ExistingCombinedSnapshotReturnsZeroHolderUnion()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "ZERO");
+        var liveHolder = await SeedHolder(seed, "live-holder");
+        seed.Add(MakeHolding(stock, liveHolder, Current, shares: 100, value: 100_000));
+        seed.Add(
+            new StockQuarterlyActivityCombined
+            {
+                CommonStockId = stock.Id,
+                ReportDate = Current,
+                PreviousReportDate = Prior,
+                CurrentShares = 0,
+                PreviousShares = 0,
+                CurrentValue = 0,
+                PreviousValue = 0,
+                CurrentFilerCount = 0,
+                PreviousFilerCount = 0,
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var count = await sut.Get13FUniverseFilerCount(Current, Prior, combined: true);
+
+        count.Should().Be(0, "an existing combined generation owns its zero denominator");
     }
 
     private static async Task<CommonStock> SeedStock(

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryUniqueFilerIdsCombinedTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryUniqueFilerIdsCombinedTests.cs
@@ -47,10 +47,16 @@ public class InstitutionalHoldingRepositoryUniqueFilerIdsCombinedTests : IDispos
             Cik = "0000000002",
             Name = "Carried Forward",
         };
+        var eventOnlyHolder = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Cik = "0000000003",
+            Name = "Schedule 13G Only",
+        };
         var previous = new DateOnly(2024, 3, 31);
         var current = new DateOnly(2024, 6, 30);
 
-        _dbContext.Set<InstitutionalHolder>().AddRange(filer, nonFiler);
+        _dbContext.Set<InstitutionalHolder>().AddRange(filer, nonFiler, eventOnlyHolder);
         _dbContext
             .Set<InstitutionalHolding>()
             .AddRange(
@@ -58,7 +64,9 @@ public class InstitutionalHoldingRepositoryUniqueFilerIdsCombinedTests : IDispos
                 Holding(stockX, filer.Id, current, "F-X-Q2"),
                 Holding(stockY, filer.Id, current, "F-Y-Q2"),
                 // Non-filer held last quarter only — carried into the combined view.
-                Holding(stockX, nonFiler.Id, previous, "N-X-Q1")
+                Holding(stockX, nonFiler.Id, previous, "N-X-Q1"),
+                // A Schedule 13G event on the quarter end is not a 13F filer.
+                Holding(stockX, eventOnlyHolder.Id, current, "E-X-Q2", FilingType.Schedule13G)
             );
         await _dbContext.SaveChangesAsync(CancellationToken.None);
 
@@ -73,7 +81,8 @@ public class InstitutionalHoldingRepositoryUniqueFilerIdsCombinedTests : IDispos
         Guid stockId,
         Guid holderId,
         DateOnly reportDate,
-        string accession
+        string accession,
+        FilingType filingType = FilingType.Form13F
     ) =>
         new()
         {
@@ -85,5 +94,6 @@ public class InstitutionalHoldingRepositoryUniqueFilerIdsCombinedTests : IDispos
             Shares = 100,
             Value = 1000,
             AccessionNumber = accession,
+            FilingType = filingType,
         };
 }

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
@@ -270,6 +271,45 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
     }
 
     [Fact]
+    public async Task GetTopBuyersSellers_CurrentZeroShareRowStillProvesAReportedExit()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "META",
+            Name = "Meta Platforms Inc.",
+            Cik = "0001326801",
+        };
+        var holder = new InstitutionalHolder { Cik = "31", Name = "Zero Row Capital" };
+        DbContext.AddRange(stock, holder);
+
+        var prior = new DateOnly(2024, 9, 30);
+        var latest = new DateOnly(2024, 12, 31);
+        DbContext.Add(MakeHolding(stock, holder, prior, shares: 1_000));
+        DbContext.Add(MakeHolding(stock, holder, latest, shares: 0));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopBuyersSellers("META");
+
+        output.Should().Contain("Zero Row Capital");
+        output.Should().Contain("-1,000");
+    }
+
+    [Fact]
     public async Task GetTopBuyersSellers_ExplicitReportDate_HonorsArgument()
     {
         var stock = new CommonStock
@@ -309,6 +349,54 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
         output.Should().Contain("as of 2024-12-31");
         output.Should().Contain("vs prior quarter 2024-09-30");
         output.Should().Contain("+400");
+    }
+
+    [Fact]
+    public async Task GetTopBuyersSellers_PrimaryRowsIgnoreSiblingListingSplits()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GOOGL",
+            Name = "Alphabet Inc.",
+            Cik = "0001652044",
+        };
+        var holder = new InstitutionalHolder { Cik = "21", Name = "Class A Capital" };
+        var prior = new DateOnly(2024, 9, 30);
+        var latest = new DateOnly(2024, 12, 31);
+        DbContext.AddRange(
+            stock,
+            holder,
+            MakeHolding(stock, holder, prior, shares: 1_000),
+            MakeHolding(stock, holder, latest, shares: 1_000),
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                EffectiveDate = new DateOnly(2024, 10, 1),
+                Numerator = 20,
+                Denominator = 1,
+                PriceSeriesTicker = "GOOG",
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopBuyersSellers("GOOGL");
+
+        output.Should().Contain("No quarter-over-quarter movement found");
     }
 
     private static InstitutionalHolding MakeHolding(

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
@@ -75,11 +76,81 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
         output.Should().Contain("10.00%");
     }
 
+    [Fact]
+    public async Task GetTopHolders_SiblingListingSplit_RestatesBeforeRankingAndPercentage()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "ACME",
+            Name = "Acme Inc.",
+            Cik = "0000000100",
+        };
+        var primaryHolder = new InstitutionalHolder { Cik = "101", Name = "Primary Fund" };
+        var siblingHolder = new InstitutionalHolder { Cik = "102", Name = "Sibling Fund" };
+        var reportDate = new DateOnly(2024, 12, 31);
+        DbContext.AddRange(stock, primaryHolder, siblingHolder);
+        DbContext.Add(MakeHolding(stock, primaryHolder, reportDate, shares: 100));
+        DbContext.Add(
+            MakeHolding(stock, siblingHolder, reportDate, shares: 100, listedTicker: "ACME.B")
+        );
+        DbContext
+            .Set<StockSplit>()
+            .AddRange(
+                new StockSplit
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    EffectiveDate = new DateOnly(2025, 1, 15),
+                    Numerator = 2m,
+                    Denominator = 1m,
+                    Source = StockSplitSource.Manual,
+                },
+                new StockSplit
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    PriceSeriesTicker = "ACME.B",
+                    EffectiveDate = new DateOnly(2025, 2, 15),
+                    Numerator = 10m,
+                    Denominator = 1m,
+                    Source = StockSplitSource.Manual,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopHolders("ACME");
+
+        var siblingIndex = output.IndexOf("Sibling Fund", StringComparison.Ordinal);
+        var primaryIndex = output.IndexOf("Primary Fund", StringComparison.Ordinal);
+        siblingIndex.Should().BeGreaterThan(0);
+        primaryIndex.Should().BeGreaterThan(siblingIndex);
+        output.Should().Contain("1,200 shares");
+        output.Should().Contain("| Common (ACME.B) | 1,000 |");
+        output.Should().Contain("83.33%");
+        output.Should().Contain("16.67%");
+    }
+
     private static InstitutionalHolding MakeHolding(
         CommonStock stock,
         InstitutionalHolder holder,
         DateOnly reportDate,
-        long shares
+        long shares,
+        string listedTicker = null
     ) =>
         new()
         {
@@ -91,6 +162,7 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
             Value = shares * 100,
             ShareType = ShareType.Shares,
             InvestmentDiscretion = InvestmentDiscretion.Sole,
+            ListedTicker = listedTicker,
             AccessionNumber = $"acc-{holder.Cik}",
         };
 }

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsMarketActivityCacheTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsMarketActivityCacheTests.cs
@@ -1,0 +1,222 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsMarketActivityCacheTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsMarketActivityCacheTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetMarketWide13FActivity_RebuildVersionInvalidatesCachedQuarter()
+    {
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "C1",
+        };
+        var holder = new InstitutionalHolder { Cik = "H1", Name = "Test Filer" };
+        DbContext.AddRange(stock, holder);
+        var computedAt = DateTime.UtcNow;
+        DbContext.AddRange(
+            MakeHolding(stock, holder, prior, shares: 100, value: 100_000),
+            MakeHolding(stock, holder, current, shares: 200, value: 200_000),
+            new StockQuarterlyActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = current,
+                PreviousReportDate = prior,
+                CurrentShares = 200,
+                PreviousShares = 100,
+                CurrentValue = 200_000,
+                PreviousValue = 100_000,
+                CurrentFilerCount = 1,
+                PreviousFilerCount = 1,
+                ComputedAt = computedAt,
+            },
+            new StockQuarterlyListingActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = current,
+                PriceSeriesTicker = stock.Ticker,
+                CurrentShares = 200,
+                PreviousShares = 100,
+                ComputedAt = computedAt,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using var firstRead = Fixture.CreateDbContext();
+        var sut = BuildTool(firstRead, cache);
+        var first = await sut.GetMarketWide13FActivity(
+            bucket: "top-buys",
+            reportDate: "2024-12-31"
+        );
+
+        await using (var update = Fixture.CreateDbContext())
+        {
+            var snapshot = await update.Set<StockQuarterlyActivity>().FindAsync(stock.Id, current);
+            snapshot.CurrentShares = 350;
+            snapshot.ComputedAt = snapshot.ComputedAt.AddMinutes(1);
+            var listing = await update.Set<StockQuarterlyListingActivity>().SingleAsync();
+            listing.CurrentShares = snapshot.CurrentShares;
+            listing.ComputedAt = snapshot.ComputedAt;
+            await update.SaveChangesAsync();
+        }
+
+        var refreshed = await sut.GetMarketWide13FActivity(
+            bucket: "top-buys",
+            reportDate: "2024-12-31"
+        );
+        refreshed.Should().NotBe(first);
+
+        using var freshCache = new MemoryCache(new MemoryCacheOptions());
+        await using var freshRead = Fixture.CreateDbContext();
+        var independentlyRead = await BuildTool(freshRead, freshCache)
+            .GetMarketWide13FActivity(bucket: "top-buys", reportDate: "2024-12-31");
+        independentlyRead.Should().Be(refreshed);
+    }
+
+    [Fact]
+    public async Task GetMarketWide13FActivity_DirtyQuarterReadsSnapshotWithoutCachingIt()
+    {
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var stock = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "C2",
+        };
+        var holder = new InstitutionalHolder { Cik = "H2", Name = "Dirty Filer" };
+        DbContext.AddRange(stock, holder);
+        var computedAt = DateTime.UtcNow;
+        DbContext.AddRange(
+            MakeHolding(stock, holder, prior, shares: 100, value: 100_000),
+            MakeHolding(stock, holder, current, shares: 200, value: 200_000),
+            new StockQuarterlyActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = current,
+                PreviousReportDate = prior,
+                CurrentShares = 200,
+                PreviousShares = 100,
+                CurrentValue = 200_000,
+                PreviousValue = 100_000,
+                CurrentFilerCount = 1,
+                PreviousFilerCount = 1,
+                ComputedAt = computedAt,
+            },
+            new StockQuarterlyListingActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = current,
+                PriceSeriesTicker = stock.Ticker,
+                CurrentShares = 200,
+                PreviousShares = 100,
+                ComputedAt = computedAt,
+            },
+            new AumQuarterlySnapshot { ReportDate = prior, FilerCount = 1 },
+            new AumQuarterlySnapshot
+            {
+                ReportDate = current,
+                FilerCount = 1,
+                DirtyAt = DateTime.UtcNow,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = BuildTool(DbContext, cache);
+        var first = await sut.GetMarketWide13FActivity(
+            bucket: "top-buys",
+            reportDate: "2024-12-31"
+        );
+
+        var currentHolding = await DbContext
+            .Set<InstitutionalHolding>()
+            .SingleAsync(row => row.ReportDate == current);
+        currentHolding.Shares = 900;
+        currentHolding.Value = 900_000;
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var afterLiveMutation = await sut.GetMarketWide13FActivity(
+            bucket: "top-buys",
+            reportDate: "2024-12-31"
+        );
+        afterLiveMutation.Should().Be(first, "dirty requests must not run the live aggregate");
+
+        var snapshot = await DbContext
+            .Set<StockQuarterlyActivity>()
+            .SingleAsync(row => row.ReportDate == current);
+        snapshot.CurrentShares = 350;
+        snapshot.CurrentValue = 350_000;
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var afterSnapshotMutation = await sut.GetMarketWide13FActivity(
+            bucket: "top-buys",
+            reportDate: "2024-12-31"
+        );
+        afterSnapshotMutation.Should().NotBe(first, "dirty snapshots are never process-cached");
+    }
+
+    private InstitutionalHoldingsTools BuildTool(
+        EquiblesFinancialDbContext context,
+        IMemoryCache cache
+    )
+    {
+        var holdingRepository = new InstitutionalHoldingRepository(context);
+        var stockSplitRepository = new StockSplitRepository(context);
+        return new InstitutionalHoldingsTools(
+            holdingRepository,
+            new InstitutionalHolderRepository(context),
+            new CommonStockRepository(context),
+            stockSplitRepository,
+            new StockCombinedQuarterService(holdingRepository, stockSplitRepository),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>(),
+            memoryCache: cache
+        );
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{stock.Ticker}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.IntegrationTests/Sec/ChunkRepositoryHybridSearchTickerFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/ChunkRepositoryHybridSearchTickerFilterTests.cs
@@ -60,6 +60,52 @@ public class ChunkRepositoryHybridSearchTickerFilterTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task HybridSearchCompanyFallback_UsesTickerTypeAndParentDocumentDate()
+    {
+        var apple = SeedStock("AAPL", "Apple Inc.", "0000320193");
+        var microsoft = SeedStock("MSFT", "Microsoft Corp.", "0000789019");
+        var insideWindow = SeedDocument(apple);
+        insideWindow.ReportingDate = new DateOnly(2026, 1, 15);
+        var expected = SeedChunk(
+            insideWindow,
+            "Orbital revenue acceleration improved operating margin.",
+            "AAPL"
+        );
+        expected.ReportingDate = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var wrongTickerDocument = SeedDocument(microsoft);
+        wrongTickerDocument.ReportingDate = insideWindow.ReportingDate;
+        SeedChunk(
+            wrongTickerDocument,
+            "Orbital revenue acceleration improved operating margin.",
+            "MSFT"
+        );
+
+        var outsideWindow = SeedDocument(apple);
+        outsideWindow.ReportingDate = new DateOnly(2024, 1, 15);
+        var staleCache = SeedChunk(
+            outsideWindow,
+            "Orbital revenue acceleration improved operating margin.",
+            "AAPL"
+        );
+        staleCache.ReportingDate = new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        await DbContext.SaveChangesAsync();
+
+        var sut = new ChunkRepository(DbContext);
+
+        var results = await sut.HybridSearchCompanyFallback(
+            "orbital revenue acceleration",
+            maxResults: 10,
+            ticker: "aapl",
+            documentTypes: [DocumentType.TenK],
+            startDate: new DateOnly(2025, 1, 1),
+            endDate: new DateOnly(2026, 12, 31)
+        );
+
+        results.Should().ContainSingle().Which.Id.Should().Be(expected.Id);
+    }
+
+    [Fact]
     public async Task HybridSearch_WithSeparatorTicker_StillMatchesViaRawTokenizer()
     {
         // The default BM25 tokenizer splits "BRK-B" into "brk"/"b", which would make a
@@ -147,26 +193,26 @@ public class ChunkRepositoryHybridSearchTickerFilterTests : ParadeDbMcpTestBase
         return document;
     }
 
-    private void SeedChunk(Document document, string content, string ticker)
+    private Chunk SeedChunk(Document document, string content, string ticker)
     {
-        DbContext.Add(
-            new Chunk
-            {
-                Document = document,
-                DocumentId = document.Id,
-                Index = 0,
-                StartPosition = 0,
-                EndPosition = content.Length,
-                StartLineNumber = 1,
-                Content = content,
-                DocumentType = document.DocumentType,
-                Ticker = ticker,
-                ReportingDate = DateTime.SpecifyKind(
-                    document.ReportingDate.ToDateTime(TimeOnly.MinValue),
-                    DateTimeKind.Utc
-                ),
-            }
-        );
+        var chunk = new Chunk
+        {
+            Document = document,
+            DocumentId = document.Id,
+            Index = 0,
+            StartPosition = 0,
+            EndPosition = content.Length,
+            StartLineNumber = 1,
+            Content = content,
+            DocumentType = document.DocumentType,
+            Ticker = ticker,
+            ReportingDate = DateTime.SpecifyKind(
+                document.ReportingDate.ToDateTime(TimeOnly.MinValue),
+                DateTimeKind.Utc
+            ),
+        };
+        DbContext.Add(chunk);
+        return chunk;
     }
 
     private sealed class CapturingCommandInterceptor : DbCommandInterceptor

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingRepositoryHolderActivityQueryTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingRepositoryHolderActivityQueryTests.cs
@@ -1,0 +1,46 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingRepositoryHolderActivityQueryTests
+{
+    [Fact]
+    public void Get13FHolderActivityByStock_AggregatesBothQuartersInSql()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only")
+            .EnableServiceProviderCaching(false)
+            .Options;
+        using var context = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new HoldingsModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+        var repository = new InstitutionalHoldingRepository(context);
+        var stock = new Equibles.CommonStocks.Data.Models.CommonStock { Id = Guid.NewGuid() };
+
+        var sql = repository
+            .Get13FHolderActivityByStock(
+                stock,
+                new DateOnly(2026, 6, 30),
+                new DateOnly(2026, 3, 31)
+            )
+            .ToQueryString();
+
+        sql.Should().Contain("GROUP BY");
+        sql.Should().Contain("ListedTicker");
+        sql.Should().Contain("CASE");
+        sql.ToUpperInvariant().Should().Contain("SUM");
+        sql.ToUpperInvariant().Should().Contain("COUNT");
+        sql.Should().NotContain("JOIN");
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingRepositoryUniqueFilerIdsCombinedQueryTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingRepositoryUniqueFilerIdsCombinedQueryTests.cs
@@ -1,0 +1,37 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingRepositoryUniqueFilerIdsCombinedQueryTests
+{
+    [Fact]
+    public void GetUniqueFilerIdsCombined_UsesDistinctTwoQuarterUnionWithoutCorrelatedProbe()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only")
+            .EnableServiceProviderCaching(false)
+            .Options;
+        using var context = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new HoldingsModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+        var repository = new InstitutionalHoldingRepository(context);
+
+        var sql = repository
+            .GetUniqueFilerIdsCombined(new DateOnly(2026, 6, 30), new DateOnly(2026, 3, 31))
+            .ToQueryString();
+
+        sql.Should().Contain("SELECT DISTINCT");
+        sql.ToUpperInvariant().Should().NotContain("NOT EXISTS");
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/MarketActivityShareRestaterTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/MarketActivityShareRestaterTests.cs
@@ -1,0 +1,39 @@
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class MarketActivityShareRestaterTests
+{
+    [Fact]
+    public void RestateListingTotal_SiblingOnlySplit_DoesNotMultiplyPrimaryShares()
+    {
+        var reportDate = new DateOnly(2024, 12, 31);
+        var listingShares = new List<StockQuarterlyListingActivity>
+        {
+            new() { PriceSeriesTicker = "ACME", CurrentShares = 100 },
+            new() { PriceSeriesTicker = "ACME.B", CurrentShares = 10 },
+        };
+        var splits = new List<StockSplit>
+        {
+            new()
+            {
+                PriceSeriesTicker = "ACME.B",
+                EffectiveDate = new DateOnly(2025, 1, 15),
+                Numerator = 10,
+                Denominator = 1,
+            },
+        };
+
+        var result = MarketActivityShareRestater.RestateListingTotal(
+            listingShares,
+            listing => listing.CurrentShares,
+            reportDate,
+            "ACME",
+            splits
+        );
+
+        Assert.Equal(200, result);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/ChunkRepositoryCompanyFallbackQueryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ChunkRepositoryCompanyFallbackQueryTests.cs
@@ -1,0 +1,55 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Media.Data;
+using Equibles.Sec.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Sec;
+
+public class ChunkRepositoryCompanyFallbackQueryTests
+{
+    [Fact]
+    public void BuildCompanyFallbackQuery_TranslatesBoundedTickerAndFilingFilters()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only", o => o.UseVector())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        using var context = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+                new MediaModuleConfiguration(),
+                new SecModuleConfiguration(),
+            }
+        );
+        var repository = new ChunkRepository(context);
+        var documentId = Guid.NewGuid();
+
+        var sql = repository
+            .BuildCompanyFallbackQuery(
+                "capital expenditure guidance",
+                25,
+                "tsm",
+                documentId,
+                [DocumentType.TenK, DocumentType.TwentyF],
+                new DateOnly(2024, 1, 1),
+                new DateOnly(2026, 12, 31)
+            )
+            .ToQueryString();
+
+        sql.Should().Contain("to_tsvector");
+        sql.Should().Contain("websearch_to_tsquery");
+        sql.Should().Contain("@normalizedTicker='TSM'");
+        sql.Should().Contain("\"Ticker\" = @normalizedTicker");
+        sql.Should().Contain("@documentId");
+        sql.Should().Contain("\"DocumentId\" = @documentId");
+        sql.Should().Contain("\"ReportingDate\"");
+        sql.Should().Contain("LIMIT");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherBm25TimeoutTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherBm25TimeoutTests.cs
@@ -60,6 +60,48 @@ public class HybridChunkSearcherBm25TimeoutTests
     }
 
     [Fact]
+    public async Task ConjunctiveTimeout_TickerScoped_CompanyFallbackReturnsWithoutOtherPasses()
+    {
+        var chunk = new Chunk
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "TSM",
+            Content = "bounded company-local match",
+        };
+        var chunkRepository = new TimeoutChunkRepository(
+            conjunctiveTimesOut: true,
+            companyFallbackResults: [chunk],
+            allChunks: [chunk]
+        );
+        var embeddingRepository = new StubEmbeddingRepository([]);
+        var searcher = NewSearcher(chunkRepository, embeddingRepository);
+
+        var results = await searcher.Search("10-K", 5, ticker: "TSM", disjunctiveFallback: true);
+
+        Assert.Equal(chunk.Id, Assert.Single(results).Id);
+        Assert.Equal(3, Assert.Single(chunkRepository.ConjunctiveBudgets));
+        Assert.Equal(1, chunkRepository.CompanyFallbackCalls);
+        Assert.Empty(chunkRepository.DisjunctiveBudgets);
+        Assert.False(embeddingRepository.SearchSimilarChunksCalled);
+    }
+
+    [Fact]
+    public async Task CompanyFallback_CallerCancellationEscapes()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var chunkRepository = new TimeoutChunkRepository(
+            conjunctiveTimesOut: true,
+            companyFallbackError: new OperationCanceledException(cancellation.Token)
+        );
+        var searcher = NewSearcher(chunkRepository, new StubEmbeddingRepository([]));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            searcher.Search("query", 5, ticker: "AAPL", cancellationToken: cancellation.Token)
+        );
+    }
+
+    [Fact]
     public async Task ConjunctiveSucceeds_DisjunctiveTimeout_KeepsTheConjunctiveResults()
     {
         var chunk = new Chunk { Id = Guid.NewGuid(), Content = "precise match" };

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherTestHarness.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherTestHarness.cs
@@ -54,10 +54,14 @@ internal sealed class TimeoutChunkRepository : ChunkRepository
     private readonly List<Chunk> _conjunctiveResults;
     private readonly List<Chunk> _disjunctiveResults;
     private readonly List<Chunk> _allChunks;
+    private readonly List<Chunk> _companyFallbackResults;
+    private readonly Exception _companyFallbackError;
 
     public List<int?> ConjunctiveBudgets { get; } = [];
 
     public List<int?> DisjunctiveBudgets { get; } = [];
+
+    public int CompanyFallbackCalls { get; private set; }
 
     public TimeoutChunkRepository(
         bool conjunctiveTimesOut = false,
@@ -65,6 +69,8 @@ internal sealed class TimeoutChunkRepository : ChunkRepository
         Exception conjunctiveError = null,
         List<Chunk> conjunctiveResults = null,
         List<Chunk> disjunctiveResults = null,
+        List<Chunk> companyFallbackResults = null,
+        Exception companyFallbackError = null,
         List<Chunk> allChunks = null
     )
         : base(null)
@@ -74,6 +80,8 @@ internal sealed class TimeoutChunkRepository : ChunkRepository
         _conjunctiveError = conjunctiveError;
         _conjunctiveResults = conjunctiveResults ?? [];
         _disjunctiveResults = disjunctiveResults ?? [];
+        _companyFallbackResults = companyFallbackResults ?? [];
+        _companyFallbackError = companyFallbackError;
         _allChunks = allChunks ?? [];
     }
 
@@ -100,6 +108,23 @@ internal sealed class TimeoutChunkRepository : ChunkRepository
                 new TimeoutException()
             );
         return Task.FromResult(conjunctive ? _conjunctiveResults : _disjunctiveResults);
+    }
+
+    public override Task<List<Chunk>> HybridSearchCompanyFallback(
+        string searchText,
+        int maxResults,
+        string ticker,
+        Guid? documentId = null,
+        IReadOnlyCollection<DocumentType> documentTypes = null,
+        DateOnly? startDate = null,
+        DateOnly? endDate = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        CompanyFallbackCalls++;
+        if (_companyFallbackError != null)
+            throw _companyFallbackError;
+        return Task.FromResult(_companyFallbackResults);
     }
 
     public override IQueryable<Chunk> GetAll() => new TestAsyncEnumerable<Chunk>(_allChunks);


### PR DESCRIPTION
## Summary

- serve market-wide and institution 13F reads from versioned materialized snapshots
- publish holder, stock, exact-listing, and combined generations atomically while preserving imports that arrive during rebuilds
- retain exact listing series for split restatement and use a bounded company-local document-search fallback
- add the exact-listing snapshot schema additively

## Validation

- full unit suite: 4,291 passed
- full integration suite: 2,583 passed
- affected projects build successfully
- migration model check reports no pending changes
- independent release audit is clean