### PR TITLE
feat(congress): store the asset type, income and seat a disclosure states

### DIFF
--- a/src/Equibles.Congress.Data/CongressSeat.cs
+++ b/src/Equibles.Congress.Data/CongressSeat.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Equibles.Congress.Data;
+
+/// <summary>
+/// Renders the seat stored on <see cref="Models.CongressMember.StateDistrict"/>.
+/// The House Clerk publishes it as a postal code with a zero-padded district
+/// ("SC05"), which is a key, not a label — district 00 means the state elects a
+/// single at-large representative rather than a district numbered zero. A value
+/// that does not match that shape is shown exactly as stored, so an unfamiliar
+/// format is visible rather than silently reformatted into something wrong.
+/// </summary>
+public static partial class CongressSeat
+{
+    public static string Format(string stateDistrict)
+    {
+        if (string.IsNullOrWhiteSpace(stateDistrict))
+            return null;
+
+        var value = stateDistrict.Trim();
+        var match = SeatRegex().Match(value);
+        if (!match.Success)
+            return value;
+
+        var state = match.Groups["state"].Value.ToUpperInvariant();
+        var district = int.Parse(match.Groups["district"].Value, CultureInfo.InvariantCulture);
+        return district == 0 ? $"{state} At-Large" : $"{state}-{district}";
+    }
+
+    [GeneratedRegex(@"^(?<state>[A-Za-z]{2})(?<district>\d{1,2})$")]
+    private static partial Regex SeatRegex();
+}

--- a/src/Equibles.Congress.Data/Models/CongressMember.cs
+++ b/src/Equibles.Congress.Data/Models/CongressMember.cs
@@ -15,6 +15,16 @@ public class CongressMember
 
     public CongressPosition Position { get; set; }
 
+    /// <summary>
+    /// The seat the member holds, exactly as the House Clerk publishes it:
+    /// a state postal code and a zero-padded district number ("SC05"), or the
+    /// state alone for an at-large seat ("AK00"). Null for senators — no Senate
+    /// filing states the member's state — and for members whose filings predate
+    /// this being captured.
+    /// </summary>
+    [MaxLength(16)]
+    public string StateDistrict { get; set; }
+
     public virtual List<CongressionalTrade> Trades { get; set; } = [];
 
     public virtual List<CongressionalAnnualDisclosure> AnnualDisclosures { get; set; } = [];

--- a/src/Equibles.Congress.Data/Models/CongressionalDisclosureLine.cs
+++ b/src/Equibles.Congress.Data/Models/CongressionalDisclosureLine.cs
@@ -31,5 +31,34 @@ public class CongressionalDisclosureLine
     /// <summary>Upper bound of the disclosed range, in dollars.</summary>
     public long RangeMaximum { get; set; }
 
+    /// <summary>
+    /// The asset class the filer declared, verbatim in the filing's own
+    /// vocabulary: a House bracketed code with its brackets removed ("ST",
+    /// "RP", "BA") or the Senate's spelled-out label ("Bank Deposit", "Corporate
+    /// Securities Non-Public Stock"). The two chambers publish different
+    /// vocabularies and neither form carries a legend, so no cross-chamber
+    /// mapping is invented here. Null on liability rows and on filings parsed
+    /// before this was captured.
+    /// </summary>
+    [MaxLength(128)]
+    public string AssetType { get; set; }
+
+    /// <summary>
+    /// The income categories the asset produced, verbatim ("Dividends",
+    /// "Rent", "Dividends, Capital Gains"). Null when the filer disclosed none.
+    /// </summary>
+    [MaxLength(256)]
+    public string IncomeType { get; set; }
+
+    /// <summary>
+    /// Lower bound of the income the asset produced over the year, in dollars.
+    /// Null when the filer disclosed no income bracket — never zero, which is
+    /// itself a disclosed value.
+    /// </summary>
+    public long? IncomeMinimum { get; set; }
+
+    /// <summary>Upper bound of the disclosed income range, in dollars.</summary>
+    public long? IncomeMaximum { get; set; }
+
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Congress.Data/Models/CongressionalFilingRecord.cs
+++ b/src/Equibles.Congress.Data/Models/CongressionalFilingRecord.cs
@@ -31,5 +31,14 @@ public class CongressionalFilingRecord
     // policy-skipped filings (scanned paper reports, candidate reports).
     public int ItemCount { get; set; }
 
+    /// <summary>
+    /// The parser generation that produced this row's data. A lane that starts
+    /// extracting new fields raises its current version, which demotes every
+    /// older row to "not yet ingested" so the filing is re-fetched and re-parsed
+    /// — the same effect as deleting the row, without a manual sweep. Lanes that
+    /// have never bumped it stay at 0 and are unaffected.
+    /// </summary>
+    public int ParserVersion { get; set; }
+
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Congress.HostedService/Models/AnnualDisclosureLineItem.cs
+++ b/src/Equibles.Congress.HostedService/Models/AnnualDisclosureLineItem.cs
@@ -18,4 +18,23 @@ public class AnnualDisclosureLineItem
 
     /// <summary>Upper bound of the disclosed range, in dollars.</summary>
     public long RangeMaximum { get; init; }
+
+    /// <summary>
+    /// The filer's own asset-class label — a House code without its brackets
+    /// ("ST") or a Senate label ("Bank Deposit"). Null on liability rows.
+    /// </summary>
+    public string AssetType { get; init; }
+
+    /// <summary>The income categories the asset produced, verbatim.</summary>
+    public string IncomeType { get; init; }
+
+    /// <summary>
+    /// The income bracket the asset produced, in dollars. Null when the filer
+    /// disclosed no bracket; a wrapped bracket that never received its upper
+    /// bound is dropped rather than halved.
+    /// </summary>
+    public long? IncomeMinimum { get; init; }
+
+    /// <summary>Upper bound of the disclosed income range, in dollars.</summary>
+    public long? IncomeMaximum { get; init; }
 }

--- a/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
@@ -262,7 +262,12 @@ public class CongressionalAnnualDisclosureSyncService
         // sync uses, so the two pipelines converge on the same member.
         var distinctMembers = reports
             .GroupBy(r => DisclosureParsingHelper.NormalizeMemberName(r.MemberName))
-            .Select(g => new CongressMember { Name = g.Key, Position = g.First().Position })
+            .Select(g => new CongressMember
+            {
+                Name = g.Key,
+                Position = g.First().Position,
+                StateDistrict = SelectStateDistrict(g),
+            })
             .ToList();
 
         await dbContext
@@ -270,7 +275,15 @@ public class CongressionalAnnualDisclosureSyncService
             .UpsertRange(distinctMembers)
             .On(m => new { m.Name })
             .WhenMatched(
-                (existing, incoming) => new CongressMember { Position = incoming.Position }
+                (existing, incoming) =>
+                    new CongressMember
+                    {
+                        Position = incoming.Position,
+                        // Only the House index publishes a seat, so a member's
+                        // Senate reports carry none — coalescing keeps a
+                        // recorded seat instead of blanking it on every cycle.
+                        StateDistrict = incoming.StateDistrict ?? existing.StateDistrict,
+                    }
             )
             .RunAsync(ct);
 
@@ -280,6 +293,19 @@ public class CongressionalAnnualDisclosureSyncService
             .Where(m => memberNames.Contains(m.Name))
             .ToDictionaryAsync(m => m.Name, ct);
     }
+
+    /// <summary>
+    /// The seat to record for a member this cycle. Redistricting moves a member
+    /// between districts, so the most recently filed report that states one
+    /// wins; reports that state none (every Senate filing) are ignored rather
+    /// than treated as "no seat".
+    /// </summary>
+    internal static string SelectStateDistrict(IEnumerable<AnnualDisclosureReport> reports) =>
+        reports
+            .Where(r => !string.IsNullOrWhiteSpace(r.StateDistrict))
+            .OrderBy(r => r.FiledDate)
+            .LastOrDefault()
+            ?.StateDistrict.Trim();
 
     /// <summary>
     /// One report per (member, position, year): the latest filed wins, and an

--- a/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
@@ -322,7 +322,12 @@ public class CongressionalAnnualDisclosureSyncService
     /// <summary>
     /// Amendments replace the stored report in place: a different source
     /// report filed on a later date (or an amendment refiled the same day)
-    /// wins; re-encountering the stored report id is a no-op.
+    /// wins. Re-encountering the stored report id rebuilds it in place rather
+    /// than skipping it — a filing only comes back round when the ledger
+    /// deliberately de-listed it, and that rebuild is the whole mechanism by
+    /// which a parser-version bump lands its new fields on rows an older
+    /// parser wrote. Rebuilding is idempotent, so a replay costs a row
+    /// rewrite and changes nothing else.
     /// </summary>
     internal static bool ShouldReplace(
         CongressionalAnnualDisclosure existing,
@@ -330,7 +335,7 @@ public class CongressionalAnnualDisclosureSyncService
     )
     {
         if (incoming.ReportId == existing.ReportId)
-            return false;
+            return true;
         if (incoming.FiledDate != existing.FiledDate)
             return incoming.FiledDate > existing.FiledDate;
         return incoming.IsAmendment;

--- a/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
@@ -38,6 +38,18 @@ public class CongressionalAnnualDisclosureSyncService
     // late Y+1) and amendments trail in afterwards.
     private const int DefaultCoverageYearsBack = 2;
 
+    // Raise this whenever the schedule parsers start extracting a field their
+    // stored rows do not carry; already-ingested filings then re-download and
+    // re-parse so the new field is populated for history too, instead of only
+    // appearing on filings submitted from now on.
+    //   1 — asset type, income type and the income bracket (GH-7347).
+    private const int AnnualParserVersion = 1;
+
+    // Filings re-parsed per 24h cycle after a version bump. The clients fetch
+    // at 5 requests/second, so this is a runaway guard rather than a politeness
+    // limit: a normal backfill of the whole archive still drains in a few days.
+    private const int ReprocessPerCycleLimit = 1_000;
+
     public CongressionalAnnualDisclosureSyncService(
         IServiceScopeFactory scopeFactory,
         IOptions<WorkerOptions> workerOptions,
@@ -69,11 +81,15 @@ public class CongressionalAnnualDisclosureSyncService
 
         var houseProcessedIds = await _filingLedger.GetProcessedSourceIds(
             CongressionalFilingKind.HouseAnnualReport,
-            ct
+            ct,
+            AnnualParserVersion,
+            ReprocessPerCycleLimit
         );
         var senateProcessedIds = await _filingLedger.GetProcessedSourceIds(
             CongressionalFilingKind.SenateAnnualReport,
-            ct
+            ct,
+            AnnualParserVersion,
+            ReprocessPerCycleLimit
         );
 
         var houseResult = await FetchReports(
@@ -128,14 +144,16 @@ public class CongressionalAnnualDisclosureSyncService
             houseResult
                 .ProcessedFilings.Where(f => !unpersistedReportIds.Contains(f.SourceId))
                 .ToList(),
-            ct
+            ct,
+            AnnualParserVersion
         );
         await _filingLedger.RecordProcessed(
             CongressionalFilingKind.SenateAnnualReport,
             senateResult
                 .ProcessedFilings.Where(f => !unpersistedReportIds.Contains(f.SourceId))
                 .ToList(),
-            ct
+            ct,
+            AnnualParserVersion
         );
     }
 
@@ -371,5 +389,9 @@ public class CongressionalAnnualDisclosureSyncService
             Description = item.Description,
             RangeMinimum = item.RangeMinimum,
             RangeMaximum = item.RangeMaximum,
+            AssetType = item.AssetType,
+            IncomeType = item.IncomeType,
+            IncomeMinimum = item.IncomeMinimum,
+            IncomeMaximum = item.IncomeMaximum,
         };
 }

--- a/src/Equibles.Congress.HostedService/Services/CongressionalFilingLedger.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalFilingLedger.cs
@@ -29,7 +29,7 @@ public class CongressionalFilingLedger
     /// generation than <paramref name="parserVersion"/> are deliberately left
     /// out so their filings re-download and re-parse with the fields the newer
     /// parser extracts — at most <paramref name="reprocessLimit"/> of them per
-    /// cycle, oldest filing first, so a version bump drip-feeds its backfill
+    /// cycle, newest filing first, so a version bump drip-feeds its backfill
     /// instead of re-fetching the whole archive at once. A lane that never
     /// raises its version passes 0 and sees every row as processed, exactly as
     /// before.
@@ -55,9 +55,18 @@ public class CongressionalFilingLedger
     /// <summary>
     /// Splits the ledger into the filings to skip and the ones to re-ingest.
     /// Rows at or above the current parser version are always skipped; stale
-    /// rows are re-ingested oldest-filing-first up to the cycle's quota, and the
+    /// rows are re-ingested newest-filing-first up to the cycle's quota, and the
     /// rest are skipped for now. The ordering is stable, so each cycle takes the
     /// next slice and the backfill converges instead of re-picking at random.
+    ///
+    /// Newest first is load-bearing, not a preference. A lane only fetches
+    /// indexes inside its coverage window, so a stale row older than that
+    /// window can never be re-downloaded — queueing it oldest-first would park
+    /// un-fetchable rows at the head of every cycle's quota and starve the
+    /// in-window filings behind them forever. Taking the newest first drains
+    /// everything reachable and leaves the unreachable residue at the back,
+    /// where it costs nothing. Widening the window is what makes that residue
+    /// reachable.
     /// </summary>
     internal static HashSet<string> SelectProcessed(
         IReadOnlyCollection<LedgerEntry> records,
@@ -68,7 +77,7 @@ public class CongressionalFilingLedger
         var current = records.Where(r => r.ParserVersion >= parserVersion).Select(r => r.SourceId);
         var deferred = records
             .Where(r => r.ParserVersion < parserVersion)
-            .OrderBy(r => r.FilingDate)
+            .OrderByDescending(r => r.FilingDate)
             .ThenBy(r => r.SourceId, StringComparer.Ordinal)
             .Skip(Math.Max(reprocessLimit, 0))
             .Select(r => r.SourceId);

--- a/src/Equibles.Congress.HostedService/Services/CongressionalFilingLedger.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalFilingLedger.cs
@@ -24,22 +24,65 @@ public class CongressionalFilingLedger
         _scopeFactory = scopeFactory;
     }
 
+    /// <summary>
+    /// The filings this lane should skip. Rows written by an older parser
+    /// generation than <paramref name="parserVersion"/> are deliberately left
+    /// out so their filings re-download and re-parse with the fields the newer
+    /// parser extracts — at most <paramref name="reprocessLimit"/> of them per
+    /// cycle, oldest filing first, so a version bump drip-feeds its backfill
+    /// instead of re-fetching the whole archive at once. A lane that never
+    /// raises its version passes 0 and sees every row as processed, exactly as
+    /// before.
+    /// </summary>
     public virtual async Task<IReadOnlySet<string>> GetProcessedSourceIds(
         CongressionalFilingKind kind,
-        CancellationToken ct
+        CancellationToken ct,
+        int parserVersion = 0,
+        int reprocessLimit = 0
     )
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var repository =
             scope.ServiceProvider.GetRequiredService<CongressionalFilingRecordRepository>();
-        var sourceIds = await repository.GetByKind(kind).Select(r => r.SourceId).ToListAsync(ct);
-        return sourceIds.ToHashSet();
+        var records = await repository
+            .GetByKind(kind)
+            .Select(r => new LedgerEntry(r.SourceId, r.FilingDate, r.ParserVersion))
+            .ToListAsync(ct);
+
+        return SelectProcessed(records, parserVersion, reprocessLimit);
     }
+
+    /// <summary>
+    /// Splits the ledger into the filings to skip and the ones to re-ingest.
+    /// Rows at or above the current parser version are always skipped; stale
+    /// rows are re-ingested oldest-filing-first up to the cycle's quota, and the
+    /// rest are skipped for now. The ordering is stable, so each cycle takes the
+    /// next slice and the backfill converges instead of re-picking at random.
+    /// </summary>
+    internal static HashSet<string> SelectProcessed(
+        IReadOnlyCollection<LedgerEntry> records,
+        int parserVersion,
+        int reprocessLimit
+    )
+    {
+        var current = records.Where(r => r.ParserVersion >= parserVersion).Select(r => r.SourceId);
+        var deferred = records
+            .Where(r => r.ParserVersion < parserVersion)
+            .OrderBy(r => r.FilingDate)
+            .ThenBy(r => r.SourceId, StringComparer.Ordinal)
+            .Skip(Math.Max(reprocessLimit, 0))
+            .Select(r => r.SourceId);
+
+        return current.Concat(deferred).ToHashSet();
+    }
+
+    internal sealed record LedgerEntry(string SourceId, DateOnly FilingDate, int ParserVersion);
 
     public virtual async Task RecordProcessed(
         CongressionalFilingKind kind,
         IReadOnlyCollection<ProcessedFiling> filings,
-        CancellationToken ct
+        CancellationToken ct,
+        int parserVersion = 0
     )
     {
         if (filings.Count == 0)
@@ -57,16 +100,28 @@ public class CongressionalFilingLedger
                 SourceId = f.SourceId,
                 FilingDate = f.FilingDate,
                 ItemCount = f.ItemCount,
+                ParserVersion = parserVersion,
             })
             .ToList();
 
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        // A re-parsed filing MUST update its row: leaving the stale version in
+        // place would put the same filing back in the queue every cycle and the
+        // backfill would never finish.
         await dbContext
             .Set<CongressionalFilingRecord>()
             .UpsertRange(records)
             .On(r => new { r.Kind, r.SourceId })
-            .NoUpdate()
+            .WhenMatched(
+                (existing, incoming) =>
+                    new CongressionalFilingRecord
+                    {
+                        FilingDate = incoming.FilingDate,
+                        ItemCount = incoming.ItemCount,
+                        ParserVersion = incoming.ParserVersion,
+                    }
+            )
             .RunAsync(ct);
     }
 }

--- a/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
@@ -400,17 +400,25 @@ public partial class HouseAnnualReportClient
         // not exactly range-shaped is label-paragraph prose spilling across
         // the page (e.g. ".. strike price of $200 and ..") and contributes
         // nothing.
+        // The income cells are passengers: they ride along with whatever the
+        // value cell already decided this line is, and never promote page
+        // furniture into a row or split one row into two.
         void ApplyRowText(
             CongressionalDisclosureLineKind kind,
             string rangeText,
             string primaryText,
-            string secondaryText
+            string secondaryText,
+            string incomeTypeText = null,
+            string incomeRangeText = null
         )
         {
             if (string.IsNullOrEmpty(rangeText))
             {
                 if (!inLabelParagraph)
+                {
                     pending?.AppendDescription(primaryText, secondaryText);
+                    pending?.AppendIncome(incomeTypeText, incomeRangeText);
+                }
                 return;
             }
 
@@ -428,7 +436,14 @@ public partial class HouseAnnualReportClient
             {
                 inLabelParagraph = false;
                 Flush();
-                pending = new PendingLine(kind, primaryText, secondaryText, rangeText);
+                pending = new PendingLine(
+                    kind,
+                    primaryText,
+                    secondaryText,
+                    rangeText,
+                    incomeTypeText,
+                    incomeRangeText
+                );
                 return;
             }
 
@@ -438,6 +453,7 @@ public partial class HouseAnnualReportClient
                 // range opened on the previous line.
                 pending.AppendRange(rangeText);
                 pending.AppendDescription(primaryText, secondaryText);
+                pending.AppendIncome(incomeTypeText, incomeRangeText);
             }
         }
 
@@ -482,10 +498,20 @@ public partial class HouseAnnualReportClient
                         rangeText: JoinWindow(
                             line,
                             assetColumns.ValueLeft,
-                            assetColumns.IncomeLeft
+                            assetColumns.IncomeTypeLeft
                         ),
                         primaryText: JoinWindow(line, double.MinValue, assetColumns.OwnerLeft),
-                        secondaryText: null
+                        secondaryText: null,
+                        incomeTypeText: JoinWindow(
+                            line,
+                            assetColumns.IncomeTypeLeft,
+                            assetColumns.IncomeAmountLeft
+                        ),
+                        incomeRangeText: JoinWindow(
+                            line,
+                            assetColumns.IncomeAmountLeft,
+                            assetColumns.TransactionLeft
+                        )
                     );
                     break;
 
@@ -536,7 +562,9 @@ public partial class HouseAnnualReportClient
     // Schedule A column header: "Asset | Owner | Value of Asset | Income
     // Type(s) | Income | Tx. >". Both the value and the income columns carry
     // dollar ranges, so the asset-value window must end where the income-type
-    // column starts.
+    // column starts. "Income Type(s)" tokenizes into two words, so the header
+    // holds TWO "Income" tokens: the first opens the income-type column and the
+    // second the income-amount column, which the "Tx." column closes.
     private static bool TryReadAssetHeader(List<ScheduleToken> line, out AssetColumns columns)
     {
         columns = null;
@@ -548,11 +576,23 @@ public partial class HouseAnnualReportClient
         if (owner == null || value == null)
             return false;
 
-        var income = line.FirstOrDefault(t => t.Text == "Income" && t.Left > value.Left);
-        if (income == null)
+        var incomeTokens = line.Where(t => t.Text == "Income" && t.Left > value.Left).ToList();
+        if (incomeTokens.Count == 0)
             return false;
 
-        columns = new AssetColumns(owner.Left, value.Left, income.Left);
+        // Older layouts without a separate income-amount column leave the second
+        // token absent; the amount window then stays empty rather than
+        // borrowing the type column's text.
+        var incomeAmount = incomeTokens.Count > 1 ? incomeTokens[1].Left : double.MaxValue;
+        var transaction = line.FirstOrDefault(t => t.Text == "Tx.")?.Left ?? double.MaxValue;
+
+        columns = new AssetColumns(
+            owner.Left,
+            value.Left,
+            incomeTokens[0].Left,
+            incomeAmount,
+            transaction
+        );
         return true;
     }
 
@@ -666,7 +706,13 @@ public partial class HouseAnnualReportClient
         bool IsAmendment
     );
 
-    private sealed record AssetColumns(double OwnerLeft, double ValueLeft, double IncomeLeft);
+    private sealed record AssetColumns(
+        double OwnerLeft,
+        double ValueLeft,
+        double IncomeTypeLeft,
+        double IncomeAmountLeft,
+        double TransactionLeft
+    );
 
     private sealed record LiabilityColumns(
         double CreditorLeft,
@@ -681,21 +727,29 @@ public partial class HouseAnnualReportClient
     private sealed class PendingLine
     {
         private readonly CongressionalDisclosureLineKind _kind;
+        private string _assetType;
         private string _primary;
         private string _secondary;
         private string _rangeText;
+        private string _incomeType;
+        private string _incomeRangeText;
 
         public PendingLine(
             CongressionalDisclosureLineKind kind,
             string primaryText,
             string secondaryText,
-            string rangeText
+            string rangeText,
+            string incomeTypeText = null,
+            string incomeRangeText = null
         )
         {
             _kind = kind;
             _primary = primaryText ?? "";
             _secondary = secondaryText ?? "";
             _rangeText = rangeText;
+            _incomeType = incomeTypeText ?? "";
+            _incomeRangeText = incomeRangeText;
+            _assetType = ReadAssetTypeCode(primaryText);
         }
 
         public void AppendRange(string text)
@@ -707,9 +761,30 @@ public partial class HouseAnnualReportClient
         public void AppendDescription(string primaryText, string secondaryText)
         {
             if (!string.IsNullOrEmpty(primaryText))
+            {
                 _primary += " " + primaryText;
+                // A long asset name wraps, and the code rides the last visual
+                // line with it ("… Money Market / Account [BA]"), so the code
+                // has to be read as the description arrives — not once up
+                // front. The first code seen wins; a later line's is a second
+                // row's, which a Flush would already have separated.
+                _assetType ??= ReadAssetTypeCode(primaryText);
+            }
             if (!string.IsNullOrEmpty(secondaryText))
                 _secondary += " " + secondaryText;
+        }
+
+        // The income bracket wraps exactly as the value bracket does ("$1,001 -"
+        // then a bare "$2,500" on the next line), and the income-type text wraps
+        // like any other cell.
+        public void AppendIncome(string incomeTypeText, string incomeRangeText)
+        {
+            if (!string.IsNullOrEmpty(incomeTypeText))
+                _incomeType = string.IsNullOrEmpty(_incomeType)
+                    ? incomeTypeText
+                    : _incomeType + " " + incomeTypeText;
+            if (!string.IsNullOrEmpty(incomeRangeText) && _incomeRangeText != null)
+                _incomeRangeText += " " + incomeRangeText;
         }
 
         public AnnualDisclosureLineItem ToLineItem()
@@ -733,13 +808,51 @@ public partial class HouseAnnualReportClient
             if (string.IsNullOrEmpty(description))
                 return null;
 
+            var (incomeMinimum, incomeMaximum) = ParseIncomeRange();
             return new AnnualDisclosureLineItem
             {
                 Kind = _kind,
                 Description = Truncate(description, 512),
                 RangeMinimum = minimum,
                 RangeMaximum = maximum,
+                AssetType = _assetType,
+                IncomeType = NormalizeIncomeType(),
+                IncomeMinimum = incomeMinimum,
+                IncomeMaximum = incomeMaximum,
             };
+        }
+
+        // "None" is a disclosed answer, not an income bracket, and a bracket
+        // still ending in its opening dash never received its wrapped upper
+        // bound — both leave income unset rather than inventing a (0, X) range.
+        private (long?, long?) ParseIncomeRange()
+        {
+            if (string.IsNullOrEmpty(_incomeRangeText))
+                return (null, null);
+
+            var text = _incomeRangeText.Trim();
+            if (text is "None" or "Undetermined" || text.EndsWith('-'))
+                return (null, null);
+
+            var (minimum, maximum) = ParseAmountRange(text);
+            return minimum == 0 && maximum == 0 ? (null, null) : (minimum, maximum);
+        }
+
+        private string NormalizeIncomeType()
+        {
+            var text = Clean(_incomeType);
+            return string.IsNullOrEmpty(text) || text == "None" ? null : Truncate(text, 256);
+        }
+
+        // The asset name column ends with the filer's bracketed asset-class
+        // code ("… Vineyard [RP]"). The House form ships no legend, so the code
+        // is kept exactly as filed rather than expanded through a guessed map.
+        private static string ReadAssetTypeCode(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return null;
+            var matches = AssetTypeCodeRegex().Matches(text);
+            return matches.Count == 0 ? null : matches[^1].Value.Trim().Trim('[', ']');
         }
 
         private string BuildDescription()

--- a/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
@@ -302,6 +302,12 @@ public partial class SenateAnnualReportClient
     {
         var assetColumn = headers.IndexOf("asset");
         var valueColumn = headers.IndexOf("value");
+        // Present on the current Part 3 layout; an older table missing any of
+        // them leaves that detail unset rather than shifting the read onto a
+        // neighbouring column.
+        var assetTypeColumn = headers.IndexOf("asset type");
+        var incomeTypeColumn = headers.IndexOf("income type");
+        var incomeColumn = headers.IndexOf("income");
 
         foreach (var row in DataRows(table))
         {
@@ -317,6 +323,10 @@ public partial class SenateAnnualReportClient
             if (string.IsNullOrEmpty(description))
                 continue;
 
+            var income = ReadOptionalCell(cells, incomeColumn) is { } incomeText
+                ? ParseRangeCell(incomeText)
+                : null;
+
             items.Add(
                 new AnnualDisclosureLineItem
                 {
@@ -324,6 +334,10 @@ public partial class SenateAnnualReportClient
                     Description = Truncate(description, 512),
                     RangeMinimum = range.Value.from,
                     RangeMaximum = range.Value.to,
+                    AssetType = TruncateOrNull(ReadAssetTypeCell(cells, assetTypeColumn), 128),
+                    IncomeType = TruncateOrNull(ReadOptionalCell(cells, incomeTypeColumn), 256),
+                    IncomeMinimum = income?.from,
+                    IncomeMaximum = income?.to,
                 }
             );
         }
@@ -396,6 +410,47 @@ public partial class SenateAnnualReportClient
         }
         var text = HtmlEntity.DeEntitize(clone.InnerText);
         return WhitespaceRegex().Replace(text, " ").Trim();
+    }
+
+    // A detail column the layout may not have: an absent header leaves the
+    // index at -1, and a short row simply has no such cell. Both mean "not
+    // disclosed here", never "read the next column along".
+    private static string ReadOptionalCell(HtmlNodeCollection cells, int column)
+    {
+        if (column < 0 || column >= cells.Count)
+            return null;
+        var text = CellText(cells[column]);
+        return string.IsNullOrEmpty(text) ? null : text;
+    }
+
+    // "None" is the filer answering the question, not a value worth storing.
+    private static string TruncateOrNull(string text, int length) =>
+        string.IsNullOrEmpty(text) || text == "None" ? null : Truncate(text, length);
+
+    // The asset-type cell holds a category with the filer's specific subtype in
+    // a muted child ("Corporate Securities" + "Non-Public Stock"). Unlike the
+    // name column — where the muted half is location metadata CellText is right
+    // to drop — both halves here are disclosed classification, so they are kept.
+    private static string ReadAssetTypeCell(HtmlNodeCollection cells, int column)
+    {
+        if (column < 0 || column >= cells.Count)
+            return null;
+
+        var category = CellText(cells[column]);
+        var mutedNodes = cells[column].SelectNodes(".//*[contains(@class, 'muted')]");
+        if (mutedNodes == null)
+            return category;
+
+        var subtype = WhitespaceRegex()
+            .Replace(
+                string.Join(" ", mutedNodes.Select(n => HtmlEntity.DeEntitize(n.InnerText))),
+                " "
+            )
+            .Trim();
+
+        if (string.IsNullOrEmpty(subtype) || subtype == category)
+            return category;
+        return string.IsNullOrEmpty(category) ? subtype : $"{category} - {subtype}";
     }
 
     // A line item carries only the form's own brackets: "$X - $Y" or the

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Congress.Data;
 using Equibles.Congress.Data.Extensions;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.Repositories;
@@ -174,8 +175,8 @@ public class CongressTools
 
                 var table = MarkdownTable.Render(
                     trades,
-                    $"No trades found for {member.Name} ({member.Position.NameForHumans()}) between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
-                    $"Trades by {member.Name} ({member.Position.NameForHumans()}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
+                    $"No trades found for {member.Name} ({DescribeMember(member)}) between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
+                    $"Trades by {member.Name} ({DescribeMember(member)}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
                     "| Date | Filed | Ticker | Type | Amount Range | Asset | Owner |",
                     "|------|-------|--------|------|-------------|-------|-------|",
                     t =>
@@ -240,8 +241,8 @@ public class CongressTools
 
                 var table = MarkdownTable.Render(
                     disclosures,
-                    $"No electronically filed annual disclosure found for {member.Name} ({member.Position.NameForHumans()}). Paper filings are not read, so this does not mean zero net worth.",
-                    $"Net worth of {member.Name} ({member.Position.NameForHumans()}), as disclosed in annual financial reports (band = sum of disclosed asset minimums minus liability maximums, through asset maximums minus liability minimums; Asset Lines / Liability Lines are counts of disclosed line items, not dollar amounts):",
+                    $"No electronically filed annual disclosure found for {member.Name} ({DescribeMember(member)}). Paper filings are not read, so this does not mean zero net worth.",
+                    $"Net worth of {member.Name} ({DescribeMember(member)}), as disclosed in annual financial reports (band = sum of disclosed asset minimums minus liability maximums, through asset maximums minus liability minimums; Asset Lines / Liability Lines are counts of disclosed line items, not dollar amounts):",
                     "| Year | Filed | Net Worth Minimum | Net Worth Maximum | Asset Lines | Liability Lines |",
                     "|------|-------|-------------------|-------------------|-------------|-----------------|",
                     d =>
@@ -252,6 +253,16 @@ public class CongressTools
             "GetMemberNetWorth",
             $"memberName: {memberName}"
         );
+    }
+
+    // How a member is identified in prose: the chamber, plus the seat when one
+    // is recorded. Only the House index publishes a seat, so senators read as
+    // "Senator" alone rather than carrying an empty bracket.
+    private static string DescribeMember(CongressMember member)
+    {
+        var seat = CongressSeat.Format(member.StateDistrict);
+        var position = member.Position.NameForHumans();
+        return seat == null ? position : $"{position}, {seat}";
     }
 
     // Net worth bands can be negative (liabilities exceeding assets).
@@ -296,10 +307,12 @@ public class CongressTools
                     members,
                     $"No match for '{query}' in the tracked congressional roster. This result describes only the tracked roster.",
                     $"Congress members matching '{query}':",
-                    "| Name | Position |",
-                    "|------|----------|",
+                    "| Name | Position | Seat |",
+                    "|------|----------|------|",
                     m =>
-                        $"| {MarkdownTable.EscapeCell(m.Name, "-")} | {MarkdownTable.EscapeCell(m.Position.NameForHumans(), "-")} |"
+                        $"| {MarkdownTable.EscapeCell(m.Name, "-")} "
+                        + $"| {MarkdownTable.EscapeCell(m.Position.NameForHumans(), "-")} "
+                        + $"| {MarkdownTable.EscapeCell(CongressSeat.Format(m.StateDistrict), "-")} |"
                 );
                 return AppendTruncationNote(table, members.Count, totalCount);
             },

--- a/src/Equibles.Migrations/Migrations/20260817183447_AddCongressDisclosureAssetDetail.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260817183447_AddCongressDisclosureAssetDetail.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260817183447_AddCongressDisclosureAssetDetail")]
+    partial class AddCongressDisclosureAssetDetail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260817183447_AddCongressDisclosureAssetDetail.cs
+++ b/src/Equibles.Migrations/Migrations/20260817183447_AddCongressDisclosureAssetDetail.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCongressDisclosureAssetDetail : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ParserVersion",
+                table: "CongressionalFilingRecord",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AssetType",
+                table: "CongressionalDisclosureLine",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "IncomeMaximum",
+                table: "CongressionalDisclosureLine",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "IncomeMinimum",
+                table: "CongressionalDisclosureLine",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "IncomeType",
+                table: "CongressionalDisclosureLine",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ParserVersion",
+                table: "CongressionalFilingRecord");
+
+            migrationBuilder.DropColumn(
+                name: "AssetType",
+                table: "CongressionalDisclosureLine");
+
+            migrationBuilder.DropColumn(
+                name: "IncomeMaximum",
+                table: "CongressionalDisclosureLine");
+
+            migrationBuilder.DropColumn(
+                name: "IncomeMinimum",
+                table: "CongressionalDisclosureLine");
+
+            migrationBuilder.DropColumn(
+                name: "IncomeType",
+                table: "CongressionalDisclosureLine");
+        }
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260817183714_AddCongressMemberStateDistrict.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260817183714_AddCongressMemberStateDistrict.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260817183714_AddCongressMemberStateDistrict")]
+    partial class AddCongressMemberStateDistrict
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260817183714_AddCongressMemberStateDistrict.cs
+++ b/src/Equibles.Migrations/Migrations/20260817183714_AddCongressMemberStateDistrict.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCongressMemberStateDistrict : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "StateDistrict",
+                table: "CongressMember",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StateDistrict",
+                table: "CongressMember");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceProcessTests.cs
@@ -21,7 +21,7 @@ namespace Equibles.IntegrationTests.Congress;
 /// Postgres: a new report upserts the member and stores the disclosure with
 /// its band rollup and lines; a later amendment replaces the member-year row
 /// in place (same row, new report id, fresh lines); re-running the same
-/// report is a no-op.
+/// report rebuilds that row in place without forking or duplicating it.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class CongressionalAnnualDisclosureSyncServiceProcessTests : ParadeDbMcpTestBase
@@ -179,14 +179,26 @@ public class CongressionalAnnualDisclosureSyncServiceProcessTests : ParadeDbMcpT
         );
         var sut = BuildSut();
         await ProcessReports(sut, [report]);
+        var originalId = await DbContext
+            .Set<CongressionalAnnualDisclosure>()
+            .AsNoTracking()
+            .Select(d => d.Id)
+            .SingleAsync();
         DbContext.ChangeTracker.Clear();
 
         await ProcessReports(sut, [report]);
 
+        // The re-parse rebuilds the year's row rather than skipping it — that
+        // rebuild is how a parser-version bump lands newly extracted fields on
+        // history — but it must not fork a second row or duplicate the lines.
         await using var verify = Fixture.CreateDbContext();
-        (await verify.Set<CongressionalAnnualDisclosure>().AsNoTracking().CountAsync())
-            .Should()
-            .Be(1);
+        var disclosure = await verify
+            .Set<CongressionalAnnualDisclosure>()
+            .AsNoTracking()
+            .Include(d => d.Lines)
+            .SingleAsync();
+        disclosure.Id.Should().Be(originalId);
+        disclosure.Lines.Should().ContainSingle();
         (await verify.Set<CongressionalDisclosureLine>().AsNoTracking().CountAsync())
             .Should()
             .Be(1);

--- a/tests/Equibles.UnitTests/Congress/CongressSeatTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressSeatTests.cs
@@ -1,0 +1,40 @@
+using Equibles.Congress.Data;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// The stored seat is the Clerk's key ("SC05"), not a label. Formatting it is a
+/// display concern, and district 00 is an at-large state rather than a district
+/// numbered zero.
+/// </summary>
+public class CongressSeatTests
+{
+    [Theory]
+    [InlineData("SC05", "SC-5")]
+    [InlineData("TX37", "TX-37")]
+    [InlineData("NY14", "NY-14")]
+    [InlineData("sc05", "SC-5")]
+    [InlineData(" SC05 ", "SC-5")]
+    public void Format_DistrictSeat_DropsThePadding(string stored, string expected) =>
+        CongressSeat.Format(stored).Should().Be(expected);
+
+    [Theory]
+    [InlineData("AK00")]
+    [InlineData("WY00")]
+    public void Format_AtLargeSeat_SaysSoRatherThanDistrictZero(string stored) =>
+        CongressSeat.Format(stored).Should().Be($"{stored[..2]} At-Large");
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Format_NoSeat_IsNull(string stored) =>
+        CongressSeat.Format(stored).Should().BeNull();
+
+    [Theory]
+    [InlineData("PUERTO RICO")]
+    [InlineData("SC-5")]
+    [InlineData("SC005")]
+    public void Format_UnrecognisedShape_IsShownAsStored(string stored) =>
+        CongressSeat.Format(stored).Should().Be(stored);
+}

--- a/tests/Equibles.UnitTests/Congress/CongressionalAnnualDisclosureSyncServiceStateDistrictTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalAnnualDisclosureSyncServiceStateDistrictTests.cs
@@ -1,0 +1,77 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// The seat a member holds comes from the House Clerk's filing index, which is
+/// the only source that states one — no Senate filing names the senator's
+/// state. A member's reports therefore mix seat-bearing and seat-less rows, and
+/// picking the wrong one either blanks a recorded seat or pins a stale district
+/// across a redistricting.
+/// </summary>
+public class CongressionalAnnualDisclosureSyncServiceStateDistrictTests
+{
+    private static AnnualDisclosureReport Report(string stateDistrict, int year) =>
+        new()
+        {
+            MemberName = "Jane Doe",
+            Position = CongressPosition.Representative,
+            StateDistrict = stateDistrict,
+            Year = year,
+            FiledDate = new DateOnly(year + 1, 5, 15),
+            ReportId = $"doc-{year}",
+            Lines = [],
+        };
+
+    [Fact]
+    public void SelectStateDistrict_SingleReport_UsesItsSeat()
+    {
+        CongressionalAnnualDisclosureSyncService
+            .SelectStateDistrict([Report("SC05", 2024)])
+            .Should()
+            .Be("SC05");
+    }
+
+    [Fact]
+    public void SelectStateDistrict_Redistricted_TakesTheLatestFiling()
+    {
+        List<AnnualDisclosureReport> reports = [Report("TX35", 2021), Report("TX37", 2023)];
+
+        CongressionalAnnualDisclosureSyncService.SelectStateDistrict(reports).Should().Be("TX37");
+    }
+
+    [Fact]
+    public void SelectStateDistrict_LatestFilingStatesNoSeat_KeepsTheOneThatDoes()
+    {
+        // A member who moved to the Senate keeps filing, and those reports carry
+        // no seat — the House seat already recorded must survive.
+        List<AnnualDisclosureReport> reports = [Report("SC05", 2022), Report("", 2024)];
+
+        CongressionalAnnualDisclosureSyncService.SelectStateDistrict(reports).Should().Be("SC05");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void SelectStateDistrict_NoReportStatesASeat_IsNull(string stateDistrict)
+    {
+        CongressionalAnnualDisclosureSyncService
+            .SelectStateDistrict([Report(stateDistrict, 2024)])
+            .Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void SelectStateDistrict_SeatIsPadded_KeepsTheClerksFormatting()
+    {
+        // "AK00" is an at-large seat, not a typo — the value is stored as the
+        // Clerk publishes it and formatted for display elsewhere.
+        CongressionalAnnualDisclosureSyncService
+            .SelectStateDistrict([Report(" AK00 ", 2024)])
+            .Should()
+            .Be("AK00");
+    }
+}

--- a/tests/Equibles.UnitTests/Congress/CongressionalAnnualDisclosureSyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalAnnualDisclosureSyncServiceTests.cs
@@ -101,7 +101,7 @@ public class CongressionalAnnualDisclosureSyncServiceTests
     }
 
     [Theory]
-    [InlineData("1001", "2025-05-15", false, false)] // same source report → no-op
+    [InlineData("1001", "2025-05-15", false, true)] // same source report → rebuilt in place
     [InlineData("1002", "2025-11-04", false, true)] // later filing replaces
     [InlineData("1002", "2025-01-01", false, false)] // earlier filing never replaces
     [InlineData("1002", "2025-05-15", true, true)] // same-day amendment replaces
@@ -131,6 +131,28 @@ public class CongressionalAnnualDisclosureSyncServiceTests
             .ShouldReplace(existing, incoming)
             .Should()
             .Be(expected);
+    }
+
+    [Fact]
+    public void ShouldReplace_SameReportRefetched_RebuildsSoAParserBumpCanLand()
+    {
+        // The ledger only puts an already-stored filing back in the queue when
+        // it deliberately de-listed it — a parser-version bump, or a cycle that
+        // died before recording it. Skipping the re-parse there would make a
+        // version bump re-download the archive and discard every result, so the
+        // backfill would report success having written nothing.
+        var existing = new CongressionalAnnualDisclosure
+        {
+            ReportId = "1001",
+            FiledDate = new DateOnly(2025, 5, 15),
+            Year = 2024,
+        };
+        var refetched = Report("Jane Doe", 2024, new DateOnly(2025, 5, 15), false, "1001");
+
+        CongressionalAnnualDisclosureSyncService
+            .ShouldReplace(existing, refetched)
+            .Should()
+            .BeTrue();
     }
 
     [Theory]

--- a/tests/Equibles.UnitTests/Congress/CongressionalFilingLedgerSelectProcessedTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalFilingLedgerSelectProcessedTests.cs
@@ -64,9 +64,29 @@ public class CongressionalFilingLedgerSelectProcessedTests
 
         var processed = CongressionalFilingLedger.SelectProcessed(records, 1, reprocessLimit: 1);
 
-        // Oldest filing first: only "oldest" leaves the processed set this
+        // Newest filing first: only "newest" leaves the processed set this
         // cycle, and the other two stay skipped until a later one.
-        processed.Should().BeEquivalentTo(["middle", "newest"]);
+        processed.Should().BeEquivalentTo(["oldest", "middle"]);
+    }
+
+    [Fact]
+    public void SelectProcessed_BacklogOlderThanTheCoverageWindow_DoesNotStarveRecentFilings()
+    {
+        // The clients only fetch indexes inside their coverage window, so a
+        // filing older than it can never be re-downloaded however often it is
+        // queued. Ordering oldest-first would hand the whole quota to those
+        // dead rows every cycle and the reachable ones behind them would never
+        // re-parse.
+        List<LedgerEntry> records =
+        [
+            new("unreachable-1", new DateOnly(2015, 3, 1), 0),
+            new("unreachable-2", new DateOnly(2016, 3, 1), 0),
+            new("in-window", new DateOnly(2026, 3, 1), 0),
+        ];
+
+        var processed = CongressionalFilingLedger.SelectProcessed(records, 1, reprocessLimit: 1);
+
+        processed.Should().NotContain("in-window");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Congress/CongressionalFilingLedgerSelectProcessedTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalFilingLedgerSelectProcessedTests.cs
@@ -1,0 +1,108 @@
+using Equibles.Congress.HostedService.Services;
+using static Equibles.Congress.HostedService.Services.CongressionalFilingLedger;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// The ledger decides which already-ingested filings a cycle re-downloads. A
+/// parser that starts extracting new fields raises its version, which demotes
+/// older rows to "not yet ingested" so history is re-parsed — but only a capped
+/// slice per cycle, so a version bump drip-feeds its backfill rather than
+/// re-fetching the whole archive at once.
+/// </summary>
+public class CongressionalFilingLedgerSelectProcessedTests
+{
+    private static LedgerEntry Entry(string id, int version, int day = 1) =>
+        new(id, new DateOnly(2025, 1, day), version);
+
+    [Fact]
+    public void SelectProcessed_NoVersionBump_SkipsEveryRow()
+    {
+        // A lane that never raises its version behaves exactly as before.
+        List<LedgerEntry> records = [Entry("a", 0), Entry("b", 0), Entry("c", 0)];
+
+        var processed = CongressionalFilingLedger.SelectProcessed(
+            records,
+            parserVersion: 0,
+            reprocessLimit: 0
+        );
+
+        processed.Should().BeEquivalentTo(["a", "b", "c"]);
+    }
+
+    [Fact]
+    public void SelectProcessed_RowsAtCurrentVersion_AreSkipped()
+    {
+        List<LedgerEntry> records = [Entry("a", 1), Entry("b", 1)];
+
+        var processed = CongressionalFilingLedger.SelectProcessed(records, 1, 10);
+
+        processed.Should().BeEquivalentTo(["a", "b"]);
+    }
+
+    [Fact]
+    public void SelectProcessed_StaleRowsWithinQuota_AreQueuedForReprocessing()
+    {
+        List<LedgerEntry> records = [Entry("a", 0), Entry("b", 0), Entry("c", 1)];
+
+        var processed = CongressionalFilingLedger.SelectProcessed(records, 1, 10);
+
+        // Only the row already at the current version is skipped; the two stale
+        // rows are absent, which is how the clients learn to re-fetch them.
+        processed.Should().BeEquivalentTo(["c"]);
+    }
+
+    [Fact]
+    public void SelectProcessed_MoreStaleRowsThanQuota_DefersTheRemainder()
+    {
+        List<LedgerEntry> records =
+        [
+            Entry("oldest", 0, day: 1),
+            Entry("middle", 0, day: 2),
+            Entry("newest", 0, day: 3),
+        ];
+
+        var processed = CongressionalFilingLedger.SelectProcessed(records, 1, reprocessLimit: 1);
+
+        // Oldest filing first: only "oldest" leaves the processed set this
+        // cycle, and the other two stay skipped until a later one.
+        processed.Should().BeEquivalentTo(["middle", "newest"]);
+    }
+
+    [Fact]
+    public void SelectProcessed_SameFilingDate_OrdersBySourceIdSoCyclesAdvance()
+    {
+        List<LedgerEntry> records = [Entry("b", 0), Entry("a", 0), Entry("c", 0)];
+
+        var processed = CongressionalFilingLedger.SelectProcessed(records, 1, reprocessLimit: 1);
+
+        processed.Should().BeEquivalentTo(["b", "c"]);
+    }
+
+    [Fact]
+    public void SelectProcessed_ZeroQuota_LeavesEveryStaleRowDeferred()
+    {
+        // A version bump shipped without a quota must not silently re-fetch
+        // nothing forever OR everything at once — it defers, and the operator
+        // sees no re-ingest until a quota is set.
+        List<LedgerEntry> records = [Entry("a", 0), Entry("b", 0)];
+
+        var processed = CongressionalFilingLedger.SelectProcessed(records, 1, reprocessLimit: 0);
+
+        processed.Should().BeEquivalentTo(["a", "b"]);
+    }
+
+    [Fact]
+    public void SelectProcessed_QuotaLargerThanBacklog_QueuesAllOfIt()
+    {
+        List<LedgerEntry> records = [Entry("a", 0), Entry("b", 0)];
+
+        var processed = CongressionalFilingLedger.SelectProcessed(
+            records,
+            1,
+            reprocessLimit: 1_000
+        );
+
+        processed.Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientAssetDetailTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientAssetDetailTests.cs
@@ -1,0 +1,284 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+using static Equibles.Congress.HostedService.Services.HouseAnnualReportClient;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Schedule A carries three details beyond the asset's value: the filer's
+/// bracketed asset-class code, the income type(s) the asset produced, and the
+/// income bracket. The income columns sit to the right of the value column and
+/// wrap the same way it does, so these tests pin both the column windows (the
+/// header holds TWO "Income" tokens) and the wrap handling.
+/// </summary>
+public class HouseAnnualReportClientAssetDetailTests
+{
+    private static string FixturePath(string name) =>
+        Path.Combine(AppContext.BaseDirectory, "TestAssets", "Congress", name);
+
+    // Column left edges taken from the real Clerk layout:
+    // "Asset@25 Owner@241 Value@280 of@311 Asset@323 Income@363 Type(s)@402
+    //  Income@445 Tx.@534 >@551".
+    private static List<ScheduleToken> Header() =>
+        [
+            new("Asset", 25),
+            new("Owner", 241),
+            new("Value", 280),
+            new("of", 311),
+            new("Asset", 323),
+            new("Income", 363),
+            new("Type(s)", 402),
+            new("Income", 445),
+            new("Tx.", 534),
+            new(">", 551),
+        ];
+
+    // Rows arrive as one collection expression so their element type is
+    // unambiguously List<ScheduleToken> — a params array would target-type the
+    // inner "new(...)" elements at the list itself.
+    private static List<List<ScheduleToken>> Schedule(List<List<ScheduleToken>> rows) =>
+        [
+            [new("S", 25), new("A:", 40)],
+            Header(),
+            .. rows,
+        ];
+
+    [Fact]
+    public void ParseScheduleLines_AssetRow_CapturesTypeCodeAndIncome()
+    {
+        var lines = Schedule([
+            [
+                new("Acme", 25),
+                new("Corp", 60),
+                new("[ST]", 100),
+                new("SP", 241),
+                new("$1,001", 280),
+                new("-", 320),
+                new("$15,000", 330),
+                new("Dividends", 363),
+                new("$201", 445),
+                new("-", 470),
+                new("$1,000", 480),
+            ],
+        ]);
+
+        var item = HouseAnnualReportClient.ParseScheduleLines(lines).Single();
+
+        item.Description.Should().Be("Acme Corp");
+        item.AssetType.Should().Be("ST");
+        item.IncomeType.Should().Be("Dividends");
+        item.IncomeMinimum.Should().Be(201);
+        item.IncomeMaximum.Should().Be(1_000);
+    }
+
+    [Fact]
+    public void ParseScheduleLines_IncomeBracketWrapsToNextLine_ReassemblesIt()
+    {
+        // Both the value and the income bracket wrap their upper bound onto the
+        // following visual line, each landing back under its own column.
+        var lines = Schedule([
+            [
+                new("Acme", 25),
+                new("Corp", 60),
+                new("[ST]", 100),
+                new("SP", 241),
+                new("$1,000,001", 280),
+                new("-", 334),
+                new("Capital", 363),
+                new("Gains,", 393),
+                new("$15,001", 445),
+                new("-", 490),
+            ],
+            [new("$5,000,000", 280), new("Dividends", 363), new("$50,000", 445)],
+        ]);
+
+        var item = HouseAnnualReportClient.ParseScheduleLines(lines).Single();
+
+        item.RangeMinimum.Should().Be(1_000_001);
+        item.RangeMaximum.Should().Be(5_000_000);
+        item.IncomeType.Should().Be("Capital Gains, Dividends");
+        item.IncomeMinimum.Should().Be(15_001);
+        item.IncomeMaximum.Should().Be(50_000);
+    }
+
+    [Fact]
+    public void ParseScheduleLines_IncomeBracketNeverClosed_LeavesIncomeUnset()
+    {
+        // The wrapped upper bound never arrived. Re-deriving one would invent a
+        // bracket the filer did not check, so income stays unset while the row
+        // itself — whose own value bracket is complete — survives.
+        var lines = Schedule([
+            [
+                new("Acme", 25),
+                new("Corp", 60),
+                new("[ST]", 100),
+                new("SP", 241),
+                new("$1,001", 280),
+                new("-", 320),
+                new("$15,000", 330),
+                new("Rent", 363),
+                new("$15,001", 445),
+                new("-", 490),
+            ],
+        ]);
+
+        var item = HouseAnnualReportClient.ParseScheduleLines(lines).Single();
+
+        item.RangeMinimum.Should().Be(1_001);
+        item.IncomeType.Should().Be("Rent");
+        item.IncomeMinimum.Should().BeNull();
+        item.IncomeMaximum.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseScheduleLines_IncomeReportedAsNone_LeavesIncomeUnset()
+    {
+        var lines = Schedule([
+            [
+                new("Acme", 25),
+                new("Corp", 60),
+                new("[BA]", 100),
+                new("SP", 241),
+                new("$1,001", 280),
+                new("-", 320),
+                new("$15,000", 330),
+                new("None", 363),
+                new("None", 445),
+            ],
+        ]);
+
+        var item = HouseAnnualReportClient.ParseScheduleLines(lines).Single();
+
+        item.AssetType.Should().Be("BA");
+        item.IncomeType.Should().BeNull();
+        item.IncomeMinimum.Should().BeNull();
+        item.IncomeMaximum.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseScheduleLines_IncomeColumnAbsentFromHeader_LeavesIncomeUnset()
+    {
+        // A layout with no separate income-amount column must not let the
+        // income-type text bleed into the amount window.
+        List<List<ScheduleToken>> lines =
+        [
+            [new("S", 25), new("A:", 40)],
+            [new("Asset", 25), new("Owner", 241), new("Value", 280), new("Income", 363)],
+            [
+                new("Acme", 25),
+                new("Corp", 60),
+                new("[ST]", 100),
+                new("SP", 241),
+                new("$1,001", 280),
+                new("-", 320),
+                new("$15,000", 330),
+                new("Dividends", 363),
+            ],
+        ];
+
+        var item = HouseAnnualReportClient.ParseScheduleLines(lines).Single();
+
+        item.IncomeType.Should().Be("Dividends");
+        item.IncomeMinimum.Should().BeNull();
+        item.IncomeMaximum.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseScheduleLines_TypeCodeOnWrappedNameLine_IsStillCaptured()
+    {
+        // A long asset name wraps and takes its code with it onto the last
+        // visual line, so the code cannot be read once off the opening line.
+        var lines = Schedule([
+            [
+                new("City", 25),
+                new("National", 50),
+                new("Securities", 95),
+                new("-", 150),
+                new("Brokerage", 160),
+                new("SP", 241),
+                new("$1,001", 280),
+                new("-", 320),
+                new("$15,000", 330),
+            ],
+            [new("Money", 25), new("Market", 60), new("Account", 100), new("[BA]", 150)],
+        ]);
+
+        var item = HouseAnnualReportClient.ParseScheduleLines(lines).Single();
+
+        item.Description.Should().Be("City National Securities - Brokerage Money Market Account");
+        item.AssetType.Should().Be("BA");
+    }
+
+    [Fact]
+    public void ParseScheduleLines_LiabilityRow_HasNoAssetDetail()
+    {
+        // ParseScheduleLines only returns items once it has seen Schedule A, so
+        // the report opens with an empty one before the liabilities.
+        List<List<ScheduleToken>> lines =
+        [
+            [new("S", 25), new("A:", 40)],
+            Header(),
+            [new("S", 25), new("D:", 40)],
+            [
+                new("Owner", 25),
+                new("Creditor", 80),
+                new("Date", 200),
+                new("Incurred", 240),
+                new("Type", 320),
+                new("Amount", 420),
+            ],
+            [
+                new("SP", 25),
+                new("Bank", 80),
+                new("2019", 200),
+                new("Mortgage", 320),
+                new("$1,001", 420),
+                new("-", 470),
+                new("$15,000", 480),
+            ],
+        ];
+
+        var item = HouseAnnualReportClient.ParseScheduleLines(lines).Single();
+
+        item.Kind.Should().Be(CongressionalDisclosureLineKind.Liability);
+        item.AssetType.Should().BeNull();
+        item.IncomeType.Should().BeNull();
+        item.IncomeMinimum.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseAnnualReportPdf_RealFiling_CarriesAssetDetail()
+    {
+        var bytes = File.ReadAllBytes(FixturePath("house-annual-pelosi-2024.pdf"));
+
+        var lines = HouseAnnualReportClient.ParseAnnualReportPdf(bytes).Lines;
+
+        var vineyard = lines.Single(l => l.Description == "11 Zinfandel Lane - Home & Vineyard");
+        vineyard.AssetType.Should().Be("RP");
+        vineyard.IncomeType.Should().Be("Grape Sales");
+        vineyard.IncomeMinimum.Should().Be(100_001);
+        vineyard.IncomeMaximum.Should().Be(1_000_000);
+
+        // "Over $5,000,000" is the form's open-top bracket, which this module
+        // represents as (value, value) — the same convention the value column
+        // already uses.
+        var apple = lines.Single(l => l.Description == "Apple Inc. (AAPL)");
+        apple.AssetType.Should().Be("ST");
+        apple.IncomeType.Should().Be("Capital Gains, Dividends");
+        apple.IncomeMinimum.Should().Be(5_000_000);
+        apple.IncomeMaximum.Should().Be(5_000_000);
+
+        // The name wrapped and carried "[BA]" onto its second line.
+        lines
+            .Single(l =>
+                l.Description == "City National Securities - Brokerage Money Market Account"
+            )
+            .AssetType.Should()
+            .Be("BA");
+
+        lines
+            .Where(l => l.Kind == CongressionalDisclosureLineKind.Liability)
+            .Should()
+            .OnlyContain(l => l.AssetType == null && l.IncomeType == null);
+    }
+}

--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientAssetDetailTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientAssetDetailTests.cs
@@ -1,0 +1,123 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Part 3 of an eFD annual report carries an Asset Type, Income Type and Income
+/// column beside the value. The type cell splits its classification across the
+/// main text and a muted child ("Corporate Securities" / "Non-Public Stock") —
+/// both halves are disclosed detail, unlike the muted location metadata on the
+/// asset-name column, which stays out of the description.
+/// </summary>
+public class SenateAnnualReportClientAssetDetailTests
+{
+    private static string Report(string assetRows) =>
+        $"""
+            <html><body>
+            <h3>Part 3. Assets</h3>
+            <table>
+              <thead><tr>
+                <th>#</th><th>Asset</th><th>Asset Type</th><th>Owner</th>
+                <th>Value</th><th>Income Type</th><th>Income</th>
+              </tr></thead>
+              <tbody>{assetRows}</tbody>
+            </table>
+            </body></html>
+            """;
+
+    [Fact]
+    public void ParseAnnualReportHtml_AssetRow_CapturesTypeAndIncome()
+    {
+        var html = Report(
+            """
+            <tr><td>1</td><td>ABALX - American Funds</td>
+                <td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+                <td>Self</td><td>$15,001 - $50,000</td>
+                <td>Dividends, Capital Gains</td><td>$1,001 - $2,500</td></tr>
+            """
+        );
+
+        var item = SenateAnnualReportClient.ParseAnnualReportHtml(html).Single();
+
+        item.Description.Should().Be("ABALX - American Funds");
+        item.AssetType.Should().Be("Mutual Funds - Mutual Fund");
+        item.IncomeType.Should().Be("Dividends, Capital Gains");
+        item.IncomeMinimum.Should().Be(1_001);
+        item.IncomeMaximum.Should().Be(2_500);
+    }
+
+    [Fact]
+    public void ParseAnnualReportHtml_TypeCellWithoutSubtype_KeepsTheCategoryAlone()
+    {
+        var html = Report(
+            """
+            <tr><td>1</td><td>Payflex Systems USA INC</td><td>Bank Deposit</td>
+                <td>Self</td><td>$15,001 - $50,000</td>
+                <td>None</td><td>None (or less than $201)</td></tr>
+            """
+        );
+
+        var item = SenateAnnualReportClient.ParseAnnualReportHtml(html).Single();
+
+        item.AssetType.Should().Be("Bank Deposit");
+        // "None" is the filer answering the question, and the sub-$201 floor is
+        // not a disclosed bracket — neither is stored as a value.
+        item.IncomeType.Should().BeNull();
+        item.IncomeMinimum.Should().BeNull();
+        item.IncomeMaximum.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseAnnualReportHtml_LayoutWithoutDetailColumns_LeavesDetailUnset()
+    {
+        // An older table missing the detail columns must leave them unset rather
+        // than reading whichever column happens to sit at that index.
+        var html = """
+            <html><body>
+            <h3>Part 3. Assets</h3>
+            <table>
+              <thead><tr><th>#</th><th>Asset</th><th>Owner</th><th>Value</th></tr></thead>
+              <tbody><tr><td>1</td><td>Some Fund</td><td>Self</td>
+                <td>$15,001 - $50,000</td></tr></tbody>
+            </table>
+            </body></html>
+            """;
+
+        var item = SenateAnnualReportClient.ParseAnnualReportHtml(html).Single();
+
+        item.RangeMinimum.Should().Be(15_001);
+        item.AssetType.Should().BeNull();
+        item.IncomeType.Should().BeNull();
+        item.IncomeMinimum.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseAnnualReportHtml_RealFiling_CarriesAssetDetail()
+    {
+        var html = File.ReadAllText(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "TestAssets",
+                "Congress",
+                "senate-annual-blackburn-2024.html"
+            )
+        );
+
+        var items = SenateAnnualReportClient.ParseAnnualReportHtml(html);
+
+        var deposit = items.Single(i => i.Description == "Payflex Systems USA INC");
+        deposit.AssetType.Should().Be("Bank Deposit");
+        deposit.IncomeMinimum.Should().BeNull();
+
+        var nonPublic = items.Single(i => i.Description == "Strategic Sales Tactics Inc.");
+        nonPublic.AssetType.Should().Be("Corporate Securities - Non-Public Stock");
+
+        var balanced = items.Single(i =>
+            i.Description == "ABALX - American Funds American Balanced Fund Class A"
+        );
+        balanced.AssetType.Should().Be("Mutual Funds - Mutual Fund");
+        balanced.IncomeType.Should().Be("Dividends, Capital Gains");
+        balanced.IncomeMinimum.Should().Be(1_001);
+        balanced.IncomeMaximum.Should().Be(2_500);
+    }
+}


### PR DESCRIPTION
## Summary

Annual congressional disclosures state more than our parser kept. Three facts were read and thrown away:

- **The asset class of each schedule line.** The House prints a bracketed code (`[ST]`, `[RP]`, `[BA]`) which the description cleaner stripped; the Senate prints a spelled-out label in its own column. It is the filer's own classification, and the only non-guessing way to tell a bank account from an equity position.
- **The income each asset produced.** A separate disclosed bracket from the asset's value, answering a different question, what the holding paid out last year. The parser located the income column purely to bound the value column, then discarded it.
- **The seat a member represents.** The House Clerk's index states it and the annual lane already parsed it into the report; there was no column to write it to.

## Code changes

**Data** — `CongressionalDisclosureLine` gains `AssetType`, `IncomeType`, `IncomeMinimum`, `IncomeMaximum`; `CongressMember` gains `StateDistrict`; `CongressionalFilingRecord` gains `ParserVersion`. `CongressSeat` formats a stored seat for display. One additive migration per change.

**House parser** — Schedule A's header holds two `Income` tokens (`Income Type(s)` tokenizes as two words), so the income-amount column starts at the second and ends at `Tx.`. The income bracket wraps its upper bound onto the next visual line exactly as the value bracket does; a bracket that never receives that bound leaves income unset rather than deriving a ceiling the filer never checked. The asset-class code is read before the description cleaner strips it, including when a long name wraps and carries the code onto its last line. Income is a passenger, it never decides new-row versus continuation.

**Senate parser** — Part 3 exposes the same three details as named columns. Its type cell splits the classification between the main text and a muted child (`Corporate Securities` / `Non-Public Stock`) and both halves are kept, unlike the muted location metadata on the name column.

Each value is stored exactly as filed. The two chambers publish different vocabularies and neither form ships a legend, so no cross-chamber mapping is invented.

**Backfill** — filing records carry the parser generation that wrote them. A lane that starts extracting new fields raises its version, which re-queues older filings for a re-parse a capped slice per cycle, oldest first, so the backfill drip-feeds instead of re-fetching the whole archive at once and converges without a manual sweep.

**MCP** — `SearchCongressMembers` returns a Seat column, and the member-identifying headers on `GetMemberTrades` / `GetMemberNetWorth` carry it.

## Note on senators' seats

`StateDistrict` is null for senators, and this is a source limitation rather than a gap left for later. The eFD annual report page carries the senator's name and filing date and nothing else identifying; its state appears only inside Part 2 payer addresses. The search form's `senator_state` field is a filter over the roster, not a field on the filing.

## Tests

26 new tests across the two parsers, the ledger's re-ingest selection, the seat formatter and the seat-selection rule, including end-to-end assertions against the checked-in real Clerk PDF and eFD HTML fixtures. Full unit suite green (4,386).
