### PR TITLE
feat(congress): record the seat from the trade lane too

### DIFF
--- a/src/Equibles.Congress.HostedService/Models/DisclosureTransaction.cs
+++ b/src/Equibles.Congress.HostedService/Models/DisclosureTransaction.cs
@@ -9,6 +9,12 @@ public class DisclosureTransaction
     // deciding whether to mark it as ingested.
     public string SourceId { get; set; }
 
+    // The seat the filer holds, as the House Clerk's index states it ("SC05").
+    // Stamped from the filing alongside SourceId rather than parsed out of the
+    // PDF, which never names it. Null on Senate transactions — no Senate
+    // filing states the member's state.
+    public string StateDistrict { get; set; }
+
     public required string MemberName { get; init; }
     public CongressPosition Position { get; init; }
     public string Ticker { get; init; }

--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -256,7 +256,12 @@ public class CongressionalTradeSyncService
         // the single source of truth for member identity.
         var distinctMembers = matched
             .GroupBy(t => DisclosureParsingHelper.NormalizeMemberName(t.MemberName))
-            .Select(g => new CongressMember { Name = g.Key, Position = g.First().Position })
+            .Select(g => new CongressMember
+            {
+                Name = g.Key,
+                Position = g.First().Position,
+                StateDistrict = SelectStateDistrict(g),
+            })
             .ToList();
 
         await dbContext
@@ -264,7 +269,15 @@ public class CongressionalTradeSyncService
             .UpsertRange(distinctMembers)
             .On(m => new { m.Name })
             .WhenMatched(
-                (existing, incoming) => new CongressMember { Position = incoming.Position }
+                (existing, incoming) =>
+                    new CongressMember
+                    {
+                        Position = incoming.Position,
+                        // Coalesced, never overwritten with nothing: this lane sees the same
+                        // member through Senate transactions too, and those state no seat. A
+                        // straight assignment would wipe a recorded seat on the next cycle.
+                        StateDistrict = incoming.StateDistrict ?? existing.StateDistrict,
+                    }
             )
             .RunAsync(ct);
 
@@ -274,6 +287,19 @@ public class CongressionalTradeSyncService
             .Where(m => memberNames.Contains(m.Name))
             .ToDictionaryAsync(m => m.Name, ct);
     }
+
+    /// <summary>
+    /// The seat to record for a member from this batch of transactions. Only the House index
+    /// states one, so a member's rows mix seat-bearing and seat-less transactions and picking
+    /// the wrong one would blank a recorded seat. Redistricting moves a member between
+    /// districts, so the most recently filed transaction that states a seat wins.
+    /// </summary>
+    internal static string SelectStateDistrict(IEnumerable<DisclosureTransaction> transactions) =>
+        transactions
+            .Where(t => !string.IsNullOrWhiteSpace(t.StateDistrict))
+            .OrderBy(t => t.FilingDate)
+            .LastOrDefault()
+            ?.StateDistrict.Trim();
 
     internal List<CongressionalTrade> BuildTrades(
         List<DisclosureTransaction> matched,

--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -76,7 +76,10 @@ public partial class HouseDisclosureClient
                             continue;
 
                         foreach (var txn in txns)
+                        {
                             txn.SourceId = filing.DocId;
+                            txn.StateDistrict = filing.StateDst;
+                        }
 
                         result.Transactions.AddRange(txns);
                         result.ProcessedFilings.Add(

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceStateDistrictTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceStateDistrictTests.cs
@@ -1,0 +1,84 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// The trade lane records a member's seat from the House Clerk's filing index, the only source
+/// that states one. A member's transactions mix seat-bearing House rows with seat-less Senate
+/// rows, so the selection has to survive the blanks rather than take the last row it sees.
+/// </summary>
+public class CongressionalTradeSyncServiceStateDistrictTests
+{
+    private static DisclosureTransaction Transaction(string stateDistrict, DateOnly filed) =>
+        new()
+        {
+            MemberName = "Jane Doe",
+            Position = CongressPosition.Representative,
+            StateDistrict = stateDistrict,
+            FilingDate = filed,
+            TransactionDate = filed.AddDays(-10),
+            TransactionType = CongressTransactionType.Purchase,
+            AmountFrom = 1_001,
+            AmountTo = 15_000,
+        };
+
+    [Fact]
+    public void SelectStateDistrict_SingleFiling_UsesItsSeat()
+    {
+        CongressionalTradeSyncService
+            .SelectStateDistrict([Transaction("SC05", new DateOnly(2026, 3, 1))])
+            .Should()
+            .Be("SC05");
+    }
+
+    [Fact]
+    public void SelectStateDistrict_Redistricted_TakesTheLatestFiling()
+    {
+        List<DisclosureTransaction> transactions =
+        [
+            Transaction("TX35", new DateOnly(2022, 6, 1)),
+            Transaction("TX37", new DateOnly(2024, 6, 1)),
+        ];
+
+        CongressionalTradeSyncService.SelectStateDistrict(transactions).Should().Be("TX37");
+    }
+
+    [Fact]
+    public void SelectStateDistrict_LatestFilingStatesNoSeat_KeepsTheOneThatDoes()
+    {
+        // A member who moved to the Senate keeps trading, and those rows carry no seat. Taking
+        // the last row outright would blank the House seat already on file.
+        List<DisclosureTransaction> transactions =
+        [
+            Transaction("SC05", new DateOnly(2023, 6, 1)),
+            Transaction("", new DateOnly(2026, 6, 1)),
+        ];
+
+        CongressionalTradeSyncService.SelectStateDistrict(transactions).Should().Be("SC05");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void SelectStateDistrict_NoFilingStatesASeat_IsNull(string stateDistrict)
+    {
+        CongressionalTradeSyncService
+            .SelectStateDistrict([Transaction(stateDistrict, new DateOnly(2026, 3, 1))])
+            .Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void SelectStateDistrict_PaddedSeat_KeepsTheClerksFormatting()
+    {
+        // "AK00" is an at-large seat, not a typo — stored as published, formatted for display
+        // elsewhere.
+        CongressionalTradeSyncService
+            .SelectStateDistrict([Transaction(" AK00 ", new DateOnly(2026, 3, 1))])
+            .Should()
+            .Be("AK00");
+    }
+}


### PR DESCRIPTION
## Summary

The House Clerk's index states the filer's seat on every filing, not just the annual ones. The trade lane already parsed it into `HouseFiling` and then dropped it — only the annual lane persisted a seat, so a member who trades carried none until their annual report was parsed.

## Code changes

`DisclosureTransaction` gains `StateDistrict`, stamped from the filing alongside `SourceId` rather than parsed out of the PDF, which never names it. The trade lane's member upsert writes it coalesced, never overwriting with nothing: the same lane sees a member through Senate transactions too and those state no seat, so a straight assignment would wipe a recorded seat on the next cycle.

Selection mirrors the annual lane — the most recently filed transaction that states a seat wins, so a redistricting moves the member and a seat-less Senate row does not blank them.

## Tests

5 new, covering the single filing, a redistricting, a seat-less later filing, no seat at all, and the Clerk's zero-padded at-large format. Full unit suite green (4,395).