### PR TITLE
fix(data): preserve filing tables and split histories

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/AppliedSplitMarkerSnapshot.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/AppliedSplitMarkerSnapshot.cs
@@ -1,0 +1,6 @@
+namespace Equibles.CorporateActions.BusinessLogic;
+
+/// <summary>
+/// The applied marker whose stored price boundary was audited.
+/// </summary>
+public readonly record struct AppliedSplitMarkerSnapshot(Guid SplitId, DateTime AppliedTime);

--- a/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
@@ -186,6 +186,44 @@ public class CorporateActionPriceReconciliationManager
         );
     }
 
+    /// <summary>
+    /// Clears reconciliation markers whose stored price boundary proves that the replacement did
+    /// not put the series on one split basis. The next selection pass retries those exact series.
+    /// </summary>
+    public async Task<int> RequeueAppliedSplits(
+        IReadOnlyCollection<AppliedSplitMarkerSnapshot> auditedMarkers,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (auditedMarkers.Count == 0)
+            return 0;
+
+        var appliedTimesById = auditedMarkers
+            .GroupBy(marker => marker.SplitId)
+            .ToDictionary(group => group.Key, group => group.Last().AppliedTime);
+
+        await using var transaction = await _stockRepository.CreateTransaction(
+            IsolationLevel.ReadCommitted,
+            cancellationToken
+        );
+        var splits = await _splitRepository.GetForUpdate(appliedTimesById.Keys, cancellationToken);
+        var applied = splits
+            .Where(split =>
+                split.PriceAdjustmentAppliedTime
+                == appliedTimesById.GetValueOrDefault(split.Id)
+            )
+            .ToList();
+
+        foreach (var split in applied)
+            split.PriceAdjustmentAppliedTime = null;
+
+        if (applied.Count > 0)
+            await _splitRepository.SaveChanges();
+
+        await transaction.CommitAsync(cancellationToken);
+        return applied.Count;
+    }
+
     private async Task<int> StampAppliedCore(
         PendingPriceReconciliationSeries selectedSeries,
         IReadOnlyCollection<CapturedDividend> priceSeriesDividends,

--- a/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
@@ -209,8 +209,7 @@ public class CorporateActionPriceReconciliationManager
         var splits = await _splitRepository.GetForUpdate(appliedTimesById.Keys, cancellationToken);
         var applied = splits
             .Where(split =>
-                split.PriceAdjustmentAppliedTime
-                == appliedTimesById.GetValueOrDefault(split.Id)
+                split.PriceAdjustmentAppliedTime == appliedTimesById.GetValueOrDefault(split.Id)
             )
             .ToList();
 

--- a/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
@@ -23,6 +23,16 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
             code => new Regex($@"\b{Regex.Escape(code)}\b", RegexOptions.Compiled)
         );
 
+    private static readonly Regex CurrencyScaleRegex = new(
+        @"^(?:(?:amounts?\s+)?in\s+)?(?:thousands|millions|billions|trillions)(?:\s*,?\s*except\s+(?:per[- ]share(?:\s+(?:amounts?|data))?|share(?:s)?))?$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
+
+    private static readonly Regex UsDollarRegex = new(
+        @"\bUS\$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
+
     public void Execute(IHtmlDocument doc)
     {
         var tables = doc.QuerySelectorAll("table").ToList();
@@ -51,15 +61,17 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
 
         for (int colIndex = 0; colIndex < maxCols - 1; colIndex++)
         {
-            if (ShouldConsolidateColumn(rows, colIndex, currencySymbols))
+            var columnCurrencySymbols = new HashSet<string>();
+            if (ShouldConsolidateColumn(rows, colIndex, columnCurrencySymbols))
             {
                 columnsToProcess.Add(colIndex);
+                currencySymbols.UnionWith(columnCurrencySymbols);
             }
         }
 
         ProcessCurrencyColumnsForConsolidation(rows, columnsToProcess);
 
-        return currencySymbols.FirstOrDefault();
+        return currencySymbols.Count == 1 ? currencySymbols.Single() : null;
     }
 
     private bool ShouldConsolidateColumn(
@@ -77,25 +89,28 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
                 continue;
 
             var currentCell = cells[colIndex].TextContent.Trim();
-            var nextCell = cells[colIndex + 1].TextContent.Trim();
-
-            if (string.IsNullOrWhiteSpace(currentCell) && string.IsNullOrWhiteSpace(nextCell))
-            {
+            if (IsEmptyCell(currentCell))
                 continue;
-            }
 
-            if (!string.IsNullOrWhiteSpace(currentCell) && IsEmptyCell(nextCell))
-            {
-                var detectedCurrency = DetectCurrency(currentCell);
-                if (detectedCurrency != null)
-                {
-                    currencySymbols.Add(detectedCurrency);
-                    shouldConsolidate = true;
-                }
-            }
+            var detectedCurrency = DetectCurrency(currentCell);
+            var nextCell = cells[colIndex + 1].TextContent.Trim();
+            if (
+                detectedCurrency == null
+                || (!IsStandaloneCurrencyCell(currentCell) && !IsEmptyCell(nextCell))
+            )
+                return false;
+
+            currencySymbols.Add(detectedCurrency);
+            shouldConsolidate = true;
         }
 
-        return shouldConsolidate && currencySymbols.Count > 0;
+        return shouldConsolidate;
+    }
+
+    private bool IsStandaloneCurrencyCell(string text)
+    {
+        var remainder = RemoveCurrencySymbols(text).Trim(' ', '\t', '\r', '\n', '(', ')');
+        return remainder.Length == 0 || CurrencyScaleRegex.IsMatch(remainder);
     }
 
     private bool IsEmptyCell(string cellText)
@@ -160,19 +175,27 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
             foreach (var row in rows)
             {
                 var cells = HtmlElementExtensions.DirectChildCells(row);
-                if (colIndex >= cells.Count || (colIndex + 1) >= cells.Count)
+                if (colIndex >= cells.Count)
                     continue;
 
                 var currentCell = cells[colIndex];
-                var nextCell = cells[colIndex + 1];
-
                 var currentText = currentCell.TextContent.Trim();
-                var nextText = nextCell.TextContent.Trim();
-                if (string.IsNullOrWhiteSpace(currentText) || !IsEmptyCell(nextText))
+
+                if (!IsEmptyCell(currentText) && DetectCurrency(currentText) == null)
                     continue;
 
                 var cleanTitle = RemoveCurrencySymbols(currentText);
-                nextCell.InnerHtml = cleanTitle;
+                if (cleanTitle.Length > 0 && (colIndex + 1) >= cells.Count)
+                    continue;
+
+                if (cleanTitle.Length > 0)
+                {
+                    var nextCell = cells[colIndex + 1];
+                    nextCell.InnerHtml = IsEmptyCell(nextCell.TextContent.Trim())
+                        ? cleanTitle
+                        : $"{cleanTitle} {nextCell.InnerHtml}";
+                }
+
                 currentCell.Remove();
             }
         }
@@ -180,6 +203,7 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
 
     private string RemoveCurrencySymbols(string text)
     {
+        text = UsDollarRegex.Replace(text, "");
         foreach (var (code, (symbol, _)) in CurrencyMap)
         {
             text = text.Replace(symbol, "");

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -7,6 +7,7 @@ using Equibles.Core.Calendars;
 using Equibles.Core.Configuration;
 using Equibles.CorporateActions.BusinessLogic;
 using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Yahoo.Contracts;
@@ -37,11 +38,30 @@ internal readonly record struct PriceSeriesTarget(
 
 internal readonly record struct LockedPriceSeries(CommonStock Stock, bool IsPrimary);
 
+internal readonly record struct AppliedSplitBoundary(
+    Guid SplitId,
+    DateTime AppliedTime,
+    decimal Numerator,
+    decimal Denominator,
+    decimal? CloseBefore,
+    decimal? CloseAfter
+);
+
+internal readonly record struct SplitBasisDefinition(
+    DateOnly EffectiveDate,
+    decimal Numerator,
+    decimal Denominator
+);
+
 [Service]
 public class YahooPriceImportService
 {
     private const double MinimumReferenceHistoryCoverageShare = 0.90;
     private const int InsertBatchSize = 500;
+    private const int AppliedSplitBasisAuditLookbackDays = 180;
+    private const decimal MaterialSplitRatioFloor = 0.5m;
+    private const decimal MaterialSplitRatioCeiling = 2m;
+    private const decimal SplitRatioMatchTolerance = 0.25m;
     private const decimal MaxPriceValue = 99_999_999_999_999.9999m; // numeric(18,4) ceiling
 
     private readonly IServiceScopeFactory _scopeFactory;
@@ -452,6 +472,8 @@ public class YahooPriceImportService
         CancellationToken cancellationToken
     )
     {
+        await RequeueStampedSplitBasisMismatches(today, cancellationToken);
+
         PendingPriceReconciliationSelection selection;
         using (var scope = _scopeFactory.CreateScope())
         {
@@ -531,6 +553,7 @@ public class YahooPriceImportService
             IsPrimary: false
         );
         var chartData = await _yahooClient.GetChart(target.Ticker, floor, today);
+        await CaptureSplits(target, chartData.Splits, cancellationToken);
 
         // A delisted/unresolved ticker returns no prices. Do NOT wipe the existing series in that
         // case — leave the split pending so a later run or another source can handle it.
@@ -543,6 +566,29 @@ public class YahooPriceImportService
             return;
         }
 
+        var splitBoundaries = selectedSeries
+            .Splits.Select(split =>
+                new SplitBasisDefinition(
+                    split.EffectiveDate,
+                    split.Numerator,
+                    split.Denominator
+                )
+            )
+            .Concat(
+                chartData.Splits.Select(split =>
+                    new SplitBasisDefinition(split.Date, split.Numerator, split.Denominator)
+                )
+            )
+            .Distinct();
+        if (
+            ShouldRejectSplitBearingHistory(
+                target.Ticker,
+                chartData.Prices,
+                splitBoundaries
+            )
+        )
+            return;
+
         var replaced = await ReplaceStoredPrices(
             target,
             floor,
@@ -553,10 +599,8 @@ public class YahooPriceImportService
         if (!replaced)
             return;
 
-        // Capture actions carried by the full-history response before stamping. Dividends that
-        // still exactly match this response can be marked from the same fetch; a concurrent
-        // restatement remains pending because the manager revalidates the locked current row.
-        await CaptureSplits(target, chartData.Splits, cancellationToken);
+        // Dividends that still exactly match this response can be marked from the same fetch; a
+        // concurrent restatement remains pending because the manager revalidates the locked row.
         var capturedDividends = await CaptureDividends(
             target,
             chartData.Dividends,
@@ -585,6 +629,156 @@ public class YahooPriceImportService
             target.Ticker,
             stamped
         );
+    }
+
+    private async Task RequeueStampedSplitBasisMismatches(
+        DateOnly today,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var splitRepository = scope.ServiceProvider.GetRequiredService<StockSplitRepository>();
+        var priceRepository = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+        var appliedSince = DateTime.UtcNow.AddDays(-AppliedSplitBasisAuditLookbackDays);
+
+        var boundaries = await splitRepository
+            .GetAll()
+            .Where(split =>
+                split.PriceAdjustmentAppliedTime >= appliedSince
+                && split.PriceSeriesTicker != null
+                && split.EffectiveDate < today
+                && split.Numerator > 0m
+                && split.Denominator > 0m
+                && (
+                    split.Numerator / split.Denominator <= MaterialSplitRatioFloor
+                    || split.Numerator / split.Denominator >= MaterialSplitRatioCeiling
+                )
+            )
+            .Select(split => new AppliedSplitBoundary(
+                split.Id,
+                split.PriceAdjustmentAppliedTime!.Value,
+                split.Numerator,
+                split.Denominator,
+                priceRepository
+                    .GetAllSeries()
+                    .Where(price =>
+                        price.CommonStockId == split.CommonStockId
+                        && price.ListedTicker == split.PriceSeriesTicker
+                        && price.Date < split.EffectiveDate
+                    )
+                    .OrderByDescending(price => price.Date)
+                    .Select(price => (decimal?)price.Close)
+                    .FirstOrDefault(),
+                priceRepository
+                    .GetAllSeries()
+                    .Where(price =>
+                        price.CommonStockId == split.CommonStockId
+                        && price.ListedTicker == split.PriceSeriesTicker
+                        && price.Date >= split.EffectiveDate
+                    )
+                    .OrderBy(price => price.Date)
+                    .Select(price => (decimal?)price.Close)
+                    .FirstOrDefault()
+            ))
+            .ToListAsync(cancellationToken);
+
+        var invalidMarkers = boundaries
+            .Where(boundary =>
+                IsSplitBoundaryDiscontinuous(
+                    boundary.CloseBefore,
+                    boundary.CloseAfter,
+                    boundary.Numerator,
+                    boundary.Denominator
+                )
+            )
+            .Select(boundary =>
+                new AppliedSplitMarkerSnapshot(boundary.SplitId, boundary.AppliedTime)
+            )
+            .ToList();
+        if (invalidMarkers.Count == 0)
+            return;
+
+        var manager = scope.ServiceProvider.GetRequiredService<CorporateActionPriceReconciliationManager>();
+        var requeued = await manager.RequeueAppliedSplits(invalidMarkers, cancellationToken);
+        _logger.LogWarning(
+            "Requeued {Count} split reconciliation marker(s) whose stored history still crossed price bases",
+            requeued
+        );
+    }
+
+    private bool ShouldRejectSplitBearingHistory(
+        string ticker,
+        IReadOnlyCollection<HistoricalPrice> prices,
+        IEnumerable<SplitBasisDefinition> splits
+    )
+    {
+        foreach (var split in splits)
+        {
+            if (
+                !HasSplitBasisDiscontinuity(
+                    prices,
+                    split.EffectiveDate,
+                    split.Numerator,
+                    split.Denominator
+                )
+            )
+                continue;
+
+            _logger.LogWarning(
+                "Yahoo full history for {Ticker} still straddles split {EffectiveDate} ({Numerator}:{Denominator}); keeping the existing series and the action pending",
+                ticker,
+                split.EffectiveDate,
+                split.Numerator,
+                split.Denominator
+            );
+            return true;
+        }
+
+        return false;
+    }
+
+    internal static bool HasSplitBasisDiscontinuity(
+        IReadOnlyCollection<HistoricalPrice> prices,
+        DateOnly effectiveDate,
+        decimal numerator,
+        decimal denominator
+    )
+    {
+        var closeBefore = prices
+            .Where(price => price.Date < effectiveDate)
+            .OrderByDescending(price => price.Date)
+            .Select(price => (decimal?)price.Close)
+            .FirstOrDefault();
+        var closeAfter = prices
+            .Where(price => price.Date >= effectiveDate)
+            .OrderBy(price => price.Date)
+            .Select(price => (decimal?)price.Close)
+            .FirstOrDefault();
+
+        return IsSplitBoundaryDiscontinuous(closeBefore, closeAfter, numerator, denominator);
+    }
+
+    internal static bool IsSplitBoundaryDiscontinuous(
+        decimal? closeBefore,
+        decimal? closeAfter,
+        decimal numerator,
+        decimal denominator
+    )
+    {
+        if (
+            closeBefore is not > 0m
+            || closeAfter is not > 0m
+            || numerator <= 0m
+            || denominator <= 0m
+        )
+            return false;
+
+        var splitRatio = numerator / denominator;
+        if (splitRatio > MaterialSplitRatioFloor && splitRatio < MaterialSplitRatioCeiling)
+            return false;
+
+        var observedRatio = closeBefore.Value / closeAfter.Value;
+        return Math.Abs(observedRatio - splitRatio) / splitRatio <= SplitRatioMatchTolerance;
     }
 
     // Transactionally swaps a stock's stored rows in [floor, today] for the fresh provider-served
@@ -795,6 +989,7 @@ public class YahooPriceImportService
 
         if (target.RequiresFullHistory)
         {
+            await CaptureSplits(target, chartData.Splits, cancellationToken);
             if (!IsCompleteReferenceHistory(chartData, PriceHistoryFloor(), today))
             {
                 _logger.LogWarning(
@@ -803,6 +998,21 @@ public class YahooPriceImportService
                 );
                 return new TickerImportResult(Fetched: true, Inserted: 0);
             }
+
+            if (
+                ShouldRejectSplitBearingHistory(
+                    target.Ticker,
+                    chartData.Prices,
+                    chartData.Splits.Select(split =>
+                        new SplitBasisDefinition(
+                            split.Date,
+                            split.Numerator,
+                            split.Denominator
+                        )
+                    )
+                )
+            )
+                return new TickerImportResult(Fetched: true, Inserted: 0);
 
             var replaced = await ReplaceStoredPrices(
                 target,
@@ -817,7 +1027,6 @@ public class YahooPriceImportService
                     "Replaced grouped bootstrap rows with full Yahoo history for reference listing {Ticker}",
                     target.Ticker
                 );
-                await CaptureSplits(target, chartData.Splits, cancellationToken);
                 await CaptureDividends(target, chartData.Dividends, cancellationToken);
             }
             return new TickerImportResult(
@@ -832,9 +1041,30 @@ public class YahooPriceImportService
         // harmless. Issuer-level action capture below independently locks and requires whichever
         // listing is primary at write time.
         var floor = PriceHistoryFloor();
+        if (chartData.Splits.Count > 0 && startDate == floor)
+        {
+            await CaptureSplits(target, chartData.Splits, cancellationToken);
+            if (
+                ShouldRejectSplitBearingHistory(
+                    target.Ticker,
+                    chartData.Prices,
+                    chartData.Splits.Select(split =>
+                        new SplitBasisDefinition(
+                            split.Date,
+                            split.Numerator,
+                            split.Denominator
+                        )
+                    )
+                )
+            )
+                return new TickerImportResult(Fetched: true, Inserted: 0);
+        }
+
         if (chartData.Splits.Count > 0 && startDate > floor)
         {
+            await CaptureSplits(target, chartData.Splits, cancellationToken);
             var fullChart = await _yahooClient.GetChart(target.Ticker, floor, today);
+            await CaptureSplits(target, fullChart.Splits, cancellationToken);
             if (fullChart.Prices.Count == 0)
             {
                 _logger.LogWarning(
@@ -843,6 +1073,21 @@ public class YahooPriceImportService
                 );
                 return new TickerImportResult(Fetched: true, Inserted: 0);
             }
+
+            var splitBoundaries = chartData
+                .Splits.Concat(fullChart.Splits)
+                .Select(split =>
+                    new SplitBasisDefinition(split.Date, split.Numerator, split.Denominator)
+                )
+                .Distinct();
+            if (
+                ShouldRejectSplitBearingHistory(
+                    target.Ticker,
+                    fullChart.Prices,
+                    splitBoundaries
+                )
+            )
+                return new TickerImportResult(Fetched: true, Inserted: 0);
 
             var replaced = await ReplaceStoredPrices(
                 target,
@@ -857,7 +1102,6 @@ public class YahooPriceImportService
                     "Reconciled {Ticker}: replaced its full listed price history",
                     target.Ticker
                 );
-                await CaptureSplits(target, chartData.Splits, cancellationToken);
                 await CaptureDividends(target, chartData.Dividends, cancellationToken);
             }
             return new TickerImportResult(Fetched: true, Inserted: 0);

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -567,26 +567,20 @@ public class YahooPriceImportService
         }
 
         var splitBoundaries = selectedSeries
-            .Splits.Select(split =>
-                new SplitBasisDefinition(
-                    split.EffectiveDate,
+            .Splits.Select(split => new SplitBasisDefinition(
+                split.EffectiveDate,
+                split.Numerator,
+                split.Denominator
+            ))
+            .Concat(
+                chartData.Splits.Select(split => new SplitBasisDefinition(
+                    split.Date,
                     split.Numerator,
                     split.Denominator
-                )
-            )
-            .Concat(
-                chartData.Splits.Select(split =>
-                    new SplitBasisDefinition(split.Date, split.Numerator, split.Denominator)
-                )
+                ))
             )
             .Distinct();
-        if (
-            ShouldRejectSplitBearingHistory(
-                target.Ticker,
-                chartData.Prices,
-                splitBoundaries
-            )
-        )
+        if (ShouldRejectSplitBearingHistory(target.Ticker, chartData.Prices, splitBoundaries))
             return;
 
         var replaced = await ReplaceStoredPrices(
@@ -691,14 +685,16 @@ public class YahooPriceImportService
                     boundary.Denominator
                 )
             )
-            .Select(boundary =>
-                new AppliedSplitMarkerSnapshot(boundary.SplitId, boundary.AppliedTime)
-            )
+            .Select(boundary => new AppliedSplitMarkerSnapshot(
+                boundary.SplitId,
+                boundary.AppliedTime
+            ))
             .ToList();
         if (invalidMarkers.Count == 0)
             return;
 
-        var manager = scope.ServiceProvider.GetRequiredService<CorporateActionPriceReconciliationManager>();
+        var manager =
+            scope.ServiceProvider.GetRequiredService<CorporateActionPriceReconciliationManager>();
         var requeued = await manager.RequeueAppliedSplits(invalidMarkers, cancellationToken);
         _logger.LogWarning(
             "Requeued {Count} split reconciliation marker(s) whose stored history still crossed price bases",
@@ -1003,13 +999,11 @@ public class YahooPriceImportService
                 ShouldRejectSplitBearingHistory(
                     target.Ticker,
                     chartData.Prices,
-                    chartData.Splits.Select(split =>
-                        new SplitBasisDefinition(
-                            split.Date,
-                            split.Numerator,
-                            split.Denominator
-                        )
-                    )
+                    chartData.Splits.Select(split => new SplitBasisDefinition(
+                        split.Date,
+                        split.Numerator,
+                        split.Denominator
+                    ))
                 )
             )
                 return new TickerImportResult(Fetched: true, Inserted: 0);
@@ -1048,13 +1042,11 @@ public class YahooPriceImportService
                 ShouldRejectSplitBearingHistory(
                     target.Ticker,
                     chartData.Prices,
-                    chartData.Splits.Select(split =>
-                        new SplitBasisDefinition(
-                            split.Date,
-                            split.Numerator,
-                            split.Denominator
-                        )
-                    )
+                    chartData.Splits.Select(split => new SplitBasisDefinition(
+                        split.Date,
+                        split.Numerator,
+                        split.Denominator
+                    ))
                 )
             )
                 return new TickerImportResult(Fetched: true, Inserted: 0);
@@ -1076,17 +1068,13 @@ public class YahooPriceImportService
 
             var splitBoundaries = chartData
                 .Splits.Concat(fullChart.Splits)
-                .Select(split =>
-                    new SplitBasisDefinition(split.Date, split.Numerator, split.Denominator)
-                )
+                .Select(split => new SplitBasisDefinition(
+                    split.Date,
+                    split.Numerator,
+                    split.Denominator
+                ))
                 .Distinct();
-            if (
-                ShouldRejectSplitBearingHistory(
-                    target.Ticker,
-                    fullChart.Prices,
-                    splitBoundaries
-                )
-            )
+            if (ShouldRejectSplitBearingHistory(target.Ticker, fullChart.Prices, splitBoundaries))
                 return new TickerImportResult(Fetched: true, Inserted: 0);
 
             var replaced = await ReplaceStoredPrices(

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileBlankSectorTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileBlankSectorTests.cs
@@ -54,6 +54,7 @@ public class YahooPriceImportServiceCompanyProfileBlankSectorTests : IDisposable
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(DailyStockPriceRepository), priceRepo),
             (typeof(CommonStockRepository), _stockRepo),
+            (typeof(StockSplitRepository), splitRepo),
             (typeof(IndustryRepository), _industryRepo),
             (typeof(SectorRepository), _sectorRepo),
             // SyncKeyStatistics resolves the EDGAR shares provider even when Yahoo has no

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfilePreservesSectorTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfilePreservesSectorTests.cs
@@ -54,6 +54,7 @@ public class YahooPriceImportServiceCompanyProfilePreservesSectorTests : IDispos
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(DailyStockPriceRepository), priceRepo),
             (typeof(CommonStockRepository), _stockRepo),
+            (typeof(StockSplitRepository), splitRepo),
             (typeof(IndustryRepository), _industryRepo),
             (typeof(SectorRepository), _sectorRepo),
             (

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
@@ -62,6 +62,7 @@ public class YahooPriceImportServiceCompanyProfileTests : IDisposable
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(DailyStockPriceRepository), priceRepo),
             (typeof(CommonStockRepository), _stockRepo),
+            (typeof(StockSplitRepository), splitRepo),
             (typeof(IndustryRepository), _industryRepo),
             (typeof(SectorRepository), _sectorRepo),
             // SyncKeyStatistics resolves the EDGAR shares provider even when Yahoo has no

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceKeepExistingSectorTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceKeepExistingSectorTests.cs
@@ -67,6 +67,7 @@ public class YahooPriceImportServiceKeepExistingSectorTests : IDisposable
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(DailyStockPriceRepository), priceRepo),
             (typeof(CommonStockRepository), _stockRepo),
+            (typeof(StockSplitRepository), splitRepo),
             (typeof(IndustryRepository), _industryRepo),
             (typeof(SectorRepository), _sectorRepo),
             (

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceMissingCommonStockTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceMissingCommonStockTests.cs
@@ -62,6 +62,7 @@ public class YahooPriceImportServiceMissingCommonStockTests : IDisposable
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(DailyStockPriceRepository), _priceRepo),
             (typeof(CommonStockRepository), _stockRepo),
+            (typeof(StockSplitRepository), splitRepo),
             (typeof(IndustryRepository), new IndustryRepository(_dbContext)),
             (typeof(SectorRepository), new SectorRepository(_dbContext)),
             (typeof(ISharesOutstandingProvider), _sharesProvider),

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -402,10 +402,7 @@ public class YahooPriceImportServiceTests : IDisposable
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
         _priceRepo.GetAllSeries().Should().Contain(price => price.Id == groupedRow.Id);
-        _splitRepo
-            .GetAll()
-            .Should()
-            .ContainSingle(split => split.EffectiveDate == effectiveDate);
+        _splitRepo.GetAll().Should().ContainSingle(split => split.EffectiveDate == effectiveDate);
     }
 
     [Fact]
@@ -1000,7 +997,10 @@ public class YahooPriceImportServiceTests : IDisposable
         var effectiveDate = today.AddDays(-4);
         var beforeDate = effectiveDate.AddDays(-1);
         var afterDate = effectiveDate.AddDays(1);
-        await SeedPrices(CreatePrice(stock, beforeDate, 3.00m), CreatePrice(stock, afterDate, 57.10m));
+        await SeedPrices(
+            CreatePrice(stock, beforeDate, 3.00m),
+            CreatePrice(stock, afterDate, 57.10m)
+        );
 
         var incremental = new YahooChartData
         {
@@ -1239,9 +1239,7 @@ public class YahooPriceImportServiceTests : IDisposable
                 Denominator = 16m,
             },
         ];
-        _yahooClient
-            .GetChart("PNDG", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
-            .Returns(response);
+        _yahooClient.GetChart("PNDG", Arg.Any<DateOnly>(), Arg.Any<DateOnly>()).Returns(response);
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -67,6 +67,7 @@ public class YahooPriceImportServiceTests : IDisposable
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(DailyStockPriceRepository), _priceRepo),
             (typeof(CommonStockRepository), _stockRepo),
+            (typeof(StockSplitRepository), _splitRepo),
             (typeof(ISharesOutstandingProvider), _sharesProvider),
             (
                 typeof(CorporateActionPriceReconciliationManager),
@@ -298,6 +299,113 @@ public class YahooPriceImportServiceTests : IDisposable
             .Single(stockRow => stockRow.Id == stock.Id)
             .PriceHistoryBackfilledTickers.Should()
             .Equal("REF");
+    }
+
+    [Fact]
+    public async Task Import_ReferenceBootstrapStillStraddlesSplit_KeepsGroupedRowsPending()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var floor = today.AddDays(-14);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        var stock = CreateStock("REF", "Reference Owner");
+        stock.ReferenceTickers = [stock.Ticker];
+        await SeedStocks(stock);
+
+        var sessions = Enumerable
+            .Range(0, today.DayNumber - floor.DayNumber)
+            .Select(floor.AddDays)
+            .Where(UsMarketCalendar.IsTradingDay)
+            .ToList();
+        var effectiveDate = sessions[sessions.Count / 2];
+        var firstBootstrap = CreatePrice(stock, sessions[^2], 100m);
+        var secondBootstrap = CreatePrice(stock, sessions[^1], 101m);
+        await SeedPrices(firstBootstrap, secondBootstrap);
+
+        var fullHistory = new YahooChartData
+        {
+            Prices = sessions
+                .Select(date =>
+                {
+                    var close = date < effectiveDate ? 3m : 57m;
+                    return new HistoricalPrice
+                    {
+                        Date = date,
+                        Open = close - 1m,
+                        High = close + 1m,
+                        Low = close - 2m,
+                        Close = close,
+                        AdjustedClose = close,
+                        Volume = 500_000,
+                    };
+                })
+                .ToList(),
+            Splits =
+            [
+                new StockSplitEvent
+                {
+                    Date = effectiveDate,
+                    Numerator = 1m,
+                    Denominator = 16m,
+                },
+            ],
+        };
+        _yahooClient.GetChart("REF", floor, Arg.Any<DateOnly>()).Returns(fullHistory);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo.GetAllSeries().Should().Contain(price => price.Id == firstBootstrap.Id);
+        _priceRepo.GetAllSeries().Should().Contain(price => price.Id == secondBootstrap.Id);
+        _stockRepo
+            .GetAll()
+            .Single(row => row.Id == stock.Id)
+            .PriceHistoryBackfilledTickers.Should()
+            .BeEmpty();
+        _splitRepo
+            .GetAll()
+            .Should()
+            .ContainSingle()
+            .Which.PriceAdjustmentAppliedTime.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public async Task Import_IncompleteReferenceHistory_CapturesReturnedSplitBeforeRejecting()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var floor = today.AddDays(-14);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        var stock = CreateStock("REF", "Reference Owner");
+        stock.ReferenceTickers = [stock.Ticker];
+        await SeedStocks(stock);
+        var latestSettled = UsMarketCalendar.PreviousTradingDay(today);
+        var groupedRow = CreatePrice(stock, latestSettled, 100m);
+        await SeedPrices(groupedRow);
+        var effectiveDate = latestSettled.AddDays(-3);
+        _yahooClient
+            .GetChart("REF", floor, Arg.Any<DateOnly>())
+            .Returns(
+                new YahooChartData
+                {
+                    Prices = CreateHistoricalPrices((latestSettled, 101m)),
+                    Splits =
+                    [
+                        new StockSplitEvent
+                        {
+                            Date = effectiveDate,
+                            Numerator = 2m,
+                            Denominator = 1m,
+                        },
+                    ],
+                }
+            );
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo.GetAllSeries().Should().Contain(price => price.Id == groupedRow.Id);
+        _splitRepo
+            .GetAll()
+            .Should()
+            .ContainSingle(split => split.EffectiveDate == effectiveDate);
     }
 
     [Fact]
@@ -836,6 +944,369 @@ public class YahooPriceImportServiceTests : IDisposable
                 Arg.Any<string>(),
                 Arg.Any<string>()
             );
+    }
+
+    [Fact]
+    public async Task Import_AppliedMarkerStillStraddlesSplit_RequeuesWithoutRestamping()
+    {
+        var stock = CreateStock("AEHL", "Antelope Enterprise Holdings");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var effectiveDate = today.AddDays(-4);
+        await SeedPrices(
+            CreatePrice(stock, effectiveDate.AddDays(-1), 3.00m),
+            CreatePrice(stock, effectiveDate.AddDays(1), 57.10m),
+            CreatePrice(stock, today.AddDays(-1), 56.00m)
+        );
+        var split = new StockSplit
+        {
+            CommonStockId = stock.Id,
+            PriceSeriesTicker = stock.Ticker,
+            EffectiveDate = effectiveDate,
+            Numerator = 1m,
+            Denominator = 16m,
+            Source = StockSplitSource.Yahoo,
+            PriceAdjustmentAppliedTime = DateTime.UtcNow,
+        };
+        _splitRepo.Add(split);
+        await _splitRepo.SaveChanges();
+        _yahooClient
+            .GetChart("AEHL", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(
+                CreateChartData(
+                    (effectiveDate.AddDays(-1), 3.20m),
+                    (effectiveDate.AddDays(1), 58.00m),
+                    (today.AddDays(-1), 57.00m)
+                )
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        split.PriceAdjustmentAppliedTime.Should().BeNull();
+        _priceRepo
+            .GetAll()
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(3.00m, 57.10m, 56.00m);
+    }
+
+    [Fact]
+    public async Task Import_OrdinarySplitFetchStillStraddlesBoundary_KeepsStoredSeriesPending()
+    {
+        var stock = CreateStock("AEHL", "Antelope Enterprise Holdings");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var effectiveDate = today.AddDays(-4);
+        var beforeDate = effectiveDate.AddDays(-1);
+        var afterDate = effectiveDate.AddDays(1);
+        await SeedPrices(CreatePrice(stock, beforeDate, 3.00m), CreatePrice(stock, afterDate, 57.10m));
+
+        var incremental = new YahooChartData
+        {
+            Prices = CreateHistoricalPrices((today.AddDays(-1), 56.00m)),
+            Splits =
+            [
+                new StockSplitEvent
+                {
+                    Date = effectiveDate,
+                    Numerator = 1m,
+                    Denominator = 16m,
+                },
+            ],
+        };
+        var mixedFullHistory = CreateChartData(
+            (beforeDate, 3.20m),
+            (afterDate, 58.00m),
+            (today.AddDays(-1), 57.00m)
+        );
+        var floor = new DateOnly(2020, 1, 1);
+        _yahooClient
+            .GetChart("AEHL", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(call => call.ArgAt<DateOnly>(1) == floor ? mixedFullHistory : incremental);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo
+            .GetAll()
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(3.00m, 57.10m);
+        _splitRepo
+            .GetAll()
+            .Should()
+            .ContainSingle()
+            .Which.PriceAdjustmentAppliedTime.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public async Task Import_OrdinaryEmptyFullHistory_CapturesReturnedSplitsBeforeRejecting()
+    {
+        var stock = CreateStock("EMPTY", "Empty Full History Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var latestSettled = UsMarketCalendar.PreviousTradingDay(today);
+        var priorSettled = UsMarketCalendar.PreviousTradingDay(latestSettled);
+        await SeedPrices(CreatePrice(stock, priorSettled, 50m));
+        var triggerDate = latestSettled;
+        var responseOnlyDate = UsMarketCalendar.PreviousTradingDay(priorSettled);
+        var incremental = new YahooChartData
+        {
+            Prices = CreateHistoricalPrices((latestSettled, 25m)),
+            Splits =
+            [
+                new StockSplitEvent
+                {
+                    Date = triggerDate,
+                    Numerator = 2m,
+                    Denominator = 1m,
+                },
+            ],
+        };
+        var emptyFull = new YahooChartData
+        {
+            Splits =
+            [
+                new StockSplitEvent
+                {
+                    Date = responseOnlyDate,
+                    Numerator = 3m,
+                    Denominator = 1m,
+                },
+            ],
+        };
+        var floor = new DateOnly(2020, 1, 1);
+        _yahooClient
+            .GetChart("EMPTY", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(call => call.ArgAt<DateOnly>(1) == floor ? emptyFull : incremental);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo.GetAllSeries().Should().ContainSingle(price => price.Close == 50m);
+        _splitRepo
+            .GetAll()
+            .Select(split => split.EffectiveDate)
+            .Should()
+            .BeEquivalentTo(new[] { triggerDate, responseOnlyDate });
+    }
+
+    [Fact]
+    public async Task Import_FirstOrdinaryHistoryStillStraddlesSplit_KeepsSeriesEmptyPending()
+    {
+        var stock = CreateStock("NEW", "Newly Imported Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var effectiveDate = today.AddDays(-4);
+        var response = CreateChartData(
+            (effectiveDate.AddDays(-1), 3.20m),
+            (effectiveDate.AddDays(1), 58.00m),
+            (today.AddDays(-1), 57.00m)
+        );
+        response.Splits =
+        [
+            new StockSplitEvent
+            {
+                Date = effectiveDate,
+                Numerator = 1m,
+                Denominator = 16m,
+            },
+        ];
+        _yahooClient
+            .GetChart("NEW", new DateOnly(2020, 1, 1), Arg.Any<DateOnly>())
+            .Returns(response);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo.GetAll().Should().BeEmpty();
+        _splitRepo
+            .GetAll()
+            .Should()
+            .ContainSingle()
+            .Which.PriceAdjustmentAppliedTime.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public async Task Import_OrdinarySplitFullResponseHasOlderMixedSplit_KeepsStoredSeriesPending()
+    {
+        var stock = CreateStock("DUAL", "Dual Split Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var latestSettled = UsMarketCalendar.PreviousTradingDay(today);
+        var priorSettled = UsMarketCalendar.PreviousTradingDay(latestSettled);
+        var olderEffectiveDate = UsMarketCalendar.PreviousTradingDay(priorSettled);
+        var olderBeforeDate = UsMarketCalendar.PreviousTradingDay(olderEffectiveDate);
+        await SeedPrices(
+            CreatePrice(stock, olderBeforeDate, 3.00m),
+            CreatePrice(stock, olderEffectiveDate, 57.10m),
+            CreatePrice(stock, priorSettled, 56.00m)
+        );
+
+        var incremental = new YahooChartData
+        {
+            Prices = CreateHistoricalPrices((latestSettled, 60m)),
+            Splits =
+            [
+                new StockSplitEvent
+                {
+                    Date = latestSettled,
+                    Numerator = 2m,
+                    Denominator = 1m,
+                },
+            ],
+        };
+        var fullHistory = CreateChartData(
+            (olderBeforeDate, 3.20m),
+            (olderEffectiveDate, 58.00m),
+            (priorSettled, 57.00m),
+            (latestSettled, 60.00m)
+        );
+        fullHistory.Splits =
+        [
+            new StockSplitEvent
+            {
+                Date = olderEffectiveDate,
+                Numerator = 1m,
+                Denominator = 16m,
+            },
+        ];
+        var floor = new DateOnly(2020, 1, 1);
+        _yahooClient
+            .GetChart("DUAL", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(call => call.ArgAt<DateOnly>(1) == floor ? fullHistory : incremental);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo
+            .GetAll()
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(3.00m, 57.10m, 56.00m);
+        _splitRepo
+            .GetAll()
+            .OrderBy(split => split.EffectiveDate)
+            .Should()
+            .HaveCount(2)
+            .And.AllSatisfy(split => split.PriceAdjustmentAppliedTime.Should().BeNull());
+    }
+
+    [Fact]
+    public async Task Import_PendingReconcileResponseHasNewMixedSplit_KeepsStoredSeriesPending()
+    {
+        var stock = CreateStock("PNDG", "Pending Split Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var selectedEffectiveDate = today.AddDays(-10);
+        var newEffectiveDate = today.AddDays(-4);
+        var storedRows = new[]
+        {
+            CreatePrice(stock, selectedEffectiveDate.AddDays(-1), 90m),
+            CreatePrice(stock, selectedEffectiveDate.AddDays(1), 91m),
+            CreatePrice(stock, newEffectiveDate.AddDays(-1), 3.00m),
+            CreatePrice(stock, newEffectiveDate.AddDays(1), 57.10m),
+            CreatePrice(stock, today.AddDays(-1), 56.00m),
+        };
+        await SeedPrices(storedRows);
+        _splitRepo.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = stock.Ticker,
+                EffectiveDate = selectedEffectiveDate,
+                Numerator = 2m,
+                Denominator = 1m,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        await _splitRepo.SaveChanges();
+
+        var response = CreateChartData(
+            (selectedEffectiveDate.AddDays(-1), 100m),
+            (selectedEffectiveDate.AddDays(1), 100m),
+            (newEffectiveDate.AddDays(-1), 3.20m),
+            (newEffectiveDate.AddDays(1), 58.00m),
+            (today.AddDays(-1), 57.00m)
+        );
+        response.Splits =
+        [
+            new StockSplitEvent
+            {
+                Date = newEffectiveDate,
+                Numerator = 1m,
+                Denominator = 16m,
+            },
+        ];
+        _yahooClient
+            .GetChart("PNDG", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(response);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo
+            .GetAll()
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(storedRows.OrderBy(price => price.Date).Select(price => price.Close));
+        _splitRepo
+            .GetAll()
+            .OrderBy(split => split.EffectiveDate)
+            .Should()
+            .HaveCount(2)
+            .And.AllSatisfy(split => split.PriceAdjustmentAppliedTime.Should().BeNull());
+    }
+
+    [Fact]
+    public async Task Import_PendingEmptyHistory_CapturesReturnedSplitBeforeRejecting()
+    {
+        var stock = CreateStock("PNDE", "Pending Empty Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var selectedDate = today.AddDays(-10);
+        var responseOnlyDate = today.AddDays(-4);
+        _splitRepo.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = stock.Ticker,
+                EffectiveDate = selectedDate,
+                Numerator = 2m,
+                Denominator = 1m,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        await _splitRepo.SaveChanges();
+        _yahooClient
+            .GetChart("PNDE", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(
+                new YahooChartData
+                {
+                    Splits =
+                    [
+                        new StockSplitEvent
+                        {
+                            Date = responseOnlyDate,
+                            Numerator = 1m,
+                            Denominator = 4m,
+                        },
+                    ],
+                }
+            );
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _splitRepo
+            .GetAll()
+            .Select(split => split.EffectiveDate)
+            .Should()
+            .BeEquivalentTo(new[] { selectedDate, responseOnlyDate });
+        _splitRepo
+            .GetAll()
+            .Should()
+            .AllSatisfy(split => split.PriceAdjustmentAppliedTime.Should().BeNull());
     }
 
     // ── MinSyncDate configuration ─────────────────────────────────────

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceVolumeResettleTests.cs
@@ -75,6 +75,7 @@ public class YahooPriceImportServiceVolumeResettleTests : IDisposable
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(DailyStockPriceRepository), _priceRepo),
             (typeof(CommonStockRepository), _stockRepo),
+            (typeof(StockSplitRepository), splitRepo),
             (typeof(ISharesOutstandingProvider), Substitute.For<ISharesOutstandingProvider>()),
             (
                 typeof(CorporateActionPriceReconciliationManager),

--- a/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
@@ -96,6 +96,48 @@ public class CorporateActionPriceReconciliationManagerStampingTests
         };
 
     [Fact]
+    public async Task RequeueAppliedSplits_ClearsOnlySelectedAppliedMarkers()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var appliedAt = new DateTime(2026, 8, 12, 0, 0, 0, DateTimeKind.Utc);
+        var selected = PendingSplit(stockId, new DateOnly(2026, 8, 10));
+        selected.PriceAdjustmentAppliedTime = appliedAt;
+        var untouched = PendingSplit(stockId, new DateOnly(2026, 7, 10));
+        untouched.PriceAdjustmentAppliedTime = appliedAt;
+        db.Add(Stock(stockId));
+        db.AddRange(selected, untouched);
+        await db.SaveChangesAsync();
+
+        var count = await NewManager(db)
+            .RequeueAppliedSplits([new AppliedSplitMarkerSnapshot(selected.Id, appliedAt)]);
+
+        count.Should().Be(1);
+        selected.PriceAdjustmentAppliedTime.Should().BeNull();
+        untouched.PriceAdjustmentAppliedTime.Should().Be(appliedAt);
+    }
+
+    [Fact]
+    public async Task RequeueAppliedSplits_MarkerChangedAfterAudit_KeepsNewerStamp()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var auditedAt = new DateTime(2026, 8, 12, 0, 0, 0, DateTimeKind.Utc);
+        var restampedAt = auditedAt.AddMinutes(1);
+        var split = PendingSplit(stockId, new DateOnly(2026, 8, 10));
+        split.PriceAdjustmentAppliedTime = restampedAt;
+        db.Add(Stock(stockId));
+        db.Add(split);
+        await db.SaveChangesAsync();
+
+        var count = await NewManager(db)
+            .RequeueAppliedSplits([new AppliedSplitMarkerSnapshot(split.Id, auditedAt)]);
+
+        count.Should().Be(0);
+        split.PriceAdjustmentAppliedTime.Should().Be(restampedAt);
+    }
+
+    [Fact]
     public async Task StampApplied_StampsSelectedSplitAndDividendSnapshots()
     {
         await using var db = NewDb();

--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepMultipleCurrencyColumnsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepMultipleCurrencyColumnsTests.cs
@@ -56,5 +56,9 @@ public class CurrencyConsolidationStepMultipleCurrencyColumnsTests
 
         var secondRow = rows[1].QuerySelectorAll("td").Select(c => c.TextContent.Trim()).ToList();
         secondRow.Should().Equal("200", "60");
+
+        doc.QuerySelector("table + p em")
+            .Should()
+            .BeNull("a table with both USD and EUR values has no truthful single-currency note");
     }
 }

--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepPopulatedValueColumnTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepPopulatedValueColumnTests.cs
@@ -1,0 +1,97 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class CurrencyConsolidationStepPopulatedValueColumnTests
+{
+    [Fact]
+    public void Execute_CurrencyColumnPrecedesPopulatedValues_RemovesColumnFromEveryRow()
+    {
+        var parser = new HtmlParser();
+        var step = new CurrencyConsolidationStep();
+        var doc = parser.ParseDocument(
+            "<html><body><table>"
+                + "<tr><td>Compute &amp; Networking</td><td>$</td><td>193,479</td><td>$</td><td>116,193</td><td>67%</td></tr>"
+                + "<tr><td>Graphics</td><td></td><td>22,459</td><td></td><td>14,304</td><td>57%</td></tr>"
+                + "<tr><td>Total</td><td>$</td><td>215,938</td><td>$</td><td>130,497</td><td>65%</td></tr>"
+                + "</table></body></html>"
+        );
+
+        step.Execute(doc);
+
+        var rows = doc.QuerySelectorAll("tr");
+        rows.Should().AllSatisfy(row => row.QuerySelectorAll("td").Should().HaveCount(4));
+        rows[0]
+            .QuerySelectorAll("td")
+            .Select(cell => cell.TextContent.Trim())
+            .Should()
+            .Equal("Compute & Networking", "193,479", "116,193", "67%");
+        rows[1]
+            .QuerySelectorAll("td")
+            .Select(cell => cell.TextContent.Trim())
+            .Should()
+            .Equal("Graphics", "22,459", "14,304", "57%");
+        rows[2]
+            .QuerySelectorAll("td")
+            .Select(cell => cell.TextContent.Trim())
+            .Should()
+            .Equal("Total", "215,938", "130,497", "65%");
+    }
+
+    [Fact]
+    public void Execute_CurrencyScaleHeaderPrecedesYear_PreservesScaleText()
+    {
+        var parser = new HtmlParser();
+        var step = new CurrencyConsolidationStep();
+        var doc = parser.ParseDocument(
+            "<html><body><table>"
+                + "<tr><td>USD in millions</td><td>2026</td><td>2025</td></tr>"
+                + "<tr><td>$</td><td>215,938</td><td>130,497</td></tr>"
+                + "</table></body></html>"
+        );
+
+        step.Execute(doc);
+
+        doc.QuerySelectorAll("tr").Should().AllSatisfy(row => row.Children.Should().HaveCount(2));
+        doc.QuerySelector("tr td").TextContent.Trim().Should().Be("in millions 2026");
+    }
+
+    [Fact]
+    public void Execute_MixedCurrencyAndNonCurrencyCandidate_LeavesTableWithoutCurrencyNote()
+    {
+        var parser = new HtmlParser();
+        var step = new CurrencyConsolidationStep();
+        var doc = parser.ParseDocument(
+            "<html><body><table>"
+                + "<tr><td>$</td><td>100</td></tr>"
+                + "<tr><td>subtotal</td><td>200</td></tr>"
+                + "</table></body></html>"
+        );
+        var originalTable = doc.QuerySelector("table").OuterHtml;
+
+        step.Execute(doc);
+
+        doc.QuerySelector("table").OuterHtml.Should().Be(originalTable);
+        doc.QuerySelector("table + p").Should().BeNull();
+    }
+
+    [Fact]
+    public void Execute_AdjacentCurrencyPrefixedValues_LeavesPeriodColumnsUnchanged()
+    {
+        var parser = new HtmlParser();
+        var step = new CurrencyConsolidationStep();
+        var doc = parser.ParseDocument(
+            "<html><body><table>"
+                + "<tr><td>Revenue</td><td>$100</td><td>$200</td></tr>"
+                + "<tr><td>Expenses</td><td>$60</td><td>$80</td></tr>"
+                + "</table></body></html>"
+        );
+        var originalTable = doc.QuerySelector("table").OuterHtml;
+
+        step.Execute(doc);
+
+        doc.QuerySelector("table").OuterHtml.Should().Be(originalTable);
+        doc.QuerySelector("table + p").Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBoundaryValidationTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBoundaryValidationTests.cs
@@ -1,0 +1,58 @@
+using Equibles.Integrations.Yahoo.Models;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+public class YahooPriceImportServiceSplitBoundaryValidationTests
+{
+    [Theory]
+    [InlineData(0.30, 5.71, 1, 16)]
+    [InlineData(100, 24, 4, 1)]
+    public void IsSplitBoundaryDiscontinuous_JumpMatchesSplitRatio_ReturnsTrue(
+        decimal closeBefore,
+        decimal closeAfter,
+        decimal numerator,
+        decimal denominator
+    )
+    {
+        YahooPriceImportService
+            .IsSplitBoundaryDiscontinuous(closeBefore, closeAfter, numerator, denominator)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void IsSplitBoundaryDiscontinuous_ContinuousSeries_ReturnsFalse()
+    {
+        YahooPriceImportService
+            .IsSplitBoundaryDiscontinuous(5.45m, 5.71m, 1m, 16m)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void HasSplitBasisDiscontinuity_UsesNearestSessionsAroundEffectiveDate()
+    {
+        HistoricalPrice[] prices =
+        [
+            new() { Date = new DateOnly(2026, 8, 6), Close = 0.28m },
+            new() { Date = new DateOnly(2026, 8, 7), Close = 0.30m },
+            new() { Date = new DateOnly(2026, 8, 10), Close = 5.71m },
+            new() { Date = new DateOnly(2026, 8, 11), Close = 5.60m },
+        ];
+
+        YahooPriceImportService
+            .HasSplitBasisDiscontinuity(prices, new DateOnly(2026, 8, 10), 1m, 16m)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void IsSplitBoundaryDiscontinuous_SmallRatioChange_IsNotClassified()
+    {
+        YahooPriceImportService
+            .IsSplitBoundaryDiscontinuous(1.50m, 1m, 3m, 2m)
+            .Should()
+            .BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBoundaryValidationTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitBoundaryValidationTests.cs
@@ -50,9 +50,6 @@ public class YahooPriceImportServiceSplitBoundaryValidationTests
     [Fact]
     public void IsSplitBoundaryDiscontinuous_SmallRatioChange_IsNotClassified()
     {
-        YahooPriceImportService
-            .IsSplitBoundaryDiscontinuous(1.50m, 1m, 3m, 2m)
-            .Should()
-            .BeFalse();
+        YahooPriceImportService.IsSplitBoundaryDiscontinuous(1.50m, 1m, 3m, 2m).Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary
- preserve populated filing table values while consolidating currency columns
- reject split-bearing histories that still cross authoritative price bases
- requeue only the exact reconciliation marker that was audited

## Verification
- Release solution build
- 4,339 unit tests
- 2,607 integration tests