### PR TITLE
fix(yahoo): keep secondary price labels authoritative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Secondary price-series responses now label exact listing tickers without appending the primary listing's name, preventing headings such as a fund-series symbol paired with its parent security name.
 - Yahoo adjusted closes now re-sync the entire exact listed series after a captured cash dividend changes, sharing the split reconciliation queue and its retry-safe snapshot stamping. Existing dividends queue a capped one-time rebase, future actions wait until their effective session settles, a durable round-robin cursor prevents failed series from starving the queue, and amount restatements from older rolling workers remain detectable.
 - Yahoo prices now keep independent exact series for every authoritative primary and secondary listing, so requests for symbols such as GOOG/GOOGL and BRK-A/BRK-B never substitute a sibling's price. The additive upgrade preserves the legacy `DailyStockPrice` table unchanged, refetches authoritative histories into `ListedDailyStockPrice`, and deliberately refuses a destructive downgrade once exact history may exist.
 - Docker Compose optional capabilities now extend the single `worker` through override files instead of starting duplicate full worker hosts, preventing scraper and resume-cursor races when embedding or stealth support is enabled. On the first upgrade from the retired profile-based layout, run `docker compose down --remove-orphans` to remove its old worker containers. Closes #4274.

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -110,15 +110,16 @@ public class StockPriceTools
                 // dividends. A differing column is useful evidence, but the provider response does
                 // not certify one universal split basis across every raw window.
                 var hasAdjustment = records.Any(p => p.AdjustedClose != p.Close);
+                var listingTitle = ListingTitle(stock, priceTicker);
 
                 var result = hasAdjustment
                     ? StartTable(
-                        $"Daily prices for {priceTicker} ({stock.Name}):",
+                        $"Daily prices for {listingTitle}:",
                         "| Date | Open | High | Low | Close | Adj Close | Volume |",
                         "|------|------|------|-----|-------|-----------|--------|"
                     )
                     : StartTable(
-                        $"Daily prices for {priceTicker} ({stock.Name}):",
+                        $"Daily prices for {listingTitle}:",
                         "| Date | Open | High | Low | Close | Volume |",
                         "|------|------|------|-----|-------|--------|"
                     );
@@ -484,7 +485,7 @@ public class StockPriceTools
                 );
 
                 return RenderNewestFirst(
-                    $"Stochastic Oscillator (%K={kPeriod}, %D={dPeriod}) for {priceTicker} ({stock.Name}):",
+                    $"Stochastic Oscillator (%K={kPeriod}, %D={dPeriod}) for {ListingTitle(stock, priceTicker)}:",
                     "| Date | Close | %K | %D |",
                     "|------|-------|----|----|",
                     records.Count,
@@ -558,7 +559,7 @@ public class StockPriceTools
                 var atr = TechnicalIndicatorService.ComputeAtr(highs, lows, closes, period);
 
                 return RenderNewestFirst(
-                    $"Average True Range (period={period}) for {priceTicker} ({stock.Name}):",
+                    $"Average True Range (period={period}) for {ListingTitle(stock, priceTicker)}:",
                     "| Date | Close | ATR |",
                     "|------|-------|-----|",
                     records.Count,
@@ -622,7 +623,7 @@ public class StockPriceTools
                 var obv = TechnicalIndicatorService.ComputeObv(closes, volumes);
 
                 return RenderNewestFirst(
-                    $"On-Balance Volume for {priceTicker} ({stock.Name}):",
+                    $"On-Balance Volume for {ListingTitle(stock, priceTicker)}:",
                     "| Date | Close | Volume | OBV |",
                     "|------|-------|--------|-----|",
                     records.Count,
@@ -696,7 +697,7 @@ public class StockPriceTools
                 );
 
                 return RenderNewestFirst(
-                    $"Bollinger Bands (period={period}, stdDev={McpFormat.Invariant(stdDev, "0.#")}) for {priceTicker} ({stock.Name}):",
+                    $"Bollinger Bands (period={period}, stdDev={McpFormat.Invariant(stdDev, "0.#")}) for {ListingTitle(stock, priceTicker)}:",
                     "| Date | Close | Lower | Middle | Upper | %B | Bandwidth |",
                     "|------|-------|-------|--------|-------|----|-----------|",
                     records.Count,
@@ -735,6 +736,13 @@ public class StockPriceTools
             return null;
         return Math.Round((upper.Value - lower.Value) / middle.Value, 4);
     }
+
+    // CommonStock.Name describes the primary SEC listing. Secondary symbols can identify a
+    // different share class or fund series, and no authoritative per-listing name is stored.
+    private static string ListingTitle(CommonStock stock, string priceTicker) =>
+        string.Equals(stock.Ticker, priceTicker, StringComparison.OrdinalIgnoreCase)
+            ? $"{priceTicker} ({stock.Name})"
+            : priceTicker;
 
     // Resolves a ticker to its filer and exact stored listing symbol, additionally accepting
     // the dot class-share notation (BRK.B) for the dash form the price data stores (BRK-B).

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
@@ -148,8 +148,12 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
     [Fact]
     public async Task GetTopHolders_CombinedViewRestatesCarriedRowsFromTheirSourceDate()
     {
-        var previous = new DateOnly(2026, 3, 31);
-        var current = new DateOnly(2026, 6, 30);
+        // GetTopHolders resolves the filing-window mode from the system clock. Keep this
+        // synthetic newest report safely inside that window so a fixed date cannot expire.
+        var current = DateOnly
+            .FromDateTime(DateTime.UtcNow)
+            .AddDays(-(CombinedQuarterHelper.FilingDeadlineDays - 1));
+        var previous = current.AddMonths(-3);
         var stock = new CommonStock
         {
             Ticker = "CARR",
@@ -168,7 +172,7 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
             {
                 CommonStockId = stock.Id,
                 PriceSeriesTicker = "CARR.B",
-                EffectiveDate = new DateOnly(2026, 5, 15),
+                EffectiveDate = current.AddDays(-30),
                 Numerator = 10m,
                 Denominator = 1m,
                 Source = StockSplitSource.Manual,

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsSecondaryTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsSecondaryTickerTests.cs
@@ -218,11 +218,14 @@ public class StockPriceToolsSecondaryTickerTests : ParadeDbMcpTestBase
     [Fact]
     public async Task GetStockPrices_ASecondarySymbol_ServesItsOwnSeries()
     {
-        await SeedBerkshire();
+        var stock = await SeedBerkshire();
 
         var result = await Sut().GetStockPrices("BRK-A");
 
-        result.Should().Contain("Daily prices for BRK-A");
+        result.Should().Contain("Daily prices for BRK-A:");
+        result
+            .Should()
+            .NotContain(stock.Name, "the parent name does not identify the secondary listing");
         result.Should().Contain("749200.00");
         result.Should().NotContain("511.54");
     }
@@ -259,6 +262,7 @@ public class StockPriceToolsSecondaryTickerTests : ParadeDbMcpTestBase
         // The dot form is a spelling of the SAME symbol, so the refusal must not catch it.
         var result = await Sut().GetStockPrices("BRK.B");
 
+        result.Should().Contain("Daily prices for BRK-B (Berkshire Hathaway Inc):");
         result.Should().Contain("511.54");
         result.Should().NotContain("749200.00");
     }
@@ -278,12 +282,15 @@ public class StockPriceToolsSecondaryTickerTests : ParadeDbMcpTestBase
     [Fact]
     public async Task GetBollingerBands_ASecondarySymbol_UsesTheSecondarySeries()
     {
-        await SeedBerkshire();
+        var stock = await SeedBerkshire();
 
         // Every indicator shares one resolution path, so none can drift back to primary bars.
         var result = await Sut().GetBollingerBands("BRK-A");
 
-        result.Should().Contain("for BRK-A");
+        result.Should().Contain("for BRK-A:");
+        result
+            .Should()
+            .NotContain(stock.Name, "indicator headings follow the exact listing identity");
         result.Should().Contain("749200.00");
         result.Should().NotContain("511.54");
     }


### PR DESCRIPTION
## Summary

Secondary price-series responses now show the exact listing symbol without incorrectly appending the primary listing name. Primary symbols, including accepted dot aliases, retain the company name.

The PR also stabilizes a pre-existing holdings regression whose fixed June 2026 filing-window date expired on August 15 and blocked CI.

## Code changes

- Centralize listing-title rendering across price history and technical indicators.
- Cover secondary and primary-alias headings with integration tests.
- Keep the synthetic combined-view holdings test inside the 45-day window using relative dates.
- Document the user-visible price-label correction in the changelog.

## Verification

- [ ] dotnet build Equibles.sln -c Release is clean locally
- [ ] dotnet test Equibles.sln --filter "Category!=Functional" passes locally
- [x] Focused StockPriceToolsSecondaryTickerTests pass (9/9)
- [x] Previously failing combined-view holdings test passes (1/1)
- [x] dotnet csharpier check is clean for changed C# files
- [x] CHANGELOG.md updated under Unreleased
- [ ] Docs / README updated (not required)

Closes #4389