### PR TITLE
fix(mcp): clarify financial fact boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Financial-fact MCP tools no longer advertise dimensioned customer-concentration disclosures as consolidated series, and peer comparisons preserve exact dotted ticker spellings instead of inferring a different dash-listed security. Unknown symbols are now identified as outside the tracked SEC issuer set. Closes #4391.
 - Secondary price-series responses now label exact listing tickers without appending the primary listing's name, preventing headings such as a fund-series symbol paired with its parent security name.
 - Yahoo adjusted closes now re-sync the entire exact listed series after a captured cash dividend changes, sharing the split reconciliation queue and its retry-safe snapshot stamping. Existing dividends queue a capped one-time rebase, future actions wait until their effective session settles, a durable round-robin cursor prevents failed series from starving the queue, and amount restatements from older rolling workers remain detectable.
 - Yahoo prices now keep independent exact series for every authoritative primary and secondary listing, so requests for symbols such as GOOG/GOOGL and BRK-A/BRK-B never substitute a sibling's price. The additive upgrade preserves the legacy `DailyStockPrice` table unchanged, refetches authoritative histories into `ListedDailyStockPrice`, and deliberately refuses a destructive downgrade once exact history may exist.

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -283,21 +283,6 @@ public static class FinancialConceptAliases
                 "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalentsPeriodIncreaseDecreaseExcludingExchangeRateEffect"
             ),
         ],
-
-        // ── Risk disclosures ────────────────────────────────────────────────
-        // Concentration-risk percentage (ASC 275/280): the share of revenue or
-        // receivables attributable to a filer's largest customer(s), as a
-        // fraction (0.31 = 31%). Filers usually tag it per customer/benchmark
-        // (dimensioned), so the consolidated-only fact tools surface it only
-        // where an entity-level figure is tagged; both taxonomy spellings are
-        // listed because issuers file the element under us-gaap and srt.
-        ["customer-concentration"] =
-        [
-            G("ConcentrationRiskPercentage1"),
-            G("ConcentrationRiskPercentage"),
-            new(FactTaxonomy.Srt, "ConcentrationRiskPercentage1"),
-            new(FactTaxonomy.Srt, "ConcentrationRiskPercentage"),
-        ],
     };
 
     // Spelt-out synonyms normalise onto a canonical key so callers can use
@@ -334,8 +319,6 @@ public static class FinancialConceptAliases
         ["pp&e"] = "property-plant-and-equipment",
         ["aoci"] = "accumulated-oci",
         ["apic"] = "additional-paid-in-capital",
-        ["concentration-risk"] = "customer-concentration",
-        ["customer-concentration-risk"] = "customer-concentration",
     };
 
     public static IReadOnlyCollection<string> SupportedAliases => Map.Keys;

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -59,8 +59,9 @@ public class FinancialFactsTools
             + "Each row carries its actual period start/end; fiscal years/quarters follow the "
             + "company's own fiscal calendar. Warns when the selected alias ends materially "
             + "before the company's other structured facts, which can indicate an XBRL tag "
-            + "change. For a full statement use GetFinancialStatement; to compare peers use "
-            + "CompareFinancialFact."
+            + "change. Dimensioned disclosures such as customer concentration are outside this "
+            + "consolidated-series tool. For a full statement use GetFinancialStatement; to "
+            + "compare peers use CompareFinancialFact."
     )]
     public Task<string> GetFinancialFact(
         [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -260,25 +261,9 @@ public class FinancialFactsTools
                 if (!FactArgs.TryParsePeriod(fiscalPeriod, out var period))
                     return $"Unknown period '{fiscalPeriod}'. Use 'FY' or 'Q1'..'Q4'.";
 
-                if (string.IsNullOrWhiteSpace(tickers))
-                    return "At least one ticker is required.";
-
-                var segments = tickers.Split(',').Select(ticker => ticker.Trim()).ToList();
-                if (segments.All(string.IsNullOrWhiteSpace))
-                    return "At least one ticker is required.";
-                if (segments.Count > MaxTickers)
-                    return $"Too many tickers ({segments.Count}). The maximum is {MaxTickers}.";
-
-                var requested = new List<string>();
-                var seenTickers = new HashSet<string>(StringComparer.Ordinal);
-                foreach (var segment in segments)
-                {
-                    var normalizedTicker = TickerNormalizer.NormalizeDashListed(segment);
-                    if (normalizedTicker == null)
-                        return $"Invalid ticker '{segment}'. Use 1-32 ASCII letters, digits, dots, or dashes.";
-                    if (seenTickers.Add(normalizedTicker))
-                        requested.Add(normalizedTicker);
-                }
+                var (requested, tickerError) = ParseComparisonTickers(tickers);
+                if (tickerError != null)
+                    return tickerError;
 
                 var conceptPriority = await ResolveConceptPriority(conceptRefs);
                 if (conceptPriority.Count == 0)
@@ -287,15 +272,7 @@ public class FinancialFactsTools
                 // Two queries instead of 2N: batch-load the requested stocks,
                 // then all matching facts in one go keyed by company.
                 var stocks = await _commonStockRepository.GetByTickers(requested).ToListAsync();
-                var stockByTicker = new Dictionary<string, CommonStock>();
-                foreach (var s in stocks)
-                {
-                    if (requested.Contains(s.Ticker))
-                        stockByTicker.TryAdd(s.Ticker, s);
-                    foreach (var secondary in s.SecondaryTickers ?? [])
-                        if (requested.Contains(secondary))
-                            stockByTicker.TryAdd(secondary, s);
-                }
+                var stockByTicker = BuildComparisonStockMap(requested, stocks);
 
                 var stockIds = stocks.Select(s => s.Id).ToList();
                 // A Q4 request must also load the year's fp=FY rows: filers whose
@@ -440,7 +417,9 @@ public class FinancialFactsTools
         {
             if (!stockByTicker.TryGetValue(ticker, out var stock))
             {
-                skipped.Add($"{FactMarkdown.Cell(ticker)} (not found)");
+                skipped.Add(
+                    $"{FactMarkdown.Cell(ticker)} (not found in the tracked SEC issuer set)"
+                );
                 continue;
             }
             if (rowTickerByStockId.TryGetValue(stock.Id, out var firstTicker))
@@ -461,6 +440,58 @@ public class FinancialFactsTools
         }
         return (rows, skipped);
     }
+
+    internal static Dictionary<string, CommonStock> BuildComparisonStockMap(
+        IReadOnlyList<string> requested,
+        IReadOnlyList<CommonStock> stocks
+    )
+    {
+        var stockByTicker = new Dictionary<string, CommonStock>(StringComparer.Ordinal);
+        foreach (var ticker in requested)
+        {
+            var stock = ResolveComparisonStock(stocks, ticker);
+            if (stock != null)
+                stockByTicker.Add(ticker, stock);
+        }
+        return stockByTicker;
+    }
+
+    internal static (List<string> Tickers, string Error) ParseComparisonTickers(string tickers)
+    {
+        if (string.IsNullOrWhiteSpace(tickers))
+            return ([], "At least one ticker is required.");
+
+        var segments = tickers.Split(',').Select(ticker => ticker.Trim()).ToList();
+        if (segments.All(string.IsNullOrWhiteSpace))
+            return ([], "At least one ticker is required.");
+        if (segments.Count > MaxTickers)
+            return ([], $"Too many tickers ({segments.Count}). The maximum is {MaxTickers}.");
+
+        var requested = new List<string>();
+        var seenTickers = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var segment in segments)
+        {
+            var normalizedTicker = TickerNormalizer.NormalizeListed(segment);
+            if (normalizedTicker == null)
+                return (
+                    [],
+                    $"Invalid ticker '{segment}'. Use 1-32 ASCII letters, digits, dots, or dashes."
+                );
+            if (seenTickers.Add(normalizedTicker))
+                requested.Add(normalizedTicker);
+        }
+        return (requested, null);
+    }
+
+    private static CommonStock ResolveComparisonStock(
+        IReadOnlyList<CommonStock> stocks,
+        string ticker
+    ) =>
+        stocks
+            .Where(stock => stock.Ticker == ticker || stock.SecondaryTickers.Contains(ticker))
+            .OrderBy(stock => stock.Ticker == ticker ? 0 : 1)
+            .ThenBy(stock => stock.Ticker, StringComparer.Ordinal)
+            .FirstOrDefault();
 
     // Peer period ends further apart than one calendar quarter mean the rows
     // cover materially different calendar months (NVDA's fiscal Q2 2025 ended

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsCompareToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsCompareToolsTests.cs
@@ -151,7 +151,7 @@ public class FinancialFactsCompareToolsTests : ParadeDbMcpTestBase
         result.Should().NotContain("$380,000,000,000", "the latest-filed restatement wins");
         result.Should().Contain("Skipped:");
         result.Should().Contain("GOOGL (no data)");
-        result.Should().Contain("ZZZZ (not found)");
+        result.Should().Contain("ZZZZ (not found in the tracked SEC issuer set)");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesCustomerConcentrationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesCustomerConcentrationTests.cs
@@ -1,52 +1,30 @@
-using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Statements;
 
 namespace Equibles.UnitTests.Sec;
 
 /// <summary>
-/// Filers that tag their customer-concentration disclosure carry it under the
-/// ConcentrationRiskPercentage elements (us-gaap and srt spellings). The
-/// 'customer-concentration' alias makes that tagged data reachable through
-/// the FinancialFacts tools; without it the tags were ingested but had no
-/// caller-facing name.
+/// Customer-concentration percentages are normally dimensioned by customer and
+/// benchmark. Consolidated fact tools discard those dimensions, so advertising
+/// this disclosure as a consolidated alias creates a guaranteed false miss.
 /// </summary>
 public class FinancialConceptAliasesCustomerConcentrationTests
 {
-    [Fact]
-    public void TryResolve_CustomerConcentration_MapsConcentrationRiskPercentageTags()
-    {
-        var resolved = FinancialConceptAliases.TryResolve(
-            "customer-concentration",
-            out var concepts
-        );
-
-        resolved.Should().BeTrue();
-        concepts
-            .Select(c => (c.Taxonomy, c.Tag))
-            .Should()
-            .ContainInOrder(
-                (FactTaxonomy.UsGaap, "ConcentrationRiskPercentage1"),
-                (FactTaxonomy.UsGaap, "ConcentrationRiskPercentage"),
-                (FactTaxonomy.Srt, "ConcentrationRiskPercentage1"),
-                (FactTaxonomy.Srt, "ConcentrationRiskPercentage")
-            );
-    }
-
     [Theory]
+    [InlineData("customer-concentration")]
     [InlineData("concentration-risk")]
     [InlineData("customer-concentration-risk")]
     [InlineData("Customer Concentration")]
-    public void TryResolve_Synonyms_ResolveToCustomerConcentration(string alias)
+    public void TryResolve_CustomerConcentrationAliases_AreNotConsolidatedFacts(string alias)
     {
         var resolved = FinancialConceptAliases.TryResolve(alias, out var concepts);
 
-        resolved.Should().BeTrue();
-        concepts.Should().Contain(c => c.Tag == "ConcentrationRiskPercentage1");
+        resolved.Should().BeFalse();
+        concepts.Should().BeEmpty();
     }
 
     [Fact]
-    public void SupportedAliases_ListCustomerConcentration()
+    public void SupportedAliases_DoNotListCustomerConcentration()
     {
-        FinancialConceptAliases.SupportedAliases.Should().Contain("customer-concentration");
+        FinancialConceptAliases.SupportedAliases.Should().NotContain("customer-concentration");
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsBuildComparisonRowsDistinguishedSkipTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsBuildComparisonRowsDistinguishedSkipTests.cs
@@ -9,7 +9,7 @@ namespace Equibles.UnitTests.Sec;
 public class FinancialFactsToolsBuildComparisonRowsDistinguishedSkipTests
 {
     // BuildComparisonRows (extracted in #1580) partitions the user-supplied
-    // tickers into two distinct skip buckets: "(not found)" when the ticker
+    // tickers into two distinct skip buckets: "not found in the tracked SEC issuer set" when the ticker
     // doesn't resolve to any stock, vs "(no data)" when the stock is known
     // but has no reported fact for the requested period. The two messages
     // mean different things to the LLM consumer — unknown ticker is a typo

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsBuildComparisonRowsDuplicateStockTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsBuildComparisonRowsDuplicateStockTests.cs
@@ -87,4 +87,95 @@ public class FinancialFactsToolsBuildComparisonRowsDuplicateStockTests
         rows[0].Ticker.Should().Be("GOOG (GOOGL)", "the caller asked for GOOG");
         skipped.Should().BeEmpty();
     }
+
+    [Fact]
+    public void BuildComparisonStockMap_DottedTicker_UsesOnlyExactAuthoritativeListing()
+    {
+        var exact = new CommonStock { Id = Guid.NewGuid(), Ticker = "FDR.V" };
+        var dash = new CommonStock { Id = Guid.NewGuid(), Ticker = "FDR-V" };
+
+        var stockByTicker = FinancialFactsTools.BuildComparisonStockMap(["FDR.V"], [dash, exact]);
+
+        stockByTicker.Should().ContainKey("FDR.V").WhoseValue.Should().BeSameAs(exact);
+    }
+
+    [Fact]
+    public void ParseComparisonTickers_DottedTicker_PreservesExactNormalizedSpelling()
+    {
+        var (tickers, error) = FinancialFactsTools.ParseComparisonTickers(" fdr.v,FDR.V ");
+
+        error.Should().BeNull();
+        tickers.Should().ContainSingle().Which.Should().Be("FDR.V");
+    }
+
+    [Fact]
+    public void BuildComparisonStockMap_DottedTicker_DoesNotInferDashListing()
+    {
+        var dash = new CommonStock { Id = Guid.NewGuid(), Ticker = "FDR-V" };
+
+        var stockByTicker = FinancialFactsTools.BuildComparisonStockMap(["FDR.V"], [dash]);
+
+        stockByTicker.Should().NotContainKey("FDR.V");
+    }
+
+    [Fact]
+    public void BuildComparisonStockMap_PrimaryTicker_WinsOverSecondaryCollision()
+    {
+        var primary = new CommonStock { Id = Guid.NewGuid(), Ticker = "DUP" };
+        var secondary = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "ZZZ",
+            SecondaryTickers = ["DUP"],
+        };
+
+        var stockByTicker = FinancialFactsTools.BuildComparisonStockMap(
+            ["DUP"],
+            [secondary, primary]
+        );
+
+        stockByTicker.Should().ContainKey("DUP").WhoseValue.Should().BeSameAs(primary);
+    }
+
+    [Fact]
+    public void BuildComparisonStockMap_SecondaryCollision_IsIndependentOfQueryOrder()
+    {
+        var alphabeticallyFirst = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAA",
+            SecondaryTickers = ["DUP"],
+        };
+        var alphabeticallyLast = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "ZZZ",
+            SecondaryTickers = ["DUP"],
+        };
+
+        var forward = FinancialFactsTools.BuildComparisonStockMap(
+            ["DUP"],
+            [alphabeticallyFirst, alphabeticallyLast]
+        );
+        var reversed = FinancialFactsTools.BuildComparisonStockMap(
+            ["DUP"],
+            [alphabeticallyLast, alphabeticallyFirst]
+        );
+
+        forward["DUP"].Should().BeSameAs(alphabeticallyFirst);
+        reversed["DUP"].Should().BeSameAs(alphabeticallyFirst);
+    }
+
+    [Fact]
+    public void BuildComparisonRows_UnknownDottedTicker_PreservesCallerSpellingAndScope()
+    {
+        var (rows, skipped) = Invoke(["FDR.V"], new Dictionary<string, CommonStock>());
+
+        rows.Should().BeEmpty();
+        skipped
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("FDR.V (not found in the tracked SEC issuer set)");
+    }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsBuildComparisonRowsNotFoundSkipTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsBuildComparisonRowsNotFoundSkipTests.cs
@@ -10,13 +10,13 @@ public class FinancialFactsToolsBuildComparisonRowsNotFoundSkipTests
 {
     // Sibling to FinancialFactsToolsBuildComparisonRowsDistinguishedSkipTests
     // (which pins the "(no data)" skip path — known stock, missing fact).
-    // This pin defends the OTHER skip arm: "(not found)" — when the
+    // This pin defends the OTHER skip arm: "(not found in the tracked SEC issuer set)" — when the
     // requested ticker doesn't resolve to any stock in stockByTicker.
     //
     // The body has TWO sequential early-continues:
     //     if (!stockByTicker.TryGetValue(ticker, out var stock))
     //     {
-    //         skipped.Add($"{FactMarkdown.Cell(ticker)} (not found)");
+    //         skipped.Add($"{FactMarkdown.Cell(ticker)} (not found in the tracked SEC issuer set)");
     //         continue;
     //     }
     //     if (!bestByStock.TryGetValue(stock.Id, out var best))
@@ -26,7 +26,7 @@ public class FinancialFactsToolsBuildComparisonRowsNotFoundSkipTests
     //     }
     //
     // Each suffix means something different to the LLM consumer:
-    //   • "(not found)" — the ticker isn't in the master CommonStocks
+    //   • "(not found in the tracked SEC issuer set)" — the ticker isn't in CommonStocks
     //     table. Causes: typo, ADR symbol the user passed in lower
     //     case, delisted ticker, never-tracked exchange.
     //   • "(no data)" — the company exists but reported no fact for
@@ -59,7 +59,7 @@ public class FinancialFactsToolsBuildComparisonRowsNotFoundSkipTests
     // Adversarial input: a requested ticker with NO entry in
     // stockByTicker AND NO matching entry in bestByStock (the latter
     // could never match because there's no stock.Id to look up).
-    // Assert (a) skipped contains exactly the "(not found)" message,
+    // Assert (a) skipped contains exactly the scoped "not found" message,
     // (b) it does NOT contain "(no data)" — separating the two
     // suffixes — and (c) rows is empty.
     [Fact]
@@ -79,7 +79,11 @@ public class FinancialFactsToolsBuildComparisonRowsNotFoundSkipTests
         var rows = (IList)result.GetType().GetField("Item1").GetValue(result);
 
         rows.Count.Should().Be(0);
-        skipped.Should().ContainSingle().Which.Should().Be("XYZ (not found)");
+        skipped
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("XYZ (not found in the tracked SEC issuer set)");
         skipped[0].Should().NotContain("(no data)");
     }
 }


### PR DESCRIPTION
## Summary

Correct two misleading financial-fact MCP contracts: dimensioned customer concentration is no longer advertised as a consolidated alias, and dotted ticker input is preserved without punctuation-based security inference.

## Code changes

- Remove customer-concentration aliases from the consolidated financial concept catalog and document the dimensional boundary.
- Parse comparison tickers with exact listed spelling, resolve only authoritative primary/secondary symbols, and preserve unknown symbols in a scoped SEC-issuer diagnostic.
- Add parser, collision, unit, and PostgreSQL integration regressions; update the changelog.

## Verification

- [x] `dotnet build Equibles.sln -c Release` is clean locally
- [x] `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release --no-build` passes locally (4,345/4,345)
- [x] `FinancialFactsCompareToolsTests` passes locally (10/10)
- [x] `dotnet csharpier check` is clean for every changed C# file
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] Tool description updated for the changed behavior

## Notes for reviewers

- Production has no authoritative primary, secondary, or reference listing for FDR, FDR.V, or FDR-V. The implementation deliberately does not infer an exchange or alternate security from punctuation.
- Independent final review found no blockers or high-confidence findings.

Closes #4391.