### PR TITLE
feat(short-data): let a deployment append a pending-settlement estimate to GetShortInterest

### DIFF
--- a/src/Equibles.Finra.Mcp/Contracts/IShortInterestEstimateSource.cs
+++ b/src/Equibles.Finra.Mcp/Contracts/IShortInterestEstimateSource.cs
@@ -1,0 +1,29 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.Finra.Mcp.Contracts;
+
+/// <summary>
+/// Optional supplement to <c>GetShortInterest</c>'s official series: an estimate of the
+/// settlement that has not been published yet. FINRA measures short interest twice a month and
+/// disseminates each file five business days after the filing deadline, so the newest reported
+/// row a caller can read is routinely two to three weeks stale — long enough for the position to
+/// have moved materially.
+///
+/// A deployment that can estimate the pending settlement registers an implementation; nothing is
+/// registered by default and none is required. The tool answers with the official FINRA series
+/// alone whenever no implementation is present, so this seam changes no existing output.
+/// </summary>
+public interface IShortInterestEstimateSource
+{
+    /// <summary>
+    /// A ready-to-append Markdown block describing the pending settlement's estimate, or
+    /// <c>null</c> when there is nothing to add — the settlement was already published, or the
+    /// implementation's own eligibility gates did not pass.
+    /// </summary>
+    /// <remarks>
+    /// The returned block is appended below the official table, never merged into it: an estimate
+    /// must stay visibly separate from FINRA's reported positions, and must label itself as an
+    /// estimate. It is the implementation's job to say so — the tool appends the text verbatim.
+    /// </remarks>
+    Task<string> Describe(CommonStock stock, CancellationToken cancellationToken = default);
+}

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -12,6 +12,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.BusinessLogic.Models;
 using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Contracts;
 using Equibles.Finra.Repositories;
 using Equibles.Mcp;
 using Equibles.Mcp.Extensions;
@@ -39,6 +40,10 @@ public class ShortDataTools
     private readonly IMemoryCache _memoryCache;
     private readonly McpToolRunner _runner;
 
+    // Injected as a sequence so the dependency stays genuinely optional: a deployment that
+    // cannot estimate the pending settlement registers nothing and resolves an empty one.
+    private readonly IShortInterestEstimateSource _estimateSource;
+
     public ShortDataTools(
         DailyShortVolumeRepository shortVolumeRepository,
         ShortInterestRepository shortInterestRepository,
@@ -46,6 +51,7 @@ public class ShortDataTools
         ShortSqueezeScoreManager shortSqueezeScoreManager,
         StockSplitRepository stockSplitRepository,
         IMemoryCache memoryCache,
+        IEnumerable<IShortInterestEstimateSource> estimateSources,
         ErrorManager errorManager,
         ILogger<ShortDataTools> logger
     )
@@ -56,6 +62,7 @@ public class ShortDataTools
         _shortSqueezeScoreManager = shortSqueezeScoreManager;
         _stockSplitRepository = stockSplitRepository;
         _memoryCache = memoryCache;
+        _estimateSource = estimateSources.FirstOrDefault();
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -148,7 +155,7 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortInterest", Title = "Short Interest History", ReadOnly = true)]
     [Description(
-        "Get bi-monthly short interest history for a stock from FINRA. Shows the reported short position, change from the previous settlement, average daily volume, and days to cover per settlement date. Share counts are restated onto today's split basis so the series stays continuous across stock splits; days to cover is as reported (FINRA caps it at 999.99). High days-to-cover (>5) suggests a potential short squeeze — for short interest as a % of shares outstanding and an actual squeeze-candidate ranking use GetShortSqueezeScores; for the market-wide latest settlement use GetShortInterestSnapshot."
+        "Get bi-monthly short interest history for a stock from FINRA. Shows the reported short position, change from the previous settlement, average daily volume, and days to cover per settlement date. Share counts are restated onto today's split basis so the series stays continuous across stock splits; days to cover is as reported (FINRA caps it at 999.99). High days-to-cover (>5) suggests a potential short squeeze — for short interest as a % of shares outstanding and an actual squeeze-candidate ranking use GetShortSqueezeScores; for the market-wide latest settlement use GetShortInterestSnapshot. FINRA publishes each file weeks after it measures the position, so the answer may also carry an estimate of the settlement that has not been reported yet — it appears BELOW the table, labelled as an estimate, and is a model prediction rather than reported data; never present it as a FINRA figure."
     )]
     public Task<string> GetShortInterest(
         [Description("Stock ticker symbol (e.g., AAPL, GME, TSLA)")] string ticker,
@@ -240,7 +247,13 @@ public class ShortDataTools
                         )
                 );
 
-                return AppendNote(table, NewestKeptNote(display.Count, total, "settlements"));
+                // The estimate is appended BELOW the table, never merged into it as a row: the
+                // table is FINRA's reported record and a prediction sitting in it would read as
+                // one. A source that has nothing to add returns null and the answer is unchanged.
+                var answer = AppendNote(table, NewestKeptNote(display.Count, total, "settlements"));
+                var estimate =
+                    _estimateSource == null ? null : await _estimateSource.Describe(stock);
+                return string.IsNullOrWhiteSpace(estimate) ? answer : $"{answer}\n{estimate}\n";
             },
             "GetShortInterest",
             $"ticker: {ticker}"


### PR DESCRIPTION
## Summary

FINRA measures short interest twice a month and disseminates each file five business days after the filing deadline, so the newest row `GetShortInterest` can return is routinely two to three weeks stale — long enough for the position to have moved materially. A deployment that can estimate the settlement FINRA has not published yet had no way to say so through this tool.

This adds an optional seam for that and nothing else. No implementation is registered here and none is required: `ShortDataTools` takes the source as an `IEnumerable<>` so an unconfigured deployment resolves an empty one and every existing answer is byte-for-byte unchanged.

## Code changes

- `Contracts/IShortInterestEstimateSource.cs` (new) — one method returning a ready-to-append Markdown block, or null when there is nothing to add (the settlement was published, or the implementation's own gates did not pass).
- `Tools/ShortDataTools.cs` — resolves the optional source and appends its block **below** the table, never as a row in it. The table is FINRA's reported record; a prediction sitting inside it would read as one. Labelling the block as an estimate is the implementation's job, and the tool's `[Description]` now tells the model the block may appear, that it sits below the table, and that it must never be presented as a FINRA figure.

## Verification

`Equibles.UnitTests` green — 4314 passed, including the MCP module wiring and tool-annotation guards. csharpier clean.