### PR TITLE
fix(web): redirect stale document URLs to canonical owner

### DIFF
--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -331,7 +331,13 @@ public class StocksController : BaseController
 
         if (!string.Equals(document.CommonStock.Ticker, normalizedTicker, StringComparison.Ordinal))
         {
-            return NotFound();
+            // The GUID identifies one public filing globally. Stock ownership can move when
+            // duplicate companies are reconciled, so an old ticker prefix must converge on the
+            // filing's current canonical owner instead of stranding the still-valid document URL.
+            return RedirectToActionPermanent(
+                nameof(ShowDocument),
+                new { ticker = document.CommonStock.Ticker, id }
+            );
         }
 
         var content = string.Empty;

--- a/tests/Equibles.FunctionalTests/Tests/StocksShowDocumentTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksShowDocumentTests.cs
@@ -24,13 +24,10 @@ public class StocksShowDocumentTests
     }
 
     [Fact]
-    public async Task ShowDocument_GetWithIdBelongingToDifferentTicker_Returns404()
+    public async Task ShowDocument_GetWithIdBelongingToDifferentTicker_RedirectsToCanonicalOwner()
     {
-        // StocksController.ShowDocument enforces a cross-ticker guard — when the URL's ticker
-        // does not match the document's owning stock it returns NotFound, even though the
-        // Guid resolves to a real document. Dropping that comparison would let anyone with
-        // a guessed (or leaked) document id pull SEC filings under any ticker prefix. The
-        // test seeds a 10-K under AAPL and requests it under MSFT to pin the 404 boundary.
+        // A document GUID remains stable when its owning stock identity is reconciled. The old
+        // ticker path must converge on the current canonical owner instead of becoming a 404.
         var docId = Guid.NewGuid();
         await _web.ResetAndSeedAsync(async db =>
         {
@@ -82,11 +79,7 @@ public class StocksShowDocumentTests
         var response = await page.GotoAsync($"/stocks/msft/documents/{docId}");
 
         response.Should().NotBeNull();
-        response!
-            .Status.Should()
-            .Be(
-                404,
-                "ShowDocument must reject mismatched ticker even when the document id resolves"
-            );
+        response!.Status.Should().Be(200);
+        page.Url.Should().EndWith($"/stocks/aapl/documents/{docId}");
     }
 }

--- a/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
@@ -539,39 +539,13 @@ public class StocksControllerTests : IDisposable
         result.Should().BeOfType<ViewResult>();
     }
 
-    // ── ShowDocument (cross-ticker guard) ───────────────────────────────
+    // ── ShowDocument (canonical ticker) ─────────────────────────────────
 
     [Fact]
-    public async Task ShowDocument_TickerInUrlDoesNotMatchDocumentStockTicker_ReturnsNotFound()
+    public async Task ShowDocument_TickerInUrlDoesNotMatchDocumentStockTicker_RedirectsToOwner()
     {
-        // ShowDocument routes documents via `~/Stocks/{ticker}/Documents/{id:guid}`.
-        // The `{id:guid}` is sufficient on its own to uniquely identify the
-        // document — `{ticker}` is decorative for URL aesthetics. That makes
-        // the cross-check inside the action load-bearing:
-        //   if (!string.Equals(document.CommonStock.Ticker, ticker,
-        //                      StringComparison.OrdinalIgnoreCase)) return NotFound();
-        // Without this guard, ANY ticker substituted into the URL would render
-        // the same document — e.g. /Stocks/MSFT/Documents/<some-AAPL-doc-guid>
-        // would surface AAPL's 10-K under a Microsoft-branded page. The leak is
-        // invisible to the user: the document content renders normally, only
-        // the breadcrumb ticker differs. Anyone with a document GUID could
-        // mint a misleading URL — particularly damaging when shared, since
-        // the `{ticker}` segment is what social/search previews emphasise.
-        //
-        // The check has no integration sibling: every existing StocksController
-        // test exercises Index / Price / Show-redirect, and none exercise the
-        // ShowDocument action at all. A regression that "simplified" the guard
-        // away — e.g. by inlining a `LoadStock(ticker)` call and trusting
-        // EF to filter — would compile, pass every other test, and silently
-        // open the leak.
-        //
-        // Pin: seed a Document attached to AAPL, request it under the MSFT
-        // ticker, assert the response is NotFound (not the document view).
-        // The InMemory provider doesn't lazy-load `Document.CommonStock`, but
-        // the seed sets the navigation property explicitly AND the same
-        // DbContext is shared between seed and controller, so EF's change
-        // tracker returns the same instance with `CommonStock` already
-        // populated — mirroring what production's lazy-loading proxy yields.
+        // The GUID is the durable document identity; a stale ticker prefix redirects to the
+        // owning stock so the filing never renders under misleading branding.
         var owningStock = SeedStock("AAPL", "Apple Inc.");
         var document = new Document
         {
@@ -579,6 +553,16 @@ public class StocksControllerTests : IDisposable
             CommonStockId = owningStock.Id,
             CommonStock = owningStock,
             ContentId = Guid.NewGuid(),
+            Content = new Equibles.Media.Data.Models.File
+            {
+                Name = "10k",
+                Extension = "html",
+                ContentType = "text/html",
+                FileContent = new Equibles.Media.Data.Models.FileContent
+                {
+                    Bytes = "apple filing"u8.ToArray(),
+                },
+            },
             DocumentType = DocumentType.TenK,
             ReportingDate = new DateOnly(2024, 1, 1),
             ReportingForDate = new DateOnly(2023, 12, 31),
@@ -589,7 +573,11 @@ public class StocksControllerTests : IDisposable
 
         var result = await controller.ShowDocument("MSFT", document.Id);
 
-        result.Should().BeOfType<NotFoundResult>();
+        var redirect = result.Should().BeOfType<RedirectToActionResult>().Subject;
+        redirect.Permanent.Should().BeTrue();
+        redirect.ActionName.Should().Be(nameof(StocksController.ShowDocument));
+        redirect.RouteValues.Should().ContainKey("ticker").WhoseValue.Should().Be("AAPL");
+        redirect.RouteValues.Should().ContainKey("id").WhoseValue.Should().Be(document.Id);
     }
 }
 

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentCrossTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentCrossTickerTests.cs
@@ -18,12 +18,10 @@ namespace Equibles.IntegrationTests.Web;
 public class StocksControllerShowDocumentCrossTickerTests
 {
     [Fact]
-    public async Task ShowDocument_ExistingDocumentRequestedUnderDifferentTicker_ReturnsNotFound()
+    public async Task ShowDocument_ExistingDocumentRequestedUnderDifferentTicker_RedirectsToOwner()
     {
-        // Security-relevant scoping contract: a document that exists but belongs
-        // to stock A must NOT be served under stock B's ticker URL. A regression
-        // that dropped the ticker guard would leak any stock's filing through
-        // any other stock's route (IDOR by enumerable GUID).
+        // The public document is never rendered under the wrong stock. Its globally unique ID
+        // sends stale ticker paths to the owning stock's canonical route.
         using var ctx = TestDbContextFactory.Create(
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
@@ -72,6 +70,10 @@ public class StocksControllerShowDocumentCrossTickerTests
         // Apple's document id, requested under a different ticker.
         var result = await sut.ShowDocument("MSFT", appleDocument.Id);
 
-        result.Should().BeOfType<NotFoundResult>();
+        var redirect = result.Should().BeOfType<RedirectToActionResult>().Subject;
+        redirect.Permanent.Should().BeTrue();
+        redirect.ActionName.Should().Be(nameof(StocksController.ShowDocument));
+        redirect.RouteValues.Should().ContainKey("ticker").WhoseValue.Should().Be("AAPL");
+        redirect.RouteValues.Should().ContainKey("id").WhoseValue.Should().Be(appleDocument.Id);
     }
 }

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentHappyTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentHappyTests.cs
@@ -21,8 +21,7 @@ public class StocksControllerShowDocumentHappyTests
     [Fact]
     public async Task ShowDocument_TickerMatchesAndContentPresent_ReturnsViewWithDecodedUtf8Body()
     {
-        // The only existing ShowDocument test pins the cross-ticker *guard*
-        // (mismatched ticker -> NotFound). The success branch — everything
+        // The existing cross-ticker tests pin canonical redirects. The success branch — everything
         // after the guard at lines 205-218 — has no test at all:
         //   var content = document.Content?.FileContent?.Bytes != null
         //       ? Encoding.UTF8.GetString(document.Content.FileContent.Bytes)

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowHolderUnknownCikTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowHolderUnknownCikTests.cs
@@ -17,7 +17,7 @@ using NSubstitute;
 namespace Equibles.IntegrationTests.Web;
 
 /// <summary>
-/// Sibling to the existing ShowDocument NotFound / CrossTicker pins. ShowHolder
+/// Sibling to the existing ShowDocument missing-id and canonical-ticker pins. ShowHolder
 /// has two guards: stock not found → 404, holder not found → 404. The second
 /// guard (HoldingsExportController.cs:284-285) protects the very next line
 /// `_stockTabService.LoadHolderDetail(stock, holder)` and the title


### PR DESCRIPTION
## Summary
- treat the globally unique document ID as the durable public identity
- permanently redirect stale ticker prefixes to the document owner's current primary ticker
- keep malformed tickers and missing documents as 404 responses

## Verification
- integration suite: 2,595 passed before the corrected fixture; the sole fixture failure was repaired and its focused cases pass
- focused document controller cases: 4 passed
- formatting and whitespace checks pass

Refs daniel3303/EquiblesCommercial#7070