### PR TITLE
fix(insider-trading): current-position row selection, issuer-based Form 144 percent, security titles, 10b5-1 reprocess copy

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -183,12 +183,13 @@ public class InsiderFilingReprocessManager
             }
 
             _logger.LogInformation(
-                "Insider filing reprocess: {Processed}/{Total} filings, reclassified={Reclassified}, repaired={Repaired}, dates corrected={DatesCorrected}, failed={Failed}",
+                "Insider filing reprocess: {Processed}/{Total} filings, reclassified={Reclassified}, repaired={Repaired}, dates corrected={DatesCorrected}, 10b5-1 stamped={Rule10b5Stamped}, failed={Failed}",
                 result.Processed,
                 result.Total,
                 result.Reclassified,
                 result.Repaired,
                 result.DatesCorrected,
+                result.Rule10b5Stamped,
                 result.Failed
             );
 
@@ -306,6 +307,15 @@ public class InsiderFilingReprocessManager
                 {
                     row.TransactionCode = reparsed.TransactionCode;
                     result.Reclassified++;
+                }
+                // Re-copy the Rule 10b5-1 checkbox (parsed since v4, but never copied
+                // here until v7 — so pre-capture rows stayed null through every
+                // reprocess). The parse is authoritative; count actual changes so a
+                // backlog run reports how many rows the copy actually flagged.
+                if (row.IsRule10b5One != reparsed.IsRule10b5One)
+                {
+                    row.IsRule10b5One = reparsed.IsRule10b5One;
+                    result.Rule10b5Stamped++;
                 }
                 // Re-derive footnotes (added in parser v2); cheap to always copy.
                 row.Notes = reparsed.Notes;

--- a/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderFilingReprocessResult.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderFilingReprocessResult.cs
@@ -27,11 +27,16 @@ public class InsiderFilingReprocessResult
     /// <summary>Rows whose implausible transaction date was corrected from source XML.</summary>
     public int DatesCorrected { get; set; }
 
+    /// <summary>Rows whose Rule 10b5-1 checkbox value changed (v7 re-copies it — the v4
+    /// capture parsed it but the reprocess never wrote it, so pre-capture rows stayed
+    /// null).</summary>
+    public int Rule10b5Stamped { get; set; }
+
     /// <summary>Filings that could not be fetched or parsed this run.</summary>
     public int Failed { get; set; }
 
     public string Summary =>
         FormattableString.Invariant(
-            $"Reprocessed {Processed:N0}/{Total:N0} filings ({Fetched:N0} fetched, {Reclassified:N0} rows reclassified, {Repaired:N0} prices repaired, {DatesCorrected:N0} dates corrected, {Failed:N0} failed)."
+            $"Reprocessed {Processed:N0}/{Total:N0} filings ({Fetched:N0} fetched, {Reclassified:N0} rows reclassified, {Repaired:N0} prices repaired, {DatesCorrected:N0} dates corrected, {Rule10b5Stamped:N0} 10b5-1 flags stamped, {Failed:N0} failed)."
         );
 }

--- a/src/Equibles.InsiderTrading.Data/Extensions/InsiderTradingQueryOrderExtensions.cs
+++ b/src/Equibles.InsiderTrading.Data/Extensions/InsiderTradingQueryOrderExtensions.cs
@@ -16,6 +16,26 @@ public static class InsiderTradingQueryOrderExtensions
             .ThenBy(t => t.Id);
     }
 
+    /// <summary>
+    /// The row holding an insider's CURRENT position: newest transaction day, newest
+    /// filing, then the LAST row of that filing (max TransactionOrder) — a multi-row
+    /// Form 4 lists a sequence of same-day transactions whose SharesOwnedAfter are
+    /// intermediate balances, so only the last row is the end-of-day position (#7164,
+    /// EquiblesCommercial). AccessionNumber DESC so that when one day carries several
+    /// filings the later-numbered filing wins, matching the newest-filing intent.
+    /// </summary>
+    public static IOrderedQueryable<InsiderTransaction> OrderCurrentPositionFirst(
+        this IQueryable<InsiderTransaction> query
+    )
+    {
+        return query
+            .OrderByDescending(t => t.TransactionDate)
+            .ThenByDescending(t => t.FilingDate)
+            .ThenByDescending(t => t.AccessionNumber)
+            .ThenByDescending(t => t.TransactionOrder)
+            .ThenByDescending(t => t.Id);
+    }
+
     public static IOrderedQueryable<Form144Filing> OrderNewestFirst(
         this IQueryable<Form144Filing> query
     )

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -35,9 +35,12 @@ public class InsiderTransaction
     /// instead of <see cref="TransactionCode.Other"/>, so the reprocess re-tags
     /// every historical holding row and transaction lists can exclude them; v6
     /// re-derives transaction dates after implausible-date validation was added,
-    /// anchoring source typos to the filing's period of report.
+    /// anchoring source typos to the filing's period of report; v7 re-copies the
+    /// Rule 10b5-1 checkbox during reprocess — the v4 capture parsed it but the
+    /// reprocess copy-loop never wrote it, so pre-capture rows (1.4M checkbox-era
+    /// rows) stayed null (#7164, EquiblesCommercial).
     /// </summary>
-    public const int CurrentParserVersion = 6;
+    public const int CurrentParserVersion = 7;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -195,7 +195,7 @@ public class InsiderTradingTools
                 sb.AppendLine($"Recent insider transactions for {stock.Name} ({stock.Ticker}):");
                 sb.AppendLine($"Showing {transactions.Count} most recent transactions");
                 sb.AppendLine(
-                    "_Shares/Price/Value are as filed; Owned After is the post-transaction balance restated onto today's split basis. Balances are tracked per security kind and ownership form (see Security/Ownership), not as one running total per insider. 10b5-1 '-' means the filing predates the 2023 checkbox._"
+                    "_Shares/Price/Value are as filed; Owned After is the post-transaction balance restated onto today's split basis. Security is the filed security title (kind when the filing names none) — balances are tracked per security and ownership form (see Security/Ownership), not as one running total per insider, so an issuer with several listed securities (e.g. ordinary shares and ADS) shows separate balances. 10b5-1 '-' means the filing predates the 2023 checkbox._"
                 );
                 sb.AppendLine();
                 sb.AppendLine(
@@ -232,7 +232,14 @@ public class InsiderTradingTools
                             false => "No",
                             null => "-",
                         };
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(ownedAfter)} | {t.SecurityKind.NameForHumans()} | {t.OwnershipNature.NameForHumans()} | {plan} |";
+                        // The filed security title distinguishes several securities of the
+                        // same kind (e.g. TSM common shares vs ADS); the kind is the
+                        // fallback when a filing names no title.
+                        var security = MarkdownTable.EscapeCell(
+                            t.SecurityTitle,
+                            t.SecurityKind.NameForHumans()
+                        );
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(ownedAfter)} | {security} | {t.OwnershipNature.NameForHumans()} | {plan} |";
                     }
                 );
 
@@ -256,7 +263,7 @@ public class InsiderTradingTools
         ReadOnly = true
     )]
     [Description(
-        "Get a summary of insider ownership for a stock, ranked by shares held. Each row is as-of that insider's most recent SEC Form 3/4/5 filing (former insiders may linger with stale dates or zero shares), and share counts are restated onto today's split basis, so they can differ from the raw figures in older filings. Returns at most maxResults insiders (default 30). Use this to understand the insider ownership structure of a company; use GetInsiderTransactions for the underlying trades."
+        "Get a summary of insider ownership for a stock, ranked by shares held. Shares Owned is each insider's actual-share (non-derivative) position — options and other derivative holdings are excluded. Each row is as-of the last line of that insider's most recent SEC Form 3/4/5 filing (former insiders may linger with stale dates or zero shares), and share counts are restated onto today's split basis, so they can differ from the raw figures in older filings. Returns at most maxResults insiders (default 30). Use this to understand the insider ownership structure of a company; use GetInsiderTransactions for the underlying trades."
     )]
     public Task<string> GetInsiderOwnership(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -279,18 +286,27 @@ public class InsiderTradingTools
 
                 maxResults = McpLimit.Clamp(maxResults);
 
-                var byStock = _transactionRepository.GetByStock(stock);
+                // An ownership summary's Shares Owned must come from the non-derivative
+                // (actual shares) table — an options/derivative row is a different balance,
+                // and the pre-v6 "no securities owned" sentinels (SecurityKind Unknown) are
+                // zero positions by construction.
+                var byStock = _transactionRepository
+                    .GetByStock(stock)
+                    .Where(t => t.SecurityKind == InsiderSecurityKind.NonDerivative);
 
-                // One row per insider (their latest filing). Materialize them ALL before
-                // ranking: each row sits on its own split basis, and cutting on the raw
-                // counts would under-rank insiders whose last filing predates a large split
-                // (pre-split counts are smaller until restated).
-                var newestByStock = byStock.OrderNewestFirst();
+                // One row per insider — the LAST row of their newest filing, which carries
+                // the end-of-day balance (earlier rows of a multi-row Form 4 are intermediate
+                // balances). Materialize them ALL before ranking: each row sits on its own
+                // split basis, and cutting on the raw counts would under-rank insiders whose
+                // last filing predates a large split (pre-split counts are smaller until
+                // restated).
+                var currentByStock = byStock.OrderCurrentPositionFirst();
                 var latestTransactions = await _transactionRepository
                     .GetByStockWithOwner(stock)
+                    .Where(t => t.SecurityKind == InsiderSecurityKind.NonDerivative)
                     .Where(t =>
                         t.Id
-                        == newestByStock
+                        == currentByStock
                             .Where(t2 => t2.InsiderOwnerId == t.InsiderOwnerId)
                             .Select(t2 => t2.Id)
                             .First()
@@ -328,7 +344,7 @@ public class InsiderTradingTools
                 sb.AppendLine($"Insider ownership summary for {stock.Name} ({stock.Ticker}):");
                 sb.AppendLine($"Showing {ranked.Count} insiders with most recent data");
                 sb.AppendLine(
-                    "_Each row is as-of that insider's most recent filing; Shares Owned is restated onto today's split basis. Former insiders may linger with stale dates or zero shares._"
+                    "_Each row is as-of that insider's most recent filing; Shares Owned is the actual-share (non-derivative) end-of-filing balance restated onto today's split basis. Former insiders may linger with stale dates or zero shares._"
                 );
                 sb.AppendLine();
                 sb.AppendLine("| Insider | Role | Shares Owned | Last Transaction | Last Date |");
@@ -374,7 +390,7 @@ public class InsiderTradingTools
         ReadOnly = true
     )]
     [Description(
-        "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the proposed sale as a share of shares outstanding, the approximate sale date, the broker, and the filer's remarks (including any stated 10b5-1 plan). Results are the most recent notices first and a note flags when more exist than were returned; use fromDate/toDate to scope a period (heavy 10b5-1 filers can flood the recency window with small daily notices). Use this to anticipate upcoming insider selling before it shows up as an executed Form 4."
+        "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the proposed sale as a share of the issuer's current shares outstanding, the approximate sale date, the broker, and the filer's remarks (including any stated 10b5-1 plan). Results are the most recent notices first and a note flags when more exist than were returned; use fromDate/toDate to scope a period (heavy 10b5-1 filers can flood the recency window with small daily notices). Use this to anticipate upcoming insider selling before it shows up as an executed Form 4."
     )]
     public Task<string> GetProposedSales(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -429,8 +445,13 @@ public class InsiderTradingTools
                 // Each Form 144 is an as-filed notice: the proposed Shares pair with the
                 // notice's own Aggregate Market Value, so both stay exactly as reported. The
                 // list is ordered by filing date, not by an adjusted quantity, so a filed share
-                // count is never compared across a split here. % Outstanding likewise divides
-                // two figures reported on the same notice, so it is split-consistent per row.
+                // count is never compared across a split here. % Outstanding divides by the
+                // ISSUER record's share count, not the notice's own field — filers sometimes
+                // type their sale count into noOfUnitsOutstanding, which rendered absurd
+                // "100% of outstanding" figures (#7164, EquiblesCommercial). The filed share
+                // count is restated onto today's split basis first so the ratio compares like
+                // with like against the current issuer count.
+                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
                 var result = MarkdownTable.Start(
                     $"Recent proposed sales (Form 144) for {stock.Name} ({stock.Ticker}):",
                     $"Showing {filings.Count} of {totalCount} most recent notices",
@@ -448,7 +469,15 @@ public class InsiderTradingTools
                         // Remarks is where a filer states the sale runs under a 10b5-1 plan, which
                         // is the difference between pre-scheduled and discretionary selling. Keep
                         // the complete filed text — a plan disclosure can occur at the end.
-                        return $"| {f.FilingDate:yyyy-MM-dd} | {MarkdownTable.EscapeCell(f.SellerName, "-")} | {MarkdownTable.EscapeCell(f.RelationshipToIssuer, "-")} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {FormatPercentOfOutstanding(f.SharesToBeSold, f.SharesOutstanding)} | {approxSaleDate} | {MarkdownTable.EscapeCell(f.BrokerName, "-")} | {MarkdownTable.EscapeCell(f.Remarks, "-")} |";
+                        var percentOfOutstanding = FormatPercentOfOutstanding(
+                            SplitAdjustment.AdjustShareCount(
+                                f.SharesToBeSold,
+                                f.FilingDate,
+                                splits
+                            ),
+                            stock.SharesOutStanding
+                        );
+                        return $"| {f.FilingDate:yyyy-MM-dd} | {MarkdownTable.EscapeCell(f.SellerName, "-")} | {MarkdownTable.EscapeCell(f.RelationshipToIssuer, "-")} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {percentOfOutstanding} | {approxSaleDate} | {MarkdownTable.EscapeCell(f.BrokerName, "-")} | {MarkdownTable.EscapeCell(f.Remarks, "-")} |";
                     }
                 );
 
@@ -466,8 +495,9 @@ public class InsiderTradingTools
         );
     }
 
-    // The standard Form 144 materiality signal: the proposed sale as a share of the notice's own
-    // reported shares outstanding. "-" when the filing reported no share count.
+    // The standard Form 144 materiality signal: the proposed sale as a share of the ISSUER
+    // record's shares outstanding (the notice's own noOfUnitsOutstanding field is not trusted —
+    // filers sometimes type their sale count there). "-" when the issuer share count is unknown.
     private static string FormatPercentOfOutstanding(long sharesToBeSold, long sharesOutstanding)
     {
         if (sharesOutstanding <= 0)
@@ -517,7 +547,7 @@ public class InsiderTradingTools
                 // tools are keyed on.
                 var ownerIds = insiders.Select(i => i.Id).ToList();
                 var byOwners = _transactionRepository.GetByOwnerIds(ownerIds);
-                var newestByOwners = byOwners.OrderNewestFirst();
+                var newestByOwners = byOwners.OrderCurrentPositionFirst();
                 var latestByOwner = (
                     await byOwners
                         .Where(t =>

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRule10b5StampTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRule10b5StampTests.cs
@@ -1,0 +1,162 @@
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+using FileContent = Equibles.Media.Data.Models.FileContent;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+/// <summary>
+/// Pins the v7 reprocess contract: the copy-loop re-copies the Rule 10b5-1
+/// checkbox from the re-parsed row. The v4 parser captured the checkbox for
+/// fresh ingests, but the reprocess copy-loop never wrote it, so every
+/// checkbox-era row ingested before the capture stayed null through the v4-v6
+/// sweeps (#7164, EquiblesCommercial).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InsiderFilingReprocessManagerRule10b5StampTests : ParadeDbMcpTestBase
+{
+    public InsiderFilingReprocessManagerRule10b5StampTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Run_V6RowWithCheckedBoxInCachedXml_StampsIsRule10b5One()
+    {
+        var reportDate = new DateOnly(2024, 6, 14);
+        var filingDate = new DateOnly(2024, 6, 17);
+        var accession = "0000320193-24-000002";
+
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0001",
+            Name = "Jane Insider",
+            City = "Cupertino",
+            StateOrCountry = "CA",
+            IsDirector = true,
+        };
+
+        // A v6 row whose filing carried the checked 10b5-1 box, ingested before the
+        // v4 capture: the checkbox is null in the store even though the cached XML
+        // has it. Every field except the flag is already correct.
+        var stale = new InsiderTransaction
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            InsiderOwnerId = owner.Id,
+            AccessionNumber = accession,
+            TransactionOrder = 0,
+            FilingDate = filingDate,
+            TransactionDate = reportDate,
+            TransactionCode = TransactionCode.Sale,
+            Shares = 1000,
+            PricePerShare = 55m,
+            ReportedPricePerShare = 55m,
+            AcquiredDisposed = AcquiredDisposed.Disposed,
+            SharesOwnedAfter = 5000,
+            OwnershipNature = OwnershipNature.Direct,
+            SecurityTitle = "Common Stock",
+            SecurityKind = InsiderSecurityKind.NonDerivative,
+            IsRule10b5One = null,
+            ParserVersion = 6,
+        };
+
+        // aff10b5One is a direct value element on the document root (EDGAR 23.1),
+        // not wrapped in <value> like the transaction fields.
+        var ownershipXml =
+            "<ownershipDocument>"
+            + "<periodOfReport>2024-06-14</periodOfReport>"
+            + "<aff10b5One>1</aff10b5One>"
+            + "<nonDerivativeTable><nonDerivativeTransaction>"
+            + "<securityTitle><value>Common Stock</value></securityTitle>"
+            + "<transactionDate><value>2024-06-14</value></transactionDate>"
+            + "<transactionCoding><transactionCode>S</transactionCode></transactionCoding>"
+            + "<transactionAmounts>"
+            + "<transactionShares><value>1000</value></transactionShares>"
+            + "<transactionPricePerShare><value>55</value></transactionPricePerShare>"
+            + "<transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>"
+            + "</transactionAmounts>"
+            + "<postTransactionAmounts><sharesOwnedFollowingTransaction><value>5000</value>"
+            + "</sharesOwnedFollowingTransaction></postTransactionAmounts>"
+            + "</nonDerivativeTransaction></nonDerivativeTable>"
+            + "</ownershipDocument>";
+        var rawBytes = Encoding.UTF8.GetBytes(ownershipXml);
+        var filing = new InsiderFiling
+        {
+            AccessionNumber = accession,
+            CaptureStatus = InsiderFilingCaptureStatus.Captured,
+            UncompressedSize = rawBytes.Length,
+            Content = new File
+            {
+                Name = accession,
+                Extension = "gz",
+                ContentType = "application/gzip",
+                FileContent = new FileContent { Bytes = GzipCompressor.Compress(rawBytes) },
+            },
+        };
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        DbContext.Add(
+            new DailyStockPrice
+            {
+                CommonStockId = stock.Id,
+                Date = reportDate,
+                Close = 55m,
+            }
+        );
+        DbContext.Add(stale);
+        DbContext.Add(filing);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var edgar = Substitute.For<ISecEdgarClient>();
+        var fileManager = InsiderReprocessTestSupport.NewFileManager();
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runCtx),
+            new InsiderFilingRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            edgar,
+            fileManager,
+            runCtx,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Total.Should().Be(1);
+        result.Processed.Should().Be(1);
+        result.Rule10b5Stamped.Should().Be(1);
+        result.Failed.Should().Be(0);
+        // Served entirely from the cached blob — no EDGAR round-trip.
+        result.Fetched.Should().Be(0);
+        await edgar.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
+
+        await using var verify = Fixture.CreateDbContext();
+        var reprocessed = await verify.Set<InsiderTransaction>().FindAsync(stale.Id);
+        reprocessed!.IsRule10b5One.Should().BeTrue();
+        reprocessed.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
@@ -1,6 +1,8 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.InsiderTrading.Data;
@@ -21,6 +23,9 @@ public class Form144ProposedSalesToolTests : IDisposable
     {
         _dbContext = TestDbContextFactory.Create(
             new CommonStocksModuleConfiguration(),
+            // GetProposedSales restates the percent numerator onto today's split
+            // basis, so the tool now reads StockSplit rows.
+            new CorporateActionsModuleConfiguration(),
             new InsiderTradingModuleConfiguration()
         );
         _tools = new InsiderTradingTools(
@@ -36,7 +41,11 @@ public class Form144ProposedSalesToolTests : IDisposable
 
     public void Dispose() => _dbContext.Dispose();
 
-    private CommonStock SeedStock(string ticker = "AAPL", string cik = "0000320193")
+    private CommonStock SeedStock(
+        string ticker = "AAPL",
+        string cik = "0000320193",
+        long sharesOutstanding = 0
+    )
     {
         var stock = new CommonStock
         {
@@ -44,6 +53,7 @@ public class Form144ProposedSalesToolTests : IDisposable
             Ticker = ticker,
             Name = "Apple Inc.",
             Cik = cik,
+            SharesOutStanding = sharesOutstanding,
         };
         _dbContext.Set<CommonStock>().Add(stock);
         _dbContext.SaveChanges();
@@ -194,33 +204,69 @@ public class Form144ProposedSalesToolTests : IDisposable
     }
 
     [Fact]
-    public async Task GetProposedSales_RendersPercentOfSharesOutstanding()
+    public async Task GetProposedSales_RendersPercentOfIssuerSharesOutstanding()
     {
-        var stock = SeedStock();
+        var stock = SeedStock(sharesOutstanding: 2_000_000_000);
         var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1_000_000);
+        // Filer typed their own sale count into noOfUnitsOutstanding (the MSFT
+        // "100% of outstanding" bug, #7164 EquiblesCommercial) — the notice's field
+        // must NOT be the denominator.
+        filing.SharesOutstanding = 1_000_000;
+        _dbContext.Set<Form144Filing>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        // 1,000,000 / 2,000,000,000 (the issuer record's share count) = 0.05%.
+        result.Should().Contain("% Outstanding");
+        result.Should().Contain("| 0.05% |");
+        result.Should().NotContain("| 100% |");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_NoIssuerShareCount_RendersDash()
+    {
+        // Issuer record carries no share count — serve "-" rather than trusting the
+        // notice's self-reported field.
+        var stock = SeedStock(sharesOutstanding: 0);
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1000);
         filing.SharesOutstanding = 2_000_000_000;
         _dbContext.Set<Form144Filing>().Add(filing);
         await _dbContext.SaveChangesAsync();
 
         var result = await _tools.GetProposedSales("AAPL");
 
-        // 1,000,000 / 2,000,000,000 = 0.05% — the notice's own share base, as filed.
-        result.Should().Contain("% Outstanding");
-        result.Should().Contain("| 0.05% |");
+        result.Should().Contain("| - |");
     }
 
     [Fact]
-    public async Task GetProposedSales_NoSharesOutstandingOnNotice_RendersDash()
+    public async Task GetProposedSales_NoticeBeforeSplit_PercentUsesTheSplitAdjustedShareCount()
     {
-        var stock = SeedStock();
-        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 1000);
-        filing.SharesOutstanding = 0;
+        // The filed share count sits on the pre-split basis while the issuer record's
+        // count is current — restate the numerator so the ratio compares like with like
+        // (10,000 pre-split shares = 100,000 post-split ÷ 2,000,000,000 = 0.005%).
+        var stock = SeedStock(sharesOutstanding: 2_000_000_000);
+        _dbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStockId = stock.Id,
+                    EffectiveDate = new DateOnly(2026, 3, 1),
+                    Numerator = 10,
+                    Denominator = 1,
+                    Source = StockSplitSource.Yahoo,
+                }
+            );
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2026, 1, 5), "ALICE", 10_000);
         _dbContext.Set<Form144Filing>().Add(filing);
         await _dbContext.SaveChangesAsync();
 
         var result = await _tools.GetProposedSales("AAPL");
 
-        result.Should().Contain("| - |");
+        // The Shares column stays as filed; only the percent numerator is restated.
+        result.Should().Contain("| 10,000 |");
+        result.Should().Contain("| 0.005% |");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests.cs
@@ -64,6 +64,7 @@ public class InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests : Para
             OwnershipNature = OwnershipNature.Direct,
             SecurityTitle = "Common Stock",
             AccessionNumber = "0001234567-24-000001",
+            SecurityKind = InsiderSecurityKind.NonDerivative,
         };
         DbContext.Set<CommonStock>().Add(stock);
         DbContext.Set<InsiderOwner>().Add(owner);

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -75,11 +75,13 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
         AcquiredDisposed acquiredDisposed = AcquiredDisposed.Acquired,
         long sharesOwnedAfter = 5000,
         string securityTitle = "Common Stock",
-        string accessionNumber = "0001234567-24-000001"
+        string accessionNumber = "0001234567-24-000001",
+        InsiderSecurityKind securityKind = InsiderSecurityKind.NonDerivative
     )
     {
         return new InsiderTransaction
         {
+            SecurityKind = securityKind,
             CommonStockId = stock.Id,
             CommonStock = stock,
             InsiderOwnerId = owner.Id,

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs
@@ -41,6 +41,7 @@ public class InsiderFilingReprocessResultSummaryCultureInvarianceTests
             Reclassified = 3456,
             Repaired = 7890,
             DatesCorrected = 6789,
+            Rule10b5Stamped = 4321,
             Failed = 2345,
         };
 
@@ -53,7 +54,8 @@ public class InsiderFilingReprocessResultSummaryCultureInvarianceTests
                 .Summary.Should()
                 .Be(
                     "Reprocessed 1,234/5,678 filings (9,012 fetched, 3,456 rows reclassified, "
-                        + "7,890 prices repaired, 6,789 dates corrected, 2,345 failed).",
+                        + "7,890 prices repaired, 6,789 dates corrected, 4,321 10b5-1 flags stamped, "
+                        + "2,345 failed).",
                     "log helpers in this repo are culture-invariant (cf. BaseScraperWorker.FormatInterval, "
                         + "FactMarkdown.Value); a non-invariant group separator forks operator log output by host locale"
                 );

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipRankingTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipRankingTests.cs
@@ -73,7 +73,9 @@ public class InsiderTradingToolsOwnershipRankingTests
         DateOnly transactionDate,
         long sharesOwnedAfter,
         string accessionNumber,
-        TransactionCode code = TransactionCode.Sale
+        TransactionCode code = TransactionCode.Sale,
+        int transactionOrder = 0,
+        InsiderSecurityKind securityKind = InsiderSecurityKind.NonDerivative
     ) =>
         new()
         {
@@ -91,6 +93,8 @@ public class InsiderTradingToolsOwnershipRankingTests
             OwnershipNature = OwnershipNature.Direct,
             SecurityTitle = "Common Stock",
             AccessionNumber = accessionNumber,
+            TransactionOrder = transactionOrder,
+            SecurityKind = securityKind,
         };
 
     [Fact]
@@ -157,6 +161,128 @@ public class InsiderTradingToolsOwnershipRankingTests
         output.Should().Contain("Pre Split Holder");
         output.Should().Contain("3,443,200");
         output.Should().NotContain("Post Split Holder");
+    }
+
+    [Fact]
+    public async Task GetInsiderOwnership_MultiRowFiling_UsesTheLastRowsEndOfDayBalance()
+    {
+        // A multi-row Form 4 lists a SEQUENCE of same-day transactions whose
+        // SharesOwnedAfter are intermediate balances — only the last row (max
+        // TransactionOrder) is the end-of-day position. The old OrderNewestFirst pick
+        // (TransactionOrder ASC) returned the FIRST row, publishing an intermediate
+        // balance as the insider's current position (#7164, EquiblesCommercial).
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var owner = new InsiderOwner
+        {
+            OwnerCik = "0000000041",
+            Name = "Sequential Seller",
+            IsDirector = true,
+        };
+        db.AddRange(stock, owner);
+        // Older filing that must NOT win.
+        db.Add(
+            NewTransaction(
+                stock,
+                owner,
+                new DateOnly(2024, 1, 10),
+                sharesOwnedAfter: 500,
+                accessionNumber: "acc-old-1"
+            )
+        );
+        // Same-day 3-row filing: 100 → 50 → 10; the end-of-day position is 10.
+        foreach (var (balance, order) in new (long, int)[] { (100, 0), (50, 1), (10, 2) })
+        {
+            db.Add(
+                NewTransaction(
+                    stock,
+                    owner,
+                    new DateOnly(2024, 6, 3),
+                    sharesOwnedAfter: balance,
+                    accessionNumber: "acc-new-1",
+                    transactionOrder: order
+                )
+            );
+        }
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("MSFT");
+
+        output.Should().Contain("| Sequential Seller | Director | 10 |");
+        output.Should().NotContain("| 100 |");
+        output.Should().NotContain("| 50 |");
+        output.Should().NotContain("| 500 |");
+    }
+
+    [Fact]
+    public async Task GetInsiderOwnership_DerivativeRows_NeverCarryTheSharesOwnedBalance()
+    {
+        // Shares Owned must come from the non-derivative (actual shares) table. A newer
+        // derivative row (an option grant's running balance) must not displace the
+        // actual-share position, and a derivative-only insider has no share position to
+        // report.
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "TSM",
+            Name = "Taiwan Semiconductor",
+            Cik = "0001046179",
+        };
+        var mixed = new InsiderOwner
+        {
+            OwnerCik = "0000000051",
+            Name = "Mixed Holder",
+            IsDirector = true,
+        };
+        var derivativeOnly = new InsiderOwner
+        {
+            OwnerCik = "0000000052",
+            Name = "Options Only Holder",
+            IsDirector = true,
+        };
+        db.AddRange(stock, mixed, derivativeOnly);
+        db.Add(
+            NewTransaction(
+                stock,
+                mixed,
+                new DateOnly(2024, 5, 1),
+                sharesOwnedAfter: 7_000,
+                accessionNumber: "acc-mixed-nd"
+            )
+        );
+        // Newer derivative row for the same insider — must not become the position.
+        db.Add(
+            NewTransaction(
+                stock,
+                mixed,
+                new DateOnly(2024, 6, 1),
+                sharesOwnedAfter: 99_999,
+                accessionNumber: "acc-mixed-d",
+                securityKind: InsiderSecurityKind.Derivative
+            )
+        );
+        db.Add(
+            NewTransaction(
+                stock,
+                derivativeOnly,
+                new DateOnly(2024, 6, 1),
+                sharesOwnedAfter: 12_345,
+                accessionNumber: "acc-deriv-only",
+                securityKind: InsiderSecurityKind.Derivative
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("TSM");
+
+        output.Should().Contain("| Mixed Holder | Director | 7,000 |");
+        output.Should().NotContain("99,999");
+        output.Should().NotContain("Options Only Holder");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes the OSS half of EquiblesCommercial#7164 — four defects in the insider-trading surfaces.

## 1. Insider ownership picked an intermediate/arbitrary row (HIGH)

The per-insider "current position" pick used `OrderNewestFirst()` + `.First()`, whose `TransactionOrder ASC` tiebreak returns the FIRST row of a multi-row Form 4 — an INTERMEDIATE post-transaction balance — and, for multi-security filings, an arbitrary security's row.

- New `OrderCurrentPositionFirst()` in `InsiderTradingQueryOrderExtensions`: `TransactionDate DESC, FilingDate DESC, AccessionNumber DESC, TransactionOrder DESC, Id DESC` — the LAST row of the newest filing is the end-of-day position. `AccessionNumber DESC` so the later-numbered filing wins when one day carries several.
- `GetInsiderOwnership` additionally scopes candidates to `SecurityKind == NonDerivative` (both the subquery and the outer set): an ownership summary's Shares Owned must come from the actual-shares table, never an options/derivative balance.
- `SearchInsiders`' latest-affiliation lookup switches to the same ordering (no kind scope — it names a company, not a position; scoping would erase affiliations for derivative-only filers).

**Unknown-kind exclusion is safe (verified on prod, 2026-08-12):** all rows sit at ParserVersion 6; the only rows with `SecurityKind = Unknown` are 35,927 "No Securities Owned" Form 3 sentinels — zero positions by construction. Visible behavior change: an insider whose only filing is a no-securities Form 3 now disappears from the ownership table instead of showing a zero row.

## 2. Form 144 "% Outstanding: 100%" (HIGH)

`Form144Filing.SharesOutstanding` is parsed verbatim from the notice's `noOfUnitsOutstanding`, and filers sometimes type their own sale count there (MSFT, Numoto Takeshi 2026-08-04: 6,444 == sharesToBeSold → rendered 100% of outstanding). `GetProposedSales` now divides by the ISSUER record's `CommonStock.SharesOutStanding`; the stored as-filed value is untouched.

Deviation from the plan, deliberate: the filed share count is restated onto today's split basis (`SplitAdjustment.AdjustShareCount(f.SharesToBeSold, f.FilingDate, splits)`) before dividing. The as-filed numerator over the CURRENT issuer count would be off by the split factor for any notice filed before a split (e.g. a pre-June-2024 NVDA notice would read 10x low). "-" when the issuer count is unknown (<= 0).

The portal's `_ProposedSalesTab` displays no percent and no outstanding count — left unchanged.

## 3. Indistinguishable securities under one ticker (HIGH)

`GetInsiderTransactions`' Security column rendered only the kind (Non-derivative/Derivative), so two different non-derivative securities (TSM common shares vs ADS) were indistinguishable. The column now renders the filed `SecurityTitle` with the kind as fallback when a filing names none; legend updated.

## 4. Rule 10b5-1 flag missing on all pre-capture rows (MEDIUM)

`InsiderFilingReprocessManager`'s copy-loop copied dates, kinds, codes and notes from the re-parsed row but never `IsRule10b5One`, so the v4 capture only ever reached freshly-ingested filings. Verified on prod: **1,428,639** checkbox-era rows (FilingDate >= 2023-07-01) still null at v6.

- The copy-loop now re-copies `IsRule10b5One`, counting actual changes in a new `Rule10b5Stamped` result counter (Summary + log line updated).
- `CurrentParserVersion` bumped 6 → 7 with the version history documented; the routine reprocess sweep delivers the backfill (cached-XML reads — v6 cached every filing, `Fetched` stays ~0).

Other fields the copy-loop does not copy, left deliberately: `Shares`, `SharesOwnedAfter`, `AcquiredDisposed`, `OwnershipNature`, `SecurityTitle`, `IsAmendment` (captured since initial ingest — no version ever changed them), `OriginalFilingDate` (drives supersession; backfilling it mid-sweep is out of scope), and the price fields (they go through `InsiderTransactionPriceValidator` by design).

## Tests

- `dotnet build Equibles.sln -c Release` — 0 errors.
- `dotnet test tests/Equibles.UnitTests --no-build -c Release` — **4293 passed, 0 failed** (new: multi-row-filing end-of-day pick, derivative-row exclusion; updated: reprocess Summary culture pin).
- `dotnet test tests/Equibles.IntegrationTests --no-build -c Release` — **2560 passed, 0 failed** (new: `InsiderFilingReprocessManagerRule10b5StampTests` — v6 row + cached `aff10b5One=1` → row true at v7; Form 144 issuer-denominator, dash-on-unknown-count and split-adjusted-numerator pins).
- Changed files formatted with the pinned csharpier.

The commercial repo consumes these changes via a follow-up submodule pin bump; its paired PR (insider REST/ALVIS surfaces) depends on this landing first.
