### PR TITLE
fix(holdings): defer CUSIP-change ledger clears so the re-import walk completes

### DIFF
--- a/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
@@ -13,6 +13,16 @@ public class ProcessedDataSet
     // the real rows for a backfill.
     public const string BackfillGuardFileName = "__backfill-guard__";
 
+    // Sentinel row name marking a CUSIP-identity rescan as QUEUED but not yet
+    // applied. StockCusipChangedConsumer only adds this row; the actual ledger
+    // clear happens at the start of HoldingsScraperWorker's next cycle. Clearing
+    // inline restarted the multi-hour oldest-first walk on every identity
+    // discovery, and the FTD sweeps discover identities near-daily — so the walk
+    // never reached the newest quarters and they never healed
+    // (EquiblesCommercial#7163). Deferring the clear lets every walk complete;
+    // events arriving mid-walk coalesce into one queued rescan for the next one.
+    public const string RescanPendingFileName = "__rescan-pending__";
+
     /// <summary>
     /// The 13F import pipeline's current parser version. Bump this when a
     /// parser fix must re-apply to already-imported data: the scraper treats

--- a/src/Equibles.Holdings.HostedService/Consumers/StockCusipChangedConsumer.cs
+++ b/src/Equibles.Holdings.HostedService/Consumers/StockCusipChangedConsumer.cs
@@ -8,15 +8,23 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.Holdings.HostedService.Consumers;
 
 /// <summary>
-/// When a CommonStock's CUSIP is set/changed (typically FTD seeding a
-/// previously-null CUSIP), the quarterly 13F data sets that were already
-/// marked processed while the stock was unresolvable hold no holdings for it.
-/// This consumer clears the <see cref="ProcessedDataSet"/> ledger (keeping a
-/// guard sentinel so the worker's first-boot backfill seeding doesn't re-skip
-/// history) so <c>HoldingsScraperWorker</c> re-imports every data set on its
-/// next cycle and backfills the now-resolvable stock. Reprocessing is
-/// idempotent (upsert), so over-invalidation is safe; the FTD cold-start
-/// burst of events collapses to a no-op once already cleared.
+/// When a CommonStock's CUSIP identity grows (FTD seeding a previously-null
+/// CUSIP, a retired-CUSIP alias, or a listed-ticker CUSIP), the quarterly 13F
+/// data sets that were already marked processed while the identity was
+/// unresolvable hold no holdings for it. This consumer QUEUES a rescan by
+/// adding the <see cref="ProcessedDataSet.RescanPendingFileName"/> sentinel;
+/// <c>HoldingsScraperWorker</c> applies it at the start of its next cycle —
+/// clearing the <see cref="ProcessedDataSet"/> ledger (keeping the backfill
+/// guard) plus the open filing season's realtime <see cref="ProcessedFiling"/>
+/// rows — and then re-imports everything.
+///
+/// The clear is deferred rather than applied here on purpose: an inline clear
+/// restarts the scraper's multi-hour oldest-first walk from scratch, and the
+/// FTD sweeps discover identities near-daily, so the walk was starved and the
+/// newest quarters never healed (EquiblesCommercial#7163). Queuing lets the
+/// in-flight walk complete; events arriving mid-walk coalesce into one pending
+/// rescan that the next walk applies with every identity known by then.
+/// Reprocessing is idempotent (upsert), so over-invalidation is safe.
 /// </summary>
 [Consumer]
 public class StockCusipChangedConsumer : IConsumer<StockCusipChanged>
@@ -38,43 +46,43 @@ public class StockCusipChangedConsumer : IConsumer<StockCusipChanged>
 
     public async Task Consume(ConsumeContext<StockCusipChanged> context)
     {
-        var rows = await _processedDataSetRepository
+        var alreadyQueued = await _processedDataSetRepository
             .GetAll()
-            .ToListAsync(context.CancellationToken);
-
-        var realRows = rows.Where(r => r.FileName != ProcessedDataSet.BackfillGuardFileName)
-            .ToList();
-        var hasGuard = rows.Any(r => r.FileName == ProcessedDataSet.BackfillGuardFileName);
-
-        if (realRows.Count == 0 && hasGuard)
+            .AnyAsync(
+                r => r.FileName == ProcessedDataSet.RescanPendingFileName,
+                context.CancellationToken
+            );
+        if (alreadyQueued)
         {
-            // Already invalidated (e.g. a prior event in the FTD seeding burst).
+            // Coalesce: the pending rescan has not been applied yet, so it will
+            // run with this event's identity too. No signal either — the event
+            // that queued the sentinel already woke the worker.
             return;
         }
 
-        if (realRows.Count > 0)
+        _processedDataSetRepository.Add(
+            new ProcessedDataSet { FileName = ProcessedDataSet.RescanPendingFileName }
+        );
+        try
         {
-            _processedDataSetRepository.Delete(realRows);
+            await _processedDataSetRepository.SaveChanges();
         }
-
-        if (!hasGuard)
+        catch (DbUpdateException)
         {
-            _processedDataSetRepository.Add(
-                new ProcessedDataSet { FileName = ProcessedDataSet.BackfillGuardFileName }
-            );
+            // A concurrent event queued the sentinel between the check and the
+            // save (FileName is unique). The rescan is pending and that
+            // consumer signalled the worker — nothing left to do.
+            return;
         }
-
-        await _processedDataSetRepository.SaveChanges();
 
         // Wake the Holdings worker now (GH-852) instead of waiting up to its
-        // 24h cycle / risking a same-cycle skip.
+        // 24h cycle; it applies the queued rescan at the start of that cycle.
         _rescanSignal.RequestRescan();
 
         _logger.LogInformation(
-            "CUSIP change for {Ticker} ({Cusip}) invalidated {Count} processed 13F data set(s); signalled the holdings worker to re-import and backfill now",
+            "CUSIP change for {Ticker} ({Cusip}) queued a deferred 13F rescan; the holdings worker clears the ledgers and re-imports at its next cycle start",
             context.Message.Ticker,
-            context.Message.Cusip,
-            realRows.Count
+            context.Message.Cusip
         );
     }
 }

--- a/src/Equibles.Holdings.HostedService/HoldingsRescanSignal.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsRescanSignal.cs
@@ -5,8 +5,8 @@ namespace Equibles.Holdings.HostedService;
 
 /// <summary>
 /// In-process wake signal so <see cref="StockCusipChangedConsumer"/> can make
-/// <see cref="HoldingsScraperWorker"/> re-run promptly after it invalidates the
-/// ProcessedDataSet ledger — instead of the backfill waiting up to the worker's
+/// <see cref="HoldingsScraperWorker"/> re-run promptly after it queues a
+/// pending rescan — instead of the backfill waiting up to the worker's
 /// 24h <c>SleepInterval</c> (and risking a same-cycle skip). Singleton so the
 /// scoped consumer and the singleton hosted worker share one instance.
 /// Requests coalesce: many CUSIP-change events in one FTD burst trigger a

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -92,6 +92,8 @@ public class HoldingsScraperWorker : BaseScraperWorker
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
+        await ApplyPendingCusipRescan(stoppingToken);
+
         await BackfillHolderClassifications(stoppingToken);
 
         var startDate = _workerOptions.MinSyncDate ?? new DateTime(2020, 1, 1);
@@ -145,6 +147,78 @@ public class HoldingsScraperWorker : BaseScraperWorker
         // Restamp FilingType on filing rollup rows written before the column existed. Self-
         // terminating like the pass above.
         await BackfillFilingRollupTypes(stoppingToken);
+    }
+
+    /// <summary>
+    /// Applies a rescan queued by <see cref="Consumers.StockCusipChangedConsumer"/>:
+    /// clears the quarterly <see cref="Holdings.Data.Models.ProcessedDataSet"/> ledger (keeping the
+    /// backfill guard so an empty table is not re-seeded as processed) and the open
+    /// filing season's realtime <see cref="ProcessedFiling"/> rows. Runs at cycle
+    /// START so a mid-walk CUSIP discovery never restarts the in-flight walk — the
+    /// starvation that kept the newest quarters from healing
+    /// (EquiblesCommercial#7163).
+    ///
+    /// The realtime clear is season-scoped: the bulk walk can only restate filings
+    /// a PUBLISHED quarterly data set covers, and the open season's submissions
+    /// exist only behind the realtime per-accession ledger — without this they
+    /// keep their pre-discovery holes until the season's data set publishes months
+    /// later. The realtime sweep re-imports the cleared accessions chronologically
+    /// (originals before amendments) and the import upserts, so re-processing is
+    /// idempotent. Any accession processed since the latest completed quarter end
+    /// is in scope; amendments are always processed after their originals, so a
+    /// cleared original's amendment is always cleared with it.
+    /// </summary>
+    // Internal for the integration pins on the sentinel/guard/season semantics.
+    internal async Task ApplyPendingCusipRescan(CancellationToken cancellationToken)
+    {
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var dataSets = scope.ServiceProvider.GetRequiredService<ProcessedDataSetRepository>();
+
+        var rows = await dataSets.GetAll().ToListAsync(cancellationToken);
+        var pending = rows.FirstOrDefault(r =>
+            r.FileName == Holdings.Data.Models.ProcessedDataSet.RescanPendingFileName
+        );
+        if (pending == null)
+            return;
+
+        var realRows = rows.Where(r =>
+                r.FileName != Holdings.Data.Models.ProcessedDataSet.BackfillGuardFileName
+                && r.FileName != Holdings.Data.Models.ProcessedDataSet.RescanPendingFileName
+            )
+            .ToList();
+
+        dataSets.Delete(pending);
+        foreach (var row in realRows)
+            dataSets.Delete(row);
+        if (
+            rows.All(r => r.FileName != Holdings.Data.Models.ProcessedDataSet.BackfillGuardFileName)
+        )
+        {
+            dataSets.Add(
+                new Holdings.Data.Models.ProcessedDataSet
+                {
+                    FileName = Holdings.Data.Models.ProcessedDataSet.BackfillGuardFileName,
+                }
+            );
+        }
+
+        await dataSets.SaveChanges();
+
+        var processedFilings =
+            scope.ServiceProvider.GetRequiredService<ProcessedFilingRepository>();
+        var seasonStart = Holdings13FRealtimeWorker
+            .LatestQuarterEnd(DateOnly.FromDateTime(DateTime.UtcNow))
+            .ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var clearedFilings = await processedFilings
+            .GetAll()
+            .Where(f => f.CreationTime >= seasonStart)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        Logger.LogInformation(
+            "Applied queued CUSIP-identity rescan: cleared {DataSets} quarterly data set marker(s) and {Filings} open-season realtime accession(s)",
+            realRows.Count,
+            clearedFilings
+        );
     }
 
     private async Task BackfillFilingRollupTypes(CancellationToken cancellationToken)

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerApplyPendingCusipRescanTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerApplyPendingCusipRescanTests.cs
@@ -1,0 +1,203 @@
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract for the deferred CUSIP-identity rescan (EquiblesCommercial#7163):
+/// the worker — not the consumer — applies a queued rescan at cycle start, so
+/// an in-flight multi-hour walk is never restarted by a mid-walk discovery.
+/// Applying clears the quarterly ledger (keeping exactly one backfill guard)
+/// and the OPEN SEASON's realtime per-accession rows, because the bulk walk
+/// can only restate filings a published quarterly data set covers — the open
+/// season's submissions exist only behind the realtime ledger and would
+/// otherwise keep pre-discovery holes until that data set publishes.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsScraperWorkerApplyPendingCusipRescanTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesFinancialDbContext> _contexts = [];
+
+    public HoldingsScraperWorkerApplyPendingCusipRescanTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private HoldingsScraperWorker BuildWorker()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(_ => CreateScopeFromFixture());
+        return new HoldingsScraperWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            scopeFactory,
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions()),
+            new ConfigurationBuilder().Build(),
+            new HoldingsRescanSignal()
+        );
+    }
+
+    private IServiceScope CreateScopeFromFixture()
+    {
+        var ctx = FreshContext();
+        var scope = Substitute.For<IServiceScope>();
+        var provider = Substitute.For<IServiceProvider>();
+        provider
+            .GetService(typeof(ProcessedDataSetRepository))
+            .Returns(new ProcessedDataSetRepository(ctx));
+        provider
+            .GetService(typeof(ProcessedFilingRepository))
+            .Returns(new ProcessedFilingRepository(ctx));
+        scope.ServiceProvider.Returns(provider);
+        return scope;
+    }
+
+    private static DateTime InSeason() => DateTime.UtcNow;
+
+    private static DateTime BeforeSeason() =>
+        DateTime.SpecifyKind(new DateTime(2020, 1, 15), DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Apply_SentinelQueued_ClearsLedgerKeepsGuardAndClearsOpenSeasonFilings()
+    {
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<ProcessedDataSet>()
+                .AddRange(
+                    new ProcessedDataSet { FileName = ProcessedDataSet.RescanPendingFileName },
+                    new ProcessedDataSet { FileName = ProcessedDataSet.BackfillGuardFileName },
+                    new ProcessedDataSet
+                    {
+                        FileName = "01mar2025-31may2025_form13f.zip",
+                        SubmissionCount = 7987,
+                    },
+                    new ProcessedDataSet
+                    {
+                        FileName = "01dec2025-28feb2026_form13f.zip",
+                        SubmissionCount = 8943,
+                    }
+                );
+            seed.Set<ProcessedFiling>()
+                .AddRange(
+                    new ProcessedFiling
+                    {
+                        AccessionNumber = "0000000000-26-000001",
+                        CreationTime = InSeason(),
+                    },
+                    new ProcessedFiling
+                    {
+                        AccessionNumber = "0000000000-20-000001",
+                        CreationTime = BeforeSeason(),
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        await BuildWorker().ApplyPendingCusipRescan(CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        var dataSets = await verify.Set<ProcessedDataSet>().Select(r => r.FileName).ToListAsync();
+        dataSets
+            .Should()
+            .ContainSingle("the rescan clears every real row and the sentinel itself")
+            .Which.Should()
+            .Be(ProcessedDataSet.BackfillGuardFileName);
+
+        // The open-season realtime accession re-imports; older accessions are
+        // covered by the bulk data sets the walk re-processes anyway.
+        var filings = await verify
+            .Set<ProcessedFiling>()
+            .Select(f => f.AccessionNumber)
+            .ToListAsync();
+        filings.Should().ContainSingle().Which.Should().Be("0000000000-20-000001");
+    }
+
+    [Fact]
+    public async Task Apply_NoSentinel_IsNoOp()
+    {
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<ProcessedDataSet>()
+                .AddRange(
+                    new ProcessedDataSet { FileName = ProcessedDataSet.BackfillGuardFileName },
+                    new ProcessedDataSet
+                    {
+                        FileName = "01mar2025-31may2025_form13f.zip",
+                        SubmissionCount = 7987,
+                    }
+                );
+            seed.Set<ProcessedFiling>()
+                .Add(
+                    new ProcessedFiling
+                    {
+                        AccessionNumber = "0000000000-26-000001",
+                        CreationTime = InSeason(),
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        await BuildWorker().ApplyPendingCusipRescan(CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        (await verify.Set<ProcessedDataSet>().CountAsync()).Should().Be(2);
+        (await verify.Set<ProcessedFiling>().CountAsync()).Should().Be(1);
+    }
+
+    // A sentinel can be queued before the guard ever existed (fresh install
+    // whose first identity discovery precedes the first walk). Applying must
+    // still leave exactly one guard so BackfillProcessedDataSets does not
+    // re-seed history as processed.
+    [Fact]
+    public async Task Apply_SentinelWithoutGuard_AddsTheGuard()
+    {
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<ProcessedDataSet>()
+                .AddRange(
+                    new ProcessedDataSet { FileName = ProcessedDataSet.RescanPendingFileName },
+                    new ProcessedDataSet
+                    {
+                        FileName = "01mar2025-31may2025_form13f.zip",
+                        SubmissionCount = 7987,
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        await BuildWorker().ApplyPendingCusipRescan(CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        var dataSets = await verify.Set<ProcessedDataSet>().Select(r => r.FileName).ToListAsync();
+        dataSets.Should().ContainSingle().Which.Should().Be(ProcessedDataSet.BackfillGuardFileName);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerMixedStateTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerMixedStateTests.cs
@@ -13,13 +13,14 @@ using Xunit;
 namespace Equibles.IntegrationTests.Holdings;
 
 /// <summary>
-/// Adversarial sibling: the feature's pins cover "real rows + no guard" and
-/// "guard only". The MIXED state — guard sentinel AND fresh real rows — is real
-/// and untested: a prior CUSIP change invalidated + added the guard, the worker
-/// re-imported quarterly sets, then another FTD-seeded CUSIP change arrives. A
-/// second CUSIP change must re-invalidate the new real rows WITHOUT inserting a
-/// duplicate guard (FileName has a unique index → duplicate insert throws and
-/// permanently breaks the consumer).
+/// Adversarial sibling: the feature's pins cover "real rows only" and
+/// "sentinel only". The MIXED state — backfill guard AND fresh real rows — is
+/// the steady state after a completed rescan: the worker applied a previous
+/// sentinel (leaving the guard), re-imported quarterly sets, and then another
+/// FTD-seeded CUSIP change arrives. The event must queue a new rescan sentinel
+/// WITHOUT touching the guard, the real rows, or throwing (FileName has a
+/// unique index → a duplicate guard insert would permanently break the
+/// consumer).
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class StockCusipChangedConsumerMixedStateTests : IAsyncLifetime
@@ -41,14 +42,14 @@ public class StockCusipChangedConsumerMixedStateTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Consume_GuardAndFreshRealRowsBothPresent_ReInvalidatesWithoutDuplicatingGuard()
+    public async Task Consume_GuardAndFreshRealRowsBothPresent_QueuesSentinelAndTouchesNothingElse()
     {
         await using (var seed = _fixture.CreateDbContext())
         {
             seed.Set<ProcessedDataSet>()
                 .AddRange(
                     new ProcessedDataSet { FileName = ProcessedDataSet.BackfillGuardFileName },
-                    // Worker re-imported these after the previous invalidation.
+                    // Worker re-imported these after the previous rescan.
                     new ProcessedDataSet
                     {
                         FileName = "01mar2025-31may2025_form13f.zip",
@@ -79,8 +80,11 @@ public class StockCusipChangedConsumerMixedStateTests : IAsyncLifetime
         await using var verify = _fixture.CreateDbContext();
         var rows = await verify.Set<ProcessedDataSet>().Select(r => r.FileName).ToListAsync();
         rows.Should()
-            .ContainSingle("real rows re-invalidated; exactly one guard, never duplicated")
-            .Which.Should()
-            .Be(ProcessedDataSet.BackfillGuardFileName);
+            .BeEquivalentTo(
+                ProcessedDataSet.BackfillGuardFileName,
+                "01mar2025-31may2025_form13f.zip",
+                "01dec2025-28feb2026_form13f.zip",
+                ProcessedDataSet.RescanPendingFileName
+            );
     }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerTests.cs
@@ -33,12 +33,13 @@ public class StockCusipChangedConsumerTests : IAsyncLifetime
         return ctx;
     }
 
-    // Contract: a CUSIP change clears the real quarterly ProcessedDataSet rows
-    // (so HoldingsScraperWorker re-imports/backfills) while leaving a guard
-    // sentinel (so the worker's empty-table backfill seeding doesn't re-skip
-    // history).
+    // Contract (EquiblesCommercial#7163): a CUSIP change QUEUES a rescan
+    // sentinel and wakes the worker — it must NOT clear the real quarterly
+    // rows itself. An inline clear restarts the scraper's multi-hour walk from
+    // the oldest data set, and near-daily identity discoveries starved the
+    // walk so the newest quarters never healed.
     [Fact]
-    public async Task Consume_InvalidatesRealDataSets_AndLeavesGuardSentinel()
+    public async Task Consume_QueuesRescanSentinel_AndLeavesRealRowsIntact()
     {
         await using (var seed = _fixture.CreateDbContext())
         {
@@ -72,24 +73,29 @@ public class StockCusipChangedConsumerTests : IAsyncLifetime
 
         await using var verify = _fixture.CreateDbContext();
         var rows = await verify.Set<ProcessedDataSet>().Select(r => r.FileName).ToListAsync();
-        rows.Should().ContainSingle().Which.Should().Be(ProcessedDataSet.BackfillGuardFileName);
+        rows.Should()
+            .BeEquivalentTo(
+                "01mar2025-31may2025_form13f.zip",
+                "01dec2025-28feb2026_form13f.zip",
+                ProcessedDataSet.RescanPendingFileName
+            );
 
-        // GH-852: invalidation must wake the Holdings worker now.
+        // GH-852: queuing must wake the Holdings worker now.
         var wait = _signal.WaitAsync(CancellationToken.None);
         (await Task.WhenAny(wait, Task.Delay(TimeSpan.FromSeconds(1))))
             .Should()
-            .Be(wait, "the consumer must signal a rescan after invalidating ProcessedDataSet");
+            .Be(wait, "the consumer must signal a rescan after queuing the sentinel");
     }
 
-    // Idempotent: once only the guard remains, a further event is a no-op
+    // Idempotent: once a rescan is queued, further events coalesce into it
     // (the FTD cold-start seeding burst publishes one event per stock).
     [Fact]
-    public async Task Consume_AlreadyInvalidated_IsNoOp()
+    public async Task Consume_RescanAlreadyQueued_IsNoOp()
     {
         await using (var seed = _fixture.CreateDbContext())
         {
             seed.Set<ProcessedDataSet>()
-                .Add(new ProcessedDataSet { FileName = ProcessedDataSet.BackfillGuardFileName });
+                .Add(new ProcessedDataSet { FileName = ProcessedDataSet.RescanPendingFileName });
             await seed.SaveChangesAsync();
         }
 
@@ -105,14 +111,15 @@ public class StockCusipChangedConsumerTests : IAsyncLifetime
             );
         }
 
-        // No invalidation happened (already cleared) → no rescan signalled.
+        // No new queue happened (already pending) → no rescan signalled: the
+        // event that queued the sentinel already woke the worker.
         var wait = _signal.WaitAsync(CancellationToken.None);
         (await Task.WhenAny(wait, Task.Delay(TimeSpan.FromMilliseconds(300))))
             .Should()
-            .NotBe(wait, "an already-invalidated no-op must not trigger a rescan");
+            .NotBe(wait, "an already-queued no-op must not trigger a rescan");
 
         await using var verify = _fixture.CreateDbContext();
         var rows = await verify.Set<ProcessedDataSet>().Select(r => r.FileName).ToListAsync();
-        rows.Should().ContainSingle().Which.Should().Be(ProcessedDataSet.BackfillGuardFileName);
+        rows.Should().ContainSingle().Which.Should().Be(ProcessedDataSet.RescanPendingFileName);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the walk-restart starvation behind EquiblesCommercial#7163: `StockCusipChangedConsumer` cleared the `ProcessedDataSet` ledger inline, restarting the holdings scraper's multi-hour oldest-first walk from the oldest data set. Identity discoveries (FTD retired-CUSIP and listed-ticker sweeps) fire near-daily, so the walk kept restarting and never reached the newest quarterly data sets — which is why three weeks of identity fixes never healed the current quarters' 13F holes (Vanguard Capital Management's 2026-03-31 book among them).

## Code changes

- `ProcessedDataSet.cs` — new `RescanPendingFileName` (`__rescan-pending__`) sentinel constant documenting the deferred-clear contract.
- `StockCusipChangedConsumer.cs` — no longer clears the ledger; queues the sentinel (idempotent, unique-index race tolerated) and wakes the worker. Events arriving while a rescan is pending coalesce.
- `HoldingsScraperWorker.cs` — new `ApplyPendingCusipRescan` at cycle start: removes the sentinel, clears the real quarterly rows (keeping exactly one backfill guard, adding it if missing), and clears the open filing season's realtime `ProcessedFiling` rows so the realtime sweep re-imports them — the bulk walk can only restate filings a *published* quarterly data set covers, and open-season submissions exist only behind the per-accession ledger (they would otherwise keep pre-discovery holes for months). Chronological re-sweep keeps originals before amendments; the import upserts, so it converges.
- `HoldingsRescanSignal.cs` — doc updated to the queue-then-apply flow.
- Tests: consumer pins rewritten to the queue contract (real rows untouched, sentinel added, signal raised; queued → no-op; mixed guard+rows state), plus new `HoldingsScraperWorkerApplyPendingCusipRescanTests` pinning the apply semantics (ledger cleared/guard kept, guard added when missing, open-season-only `ProcessedFiling` scope, no-op without sentinel).

Verified: solution builds clean; unit suite 4,285/4,285; integration suite 2,558/2,558.