### PR TITLE
fix(holdings): keep originals beneath NEW HOLDINGS 13F amendments

### DIFF
--- a/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
@@ -74,8 +74,17 @@ public class ProcessedDataSet
     /// realtime-swept accessions are behind the realtime watermark, not this
     /// ledger, so the current quarter's affected rows stay understated until
     /// its bulk quarterly data set lands and re-imports them.
+    /// Version 9: stop deduplicating away an original superseded only by a
+    /// "NEW HOLDINGS" amendment (EquiblesCommercial#7163). That amendment type
+    /// only ADDS positions, but the dedup kept just the latest submission per
+    /// (CIK, period) — so a filer whose newest filing was a NEW HOLDINGS
+    /// amendment had its entire original book skipped on every bulk import
+    /// (48 filers in the 2026 Q2 data set alone, including all three
+    /// restructured Vanguard entities, whose Q1 2026 XOM/BRK-B positions could
+    /// never heal). The re-import walks history with the original + additive
+    /// amendments both retained.
     /// </summary>
-    public const int CurrentParserVersion = 8;
+    public const int CurrentParserVersion = 9;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -73,10 +73,12 @@ public class HoldingsImportService
             return new ImportResult(0, IsComplete: false);
         if (parseResult == false)
             return new ImportResult(0, IsComplete: true);
+        // Cover pages must parse BEFORE the dedup: whether a later filing supersedes
+        // its original depends on the amendment type, which lives on the cover page.
+        if (!await ParseCoverPages(context, cancellationToken))
+            return new ImportResult(context.Submissions.Count, IsComplete: false);
         DeduplicateSubmissions(context);
         var submissionCount = context.Submissions.Count;
-        if (!await ParseCoverPages(context, cancellationToken))
-            return new ImportResult(submissionCount, IsComplete: false);
         await ParseSummaryPages(context, cancellationToken);
         var cusipResult = await BuildCusipMapping(context, cancellationToken);
         if (cusipResult == CusipMappingOutcome.NoInfoTable)
@@ -257,16 +259,32 @@ public class HoldingsImportService
             // can still tie on the parsed date; break those ties by accession
             // number — SEC assigns these monotonically per filer agent, so the
             // lexicographically greatest accession is the later submission.
-            var latest = group
-                .OrderByDescending(s =>
+            var ordered = group
+                .OrderBy(s =>
                     TryParseDateOnly(s.FilingDate, out var filingDate)
                         ? filingDate
                         : DateOnly.MinValue
                 )
-                .ThenByDescending(s => s.AccessionNumber, StringComparer.Ordinal)
-                .First();
+                .ThenBy(s => s.AccessionNumber, StringComparer.Ordinal)
+                .ToList();
 
-            foreach (var s in group.Where(s => s.AccessionNumber != latest.AccessionNumber))
+            // A submission is superseded only by a later filing that REPLACES the
+            // whole book: the newest original or RESTATEMENT amendment is the base,
+            // and everything before it is dropped. A "NEW HOLDINGS" amendment only
+            // ADDS positions, so it supersedes nothing — dropping its original
+            // discarded the filer's entire book from every bulk import (all three
+            // restructured Vanguard entities filed one for 2026-03-31, and the bulk
+            // re-import could never heal what the realtime pass had missed —
+            // EquiblesCommercial#7163). An amendment without a typed cover page
+            // keeps the historical behaviour and counts as a restatement, matching
+            // HandleAmendments' delete rule.
+            var baseIndex = ordered.FindLastIndex(s =>
+                !IsNewHoldingsAmendment(s.AccessionNumber, context)
+            );
+            if (baseIndex <= 0)
+                continue;
+
+            foreach (var s in ordered.Take(baseIndex))
             {
                 superseded.Add(s.AccessionNumber);
             }
@@ -1452,7 +1470,8 @@ public class HoldingsImportService
 
     private static bool IsNewHoldingsAmendment(string accession, ImportContext context)
     {
-        return context.CoverPages.TryGetValue(accession, out var coverPage)
+        return context.CoverPages != null
+            && context.CoverPages.TryGetValue(accession, out var coverPage)
             && string.Equals(
                 coverPage.AmendmentType,
                 "NEW HOLDINGS",

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateNewHoldingsAmendmentTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateNewHoldingsAmendmentTests.cs
@@ -1,0 +1,180 @@
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceDeduplicateNewHoldingsAmendmentTests
+{
+    // Contract: a "NEW HOLDINGS" amendment only ADDS positions, so it supersedes
+    // nothing — the dedup must keep the original (or the newest restatement)
+    // as the base plus every additive amendment after it. Keeping only the
+    // latest submission per (CIK, period) discarded the base's entire book
+    // from every bulk import: all three restructured Vanguard entities filed a
+    // NEW HOLDINGS amendment for 2026-03-31, so their 3,600-row originals were
+    // skipped on every pass and the re-import lever could never heal them
+    // (EquiblesCommercial#7163 — 48 filers in that one data set alone).
+    //
+    // A RESTATEMENT (or an untyped legacy amendment — the null-cover-page arm
+    // is pinned by the sibling FilingDatePrimary/Tiebreaker tests) still
+    // supersedes everything filed before it: HandleAmendments deletes the
+    // holder-quarter for those, so re-streaming a superseded original would
+    // resurrect the positions the restatement removed.
+
+    private static SubmissionRow Submission(
+        string accession,
+        string filingDate,
+        string formType = "13F-HR"
+    ) =>
+        new()
+        {
+            AccessionNumber = accession,
+            Cik = "1811242",
+            PeriodOfReport = "2026-03-31",
+            FilingDate = filingDate,
+            FormType = formType,
+        };
+
+    private static CoverPageRow Amendment(string accession, string amendmentType) =>
+        new()
+        {
+            AccessionNumber = accession,
+            IsAmendment = "Y",
+            AmendmentType = amendmentType,
+        };
+
+    private static ImportContext Context(
+        IEnumerable<SubmissionRow> submissions,
+        IEnumerable<CoverPageRow> coverPages
+    )
+    {
+        return new ImportContext
+        {
+            Submissions = submissions.ToDictionary(
+                s => s.AccessionNumber,
+                StringComparer.OrdinalIgnoreCase
+            ),
+            CoverPages = coverPages.ToDictionary(
+                c => c.AccessionNumber,
+                StringComparer.OrdinalIgnoreCase
+            ),
+        };
+    }
+
+    [Fact]
+    public void DeduplicateSubmissions_NewHoldingsAmendment_KeepsTheOriginalBeneathIt()
+    {
+        var context = Context(
+            [
+                Submission("0001811242-26-000004", "08-MAY-2026"),
+                Submission("0001811242-26-000008", "15-MAY-2026", "13F-HR/A"),
+            ],
+            [Amendment("0001811242-26-000008", "NEW HOLDINGS")]
+        );
+
+        HoldingsImportService.DeduplicateSubmissions(context);
+
+        context
+            .Submissions.Keys.Should()
+            .BeEquivalentTo("0001811242-26-000004", "0001811242-26-000008");
+    }
+
+    [Fact]
+    public void DeduplicateSubmissions_RestatementAmendment_StillSupersedesTheOriginal()
+    {
+        var context = Context(
+            [
+                Submission("0001811242-26-000004", "08-MAY-2026"),
+                Submission("0001811242-26-000008", "15-MAY-2026", "13F-HR/A"),
+            ],
+            [Amendment("0001811242-26-000008", "RESTATEMENT")]
+        );
+
+        HoldingsImportService.DeduplicateSubmissions(context);
+
+        context.Submissions.Keys.Should().BeEquivalentTo("0001811242-26-000008");
+    }
+
+    [Fact]
+    public void DeduplicateSubmissions_RestatementAfterNewHoldings_SupersedesBoth()
+    {
+        var context = Context(
+            [
+                Submission("0001811242-26-000004", "08-MAY-2026"),
+                Submission("0001811242-26-000008", "15-MAY-2026", "13F-HR/A"),
+                Submission("0001811242-26-000012", "22-MAY-2026", "13F-HR/A"),
+            ],
+            [
+                Amendment("0001811242-26-000008", "NEW HOLDINGS"),
+                Amendment("0001811242-26-000012", "RESTATEMENT"),
+            ]
+        );
+
+        HoldingsImportService.DeduplicateSubmissions(context);
+
+        context.Submissions.Keys.Should().BeEquivalentTo("0001811242-26-000012");
+    }
+
+    [Fact]
+    public void DeduplicateSubmissions_NewHoldingsAfterRestatement_KeepsRestatementAndAddition()
+    {
+        var context = Context(
+            [
+                Submission("0001811242-26-000004", "08-MAY-2026"),
+                Submission("0001811242-26-000008", "15-MAY-2026", "13F-HR/A"),
+                Submission("0001811242-26-000012", "22-MAY-2026", "13F-HR/A"),
+            ],
+            [
+                Amendment("0001811242-26-000008", "RESTATEMENT"),
+                Amendment("0001811242-26-000012", "NEW HOLDINGS"),
+            ]
+        );
+
+        HoldingsImportService.DeduplicateSubmissions(context);
+
+        context
+            .Submissions.Keys.Should()
+            .BeEquivalentTo("0001811242-26-000008", "0001811242-26-000012");
+    }
+
+    [Fact]
+    public void DeduplicateSubmissions_SeveralNewHoldingsAmendments_AllSurviveWithTheOriginal()
+    {
+        var context = Context(
+            [
+                Submission("0001811242-26-000004", "08-MAY-2026"),
+                Submission("0001811242-26-000008", "15-MAY-2026", "13F-HR/A"),
+                Submission("0001811242-26-000012", "22-MAY-2026", "13F-HR/A"),
+            ],
+            [
+                Amendment("0001811242-26-000008", "NEW HOLDINGS"),
+                Amendment("0001811242-26-000012", "NEW HOLDINGS"),
+            ]
+        );
+
+        HoldingsImportService.DeduplicateSubmissions(context);
+
+        context.Submissions.Should().HaveCount(3);
+    }
+
+    // A data set can hold ONLY additive amendments for a (CIK, period) — the
+    // original lives in an earlier quarter's archive. Nothing supersedes
+    // anything; both amendments stream.
+    [Fact]
+    public void DeduplicateSubmissions_OnlyNewHoldingsAmendments_KeepsAll()
+    {
+        var context = Context(
+            [
+                Submission("0001811242-26-000008", "15-MAY-2026", "13F-HR/A"),
+                Submission("0001811242-26-000012", "22-MAY-2026", "13F-HR/A"),
+            ],
+            [
+                Amendment("0001811242-26-000008", "NEW HOLDINGS"),
+                Amendment("0001811242-26-000012", "NEW HOLDINGS"),
+            ]
+        );
+
+        HoldingsImportService.DeduplicateSubmissions(context);
+
+        context.Submissions.Should().HaveCount(2);
+    }
+}


### PR DESCRIPTION
## Summary
The bulk 13F import's submission dedup keeps only the latest filing per (CIK, period). That is correct when the latest is a RESTATEMENT (it replaces the book), but a **NEW HOLDINGS** amendment only ADDS positions — dropping its original discards the filer's entire book from every bulk import, and the parser-version re-import lever can never heal those filers. In the 2026 Q2 data set alone, 48 filers' latest submission is a NEW HOLDINGS amendment — including all three restructured Vanguard entities, whose Q1 2026 XOM/BRK-B positions were permanently missing (EquiblesCommercial#7163).

## Code changes
- `HoldingsImportService.DeduplicateSubmissions`: sorts each (CIK, period) group by parsed filing date + accession, keeps the newest original-or-RESTATEMENT as the base plus every NEW HOLDINGS amendment after it, and supersedes only what a restatement genuinely replaces. Untyped legacy amendments keep the historical behaviour (count as restatements, matching `HandleAmendments`).
- Cover pages now parse **before** the dedup — the amendment type lives on the cover page. `IsNewHoldingsAmendment` is null-safe for contexts without cover pages.
- `ProcessedDataSet.CurrentParserVersion` bumped to 9 so all history re-imports with originals + additive amendments both retained.
- 6 new unit tests pin the base/additive-chain rule (original kept beneath a NEW HOLDINGS /A; restatement still supersedes; mixed chains; amendment-only groups).

Verified: full OSS solution builds Release with 0 errors; unit suite 4,314/4,314 green (all 17 dedup tests pass, existing behaviour for restatements and untyped amendments unchanged).