### PR TITLE
fix(corporate-actions): keep announced splits out of every remaining read-time restatement

### DIFF
--- a/src/Equibles.CorporateActions.Repositories/StockSplitRepository.cs
+++ b/src/Equibles.CorporateActions.Repositories/StockSplitRepository.cs
@@ -27,6 +27,16 @@ public class StockSplitRepository : BaseRepository<StockSplit>
         return GetByStock(commonStockId).Where(s => s.EffectiveDate <= asOf);
     }
 
+    /// <summary>
+    /// Batch companion to <see cref="GetEffectiveByStock"/> for callers that restate many
+    /// stocks with one query: every split already effective as of <paramref name="asOf"/>,
+    /// across all stocks. Compose the stock filter on top.
+    /// </summary>
+    public IQueryable<StockSplit> GetEffective(DateOnly asOf)
+    {
+        return GetAll().Where(s => s.EffectiveDate <= asOf);
+    }
+
     public IQueryable<StockSplit> GetPendingPriceAdjustment()
     {
         // SQL-translatable mirror of StockSplit.IsPriceAdjustmentApplied: a marker written on or

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -259,7 +259,7 @@ public class ShortSqueezeScoreManager
         // split factor (e.g. a 10:1 split makes the raw ratio 10× too small).
         var splitsByStock = (
             await _stockSplitRepository
-                .GetAll()
+                .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
                 .Where(s => stockIds.Contains(s.CommonStockId))
                 .ToListAsync(cancellationToken)
         )

--- a/src/Equibles.Holdings.BusinessLogic/MarketActivityShareRestater.cs
+++ b/src/Equibles.Holdings.BusinessLogic/MarketActivityShareRestater.cs
@@ -46,7 +46,7 @@ public class MarketActivityShareRestater
             .ToDictionaryAsync(stock => stock.Id, stock => stock.Ticker, cancellationToken);
         var splitsByStock = (
             await _stockSplitRepository
-                .GetAll()
+                .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
                 .AsNoTracking()
                 .Where(split => stockIds.Contains(split.CommonStockId))
                 .ToListAsync(cancellationToken)
@@ -94,7 +94,7 @@ public class MarketActivityShareRestater
             return;
 
         var splits = await _stockSplitRepository
-            .GetByStock(stock.Id)
+            .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
             .AsNoTracking()
             .ToListAsync(cancellationToken);
         if (splits.Count == 0)

--- a/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
+++ b/src/Equibles.Holdings.BusinessLogic/StockCombinedQuarterService.cs
@@ -140,7 +140,7 @@ public class StockCombinedQuarterService
         }
 
         var splits = await _stockSplitRepository
-            .GetByStock(stock.Id)
+            .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
             .AsNoTracking()
             .ToListAsync(cancellationToken);
         var combinedShares = MarketActivityShareRestater.RestateListingTotal(

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -2394,7 +2394,7 @@ public class InstitutionalHoldingsTools
             return new Dictionary<Guid, List<StockSplit>>();
 
         var splits = await _stockSplitRepository
-            .GetAll()
+            .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
             .Where(s => ids.Contains(s.CommonStockId))
             .ToListAsync();
         return splits.GroupBy(s => s.CommonStockId).ToDictionary(g => g.Key, g => g.ToList());

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -326,8 +326,7 @@ public class InsiderFilingReprocessManager
         // repaired trading day rather than the impossible source typo.
         var bars = await FetchBars(first.CommonStockId, rows);
         var splits = await _stockSplitRepository
-            .GetAll()
-            .Where(sp => sp.CommonStockId == first.CommonStockId)
+            .GetEffectiveByStock(first.CommonStockId, DateOnly.FromDateTime(DateTime.UtcNow))
             .ToListAsync();
         var identity = await _dbContext
             .Set<CommonStock>()

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
@@ -261,7 +261,7 @@ public class InsiderTransactionPriceBackfillManager
 
         var splitsByStock = (
             await _stockSplitRepository
-                .GetAll()
+                .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
                 .Where(sp => stockIds.Contains(sp.CommonStockId))
                 .ToListAsync()
         )

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -807,8 +807,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             .ToListAsync();
 
         var splits = await stockSplitRepository
-            .GetAll()
-            .Where(sp => sp.CommonStockId == companyId)
+            .GetEffectiveByStock(companyId, DateOnly.FromDateTime(DateTime.UtcNow))
             .ToListAsync();
 
         foreach (var transaction in transactions)

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
@@ -33,6 +33,7 @@ public class ShortDataToolsGetLargestShortVolumeCultureInvarianceTests : ParadeD
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
@@ -34,6 +34,7 @@ public class ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
@@ -33,6 +33,7 @@ public class ShortDataToolsGetShortInterestCultureInvarianceTests : ParadeDbMcpT
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
@@ -33,6 +33,7 @@ public class ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests : Para
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
@@ -42,6 +42,7 @@ public class ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTes
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -33,6 +33,7 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
@@ -33,6 +33,7 @@ public class ShortDataToolsGetShortVolumeCultureInvarianceTests : ParadeDbMcpTes
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
@@ -40,6 +40,7 @@ public class ShortDataToolsHistoryOutputNotesTests : ParadeDbMcpTestBase
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsLargestShortVolumeSortAndLegendTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsLargestShortVolumeSortAndLegendTests.cs
@@ -38,6 +38,7 @@ public class ShortDataToolsLargestShortVolumeSortAndLegendTests : ParadeDbMcpTes
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsSnapshotSentinelTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsSnapshotSentinelTests.cs
@@ -40,6 +40,7 @@ public class ShortDataToolsSnapshotSentinelTests : ParadeDbMcpTestBase
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsStrictDateArgumentsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsStrictDateArgumentsTests.cs
@@ -40,6 +40,7 @@ public class ShortDataToolsStrictDateArgumentsTests : ParadeDbMcpTestBase
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -32,6 +32,7 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
@@ -44,6 +44,7 @@ public class ShortDataToolsZeroChangeTests : ParadeDbMcpTestBase
             ),
             new StockSplitRepository(DbContext),
             new MemoryCache(new MemoryCacheOptions()),
+            estimateSources: [],
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.UnitTests/CorporateActions/StockSplitRepositoryEffectiveTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/StockSplitRepositoryEffectiveTests.cs
@@ -1,0 +1,97 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Equibles.UnitTests.CorporateActions;
+
+/// <summary>
+/// Pins the effective-splits seam every read-time restatement goes through. Split rows are
+/// captured at ANNOUNCEMENT, ahead of their effective date, so the unfiltered set scales a
+/// series by a split that has not happened yet for the whole announcement window (GH-7254).
+/// <see cref="StockSplitRepository.GetEffectiveByStock"/> / <see cref="StockSplitRepository.GetEffective"/>
+/// must return only splits effective on or before the as-of date; the boundary is INCLUSIVE
+/// so a split effective today already restates (matching SplitAdjustment's strictly-after rule).
+/// </summary>
+public class StockSplitRepositoryEffectiveTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        var context = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    private static StockSplit Split(Guid stockId, DateOnly effectiveDate) =>
+        new()
+        {
+            CommonStockId = stockId,
+            EffectiveDate = effectiveDate,
+            Numerator = 10,
+            Denominator = 1,
+            Source = StockSplitSource.Yahoo,
+        };
+
+    [Fact]
+    public async Task GetEffectiveByStock_ExcludesAnnouncedFutureSplit_KeepsPastAndSameDay()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock { Ticker = "NVDA" };
+        var asOf = new DateOnly(2026, 8, 13);
+        db.Add(stock);
+        db.AddRange(
+            Split(stock.Id, asOf.AddYears(-1)), // long effective
+            Split(stock.Id, asOf), // effective today — inclusive boundary
+            Split(stock.Id, asOf.AddDays(7)) // announced, not yet a basis change
+        );
+        await db.SaveChangesAsync();
+
+        var effective = await new StockSplitRepository(db)
+            .GetEffectiveByStock(stock.Id, asOf)
+            .Select(s => s.EffectiveDate)
+            .ToListAsync();
+
+        effective.Should().BeEquivalentTo([asOf.AddYears(-1), asOf]);
+    }
+
+    [Fact]
+    public async Task GetEffective_BatchVariant_AppliesTheSameCutoffAcrossStocks()
+    {
+        await using var db = NewDb();
+        var first = new CommonStock { Ticker = "AAA" };
+        var second = new CommonStock { Ticker = "BBB" };
+        var asOf = new DateOnly(2026, 8, 13);
+        db.AddRange(first, second);
+        db.AddRange(
+            Split(first.Id, asOf.AddMonths(-2)),
+            Split(first.Id, asOf.AddDays(1)), // announced for tomorrow — excluded
+            Split(second.Id, asOf.AddDays(30)) // whole stock still inside its announcement window
+        );
+        await db.SaveChangesAsync();
+
+        var effective = await new StockSplitRepository(db)
+            .GetEffective(asOf)
+            .Select(s => new { s.CommonStockId, s.EffectiveDate })
+            .ToListAsync();
+
+        effective.Should().HaveCount(1);
+        effective[0].CommonStockId.Should().Be(first.Id);
+        effective[0].EffectiveDate.Should().Be(asOf.AddMonths(-2));
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #4380. That PR filtered the per-stock MCP display restatements to effective splits only; this one closes the remaining readers that still used the unfiltered set — during a split's announcement window they scaled series by a split that had not happened yet.

## Code changes
- `StockSplitRepository.GetEffective(asOf)` — batch companion to `GetEffectiveByStock` for callers restating many stocks with one query.
- Switched to effective-only splits: `InstitutionalHoldingsTools.LoadSplitsByStock` (portfolio + quarterly-activity batch), `ShortSqueezeScoreManager`, `MarketActivityShareRestater` (both paths), `StockCombinedQuarterService`, and the three insider price-validation sites building `SplitFactorToPresent` (`InsiderTradingFilingProcessor`, `InsiderTransactionPriceBackfillManager`, `InsiderFilingReprocessManager`) — a future split is not part of today's bar basis.
- Writers (`StockSplitCaptureManager`, reconciliation) still read announced rows via `GetByStock`/`GetAll`; `StockPriceTools` already bounds by the latest bar date and is untouched.
- New `StockSplitRepositoryEffectiveTests` pin both seams (inclusive same-day boundary, future split excluded, batch cutoff across stocks).
- Repairs the `ShortDataTools` integration-test constructor calls that were missed when the estimate-source seam landed (they didn't pass the new parameter, so the integration project stopped compiling).

Unit suite: 4324 passed. csharpier clean.