### PR TITLE
docs: add cloud earnings narrative shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Everything marked **Self-hosted** is scraped, stored, and served by this repo �
 | **FDA Catalysts** | FDA.gov | ✅ | ✅ | Advisory-committee (AdComm) meeting calendar — scheduled FDA panel dates, center, and title that act as regulatory catalysts for biotech/pharma stocks |
 | **Earnings Call Transcripts** | Company webcasts | — | ✅ | Full quarterly-call transcripts with speaker attribution, searchable alongside filings |
 | **Earnings Call Audio** | Company webcasts | — | ✅ | The recorded call itself, playable and aligned to the transcript |
+| **Earnings Briefs & Narrative Shift** | Earnings calls + releases | — | ✅ | Verifier-approved quarter summaries, bull/bear points, call quotes, and a derived comparison with the previous available approved earnings brief |
 | **Live Quotes** | Licensed market feed | — | ✅ | Real-time US equity quotes |
 | **Options Chains** | Licensed options feed | — | ✅ | Chains by expiration and strike with bid/ask, volume, open interest, implied volatility, and delta/gamma/theta/vega |
 | **Company KPIs** | Filings + earnings releases | — | ✅ | Operating metrics a company reports but XBRL never standardised, plus GAAP-to-non-GAAP bridges |


### PR DESCRIPTION
## Summary

- add earnings briefs and narrative shift to the feature matrix
- classify the capability as cloud-only
- distinguish verifier-approved brief content from the derived prior-quarter comparison

## Verification

- `git diff --check`