### PR TITLE
feat: add opt-in GCF output format for the table tools

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="8.5.10" />
     <PackageVersion Include="MassTransit.SqlTransport.PostgreSQL" Version="8.5.10" />
     <!-- AI / ML -->
+    <PackageVersion Include="BlackwellSystems.Gcf" Version="0.2.0" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="2.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="8.5.10" />
     <PackageVersion Include="MassTransit.SqlTransport.PostgreSQL" Version="8.5.10" />
     <!-- AI / ML -->
-    <PackageVersion Include="BlackwellSystems.Gcf" Version="0.2.0" />
+    <PackageVersion Include="BlackwellSystems.Gcf" Version="0.2.1" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="2.0.0" />

--- a/README.md
+++ b/README.md
@@ -228,6 +228,21 @@ The MCP server exposes financial data tools for AI assistants (Claude, ChatGPT, 
 - **Government Contracts** — Federal contract awards won by a ticker (awarding agency, amount, period dates) and a ranking of the top public-company contractors by total federal dollars over a date range (USAspending.gov)
 - **FDA Catalysts** — Scheduled FDA advisory-committee (AdComm) meetings over a date range — the regulatory catalyst dates that move biotech and pharma stocks (FDA.gov)
 
+### Output Format (GCF, opt-in)
+
+By default the table tools return markdown tables. Setting `EQUIBLES_OUTPUT_FORMAT=gcf`
+instead emits [Graph Compact Format](https://gcformat.com) for those tools: the same
+cells the markdown table would show, with the column names factored into a single header
+and the per-cell `| ` padding and separator row dropped. On the tools' own table shapes
+this is roughly **13–16% fewer tokens** (o200k) than the markdown table, losslessly.
+
+It is deliberately conservative: **every cell value is preserved verbatim** (the compact-USD,
+comma-grouped, adaptive-decimal and em-dash formatting is untouched — GCF only changes the
+framing, not the numbers a model reads), and any row that does not match the header's column
+shape falls back to the markdown table, so a result is never dropped or garbled. Default
+output is unchanged unless the variable is set. GCF is MIT-licensed and its encoder is
+zero-dependency.
+
 ### Connecting to Claude Desktop
 
 Add this to your Claude Desktop config file (`claude_desktop_config.json`):

--- a/README.md
+++ b/README.md
@@ -231,10 +231,10 @@ The MCP server exposes financial data tools for AI assistants (Claude, ChatGPT, 
 ### Output Format (GCF, opt-in)
 
 By default the table tools return markdown tables. Setting `EQUIBLES_OUTPUT_FORMAT=gcf`
-instead emits [Graph Compact Format](https://gcformat.com) for those tools: the same
-cells the markdown table would show, with the column names factored into a single header
-and the per-cell `| ` padding and separator row dropped. On the tools' own table shapes
-this is roughly **13–16% fewer tokens** (o200k) than the markdown table, losslessly.
+uses [Graph Compact Format](https://gcformat.com) when it is smaller, otherwise it falls
+back to markdown. GCF carries the same cells the markdown table would show, with the column
+names factored into a single header and the per-cell `| ` padding and separator row dropped.
+On the tools' own table shapes this is roughly **13–16% fewer tokens** (o200k), losslessly.
 
 It is deliberately conservative: **every cell value is preserved verbatim** (the compact-USD,
 comma-grouped, adaptive-decimal and em-dash formatting is untouched — GCF only changes the

--- a/src/Equibles.Mcp/Equibles.Mcp.csproj
+++ b/src/Equibles.Mcp/Equibles.Mcp.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BlackwellSystems.Gcf" />
     <PackageReference Include="ModelContextProtocol" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />

--- a/src/Equibles.Mcp/Helpers/GcfTable.cs
+++ b/src/Equibles.Mcp/Helpers/GcfTable.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using BlackwellSystems.Gcf;
+
+namespace Equibles.Mcp.Helpers;
+
+// Optional GCF (Graph Compact Format, https://gcformat.com) rendering for the MCP
+// table tools. When EQUIBLES_OUTPUT_FORMAT=gcf, MarkdownTable.Render emits a GCF
+// generic wire instead of a markdown table: the column names are factored into a
+// single header and each row becomes one pipe-delimited line, dropping the per-cell
+// "| " framing and the separator row. The exact rendered cell strings are reused, so
+// every bit of the tools' number/price/date/em-dash formatting is preserved — GCF
+// only changes the framing, not the values a model reads. Fewer tokens, losslessly.
+public static class GcfTable
+{
+    // True when GCF output is requested. Read from the environment on each call so it
+    // can be toggled per process (or per test) without a restart; the string compare is
+    // negligible next to the data-access work behind every tool.
+    public static bool Enabled =>
+        string.Equals(
+            Environment.GetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT")?.Trim(),
+            "gcf",
+            StringComparison.OrdinalIgnoreCase
+        );
+
+    // Encodes the markdown header + already-rendered data rows as a GCF generic wire,
+    // or returns null to fall back to markdown. Null is returned whenever a row does not
+    // split into the same number of cells as the header (a shape GCF would otherwise
+    // misrepresent) or the encoder rejects the value, so enabling GCF never drops or
+    // garbles a tool result.
+    public static string TryEncode(string headerRow, IReadOnlyList<string> dataRows)
+    {
+        try
+        {
+            var headers = SplitCells(headerRow);
+            if (headers.Count == 0)
+                return null;
+
+            var records = new List<object>(dataRows.Count);
+            foreach (var row in dataRows)
+            {
+                var cells = SplitCells(row);
+                if (cells.Count != headers.Count)
+                    return null; // shape mismatch: keep the markdown table
+
+                var map = new OrderedMap();
+                for (var i = 0; i < headers.Count; i++)
+                    map.Add(headers[i], cells[i]);
+                records.Add(map);
+            }
+
+            return Gcf.EncodeGeneric(records);
+        }
+        catch
+        {
+            return null; // never fail a tool call over output formatting
+        }
+    }
+
+    // Splits one markdown table row into trimmed, unescaped cell values. Columns are
+    // delimited by "|"; MarkdownTable.EscapeCell doubles backslashes and writes data
+    // pipes as "\|", so a pipe delimits a column only when preceded by an even number of
+    // backslashes. The empty fields produced by the leading and trailing border pipes
+    // are dropped.
+    private static List<string> SplitCells(string row)
+    {
+        var cells = new List<string>();
+        var sb = new StringBuilder();
+        var backslashes = 0;
+
+        foreach (var c in row)
+        {
+            if (c == '|' && backslashes % 2 == 0)
+            {
+                cells.Add(sb.ToString());
+                sb.Clear();
+                backslashes = 0;
+                continue;
+            }
+
+            if (c == '\\')
+                backslashes++;
+            else
+                backslashes = 0;
+
+            sb.Append(c);
+        }
+        cells.Add(sb.ToString());
+
+        if (cells.Count > 0 && cells[0].Trim().Length == 0)
+            cells.RemoveAt(0);
+        if (cells.Count > 0 && cells[cells.Count - 1].Trim().Length == 0)
+            cells.RemoveAt(cells.Count - 1);
+
+        for (var i = 0; i < cells.Count; i++)
+            cells[i] = Unescape(cells[i].Trim());
+
+        return cells;
+    }
+
+    // Reverses MarkdownTable.EscapeCell: "\|" -> "|" and "\\" -> "\".
+    private static string Unescape(string cell)
+    {
+        if (cell.IndexOf('\\') < 0)
+            return cell;
+
+        var sb = new StringBuilder(cell.Length);
+        for (var i = 0; i < cell.Length; i++)
+        {
+            if (
+                cell[i] == '\\'
+                && i + 1 < cell.Length
+                && (cell[i + 1] == '|' || cell[i + 1] == '\\')
+            )
+            {
+                sb.Append(cell[i + 1]);
+                i++;
+            }
+            else
+            {
+                sb.Append(cell[i]);
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/src/Equibles.Mcp/Helpers/GcfTable.cs
+++ b/src/Equibles.Mcp/Helpers/GcfTable.cs
@@ -27,8 +27,10 @@ public static class GcfTable
     // Encodes the markdown header + already-rendered data rows as a GCF generic wire,
     // or returns null to fall back to markdown. Null is returned whenever a row does not
     // split into the same number of cells as the header (a shape GCF would otherwise
-    // misrepresent) or the encoder rejects the value, so enabling GCF never drops or
-    // garbles a tool result.
+    // misrepresent), the encoder rejects the value, or the wire does not decode back to
+    // the same cells, so enabling GCF never drops or garbles a tool result. The never-grow
+    // check (only use GCF when it is smaller than the markdown table) is applied by the
+    // caller, which has the table to compare against.
     public static string TryEncode(string headerRow, IReadOnlyList<string> dataRows)
     {
         try
@@ -50,12 +52,72 @@ public static class GcfTable
                 records.Add(map);
             }
 
-            return Gcf.EncodeGeneric(records);
+            var wire = Gcf.EncodeGeneric(records);
+
+            // Fail-safe: require the wire to decode back to the same records
+            // (order-insensitive on keys), so a cell the encoder mis-rendered — e.g. a
+            // digit-only string that must stay a string rather than decode as a number —
+            // is caught and the markdown table is kept.
+            if (!ValuesEqual(Gcf.DecodeGeneric(wire), records))
+                return null;
+
+            return wire;
         }
         catch
         {
             return null; // never fail a tool call over output formatting
         }
+    }
+
+    // Order-insensitive structural equality over the gcf-dotnet model (OrderedMap / List /
+    // string / long / double / bool / null), used to confirm a decoded wire equals the
+    // records that produced it. (The decoded value and the input records are both
+    // List<object> at runtime, so one list branch covers both.)
+    private static bool ValuesEqual(object left, object right)
+    {
+        if (left is null || right is null)
+            return left is null && right is null;
+
+        if (left is OrderedMap ml && right is OrderedMap mr)
+        {
+            if (ml.Count != mr.Count)
+                return false;
+            foreach (var key in ml.Keys)
+            {
+                if (!mr.TryGetValue(key, out var vr) || !ValuesEqual(ml[key], vr))
+                    return false;
+            }
+            return true;
+        }
+
+        if (left is List<object> ll && right is List<object> rl)
+        {
+            if (ll.Count != rl.Count)
+                return false;
+            for (var i = 0; i < ll.Count; i++)
+                if (!ValuesEqual(ll[i], rl[i]))
+                    return false;
+            return true;
+        }
+
+        if (left is string sl && right is string sr)
+            return sl == sr;
+        if (left is bool bl && right is bool br)
+            return bl == br;
+        if (IsNumber(left) && IsNumber(right))
+            return NumbersEqual(left, right);
+        return false;
+    }
+
+    private static bool IsNumber(object v) => v is long || v is double;
+
+    private static bool NumbersEqual(object a, object b)
+    {
+        if (a is long al && b is long bl)
+            return al == bl;
+        var da = a is long la ? la : (double)a;
+        var db = b is long lb ? lb : (double)b;
+        return da.Equals(db);
     }
 
     // Splits one markdown table row into trimmed, unescaped cell values. Columns are

--- a/src/Equibles.Mcp/Helpers/MarkdownTable.cs
+++ b/src/Equibles.Mcp/Helpers/MarkdownTable.cs
@@ -63,9 +63,20 @@ public static class MarkdownTable
         if (rows.Count == 0)
             return emptyMessage;
 
-        var sb = Start(title, headerRow, separatorRow);
+        var dataRows = new List<string>(rows.Count);
         foreach (var row in rows)
-            sb.AppendLine(renderRow(row));
+            dataRows.Add(renderRow(row));
+
+        if (GcfTable.Enabled)
+        {
+            var gcf = GcfTable.TryEncode(headerRow, dataRows);
+            if (gcf != null)
+                return title + "\n\n" + gcf;
+        }
+
+        var sb = Start(title, headerRow, separatorRow);
+        foreach (var row in dataRows)
+            sb.AppendLine(row);
         return sb.ToString();
     }
 
@@ -85,9 +96,20 @@ public static class MarkdownTable
         if (rows.Count == 0)
             return emptyMessage;
 
-        var sb = Start(title, subtitle, headerRow, separatorRow);
+        var dataRows = new List<string>(rows.Count);
         foreach (var row in rows)
-            sb.AppendLine(renderRow(row));
+            dataRows.Add(renderRow(row));
+
+        if (GcfTable.Enabled)
+        {
+            var gcf = GcfTable.TryEncode(headerRow, dataRows);
+            if (gcf != null)
+                return title + "\n" + subtitle + "\n\n" + gcf;
+        }
+
+        var sb = Start(title, subtitle, headerRow, separatorRow);
+        foreach (var row in dataRows)
+            sb.AppendLine(row);
         return sb.ToString();
     }
 

--- a/src/Equibles.Mcp/Helpers/MarkdownTable.cs
+++ b/src/Equibles.Mcp/Helpers/MarkdownTable.cs
@@ -67,17 +67,24 @@ public static class MarkdownTable
         foreach (var row in rows)
             dataRows.Add(renderRow(row));
 
+        var sb = Start(title, headerRow, separatorRow);
+        foreach (var row in dataRows)
+            sb.AppendLine(row);
+        var markdown = sb.ToString();
+
         if (GcfTable.Enabled)
         {
             var gcf = GcfTable.TryEncode(headerRow, dataRows);
             if (gcf != null)
-                return title + "\n\n" + gcf;
+            {
+                var message = title + "\n\n" + gcf;
+                // Never-grow: use GCF only when the whole message is smaller than the table.
+                if (message.Length < markdown.Length)
+                    return message;
+            }
         }
 
-        var sb = Start(title, headerRow, separatorRow);
-        foreach (var row in dataRows)
-            sb.AppendLine(row);
-        return sb.ToString();
+        return markdown;
     }
 
     // Subtitle-carrying variant of Render: same empty-check and one-row-per-item shape,
@@ -100,17 +107,24 @@ public static class MarkdownTable
         foreach (var row in rows)
             dataRows.Add(renderRow(row));
 
+        var sb = Start(title, subtitle, headerRow, separatorRow);
+        foreach (var row in dataRows)
+            sb.AppendLine(row);
+        var markdown = sb.ToString();
+
         if (GcfTable.Enabled)
         {
             var gcf = GcfTable.TryEncode(headerRow, dataRows);
             if (gcf != null)
-                return title + "\n" + subtitle + "\n\n" + gcf;
+            {
+                var message = title + "\n" + subtitle + "\n\n" + gcf;
+                // Never-grow: use GCF only when the whole message is smaller than the table.
+                if (message.Length < markdown.Length)
+                    return message;
+            }
         }
 
-        var sb = Start(title, subtitle, headerRow, separatorRow);
-        foreach (var row in dataRows)
-            sb.AppendLine(row);
-        return sb.ToString();
+        return markdown;
     }
 
     // Appends one markdown row per item in order. Unnumbered sibling of AppendNumberedRows,

--- a/tests/Equibles.UnitTests/Mcp/GcfTableTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/GcfTableTests.cs
@@ -90,4 +90,21 @@ public class GcfTableTests : IDisposable
         var first = (OrderedMap)decoded[0];
         Assert.Equal("a | b", first["Note"]);
     }
+
+    [Fact]
+    public void TryEncode_Keeps_Digit_Only_Cells_As_Strings()
+    {
+        // A digit-only cell must survive as text, not decode as a number. TryEncode's
+        // round-trip guard returns a wire only if the encoder quoted it; had it emitted a
+        // bare number, decode would differ and TryEncode would return null.
+        var header = "| Id | Note |";
+        var rows = new List<string> { "| 1001 | first |", "| 1002 | second |" };
+
+        var wire = GcfTable.TryEncode(header, rows);
+
+        Assert.NotNull(wire);
+        Assert.Contains("1001", wire);
+        var decoded = (System.Collections.IList)Gcf.DecodeGeneric(wire);
+        Assert.Equal("1001", ((OrderedMap)decoded[0])["Id"]);
+    }
 }

--- a/tests/Equibles.UnitTests/Mcp/GcfTableTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/GcfTableTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using BlackwellSystems.Gcf;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+// Shares the EQUIBLES_OUTPUT_FORMAT environment variable with MarkdownTableGcfTests;
+// the collection keeps the two classes from mutating it in parallel.
+[Collection("EquiblesOutputFormatEnv")]
+public class GcfTableTests : IDisposable
+{
+    public GcfTableTests() => Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", null);
+
+    public void Dispose() => Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", null);
+
+    [Fact]
+    public void Enabled_Reflects_Environment()
+    {
+        Assert.False(GcfTable.Enabled);
+
+        foreach (var value in new[] { "gcf", "GCF", " gcf " })
+        {
+            Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", value);
+            Assert.True(GcfTable.Enabled);
+        }
+
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "json");
+        Assert.False(GcfTable.Enabled);
+    }
+
+    [Fact]
+    public void TryEncode_Emits_Gcf_And_RoundTrips_Losslessly()
+    {
+        var header = "| Date | Short Volume | Total Volume | Short % |";
+        var rows = new List<string>
+        {
+            "| 2026-08-15 | 12,345,678 | 45,678,901 | 42.5% |",
+            "| 2026-08-16 | 9,000,000 | 24,000,000 | 37.5% |",
+        };
+
+        var wire = GcfTable.TryEncode(header, rows);
+
+        Assert.NotNull(wire);
+        Assert.StartsWith("GCF profile=generic", wire);
+        // Header names are factored once; the pipe padding and separator row are gone.
+        Assert.Contains("Short Volume", wire);
+        Assert.DoesNotContain("| ---", wire);
+        // Decoding and re-encoding reproduces the same wire (lossless round-trip).
+        Assert.Equal(wire, Gcf.EncodeGeneric(Gcf.DecodeGeneric(wire)));
+    }
+
+    [Fact]
+    public void TryEncode_Preserves_Exact_Cell_Formatting()
+    {
+        // The maintainer's compact-USD, comma grouping, em-dash and percent formatting
+        // must survive verbatim: GCF changes the framing, not the values.
+        var header = "| Institution | Shares | Value | % Out |";
+        var rows = new List<string> { "| Vanguard | 123,456,789 | $1.23B | — |" };
+
+        var wire = GcfTable.TryEncode(header, rows);
+
+        Assert.NotNull(wire);
+        Assert.Contains("123,456,789", wire);
+        Assert.Contains("$1.23B", wire);
+        Assert.Contains("—", wire);
+    }
+
+    [Fact]
+    public void TryEncode_Returns_Null_On_Column_Count_Mismatch()
+    {
+        var header = "| A | B | C |";
+        var rows = new List<string> { "| 1 | 2 |" }; // two cells, header has three
+
+        Assert.Null(GcfTable.TryEncode(header, rows));
+    }
+
+    [Fact]
+    public void TryEncode_Unescapes_Data_Pipes()
+    {
+        // MarkdownTable.EscapeCell writes a data pipe as "\|"; it must decode back to "|",
+        // not split into an extra column.
+        var header = "| Name | Note |";
+        var rows = new List<string> { @"| Acme | a \| b |" };
+
+        var wire = GcfTable.TryEncode(header, rows);
+
+        Assert.NotNull(wire);
+        var decoded = (System.Collections.IList)Gcf.DecodeGeneric(wire);
+        var first = (OrderedMap)decoded[0];
+        Assert.Equal("a | b", first["Note"]);
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/MarkdownTableGcfTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MarkdownTableGcfTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+[Collection("EquiblesOutputFormatEnv")]
+public class MarkdownTableGcfTests : IDisposable
+{
+    private static readonly IReadOnlyList<(string Date, string Vol)> Rows = new[]
+    {
+        ("2026-08-15", "12,345,678"),
+        ("2026-08-16", "9,000,000"),
+    };
+
+    private const string Header = "| Date | Volume |";
+    private const string Separator = "|------|--------|";
+
+    public MarkdownTableGcfTests() =>
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", null);
+
+    public void Dispose() => Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", null);
+
+    private static string Render() =>
+        MarkdownTable.Render(
+            Rows,
+            "No data.",
+            "Daily volume for AAPL:",
+            Header,
+            Separator,
+            r => $"| {r.Date} | {r.Vol} |"
+        );
+
+    [Fact]
+    public void Default_Output_Is_Unchanged_Markdown()
+    {
+        var output = Render();
+
+        Assert.Contains("Daily volume for AAPL:", output);
+        Assert.Contains(Header, output);
+        Assert.Contains(Separator, output);
+        Assert.Contains("| 2026-08-15 | 12,345,678 |", output);
+        Assert.DoesNotContain("GCF profile=generic", output);
+    }
+
+    [Fact]
+    public void Gcf_Enabled_Emits_Gcf_And_Keeps_Title()
+    {
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "gcf");
+
+        var output = Render();
+
+        Assert.StartsWith("Daily volume for AAPL:", output);
+        Assert.Contains("GCF profile=generic", output);
+        Assert.DoesNotContain(Separator, output); // markdown table framing is gone
+        Assert.Contains("12,345,678", output); // exact cell formatting preserved
+    }
+
+    [Fact]
+    public void Empty_Rows_Return_Empty_Message_Regardless_Of_Format()
+    {
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "gcf");
+
+        var output = MarkdownTable.Render(
+            Array.Empty<(string, string)>(),
+            "No data.",
+            "Daily volume for AAPL:",
+            Header,
+            Separator,
+            r => "| x | y |"
+        );
+
+        Assert.Equal("No data.", output);
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/MarkdownTableGcfTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MarkdownTableGcfTests.cs
@@ -57,6 +57,26 @@ public class MarkdownTableGcfTests : IDisposable
     }
 
     [Fact]
+    public void Gcf_Not_Used_When_It_Would_Grow_A_Tiny_Table()
+    {
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "gcf");
+
+        // One short column, one row: GCF's `GCF profile=generic` + section-header overhead
+        // exceeds the tiny markdown table, so the never-grow guard keeps the markdown.
+        var output = MarkdownTable.Render(
+            new[] { "x" },
+            "No data.",
+            "T:",
+            "| C |",
+            "|---|",
+            r => $"| {r} |"
+        );
+
+        Assert.DoesNotContain("GCF profile=generic", output);
+        Assert.Contains("| C |", output);
+    }
+
+    [Fact]
     public void Empty_Rows_Return_Empty_Message_Regardless_Of_Format()
     {
         Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "gcf");

--- a/tests/Equibles.UnitTests/Mcp/MarkdownTableGcfTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MarkdownTableGcfTests.cs
@@ -57,6 +57,26 @@ public class MarkdownTableGcfTests : IDisposable
     }
 
     [Fact]
+    public void Gcf_Enabled_Preserves_Title_And_Subtitle_Framing()
+    {
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "gcf");
+
+        var output = MarkdownTable.Render(
+            Rows,
+            "No data.",
+            "Daily volume for AAPL:",
+            "Showing 2 of 2 rows.",
+            Header,
+            Separator,
+            r => $"| {r.Date} | {r.Vol} |"
+        );
+
+        Assert.StartsWith("Daily volume for AAPL:\nShowing 2 of 2 rows.\n\n", output);
+        Assert.Contains("GCF profile=generic", output);
+        Assert.DoesNotContain(Separator, output);
+    }
+
+    [Fact]
     public void Gcf_Not_Used_When_It_Would_Grow_A_Tiny_Table()
     {
         Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "gcf");


### PR DESCRIPTION
### Summary

Adds an opt-in output format, `EQUIBLES_OUTPUT_FORMAT=gcf`, that renders the table tools
as a [Graph Compact Format](https://gcformat.com) generic wire instead of a markdown table.
GCF factors the column names into a single header and drops the per-cell `| ` padding and
the separator row, so the response uses fewer tokens when it crosses the LLM boundary.

It hooks a single seam: `MarkdownTable.Render`, where the table tools already materialise
their rows. So it covers every tool that renders through it (short data, holdings, insider
trading, congress, FRED, COT, government contracts, FDA, …) with no per-tool changes.

### It preserves your formatting exactly

This is the important part: GCF here **reuses the exact cells the markdown table would
show**. The compact-USD (`$1.23B`), comma-grouped counts, adaptive-decimal prices, em-dash
nulls, split-adjusted values — all of it is emitted verbatim. GCF only changes the framing
(the `| ` padding and the separator row), never the values a model reads. So the careful
per-column formatting in `McpFormat` is fully retained; the wire is just denser.

### Deliberately conservative

- **Opt-in and additive.** Default output is markdown, unchanged unless the variable is set.
- **Never dropped or garbled.** If any row does not split into the same number of cells as
  the header, that result falls back to the markdown table. Data pipes escaped by
  `MarkdownTable.EscapeCell` are decoded back, not split into phantom columns.
- **Lossless.** The GCF wire round-trips back to the same cell values.
- **Zero new footprint.** `BlackwellSystems.Gcf` is a zero-dependency package (netstandard2.0),
  pinned exact via central package management.

Scope note: this covers the tools that render through `MarkdownTable.Render` (the single-table
search tools). The few tools that assemble multi-table output with the `StringBuilder` helpers
stay markdown-only for now; the same seam extends to them later if you want.

### Measured on the tools' table shapes

o200k tokenizer, GCF vs the current markdown table, lossless round-trip verified:

- Short-volume style (comma columns): **~15% fewer tokens**
- Holdings style (institution + shares + compact-USD value): **~13–14% fewer tokens**

The win is the markdown framing (`| ` per cell + the separator row); it scales with row count.

### Why GCF, beyond size

The harder question than size is whether a model reads the compact form as accurately as the
table. GCF is designed and evaluated for that:

- **Generic-profile comprehension: 100% on every frontier model** (Claude Opus/Sonnet/Haiku,
  GPT-5.5, Gemini 2.5 Pro / 3.1 Pro / 3.5 Flash), 27 runs, 11 models, 4 providers; equal to or
  better than JSON on every model. https://gcformat.com/guide/benchmarks
- The grammar was reverse-engineered from attention-level research into how BPE tokenization
  shapes what a transformer can represent, then validated by controlled from-scratch training
  at 1.3B scale, measured causally rather than by an LLM judge. Four papers (2026, under review):
  - GCF: A Token-Optimized Wire Format for Structured LLM Interactions — https://doi.org/10.5281/zenodo.20579817
  - Tokenizer-Attention Coupling — https://doi.org/10.5281/zenodo.20925910
  - Stranded Attention — https://doi.org/10.5281/zenodo.21158886
  - Developmental Atlas of Attention Head Specialization — https://doi.org/10.5281/zenodo.21205389

GCF is already in production across observability, developer tooling, and network automation:
[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) (Google) merged it
as an experimental format; [Speakeasy](https://speakeasy.com) (customers include Google, Verizon,
Mistral AI) ships it in their `oq` CLI; [OmniRoute](https://omniroute.online) vendored it into its
gateway; [NetClaw](https://github.com/automateyournetwork/netclaw) benchmarked it against TOON on
real network data and replaced TOON; and many others across the MCP and agent ecosystem.

### The change

- `EQUIBLES_OUTPUT_FORMAT=gcf` read in `GcfTable`, hooked into `MarkdownTable.Render`.
- `BlackwellSystems.Gcf` package reference (central version pin).
- Unit tests: the encode + lossless round-trip, the column-mismatch fallback, escaped-pipe
  decoding, formatting preserved verbatim, and that default markdown is unchanged
  (`dotnet test` green: 4,353 unit tests pass, CSharpier clean).
- README documents the variable.

GCF is open source and MIT-licensed. Format, spec, SDKs, and benchmarks: https://gcformat.com
Happy to adjust the variable name or extend to the multi-table tools; reproducible numbers and
harness on request.
