### PR TITLE
fix(financial-facts): one shared revenue-breakdown lane with per-partner cross-cut roll-up

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/ArithmeticRollupMembers.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/ArithmeticRollupMembers.cs
@@ -1,0 +1,146 @@
+using System.Numerics;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
+
+// Drops arithmetic ROLLUP members from a pivoted breakdown axis — members that duplicate
+// other members' revenue as a subtotal (INTC tags a combined "CCG + DCAI + NEX" member
+// ALONGSIDE its components; AAPL tags the parent us-gaap:ProductMember alongside its four
+// product lines), so every consumer that sums the axis double-counts.
+// CollapseOverlappingSchemes can't catch this shape: the rollup plus the leftover members
+// never partition into two full-total subsets, so the period is left untouched and the
+// subtotal lingers.
+//
+// Detection is ARITHMETIC PROOF, never name matching:
+// a member is a rollup only when
+//   - EVERY period it reports is EXACTLY equal — on the raw tagged values — to the sum
+//     of two or more other members' same-period values, across at least
+//     MinimumEvidencePeriods periods (a single exactly-matching period is not evidence;
+//     round-figure coincidence is real), AND
+//   - at least one component SUBSET recurs across MinimumEvidencePeriods periods. The
+//     recurring subtotal is what an issuer actually tags; two periods each explained
+//     only by a DIFFERENT ad-hoc subset is the signature of coincidence on a
+//     round-valued axis, not of a rollup. Other periods may still match a different
+//     subset — reorganisations move components between years (Intel's combined member
+//     equals CCG+DCAI+NEX in FY2022 and CCG+DCAI from FY2023 on, exact in all four
+//     years, so {CCG, DCAI} recurs three times).
+// One unexplained period keeps the member (a real segment that coincidentally matched
+// once). A member with any non-positive reported period is never a rollup, and
+// non-positive values never count as subset components — segment subtotals are sums of
+// positive revenue, and admitting zeros would flag any member that merely duplicates
+// another's value. Conservative consequence: an axis carrying an eliminations member
+// inside the subtotal's component set is never collapsed.
+public static class ArithmeticRollupMembers
+{
+    // How many exactly-explained periods — and recurrences of one component subset —
+    // a member needs before it is dropped as a rollup.
+    public const int MinimumEvidencePeriods = 2;
+
+    // Combinatorial guard: the subset search is exhaustive over the other members, so
+    // past this many members the axis is returned unfiltered. Breakdown axes carry well
+    // under this in practice (filers tag 3–10 members).
+    public const int MaxSearchMembers = 12;
+
+    // The axis's members minus arithmetic rollups. Order preserved; the input list is
+    // never mutated. Below three members no subtotal-plus-two-components shape exists.
+    public static List<AxisMemberSeries> Filter(List<AxisMemberSeries> members)
+    {
+        if (members.Count < 3 || members.Count > MaxSearchMembers)
+        {
+            return members;
+        }
+        return members.Where(m => !IsArithmeticRollup(m, members)).ToList();
+    }
+
+    private static bool IsArithmeticRollup(
+        AxisMemberSeries member,
+        IReadOnlyList<AxisMemberSeries> allMembers
+    )
+    {
+        var reported = Enumerable
+            .Range(0, member.Values.Count)
+            .Where(i => member.Values[i].HasValue)
+            .ToList();
+        if (reported.Count < MinimumEvidencePeriods)
+        {
+            return false;
+        }
+
+        // Component subsets are identified by a bitmask over the axis's member list, so
+        // the same subset found in different periods counts as one recurring subtotal.
+        var subsetPeriods = new Dictionary<int, int>();
+        foreach (var index in reported)
+        {
+            var target = member.Values[index].Value;
+            if (target <= 0)
+            {
+                return false;
+            }
+
+            var components = new List<(int MemberIndex, decimal Value)>();
+            for (var other = 0; other < allMembers.Count; other++)
+            {
+                if (ReferenceEquals(allMembers[other], member))
+                {
+                    continue;
+                }
+                var value =
+                    index < allMembers[other].Values.Count ? allMembers[other].Values[index] : null;
+                if (value is > 0)
+                {
+                    components.Add((other, value.Value));
+                }
+            }
+
+            var matches = ExactSubsetMasks(components, target);
+            if (matches.Count == 0)
+            {
+                return false;
+            }
+            foreach (var mask in matches)
+            {
+                subsetPeriods[mask] = subsetPeriods.GetValueOrDefault(mask) + 1;
+            }
+        }
+
+        return subsetPeriods.Values.Any(periods => periods >= MinimumEvidencePeriods);
+    }
+
+    // Every subset of two or more values summing exactly to the target, each returned
+    // as a bitmask over the axis's member indexes. Exhaustive bitmask search — a few
+    // thousand combinations at most under MaxSearchMembers. The local bound makes the
+    // shift safety self-contained: C# masks shift counts, so without it a raised
+    // MaxSearchMembers would silently turn the loop off instead of overflowing loudly.
+    private static List<int> ExactSubsetMasks(
+        IReadOnlyList<(int MemberIndex, decimal Value)> components,
+        decimal target
+    )
+    {
+        var masks = new List<int>();
+        if (components.Count < 2 || components.Count >= MaxSearchMembers)
+        {
+            return masks;
+        }
+        for (var subset = 1; subset < 1 << components.Count; subset++)
+        {
+            if (BitOperations.PopCount((uint)subset) < 2)
+            {
+                continue;
+            }
+            var sum = 0m;
+            var memberMask = 0;
+            for (var bit = 0; bit < components.Count; bit++)
+            {
+                if ((subset & (1 << bit)) != 0)
+                {
+                    sum += components[bit].Value;
+                    memberMask |= 1 << components[bit].MemberIndex;
+                }
+            }
+            if (sum == target)
+            {
+                masks.Add(memberMask);
+            }
+        }
+        return masks;
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/AxisMemberSeries.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/AxisMemberSeries.cs
@@ -1,0 +1,19 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
+
+/// <summary>
+/// One member row of a pivoted axis: the representative member QName (latest-filed
+/// spelling of its fold group), a humanized label, and one value per period column
+/// (null where the member did not report). <see cref="PeriodStarts"/> parallels
+/// <see cref="Values"/> with each cell's exact duration start, for joins that must not
+/// pair same-end/different-span facts.
+/// </summary>
+public sealed record AxisMemberSeries(
+    string Member,
+    string Label,
+    List<decimal?> Values,
+    List<DateOnly?> PeriodStarts = null
+)
+{
+    public DateOnly? PeriodStartAt(int index) =>
+        PeriodStarts != null && index < PeriodStarts.Count ? PeriodStarts[index] : null;
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/AxisSeries.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/AxisSeries.cs
@@ -1,0 +1,11 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
+
+/// <summary>
+/// One breakdown axis pivoted into period-end columns (oldest first) × member rows, in a
+/// single pinned unit. An axis with no members means the company reports nothing on it.
+/// </summary>
+public sealed record AxisSeries(
+    string Unit,
+    List<DateOnly> PeriodEnds,
+    List<AxisMemberSeries> Members
+);

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/CrossCutRevenueRow.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/CrossCutRevenueRow.cs
@@ -1,0 +1,20 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
+
+/// <summary>
+/// One TWO-dimensional revenue fact (a cross-cut such as product × segment). Filers can
+/// move a disaggregation to two-dimensional tagging entirely, leaving an axis family with
+/// no single-axis facts; the roll-up in
+/// <see cref="RevenueBreakdownCore.RollUpCrossCuts"/> reconstructs the family from these.
+/// </summary>
+public sealed record CrossCutRevenueRow(
+    string AxisA,
+    string MemberA,
+    string AxisB,
+    string MemberB,
+    DateOnly PeriodEnd,
+    decimal Value,
+    string Unit,
+    DateOnly FiledDate,
+    DateOnly? PeriodStart = null,
+    int FiscalYear = 0
+);

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/DimensionalRevenueRow.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/DimensionalRevenueRow.cs
@@ -1,0 +1,19 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
+
+/// <summary>
+/// One single-axis dimensional revenue (or segment income) fact, projected for the
+/// revenue-breakdown selection. <paramref name="PeriodStart"/> keeps the exact duration
+/// so a downstream ratio cannot join same-end/different-span facts;
+/// <paramref name="FiscalYear"/> carries the filer's own period stamp for consumers that
+/// label columns by fiscal year.
+/// </summary>
+public sealed record DimensionalRevenueRow(
+    string Axis,
+    string Member,
+    DateOnly PeriodEnd,
+    decimal Value,
+    string Unit,
+    DateOnly FiledDate,
+    DateOnly? PeriodStart = null,
+    int FiscalYear = 0
+);

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/RevenueBreakdownCore.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/RevenueBreakdownCore.cs
@@ -1,0 +1,723 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
+
+/// <summary>
+/// The ONE selection lane for revenue disaggregated by business segment, geography and
+/// product/service from dimensional XBRL facts. Every surface serving a revenue
+/// breakdown — the MCP tool, the commercial REST endpoint and the portal — must build
+/// its member sets and values through this class, so the transports can never disagree
+/// on what a company's segments are (EquiblesCommercial#7166). Consumers keep their own
+/// queries and rendering; the selection rules live here.
+/// </summary>
+public static class RevenueBreakdownCore
+{
+    // Issuers moved geography/product from us-gaap to the srt taxonomy in 2018; both
+    // QNames identify the same axis, so each bucket accepts both spellings.
+    public static readonly string[] SegmentAxes = ["us-gaap:StatementBusinessSegmentsAxis"];
+    public static readonly string[] GeographyAxes =
+    [
+        "srt:StatementGeographicalAxis",
+        "us-gaap:StatementGeographicalAxis",
+    ];
+    public static readonly string[] ProductAxes =
+    [
+        "srt:ProductOrServiceAxis",
+        "us-gaap:ProductOrServiceAxis",
+    ];
+    public static readonly string[] AllAxes = [.. SegmentAxes, .. GeographyAxes, .. ProductAxes];
+
+    // The canonical family order — used only to break ties deterministically when two
+    // partner families score identically in the cross-cut roll-up.
+    public static readonly string[][] AxisFamilies = [SegmentAxes, GeographyAxes, ProductAxes];
+
+    // srt:ConsolidationItemsAxis = us-gaap:OperatingSegmentsMember is a transparent
+    // qualifier ("this figure is a pure operating-segment total"), not a second slice of
+    // the value. A fact carrying it alongside one real axis still partitions total revenue,
+    // so it must not be discarded as a cross-cut. Issuers such as Apple tag every operating
+    // segment this way from FY2025 on, which otherwise drops the latest fiscal year (#3628).
+    public const string ConsolidationItemsAxis = "srt:ConsolidationItemsAxis";
+    public const string OperatingSegmentsMember = "us-gaap:OperatingSegmentsMember";
+
+    // How close a member set must sum to consolidated total revenue to count as a
+    // complete re-disaggregation (see ReconcileToTotal). Half a percent absorbs
+    // rounding and minor unit scaling without admitting a partial amendment.
+    public const decimal ReconciliationTolerance = 0.005m;
+
+    // Combinatorial guards for the overlapping-scheme collapse (see FindFullTotalPartition).
+    // Three independent bounds, each with its own job:
+    //  - MaxCollapseMembers = 31 keeps every index inside the 32 bits the subset bitmasks
+    //    address — past 32 members `1 << i` aliases (the shift count wraps) and the cover
+    //    search degenerated into a non-terminating loop. 31 deliberately does NOT try to
+    //    bound cost: a 13-20-member axis is cheap to search and collapsing it is
+    //    load-bearing (#3897 double-count), so a tighter cap would silently re-open that
+    //    bug there.
+    //  - MaxSubsetSearchNodes is the cost bound. Node count ≤ 2^members, so from ~18
+    //    near-equal members the enumeration can pass 200k nodes; the budget stops it in
+    //    bounded time regardless of shape, and an exhausted budget discards the
+    //    (incomplete) result.
+    //  - MaxCoverSubsets bounds the cover search's input. ≤ 2^12 keeps FindBestCover no
+    //    worse than it ever was under the search's original "well under 15 members"
+    //    assumption; a genuine overlap yields a handful of full-total subsets.
+    private const int MaxCollapseMembers = 31;
+    private const int MaxSubsetSearchNodes = 200_000;
+    private const int MaxCoverSubsets = 4_096;
+
+    /// <summary>
+    /// Rolls TWO-dimensional cross-cut facts up onto one axis family, ONLY for periods
+    /// where the family has no single-axis cut (a reported single-axis disaggregation
+    /// always beats a derived roll-up). Filers can move a cut to two-dimensional tagging
+    /// entirely (SoFi tags every product fact product × segment from FY2023; XOM tags
+    /// segments and geographies only in cross-cuts after its 2022 reorganisation), which
+    /// the single-axis query rightly excludes — without the roll-up those axes freeze at
+    /// the last single-axis fiscal year.
+    ///
+    /// The roll-up NEVER mixes partner families: a member's legs are summed over exactly
+    /// one partner axis family per period. Summing legs from several partner families
+    /// counts the same revenue once per family — XOM's geography axis published ~2.34×
+    /// consolidated revenue that way (product×geo legs plus geo×segment legs both
+    /// credited to each country; EquiblesCommercial#7166). One partner family is chosen
+    /// per (period, unit): the family whose member sum reconciles best against the
+    /// consolidated totals — reconciling within tolerance wins outright, otherwise the
+    /// smallest relative deviation; ties break on more members (the more granular view),
+    /// then canonical family order. Per (member, partner-member) the latest-filed leg
+    /// wins before the sum — the standard restatement rule — and the rolled row carries
+    /// the newest leg's filing date with the smallest leg fiscal year as its identity.
+    /// </summary>
+    public static List<DimensionalRevenueRow> RollUpCrossCuts(
+        IReadOnlyList<CrossCutRevenueRow> crossCuts,
+        string[] family,
+        IReadOnlyList<DimensionalRevenueRow> singleAxisRows,
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
+    )
+    {
+        var coveredPeriods = singleAxisRows
+            .Where(r => family.Contains(r.Axis))
+            .Select(r => r.PeriodEnd)
+            .ToHashSet();
+
+        // Orient each cross-cut: exactly one side on the requested family, the other on a
+        // DIFFERENT family (a cross-cut inside one family would double-count it).
+        var oriented = crossCuts
+            .Select(c =>
+                family.Contains(c.AxisA) && !family.Contains(c.AxisB)
+                    ? new
+                    {
+                        OwnAxis = c.AxisA,
+                        OwnMember = c.MemberA,
+                        OtherAxis = c.AxisB,
+                        OtherMember = c.MemberB,
+                        Row = c,
+                    }
+                : family.Contains(c.AxisB) && !family.Contains(c.AxisA)
+                    ? new
+                    {
+                        OwnAxis = c.AxisB,
+                        OwnMember = c.MemberB,
+                        OtherAxis = c.AxisA,
+                        OtherMember = c.MemberA,
+                        Row = c,
+                    }
+                : null
+            )
+            .Where(c => c != null && !coveredPeriods.Contains(c.Row.PeriodEnd))
+            .Select(c => new
+            {
+                c.OwnAxis,
+                c.OwnMember,
+                c.OtherAxis,
+                c.OtherMember,
+                c.Row,
+                PartnerFamily = PartnerFamilyIndex(c.OtherAxis),
+            })
+            .Where(c => c.PartnerFamily >= 0)
+            .ToList();
+
+        var result = new List<DimensionalRevenueRow>();
+        foreach (var periodGroup in oriented.GroupBy(c => (c.Row.PeriodEnd, c.Row.Unit)))
+        {
+            // One rolled candidate per partner family present in this period.
+            var candidates = periodGroup
+                .GroupBy(c => c.PartnerFamily)
+                .Select(fg => new
+                {
+                    Family = fg.Key,
+                    Rows = fg.GroupBy(c => (c.OwnAxis, c.OwnMember))
+                        .Select(mg =>
+                        {
+                            var legs = mg.GroupBy(c => (c.OtherAxis, c.OtherMember))
+                                .Select(leg =>
+                                    leg.OrderByDescending(c => c.Row.FiledDate).First().Row
+                                )
+                                .ToList();
+                            return new DimensionalRevenueRow(
+                                mg.Key.OwnAxis,
+                                mg.Key.OwnMember,
+                                periodGroup.Key.PeriodEnd,
+                                legs.Sum(l => l.Value),
+                                periodGroup.Key.Unit,
+                                legs.Max(l => l.FiledDate),
+                                legs.Min(l => l.PeriodStart),
+                                legs.Min(l => l.FiscalYear)
+                            );
+                        })
+                        .ToList(),
+                })
+                .ToList();
+
+            var totalCandidates = totals.TryGetValue(periodGroup.Key, out var totalsForPeriod)
+                ? totalsForPeriod
+                : [];
+            var best = candidates
+                .OrderBy(c => ReconciliationScore(c.Rows.Sum(r => r.Value), totalCandidates))
+                .ThenByDescending(c => c.Rows.Count)
+                .ThenBy(c => c.Family)
+                .First();
+            result.AddRange(best.Rows);
+        }
+        return result;
+    }
+
+    // The index of the family an axis belongs to, -1 for an unknown axis. Drives the
+    // per-partner grouping and the deterministic tie-break in RollUpCrossCuts.
+    private static int PartnerFamilyIndex(string axis)
+    {
+        for (var i = 0; i < AxisFamilies.Length; i++)
+        {
+            if (AxisFamilies[i].Contains(axis))
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    // Relative deviation of a candidate member sum from its NEAREST consolidated total —
+    // the roll-up's selection metric. No totals to compare against scores worst, so a
+    // validated candidate always beats an unvalidatable one.
+    private static decimal ReconciliationScore(decimal sum, IReadOnlyList<decimal> totals)
+    {
+        var best = decimal.MaxValue;
+        foreach (var total in totals)
+        {
+            if (total == 0m)
+            {
+                continue;
+            }
+            var deviation = Math.Abs(sum - total) / Math.Abs(total);
+            if (deviation < best)
+            {
+                best = deviation;
+            }
+        }
+        return best;
+    }
+
+    /// <summary>
+    /// Resolve the surviving (member, period) facts for one axis, one row per cell — all
+    /// in a single pinned unit. The default rule keeps the latest-filed fact per
+    /// (member, period) — correct for a restatement that re-reports a member with a new
+    /// value. It is wrong when a later filing instead *drops* a member it has
+    /// reclassified away (NVDA's Singapore, AMD's Japan/Europe, KO/CAT renames): nothing
+    /// supersedes the dropped member, so it lingers from the older filing and the axis
+    /// double-counts it.
+    ///
+    /// The fix is arithmetic, not pattern-matching: for each period, if the latest
+    /// filing's own members already reconcile to a consolidated total revenue (in the
+    /// same unit), that filing is a complete re-disaggregation — use only its members
+    /// and discard anything carried over from older filings. Otherwise the latest filing
+    /// only restated some members (a partial amendment), so fall back to the
+    /// latest-filed-per-member merge that carries un-amended members forward.
+    /// </summary>
+    public static List<DimensionalRevenueRow> ReconcileToTotal(
+        IEnumerable<DimensionalRevenueRow> axisRowsInUnit,
+        string unit,
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
+    )
+    {
+        var result = new List<DimensionalRevenueRow>();
+        foreach (var period in axisRowsInUnit.GroupBy(r => r.PeriodEnd))
+        {
+            var latestFiled = period.Max(r => r.FiledDate);
+            var latestFiling = period.Where(r => r.FiledDate == latestFiled).ToList();
+            var latestSum = latestFiling.Sum(r => r.Value);
+
+            // Compared against the consolidated total in the SAME unit as the pinned
+            // members. Several revenue concepts may each report a total; the members
+            // complete the period if they reconcile to any one of them (e.g. ASC 606
+            // revenue vs. total Revenues).
+            var candidates = totals.TryGetValue((period.Key, unit), out var totalsForPeriod)
+                ? totalsForPeriod
+                : [];
+            var complete = candidates.Any(total =>
+                total != 0m
+                && Math.Abs(latestSum - total) <= Math.Abs(total) * ReconciliationTolerance
+            );
+
+            List<DimensionalRevenueRow> periodRows;
+            if (complete)
+            {
+                // Latest filing re-disaggregates the whole period — keep only its members,
+                // collapsing any duplicate member within the same filing to its first fact.
+                periodRows = latestFiling.GroupBy(r => r.Member).Select(g => g.First()).ToList();
+            }
+            else
+            {
+                // Partial amendment — latest-filed fact wins per member, older members
+                // carried.
+                periodRows = period
+                    .GroupBy(r => r.Member)
+                    .Select(g => g.OrderByDescending(r => r.FiledDate).First())
+                    .ToList();
+            }
+
+            // An issuer can tag two overlapping disaggregation schemes on the same axis
+            // in one filing (e.g. a regional partition AND a by-country partition), each
+            // summing to consolidated total revenue. Both survive the merge above, so the
+            // axis would show ~2x actual revenue (#3897). Collapse to one scheme when the
+            // members partition cleanly into 2+ full-total subsets; otherwise leave the
+            // period untouched.
+            result.AddRange(CollapseOverlappingSchemes(periodRows, candidates));
+        }
+        return result;
+    }
+
+    // When the members of one period partition into 2+ DISJOINT subsets that EACH
+    // reconcile to a consolidated total revenue (with no member left over), the issuer
+    // tagged multiple overlapping schemes on the same axis. Keep only the MOST GRANULAR
+    // full-total subset (the most members — the most informative view); every full-total
+    // subset is individually correct, so this only chooses which correct view to show,
+    // never alters a number.
+    //
+    // Pure arithmetic, no member-name matching. The guard is strict: act only when the
+    // members FULLY partition into >=2 disjoint full-total subsets. A single scheme, or a
+    // partial overlap with no clean second full-total subset, is left unchanged — nothing
+    // is dropped.
+    private static List<DimensionalRevenueRow> CollapseOverlappingSchemes(
+        List<DimensionalRevenueRow> periodRows,
+        IReadOnlyList<decimal> candidates
+    )
+    {
+        if (periodRows.Count < 2)
+        {
+            return periodRows;
+        }
+
+        foreach (var total in candidates.Where(t => t != 0m).Distinct())
+        {
+            var tolerance = Math.Abs(total) * ReconciliationTolerance;
+
+            // Skip the trivial case where the whole member set already equals the total —
+            // that is one scheme, not an overlap of two.
+            if (Math.Abs(periodRows.Sum(r => r.Value) - total) <= tolerance)
+            {
+                continue;
+            }
+
+            var partition = FindFullTotalPartition(periodRows, total, tolerance);
+            if (partition != null && partition.Count >= 2)
+            {
+                // Keep the most granular subset; ties broken by the larger summed value,
+                // then a stable member ordering, so the choice is deterministic.
+                return partition
+                    .OrderByDescending(subset => subset.Count)
+                    .ThenByDescending(subset => subset.Sum(r => r.Value))
+                    .ThenBy(subset => string.Join("|", subset.Select(r => r.Member).Order()))
+                    .First();
+            }
+        }
+
+        return periodRows;
+    }
+
+    // Partition the members into disjoint subsets that each sum to `total` (within
+    // tolerance), covering every member exactly once. Returns the cover that minimises
+    // the total deviation from `total` across its subsets — so the genuine schemes (each
+    // summing to the exact consolidated figure) win over a tolerance-admitted near-miss
+    // that stitches members from different schemes together. Returns null when no full
+    // cover exists (not a clean overlap) or when any combinatorial bound trips — the
+    // period then passes through exactly as reported, the search's existing fail-safe.
+    private static List<List<DimensionalRevenueRow>> FindFullTotalPartition(
+        List<DimensionalRevenueRow> periodRows,
+        decimal total,
+        decimal tolerance
+    )
+    {
+        // Bitmask-width guard: 31 keeps every index inside the 32 bits the masks address.
+        if (periodRows.Count > MaxCollapseMembers)
+        {
+            return null;
+        }
+
+        // Order once so every subset and the final cover are produced deterministically.
+        var members = periodRows
+            .OrderByDescending(r => r.Value)
+            .ThenBy(r => r.Member, StringComparer.Ordinal)
+            .ToList();
+
+        // All subsets summing to total within tolerance, each as a bitmask over
+        // `members`. The subset-count cap keeps the cover search's input no larger than
+        // it ever was under the original assumption; a genuine overlap yields a handful
+        // of full-total subsets.
+        var fullTotalSubsets = new List<(int Mask, decimal Deviation)>();
+        var budget = MaxSubsetSearchNodes;
+        EnumerateFullTotalSubsets(
+            members,
+            0,
+            0,
+            0m,
+            total,
+            tolerance,
+            fullTotalSubsets,
+            ref budget
+        );
+        if (fullTotalSubsets.Count == 0 || budget <= 0 || fullTotalSubsets.Count > MaxCoverSubsets)
+        {
+            return null;
+        }
+
+        var (bestMasks, found) = FindBestCover(members.Count, fullTotalSubsets);
+        if (!found)
+        {
+            return null;
+        }
+
+        return bestMasks
+            .Select(mask =>
+                Enumerable
+                    .Range(0, members.Count)
+                    .Where(i => (mask & (1 << i)) != 0)
+                    .Select(i => members[i])
+                    .ToList()
+            )
+            .ToList();
+    }
+
+    // Depth-first enumeration of every subset of members[startIndex..] whose running sum
+    // reaches `total` within tolerance, recorded as a bitmask plus its absolute deviation
+    // from total.
+    //
+    // `budget` counts down the visited nodes across the whole recursion: a set of
+    // near-equal members can explore a large share of 2^n even under the member cap, so
+    // the budget stops the walk in bounded time regardless of shape. An exhausted budget
+    // means the enumeration is incomplete, so the caller must discard the result rather
+    // than act on a partial list.
+    private static void EnumerateFullTotalSubsets(
+        List<DimensionalRevenueRow> members,
+        int startIndex,
+        int mask,
+        decimal sum,
+        decimal total,
+        decimal tolerance,
+        List<(int Mask, decimal Deviation)> output,
+        ref int budget
+    )
+    {
+        if (budget <= 0)
+        {
+            return;
+        }
+        budget--;
+
+        if (mask != 0 && Math.Abs(sum - total) <= tolerance)
+        {
+            output.Add((mask, Math.Abs(sum - total)));
+            // A superset only adds positive values, moving further from total — so stop
+            // here. Negative members (segment operating losses) can under-enumerate past
+            // this prune, which only ever SKIPS a collapse — any partition returned still
+            // passes the full-total checks, so a wrong collapse remains impossible.
+            return;
+        }
+        if (sum - total > tolerance)
+        {
+            return;
+        }
+
+        for (var i = startIndex; i < members.Count; i++)
+        {
+            EnumerateFullTotalSubsets(
+                members,
+                i + 1,
+                mask | (1 << i),
+                sum + members[i].Value,
+                total,
+                tolerance,
+                output,
+                ref budget
+            );
+            if (budget <= 0)
+            {
+                return;
+            }
+        }
+    }
+
+    // Choose the disjoint cover of all members (each index used once) built from the
+    // full-total subsets, minimising summed deviation, then preferring more subsets.
+    // Anchors each step on the lowest uncovered index so the search is forced and
+    // bounded.
+    private static (List<int> Masks, bool Found) FindBestCover(
+        int memberCount,
+        List<(int Mask, decimal Deviation)> subsets
+    )
+    {
+        var allCovered = (1 << memberCount) - 1;
+        List<int> best = null;
+        var bestDeviation = decimal.MaxValue;
+
+        void Search(int covered, List<int> chosen, decimal deviation)
+        {
+            if (deviation >= bestDeviation)
+            {
+                return;
+            }
+            if (covered == allCovered)
+            {
+                if (
+                    best == null
+                    || deviation < bestDeviation
+                    || (deviation == bestDeviation && chosen.Count > best.Count)
+                )
+                {
+                    best = [.. chosen];
+                    bestDeviation = deviation;
+                }
+                return;
+            }
+
+            var anchor = 0;
+            while ((covered & (1 << anchor)) != 0)
+            {
+                anchor++;
+            }
+
+            foreach (var (mask, dev) in subsets)
+            {
+                if ((mask & (1 << anchor)) != 0 && (mask & covered) == 0)
+                {
+                    chosen.Add(mask);
+                    Search(covered | mask, chosen, deviation + dev);
+                    chosen.RemoveAt(chosen.Count - 1);
+                }
+            }
+        }
+
+        Search(0, [], 0m);
+        return (best ?? [], best != null);
+    }
+
+    /// <summary>
+    /// Pivot one axis's rows into period-end columns (oldest first) × member rows, all in
+    /// a single pinned unit (the latest-filed fact's, so a reporting-currency change
+    /// can't mix currencies in one series). Filings re-report comparative prior years, so
+    /// the latest-filed fact wins per (member, period-end); ReconcileToTotal runs on the
+    /// single-unit rows first. Members merge under the XbrlMemberNames fold — an issuer
+    /// respelling its own extension QName across filings (amd:DatacenterMember /
+    /// amd:DataCenterMember) otherwise splits one member into two half-series — with the
+    /// latest-filed spelling fronting the merged series. Arithmetic rollup members
+    /// (subtotals an issuer tags ALONGSIDE their components — INTC's combined
+    /// "CCG + DCAI + NEX", AAPL's parent Product line) are dropped last: they escape
+    /// CollapseOverlappingSchemes because the subtotal plus the leftover members never
+    /// partition into two full-total subsets, and the proof needs the same member's
+    /// values across periods, so it runs on the pivoted members.
+    /// </summary>
+    public static AxisSeries BuildAxisSeries(
+        List<DimensionalRevenueRow> rows,
+        string[] axes,
+        int maxYears,
+        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
+    )
+    {
+        var axisRows = rows.Where(r => axes.Contains(r.Axis)).ToList();
+        if (axisRows.Count == 0)
+        {
+            return new AxisSeries(null, [], []);
+        }
+
+        // Pin the unit first (latest-filed fact's unit) so the reconciliation sum and the
+        // consolidated total are always in the same currency.
+        var unit = axisRows.OrderByDescending(r => r.FiledDate).First().Unit;
+        var inUnit = axisRows.Where(r => r.Unit == unit);
+        var current = ReconcileToTotal(inUnit, unit, totals);
+        if (current.Count == 0)
+        {
+            return new AxisSeries(null, [], []);
+        }
+
+        var periodEnds = current
+            .Select(r => r.PeriodEnd)
+            .Distinct()
+            .OrderByDescending(d => d)
+            .Take(maxYears)
+            .OrderBy(d => d)
+            .ToList();
+
+        var latest = periodEnds[^1];
+        var members = current
+            .GroupBy(r => XbrlMemberNames.Fold(r.Member), StringComparer.Ordinal)
+            .Select(g => new
+            {
+                Key = g.OrderByDescending(r => r.FiledDate)
+                    .ThenByDescending(r => r.PeriodEnd)
+                    .First()
+                    .Member,
+                ByPeriod = g.GroupBy(r => r.PeriodEnd)
+                    .ToDictionary(
+                        pg => pg.Key,
+                        pg => pg.OrderByDescending(r => r.FiledDate).First()
+                    ),
+            })
+            .Select(m => new
+            {
+                m.Key,
+                Latest = m.ByPeriod.TryGetValue(latest, out var latestRow)
+                    ? latestRow.Value
+                    : (decimal?)null,
+                Values = periodEnds
+                    .Select(p =>
+                        m.ByPeriod.TryGetValue(p, out var row) ? row.Value : (decimal?)null
+                    )
+                    .ToList(),
+                PeriodStarts = periodEnds
+                    .Select(p =>
+                        m.ByPeriod.TryGetValue(p, out var row) ? row.PeriodStart : (DateOnly?)null
+                    )
+                    .ToList(),
+            })
+            .Where(m => m.Values.Any(v => v.HasValue))
+            .OrderByDescending(m => m.Latest ?? decimal.MinValue)
+            .ThenBy(m => m.Key)
+            .Select(m => new AxisMemberSeries(m.Key, Humanize(m.Key), m.Values, m.PeriodStarts))
+            .ToList();
+
+        return new AxisSeries(unit, periodEnds, ArithmeticRollupMembers.Filter(members));
+    }
+
+    /// <summary>
+    /// The derived margin axis: join the revenue and operating-income segment series by
+    /// issuer member QName (under the fold), exact duration, and unit — never by display
+    /// label or row position. Reported figures only: a missing leg or a non-positive
+    /// revenue denominator yields no cell, and members/periods with no computable cell
+    /// drop out entirely.
+    /// </summary>
+    public static AxisSeries BuildSegmentMarginSeries(AxisSeries revenue, AxisSeries income)
+    {
+        if (
+            revenue.Members.Count == 0
+            || income.Members.Count == 0
+            || !string.Equals(revenue.Unit, income.Unit, StringComparison.Ordinal)
+        )
+        {
+            return new AxisSeries("%", [], []);
+        }
+
+        var incomeByMember = income
+            .Members.GroupBy(m => XbrlMemberNames.Fold(m.Member), StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+        var incomePeriodIndex = income
+            .PeriodEnds.Select((periodEnd, index) => (periodEnd, index))
+            .ToDictionary(p => p.periodEnd, p => p.index);
+
+        var members = new List<AxisMemberSeries>();
+        var usedPeriods = new bool[revenue.PeriodEnds.Count];
+        foreach (var revenueMember in revenue.Members)
+        {
+            if (
+                !incomeByMember.TryGetValue(
+                    XbrlMemberNames.Fold(revenueMember.Member),
+                    out var incomeMember
+                )
+            )
+            {
+                continue;
+            }
+
+            var values = new List<decimal?>();
+            var any = false;
+            for (var i = 0; i < revenue.PeriodEnds.Count; i++)
+            {
+                decimal? margin = null;
+                if (
+                    incomePeriodIndex.TryGetValue(revenue.PeriodEnds[i], out var incomeIndex)
+                    && revenueMember.PeriodStartAt(i) == incomeMember.PeriodStartAt(incomeIndex)
+                    && revenueMember.Values[i] is { } revenueValue
+                    && revenueValue > 0m
+                    && incomeMember.Values[incomeIndex] is { } incomeValue
+                )
+                {
+                    margin = incomeValue / revenueValue * 100m;
+                    any = true;
+                    usedPeriods[i] = true;
+                }
+                values.Add(margin);
+            }
+
+            if (any)
+            {
+                members.Add(
+                    new AxisMemberSeries(revenueMember.Member, revenueMember.Label, values)
+                );
+            }
+        }
+
+        if (members.Count == 0)
+        {
+            return new AxisSeries("%", [], []);
+        }
+
+        var keptIndexes = Enumerable
+            .Range(0, revenue.PeriodEnds.Count)
+            .Where(i => usedPeriods[i])
+            .ToList();
+        return new AxisSeries(
+            "%",
+            keptIndexes.Select(i => revenue.PeriodEnds[i]).ToList(),
+            members
+                .Select(m => new AxisMemberSeries(
+                    m.Member,
+                    m.Label,
+                    keptIndexes.Select(i => m.Values[i]).ToList(),
+                    keptIndexes.Select(i => m.PeriodStartAt(i)).ToList()
+                ))
+                .ToList()
+        );
+    }
+
+    /// <summary>
+    /// Display label from the XBRL member QName: ISO country members get their English
+    /// name; everything else drops the Member suffix and spaces the PascalCase local
+    /// name.
+    /// </summary>
+    public static string Humanize(string memberQName)
+    {
+        var colon = memberQName.IndexOf(':');
+        var prefix = colon > 0 ? memberQName[..colon] : "";
+        var local = colon > 0 ? memberQName[(colon + 1)..] : memberQName;
+
+        if (prefix == "country")
+        {
+            try
+            {
+                return new RegionInfo(local).EnglishName;
+            }
+            catch (ArgumentException)
+            {
+                return local;
+            }
+        }
+
+        if (local.EndsWith("Member", StringComparison.Ordinal) && local.Length > "Member".Length)
+        {
+            local = local[..^"Member".Length];
+        }
+        // The (?<!^[A-Z]) guard keeps a lone leading capital attached to the word
+        // that follows: Apple's IPhoneMember reads "IPhone", never "I Phone".
+        // Boundaries deeper in the name still split ("USSegment" → "US Segment").
+        return Regex.Replace(
+            local,
+            "(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?<!^[A-Z])(?=[A-Z][a-z])",
+            " "
+        );
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/XbrlMemberNames.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/XbrlMemberNames.cs
@@ -1,0 +1,39 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
+
+/// <summary>
+/// The one folding rule for comparing issuer XBRL extension member QNames: lowercase +
+/// strip underscores. Issuers respell their own extension names across their own filings
+/// (amd:DatacenterMember in every 10-K, amd:DataCenterMember in every 10-Q); comparing
+/// ordinally splits one member into two half-series. The fold deliberately does NOT touch
+/// digits (us-gaap:...Amount1 is a genuinely distinct element), plurals or typos, and it
+/// keeps the namespace prefix, so two issuers' equal-looking local names never merge.
+/// Standard-taxonomy names have exactly one spelling corpus-wide, so literal comparisons
+/// against standard names (axis lists, alias tags) stay ordinal on purpose.
+/// </summary>
+public static class XbrlMemberNames
+{
+    public static string Fold(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+        return name.Replace("_", "").ToLowerInvariant();
+    }
+
+    /// <summary>Equality under the fold, for GroupBy/ToDictionary over member strings.</summary>
+    public static readonly IEqualityComparer<string> Comparer = new FoldEqualityComparer();
+
+    private sealed class FoldEqualityComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string x, string y)
+        {
+            return string.Equals(Fold(x), Fold(y), StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(string obj)
+        {
+            return (Fold(obj) ?? string.Empty).GetHashCode();
+        }
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Equibles.Sec.FinancialFacts.Mcp.csproj
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Equibles.Sec.FinancialFacts.Mcp.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
     <ProjectReference Include="..\Equibles.Mcp\Equibles.Mcp.csproj" />
+    <ProjectReference Include="..\Equibles.Sec.FinancialFacts.BusinessLogic\Equibles.Sec.FinancialFacts.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Repositories\Equibles.Sec.FinancialFacts.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/RevenueBreakdownTools.cs
@@ -1,7 +1,5 @@
 using System.ComponentModel;
-using System.Globalization;
 using System.Text;
-using System.Text.RegularExpressions;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
@@ -9,6 +7,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Mcp;
 using Equibles.Mcp.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Statements;
 using Equibles.Sec.FinancialFacts.Mcp.Helpers;
@@ -19,37 +18,13 @@ using ModelContextProtocol.Server;
 
 namespace Equibles.Sec.FinancialFacts.Mcp.Tools;
 
+// Selection rules (axes, reconciliation, cross-cut roll-up, member fold, rollup-member
+// filter) live in RevenueBreakdownCore — the ONE lane shared with the commercial REST
+// endpoint and portal, so the transports can never disagree on a company's member sets
+// (EquiblesCommercial#7166). This class owns only the queries and the markdown rendering.
 [McpServerToolType]
 public class RevenueBreakdownTools
 {
-    // Issuers moved geography/product from us-gaap to the srt taxonomy in 2018; both
-    // QNames identify the same axis, so each bucket accepts both spellings.
-    private static readonly string[] SegmentAxes = ["us-gaap:StatementBusinessSegmentsAxis"];
-    private static readonly string[] GeographyAxes =
-    [
-        "srt:StatementGeographicalAxis",
-        "us-gaap:StatementGeographicalAxis",
-    ];
-    private static readonly string[] ProductAxes =
-    [
-        "srt:ProductOrServiceAxis",
-        "us-gaap:ProductOrServiceAxis",
-    ];
-    private static readonly string[] AllAxes = [.. SegmentAxes, .. GeographyAxes, .. ProductAxes];
-
-    // srt:ConsolidationItemsAxis = us-gaap:OperatingSegmentsMember is a transparent
-    // qualifier ("this figure is a pure operating-segment total"), not a second slice of
-    // the value. A fact carrying it alongside one real axis still partitions total revenue,
-    // so it must not be discarded as a cross-cut. Issuers such as Apple tag every operating
-    // segment this way from FY2025 on, which otherwise drops the latest fiscal year (#3628).
-    private const string ConsolidationItemsAxis = "srt:ConsolidationItemsAxis";
-    private const string OperatingSegmentsMember = "us-gaap:OperatingSegmentsMember";
-
-    // How close the latest filing's members must sum to consolidated total revenue to count
-    // as a complete re-disaggregation (see ReconcileToTotal). Half a percent absorbs
-    // rounding and minor unit scaling without admitting a partial amendment.
-    private const decimal ReconciliationTolerance = 0.005m;
-
     private const int DefaultYears = 8;
     private const int MaxYearsCap = 12;
 
@@ -134,47 +109,18 @@ public class RevenueBreakdownTools
                     .ToDictionary(c => c.Id, c => priorityByPair[(c.Taxonomy, c.Tag)]);
                 var conceptIds = priorityById.Keys.ToList();
 
-                // Annual revenue facts carrying exactly one dimension on a known axis.
-                // Cross-cut facts (e.g. segment × geography) are excluded — including
-                // them in a single-axis mix would double-count the revenue they slice.
-                // The OperatingSegments qualifier (see above) is the one allowed extra
-                // dimension: it tags the fact as a pure segment total without slicing it.
-                var rows = await _financialFactRepository
-                    .GetByStock(stock)
-                    .Where(f =>
-                        conceptIds.Contains(f.FinancialConceptId)
-                        && f.PeriodType == FactPeriodType.Duration
-                        && f.PeriodStart.AddDays(FiscalPeriodSpanDays.MinAnnualSpanDays)
-                            <= f.PeriodEnd
-                        && f.PeriodStart.AddDays(FiscalPeriodSpanDays.MaxAnnualSpanDays)
-                            >= f.PeriodEnd
-                        && f.DimensionsKey != ""
-                        && f.Dimensions.Count(d => AllAxes.Contains(d.Axis)) == 1
-                        && f.Dimensions.All(d =>
-                            AllAxes.Contains(d.Axis)
-                            || (
-                                d.Axis == ConsolidationItemsAxis
-                                && d.Member == OperatingSegmentsMember
-                            )
-                        )
-                    )
-                    .Select(f => new DimensionalRevenueRow(
-                        f.Dimensions.First(d => AllAxes.Contains(d.Axis)).Axis,
-                        f.Dimensions.First(d => AllAxes.Contains(d.Axis)).Member,
-                        f.PeriodEnd,
-                        f.Value,
-                        f.Unit,
-                        f.FiledDate,
-                        f.PeriodStart
-                    ))
-                    .ToListAsync();
+                var rows = await LoadSingleAxisRows(
+                    stock,
+                    conceptIds,
+                    RevenueBreakdownCore.AllAxes
+                );
 
                 // Consolidated (no-dimension) total revenue — the figure each axis's members
                 // must add up to, used to detect a complete re-disaggregation so a member a
-                // later filing drops doesn't linger (see ReconcileToTotal). Several revenue
-                // concepts can be tagged (e.g. Revenues plus the ASC 606 tag), so we keep one
-                // candidate total per (period, unit, concept) — latest-filed wins — and the
-                // members need only reconcile to any one of them.
+                // later filing drops doesn't linger (see RevenueBreakdownCore.ReconcileToTotal).
+                // Several revenue concepts can be tagged (e.g. Revenues plus the ASC 606 tag),
+                // so we keep one candidate total per (period, unit, concept) — latest-filed
+                // wins — and the members need only reconcile to any one of them.
                 var consolidated = await _financialFactRepository
                     .GetConsolidatedByStock(stock)
                     .Where(f =>
@@ -206,6 +152,22 @@ public class RevenueBreakdownTools
                                     )
                                     .ToList()
                     );
+
+                // Filers can move a cut to TWO-dimensional tagging entirely (SoFi tags every
+                // product fact product × segment from FY2023; XOM tags segments and
+                // geographies only in cross-cuts after its 2022 reorganisation) — the
+                // single-axis query rightly excludes those as cross-cuts, which froze the
+                // axis at the last single-axis fiscal year. Roll the cross-cuts up per axis
+                // family, only for periods with no single-axis cut; the core picks ONE
+                // partner family per period against the consolidated totals so the same
+                // revenue is never counted once per partner axis.
+                var crossCuts = await LoadCrossCutRows(stock, conceptIds);
+                foreach (var family in RevenueBreakdownCore.AxisFamilies)
+                {
+                    rows.AddRange(
+                        RevenueBreakdownCore.RollUpCrossCuts(crossCuts, family, rows, totals)
+                    );
+                }
 
                 // One display figure per (period, unit) for the tables' total
                 // row: the alias's primary tag wins, then the latest filing —
@@ -245,7 +207,7 @@ public class RevenueBreakdownTools
                         result,
                         "By segment",
                         rows,
-                        SegmentAxes,
+                        RevenueBreakdownCore.SegmentAxes,
                         years,
                         totals,
                         displayTotals
@@ -254,7 +216,7 @@ public class RevenueBreakdownTools
                         result,
                         "By geography",
                         rows,
-                        GeographyAxes,
+                        RevenueBreakdownCore.GeographyAxes,
                         years,
                         totals,
                         displayTotals
@@ -263,7 +225,7 @@ public class RevenueBreakdownTools
                         result,
                         "By product & service",
                         rows,
-                        ProductAxes,
+                        RevenueBreakdownCore.ProductAxes,
                         years,
                         totals,
                         displayTotals
@@ -286,6 +248,102 @@ public class RevenueBreakdownTools
             "GetRevenueBreakdown",
             $"ticker: {FactMarkdown.Clean(ticker)}"
         );
+    }
+
+    // Annual facts carrying exactly one dimension on a requested axis. Cross-cut facts
+    // (e.g. segment × geography) are excluded — including them in a single-axis mix
+    // would double-count the revenue they slice. The OperatingSegments qualifier is the
+    // one allowed extra dimension: it tags the fact as a pure segment total without
+    // slicing it.
+    private async Task<List<DimensionalRevenueRow>> LoadSingleAxisRows(
+        CommonStock stock,
+        List<Guid> conceptIds,
+        string[] axes
+    )
+    {
+        return await _financialFactRepository
+            .GetByStock(stock)
+            .Where(f =>
+                conceptIds.Contains(f.FinancialConceptId)
+                && f.PeriodType == FactPeriodType.Duration
+                && f.PeriodStart.AddDays(FiscalPeriodSpanDays.MinAnnualSpanDays) <= f.PeriodEnd
+                && f.PeriodStart.AddDays(FiscalPeriodSpanDays.MaxAnnualSpanDays) >= f.PeriodEnd
+                && f.DimensionsKey != ""
+                && f.Dimensions.Count(d => axes.Contains(d.Axis)) == 1
+                && f.Dimensions.All(d =>
+                    axes.Contains(d.Axis)
+                    || (
+                        d.Axis == RevenueBreakdownCore.ConsolidationItemsAxis
+                        && d.Member == RevenueBreakdownCore.OperatingSegmentsMember
+                    )
+                )
+            )
+            .Select(f => new DimensionalRevenueRow(
+                f.Dimensions.First(d => axes.Contains(d.Axis)).Axis,
+                f.Dimensions.First(d => axes.Contains(d.Axis)).Member,
+                f.PeriodEnd,
+                f.Value,
+                f.Unit,
+                f.FiledDate,
+                f.PeriodStart,
+                f.FiscalYear
+            ))
+            .ToListAsync();
+    }
+
+    // Annual facts carrying exactly TWO dimensions on known breakdown axes (a cross-cut
+    // like product × segment), qualifier tolerated like the single-axis query.
+    private async Task<List<CrossCutRevenueRow>> LoadCrossCutRows(
+        CommonStock stock,
+        List<Guid> conceptIds
+    )
+    {
+        var facts = await _financialFactRepository
+            .GetByStock(stock)
+            .Where(f =>
+                conceptIds.Contains(f.FinancialConceptId)
+                && f.PeriodType == FactPeriodType.Duration
+                && f.PeriodStart.AddDays(FiscalPeriodSpanDays.MinAnnualSpanDays) <= f.PeriodEnd
+                && f.PeriodStart.AddDays(FiscalPeriodSpanDays.MaxAnnualSpanDays) >= f.PeriodEnd
+                && f.DimensionsKey != ""
+                && f.Dimensions.Count(d => RevenueBreakdownCore.AllAxes.Contains(d.Axis)) == 2
+                && f.Dimensions.All(d =>
+                    RevenueBreakdownCore.AllAxes.Contains(d.Axis)
+                    || (
+                        d.Axis == RevenueBreakdownCore.ConsolidationItemsAxis
+                        && d.Member == RevenueBreakdownCore.OperatingSegmentsMember
+                    )
+                )
+            )
+            .Select(f => new
+            {
+                f.PeriodEnd,
+                f.Value,
+                f.Unit,
+                f.FiledDate,
+                f.PeriodStart,
+                f.FiscalYear,
+                Dims = f
+                    .Dimensions.Where(d => RevenueBreakdownCore.AllAxes.Contains(d.Axis))
+                    .Select(d => new { d.Axis, d.Member })
+                    .ToList(),
+            })
+            .ToListAsync();
+        return facts
+            .Where(f => f.Dims.Count == 2)
+            .Select(f => new CrossCutRevenueRow(
+                f.Dims[0].Axis,
+                f.Dims[0].Member,
+                f.Dims[1].Axis,
+                f.Dims[1].Member,
+                f.PeriodEnd,
+                f.Value,
+                f.Unit,
+                f.FiledDate,
+                f.PeriodStart,
+                f.FiscalYear
+            ))
+            .ToList();
     }
 
     // The profitability view of the segment cut: operating income tagged on the same
@@ -312,30 +370,7 @@ public class RevenueBreakdownTools
         if (conceptIds.Count == 0)
             return false;
 
-        var rows = await _financialFactRepository
-            .GetByStock(stock)
-            .Where(f =>
-                conceptIds.Contains(f.FinancialConceptId)
-                && f.PeriodType == FactPeriodType.Duration
-                && f.PeriodStart.AddDays(FiscalPeriodSpanDays.MinAnnualSpanDays) <= f.PeriodEnd
-                && f.PeriodStart.AddDays(FiscalPeriodSpanDays.MaxAnnualSpanDays) >= f.PeriodEnd
-                && f.DimensionsKey != ""
-                && f.Dimensions.Count(d => SegmentAxes.Contains(d.Axis)) == 1
-                && f.Dimensions.All(d =>
-                    SegmentAxes.Contains(d.Axis)
-                    || (d.Axis == ConsolidationItemsAxis && d.Member == OperatingSegmentsMember)
-                )
-            )
-            .Select(f => new DimensionalRevenueRow(
-                f.Dimensions.First(d => SegmentAxes.Contains(d.Axis)).Axis,
-                f.Dimensions.First(d => SegmentAxes.Contains(d.Axis)).Member,
-                f.PeriodEnd,
-                f.Value,
-                f.Unit,
-                f.FiledDate,
-                f.PeriodStart
-            ))
-            .ToListAsync();
+        var rows = await LoadSingleAxisRows(stock, conceptIds, RevenueBreakdownCore.SegmentAxes);
         if (rows.Count == 0)
             return false;
 
@@ -371,7 +406,12 @@ public class RevenueBreakdownTools
             .GroupBy(f => (f.PeriodEnd, f.Unit))
             .ToDictionary(g => g.Key, g => g.OrderByDescending(f => f.FiledDate).First().Value);
 
-        var incomeSeries = BuildAxisSeries(rows, SegmentAxes, years, totals);
+        var incomeSeries = RevenueBreakdownCore.BuildAxisSeries(
+            rows,
+            RevenueBreakdownCore.SegmentAxes,
+            years,
+            totals
+        );
         if (incomeSeries.Members.Count == 0)
             return false;
 
@@ -379,7 +419,7 @@ public class RevenueBreakdownTools
             result,
             "Segment operating income",
             rows,
-            SegmentAxes,
+            RevenueBreakdownCore.SegmentAxes,
             years,
             totals,
             displayTotals,
@@ -392,8 +432,16 @@ public class RevenueBreakdownTools
                 + "consolidated operating income._"
         );
 
-        var revenueSeries = BuildAxisSeries(revenueRows, SegmentAxes, years, revenueTotals);
-        var marginSeries = BuildSegmentMarginSeries(revenueSeries, incomeSeries);
+        var revenueSeries = RevenueBreakdownCore.BuildAxisSeries(
+            revenueRows,
+            RevenueBreakdownCore.SegmentAxes,
+            years,
+            revenueTotals
+        );
+        var marginSeries = RevenueBreakdownCore.BuildSegmentMarginSeries(
+            revenueSeries,
+            incomeSeries
+        );
         if (marginSeries.Members.Count > 0)
         {
             AppendSeriesTable(result, "Segment operating margin", marginSeries);
@@ -430,7 +478,7 @@ public class RevenueBreakdownTools
         bool checkOverlap = true
     )
     {
-        var series = BuildAxisSeries(rows, axes, maxYears, totals);
+        var series = RevenueBreakdownCore.BuildAxisSeries(rows, axes, maxYears, totals);
         if (series.Members.Count == 0)
             return;
 
@@ -451,11 +499,11 @@ public class RevenueBreakdownTools
             result.AppendLine($"| **{totalLabel}** | " + string.Join(" | ", totalCells) + " |");
 
         // An issuer can tag a parent level alongside its components on the same
-        // axis (AAPL's Product/Service next to iPhone/Mac/iPad; NVDA's Data
-        // Center next to Compute/Networking). Those rows survive the disjoint-
-        // scheme collapse because the schemes share or nest members, so the
-        // column sums to well over consolidated revenue — say so rather than
-        // let a consumer double-count.
+        // axis (XOM's Canada highlight inside Non-US; NVDA's Data Center next to
+        // Compute/Networking). Those rows survive the disjoint-scheme collapse
+        // because the schemes share or nest members, so the column sums to well
+        // over consolidated revenue — say so rather than let a consumer
+        // double-count.
         var overlaps = false;
         for (var i = 0; i < periodEnds.Count && !overlaps && checkOverlap; i++)
         {
@@ -508,520 +556,4 @@ public class RevenueBreakdownTools
             );
         }
     }
-
-    // Resolve the surviving (member, period) facts for one axis, one row per cell — all in a
-    // single pinned unit. The default rule keeps the latest-filed fact per (member, period) —
-    // correct for a restatement that re-reports a member with a new value. It is wrong when a
-    // later filing instead *drops* a member it has reclassified away (NVDA's Singapore, AMD's
-    // Japan/Europe, KO/CAT renames): nothing supersedes the dropped member, so it lingers from
-    // the older filing and the axis double-counts it.
-    //
-    // The fix is arithmetic, not pattern-matching: for each period, if the latest filing's own
-    // members already reconcile to a consolidated total revenue (in the same unit), that filing
-    // is a complete re-disaggregation — use only its members and discard anything carried over
-    // from older filings. Otherwise the latest filing only restated some members (a partial
-    // amendment), so fall back to the latest-filed-per-member merge that carries un-amended
-    // members forward.
-    private static List<DimensionalRevenueRow> ReconcileToTotal(
-        IEnumerable<DimensionalRevenueRow> axisRowsInUnit,
-        string unit,
-        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
-    )
-    {
-        var result = new List<DimensionalRevenueRow>();
-        foreach (var period in axisRowsInUnit.GroupBy(r => r.PeriodEnd))
-        {
-            var latestFiled = period.Max(r => r.FiledDate);
-            var latestFiling = period.Where(r => r.FiledDate == latestFiled).ToList();
-            var latestSum = latestFiling.Sum(r => r.Value);
-
-            // Compared against the consolidated total in the SAME unit as the pinned members.
-            // Several revenue concepts may each report a total; the members complete the period
-            // if they reconcile to any one of them (e.g. ASC 606 revenue vs. total Revenues).
-            var candidates = totals.TryGetValue((period.Key, unit), out var totalsForPeriod)
-                ? totalsForPeriod
-                : [];
-            var complete = candidates.Any(total =>
-                total != 0m
-                && Math.Abs(latestSum - total) <= Math.Abs(total) * ReconciliationTolerance
-            );
-
-            List<DimensionalRevenueRow> periodRows;
-            if (complete)
-            {
-                // Latest filing re-disaggregates the whole period — keep only its members,
-                // collapsing any duplicate member within the same filing to its first fact.
-                periodRows = latestFiling.GroupBy(r => r.Member).Select(g => g.First()).ToList();
-            }
-            else
-            {
-                // Partial amendment — latest-filed fact wins per member, older members carried.
-                periodRows = period
-                    .GroupBy(r => r.Member)
-                    .Select(g => g.OrderByDescending(r => r.FiledDate).First())
-                    .ToList();
-            }
-
-            // An issuer can tag two overlapping disaggregation schemes on the same axis in one
-            // filing (e.g. a regional partition AND a by-country partition), each summing to
-            // consolidated total revenue. Both survive the merge above, so the axis would show
-            // ~2x actual revenue (#3897). Collapse to one scheme when the members partition
-            // cleanly into 2+ full-total subsets; otherwise leave the period untouched.
-            result.AddRange(CollapseOverlappingSchemes(periodRows, candidates));
-        }
-        return result;
-    }
-
-    // When the members of one period partition into 2+ DISJOINT subsets that EACH reconcile to
-    // a consolidated total revenue (with no member left over), the issuer tagged multiple
-    // overlapping schemes on the same axis. Keep only the MOST GRANULAR full-total subset (the
-    // most members — the most informative view); every full-total subset is individually
-    // correct, so this only chooses which correct view to show, never alters a number.
-    //
-    // Pure arithmetic, no member-name matching. The guard is strict: act only when the members
-    // FULLY partition into >=2 disjoint full-total subsets. A single scheme, or a partial
-    // overlap with no clean second full-total subset, is left unchanged — nothing is dropped.
-    private static List<DimensionalRevenueRow> CollapseOverlappingSchemes(
-        List<DimensionalRevenueRow> periodRows,
-        IReadOnlyList<decimal> candidates
-    )
-    {
-        if (periodRows.Count < 2)
-        {
-            return periodRows;
-        }
-
-        foreach (var total in candidates.Where(t => t != 0m).Distinct())
-        {
-            var tolerance = Math.Abs(total) * ReconciliationTolerance;
-
-            // Skip the trivial case where the whole member set already equals the total — that
-            // is one scheme, not an overlap of two.
-            if (Math.Abs(periodRows.Sum(r => r.Value) - total) <= tolerance)
-            {
-                continue;
-            }
-
-            var partition = FindFullTotalPartition(periodRows, total, tolerance);
-            if (partition != null && partition.Count >= 2)
-            {
-                // Keep the most granular subset; ties broken by the larger summed value, then a
-                // stable member ordering, so the choice is deterministic.
-                return partition
-                    .OrderByDescending(subset => subset.Count)
-                    .ThenByDescending(subset => subset.Sum(r => r.Value))
-                    .ThenBy(subset => string.Join("|", subset.Select(r => r.Member).Order()))
-                    .First();
-            }
-        }
-
-        return periodRows;
-    }
-
-    // Partition the members into disjoint subsets that each sum to `total` (within tolerance),
-    // covering every member exactly once. Returns the cover that minimises the total deviation
-    // from `total` across its subsets — so the genuine schemes (each summing to the exact
-    // consolidated figure) win over a tolerance-admitted near-miss that stitches members from
-    // different schemes together. Returns null when no full cover exists (not a clean overlap)
-    // or when any combinatorial bound trips — the period then passes through exactly as
-    // reported, the search's existing fail-safe.
-    //
-    // The bounds are load-bearing, not defensive fluff. The walk is exhaustive (~2^n), and the
-    // product axis breaks the "well under 15 members" assumption geography axes satisfy: a
-    // pharma issuer tags one member per drug (PFE 76, JNJ 46, LLY 40 on
-    // srt:ProductOrServiceAxis). Unbounded, one such call burned a CPU core indefinitely — and
-    // past 32 members the `1 << i` bitmasks alias (the shift count wraps), which corrupted the
-    // cover search into a literal non-terminating loop.
-    private const int MaxCollapseMembers = 31;
-    private const int MaxSubsetSearchNodes = 200_000;
-    private const int MaxCoverSubsets = 4_096;
-
-    private static List<List<DimensionalRevenueRow>> FindFullTotalPartition(
-        List<DimensionalRevenueRow> periodRows,
-        decimal total,
-        decimal tolerance
-    )
-    {
-        // Bitmask-width guard: 31 keeps every index inside the 32 bits the masks address. It
-        // deliberately does not try to bound cost — mid-size axes are cheap to search and the
-        // collapse is load-bearing for them — the node budget below is the cost bound.
-        if (periodRows.Count > MaxCollapseMembers)
-        {
-            return null;
-        }
-
-        // Order once so every subset and the final cover are produced deterministically.
-        var members = periodRows
-            .OrderByDescending(r => r.Value)
-            .ThenBy(r => r.Member, StringComparer.Ordinal)
-            .ToList();
-
-        // All subsets summing to total within tolerance, each as a bitmask over `members`.
-        // The subset-count cap keeps the cover search's input no larger than it ever was under
-        // the original assumption; a genuine overlap yields a handful of full-total subsets.
-        var fullTotalSubsets = new List<(int Mask, decimal Deviation)>();
-        var budget = MaxSubsetSearchNodes;
-        EnumerateFullTotalSubsets(
-            members,
-            0,
-            0,
-            0m,
-            total,
-            tolerance,
-            fullTotalSubsets,
-            ref budget
-        );
-        if (fullTotalSubsets.Count == 0 || budget <= 0 || fullTotalSubsets.Count > MaxCoverSubsets)
-        {
-            return null;
-        }
-
-        var (bestMasks, found) = FindBestCover(members.Count, fullTotalSubsets, total);
-        if (!found)
-        {
-            return null;
-        }
-
-        return bestMasks
-            .Select(mask =>
-                Enumerable
-                    .Range(0, members.Count)
-                    .Where(i => (mask & (1 << i)) != 0)
-                    .Select(i => members[i])
-                    .ToList()
-            )
-            .ToList();
-    }
-
-    // Depth-first enumeration of every subset of members[startIndex..] whose running sum reaches
-    // `total` within tolerance, recorded as a bitmask plus its absolute deviation from total.
-    //
-    // `budget` counts down the visited nodes across the whole recursion: a set of near-equal
-    // members can explore a large share of 2^n even under the member cap, so the budget stops
-    // the walk in bounded time regardless of shape. An exhausted budget means the enumeration
-    // is incomplete, so the caller must discard the result rather than act on a partial list.
-    private static void EnumerateFullTotalSubsets(
-        List<DimensionalRevenueRow> members,
-        int startIndex,
-        int mask,
-        decimal sum,
-        decimal total,
-        decimal tolerance,
-        List<(int Mask, decimal Deviation)> output,
-        ref int budget
-    )
-    {
-        if (budget <= 0)
-        {
-            return;
-        }
-        budget--;
-
-        if (mask != 0 && Math.Abs(sum - total) <= tolerance)
-        {
-            output.Add((mask, Math.Abs(sum - total)));
-            // A superset only adds positive values, moving further from total — so stop here.
-            return;
-        }
-        if (sum - total > tolerance)
-        {
-            return;
-        }
-
-        for (var i = startIndex; i < members.Count; i++)
-        {
-            EnumerateFullTotalSubsets(
-                members,
-                i + 1,
-                mask | (1 << i),
-                sum + members[i].Value,
-                total,
-                tolerance,
-                output,
-                ref budget
-            );
-            if (budget <= 0)
-            {
-                return;
-            }
-        }
-    }
-
-    // Choose the disjoint cover of all members (each index used once) built from the full-total
-    // subsets, minimising summed deviation, then preferring more subsets. Anchors each step on
-    // the lowest uncovered index so the search is forced and bounded.
-    private static (List<int> Masks, bool Found) FindBestCover(
-        int memberCount,
-        List<(int Mask, decimal Deviation)> subsets,
-        decimal total
-    )
-    {
-        var allCovered = (1 << memberCount) - 1;
-        List<int> best = null;
-        var bestDeviation = decimal.MaxValue;
-
-        void Search(int covered, List<int> chosen, decimal deviation)
-        {
-            if (deviation >= bestDeviation)
-            {
-                return;
-            }
-            if (covered == allCovered)
-            {
-                if (
-                    best == null
-                    || deviation < bestDeviation
-                    || (deviation == bestDeviation && chosen.Count > best.Count)
-                )
-                {
-                    best = [.. chosen];
-                    bestDeviation = deviation;
-                }
-                return;
-            }
-
-            var anchor = 0;
-            while ((covered & (1 << anchor)) != 0)
-            {
-                anchor++;
-            }
-
-            foreach (var (mask, dev) in subsets)
-            {
-                if ((mask & (1 << anchor)) != 0 && (mask & covered) == 0)
-                {
-                    chosen.Add(mask);
-                    Search(covered | mask, chosen, deviation + dev);
-                    chosen.RemoveAt(chosen.Count - 1);
-                }
-            }
-        }
-
-        Search(0, [], 0m);
-        return (best ?? [], best != null);
-    }
-
-    // Pivot one axis's rows into period-end columns (oldest first) × member rows. Each cell also
-    // retains its exact duration start so a downstream ratio cannot join same-end/different-span
-    // facts. Filings
-    // re-report comparative prior years, so the latest-filed fact wins per (member,
-    // period-end); the axis is pinned to the latest-filed fact's unit so a reporting-
-    // currency change can't mix currencies in one series. ReconcileToTotal then runs on the
-    // single-unit rows — when a later filing completely re-disaggregates a period, members it
-    // dropped must not linger from an older filing.
-    internal static AxisSeries BuildAxisSeries(
-        List<DimensionalRevenueRow> rows,
-        string[] axes,
-        int maxYears,
-        IReadOnlyDictionary<(DateOnly PeriodEnd, string Unit), IReadOnlyList<decimal>> totals
-    )
-    {
-        var axisRows = rows.Where(r => axes.Contains(r.Axis)).ToList();
-        if (axisRows.Count == 0)
-            return new AxisSeries(null, [], []);
-
-        // Pin the unit first (latest-filed fact's unit) so the reconciliation sum and the
-        // consolidated total are always in the same currency.
-        var unit = axisRows.OrderByDescending(r => r.FiledDate).First().Unit;
-        var inUnit = axisRows.Where(r => r.Unit == unit);
-        var current = ReconcileToTotal(inUnit, unit, totals);
-        if (current.Count == 0)
-            return new AxisSeries(null, [], []);
-
-        var periodEnds = current
-            .Select(r => r.PeriodEnd)
-            .Distinct()
-            .OrderByDescending(d => d)
-            .Take(maxYears)
-            .OrderBy(d => d)
-            .ToList();
-
-        var latest = periodEnds[^1];
-        // Fold before pivoting, not only when revenue and income are joined. An issuer can respell
-        // one member across filings (amd:DatacenterMember / amd:DataCenterMember); exact grouping
-        // would produce two half-series and make one side of a later margin join disappear. The
-        // latest-filed spelling fronts the merged series, and the latest-filed fact wins when two
-        // spellings survive for the same period.
-        var members = current
-            .GroupBy(r => FoldMemberQName(r.Member), StringComparer.Ordinal)
-            .Select(g => new
-            {
-                Key = g.OrderByDescending(r => r.FiledDate)
-                    .ThenByDescending(r => r.PeriodEnd)
-                    .First()
-                    .Member,
-                ByPeriod = g.GroupBy(r => r.PeriodEnd)
-                    .ToDictionary(
-                        pg => pg.Key,
-                        pg => pg.OrderByDescending(r => r.FiledDate).First()
-                    ),
-            })
-            .Select(m => new
-            {
-                m.Key,
-                Latest = m.ByPeriod.TryGetValue(latest, out var latestRow)
-                    ? latestRow.Value
-                    : (decimal?)null,
-                Values = periodEnds
-                    .Select(p =>
-                        m.ByPeriod.TryGetValue(p, out var row) ? row.Value : (decimal?)null
-                    )
-                    .ToList(),
-                PeriodStarts = periodEnds
-                    .Select(p =>
-                        m.ByPeriod.TryGetValue(p, out var row) ? row.PeriodStart : (DateOnly?)null
-                    )
-                    .ToList(),
-            })
-            .Where(m => m.Values.Any(v => v.HasValue))
-            .OrderByDescending(m => m.Latest ?? decimal.MinValue)
-            .ThenBy(m => m.Key)
-            .Select(m => new AxisMemberSeries(m.Key, Humanize(m.Key), m.Values, m.PeriodStarts))
-            .ToList();
-        return new AxisSeries(unit, periodEnds, members);
-    }
-
-    // REST parity for the derived margin axis: join the two independently selected axes by
-    // issuer member QName, exact duration, and unit, never by display label or row position. The fold is
-    // the corpus-backed XBRL identifier rule shared by the REST provider (case and underscores
-    // drift across filings); it retains the namespace prefix, so equal-looking labels from two
-    // different members cannot be combined.
-    internal static AxisSeries BuildSegmentMarginSeries(AxisSeries revenue, AxisSeries income)
-    {
-        if (
-            revenue.Members.Count == 0
-            || income.Members.Count == 0
-            || !string.Equals(revenue.Unit, income.Unit, StringComparison.Ordinal)
-        )
-            return new AxisSeries("%", [], []);
-
-        var incomeByMember = income
-            .Members.GroupBy(m => FoldMemberQName(m.Member), StringComparer.Ordinal)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
-        var incomePeriodIndex = income
-            .PeriodEnds.Select((periodEnd, index) => (periodEnd, index))
-            .ToDictionary(p => p.periodEnd, p => p.index);
-
-        var members = new List<AxisMemberSeries>();
-        var usedPeriods = new bool[revenue.PeriodEnds.Count];
-        foreach (var revenueMember in revenue.Members)
-        {
-            if (
-                !incomeByMember.TryGetValue(
-                    FoldMemberQName(revenueMember.Member),
-                    out var incomeMember
-                )
-            )
-                continue;
-
-            var values = new List<decimal?>();
-            var any = false;
-            for (var i = 0; i < revenue.PeriodEnds.Count; i++)
-            {
-                decimal? margin = null;
-                if (
-                    incomePeriodIndex.TryGetValue(revenue.PeriodEnds[i], out var incomeIndex)
-                    && revenueMember.PeriodStartAt(i) == incomeMember.PeriodStartAt(incomeIndex)
-                    && revenueMember.Values[i] is { } revenueValue
-                    && revenueValue > 0m
-                    && incomeMember.Values[incomeIndex] is { } incomeValue
-                )
-                {
-                    margin = incomeValue / revenueValue * 100m;
-                    any = true;
-                    usedPeriods[i] = true;
-                }
-                values.Add(margin);
-            }
-
-            if (any)
-            {
-                members.Add(
-                    new AxisMemberSeries(revenueMember.Member, revenueMember.Label, values)
-                );
-            }
-        }
-
-        if (members.Count == 0)
-            return new AxisSeries("%", [], []);
-
-        var keptIndexes = Enumerable
-            .Range(0, revenue.PeriodEnds.Count)
-            .Where(i => usedPeriods[i])
-            .ToList();
-        return new AxisSeries(
-            "%",
-            keptIndexes.Select(i => revenue.PeriodEnds[i]).ToList(),
-            members
-                .Select(m => new AxisMemberSeries(
-                    m.Member,
-                    m.Label,
-                    keptIndexes.Select(i => m.Values[i]).ToList(),
-                    keptIndexes.Select(i => m.PeriodStartAt(i)).ToList()
-                ))
-                .ToList()
-        );
-    }
-
-    private static string FoldMemberQName(string member) =>
-        member?.Replace("_", "").ToLowerInvariant();
-
-    // Display label from the XBRL member QName: ISO country members get their English
-    // name; everything else drops the Member suffix and spaces the PascalCase local name.
-    internal static string Humanize(string memberQName)
-    {
-        var colon = memberQName.IndexOf(':');
-        var prefix = colon > 0 ? memberQName[..colon] : "";
-        var local = colon > 0 ? memberQName[(colon + 1)..] : memberQName;
-
-        if (prefix == "country")
-        {
-            try
-            {
-                return new RegionInfo(local).EnglishName;
-            }
-            catch (ArgumentException)
-            {
-                return local;
-            }
-        }
-
-        if (local.EndsWith("Member", StringComparison.Ordinal) && local.Length > "Member".Length)
-            local = local[..^"Member".Length];
-        // The (?<!^[A-Z]) guard keeps a lone leading capital attached to the word
-        // that follows: Apple's IPhoneMember reads "IPhone", never "I Phone".
-        // Boundaries deeper in the name still split ("USSegment" → "US Segment").
-        return Regex.Replace(
-            local,
-            "(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?<!^[A-Z])(?=[A-Z][a-z])",
-            " "
-        );
-    }
-
-    internal sealed record DimensionalRevenueRow(
-        string Axis,
-        string Member,
-        DateOnly PeriodEnd,
-        decimal Value,
-        string Unit,
-        DateOnly FiledDate,
-        DateOnly? PeriodStart = null
-    );
-
-    internal sealed record AxisMemberSeries(
-        string Member,
-        string Label,
-        List<decimal?> Values,
-        List<DateOnly?> PeriodStarts = null
-    )
-    {
-        internal DateOnly? PeriodStartAt(int index) =>
-            PeriodStarts != null && index < PeriodStarts.Count ? PeriodStarts[index] : null;
-    }
-
-    internal sealed record AxisSeries(
-        string Unit,
-        List<DateOnly> PeriodEnds,
-        List<AxisMemberSeries> Members
-    );
 }

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownCoreArithmeticRollupMemberTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownCoreArithmeticRollupMemberTests.cs
@@ -1,0 +1,97 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the arithmetic rollup-member filter inside BuildAxisSeries
+/// (EquiblesCommercial#7166): AAPL tags the parent us-gaap:ProductMember alongside its
+/// component product lines — the parent equals the exact sum of its children in every
+/// period, so a consumer that sums the axis double-counts. The parent must be dropped by
+/// arithmetic proof (exact same-subset match across 2+ periods), never by name matching;
+/// a single-period coincidence keeps the member.
+/// </summary>
+public class RevenueBreakdownCoreArithmeticRollupMemberTests
+{
+    private static readonly DateOnly Fy2024 = new(2024, 9, 28);
+    private static readonly DateOnly Fy2025 = new(2025, 9, 27);
+
+    private static DimensionalRevenueRow Row(string member, DateOnly periodEnd, decimal value) =>
+        new(
+            "srt:ProductOrServiceAxis",
+            member,
+            periodEnd,
+            value,
+            "USD",
+            new DateOnly(2025, 11, 1),
+            periodEnd.AddDays(-364),
+            periodEnd.Year
+        );
+
+    [Fact]
+    public void BuildAxisSeries_ParentEqualToChildSumInEveryPeriod_IsDroppedAsARollup()
+    {
+        var rows = new List<DimensionalRevenueRow>
+        {
+            // The parent line: exactly the sum of the three product children, both years.
+            Row("us-gaap:ProductMember", Fy2024, 60m),
+            Row("us-gaap:ProductMember", Fy2025, 66m),
+            Row("aapl:IPhoneMember", Fy2024, 40m),
+            Row("aapl:IPhoneMember", Fy2025, 44m),
+            Row("aapl:MacMember", Fy2024, 12m),
+            Row("aapl:MacMember", Fy2025, 13m),
+            Row("aapl:IPadMember", Fy2024, 8m),
+            Row("aapl:IPadMember", Fy2025, 9m),
+            Row("us-gaap:ServiceMember", Fy2024, 25m),
+            Row("us-gaap:ServiceMember", Fy2025, 30m),
+        };
+
+        var series = RevenueBreakdownCore.BuildAxisSeries(
+            rows,
+            RevenueBreakdownCore.ProductAxes,
+            8,
+            new Dictionary<(DateOnly, string), IReadOnlyList<decimal>>
+            {
+                [(Fy2024, "USD")] = [85m],
+                [(Fy2025, "USD")] = [96m],
+            }
+        );
+
+        series.Members.Select(m => m.Member).Should().NotContain("us-gaap:ProductMember");
+        series
+            .Members.Select(m => m.Member)
+            .Should()
+            .BeEquivalentTo([
+                "aapl:IPhoneMember",
+                "aapl:MacMember",
+                "aapl:IPadMember",
+                "us-gaap:ServiceMember",
+            ]);
+    }
+
+    [Fact]
+    public void BuildAxisSeries_SinglePeriodCoincidence_KeepsTheMember()
+    {
+        var rows = new List<DimensionalRevenueRow>
+        {
+            // Matches iPhone + Mac exactly in FY2024 only (40 + 12); its FY2025 value
+            // matches no subset — coincidence, not a rollup.
+            Row("aapl:AccessoriesMember", Fy2024, 52m),
+            Row("aapl:AccessoriesMember", Fy2025, 58m),
+            Row("aapl:IPhoneMember", Fy2024, 40m),
+            Row("aapl:IPhoneMember", Fy2025, 44m),
+            Row("aapl:MacMember", Fy2024, 12m),
+            Row("aapl:MacMember", Fy2025, 13m),
+        };
+
+        var series = RevenueBreakdownCore.BuildAxisSeries(
+            rows,
+            RevenueBreakdownCore.ProductAxes,
+            8,
+            new Dictionary<(DateOnly, string), IReadOnlyList<decimal>>()
+        );
+
+        series.Members.Select(m => m.Member).Should().Contain("aapl:AccessoriesMember");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownCoreRollUpCrossCutsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownCoreRollUpCrossCutsTests.cs
@@ -1,0 +1,198 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the cross-cut roll-up's ONE-partner-family rule (EquiblesCommercial#7166). XOM
+/// tags geography only in cross-cuts (product × geography AND geography × segment); a
+/// roll-up that sums a country's legs from BOTH partner families counts the same revenue
+/// once per family — prod published ~2.34× consolidated revenue for XOM's geography axis
+/// that way, with Non-US alone at 145% of consolidated. Exactly one partner family may
+/// contribute per period, chosen by reconciliation against the consolidated totals.
+/// </summary>
+public class RevenueBreakdownCoreRollUpCrossCutsTests
+{
+    private static readonly DateOnly Fy2025End = new(2025, 12, 31);
+    private static readonly DateOnly Fy2025Start = new(2025, 1, 1);
+    private static readonly DateOnly Filed = new(2026, 2, 18);
+
+    private static CrossCutRevenueRow GeoCross(
+        string otherAxis,
+        string otherMember,
+        string geoMember,
+        decimal value,
+        DateOnly? filed = null
+    ) =>
+        new(
+            "srt:StatementGeographicalAxis",
+            geoMember,
+            otherAxis,
+            otherMember,
+            Fy2025End,
+            value,
+            "USD",
+            filed ?? Filed,
+            Fy2025Start,
+            2025
+        );
+
+    // The XOM FY2025 shape, condensed: a product × geography partition that lands near
+    // consolidated total revenue, and a geography × segment partition that overshoots it
+    // (segment revenue includes intersegment sales).
+    private static List<CrossCutRevenueRow> XomShape() =>
+        [
+            GeoCross("srt:ProductOrServiceAxis", "xom:SalesMember", "country:US", 137m),
+            GeoCross("srt:ProductOrServiceAxis", "xom:SalesMember", "us-gaap:NonUsMember", 186m),
+            GeoCross(
+                "us-gaap:StatementBusinessSegmentsAxis",
+                "xom:EnergyMember",
+                "country:US",
+                118m
+            ),
+            GeoCross(
+                "us-gaap:StatementBusinessSegmentsAxis",
+                "xom:EnergyMember",
+                "us-gaap:NonUsMember",
+                173m
+            ),
+            GeoCross(
+                "us-gaap:StatementBusinessSegmentsAxis",
+                "xom:UpstreamMember",
+                "country:US",
+                74m
+            ),
+            GeoCross(
+                "us-gaap:StatementBusinessSegmentsAxis",
+                "xom:UpstreamMember",
+                "us-gaap:NonUsMember",
+                87m
+            ),
+        ];
+
+    private static Dictionary<(DateOnly, string), IReadOnlyList<decimal>> Totals(
+        params decimal[] totals
+    ) => new() { [(Fy2025End, "USD")] = totals };
+
+    [Fact]
+    public void RollUpCrossCuts_TwoPartnerFamilies_NeverMixesLegsAcrossFamilies()
+    {
+        var rolled = RevenueBreakdownCore.RollUpCrossCuts(
+            XomShape(),
+            RevenueBreakdownCore.GeographyAxes,
+            [],
+            Totals(323m)
+        );
+
+        // The product partner reconciles (137 + 186 = 323); the segment partner
+        // overshoots (192 + 260 = 452). A mixed sum would publish US = 329 / Non-US =
+        // 446 — the 2.34× corruption.
+        rolled.Should().HaveCount(2);
+        rolled.Single(r => r.Member == "country:US").Value.Should().Be(137m);
+        rolled.Single(r => r.Member == "us-gaap:NonUsMember").Value.Should().Be(186m);
+    }
+
+    [Fact]
+    public void RollUpCrossCuts_NoPartnerReconciles_TheClosestPartnerWinsAlone()
+    {
+        // Neither partner reconciles to 400, but the segment partner (sum 452) deviates
+        // less than the product partner (sum 323) — it must win ALONE, never merged.
+        var rolled = RevenueBreakdownCore.RollUpCrossCuts(
+            XomShape(),
+            RevenueBreakdownCore.GeographyAxes,
+            [],
+            Totals(400m)
+        );
+
+        rolled.Should().HaveCount(2);
+        rolled.Single(r => r.Member == "country:US").Value.Should().Be(118m + 74m);
+        rolled.Single(r => r.Member == "us-gaap:NonUsMember").Value.Should().Be(173m + 87m);
+    }
+
+    [Fact]
+    public void RollUpCrossCuts_PeriodWithSingleAxisCut_IsNeverRolledUp()
+    {
+        var singleAxis = new List<DimensionalRevenueRow>
+        {
+            new(
+                "srt:StatementGeographicalAxis",
+                "country:US",
+                Fy2025End,
+                999m,
+                "USD",
+                Filed,
+                Fy2025Start,
+                2025
+            ),
+        };
+
+        var rolled = RevenueBreakdownCore.RollUpCrossCuts(
+            XomShape(),
+            RevenueBreakdownCore.GeographyAxes,
+            singleAxis,
+            Totals(323m)
+        );
+
+        // A reported single-axis disaggregation always beats a derived roll-up.
+        rolled.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RollUpCrossCuts_RestatedLeg_LatestFiledLegWinsBeforeTheSum()
+    {
+        var crossCuts = new List<CrossCutRevenueRow>
+        {
+            GeoCross(
+                "srt:ProductOrServiceAxis",
+                "xom:SalesMember",
+                "country:US",
+                100m,
+                new DateOnly(2026, 2, 1)
+            ),
+            // The same (member, partner-member) leg restated by a later filing.
+            GeoCross(
+                "srt:ProductOrServiceAxis",
+                "xom:SalesMember",
+                "country:US",
+                120m,
+                new DateOnly(2026, 3, 1)
+            ),
+            GeoCross(
+                "srt:ProductOrServiceAxis",
+                "xom:ServicesMember",
+                "country:US",
+                30m,
+                new DateOnly(2026, 2, 1)
+            ),
+        };
+
+        var rolled = RevenueBreakdownCore.RollUpCrossCuts(
+            crossCuts,
+            RevenueBreakdownCore.GeographyAxes,
+            [],
+            Totals(150m)
+        );
+
+        rolled.Should().ContainSingle().Which.Value.Should().Be(120m + 30m);
+    }
+
+    [Fact]
+    public void RollUpCrossCuts_NoConsolidatedTotals_PicksDeterministically()
+    {
+        // Without a total to validate against, the tie breaks on member count then the
+        // canonical family order — the pick must be stable, and still one family only.
+        var rolled = RevenueBreakdownCore.RollUpCrossCuts(
+            XomShape(),
+            RevenueBreakdownCore.GeographyAxes,
+            [],
+            new Dictionary<(DateOnly, string), IReadOnlyList<decimal>>()
+        );
+
+        rolled.Should().HaveCount(2);
+        // Both families produce 2 members; the segment family precedes the product
+        // family in the canonical order.
+        rolled.Single(r => r.Member == "country:US").Value.Should().Be(118m + 74m);
+        rolled.Single(r => r.Member == "us-gaap:NonUsMember").Value.Should().Be(173m + 87m);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsBuildAxisSeriesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsBuildAxisSeriesTests.cs
@@ -1,4 +1,4 @@
-using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
 using FluentAssertions;
 
 namespace Equibles.UnitTests.Sec;
@@ -15,7 +15,7 @@ public class RevenueBreakdownToolsBuildAxisSeriesTests
         // requested axes contribute, the latest-filed fact wins a restated
         // (member, period) cell, columns read oldest-first, and a member missing a
         // year carries null (rendered as a dash) — never a fabricated zero.
-        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        var rows = new List<DimensionalRevenueRow>
         {
             new(
                 "us-gaap:StatementBusinessSegmentsAxis",
@@ -62,7 +62,7 @@ public class RevenueBreakdownToolsBuildAxisSeriesTests
             ),
         };
 
-        var (unit, periodEnds, members) = RevenueBreakdownTools.BuildAxisSeries(
+        var (unit, periodEnds, members) = RevenueBreakdownCore.BuildAxisSeries(
             rows,
             ["us-gaap:StatementBusinessSegmentsAxis"],
             maxYears: 8,

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsBuildSegmentMarginSeriesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsBuildSegmentMarginSeriesTests.cs
@@ -1,4 +1,4 @@
-using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -13,7 +13,7 @@ public class RevenueBreakdownToolsBuildSegmentMarginSeriesTests
         var fy2023Start = new DateOnly(2023, 1, 1);
         var fy2024Start = new DateOnly(2024, 1, 1);
         var fy2025Start = new DateOnly(2025, 1, 1);
-        var revenue = new RevenueBreakdownTools.AxisSeries(
+        var revenue = new AxisSeries(
             "USD",
             [fy2023, fy2024],
             [
@@ -22,7 +22,7 @@ public class RevenueBreakdownToolsBuildSegmentMarginSeriesTests
                 new("acme:ZeroMember", "Zero", [0m, 0m], [fy2023Start, fy2024Start]),
             ]
         );
-        var income = new RevenueBreakdownTools.AxisSeries(
+        var income = new AxisSeries(
             "USD",
             [fy2024, fy2025],
             [
@@ -32,7 +32,7 @@ public class RevenueBreakdownToolsBuildSegmentMarginSeriesTests
             ]
         );
 
-        var result = RevenueBreakdownTools.BuildSegmentMarginSeries(revenue, income);
+        var result = RevenueBreakdownCore.BuildSegmentMarginSeries(revenue, income);
 
         result.Unit.Should().Be("%");
         result
@@ -58,18 +58,18 @@ public class RevenueBreakdownToolsBuildSegmentMarginSeriesTests
     public void BuildSegmentMarginSeries_SameEndButDifferentDuration_DoesNotDivide()
     {
         var end = new DateOnly(2024, 12, 31);
-        var revenue = new RevenueBreakdownTools.AxisSeries(
+        var revenue = new AxisSeries(
             "USD",
             [end],
             [new("acme:CloudMember", "Cloud", [200m], [new DateOnly(2024, 1, 1)])]
         );
-        var income = new RevenueBreakdownTools.AxisSeries(
+        var income = new AxisSeries(
             "USD",
             [end],
             [new("acme:CloudMember", "Cloud", [50m], [new DateOnly(2023, 10, 1)])]
         );
 
-        var result = RevenueBreakdownTools.BuildSegmentMarginSeries(revenue, income);
+        var result = RevenueBreakdownCore.BuildSegmentMarginSeries(revenue, income);
 
         result.Members.Should().BeEmpty("an exact period match includes both duration endpoints");
     }
@@ -79,18 +79,18 @@ public class RevenueBreakdownToolsBuildSegmentMarginSeriesTests
     {
         var end = new DateOnly(2024, 12, 31);
         var start = new DateOnly(2024, 1, 1);
-        var revenue = new RevenueBreakdownTools.AxisSeries(
+        var revenue = new AxisSeries(
             "USD",
             [end],
             [new("acme:CloudMember", "Cloud", [200m], [start])]
         );
-        var income = new RevenueBreakdownTools.AxisSeries(
+        var income = new AxisSeries(
             "EUR",
             [end],
             [new("acme:CloudMember", "Cloud", [50m], [start])]
         );
 
-        var result = RevenueBreakdownTools.BuildSegmentMarginSeries(revenue, income);
+        var result = RevenueBreakdownCore.BuildSegmentMarginSeries(revenue, income);
 
         result.Members.Should().BeEmpty("a ratio across different currencies is meaningless");
     }

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsCollapseOverlappingSchemesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsCollapseOverlappingSchemesTests.cs
@@ -1,4 +1,4 @@
-using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
 using FluentAssertions;
 
 namespace Equibles.UnitTests.Sec;
@@ -26,7 +26,7 @@ public class RevenueBreakdownToolsCollapseOverlappingSchemesTests
     [Fact]
     public void BuildAxisSeries_TwoOverlappingSchemesEachSummingToTotal_KeepsMostGranularScheme()
     {
-        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        var rows = new List<DimensionalRevenueRow>
         {
             // Region scheme — 3 members, sums to 63,887.
             new(Geo, "avgo:AmericasMember", Fy2025, 18939m, "USD", Filed),
@@ -40,7 +40,7 @@ public class RevenueBreakdownToolsCollapseOverlappingSchemesTests
             new(Geo, "avgo:AllOtherMember", Fy2025, 18979m, "USD", Filed),
         };
 
-        var (unit, periodEnds, members) = RevenueBreakdownTools.BuildAxisSeries(
+        var (unit, periodEnds, members) = RevenueBreakdownCore.BuildAxisSeries(
             rows,
             [Geo],
             maxYears: 8,
@@ -67,7 +67,7 @@ public class RevenueBreakdownToolsCollapseOverlappingSchemesTests
     [Fact]
     public void BuildAxisSeries_RegionAndUsNonUsSchemes_KeepsFourMemberRegionScheme()
     {
-        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        var rows = new List<DimensionalRevenueRow>
         {
             // Region scheme — 4 members summing to 67,589.
             new(Geo, "cat:NorthAmericaMember", Fy2025, 38000m, "USD", Filed),
@@ -79,7 +79,7 @@ public class RevenueBreakdownToolsCollapseOverlappingSchemesTests
             new(Geo, "cat:NonUsMember", Fy2025, 33589m, "USD", Filed),
         };
 
-        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+        var (_, _, members) = RevenueBreakdownCore.BuildAxisSeries(
             rows,
             [Geo],
             maxYears: 8,
@@ -99,14 +99,14 @@ public class RevenueBreakdownToolsCollapseOverlappingSchemesTests
     [Fact]
     public void BuildAxisSeries_SingleSchemeSummingToTotal_LeftIntact()
     {
-        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        var rows = new List<DimensionalRevenueRow>
         {
             new(Geo, "country:US", Fy2025, 40m, "USD", Filed),
             new(Geo, "country:CN", Fy2025, 35m, "USD", Filed),
             new(Geo, "country:SG", Fy2025, 25m, "USD", Filed),
         };
 
-        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+        var (_, _, members) = RevenueBreakdownCore.BuildAxisSeries(
             rows,
             [Geo],
             maxYears: 8,
@@ -123,7 +123,7 @@ public class RevenueBreakdownToolsCollapseOverlappingSchemesTests
     [Fact]
     public void BuildAxisSeries_NoCleanSecondFullTotalSubset_LeftUnchanged()
     {
-        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        var rows = new List<DimensionalRevenueRow>
         {
             new(Geo, "country:US", Fy2025, 40m, "USD", Filed),
             new(Geo, "country:CN", Fy2025, 35m, "USD", Filed),
@@ -131,7 +131,7 @@ public class RevenueBreakdownToolsCollapseOverlappingSchemesTests
             new(Geo, "country:TW", Fy2025, 10m, "USD", Filed),
         };
 
-        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+        var (_, _, members) = RevenueBreakdownCore.BuildAxisSeries(
             rows,
             [Geo],
             maxYears: 8,

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizeInvalidCountryFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizeInvalidCountryFallbackTests.cs
@@ -1,9 +1,9 @@
-using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
 
 namespace Equibles.UnitTests.Sec;
 
 /// <summary>
-/// Contract (RevenueBreakdownTools.cs country arm): a "country:" member resolves to its English
+/// Contract (RevenueBreakdownCore.cs country arm): a "country:" member resolves to its English
 /// region name, but an unrecognised code must fall back to the raw local part rather than throw —
 /// the RegionInfo constructor raises ArgumentException for a non-ISO code and the catch returns
 /// `local`. Asserting the fallback (not a valid code's EnglishName) keeps the test independent of
@@ -14,7 +14,7 @@ public class RevenueBreakdownToolsHumanizeInvalidCountryFallbackTests
     [Fact]
     public void Humanize_CountryQNameWithInvalidRegionCode_FallsBackToLocalName()
     {
-        var result = RevenueBreakdownTools.Humanize("country:Atlantis");
+        var result = RevenueBreakdownCore.Humanize("country:Atlantis");
 
         result
             .Should()

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizeLeadingCapitalTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizeLeadingCapitalTests.cs
@@ -1,4 +1,4 @@
-using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -16,18 +16,18 @@ public class RevenueBreakdownToolsHumanizeLeadingCapitalTests
     [InlineData("aapl:MacMember", "Mac")]
     public void Humanize_LoneLeadingCapital_StaysAttachedToItsWord(string qname, string expected)
     {
-        RevenueBreakdownTools.Humanize(qname).Should().Be(expected);
+        RevenueBreakdownCore.Humanize(qname).Should().Be(expected);
     }
 
     [Fact]
     public void Humanize_AcronymPrefixDeeperInName_StillSplits()
     {
-        RevenueBreakdownTools.Humanize("x:USSegmentMember").Should().Be("US Segment");
+        RevenueBreakdownCore.Humanize("x:USSegmentMember").Should().Be("US Segment");
     }
 
     [Fact]
     public void Humanize_PlainPascalCase_StillSplits()
     {
-        RevenueBreakdownTools.Humanize("nvda:DataCenterMember").Should().Be("Data Center");
+        RevenueBreakdownCore.Humanize("nvda:DataCenterMember").Should().Be("Data Center");
     }
 }

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizePascalCaseSpacingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizePascalCaseSpacingTests.cs
@@ -1,9 +1,9 @@
-using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
 
 namespace Equibles.UnitTests.Sec;
 
 /// <summary>
-/// Contract (RevenueBreakdownTools.cs:221-223): the "everything else" branch
+/// Contract (RevenueBreakdownCore.cs:221-223): the "everything else" branch
 /// of Humanize drops the "Member" suffix and spaces the PascalCase local
 /// name. A non-country QName with three PascalCase words and no "Member"
 /// suffix is the diagnostic input — it exercises the regex (lower→upper
@@ -15,7 +15,7 @@ public class RevenueBreakdownToolsHumanizePascalCaseSpacingTests
     [Fact]
     public void Humanize_NonCountryQNameWithoutMemberSuffix_SpacesPascalCaseLocalName()
     {
-        var result = RevenueBreakdownTools.Humanize("us-gaap:StatementGeographicalAxis");
+        var result = RevenueBreakdownCore.Humanize("us-gaap:StatementGeographicalAxis");
 
         result.Should().Be("Statement Geographical Axis");
     }

--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsReconcileToTotalTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsReconcileToTotalTests.cs
@@ -1,4 +1,4 @@
-using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.BusinessLogic.RevenueBreakdown;
 using FluentAssertions;
 
 namespace Equibles.UnitTests.Sec;
@@ -21,7 +21,7 @@ public class RevenueBreakdownToolsReconcileToTotalTests
     [Fact]
     public void BuildAxisSeries_LaterFilingDropsMemberReconcilingToTotal_DropsStaleMember()
     {
-        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        var rows = new List<DimensionalRevenueRow>
         {
             // Older filing: A, B, C, Singapore reconcile to 100 in total.
             new(Geo, "country:US", Fy2024, 30m, "USD", OldFiling),
@@ -34,7 +34,7 @@ public class RevenueBreakdownToolsReconcileToTotalTests
             new(Geo, "country:CN", Fy2024, 30m, "USD", NewFiling),
         };
 
-        var (unit, periodEnds, members) = RevenueBreakdownTools.BuildAxisSeries(
+        var (unit, periodEnds, members) = RevenueBreakdownCore.BuildAxisSeries(
             rows,
             [Geo],
             maxYears: 8,
@@ -60,7 +60,7 @@ public class RevenueBreakdownToolsReconcileToTotalTests
     [Fact]
     public void BuildAxisSeries_PartialAmendmentNotReconcilingToTotal_KeepsCarriedForwardMembers()
     {
-        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        var rows = new List<DimensionalRevenueRow>
         {
             // Older filing: two members reconcile to 100.
             new(Geo, "country:US", Fy2024, 60m, "USD", OldFiling),
@@ -69,7 +69,7 @@ public class RevenueBreakdownToolsReconcileToTotalTests
             new(Geo, "country:US", Fy2024, 70m, "USD", NewFiling),
         };
 
-        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+        var (_, _, members) = RevenueBreakdownCore.BuildAxisSeries(
             rows,
             [Geo],
             maxYears: 8,
@@ -80,12 +80,12 @@ public class RevenueBreakdownToolsReconcileToTotalTests
         // Identify members by the same label the code derives, so the assertion does not depend
         // on the runtime's ICU/CLDR English name for a country (e.g. "China mainland" vs "China").
         members
-            .Single(m => m.Label == RevenueBreakdownTools.Humanize("country:US"))
+            .Single(m => m.Label == RevenueBreakdownCore.Humanize("country:US"))
             .Values[0]
             .Should()
             .Be(70m, "the restated value wins for the amended member");
         members
-            .Single(m => m.Label == RevenueBreakdownTools.Humanize("country:CN"))
+            .Single(m => m.Label == RevenueBreakdownCore.Humanize("country:CN"))
             .Values[0]
             .Should()
             .Be(40m, "the un-amended member carries forward from the prior filing");
@@ -98,7 +98,7 @@ public class RevenueBreakdownToolsReconcileToTotalTests
     [Fact]
     public void BuildAxisSeries_ReconcilesToOneOfSeveralConceptTotals_DropsStaleMember()
     {
-        var rows = new List<RevenueBreakdownTools.DimensionalRevenueRow>
+        var rows = new List<DimensionalRevenueRow>
         {
             // Older filing: members sum to the ASC 606 subtotal of 80, including a stale member.
             new(Geo, "country:US", Fy2024, 30m, "USD", OldFiling),
@@ -110,7 +110,7 @@ public class RevenueBreakdownToolsReconcileToTotalTests
         };
 
         // Two candidate totals for the period: total Revenues 100 and the ASC 606 subtotal 80.
-        var (_, _, members) = RevenueBreakdownTools.BuildAxisSeries(
+        var (_, _, members) = RevenueBreakdownCore.BuildAxisSeries(
             rows,
             [Geo],
             maxYears: 8,


### PR DESCRIPTION
## Summary
Extracts the revenue-breakdown selection rules into `Equibles.Sec.FinancialFacts.BusinessLogic/RevenueBreakdown/RevenueBreakdownCore` — the one lane both the MCP tool and the commercial REST/portal surfaces must build member sets through (EquiblesCommercial#7166 found the two transports serving different member sets for the same company).

## Code changes
- **RevenueBreakdownCore** (new): axis constants, ReconcileToTotal + overlapping-scheme collapse (ported verbatim), BuildAxisSeries pivot with the XBRL member fold, BuildSegmentMarginSeries, Humanize, and the NEW per-partner-family cross-cut roll-up: one partner axis family per (period, unit), picked by reconciliation against consolidated totals (reconciling wins, else closest; ties → more members, then canonical family order). Mixing partner families counted the same revenue once per family — XOM's geography axis published ~2.34× consolidated revenue that way.
- **ArithmeticRollupMembers** (new, ported from the commercial repo onto AxisMemberSeries): drops a parent member equal to the exact sum of a recurring component subset across ≥2 periods (AAPL's parent us-gaap:ProductMember alongside its children) — arithmetic proof, never name matching.
- **RevenueBreakdownTools** (MCP): now queries + markdown rendering only; gains the cross-cut query + roll-up and the rollup-member filter via the core. Consolidated-totals and display-total picks unchanged.
- **Tests**: existing unit pins re-pointed at the core; new pins for the one-partner-family rule (the XOM shape, incl. closest-partner fallback and latest-filed-leg restatement) and the rollup-member filter (parent dropped, single-period coincidence kept).

The commercial repo follows with a PR replacing its provider's private copies with this core (same pin bump).