### PR TITLE
fix(holdings): index recent filing activity

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -42,6 +42,20 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
                 h.Shares,
             });
 
+        // Covering index for the stock shell's recent-filing badge:
+        // WHERE CommonStockId = @stock AND FilingDate >= @since, followed by
+        // COUNT(DISTINCT AccessionNumber/InstitutionalHolderId). The ReportDate
+        // index above made Postgres read every historical position for a stock and
+        // heap-filter FilingDate; during 13F ingest pressure this exhausted the
+        // portal's 30-second command timeout (#6049). Lead with the exact range
+        // predicate and carry both distinct-count keys so the query stays bounded
+        // to the recent filing window and can run index-only.
+        builder
+            .Entity<InstitutionalHolding>()
+            .HasIndex(h => new { h.CommonStockId, h.FilingDate })
+            .IncludeProperties(h => new { h.AccessionNumber, h.InstitutionalHolderId })
+            .IsCreatedConcurrently();
+
         // Covering index for the per-holder portfolio rollups on the holder page
         // (StocksController.ShowHolder → ComputeTopPortfolioPositions /
         // HolderPortfolioProvider.GetTrend). Both filter by holder and GROUP BY

--- a/src/Equibles.Migrations/Migrations/20260815193355_OptimizeStockFilingActivity.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260815193355_OptimizeStockFilingActivity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260815193355_OptimizeStockFilingActivity")]
+    partial class OptimizeStockFilingActivity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260815193355_OptimizeStockFilingActivity.cs
+++ b/src/Equibles.Migrations/Migrations/20260815193355_OptimizeStockFilingActivity.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <summary>
+    /// Adds the covering stock+filing-date index behind the portal's recent-filing aggregate
+    /// (#6049). InstitutionalHolding contains tens of millions of rows, so the index is built
+    /// concurrently and outside the migration transaction to keep live ingestion writable.
+    /// The invalid-index cleanup makes a failed or interrupted concurrent build retry-safe.
+    /// </summary>
+    public partial class OptimizeStockFilingActivity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DO $$ BEGIN "
+                    + "IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                    + "WHERE c.relname = 'IX_InstitutionalHolding_CommonStockId_FilingDate' AND NOT i.indisvalid) THEN "
+                    + "EXECUTE 'DROP INDEX \"IX_InstitutionalHolding_CommonStockId_FilingDate\"'; END IF; END $$;",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_InstitutionalHolding_CommonStockId_FilingDate\" "
+                    + "ON \"InstitutionalHolding\" (\"CommonStockId\", \"FilingDate\") "
+                    + "INCLUDE (\"AccessionNumber\", \"InstitutionalHolderId\");",
+                suppressTransaction: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InstitutionalHolding_CommonStockId_FilingDate\";",
+                suppressTransaction: true
+            );
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsModuleStockFilingActivityCoveringIndexTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsModuleStockFilingActivityCoveringIndexTests.cs
@@ -1,0 +1,69 @@
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Pins the stock shell's recent-filing access path. Without a stock+filing-date
+// covering index, Postgres scans every historical holding for the stock through
+// the ReportDate index, heap-filters the 30-day window, and times out under 13F
+// ingest pressure (#6049).
+public class HoldingsModuleStockFilingActivityCoveringIndexTests
+{
+    private const string IndexIncludeAnnotation = "Npgsql:IndexInclude";
+    private const string IndexConcurrentAnnotation = "Npgsql:CreatedConcurrently";
+
+    [Fact]
+    public void StockFilingDateIndex_CoversBothDistinctCountKeys()
+    {
+        using var db = NewDb();
+
+        var entity = db.Model.FindEntityType(typeof(InstitutionalHolding));
+        entity.Should().NotBeNull();
+
+        var stockFilingDateIndex = entity
+            .GetIndexes()
+            .Single(i =>
+                i.Properties.Select(p => p.Name)
+                    .SequenceEqual(
+                        new[]
+                        {
+                            nameof(InstitutionalHolding.CommonStockId),
+                            nameof(InstitutionalHolding.FilingDate),
+                        }
+                    )
+            );
+
+        var includedColumns =
+            stockFilingDateIndex.FindAnnotation(IndexIncludeAnnotation)?.Value
+            as IReadOnlyList<string>;
+
+        includedColumns
+            .Should()
+            .NotBeNull("the recent-filing aggregate must avoid heap reads under ingest pressure")
+            .And.Contain(nameof(InstitutionalHolding.AccessionNumber))
+            .And.Contain(nameof(InstitutionalHolding.InstitutionalHolderId));
+
+        stockFilingDateIndex
+            .FindAnnotation(IndexConcurrentAnnotation)
+            ?.Value.Should()
+            .Be(true, "a multi-million-row holdings index must not block live ingest writes");
+    }
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new HoldingsModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a covering `(CommonStockId, FilingDate)` index for the stock-shell recent-filing aggregate
- include both distinct-count columns so PostgreSQL can use an index-only scan
- build concurrently with retry-safe cleanup for interrupted builds
- pin the access path and concurrency annotation in a model regression test

## Verification

- `dotnet build Equibles.sln -c Release`
- `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --no-build -c Release` — 4,346 passed
- `dotnet csharpier check .` — 3,368 files checked
- `dotnet ef migrations has-pending-model-changes --project src/Equibles.Migrations` — none

Addresses daniel3303/EquiblesCommercial#6049.