### PR TITLE
fix(insiders): optimize reprocess selection

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -105,23 +105,36 @@ public class InsiderFilingReprocessManager
 
         // No DB cursor: a reprocessed filing's rows advance to the current version and
         // drop out of the filter, so each pass takes the next batch of unprocessed
-        // accessions. Filings that fail this run are held in-memory and excluded so the
-        // run still terminates; they're retried on the next run (string ordering would
-        // be collation-dependent, so a textual keyset is deliberately avoided).
+        // accessions. Drain one exact parser version at a time so the composite
+        // (ParserVersion, AccessionNumber) index can stream DISTINCT accessions directly
+        // into LIMIT instead of filtering current rows from the accession index (#4374).
+        // Filings that fail this run are held in-memory and excluded so the run still
+        // terminates; they're retried on the next run. The textual order is local to one
+        // batch, not a persisted keyset boundary, so database collation cannot skip work.
         var failedThisRun = new HashSet<string>();
         while (!cancellationToken.IsCancellationRequested)
         {
-            var accessions = await _transactionRepository
+            var pending = _transactionRepository
                 .GetAll()
                 .Where(t => t.ParserVersion < InsiderTransaction.CurrentParserVersion)
-                .Where(t => !failedThisRun.Contains(t.AccessionNumber))
+                .Where(t => !failedThisRun.Contains(t.AccessionNumber));
+            var oldestParserVersion = await pending
+                .Select(t => (int?)t.ParserVersion)
+                .MinAsync(cancellationToken);
+
+            if (oldestParserVersion == null)
+                break;
+
+            var accessions = await pending
+                .Where(t => t.ParserVersion == oldestParserVersion.Value)
                 .Select(t => t.AccessionNumber)
                 .Distinct()
+                .OrderBy(accession => accession)
                 .Take(BatchSize)
                 .ToListAsync(cancellationToken);
 
             if (accessions.Count == 0)
-                break;
+                continue;
 
             var attempted = 0;
             foreach (var accession in accessions)

--- a/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
+++ b/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
@@ -25,6 +25,15 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
             .IsRequired()
             .HasDefaultValueSql("'{}'");
 
+        // The reprocess drain selects DISTINCT accessions from one exact stale parser
+        // version at a time. This key order lets Postgres seek that version and stream
+        // accession order into Unique + Limit without scanning current-version rows
+        // (#4374). Build concurrently because the scraper continuously writes this table.
+        builder
+            .Entity<InsiderTransaction>()
+            .HasIndex(t => new { t.ParserVersion, t.AccessionNumber })
+            .IsCreatedConcurrently();
+
         // Covering index for every ~90-day TransactionDate window scan. Two
         // consumers share it:
         //   - the insider-trading dashboard's "top by dollar volume" boards (run

--- a/src/Equibles.Migrations/Migrations/20260814040005_OptimizeInsiderReprocessSelection.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260814040005_OptimizeInsiderReprocessSelection.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814040005_OptimizeInsiderReprocessSelection")]
+    partial class OptimizeInsiderReprocessSelection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260814040005_OptimizeInsiderReprocessSelection.cs
+++ b/src/Equibles.Migrations/Migrations/20260814040005_OptimizeInsiderReprocessSelection.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <summary>
+    /// Adds the composite index that lets the insider reprocess drain seek one exact parser
+    /// version and stream distinct accessions into its batch limit (#4374). The build is
+    /// restart-safe because a failed concurrent build leaves an invalid index behind, while a
+    /// crash after a successful build can occur before EF records the migration as applied.
+    /// </summary>
+    public partial class OptimizeInsiderReprocessSelection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DO $$ BEGIN "
+                    + "IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                    + "WHERE c.relname = 'IX_InsiderTransaction_ParserVersion_AccessionNumber' AND NOT i.indisvalid) THEN "
+                    + "EXECUTE 'DROP INDEX \"IX_InsiderTransaction_ParserVersion_AccessionNumber\"'; END IF; END $$;",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_InsiderTransaction_ParserVersion_AccessionNumber\" "
+                    + "ON \"InsiderTransaction\" (\"ParserVersion\", \"AccessionNumber\");",
+                suppressTransaction: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InsiderTransaction_ParserVersion_AccessionNumber\";",
+                suppressTransaction: true
+            );
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerVersionDrainTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerVersionDrainTests.cs
@@ -1,0 +1,264 @@
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+using FileContent = Equibles.Media.Data.Models.FileContent;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+/// <summary>
+/// Pins the ordered parser-version drain behind issue #4374. A batch must contain only the
+/// oldest remaining version so its composite index range can stream distinct accessions and
+/// stop at the batch limit instead of rescanning current rows or aggregating every stale version.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InsiderFilingReprocessManagerVersionDrainTests : ParadeDbMcpTestBase
+{
+    public InsiderFilingReprocessManagerVersionDrainTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Run_MultipleStaleVersions_CompletesOldestVersionBeforeAdvancing()
+    {
+        var date = new DateOnly(2024, 6, 14);
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0001",
+            Name = "Jane Insider",
+            City = "Cupertino",
+            StateOrCountry = "CA",
+            IsDirector = true,
+        };
+        var oldestAccessions = new[] { "0000320193-24-000071", "0000320193-24-000072" };
+        var newerAccession = "0000320193-24-000073";
+
+        var ownershipXml =
+            "<ownershipDocument>"
+            + "<nonDerivativeTable><nonDerivativeTransaction>"
+            + "<securityTitle><value>Common Stock</value></securityTitle>"
+            + "<transactionDate><value>2024-06-14</value></transactionDate>"
+            + "<transactionCoding><transactionCode>P</transactionCode></transactionCoding>"
+            + "<transactionAmounts>"
+            + "<transactionShares><value>1000</value></transactionShares>"
+            + "<transactionPricePerShare><value>55</value></transactionPricePerShare>"
+            + "</transactionAmounts>"
+            + "</nonDerivativeTransaction></nonDerivativeTable>"
+            + "</ownershipDocument>";
+        var rawBytes = Encoding.UTF8.GetBytes(ownershipXml);
+
+        InsiderTransaction MakeStale(string accession, int parserVersion) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                CommonStockId = stock.Id,
+                InsiderOwnerId = owner.Id,
+                AccessionNumber = accession,
+                TransactionOrder = 0,
+                FilingDate = date,
+                TransactionDate = date,
+                TransactionCode = TransactionCode.Purchase,
+                Shares = 1000,
+                PricePerShare = 55m,
+                ReportedPricePerShare = 55m,
+                AcquiredDisposed = AcquiredDisposed.Acquired,
+                SharesOwnedAfter = 5000,
+                OwnershipNature = OwnershipNature.Direct,
+                SecurityTitle = "Common Stock",
+                SecurityKind = InsiderSecurityKind.NonDerivative,
+                ParserVersion = parserVersion,
+            };
+
+        InsiderFiling MakeFiling(string accession) =>
+            new()
+            {
+                AccessionNumber = accession,
+                CaptureStatus = InsiderFilingCaptureStatus.Captured,
+                UncompressedSize = rawBytes.Length,
+                Content = new File
+                {
+                    Name = accession,
+                    Extension = "gz",
+                    ContentType = "application/gzip",
+                    FileContent = new FileContent { Bytes = GzipCompressor.Compress(rawBytes) },
+                },
+            };
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        foreach (var accession in oldestAccessions)
+        {
+            DbContext.Add(MakeStale(accession, 0));
+            DbContext.Add(MakeFiling(accession));
+        }
+        DbContext.Add(MakeStale(newerAccession, 1));
+        DbContext.Add(MakeFiling(newerAccession));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        using var cts = new CancellationTokenSource();
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runCtx),
+            new InsiderFilingRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            Substitute.For<ISecEdgarClient>(),
+            InsiderReprocessTestSupport.NewFileManager(),
+            runCtx,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run(
+            _ =>
+            {
+                cts.Cancel();
+                return Task.CompletedTask;
+            },
+            cts.Token
+        );
+
+        result.Total.Should().Be(3);
+        result.Processed.Should().Be(2);
+
+        await using var verify = Fixture.CreateDbContext();
+        var versions = await verify
+            .Set<InsiderTransaction>()
+            .ToDictionaryAsync(t => t.AccessionNumber, t => t.ParserVersion);
+        versions[oldestAccessions[0]].Should().Be(InsiderTransaction.CurrentParserVersion);
+        versions[oldestAccessions[1]].Should().Be(InsiderTransaction.CurrentParserVersion);
+        versions[newerAccession].Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Run_OldestVersionFailsOnce_ExcludesItAndAdvancesToNewerVersion()
+    {
+        var date = new DateOnly(2024, 6, 14);
+        var oldestAccession = "0000320193-24-000081";
+        var newerAccession = "0000320193-24-000082";
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0002",
+            Name = "John Insider",
+            City = "Redmond",
+            StateOrCountry = "WA",
+            IsOfficer = true,
+        };
+
+        InsiderTransaction MakeStale(string accession, int parserVersion) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                CommonStockId = stock.Id,
+                InsiderOwnerId = owner.Id,
+                AccessionNumber = accession,
+                TransactionOrder = 0,
+                FilingDate = date,
+                TransactionDate = date,
+                TransactionCode = TransactionCode.Purchase,
+                Shares = 100,
+                PricePerShare = 400m,
+                ReportedPricePerShare = 400m,
+                AcquiredDisposed = AcquiredDisposed.Acquired,
+                SharesOwnedAfter = 1000,
+                OwnershipNature = OwnershipNature.Direct,
+                SecurityTitle = "Common Stock",
+                SecurityKind = InsiderSecurityKind.NonDerivative,
+                ParserVersion = parserVersion,
+            };
+
+        var ownershipXml =
+            "<ownershipDocument>"
+            + "<nonDerivativeTable><nonDerivativeTransaction>"
+            + "<securityTitle><value>Common Stock</value></securityTitle>"
+            + "<transactionDate><value>2024-06-14</value></transactionDate>"
+            + "<transactionCoding><transactionCode>P</transactionCode></transactionCoding>"
+            + "<transactionAmounts>"
+            + "<transactionShares><value>100</value></transactionShares>"
+            + "<transactionPricePerShare><value>400</value></transactionPricePerShare>"
+            + "</transactionAmounts>"
+            + "</nonDerivativeTransaction></nonDerivativeTable>"
+            + "</ownershipDocument>";
+        var rawBytes = Encoding.UTF8.GetBytes(ownershipXml);
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        DbContext.Add(MakeStale(oldestAccession, 0));
+        DbContext.Add(MakeStale(newerAccession, 1));
+        DbContext.Add(
+            new InsiderFiling
+            {
+                AccessionNumber = newerAccession,
+                CaptureStatus = InsiderFilingCaptureStatus.Captured,
+                UncompressedSize = rawBytes.Length,
+                Content = new File
+                {
+                    Name = newerAccession,
+                    Extension = "gz",
+                    ContentType = "application/gzip",
+                    FileContent = new FileContent { Bytes = GzipCompressor.Compress(rawBytes) },
+                },
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar
+            .GetDocumentContent(oldestAccession, Arg.Any<string>())
+            .Returns<string>(_ => throw new HttpRequestException("transient EDGAR failure"));
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runCtx),
+            new InsiderFilingRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            edgar,
+            InsiderReprocessTestSupport.NewFileManager(),
+            runCtx,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Total.Should().Be(2);
+        result.Processed.Should().Be(2);
+        result.Failed.Should().Be(1);
+        await edgar.Received(1).GetDocumentContent(oldestAccession, Arg.Any<string>());
+
+        await using var verify = Fixture.CreateDbContext();
+        var versions = await verify
+            .Set<InsiderTransaction>()
+            .ToDictionaryAsync(t => t.AccessionNumber, t => t.ParserVersion);
+        versions[oldestAccession].Should().Be(0);
+        versions[newerAccession].Should().Be(InsiderTransaction.CurrentParserVersion);
+    }
+}

--- a/tests/Equibles.UnitTests/InsiderTrading/InsiderTradingModuleReprocessIndexTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/InsiderTradingModuleReprocessIndexTests.cs
@@ -1,0 +1,47 @@
+using Equibles.Data;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Media.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.InsiderTrading;
+
+public class InsiderTradingModuleReprocessIndexTests
+{
+    [Fact]
+    public void ParserVersionAccessionIndex_SupportsConcurrentOrderedReprocessSelection()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var db = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new InsiderTradingModuleConfiguration(),
+                new MediaModuleConfiguration(),
+            }
+        );
+
+        var entity = db.Model.FindEntityType(typeof(InsiderTransaction));
+        entity.Should().NotBeNull();
+
+        var index = entity
+            .GetIndexes()
+            .Single(i =>
+                i.Properties.Select(p => p.Name)
+                    .SequenceEqual(
+                        new[]
+                        {
+                            nameof(InsiderTransaction.ParserVersion),
+                            nameof(InsiderTransaction.AccessionNumber),
+                        }
+                    )
+            );
+
+        index
+            .IsCreatedConcurrently()
+            .Should()
+            .BeTrue("the live insider table must remain writable while the index builds");
+    }
+}


### PR DESCRIPTION
## Summary
- drain the oldest stale parser version so PostgreSQL can stop at the 32-accession batch limit
- add a concurrent, restart-safe composite index for the selection path
- cover version ordering, failed-accession progress, and index metadata

Closes #4374

## Code changes
- keep the small resumable batch size while eliminating repeated broad scans
- add matching forward and rollback migration safeguards
- add unit and integration regressions

## Verification
- 4,328 unit tests passed
- 2,598 integration tests passed
- formatting and generated migration SQL checks passed
- independent review found no blocking or high-confidence issues