### PR TITLE
fix(holdings): finish incomplete snapshot generations first

### DIFF
--- a/src/Equibles.Holdings.HostedService/AumSnapshotDrainWorker.cs
+++ b/src/Equibles.Holdings.HostedService/AumSnapshotDrainWorker.cs
@@ -96,6 +96,16 @@ public class AumSnapshotDrainWorker : BackgroundService
             due = await dbContext
                 .Set<AumQuarterlySnapshot>()
                 .Where(s => s.DirtyAt != null && s.DirtyAt < cutoff)
+                // A newly introduced snapshot family is empty until its first rebuild.
+                // Prioritize those quarters so public reads stop falling back to the
+                // holdings corpus before routine dirty generations are refreshed.
+                .OrderBy(s =>
+                    dbContext
+                        .Set<StockQuarterlyListingActivity>()
+                        .Any(a => a.ReportDate == s.ReportDate && !a.IsCombined)
+                )
+                .ThenBy(s => s.DirtyAt)
+                .ThenBy(s => s.ReportDate)
                 .Select(s => new DueRebuild
                 {
                     ReportDate = s.ReportDate,

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -209,12 +209,18 @@ public class HoldingsAggregateRefreshService
 
         async Task PublishSnapshotGeneration()
         {
-            await UpsertAumSnapshot(dbContext, reportDate, cancellationToken);
             await UpsertSectorSnapshots(dbContext, reportDate, cancellationToken);
             await UpsertStockActivitySnapshots(dbContext, reportDate, cancellationToken);
             await UpsertHolderSnapshots(dbContext, reportDate, cancellationToken);
             await BeforeCombinedLaneRefresh(reportDate, cancellationToken);
             await RefreshCombinedLane(dbContext, reportDate, cancellationToken);
+
+            // AumQuarterlySnapshot also carries the drain's renewable DirtyAt lease.
+            // Write it last so the transaction does not lock that row while the
+            // expensive aggregate families are still being rebuilt; otherwise the
+            // separate renewal connection blocks behind this transaction and a valid
+            // long rebuild inevitably outlives its lease.
+            await UpsertAumSnapshot(dbContext, reportDate, cancellationToken);
         }
 
         if (!dbContext.Database.IsRelational())

--- a/tests/Equibles.IntegrationTests/Holdings/AumSnapshotDrainWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/AumSnapshotDrainWorkerTests.cs
@@ -257,6 +257,81 @@ public class AumSnapshotDrainWorkerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DrainOnce_TransactionalRebuildDoesNotBlockClaimRenewal()
+    {
+        await SeedHoldings();
+        var dirtyAt = DateTime.UtcNow.AddHours(-2);
+        await using (var seed = FreshContext())
+        {
+            seed.Add(new AumQuarterlySnapshot { ReportDate = Q4, DirtyAt = dirtyAt });
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = BuildScopeFactory();
+        var worker = new TestableDrainWorker(
+            scopeFactory,
+            new DelayedBeforeCombinedRefreshService(
+                scopeFactory,
+                NullLogger<HoldingsAggregateRefreshService>.Instance,
+                TimeSpan.FromMilliseconds(180)
+            ),
+            NullLogger<AumSnapshotDrainWorker>.Instance,
+            cooldown: TimeSpan.Zero,
+            claimLease: TimeSpan.FromMilliseconds(80),
+            claimRenewInterval: TimeSpan.FromMilliseconds(15)
+        );
+
+        await worker.DrainOnce(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var snapshot = await read.Set<AumQuarterlySnapshot>().SingleAsync();
+        snapshot
+            .DirtyAt.Should()
+            .BeNull("the transaction leaves the lease row unlocked until publication");
+    }
+
+    [Fact]
+    public async Task DrainOnce_MissingListingGenerationRunsBeforeMaterializedQuarter()
+    {
+        await SeedHoldings();
+        var missingDate = new DateOnly(2025, 3, 31);
+        var dirtyAt = DateTime.UtcNow.AddHours(-2);
+        await using (var seed = FreshContext())
+        {
+            var stockId = await seed.Set<CommonStock>().Select(s => s.Id).FirstAsync();
+            seed.AddRange(
+                new AumQuarterlySnapshot { ReportDate = Q4, DirtyAt = dirtyAt },
+                new AumQuarterlySnapshot { ReportDate = missingDate, DirtyAt = dirtyAt },
+                new StockQuarterlyListingActivity
+                {
+                    CommonStockId = stockId,
+                    ReportDate = Q4,
+                    PriceSeriesTicker = "AAPL",
+                    CurrentShares = 1,
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var rebuildOrder = new List<DateOnly>();
+        var scopeFactory = BuildScopeFactory();
+        var worker = new TestableDrainWorker(
+            scopeFactory,
+            new RecordingRefreshService(
+                scopeFactory,
+                NullLogger<HoldingsAggregateRefreshService>.Instance,
+                rebuildOrder
+            ),
+            NullLogger<AumSnapshotDrainWorker>.Instance,
+            cooldown: TimeSpan.Zero
+        );
+
+        await worker.DrainOnce(CancellationToken.None);
+
+        rebuildOrder.Should().Equal(missingDate, Q4);
+    }
+
+    [Fact]
     public async Task DrainOnce_ExpiredUnrenewedClaimIsRearmedInsteadOfCleared()
     {
         var dirtyAt = DateTime.UtcNow.AddHours(-2);
@@ -439,6 +514,50 @@ public class AumSnapshotDrainWorkerTests : IAsyncLifetime
             DateOnly reportDate,
             CancellationToken cancellationToken
         ) => Task.Delay(_delay, cancellationToken);
+    }
+
+    private sealed class DelayedBeforeCombinedRefreshService : HoldingsAggregateRefreshService
+    {
+        private readonly TimeSpan _delay;
+
+        public DelayedBeforeCombinedRefreshService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<HoldingsAggregateRefreshService> logger,
+            TimeSpan delay
+        )
+            : base(scopeFactory, logger)
+        {
+            _delay = delay;
+        }
+
+        protected override Task BeforeCombinedLaneRefresh(
+            DateOnly reportDate,
+            CancellationToken cancellationToken
+        ) => Task.Delay(_delay, cancellationToken);
+    }
+
+    private sealed class RecordingRefreshService : HoldingsAggregateRefreshService
+    {
+        private readonly List<DateOnly> _rebuildOrder;
+
+        public RecordingRefreshService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<HoldingsAggregateRefreshService> logger,
+            List<DateOnly> rebuildOrder
+        )
+            : base(scopeFactory, logger)
+        {
+            _rebuildOrder = rebuildOrder;
+        }
+
+        public override Task RebuildQuarterAsync(
+            DateOnly reportDate,
+            CancellationToken cancellationToken
+        )
+        {
+            _rebuildOrder.Add(reportDate);
+            return Task.CompletedTask;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary\n\n- prioritize incomplete listing-activity generations before routine dirty refreshes\n- keep the renewable snapshot claim row unlocked during expensive transactional rebuild work\n- cover PostgreSQL ordering and long transactional renewal behavior\n\n## Validation\n\n- Release solution build passed\n- 4,306 unit tests passed\n- 2,596 database integration tests passed\n- repository-wide formatting and diff checks passed\n- independent final review was clean\n\nRefs daniel3303/EquiblesCommercial#7063