### PR TITLE
fix(sec): deduplicate ranked search chunks

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/HybridChunkSearcher.cs
@@ -177,6 +177,12 @@ public class HybridChunkSearcher
             }
         }
 
+        // ParadeDB can occasionally materialize the same indexed row more than once. Rankings
+        // must contain unique ids: duplicates would make the pool look full, be counted twice by
+        // RRF, and make the final id-to-chunk lookup throw. Keep the first occurrence because it
+        // has the best BM25 rank.
+        bm25 = bm25.DistinctBy(chunk => chunk.Id).ToList();
+
         // Opt-in recall fallback: BM25 ANDs every query token, so a wordy natural-language
         // query where a single token has no match ("drivers" vs the filing's "driven")
         // excludes every on-point chunk. When the conjunctive pass can't fill the request,
@@ -202,8 +208,7 @@ public class HybridChunkSearcher
                     commandTimeoutSeconds: bm25Timeout != null ? DegradedPassTimeoutSeconds : null,
                     cancellationToken: cancellationToken
                 );
-                var seen = bm25.Select(chunk => chunk.Id).ToHashSet();
-                bm25 = bm25.Concat(disjunctive.Where(chunk => !seen.Contains(chunk.Id))).ToList();
+                bm25 = bm25.Concat(disjunctive).DistinctBy(chunk => chunk.Id).ToList();
                 // The disjunctive pass matches a superset of the conjunctive pass, so its
                 // completed result also answers for a timed-out conjunctive pass — an
                 // empty pool now genuinely means "no matches", not "ran out of budget".

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherAutoVectorSourceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherAutoVectorSourceTests.cs
@@ -141,6 +141,65 @@ public class HybridChunkSearcherAutoVectorSourceTests
     }
 
     [Fact]
+    public async Task TickerScoped_AutoMode_DuplicateBm25Rows_ReturnsEachChunkOnce()
+    {
+        var chunkId = Guid.NewGuid();
+        var bestRankedInstance = new Chunk
+        {
+            Id = chunkId,
+            Ticker = "AAPL",
+            Content = "best-ranked materialization",
+        };
+        var duplicateInstance = new Chunk
+        {
+            Id = chunkId,
+            Ticker = "AAPL",
+            Content = "duplicate materialization",
+        };
+        var chunkRepository = new StubChunkRepository(
+            bm25Results: [bestRankedInstance, duplicateInstance],
+            allChunks: [bestRankedInstance]
+        );
+        var embeddingRepository = new StubEmbeddingRepository(similarChunkIds: [chunkId]);
+        var searcher = NewSearcher(chunkRepository, embeddingRepository);
+
+        var results = await searcher.Search("semantic question", 5, ticker: "AAPL");
+
+        var result = Assert.Single(results);
+        Assert.Same(bestRankedInstance, result);
+    }
+
+    [Fact]
+    public async Task TickerScoped_AutoMode_DuplicateBm25Rows_DoNotInflateRrfScore()
+    {
+        var duplicate = new Chunk
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Content = "keyword-only result",
+        };
+        var semanticMatch = new Chunk
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Content = "semantic match",
+        };
+        var chunkRepository = new StubChunkRepository(
+            bm25Results: [duplicate, duplicate, semanticMatch],
+            allChunks: [duplicate, semanticMatch]
+        );
+        var embeddingRepository = new StubEmbeddingRepository(
+            similarChunkIds: [semanticMatch.Id]
+        );
+        var searcher = NewSearcher(chunkRepository, embeddingRepository);
+
+        var results = await searcher.Search("semantic question", 5, ticker: "AAPL");
+
+        Assert.Equal(semanticMatch.Id, results[0].Id);
+        Assert.Equal(2, results.Count);
+    }
+
+    [Fact]
     public void Auto_IsTheDefaultVectorSource()
     {
         Assert.Equal(VectorSource.Auto, new HybridSearchOptions().VectorSource);

--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherBm25TimeoutTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherBm25TimeoutTests.cs
@@ -119,6 +119,24 @@ public class HybridChunkSearcherBm25TimeoutTests
     }
 
     [Fact]
+    public async Task DuplicateConjunctiveRows_DoNotSuppressDisjunctiveFallback()
+    {
+        var precise = new Chunk { Id = Guid.NewGuid(), Content = "precise match" };
+        var broad = new Chunk { Id = Guid.NewGuid(), Content = "broadened match" };
+        var chunkRepository = new TimeoutChunkRepository(
+            conjunctiveResults: [precise, precise, precise, precise, precise],
+            disjunctiveResults: [precise, broad],
+            allChunks: [precise, broad]
+        );
+        var searcher = NewSearcher(chunkRepository, new StubEmbeddingRepository([]));
+
+        var results = await searcher.Search("query", 5, disjunctiveFallback: true);
+
+        Assert.Equal([precise.Id, broad.Id], results.Select(chunk => chunk.Id));
+        Assert.Single(chunkRepository.DisjunctiveBudgets);
+    }
+
+    [Fact]
     public async Task ConjunctiveTimeout_DisjunctiveCompletesEmpty_ReturnsProvenEmptyWithoutThrowing()
     {
         // The disjunctive pass matches a SUPERSET of the conjunctive pass — when it


### PR DESCRIPTION
## Summary

Prevent duplicate ParadeDB chunk rows from crashing hybrid SEC document searches or distorting ranking and fallback behavior.

## Code changes

- Deduplicate BM25 rows before deciding whether a disjunctive top-up is needed.
- Preserve the first-ranked chunk while uniquely merging fallback results before RRF.
- Add regressions for duplicate materialization, RRF score inflation, and fallback suppression.