### PR TITLE
fix(funds): deduplicate cross-population series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- The fund-series directory now preserves every NPORT series exposed through a shared issuer feed instead of failing its rebuild on duplicate stock-scoped identities.
+- The fund-series directory now preserves every NPORT series exposed through a shared issuer feed and deduplicates SEC series seen through both issuer-feed and sweep ingestion, instead of failing rebuilds on duplicate identities or route slugs.
 - Financial-fact MCP tools no longer advertise dimensioned customer-concentration disclosures as consolidated series, and peer comparisons preserve exact dotted ticker spellings instead of inferring a different dash-listed security. Unknown symbols are now identified as outside the tracked SEC issuer set. Closes #4391.
 - Secondary price-series responses now label exact listing tickers without appending the primary listing's name, preventing headings such as a fund-series symbol paired with its parent security name.
 - Yahoo adjusted closes now re-sync the entire exact listed series after a captured cash dividend changes, sharing the split reconciliation queue and its retry-safe snapshot stamping. Existing dividends queue a capped one-time rebase, future actions wait until their effective session settles, a durable round-robin cursor prevents failed series from starving the queue, and amount restatements from older rolling workers remain detectable.

--- a/src/Equibles.Sec.Data/Models/FundSeries.cs
+++ b/src/Equibles.Sec.Data/Models/FundSeries.cs
@@ -21,10 +21,11 @@ namespace Equibles.Sec.Data.Models;
 /// an issuer-feed filing is scoped by <see cref="CommonStockId"/> plus its non-empty
 /// <see cref="SeriesId"/> (or by stock alone for an id-less standalone fund); a fund-family trust
 /// series discovered by the daily-index sweep is scoped by <see cref="RegistrantCik"/> plus
-/// <see cref="SeriesId"/>. For the sweep-discovered trusts only the holdings carrying a tracked
-/// stock's CUSIP are stored, so <see cref="PositionCount"/> counts the fund's positions in tracked
-/// stocks, not its whole portfolio; <see cref="NetAssets"/> and <see cref="TotalAssets"/> are the
-/// fund's real totals from the report header regardless.
+/// <see cref="SeriesId"/>. If a series has filings in both populations, the newest filing decides
+/// which identity is materialised. For the sweep-discovered trusts only the holdings carrying a
+/// tracked stock's CUSIP are stored, so <see cref="PositionCount"/> counts the fund's positions in
+/// tracked stocks, not its whole portfolio; <see cref="NetAssets"/> and
+/// <see cref="TotalAssets"/> are the fund's real totals from the report header regardless.
 /// </summary>
 [Index(nameof(IdentityKey), IsUnique = true)]
 [Index(nameof(Slug), IsUnique = true)]

--- a/src/Equibles.Sec.Data/Models/NportFiling.cs
+++ b/src/Equibles.Sec.Data/Models/NportFiling.cs
@@ -16,7 +16,8 @@ namespace Equibles.Sec.Data.Models;
 /// ("Vanguard Index Funds", "Fidelity Concord Street Trust", "iShares Trust") are not tracked
 /// issuers, so they are instead discovered by the daily-index NPORT-P sweep — <see cref="CommonStockId"/>
 /// is null and the registrant is identified by <see cref="RegistrantCik"/>. Exactly one of the two
-/// is set, so the two populations never share a series.
+/// is set on each filing. A series can still appear in both populations over its history when its
+/// ingestion route changes; its SEC <see cref="SeriesId"/> remains the cross-population authority.
 ///
 /// The record captures the series' header facts — name, identifier, reporting period, total assets
 /// and liabilities, net assets — plus the schedule of portfolio investments in

--- a/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
@@ -93,8 +93,25 @@ public class FundSeriesRefreshService
 
         _logger.LogInformation("Rebuilding fund-series directory: {Count} series", rows.Count);
 
+        await using var transaction = await dbContext.Database.BeginTransactionAsync(
+            cancellationToken
+        );
+
         if (rows.Count > 0)
         {
+            // A series can move between the issuer-feed and sweep populations while retaining its
+            // canonical route slug. Remove the superseded identity first so the unique Slug index
+            // cannot block the replacement; the transaction preserves the old directory if the
+            // subsequent rebuild fails.
+            var currentIdentityKeys = rows.Select(s => s.IdentityKey).ToList();
+            var currentSlugs = rows.Select(s => s.Slug).ToList();
+            await dbContext
+                .Set<FundSeries>()
+                .Where(s =>
+                    currentSlugs.Contains(s.Slug) && !currentIdentityKeys.Contains(s.IdentityKey)
+                )
+                .ExecuteDeleteAsync(cancellationToken);
+
             await dbContext
                 .Set<FundSeries>()
                 .UpsertRange(rows)
@@ -133,6 +150,8 @@ public class FundSeriesRefreshService
         {
             _logger.LogInformation("Pruned {Count} stale fund-series rows", deleted);
         }
+
+        await transaction.CommitAsync(cancellationToken);
     }
 
     // Latest N-CEN registration type per tracked fund. N-CEN is filed only by tracked funds

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -108,43 +108,74 @@ public class NportFilingRepository : BaseRepository<NportFiling>
     /// filings ("and"/"&amp;", "Inc"/"Inc.", stray spaces, legal renames), which would freeze a
     /// stale "latest" report under every spelling.
     ///
-    /// A series is scoped to its registrant: a filing crawled through a tracked stock's feed is
-    /// scoped by <see cref="NportFiling.CommonStockId"/>; a filing discovered by the daily-index
-    /// sweep (whose registrant is a fund-family trust that is not a tracked stock) is scoped by
-    /// <see cref="NportFiling.RegistrantCik"/>. Exactly one is set per filing, so the two
-    /// populations never collide. Within a registrant, filings carrying the same non-empty
-    /// <see cref="NportFiling.SeriesId"/> are the same series; filings carrying different non-empty
-    /// ids are genuinely different series and never supersede each other; and an id-less filing
-    /// belongs to the registrant's single fund (listed closed-end funds file with no series id at
-    /// all), so it shares identity with every filing of its registrant.
+    /// A series is normally scoped to its registrant: a filing crawled through a tracked stock's
+    /// feed is scoped by <see cref="NportFiling.CommonStockId"/>; a filing discovered by the
+    /// daily-index sweep is scoped by <see cref="NportFiling.RegistrantCik"/>. A non-empty SEC
+    /// <see cref="NportFiling.SeriesId"/> is globally authoritative, however, so if the same series
+    /// has reached both ingestion populations only the newest filing survives. Different non-empty
+    /// series ids never supersede each other. An id-less filing belongs to the registrant's single
+    /// fund, so it shares identity with every filing of that registrant.
     ///
     /// The latest report is the one with the greatest report period, breaking ties by filing date
     /// and then accession number so amendments and re-filings of the same period win.
     ///
-    /// The supersedes check is split into three registrant-population branches (tracked-stock
-    /// filings, CIK-scoped trust filings, identity-less filings) concatenated with UNION ALL,
-    /// rather than one anti-join whose identity condition ORs the populations together: a filing
-    /// only ever competes with filings of its own population, and the OR form gives the anti-join
-    /// no hashable key, degrading it to an O(N²) nested loop over every pair of filings (observed
-    /// at ~8 s per call). Each branch leads with a plain equality on its population's key, so the
-    /// planner hash-partitions the anti-join and the whole dedup runs in milliseconds. The series
-    /// wildcard and newer-report conditions are identical in every branch.
+    /// Series-bearing and id-less filings are split into separate population branches concatenated
+    /// with UNION ALL. A non-empty series id first competes globally through a plain equality;
+    /// id-less filings then compete through their population key. Keeping both anti-joins outside
+    /// OR predicates gives PostgreSQL a hashable key and avoids an O(N²) correlated scan (observed
+    /// at ~8 s per call with the former combined identity predicate).
     /// </summary>
     public IQueryable<NportFiling> GetLatestPerSeries(DateOnly floor)
     {
         var filings = GetAll().Where(f => f.ReportPeriodDate >= floor);
 
-        // Tracked funds: scoped by CommonStockId.
-        var trackedFunds = filings
-            .Where(f => f.CommonStockId != null)
+        // A series-bearing tracked fund first competes globally by SEC series id, then against an
+        // id-less filing scoped to the same tracked stock.
+        var trackedSeries = filings
+            .Where(f => f.CommonStockId != null && !string.IsNullOrEmpty(f.SeriesId))
+            .Where(f =>
+                !filings.Any(f2 =>
+                    f2.SeriesId == f.SeriesId
+                    && (
+                        f2.ReportPeriodDate > f.ReportPeriodDate
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate > f.FilingDate
+                        )
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate == f.FilingDate
+                            && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+                        )
+                    )
+                )
+            )
             .Where(f =>
                 !filings.Any(f2 =>
                     f2.CommonStockId == f.CommonStockId
+                    && string.IsNullOrEmpty(f2.SeriesId)
                     && (
-                        f2.SeriesId == f.SeriesId
-                        || string.IsNullOrEmpty(f.SeriesId)
-                        || string.IsNullOrEmpty(f2.SeriesId)
+                        f2.ReportPeriodDate > f.ReportPeriodDate
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate > f.FilingDate
+                        )
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate == f.FilingDate
+                            && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+                        )
                     )
+                )
+            );
+
+        // An id-less tracked filing represents the stock's whole fund and therefore competes with
+        // every filing scoped to that stock.
+        var trackedIdless = filings
+            .Where(f => f.CommonStockId != null && string.IsNullOrEmpty(f.SeriesId))
+            .Where(f =>
+                !filings.Any(f2 =>
+                    f2.CommonStockId == f.CommonStockId
                     && (
                         f2.ReportPeriodDate > f.ReportPeriodDate
                         || (
@@ -165,17 +196,62 @@ public class NportFilingRepository : BaseRepository<NportFiling>
         // emit a plain (hashable) equality instead of null-compensating it into
         // "= OR both-null" — which would give the anti-join no hash key again.
         var trustSeries = filings
-            .Where(f => f.CommonStockId == null && f.RegistrantCik != null)
+            .Where(f =>
+                f.CommonStockId == null
+                && f.RegistrantCik != null
+                && !string.IsNullOrEmpty(f.SeriesId)
+            )
+            .Where(f =>
+                !filings.Any(f2 =>
+                    f2.SeriesId == f.SeriesId
+                    && (
+                        f2.ReportPeriodDate > f.ReportPeriodDate
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate > f.FilingDate
+                        )
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate == f.FilingDate
+                            && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+                        )
+                    )
+                )
+            )
             .Where(f =>
                 !filings.Any(f2 =>
                     f2.CommonStockId == null
                     && f.RegistrantCik != null
                     && f2.RegistrantCik == f.RegistrantCik
+                    && string.IsNullOrEmpty(f2.SeriesId)
                     && (
-                        f2.SeriesId == f.SeriesId
-                        || string.IsNullOrEmpty(f.SeriesId)
-                        || string.IsNullOrEmpty(f2.SeriesId)
+                        f2.ReportPeriodDate > f.ReportPeriodDate
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate > f.FilingDate
+                        )
+                        || (
+                            f2.ReportPeriodDate == f.ReportPeriodDate
+                            && f2.FilingDate == f.FilingDate
+                            && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+                        )
                     )
+                )
+            );
+
+        // An id-less sweep filing represents the registrant's whole fund and therefore competes
+        // with every sweep filing scoped to that registrant.
+        var trustIdless = filings
+            .Where(f =>
+                f.CommonStockId == null
+                && f.RegistrantCik != null
+                && string.IsNullOrEmpty(f.SeriesId)
+            )
+            .Where(f =>
+                !filings.Any(f2 =>
+                    f2.CommonStockId == null
+                    && f.RegistrantCik != null
+                    && f2.RegistrantCik == f.RegistrantCik
                     && (
                         f2.ReportPeriodDate > f.ReportPeriodDate
                         || (
@@ -219,7 +295,11 @@ public class NportFilingRepository : BaseRepository<NportFiling>
                 )
             );
 
-        return trackedFunds.Concat(trustSeries).Concat(identityless);
+        return trackedSeries
+            .Concat(trackedIdless)
+            .Concat(trustSeries)
+            .Concat(trustIdless)
+            .Concat(identityless);
     }
 
     /// <summary>

--- a/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
@@ -241,6 +241,110 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RebuildAll_SeriesMovesBetweenPopulations_ReplacesConflictingSlugIdentity()
+    {
+        await using var seed = FreshContext();
+        var trust = await SeedStock(seed, "AAXJ", "0001100663");
+        var tracked = MakeFiling(
+            trust.Id,
+            null,
+            "0001100663-25-000001",
+            "S000002277",
+            "iShares Russell 2000 ETF",
+            "iShares Trust",
+            new DateOnly(2024, 12, 31),
+            netAssets: 2_000m,
+            totalAssets: 2_050m
+        );
+        var swept = MakeFiling(
+            null,
+            "0001100663",
+            "0001100663-25-000002",
+            "S000002277",
+            "iShares Russell 2000 ETF",
+            "iShares Trust",
+            new DateOnly(2025, 1, 31),
+            netAssets: 2_100m,
+            totalAssets: 2_150m
+        );
+        seed.AddRange(tracked, swept);
+        seed.Set<FundSeries>()
+            .Add(
+                new FundSeries
+                {
+                    IdentityKey = $"cs:{trust.Id}:S000002277",
+                    Slug = "ishares-russell-2000-etf-s000002277",
+                    CommonStockId = trust.Id,
+                    SeriesId = "S000002277",
+                    SeriesName = "iShares Russell 2000 ETF",
+                    LatestReportPeriodDate = tracked.ReportPeriodDate,
+                    LatestFilingDate = tracked.FilingDate,
+                }
+            );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildAllAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var row = await read.Set<FundSeries>().SingleAsync();
+        row.IdentityKey.Should().Be("rc:0001100663:S000002277");
+        row.Slug.Should().Be("ishares-russell-2000-etf-s000002277");
+        row.CommonStockId.Should().BeNull();
+        row.NetAssets.Should().Be(2_100m);
+    }
+
+    [Fact]
+    public async Task RebuildAll_ReplacementUpsertFails_RollsBackConflictingSlugDeletion()
+    {
+        await using var seed = FreshContext();
+        var trust = await SeedStock(seed, "AAXJ", "0001100663");
+        var swept = MakeFiling(
+            null,
+            "0001100663",
+            "0001100663-25-000002",
+            "S000002277",
+            "iShares Russell 2000 ETF",
+            "iShares Trust",
+            new DateOnly(2025, 1, 31),
+            netAssets: 2_100m,
+            totalAssets: 2_150m
+        );
+        seed.Add(swept);
+        var previous = new FundSeries
+        {
+            IdentityKey = $"cs:{trust.Id}:S000002277",
+            Slug = "ishares-russell-2000-etf-s000002277",
+            CommonStockId = trust.Id,
+            SeriesId = "S000002277",
+            SeriesName = "iShares Russell 2000 ETF",
+            LatestReportPeriodDate = new DateOnly(2024, 12, 31),
+            LatestFilingDate = new DateOnly(2025, 1, 30),
+        };
+        seed.Add(previous);
+        await seed.SaveChangesAsync();
+
+        var service = BuildService([
+            new FundClassTicker
+            {
+                Cik = "0001100663",
+                SeriesId = "S000002277",
+                ClassId = "C000006768",
+                Symbol = "SYMBOL-OVER-16-CHARS",
+            },
+        ]);
+
+        Func<Task> act = () => service.RebuildAllAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<Exception>();
+
+        await using var read = FreshContext();
+        var surviving = await read.Set<FundSeries>().SingleAsync();
+        surviving.Id.Should().Be(previous.Id);
+        surviving.IdentityKey.Should().Be(previous.IdentityKey);
+        surviving.Slug.Should().Be(previous.Slug);
+    }
+
+    [Fact]
     public async Task RebuildAll_PopulatesFundType_FromLatestNCen()
     {
         await using var seed = FreshContext();

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
@@ -410,6 +410,102 @@ public class NportFilingRepositoryTests : IDisposable
         result.Should().ContainSingle().Which.Id.Should().Be(newest.Id);
     }
 
+    [Fact]
+    public async Task GetLatestPerSeries_SameSecSeriesAcrossPopulations_NewestWinsOnce()
+    {
+        var stock = CreateStock("AAXJ", "0001100663");
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var tracked = CreateFiling(
+            stock.Id,
+            "0001100663-25-000001",
+            new DateOnly(2025, 1, 15),
+            "iShares Russell 2000 ETF",
+            "S000002277"
+        );
+        tracked.ReportPeriodDate = new DateOnly(2024, 12, 31);
+        var swept = CreateTrustFiling(
+            "1100663",
+            "0001100663-25-000002",
+            new DateOnly(2025, 2, 15),
+            "iShares Russell 2000 ETF",
+            "S000002277"
+        );
+        swept.ReportPeriodDate = new DateOnly(2025, 1, 31);
+        _repository.Add(tracked);
+        _repository.Add(swept);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetLatestPerSeries(DateOnly.MinValue).ToListAsync();
+
+        result.Should().ContainSingle().Which.Id.Should().Be(swept.Id);
+    }
+
+    [Fact]
+    public async Task GetLatestPerSeries_SameCrossPopulationPeriod_LatestFilingDateWins()
+    {
+        var stock = CreateStock("AAXJ", "0001100663");
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var tracked = CreateFiling(
+            stock.Id,
+            "0001100663-25-000001",
+            new DateOnly(2025, 1, 15),
+            "iShares Russell 2000 ETF",
+            "S000002277"
+        );
+        tracked.ReportPeriodDate = new DateOnly(2024, 12, 31);
+        var swept = CreateTrustFiling(
+            "1100663",
+            "0001100663-25-000002",
+            new DateOnly(2025, 2, 15),
+            "iShares Russell 2000 ETF",
+            "S000002277"
+        );
+        swept.ReportPeriodDate = tracked.ReportPeriodDate;
+        _repository.Add(tracked);
+        _repository.Add(swept);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetLatestPerSeries(DateOnly.MinValue).ToListAsync();
+
+        result.Should().ContainSingle().Which.Id.Should().Be(swept.Id);
+    }
+
+    [Fact]
+    public async Task GetLatestPerSeries_SameCrossPopulationDates_HighestAccessionWins()
+    {
+        var stock = CreateStock("AAXJ", "0001100663");
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var tracked = CreateFiling(
+            stock.Id,
+            "0001100663-25-000001",
+            new DateOnly(2025, 1, 15),
+            "iShares Russell 2000 ETF",
+            "S000002277"
+        );
+        tracked.ReportPeriodDate = new DateOnly(2024, 12, 31);
+        var swept = CreateTrustFiling(
+            "1100663",
+            "0001100663-25-000002",
+            tracked.FilingDate,
+            "iShares Russell 2000 ETF",
+            "S000002277"
+        );
+        swept.ReportPeriodDate = tracked.ReportPeriodDate;
+        _repository.Add(tracked);
+        _repository.Add(swept);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetLatestPerSeries(DateOnly.MinValue).ToListAsync();
+
+        result.Should().ContainSingle().Which.Id.Should().Be(swept.Id);
+    }
+
     // Two id-less trust filings from different registrants are different funds — registrant CIK,
     // not a shared null CommonStockId, must keep them apart (otherwise every trust-only id-less
     // filing would collapse into one).

--- a/tests/Equibles.UnitTests/Sec/NportFilingRepositoryQueryTranslationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/NportFilingRepositoryQueryTranslationTests.cs
@@ -62,8 +62,9 @@ public class NportFilingRepositoryQueryTranslationTests
         var sql = repository.GetLatestPerSeries(new DateOnly(2024, 1, 1)).ToQueryString();
         var flat = System.Text.RegularExpressions.Regex.Replace(sql, @"\s+", " ");
 
-        // One branch per registrant population, concatenated — never one OR-ed identity.
-        System.Text.RegularExpressions.Regex.Matches(flat, "UNION ALL").Count.Should().Be(2);
+        // Series-bearing and id-less paths are separate within each real population, followed by
+        // the identity-less fallback — never an OR around a correlated anti-join.
+        System.Text.RegularExpressions.Regex.Matches(flat, "UNION ALL").Count.Should().Be(4);
 
         // The trust branch's anti-join must keep a bare RegistrantCik equality: EF null
         // compensation ("= OR both-null") would strip the anti-join of its hash key and


### PR DESCRIPTION
## Summary

- treat a non-empty SEC SeriesId as authoritative across issuer-feed and sweep ingestion
- replace stale population identities transactionally when they own an incoming route slug
- preserve hash anti-join query planning and add cross-population/rollback regressions

## Verification

- 4,345 OSS unit tests passed
- 26 focused PostgreSQL integration tests passed
- production EXPLAIN ANALYZE: parallel hash anti-joins, 43 ms over ~124k filings
- independent review clean