### PR TITLE
fix(holdings): optimize stock holder rank aggregate

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -42,6 +42,24 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
                 h.Shares,
             });
 
+        // Partial covering index for the holder-rank aggregate on the single-holder /
+        // single-stock page. That query needs only common-share 13F rows for one
+        // stock+quarter, grouped by holder and summed by Value. Keeping the predicate
+        // in the index avoids heap-filtering FilingType / OptionType while ingestion is
+        // churning the 30M+ row holdings table (#6049).
+        builder
+            .Entity<InstitutionalHolding>()
+            .HasIndex(h => new
+            {
+                h.CommonStockId,
+                h.ReportDate,
+                h.InstitutionalHolderId,
+            })
+            .HasDatabaseName("IX_InstitutionalHolding_StockQuarterCommonValue")
+            .IncludeProperties(h => h.Value)
+            .HasFilter("\"FilingType\" = 0 AND \"OptionType\" IS NULL")
+            .IsCreatedConcurrently();
+
         // Covering index for the stock shell's recent-filing badge:
         // WHERE CommonStockId = @stock AND FilingDate >= @since, followed by
         // COUNT(DISTINCT AccessionNumber/InstitutionalHolderId). The ReportDate

--- a/src/Equibles.Migrations/Migrations/20260816151558_OptimizeStockHolderRank.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260816151558_OptimizeStockHolderRank.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260816151558_OptimizeStockHolderRank")]
+    partial class OptimizeStockHolderRank
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260816151558_OptimizeStockHolderRank.cs
+++ b/src/Equibles.Migrations/Migrations/20260816151558_OptimizeStockHolderRank.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <summary>
+    /// Adds the partial covering index behind the per-stock holder-rank aggregate (#6049).
+    /// The holdings table contains tens of millions of rows, so the index is built
+    /// concurrently and outside the migration transaction. Invalid-index cleanup makes an
+    /// interrupted concurrent build retry-safe.
+    /// </summary>
+    public partial class OptimizeStockHolderRank : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DO $$ BEGIN "
+                    + "IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                    + "WHERE c.relname = 'IX_InstitutionalHolding_StockQuarterCommonValue' AND NOT i.indisvalid) THEN "
+                    + "EXECUTE 'DROP INDEX \"IX_InstitutionalHolding_StockQuarterCommonValue\"'; END IF; END $$;",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_InstitutionalHolding_StockQuarterCommonValue\" "
+                    + "ON \"InstitutionalHolding\" (\"CommonStockId\", \"ReportDate\", \"InstitutionalHolderId\") "
+                    + "INCLUDE (\"Value\") WHERE \"FilingType\" = 0 AND \"OptionType\" IS NULL;",
+                suppressTransaction: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InstitutionalHolding_StockQuarterCommonValue\";",
+                suppressTransaction: true
+            );
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsModuleStockQuarterCommonValueIndexTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsModuleStockQuarterCommonValueIndexTests.cs
@@ -38,10 +38,7 @@ public class HoldingsModuleStockQuarterCommonValueIndexTests
             .FindAnnotation(IndexIncludeAnnotation)
             ?.Value.Should()
             .BeEquivalentTo(new[] { nameof(InstitutionalHolding.Value) });
-        index
-            .GetFilter()
-            .Should()
-            .Be("\"FilingType\" = 0 AND \"OptionType\" IS NULL");
+        index.GetFilter().Should().Be("\"FilingType\" = 0 AND \"OptionType\" IS NULL");
         index
             .FindAnnotation(IndexConcurrentAnnotation)
             ?.Value.Should()

--- a/tests/Equibles.UnitTests/Holdings/HoldingsModuleStockQuarterCommonValueIndexTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsModuleStockQuarterCommonValueIndexTests.cs
@@ -1,0 +1,65 @@
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Pins the holder-rank aggregate's access path. The rank query filters one
+// stock+quarter to common-share 13F rows, groups by holder and sums Value. A
+// partial covering index keeps that read off the churned holdings heap during
+// filing-season ingestion pressure (#6049).
+public class HoldingsModuleStockQuarterCommonValueIndexTests
+{
+    private const string IndexName = "IX_InstitutionalHolding_StockQuarterCommonValue";
+    private const string IndexIncludeAnnotation = "Npgsql:IndexInclude";
+    private const string IndexConcurrentAnnotation = "Npgsql:CreatedConcurrently";
+
+    [Fact]
+    public void StockQuarterCommonValueIndex_CoversTheRankAggregate()
+    {
+        using var db = NewDb();
+
+        var entity = db.Model.FindEntityType(typeof(InstitutionalHolding));
+        entity.Should().NotBeNull();
+
+        var index = entity.GetIndexes().Single(i => i.GetDatabaseName() == IndexName);
+
+        index
+            .Properties.Select(p => p.Name)
+            .Should()
+            .Equal(
+                nameof(InstitutionalHolding.CommonStockId),
+                nameof(InstitutionalHolding.ReportDate),
+                nameof(InstitutionalHolding.InstitutionalHolderId)
+            );
+        index
+            .FindAnnotation(IndexIncludeAnnotation)
+            ?.Value.Should()
+            .BeEquivalentTo(new[] { nameof(InstitutionalHolding.Value) });
+        index
+            .GetFilter()
+            .Should()
+            .Be("\"FilingType\" = 0 AND \"OptionType\" IS NULL");
+        index
+            .FindAnnotation(IndexConcurrentAnnotation)
+            ?.Value.Should()
+            .Be(true, "the live holdings table must remain writable while the index builds");
+    }
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new HoldingsModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a partial covering index for the per-stock/per-quarter common-share 13F holder-rank aggregate
- build and drop the large-table index concurrently with interrupted-build cleanup
- pin the complete EF index contract with a regression test

## Verification
- `dotnet build Equibles.sln -c Release --no-restore`
- 662 holdings tests passed
- `dotnet ef migrations has-pending-model-changes --project src/Equibles.Migrations`
- independent audit: no findings

Refs daniel3303/EquiblesCommercial#6049