### PR TITLE
fix(corporate-actions): restate read-time series with effective splits only

### DIFF
--- a/src/Equibles.CorporateActions.Repositories/StockSplitRepository.cs
+++ b/src/Equibles.CorporateActions.Repositories/StockSplitRepository.cs
@@ -15,6 +15,18 @@ public class StockSplitRepository : BaseRepository<StockSplit>
         return GetAll().Where(s => s.CommonStockId == commonStockId);
     }
 
+    /// <summary>
+    /// The stock's splits already effective as of <paramref name="asOf"/> — the set every
+    /// read-time restatement must use. Split rows are captured at announcement, ahead of their
+    /// effective date, so restating a historical series with the unfiltered set scales it by a
+    /// split that has not happened yet, for the whole announcement window. <see cref="GetByStock"/>
+    /// remains for writers (capture/reconciliation), which do need the announced rows.
+    /// </summary>
+    public IQueryable<StockSplit> GetEffectiveByStock(Guid commonStockId, DateOnly asOf)
+    {
+        return GetByStock(commonStockId).Where(s => s.EffectiveDate <= asOf);
+    }
+
     public IQueryable<StockSplit> GetPendingPriceAdjustment()
     {
         // SQL-translatable mirror of StockSplit.IsPriceAdjustmentApplied: a marker written on or

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -129,7 +129,9 @@ public class ShortDataTools
                 // continuous across a split (a raw pre-split day would otherwise show a
                 // phantom step against post-split days). The same-day Short % is a ratio of
                 // two counts on the same date, so it is split-invariant and left as-is.
-                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var splits = await _stockSplitRepository
+                    .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                    .ToListAsync();
 
                 var table = MarkdownTable.Render(
                     records.OrderBy(r => r.Date).ToList(),
@@ -206,7 +208,9 @@ public class ShortDataTools
                 // split. Days to cover is a same-settlement ratio (position ÷ ADV) and is left
                 // as reported — restating the numerator and denominator by the same factor
                 // leaves it unchanged anyway.
-                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var splits = await _stockSplitRepository
+                    .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                    .ToListAsync();
 
                 // FINRA's raw change is (current − previous) where the previous position is on
                 // the PREVIOUS settlement's split basis, so scaling it by the current factor

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -164,7 +164,9 @@ public class InstitutionalHoldingsTools
                 if (holdings.Count == 0)
                     return $"No institutional holdings found for {ticker} as of {FormatDate(targetDate)}.";
 
-                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var splits = await _stockSplitRepository
+                    .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                    .ToListAsync();
                 foreach (var holding in holdings)
                 {
                     var listing = holding.ListedTicker ?? stock.Ticker;
@@ -864,7 +866,9 @@ public class InstitutionalHoldingsTools
                 // quarters sit on different bases if a split fell between them) so Δ Shares
                 // and the Prior → New column reflect a real position change, not the split.
                 // Δ Value is a dollar figure and is split-invariant — leave the stored value.
-                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var splits = await _stockSplitRepository
+                    .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                    .ToListAsync();
                 long AdjustShares(long shares, DateOnly asOf, string listedTicker)
                 {
                     var exactTicker = listedTicker ?? stock.Ticker;

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -189,7 +189,9 @@ public class InsiderTradingTools
                 // own price/value — never compared across dates). Only the running
                 // post-transaction balance (Owned After) is compared across dates and insiders,
                 // so it alone is restated onto today's split basis.
-                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var splits = await _stockSplitRepository
+                    .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                    .ToListAsync();
 
                 var sb = new StringBuilder();
                 sb.AppendLine($"Recent insider transactions for {stock.Name} ({stock.Ticker}):");
@@ -316,7 +318,9 @@ public class InsiderTradingTools
                 // Restate every position onto today's basis, then rank and cut on the
                 // adjusted holding so the ordering — and the top-N cut itself — compares
                 // like with like.
-                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var splits = await _stockSplitRepository
+                    .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                    .ToListAsync();
                 offset = McpLimit.ClampOffset(offset);
                 // Adjusted holdings tie constantly (zero-share former insiders), so the
                 // ordering ends on stable keys — an offset over a partial order would
@@ -451,7 +455,9 @@ public class InsiderTradingTools
                 // "100% of outstanding" figures (#7164, EquiblesCommercial). The filed share
                 // count is restated onto today's split basis first so the ratio compares like
                 // with like against the current issuer count.
-                var splits = await _stockSplitRepository.GetByStock(stock.Id).ToListAsync();
+                var splits = await _stockSplitRepository
+                    .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                    .ToListAsync();
                 var result = MarkdownTable.Start(
                     $"Recent proposed sales (Form 144) for {stock.Name} ({stock.Ticker}):",
                     $"Showing {filings.Count} of {totalCount} most recent notices",

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsSplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsSplitAdjustmentTests.cs
@@ -132,6 +132,66 @@ public class InsiderTradingToolsSplitAdjustmentTests
         output.Should().Contain("| 1,000,000 |");
     }
 
+    // Split rows are captured at announcement, ahead of their effective date. A split that has
+    // not happened yet must not restate anything: during its announcement window the unfiltered
+    // set scaled every running balance by a factor the market had not applied (GH-7254).
+    [Fact]
+    public async Task GetInsiderTransactions_AnnouncedFutureSplit_DoesNotRestateTheRunningBalance()
+    {
+        await using var db = NewDb();
+
+        var stock = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "0001045810",
+        };
+        var owner = new InsiderOwner
+        {
+            OwnerCik = "0009876543",
+            Name = "Jensen Huang",
+            IsOfficer = true,
+            OfficerTitle = "CEO",
+        };
+        db.AddRange(stock, owner);
+        db.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                EffectiveDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(7),
+                Numerator = 10,
+                Denominator = 1,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        db.Add(
+            new InsiderTransaction
+            {
+                CommonStockId = stock.Id,
+                CommonStock = stock,
+                InsiderOwnerId = owner.Id,
+                InsiderOwner = owner,
+                TransactionDate = new DateOnly(2024, 6, 1),
+                FilingDate = new DateOnly(2024, 6, 3),
+                TransactionCode = TransactionCode.Sale,
+                Shares = 40_000,
+                PricePerShare = 800.00m,
+                AcquiredDisposed = AcquiredDisposed.Disposed,
+                SharesOwnedAfter = 100_000,
+                OwnershipNature = OwnershipNature.Direct,
+                SecurityTitle = "Common Stock",
+                AccessionNumber = "acc-nvda-1",
+            }
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderTransactions("NVDA");
+
+        // The running balance stays as filed — the announced split is not yet a basis change.
+        output.Should().Contain("| 100,000 |");
+        output.Should().NotContain("1,000,000");
+    }
+
     [Fact]
     public async Task GetProposedSales_NoticeBeforeSplit_KeepsSharesAsFiledBesideMarketValue()
     {


### PR DESCRIPTION
## Summary

Split rows are captured at announcement, ahead of their effective date — but the MCP display tools restated historical series with the **unfiltered** split set. During a split's announcement window (announcement → effective date), `GetShortVolume`, `GetShortInterest`, the 13F holdings tools, and the insider tools all scaled their share counts by a split the market had not applied yet: a 10:1 announcement made every short position and running balance read 10× too high for days.

## Code changes

- `StockSplitRepository.GetEffectiveByStock(stockId, asOf)` (new) — the splits already effective as of a date, the set every read-time restatement must use. `GetByStock` remains for writers (capture/reconciliation), which do need announced rows.
- All seven display call sites switch to it: `ShortDataTools` ×2, `InstitutionalHoldingsTools` ×2, `InsiderTradingTools` ×3.
- New test in `InsiderTradingToolsSplitAdjustmentTests`: an announced split effective next week leaves the running balance as filed.

## Verification

`Equibles.UnitTests` green — 4322 passed. csharpier clean.