### PR TITLE
fix(holdings): serve ownership history from snapshots

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
+++ b/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
@@ -80,7 +80,7 @@ public class StockCombinedQuarterService
             ? _holdingRepository.GetCombinedQuarterByStock(
                 stock,
                 anchor.ReportDate,
-                anchor.PreviousReportDate.Value
+                RequirePreviousReportDate(anchor)
             )
             : _holdingRepository.Get13FByStock(stock, anchor.ReportDate);
     }
@@ -95,7 +95,7 @@ public class StockCombinedQuarterService
             ? _holdingRepository.GetCombinedQuarterByStockWithHolder(
                 stock,
                 anchor.ReportDate,
-                anchor.PreviousReportDate.Value
+                RequirePreviousReportDate(anchor)
             )
             : _holdingRepository.Get13FByStockWithHolder(stock, anchor.ReportDate);
     }
@@ -118,6 +118,7 @@ public class StockCombinedQuarterService
                 "Reported activity is only defined for a combined anchor (open filing window "
                     + "with a previous quarter to compare against)."
             );
+        var previousReportDate = RequirePreviousReportDate(anchor);
 
         var asFiled = (
             await _holdingRepository.GetStockActivitySnapshotsByStockSnapshotBacked(
@@ -128,7 +129,7 @@ public class StockCombinedQuarterService
         var combined = await _holdingRepository.GetCombinedStockActivitySnapshotBacked(
             stock,
             anchor.ReportDate,
-            anchor.PreviousReportDate.Value,
+            previousReportDate,
             cancellationToken
         );
         if (asFiled == null || combined == null)
@@ -152,7 +153,7 @@ public class StockCombinedQuarterService
         var previousShares = MarketActivityShareRestater.RestateListingTotal(
             combined.ListingShares,
             listing => listing.PreviousShares,
-            anchor.PreviousReportDate.Value,
+            previousReportDate,
             stock.Ticker,
             splits
         );
@@ -171,4 +172,10 @@ public class StockCombinedQuarterService
             CombinedValue = combined.CurrentValue,
         };
     }
+
+    private static DateOnly RequirePreviousReportDate(StockQuarterAnchor anchor) =>
+        anchor.PreviousReportDate
+        ?? throw new InvalidOperationException(
+            "A combined-quarter anchor must include its previous report date."
+        );
 }

--- a/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
+++ b/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
@@ -1,6 +1,5 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
-using Equibles.CorporateActions.Data;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.BusinessLogic.Models;
 using Equibles.Holdings.Data.Models;
@@ -104,8 +103,9 @@ public class StockCombinedQuarterService
     /// <summary>
     /// Reported-so-far activity for a combined anchor: what the funds that already filed the
     /// new quarter did in this stock, plus the combined-view totals. Only meaningful while
-    /// <see cref="StockQuarterAnchor.IsCombined"/>; three small per-stock reads, aggregated in
-    /// memory.
+    /// <see cref="StockQuarterAnchor.IsCombined"/>. Both quarter modes come from the materialized
+    /// stock/listing snapshots; only a missing generation uses the repository's bounded two-quarter
+    /// fallback.
     /// </summary>
     public async Task<StockReportedActivity> LoadReportedActivity(
         CommonStock stock,
@@ -119,80 +119,56 @@ public class StockCombinedQuarterService
                     + "with a previous quarter to compare against)."
             );
 
-        var current = await _holdingRepository
-            .Get13FByStock(stock, anchor.ReportDate)
-            .Select(h => new
-            {
-                h.InstitutionalHolderId,
-                h.Shares,
-                h.Value,
-            })
-            .ToListAsync(cancellationToken);
-        var previous = await _holdingRepository
-            .Get13FByStock(stock, anchor.PreviousReportDate.Value)
-            .Select(h => new
-            {
-                h.InstitutionalHolderId,
-                h.Shares,
-                h.Value,
-            })
-            .ToListAsync(cancellationToken);
+        var asFiled = (
+            await _holdingRepository.GetStockActivitySnapshotsByStockSnapshotBacked(
+                stock,
+                cancellationToken
+            )
+        ).SingleOrDefault(row => row.ReportDate == anchor.ReportDate);
+        var combined = await _holdingRepository.GetCombinedStockActivitySnapshotBacked(
+            stock,
+            anchor.ReportDate,
+            anchor.PreviousReportDate.Value,
+            cancellationToken
+        );
+        if (asFiled == null || combined == null)
+        {
+            throw new InvalidOperationException(
+                $"Combined holdings activity is unavailable for {stock.Ticker} on {anchor.ReportDate:yyyy-MM-dd}."
+            );
+        }
 
-        var currentHolders = current.Select(h => h.InstitutionalHolderId).ToHashSet();
-        var previousHolders = previous.Select(h => h.InstitutionalHolderId).ToHashSet();
-
-        // Previous holders who filed the new quarter ANYWHERE — present in it or proven exits.
-        var filedPreviousHolders = (
-            await _holdingRepository
-                .GetFiledHolderIdsAmong(anchor.ReportDate, previousHolders.ToList())
-                .ToListAsync(cancellationToken)
-        ).ToHashSet();
-
-        var carried = previous
-            .Where(h => !filedPreviousHolders.Contains(h.InstitutionalHolderId))
-            .ToList();
-
-        // Restate both quarters' share counts onto today's post-split basis before any sum —
-        // a split falling between the two quarters while the window is open would otherwise
-        // read as every continuing filer doubling/halving its position (the same restatement
-        // every other 13F comparison surface applies). Dollar values are split-invariant.
         var splits = await _stockSplitRepository
             .GetByStock(stock.Id)
+            .AsNoTracking()
             .ToListAsync(cancellationToken);
-        var currentFactor = SplitAdjustment.ShareCountFactor(anchor.ReportDate, splits);
-        var previousFactor = SplitAdjustment.ShareCountFactor(
-            anchor.PreviousReportDate.Value,
+        var combinedShares = MarketActivityShareRestater.RestateListingTotal(
+            combined.ListingShares,
+            listing => listing.CurrentShares,
+            anchor.ReportDate,
+            stock.Ticker,
             splits
         );
-        var currentShares = SplitAdjustment.AdjustShareCount(
-            current.Sum(h => h.Shares),
-            currentFactor
-        );
-        var reportedPreviousShares = SplitAdjustment.AdjustShareCount(
-            previous
-                .Where(h => filedPreviousHolders.Contains(h.InstitutionalHolderId))
-                .Sum(h => h.Shares),
-            previousFactor
-        );
-        var carriedShares = SplitAdjustment.AdjustShareCount(
-            carried.Sum(h => h.Shares),
-            previousFactor
+        var previousShares = MarketActivityShareRestater.RestateListingTotal(
+            combined.ListingShares,
+            listing => listing.PreviousShares,
+            anchor.PreviousReportDate.Value,
+            stock.Ticker,
+            splits
         );
 
         return new StockReportedActivity
         {
-            PreviousHolderCount = previousHolders.Count,
-            ReportedFilerCount = currentHolders.Union(filedPreviousHolders).Count(),
-            NewFilerCount = currentHolders.Count(id => !previousHolders.Contains(id)),
-            SoldOutFilerCount = filedPreviousHolders.Count(id => !currentHolders.Contains(id)),
+            PreviousHolderCount = combined.PreviousFilerCount,
+            ReportedFilerCount = asFiled.CurrentFilerCount + combined.SoldOutFilerCount,
+            NewFilerCount = combined.NewFilerCount,
+            SoldOutFilerCount = combined.SoldOutFilerCount,
             // Net over reporters only: their new shares (zero for exits) minus their previous
             // shares (zero for new positions). Carried positions contribute nothing.
-            NetReportedShareDelta = currentShares - reportedPreviousShares,
-            CombinedHolderCount = currentHolders
-                .Union(carried.Select(h => h.InstitutionalHolderId))
-                .Count(),
-            CombinedShares = currentShares + carriedShares,
-            CombinedValue = current.Sum(h => h.Value) + carried.Sum(h => h.Value),
+            NetReportedShareDelta = combinedShares - previousShares,
+            CombinedHolderCount = combined.CurrentFilerCount,
+            CombinedShares = combinedShares,
+            CombinedValue = combined.CurrentValue,
         };
     }
 }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -326,62 +326,43 @@ public class HoldingsAggregateRefreshService
                 .ToListAsync(cancellationToken)
         ).ToDictionary(c => c.CommonStockId);
 
-        var combinedListingShares = await repository
-            .GetCombinedQuarter(latest, previous)
-            .Join(
-                dbContext.Set<CommonStock>(),
-                holding => holding.CommonStockId,
-                stock => stock.Id,
-                (holding, stock) => new { Holding = holding, stock.Ticker }
-            )
-            .GroupBy(row => new
-            {
-                row.Holding.CommonStockId,
-                PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
-            })
-            .Select(group => new
-            {
-                group.Key.CommonStockId,
-                group.Key.PriceSeriesTicker,
-                Shares = group.Sum(row => row.Holding.Shares),
-            })
-            .ToListAsync(cancellationToken);
-        var previousListingShares = await dbContext
-            .Set<InstitutionalHolding>()
-            .Where(holding =>
-                holding.ReportDate == previous && holding.FilingType == FilingType.Form13F
-            )
-            .Join(
-                dbContext.Set<CommonStock>(),
-                holding => holding.CommonStockId,
-                stock => stock.Id,
-                (holding, stock) => new { Holding = holding, stock.Ticker }
-            )
-            .GroupBy(row => new
-            {
-                row.Holding.CommonStockId,
-                PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
-            })
-            .Select(group => new
-            {
-                group.Key.CommonStockId,
-                group.Key.PriceSeriesTicker,
-                Shares = group.Sum(row => row.Holding.Shares),
-            })
-            .ToListAsync(cancellationToken);
-
         var computedAt = DateTime.UtcNow;
+        var listingRows = await repository.GetLiveListingShareActivity(
+            latest,
+            previous,
+            combined: true,
+            activity.Select(row => row.CommonStockId).ToArray(),
+            cancellationToken
+        );
+        foreach (var listing in listingRows)
+            listing.ComputedAt = computedAt;
+        var listingTotalsByStock = listingRows
+            .GroupBy(row => row.CommonStockId)
+            .ToDictionary(
+                group => group.Key,
+                group => new
+                {
+                    CurrentShares = group.Sum(row => row.CurrentShares),
+                    PreviousShares = group.Sum(row => row.PreviousShares),
+                }
+            );
         var rows = activity
             .Select(a =>
             {
+                if (!listingTotalsByStock.TryGetValue(a.CommonStockId, out var listingTotals))
+                {
+                    throw new InvalidOperationException(
+                        $"Combined holdings activity for stock {a.CommonStockId} has no listing-share rows."
+                    );
+                }
                 churn.TryGetValue(a.CommonStockId, out var c);
                 return new StockQuarterlyActivityCombined
                 {
                     CommonStockId = a.CommonStockId,
                     ReportDate = latest,
                     PreviousReportDate = previous,
-                    CurrentShares = a.CurrentShares,
-                    PreviousShares = a.PreviousShares,
+                    CurrentShares = listingTotals.CurrentShares,
+                    PreviousShares = listingTotals.PreviousShares,
                     CurrentValue = a.CurrentValue,
                     PreviousValue = a.PreviousValue,
                     CurrentFilerCount = a.CurrentFilerCount,
@@ -390,27 +371,6 @@ public class HoldingsAggregateRefreshService
                     SoldOutFilerCount = c?.SoldOutFilerCount ?? 0,
                     ComputedAt = computedAt,
                 };
-            })
-            .ToList();
-        var currentListingLookup = combinedListingShares.ToDictionary(
-            row => (row.CommonStockId, row.PriceSeriesTicker),
-            row => row.Shares
-        );
-        var previousListingLookup = previousListingShares.ToDictionary(
-            row => (row.CommonStockId, row.PriceSeriesTicker),
-            row => row.Shares
-        );
-        var listingRows = currentListingLookup
-            .Keys.Union(previousListingLookup.Keys)
-            .Select(key => new StockQuarterlyListingActivity
-            {
-                CommonStockId = key.CommonStockId,
-                ReportDate = latest,
-                IsCombined = true,
-                PriceSeriesTicker = key.PriceSeriesTicker,
-                CurrentShares = currentListingLookup.GetValueOrDefault(key),
-                PreviousShares = previousListingLookup.GetValueOrDefault(key),
-                ComputedAt = computedAt,
             })
             .ToList();
 

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -141,7 +141,7 @@ public class InstitutionalHoldingsTools
                     ? _holdingRepository.GetCombinedQuarterByStockWithHolder(
                         stock,
                         anchor.ReportDate,
-                        anchor.PreviousReportDate.Value
+                        RequirePreviousReportDate(anchor)
                     )
                     : _holdingRepository.Get13FByStockWithHolder(stock, targetDate);
                 // Materialise one compact projection. Exact-listing split factors can change
@@ -156,6 +156,7 @@ public class InstitutionalHoldingsTools
                         InstitutionName = h.InstitutionalHolder.Name,
                         Shares = h.Shares,
                         Value = h.Value,
+                        ReportDate = h.ReportDate,
                         ListedTicker = h.ListedTicker,
                         OptionType = h.OptionType,
                     })
@@ -169,7 +170,7 @@ public class InstitutionalHoldingsTools
                     var listing = holding.ListedTicker ?? stock.Ticker;
                     holding.Shares = SplitAdjustment.AdjustShareCount(
                         holding.Shares,
-                        targetDate,
+                        holding.ReportDate,
                         PriceSeriesSplitScope.ForListing(splits, stock.Ticker, listing)
                     );
                 }
@@ -220,7 +221,13 @@ public class InstitutionalHoldingsTools
     private static string CombinedViewNote(DateOnly targetDate, StockQuarterAnchor anchor) =>
         $"Note: the {FormatDate(targetDate)} filing window is still open (13Fs are due 45 days "
         + $"after quarter end). Combined view: funds that have not filed yet carry their "
-        + $"{FormatDate(anchor.PreviousReportDate.Value)} positions.";
+        + $"{FormatDate(RequirePreviousReportDate(anchor))} positions.";
+
+    private static DateOnly RequirePreviousReportDate(StockQuarterAnchor anchor) =>
+        anchor.PreviousReportDate
+        ?? throw new InvalidOperationException(
+            "A combined-quarter anchor must include its previous report date."
+        );
 
     // Stable pure rendering seam retained for the culture/date/zero-denominator contracts.
     // The request path above uses exact-listing adjusted rows because sibling classes can
@@ -246,6 +253,7 @@ public class InstitutionalHoldingsTools
                 InstitutionName = h.InstitutionalHolder?.Name ?? "Unknown",
                 Shares = SplitAdjustment.AdjustShareCount(h.Shares, shareFactor),
                 Value = h.Value,
+                ReportDate = h.ReportDate,
                 ListedTicker = h.ListedTicker,
                 OptionType = h.OptionType,
             })
@@ -325,6 +333,7 @@ public class InstitutionalHoldingsTools
         public string InstitutionName { get; set; }
         public long Shares { get; set; }
         public long Value { get; set; }
+        public DateOnly ReportDate { get; set; }
         public string ListedTicker { get; set; }
         public OptionType? OptionType { get; set; }
     }
@@ -363,7 +372,7 @@ public class InstitutionalHoldingsTools
                     var combined = await _holdingRepository.GetCombinedStockActivitySnapshotBacked(
                         stock,
                         anchor.ReportDate,
-                        anchor.PreviousReportDate.Value
+                        RequirePreviousReportDate(anchor)
                     );
                     if (combined == null)
                     {
@@ -1523,16 +1532,22 @@ public class InstitutionalHoldingsTools
                 {
                     "filersdelta" => ranking
                         .OrderByDescending(a => a.CurrentFilerCount - a.PreviousFilerCount)
-                        .ThenByDescending(a => a.CurrentFilerCount),
+                        .ThenByDescending(a => a.CurrentFilerCount)
+                        .ThenByDescending(a => a.CurrentValue)
+                        .ThenBy(a => a.CommonStockId),
                     "filersdeltaasc" => ranking
                         .OrderBy(a => a.CurrentFilerCount - a.PreviousFilerCount)
-                        .ThenByDescending(a => a.CurrentFilerCount),
+                        .ThenByDescending(a => a.CurrentFilerCount)
+                        .ThenByDescending(a => a.CurrentValue)
+                        .ThenBy(a => a.CommonStockId),
                     "value" => ranking
                         .OrderByDescending(a => a.CurrentValue)
-                        .ThenByDescending(a => a.CurrentFilerCount),
+                        .ThenByDescending(a => a.CurrentFilerCount)
+                        .ThenBy(a => a.CommonStockId),
                     _ => ranking
                         .OrderByDescending(a => a.CurrentFilerCount)
-                        .ThenByDescending(a => a.CurrentValue),
+                        .ThenByDescending(a => a.CurrentValue)
+                        .ThenBy(a => a.CommonStockId),
                 };
                 var rows = ranking.Take(McpLimit.Clamp(maxResults)).ToList();
                 if (rows.Count == 0)

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -352,27 +352,51 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = (
-                    await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(stock)
-                )
-                    .Take(McpLimit.Clamp(maxPeriods))
-                    .ToList();
-
-                if (reportDates.Count == 0)
+                var activity =
+                    await _holdingRepository.GetStockActivitySnapshotsByStockSnapshotBacked(stock);
+                if (activity.All(row => row.CurrentFilerCount <= 0))
                     return $"No institutional holdings history available for {ticker}.";
 
                 var anchor = await _combinedQuarterService.Resolve(stock);
-                return await RenderOwnershipHistory(stock, ticker, reportDates, anchor);
+                if (anchor is { IsCombined: true })
+                {
+                    var combined = await _holdingRepository.GetCombinedStockActivitySnapshotBacked(
+                        stock,
+                        anchor.ReportDate,
+                        anchor.PreviousReportDate.Value
+                    );
+                    if (combined == null)
+                    {
+                        throw new InvalidOperationException(
+                            $"Combined holdings activity is unavailable for {stock.Ticker} on {anchor.ReportDate:yyyy-MM-dd}."
+                        );
+                    }
+
+                    var index = activity.FindIndex(row => row.ReportDate == anchor.ReportDate);
+                    if (index >= 0)
+                        activity[index] = combined;
+                    else
+                        activity.Add(combined);
+                }
+
+                var selected = activity
+                    .Where(row => row.CurrentFilerCount > 0)
+                    .OrderByDescending(row => row.ReportDate)
+                    .Take(McpLimit.Clamp(maxPeriods))
+                    .OrderBy(row => row.ReportDate)
+                    .ToList();
+                await _marketActivityShareRestater.RestateStockActivity(stock, selected);
+                return RenderOwnershipHistory(stock, ticker, selected, anchor);
             },
             "GetOwnershipHistory",
             $"ticker: {ticker}"
         );
     }
 
-    private async Task<string> RenderOwnershipHistory(
+    private static string RenderOwnershipHistory(
         CommonStock stock,
         string ticker,
-        List<DateOnly> reportDates,
+        IReadOnlyList<StockQuarterlyActivity> activity,
         StockQuarterAnchor anchor
     )
     {
@@ -382,44 +406,20 @@ public class InstitutionalHoldingsTools
             "|------------|-------------|-------------|-----------------|--------|"
         );
 
-        // Restate each quarter's total shares onto today's split basis before the
-        // quarter-over-quarter change so a split between two report dates does not read as a
-        // real change in institutional ownership (a 2:1 split would otherwise show +100%).
-        var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
-
         long previousShares = 0;
         var combinedRowShown = false;
-        foreach (var date in reportDates.OrderBy(d => d))
+        foreach (var row in activity)
         {
-            // The newest quarter is presented as the combined view while its filing window is
-            // open — its as-filed totals would only cover the early filers and the trend would
-            // end on a fabricated collapse.
-            var isCombinedRow = anchor is { IsCombined: true } && date == anchor.ReportDate;
-            var holdings = isCombinedRow
-                ? await _holdingRepository
-                    .GetCombinedQuarterByStock(
-                        stock,
-                        anchor.ReportDate,
-                        anchor.PreviousReportDate.Value
-                    )
-                    .ToListAsync()
-                : await _holdingRepository.Get13FByStock(stock, date).ToListAsync();
+            var isCombinedRow =
+                anchor is { IsCombined: true } && row.ReportDate == anchor.ReportDate;
             combinedRowShown |= isCombinedRow;
-            var totalShares = SplitAdjustment.AdjustShareCount(
-                holdings.Sum(h => h.Shares),
-                date,
-                splits
-            );
-            var totalValue = holdings.Sum(h => h.Value);
-            var institutionCount = holdings.Select(h => h.InstitutionalHolderId).Distinct().Count();
-
-            var change = FormatShareChange(totalShares, previousShares);
+            var change = FormatShareChange(row.CurrentShares, previousShares);
 
             result.AppendLine(
-                $"| {FormatDate(date)}{(isCombinedRow ? " \\*" : "")} | {McpFormat.WholeNumber(institutionCount)} | {McpFormat.WholeNumber(totalShares)} | {FormatMillions(totalValue)} | {change} |"
+                $"| {FormatDate(row.ReportDate)}{(isCombinedRow ? " \\*" : "")} | {McpFormat.WholeNumber(row.CurrentFilerCount)} | {McpFormat.WholeNumber(row.CurrentShares)} | {FormatMillions(row.CurrentValue)} | {change} |"
             );
 
-            previousShares = totalShares;
+            previousShares = row.CurrentShares;
         }
 
         if (combinedRowShown)

--- a/src/Equibles.Holdings.Repositories/Equibles.Holdings.Repositories.csproj
+++ b/src/Equibles.Holdings.Repositories/Equibles.Holdings.Repositories.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <ProjectReference Include="..\Equibles.CorporateActions.Data\Equibles.CorporateActions.Data.csproj" />
     <ProjectReference Include="..\Equibles.Holdings.Data\Equibles.Holdings.Data.csproj" />
     <ProjectReference Include="..\Equibles.Search.Abstractions\Equibles.Search.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -1,6 +1,8 @@
 using System.Linq.Expressions;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Data;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories.Extensions;
@@ -786,6 +788,116 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return snapshots;
     }
 
+    // Snapshot-first open-window point for one stock. Ownership-history surfaces replace only
+    // their newest as-filed row with this combined view, so they never loop over raw holdings by
+    // quarter. The exact-listing rows are version-checked with the stock row before split
+    // restatement; a missing generation falls back only to this stock's two-quarter aggregate.
+    public async Task<StockQuarterlyActivity> GetCombinedStockActivitySnapshotBacked(
+        CommonStock stock,
+        DateOnly currentReportDate,
+        DateOnly previousReportDate,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var snapshot = await GetStockActivitySnapshotsCombined(currentReportDate)
+            .AsNoTracking()
+            .SingleOrDefaultAsync(row => row.CommonStockId == stock.Id, cancellationToken);
+        if (snapshot != null)
+        {
+            var listingShares = await GetStockListingActivitySnapshots(
+                    currentReportDate,
+                    combined: true
+                )
+                .AsNoTracking()
+                .Where(row => row.CommonStockId == stock.Id)
+                .ToListAsync(cancellationToken);
+            if (
+                listingShares.Count > 0
+                && listingShares.All(row => row.ComputedAt == snapshot.ComputedAt)
+            )
+            {
+                return ToStockActivity(snapshot, listingShares);
+            }
+        }
+
+        var current = await Get13FByStock(stock, currentReportDate)
+            .AsNoTracking()
+            .Select(row => new { row.InstitutionalHolderId, row.Value })
+            .ToListAsync(cancellationToken);
+        var previous = await Get13FByStock(stock, previousReportDate)
+            .AsNoTracking()
+            .Select(row => new { row.InstitutionalHolderId, row.Value })
+            .ToListAsync(cancellationToken);
+        if (current.Count == 0 && previous.Count == 0)
+            return null;
+
+        var currentHolders = current.Select(row => row.InstitutionalHolderId).ToHashSet();
+        var previousHolders = previous.Select(row => row.InstitutionalHolderId).ToHashSet();
+        var filedPreviousHolders =
+            previousHolders.Count == 0
+                ? new HashSet<Guid>()
+                : (
+                    await GetFiledHolderIdsAmong(currentReportDate, previousHolders)
+                        .ToListAsync(cancellationToken)
+                ).ToHashSet();
+        var carried = previous
+            .Where(row => !filedPreviousHolders.Contains(row.InstitutionalHolderId))
+            .ToList();
+
+        var liveListingShares = await GetLiveListingShareActivity(
+            currentReportDate,
+            previousReportDate,
+            combined: true,
+            [stock.Id],
+            cancellationToken
+        );
+        if (liveListingShares.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot load combined holdings activity for {stock.Ticker} without listing-share rows."
+            );
+        }
+
+        return new StockQuarterlyActivity
+        {
+            CommonStockId = stock.Id,
+            ReportDate = currentReportDate,
+            PreviousReportDate = previousReportDate,
+            CurrentShares = liveListingShares.Sum(row => row.CurrentShares),
+            PreviousShares = liveListingShares.Sum(row => row.PreviousShares),
+            CurrentValue = current.Sum(row => row.Value) + carried.Sum(row => row.Value),
+            PreviousValue = previous.Sum(row => row.Value),
+            CurrentFilerCount = currentHolders
+                .Union(carried.Select(row => row.InstitutionalHolderId))
+                .Count(),
+            PreviousFilerCount = previousHolders.Count,
+            NewFilerCount = currentHolders.Count(id => !previousHolders.Contains(id)),
+            SoldOutFilerCount = filedPreviousHolders.Count(id => !currentHolders.Contains(id)),
+            ListingShares = liveListingShares,
+        };
+    }
+
+    private static StockQuarterlyActivity ToStockActivity(
+        StockQuarterlyActivityCombined snapshot,
+        IReadOnlyList<StockQuarterlyListingActivity> listingShares
+    ) =>
+        new()
+        {
+            CommonStockId = snapshot.CommonStockId,
+            ReportDate = snapshot.ReportDate,
+            PreviousReportDate = snapshot.PreviousReportDate,
+            CurrentShares = snapshot.CurrentShares,
+            PreviousShares = snapshot.PreviousShares,
+            CurrentValue = snapshot.CurrentValue,
+            PreviousValue = snapshot.PreviousValue,
+            CurrentFilerCount = snapshot.CurrentFilerCount,
+            PreviousFilerCount = snapshot.PreviousFilerCount,
+            NewFilerCount = snapshot.NewFilerCount,
+            SoldOutFilerCount = snapshot.SoldOutFilerCount,
+            ComputedAt = snapshot.ComputedAt,
+            ListingShares = listingShares,
+        };
+
     // Refresh-lag fallback for one just-opened quarter. Its comparison is bounded to that
     // quarter and the immediately preceding live quarter instead of regrouping the stock's
     // entire filing history whenever the aggregate worker trails ingestion.
@@ -1101,12 +1213,16 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             .GroupBy(row => new
             {
                 row.Holding.CommonStockId,
+                PrimaryTicker = row.Ticker,
                 PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
+                SourceReportDate = row.Holding.ReportDate,
             })
             .Select(group => new
             {
                 group.Key.CommonStockId,
+                group.Key.PrimaryTicker,
                 group.Key.PriceSeriesTicker,
+                group.Key.SourceReportDate,
                 Shares = group.Sum(row => row.Holding.Shares),
             })
             .ToListAsync(cancellationToken);
@@ -1124,19 +1240,47 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             .GroupBy(row => new
             {
                 row.Holding.CommonStockId,
+                PrimaryTicker = row.Ticker,
                 PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
             })
             .Select(group => new
             {
                 group.Key.CommonStockId,
+                group.Key.PrimaryTicker,
                 group.Key.PriceSeriesTicker,
                 Shares = group.Sum(row => row.Holding.Shares),
             })
             .ToListAsync(cancellationToken);
-        var currentLookup = currentRows.ToDictionary(
-            row => (row.CommonStockId, row.PriceSeriesTicker),
-            row => row.Shares
-        );
+        var splitsByStock = (
+            await DbContext
+                .Set<StockSplit>()
+                .AsNoTracking()
+                .Where(split => commonStockIds.Contains(split.CommonStockId))
+                .ToListAsync(cancellationToken)
+        )
+            .GroupBy(split => split.CommonStockId)
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<StockSplit>)group.ToList());
+        var currentLookup = currentRows
+            .GroupBy(row => new
+            {
+                row.CommonStockId,
+                row.PrimaryTicker,
+                row.PriceSeriesTicker,
+            })
+            .ToDictionary(
+                group => (group.Key.CommonStockId, group.Key.PriceSeriesTicker),
+                group =>
+                    group.Sum(row =>
+                        RestateShareCountBetween(
+                            row.Shares,
+                            row.SourceReportDate,
+                            current,
+                            group.Key.PrimaryTicker,
+                            group.Key.PriceSeriesTicker,
+                            splitsByStock.GetValueOrDefault(group.Key.CommonStockId) ?? []
+                        )
+                    )
+            );
         var previousLookup = previousRows.ToDictionary(
             row => (row.CommonStockId, row.PriceSeriesTicker),
             row => row.Shares
@@ -1153,6 +1297,26 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
                 PreviousShares = previousLookup.GetValueOrDefault(key),
             })
             .ToList();
+    }
+
+    private static long RestateShareCountBetween(
+        long shares,
+        DateOnly sourceReportDate,
+        DateOnly targetReportDate,
+        string primaryTicker,
+        string priceSeriesTicker,
+        IReadOnlyList<StockSplit> splits
+    )
+    {
+        if (sourceReportDate >= targetReportDate || splits.Count == 0)
+            return shares;
+
+        var scoped = PriceSeriesSplitScope.ForListing(splits, primaryTicker, priceSeriesTicker);
+        var sourceFactor = SplitAdjustment.ShareCountFactor(sourceReportDate, scoped);
+        var targetFactor = SplitAdjustment.ShareCountFactor(targetReportDate, scoped);
+        return targetFactor == 0m
+            ? shares
+            : SplitAdjustment.AdjustShareCount(shares, sourceFactor / targetFactor);
     }
 
     // Double-down report: per-(holder, stock) positions where the share-count

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceCombinedLaneTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceCombinedLaneTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Services;
 using Equibles.IntegrationTests.Helpers;
@@ -126,6 +127,50 @@ public class HoldingsAggregateRefreshServiceCombinedLaneTests : IAsyncLifetime
         listing.CurrentShares.Should().Be(2_000);
         listing.PreviousShares.Should().Be(1_600);
         listing.ComputedAt.Should().Be(row.ComputedAt);
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_WindowOpen_NormalizesCarriedSharesToCurrentBasis()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var stock = await SeedStock(seed, "SPLT", industry);
+        var reporter = await SeedHolder(seed, "H010");
+        var nonFiler = await SeedHolder(seed, "H011");
+        seed.AddRange(
+            MakeHolding(stock, reporter, OpenPrev, 100_000, "acc-reporter-prev"),
+            MakeHolding(stock, nonFiler, OpenPrev, 50_000, "acc-carried-prev"),
+            MakeHolding(stock, reporter, OpenCur, 120_000, "acc-reporter-cur"),
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                EffectiveDate = OpenPrev.AddDays(30),
+                Numerator = 2,
+                Denominator = 1,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(OpenCur, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var row = await read.Set<StockQuarterlyActivityCombined>()
+            .SingleAsync(snapshot =>
+                snapshot.CommonStockId == stock.Id && snapshot.ReportDate == OpenCur
+            );
+        var listing = await read.Set<StockQuarterlyListingActivity>()
+            .SingleAsync(snapshot =>
+                snapshot.CommonStockId == stock.Id
+                && snapshot.ReportDate == OpenCur
+                && snapshot.IsCombined
+            );
+
+        row.CurrentShares.Should()
+            .Be(2_200, "the filed 1,200 is already post-split and the carried 500 becomes 1,000");
+        row.PreviousShares.Should().Be(1_500);
+        listing.CurrentShares.Should().Be(2_200);
+        listing.PreviousShares.Should().Be(1_500);
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
@@ -427,6 +427,70 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
     }
 
     [Fact]
+    public async Task GetCombinedStockActivitySnapshotBacked_LoadsOneVersionedListingGeneration()
+    {
+        var stock = Stock("TREND-COMBINED");
+        var previous = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var computedAt = DateTime.UtcNow;
+        _dbContext.Add(stock);
+        _dbContext.Add(
+            new StockQuarterlyActivityCombined
+            {
+                CommonStockId = stock.Id,
+                ReportDate = current,
+                PreviousReportDate = previous,
+                CurrentShares = 2_500,
+                PreviousShares = 2_100,
+                CurrentValue = 250_000,
+                PreviousValue = 210_000,
+                CurrentFilerCount = 8,
+                PreviousFilerCount = 7,
+                ComputedAt = computedAt,
+            }
+        );
+        _dbContext
+            .Set<StockQuarterlyListingActivity>()
+            .AddRange(
+                new StockQuarterlyListingActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = current,
+                    IsCombined = true,
+                    PriceSeriesTicker = stock.Ticker,
+                    CurrentShares = 1_000,
+                    PreviousShares = 900,
+                    ComputedAt = computedAt,
+                },
+                new StockQuarterlyListingActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = current,
+                    IsCombined = true,
+                    PriceSeriesTicker = "TREND-COMBINED.B",
+                    CurrentShares = 1_500,
+                    PreviousShares = 1_200,
+                    ComputedAt = computedAt,
+                }
+            );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var row = await _repository.GetCombinedStockActivitySnapshotBacked(
+            stock,
+            current,
+            previous
+        );
+
+        row.Should().NotBeNull();
+        row.CurrentShares.Should().Be(2_500);
+        row.CurrentValue.Should().Be(250_000);
+        row.CurrentFilerCount.Should().Be(8);
+        row.ListingShares.Select(listing => listing.PriceSeriesTicker)
+            .Should()
+            .BeEquivalentTo(stock.Ticker, "TREND-COMBINED.B");
+    }
+
+    [Fact]
     public async Task GetHolderQuarterlySnapshotsSnapshotBacked_FallsBackOnlyForMissingHolder()
     {
         var stock = Stock("FUNDS");

--- a/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
@@ -379,6 +380,65 @@ public class InstitutionalHoldingsToolsTests : ParadeDbMcpTestBase
 
         result.Should().Contain("15,000");
         result.Should().Contain("1.5");
+    }
+
+    [Fact]
+    public async Task GetOwnershipHistory_UsesSnapshotAndRestatesEachExactListing()
+    {
+        var stock = CreateStock("GOOGL", "Alphabet Inc");
+        var holder = CreateHolder("0000000021", "Raw Holder");
+        var reportDate = new DateOnly(2024, 12, 31);
+        var computedAt = DateTime.UtcNow;
+        DbContext.AddRange(stock, holder);
+        DbContext.Add(CreateHolding(stock, holder, reportDate, shares: 99_999, value: 9_999_999));
+        DbContext.Add(
+            new StockQuarterlyActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = reportDate,
+                CurrentShares = 1_150,
+                CurrentValue = 115_000,
+                CurrentFilerCount = 2,
+                ComputedAt = computedAt,
+            }
+        );
+        DbContext
+            .Set<StockQuarterlyListingActivity>()
+            .AddRange(
+                new StockQuarterlyListingActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = reportDate,
+                    PriceSeriesTicker = stock.Ticker,
+                    CurrentShares = 1_000,
+                    ComputedAt = computedAt,
+                },
+                new StockQuarterlyListingActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = reportDate,
+                    PriceSeriesTicker = "GOOG",
+                    CurrentShares = 150,
+                    ComputedAt = computedAt,
+                }
+            );
+        DbContext.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = "GOOG",
+                EffectiveDate = new DateOnly(2025, 1, 15),
+                Numerator = 10,
+                Denominator = 1,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetOwnershipHistory("GOOGL");
+
+        result.Should().Contain("| 2024-12-31 | 2 | 2,500 | 0.1 | — |");
+        result.Should().NotContain("99,999");
     }
 
     // ── GetInstitutionPortfolio ──────────────────────────────────────────

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
@@ -138,6 +138,40 @@ public class InstitutionalHoldingsToolsGetMostHeldStocksTests : ParadeDbMcpTestB
         output.Should().NotContain("NVDA");
     }
 
+    [Fact]
+    public async Task GetMostHeldStocks_ExactMetricTies_OrderByStockId()
+    {
+        var reportDate = new DateOnly(2024, 12, 31);
+        var first = new CommonStock
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            Ticker = "ZZZZ",
+            Name = "First by identifier",
+            Cik = "C1",
+        };
+        var second = new CommonStock
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000002"),
+            Ticker = "AAAA",
+            Name = "Second by identifier",
+            Cik = "C2",
+        };
+        var holder = new InstitutionalHolder { Cik = "H1", Name = "Filer 1" };
+        DbContext.AddRange(first, second, holder);
+        DbContext.Add(MakeHolding(first, holder, reportDate, shares: 100, value: 100_000));
+        DbContext.Add(MakeHolding(second, holder, reportDate, shares: 100, value: 100_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var output = await NewSut(verify).GetMostHeldStocks();
+
+        output
+            .IndexOf("ZZZZ", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("AAAA", StringComparison.Ordinal));
+    }
+
     private async Task SeedThreeStockUniverse()
     {
         var prior = new DateOnly(2024, 9, 30);

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
@@ -145,6 +145,59 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
         output.Should().Contain("16.67%");
     }
 
+    [Fact]
+    public async Task GetTopHolders_CombinedViewRestatesCarriedRowsFromTheirSourceDate()
+    {
+        var previous = new DateOnly(2026, 3, 31);
+        var current = new DateOnly(2026, 6, 30);
+        var stock = new CommonStock
+        {
+            Ticker = "CARR",
+            Name = "Carried Position Corp.",
+            Cik = "0000000101",
+        };
+        var currentFiler = new InstitutionalHolder { Cik = "103", Name = "Current Fund" };
+        var carriedFiler = new InstitutionalHolder { Cik = "104", Name = "Carried Fund" };
+        DbContext.AddRange(stock, currentFiler, carriedFiler);
+        DbContext.Add(MakeHolding(stock, currentFiler, current, shares: 100));
+        DbContext.Add(
+            MakeHolding(stock, carriedFiler, previous, shares: 10, listedTicker: "CARR.B")
+        );
+        DbContext.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = "CARR.B",
+                EffectiveDate = new DateOnly(2026, 5, 15),
+                Numerator = 10m,
+                Denominator = 1m,
+                Source = StockSplitSource.Manual,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            new StockSplitRepository(verify),
+            new StockCombinedQuarterService(
+                new InstitutionalHoldingRepository(verify),
+                new StockSplitRepository(verify)
+            ),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopHolders(stock.Ticker);
+
+        output.Should().Contain("Combined view");
+        output.Should().Contain("200 shares");
+        output.Should().Contain("| Carried Fund | Common (CARR.B) | 100 |");
+    }
+
     private static InstitutionalHolding MakeHolding(
         CommonStock stock,
         InstitutionalHolder holder,


### PR DESCRIPTION
## Summary
- serve per-stock ownership history from materialized stock-quarter snapshots
- use the combined open-quarter snapshot and exact listing split basis
- normalize carried positions to the current report-date basis before publication

## Validation
- Release build
- 4,297 unit tests
- 2,589 database tests
- independent audit of the final diff

Refs daniel3303/EquiblesCommercial#7063