### PR TITLE
chore(sec): format duplicate search regression

### DIFF
--- a/tests/Equibles.UnitTests/Sec/HybridChunkSearcherAutoVectorSourceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HybridChunkSearcherAutoVectorSourceTests.cs
@@ -188,9 +188,7 @@ public class HybridChunkSearcherAutoVectorSourceTests
             bm25Results: [duplicate, duplicate, semanticMatch],
             allChunks: [duplicate, semanticMatch]
         );
-        var embeddingRepository = new StubEmbeddingRepository(
-            similarChunkIds: [semanticMatch.Id]
-        );
+        var embeddingRepository = new StubEmbeddingRepository(similarChunkIds: [semanticMatch.Id]);
         var searcher = NewSearcher(chunkRepository, embeddingRepository);
 
         var results = await searcher.Search("semantic question", 5, ticker: "AAPL");


### PR DESCRIPTION
## Summary

Fix the CSharpier lint failure left by the duplicate ranked-search regression tests.

## Code changes

- Apply the repository formatter to the `StubEmbeddingRepository` construction.
- Keep test behavior unchanged.