### PR TITLE
fix(holdings): run snapshot reads through retry strategy

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -1113,20 +1113,24 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         CancellationToken cancellationToken = default
     )
     {
-        async Task<List<MarketWideStockActivity>> Load()
+        async Task<List<MarketWideStockActivity>> Load(CancellationToken operationCancellationToken)
         {
-            var snapshot = await GetMarketActivitySnapshots(current, combined, cancellationToken);
+            var snapshot = await GetMarketActivitySnapshots(
+                current,
+                combined,
+                operationCancellationToken
+            );
             if (snapshot.Count > 0)
                 return snapshot;
 
             var activity = await GetQuarterlyActivity(current, previous, combined)
-                .ToListAsync(cancellationToken);
+                .ToListAsync(operationCancellationToken);
             var listings = await GetLiveListingShareActivity(
                 current,
                 previous,
                 combined,
                 activity.Select(row => row.CommonStockId).ToArray(),
-                cancellationToken
+                operationCancellationToken
             );
             var byStock = listings
                 .GroupBy(row => row.CommonStockId)
@@ -1142,15 +1146,22 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         }
 
         if (!DbContext.Database.IsRelational() || DbContext.Database.CurrentTransaction != null)
-            return await Load();
+            return await Load(cancellationToken);
 
-        await using var transaction = await DbContext.Database.BeginTransactionAsync(
-            System.Data.IsolationLevel.RepeatableRead,
+        var strategy = DbContext.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(
+            async operationCancellationToken =>
+            {
+                await using var transaction = await DbContext.Database.BeginTransactionAsync(
+                    System.Data.IsolationLevel.RepeatableRead,
+                    operationCancellationToken
+                );
+                var result = await Load(operationCancellationToken);
+                await transaction.CommitAsync(operationCancellationToken);
+                return result;
+            },
             cancellationToken
         );
-        var result = await Load();
-        await transaction.CommitAsync(cancellationToken);
-        return result;
     }
 
     // Exact listing grain for the rare live fallback while a snapshot generation is absent.

--- a/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
@@ -91,7 +91,8 @@ public class ParadeDbFixture : IAsyncLifetime
     /// and the migrations assembly so any future <c>MigrateAsync</c> call (e.g., reset)
     /// uses the same migration set.
     /// </summary>
-    public EquiblesFinancialDbContext CreateDbContext() => CreateDbContext(configure: null);
+    public EquiblesFinancialDbContext CreateDbContext() =>
+        CreateDbContext(configure: null, configureNpgsql: null);
 
     /// <summary>
     /// Returns a fresh <see cref="EquiblesFinancialDbContext"/> after applying the
@@ -101,7 +102,9 @@ public class ParadeDbFixture : IAsyncLifetime
     /// without duplicating the full production-mirror setup.
     /// </summary>
     public EquiblesFinancialDbContext CreateDbContext(
-        Action<DbContextOptionsBuilder<EquiblesFinancialDbContext>> configure
+        Action<DbContextOptionsBuilder<EquiblesFinancialDbContext>> configure,
+        Action<Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.NpgsqlDbContextOptionsBuilder> configureNpgsql =
+            null
     )
     {
         var optionsBuilder = new DbContextOptionsBuilder<EquiblesFinancialDbContext>();
@@ -115,6 +118,7 @@ public class ParadeDbFixture : IAsyncLifetime
                 npgsql.MigrationsAssembly(
                     typeof(Equibles.Migrations.DesignTimeDbContextFactory).Assembly
                 );
+                configureNpgsql?.Invoke(npgsql);
             }
         );
         optionsBuilder.UseLazyLoadingProxies();

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryMostHeldTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryMostHeldTests.cs
@@ -392,6 +392,53 @@ public class InstitutionalHoldingRepositoryMostHeldTests : IAsyncLifetime
         count.Should().Be(0, "an existing combined generation owns its zero denominator");
     }
 
+    [Fact]
+    public async Task GetMarketActivitySnapshotBacked_WithRetryStrategy_ReadsVersionedGeneration()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "RETRY");
+        var computedAt = DateTime.UtcNow;
+        seed.AddRange(
+            new StockQuarterlyActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = Current,
+                PreviousReportDate = Prior,
+                CurrentShares = 1_200,
+                PreviousShares = 1_000,
+                CurrentValue = 120_000,
+                PreviousValue = 100_000,
+                CurrentFilerCount = 12,
+                PreviousFilerCount = 10,
+                ComputedAt = computedAt,
+            },
+            new StockQuarterlyListingActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = Current,
+                PriceSeriesTicker = stock.Ticker,
+                CurrentShares = 1_200,
+                PreviousShares = 1_000,
+                ComputedAt = computedAt,
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await using var read = _fixture.CreateDbContext(
+            configure: null,
+            configureNpgsql: npgsql => npgsql.EnableRetryOnFailure()
+        );
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var rows = await sut.GetMarketActivitySnapshotBacked(Current, Prior, combined: false);
+
+        rows.Should().ContainSingle();
+        rows[0].CommonStockId.Should().Be(stock.Id);
+        rows[0].CurrentShares.Should().Be(1_200);
+        rows[0].ListingShares.Should().ContainSingle();
+        rows[0].ListingShares[0].PriceSeriesTicker.Should().Be(stock.Ticker);
+    }
+
     private static async Task<CommonStock> SeedStock(
         Equibles.Data.EquiblesFinancialDbContext ctx,
         string ticker


### PR DESCRIPTION
## Summary\n\n- Execute repeatable-read market snapshot loads through the configured EF retry strategy.\n- Propagate request cancellation through retry delays, transactions, and snapshot queries.\n- Add PostgreSQL coverage with transient retries enabled.\n\n## Validation\n\n- Release solution build: passed\n- Unit tests: 4,306 passed\n- Focused PostgreSQL tests: 13 passed\n- Formatting and diff checks: passed