### PR TITLE
fix(short-data): keep the pending-settlement estimate out of the table and off historical windows

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -247,13 +247,13 @@ public class ShortDataTools
                         )
                 );
 
-                // The estimate is appended BELOW the table, never merged into it as a row: the
-                // table is FINRA's reported record and a prediction sitting in it would read as
-                // one. A source that has nothing to add returns null and the answer is unchanged.
                 var answer = AppendNote(table, NewestKeptNote(display.Count, total, "settlements"));
+                if (!WindowReachesPresent(end))
+                    return answer;
+
                 var estimate =
                     _estimateSource == null ? null : await _estimateSource.Describe(stock);
-                return string.IsNullOrWhiteSpace(estimate) ? answer : $"{answer}\n{estimate}\n";
+                return AppendEstimate(answer, estimate);
             },
             "GetShortInterest",
             $"ticker: {ticker}"
@@ -604,6 +604,20 @@ public class ShortDataTools
     // renderers keep the table intact); a no-op for the empty note or an empty-state message.
     private static string AppendNote(string table, string note) =>
         note.Length == 0 ? table : $"{table}\n{note}\n";
+
+    // The pending-settlement estimate answers "where is short interest NOW", so it belongs only
+    // to a request whose window runs to the present. Appending it under a 2019 table would answer
+    // a question the caller did not ask — and the default endDate already IS today, so this only
+    // ever withholds it from someone who explicitly asked for a historical window.
+    private static bool WindowReachesPresent(DateOnly end) =>
+        end >= DateOnly.FromDateTime(DateTime.UtcNow);
+
+    // Separated from the table by a BLANK line, never merged into it: the table is FINRA's
+    // reported record, and a prediction sitting inside it would read as one. The blank line is
+    // load-bearing — with a single newline the block becomes a lazy continuation of whatever
+    // precedes it, which in the no-rows case fuses it into the "no data found" sentence.
+    private static string AppendEstimate(string answer, string estimate) =>
+        string.IsNullOrWhiteSpace(estimate) ? answer : $"{answer.TrimEnd('\n')}\n\n{estimate}\n";
 
     private static string FormatSignedChange(long change) =>
         change >= 0 ? $"+{McpFormat.WholeNumber(change)}" : McpFormat.WholeNumber(change);

--- a/tests/Equibles.UnitTests/Mcp/ShortDataToolsEstimateAppendTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/ShortDataToolsEstimateAppendTests.cs
@@ -1,0 +1,93 @@
+using System.Reflection;
+using Equibles.Finra.Mcp.Tools;
+
+namespace Equibles.UnitTests.Mcp;
+
+// GetShortInterest may append a pending-settlement estimate supplied by the deployment. The table
+// above it is FINRA's reported record, so the two rules that keep the estimate from being read as
+// reported data — it is separated by a BLANK line, and it only appears at all when the caller's
+// window runs to the present — are pinned here rather than left to the call site's formatting.
+public class ShortDataToolsEstimateAppendTests
+{
+    private static string AppendEstimate(string answer, string estimate) =>
+        (string)
+            typeof(ShortDataTools)
+                .GetMethod("AppendEstimate", BindingFlags.NonPublic | BindingFlags.Static)!
+                .Invoke(null, [answer, estimate]);
+
+    private static bool WindowReachesPresent(DateOnly end) =>
+        (bool)
+            typeof(ShortDataTools)
+                .GetMethod("WindowReachesPresent", BindingFlags.NonPublic | BindingFlags.Static)!
+                .Invoke(null, [end]);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoEstimateLeavesTheAnswerExactlyAsItWas(string estimate)
+    {
+        const string answer = "Short interest for NVDA (Nvidia Corp):\n\n| a |\n|---|\n| 1 |\n";
+
+        AppendEstimate(answer, estimate)
+            .Should()
+            .BeSameAs(
+                answer,
+                "a deployment that registers no estimate source must get byte-identical output"
+            );
+    }
+
+    [Fact]
+    public void TheEstimateIsSeparatedFromTheTableByABlankLine()
+    {
+        var result = AppendEstimate(
+            "Short interest for NVDA (Nvidia Corp):\n\n| a |\n|---|\n| 1 |\n",
+            "**Model estimate — not official FINRA data.**"
+        );
+
+        result
+            .Should()
+            .Contain(
+                "| 1 |\n\n**Model estimate",
+                "a single newline makes the block a lazy continuation of the table's last line in CommonMark, which is exactly the merge the separation exists to prevent"
+            );
+    }
+
+    // The no-rows answer is a bare sentence with no trailing newline. Without normalising the
+    // join, the estimate fused into "No short interest data found for X ..." and the tool's only
+    // content became a prediction wearing a no-data sentence as its opening clause.
+    [Fact]
+    public void AnEmptyResultDoesNotSwallowTheEstimateIntoItsSentence()
+    {
+        var result = AppendEstimate(
+            "No short interest data found for NVDA in the specified date range.",
+            "**Model estimate — not official FINRA data.**"
+        );
+
+        result
+            .Should()
+            .Be(
+                "No short interest data found for NVDA in the specified date range.\n\n**Model estimate — not official FINRA data.**\n"
+            );
+    }
+
+    [Fact]
+    public void ADefaultWindowRunningToTodayCarriesTheEstimate()
+    {
+        WindowReachesPresent(DateOnly.FromDateTime(DateTime.UtcNow)).Should().BeTrue();
+        WindowReachesPresent(DateOnly.FromDateTime(DateTime.UtcNow).AddDays(30))
+            .Should()
+            .BeTrue("a window ending in the future still asks about the present");
+    }
+
+    [Fact]
+    public void AHistoricalWindowDoesNotCarryATodayEstimate()
+    {
+        WindowReachesPresent(new DateOnly(2019, 12, 31))
+            .Should()
+            .BeFalse(
+                "appending a pending-settlement estimate under a 2019 table answers a question the caller did not ask"
+            );
+        WindowReachesPresent(DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1)).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Follow-up to #4378, which added the optional estimate seam. Review of the first consumer surfaced two ways the appended block could misrepresent itself.

## Summary

**The block could fuse into the answer above it.** `MarkdownTable.Render` returns the empty-state sentence with no trailing newline, and the join used a single `\n`. In CommonMark that makes the block a lazy continuation of the preceding paragraph, so `No short interest data found for X in the specified date range.` and the estimate became one paragraph — a tool answer whose only content is a prediction wearing a no-data sentence as its opening clause. The join now normalises to a blank line, which also guarantees the block can never be read as a trailing table row.

**The block ignored the caller's date range.** `GetShortInterest("GME", startDate: "2019-01-01", endDate: "2019-12-31")` rendered a 2019 table and appended an estimate of today's pending settlement. It is now withheld unless the requested window runs to the present — and since `endDate` already defaults to today, that only ever affects a caller who explicitly asked for a historical window.

## Code changes

- `Tools/ShortDataTools.cs` — `AppendEstimate` (blank-line separation, unchanged answer when there is nothing to append) and `WindowReachesPresent` (relevance gate) replace the inline interpolation at the call site.
- `tests/Equibles.UnitTests/Mcp/ShortDataToolsEstimateAppendTests.cs` (new) — pins both rules plus the byte-identical no-source path, which was previously unguarded in either direction.

## Verification

`Equibles.UnitTests` green — 4321 passed. csharpier clean.