### PR TITLE
fix(yahoo): restate a straddling serve by the captured split ratio, and stamp only certified splits

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -666,8 +666,16 @@ public class YahooPriceImportService
                     split.Denominator
                 ))
             )
-            .Distinct();
-        if (ShouldRejectSplitBearingHistory(target.Ticker, chartData.Prices, splitBoundaries))
+            .Distinct()
+            .ToList();
+        if (
+            !TryPutHistoryOnSingleSplitBasis(
+                target.Ticker,
+                chartData.Prices,
+                splitBoundaries,
+                today
+            )
+        )
             return;
 
         var replaced = await ReplaceStoredPrices(
@@ -688,18 +696,37 @@ public class YahooPriceImportService
             cancellationToken
         );
 
+        // A serve whose last bar predates a split's effective date passed the boundary check
+        // vacuously (no post-effective close to compare), so it cannot certify that split's basis:
+        // stamping it applied here parked BYND's 1-for-30 outside the pending queue while the
+        // stored series stayed pre-split. Keep such splits pending; the fair queue retries them.
+        var certifiableSeries = selectedSeries with
+        {
+            Splits = CertifiableSplits(selectedSeries.Splits, chartData.Prices.Max(p => p.Date)),
+        };
+        if (certifiableSeries.Splits.Count < selectedSeries.Splits.Count)
+        {
+            _logger.LogWarning(
+                "Provider history for {Ticker} ends before {Count} pending split(s) became effective; keeping them pending",
+                target.Ticker,
+                selectedSeries.Splits.Count - certifiableSeries.Splits.Count
+            );
+        }
+
         // A split changes the share base, so refresh the authoritative current share count +
         // market cap by refetch, not arithmetic (#2879). A dividend-only price reconciliation is
         // complete after the atomic history replacement and must not depend on unrelated
-        // quote-summary or EDGAR enrichment succeeding.
-        if (selectedSeries.Splits.Count > 0)
+        // quote-summary or EDGAR enrichment succeeding. Gate on the certifiable set: a provider
+        // that has not served the split's first post-effective bar is serving pre-split
+        // key statistics too.
+        if (certifiableSeries.Splits.Count > 0)
             await SyncKeyStatistics(target, cancellationToken);
 
         using var scope = _scopeFactory.CreateScope();
         var manager =
             scope.ServiceProvider.GetRequiredService<CorporateActionPriceReconciliationManager>();
         var stamped = await manager.StampApplied(
-            selectedSeries,
+            certifiableSeries,
             capturedDividends,
             today,
             DateTime.UtcNow,
@@ -787,6 +814,91 @@ public class YahooPriceImportService
             "Requeued {Count} split reconciliation marker(s) whose stored history still crossed price bases",
             requeued
         );
+    }
+
+    // Accepts a fetched history only when it sits on one split basis, restating it first when the
+    // authoritative captured ratio explains the jump. Yahoo can serve an unrestated history for
+    // days after a split becomes effective; waiting for it froze the whole series (no new bars,
+    // no rebase) for exactly the names customers are watching. The restatement is deterministic
+    // arithmetic off the captured ratio — never an inference — because it only fires when the
+    // observed boundary jump already matches that ratio.
+    private bool TryPutHistoryOnSingleSplitBasis(
+        string ticker,
+        List<HistoricalPrice> prices,
+        IReadOnlyCollection<SplitBasisDefinition> splits,
+        DateOnly today
+    )
+    {
+        var restated = RestateHistoryAcrossKnownSplits(prices, splits, today);
+        if (restated > 0)
+        {
+            _logger.LogWarning(
+                "Restated {Ticker}'s fetched history across {Count} captured split boundary(ies) the provider had not adjusted yet",
+                ticker,
+                restated
+            );
+        }
+
+        return !ShouldRejectSplitBearingHistory(ticker, prices, splits);
+    }
+
+    // Puts the segment before each straddled effective split onto the post-split basis: prices
+    // scale by denominator/numerator and volumes by numerator/denominator, exactly cancelling the
+    // boundary jump. A boundary is restated ONLY when its observed jump matches the captured
+    // ratio — restating on the ratio alone would double-apply a split the provider had already
+    // adjusted, and a future (announced) split must never restate anything.
+    internal static int RestateHistoryAcrossKnownSplits(
+        List<HistoricalPrice> prices,
+        IEnumerable<SplitBasisDefinition> splits,
+        DateOnly today
+    )
+    {
+        var restated = 0;
+        foreach (var split in splits.OrderByDescending(split => split.EffectiveDate))
+        {
+            if (split.EffectiveDate > today || split.Numerator <= 0m || split.Denominator <= 0m)
+                continue;
+            if (
+                !HasSplitBasisDiscontinuity(
+                    prices,
+                    split.EffectiveDate,
+                    split.Numerator,
+                    split.Denominator
+                )
+            )
+                continue;
+
+            var priceFactor = split.Denominator / split.Numerator;
+            var volumeFactor = split.Numerator / split.Denominator;
+            foreach (var price in prices)
+            {
+                if (price.Date >= split.EffectiveDate)
+                    continue;
+
+                price.Open = Math.Round(price.Open * priceFactor, 4);
+                price.High = Math.Round(price.High * priceFactor, 4);
+                price.Low = Math.Round(price.Low * priceFactor, 4);
+                price.Close = Math.Round(price.Close * priceFactor, 4);
+                price.AdjustedClose = Math.Round(price.AdjustedClose * priceFactor, 4);
+                price.Volume = (long)Math.Round(price.Volume * volumeFactor);
+            }
+
+            restated++;
+        }
+
+        return restated;
+    }
+
+    // The splits a replacement history can actually certify: only a serve containing at least one
+    // bar on or after a split's effective date can prove the series is on that split's basis. A
+    // serve ending earlier passes the discontinuity check vacuously and must leave the split
+    // pending instead of stamping it applied.
+    internal static IReadOnlyList<PendingSplitSnapshot> CertifiableSplits(
+        IReadOnlyList<PendingSplitSnapshot> splits,
+        DateOnly lastServedDate
+    )
+    {
+        return splits.Where(split => split.EffectiveDate <= lastServedDate).ToList();
     }
 
     private bool ShouldRejectSplitBearingHistory(
@@ -1083,14 +1195,17 @@ public class YahooPriceImportService
             }
 
             if (
-                ShouldRejectSplitBearingHistory(
+                !TryPutHistoryOnSingleSplitBasis(
                     target.Ticker,
                     chartData.Prices,
-                    chartData.Splits.Select(split => new SplitBasisDefinition(
-                        split.Date,
-                        split.Numerator,
-                        split.Denominator
-                    ))
+                    chartData
+                        .Splits.Select(split => new SplitBasisDefinition(
+                            split.Date,
+                            split.Numerator,
+                            split.Denominator
+                        ))
+                        .ToList(),
+                    today
                 )
             )
                 return new TickerImportResult(Fetched: true, Inserted: 0);
@@ -1126,14 +1241,17 @@ public class YahooPriceImportService
         {
             await CaptureSplits(target, chartData.Splits, cancellationToken);
             if (
-                ShouldRejectSplitBearingHistory(
+                !TryPutHistoryOnSingleSplitBasis(
                     target.Ticker,
                     chartData.Prices,
-                    chartData.Splits.Select(split => new SplitBasisDefinition(
-                        split.Date,
-                        split.Numerator,
-                        split.Denominator
-                    ))
+                    chartData
+                        .Splits.Select(split => new SplitBasisDefinition(
+                            split.Date,
+                            split.Numerator,
+                            split.Denominator
+                        ))
+                        .ToList(),
+                    today
                 )
             )
                 return new TickerImportResult(Fetched: true, Inserted: 0);
@@ -1160,8 +1278,16 @@ public class YahooPriceImportService
                     split.Numerator,
                     split.Denominator
                 ))
-                .Distinct();
-            if (ShouldRejectSplitBearingHistory(target.Ticker, fullChart.Prices, splitBoundaries))
+                .Distinct()
+                .ToList();
+            if (
+                !TryPutHistoryOnSingleSplitBasis(
+                    target.Ticker,
+                    fullChart.Prices,
+                    splitBoundaries,
+                    today
+                )
+            )
                 return new TickerImportResult(Fetched: true, Inserted: 0);
 
             var replaced = await ReplaceStoredPrices(

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -302,7 +302,7 @@ public class YahooPriceImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Import_ReferenceBootstrapStillStraddlesSplit_KeepsGroupedRowsPending()
+    public async Task Import_ReferenceBootstrapStraddlingKnownSplit_RestatesAndCompletesBackfill()
     {
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
         var floor = today.AddDays(-14);
@@ -353,13 +353,28 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
-        _priceRepo.GetAllSeries().Should().Contain(price => price.Id == firstBootstrap.Id);
-        _priceRepo.GetAllSeries().Should().Contain(price => price.Id == secondBootstrap.Id);
+        // The serve straddles the captured effective 1:16 split at the matching ratio, so the
+        // pre-effective segment is restated (3 x 16 = 48) instead of parking the whole bootstrap
+        // until the provider restates. The bootstrap rows are replaced by the full history.
+        var stored = _priceRepo
+            .GetAllSeries()
+            .Where(price => price.CommonStockId == stock.Id && price.ListedTicker == "REF")
+            .OrderBy(price => price.Date)
+            .ToList();
+        stored.Select(price => price.Date).Should().Equal(sessions);
+        stored
+            .Select(price => price.Close)
+            .Should()
+            .Equal(sessions.Select(date => date < effectiveDate ? 48m : 57m));
+        stored.Should().NotContain(price => price.Id == firstBootstrap.Id);
+        stored.Should().NotContain(price => price.Id == secondBootstrap.Id);
         _stockRepo
             .GetAll()
             .Single(row => row.Id == stock.Id)
             .PriceHistoryBackfilledTickers.Should()
-            .BeEmpty();
+            .Equal("REF");
+        // The split was captured from this same response, after the cycle's reconcile pass ran,
+        // so its marker is stamped on a later cycle rather than this one.
         _splitRepo
             .GetAll()
             .Should()
@@ -944,7 +959,7 @@ public class YahooPriceImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Import_AppliedMarkerStillStraddlesSplit_RequeuesWithoutRestamping()
+    public async Task Import_AppliedMarkerStillStraddlesSplit_RequeuesThenRestatesFromCapturedRatio()
     {
         var stock = CreateStock("AEHL", "Antelope Enterprise Holdings");
         await SeedStocks(stock);
@@ -979,17 +994,20 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _service.Import(CancellationToken.None);
 
-        split.PriceAdjustmentAppliedTime.Should().BeNull();
+        // The audit clears the false marker, then the same cycle's reconcile restates the still-
+        // straddling serve with the captured 1:16 ratio (3.20 x 16 = 51.2), replaces the series on
+        // one basis, and stamps the split off a serve that now certifies its boundary.
+        split.PriceAdjustmentAppliedTime.Should().NotBeNull();
         _priceRepo
             .GetAll()
             .OrderBy(price => price.Date)
             .Select(price => price.Close)
             .Should()
-            .Equal(3.00m, 57.10m, 56.00m);
+            .Equal(51.20m, 58.00m, 57.00m);
     }
 
     [Fact]
-    public async Task Import_OrdinarySplitFetchStillStraddlesBoundary_KeepsStoredSeriesPending()
+    public async Task Import_OrdinarySplitFetchStraddlingKnownSplit_RestatesTheFullHistory()
     {
         var stock = CreateStock("AEHL", "Antelope Enterprise Holdings");
         await SeedStocks(stock);
@@ -1027,12 +1045,17 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
+        // The full serve still straddles the newly captured 1:16 split at the matching ratio, so
+        // its pre-effective segment is restated (3.20 x 16 = 51.2) and the atomic replacement
+        // proceeds instead of freezing the stored series until the provider restates.
         _priceRepo
             .GetAll()
             .OrderBy(price => price.Date)
             .Select(price => price.Close)
             .Should()
-            .Equal(3.00m, 57.10m);
+            .Equal(51.20m, 58.00m, 57.00m);
+        // The ordinary rebase path never stamps; the split captured this cycle stays pending for
+        // the reconcile queue, which ran before this stock's fetch.
         _splitRepo
             .GetAll()
             .Should()
@@ -1093,7 +1116,7 @@ public class YahooPriceImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Import_FirstOrdinaryHistoryStillStraddlesSplit_KeepsSeriesEmptyPending()
+    public async Task Import_FirstOrdinaryHistoryStraddlingKnownSplit_RestatesAndInserts()
     {
         var stock = CreateStock("NEW", "Newly Imported Company");
         await SeedStocks(stock);
@@ -1119,7 +1142,14 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
-        _priceRepo.GetAll().Should().BeEmpty();
+        // A first backfill whose serve straddles the captured split at the matching ratio is put
+        // on one basis (3.20 x 16 = 51.2) and inserted, instead of leaving the series empty.
+        _priceRepo
+            .GetAll()
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(51.20m, 58.00m, 57.00m);
         _splitRepo
             .GetAll()
             .Should()
@@ -1129,7 +1159,7 @@ public class YahooPriceImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Import_OrdinarySplitFullResponseHasOlderMixedSplit_KeepsStoredSeriesPending()
+    public async Task Import_OrdinarySplitFullResponseHasOlderMixedSplit_RestatesTheOlderBoundary()
     {
         var stock = CreateStock("DUAL", "Dual Split Company");
         await SeedStocks(stock);
@@ -1179,12 +1209,15 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
+        // The older 1:16 boundary still straddles at the matching ratio and is restated
+        // (3.20 x 16 = 51.2); the newer 2:1 event shows no boundary jump (the provider already
+        // adjusted it), so the serve is accepted as one continuous basis and replaces the store.
         _priceRepo
             .GetAll()
             .OrderBy(price => price.Date)
             .Select(price => price.Close)
             .Should()
-            .Equal(3.00m, 57.10m, 56.00m);
+            .Equal(51.20m, 58.00m, 57.00m, 60.00m);
         _splitRepo
             .GetAll()
             .OrderBy(split => split.EffectiveDate)
@@ -1194,7 +1227,7 @@ public class YahooPriceImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Import_PendingReconcileResponseHasNewMixedSplit_KeepsStoredSeriesPending()
+    public async Task Import_PendingReconcileResponseHasNewMixedSplit_RestatesAndStampsTheSelected()
     {
         var stock = CreateStock("PNDG", "Pending Split Company");
         await SeedStocks(stock);
@@ -1243,18 +1276,22 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
+        // The newly returned 1:16 event is captured first, its matching boundary is restated
+        // (rows before it scale x 16: 100 -> 1600 and 3.20 -> 51.2), and the selected 2:1 split's
+        // own boundary shows no jump — so the serve is accepted, replaces the store, and the
+        // selected split is stamped. The new 1:16 stays pending for a later cycle.
         _priceRepo
             .GetAll()
             .OrderBy(price => price.Date)
             .Select(price => price.Close)
             .Should()
-            .Equal(storedRows.OrderBy(price => price.Date).Select(price => price.Close));
-        _splitRepo
-            .GetAll()
-            .OrderBy(split => split.EffectiveDate)
-            .Should()
-            .HaveCount(2)
-            .And.AllSatisfy(split => split.PriceAdjustmentAppliedTime.Should().BeNull());
+            .Equal(1600m, 1600m, 51.20m, 58.00m, 57.00m);
+        var splits = _splitRepo.GetAll().OrderBy(split => split.EffectiveDate).ToList();
+        splits.Should().HaveCount(2);
+        splits[0].EffectiveDate.Should().Be(selectedEffectiveDate);
+        splits[0].PriceAdjustmentAppliedTime.Should().NotBeNull();
+        splits[1].EffectiveDate.Should().Be(newEffectiveDate);
+        splits[1].PriceAdjustmentAppliedTime.Should().BeNull();
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitRestatementTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceSplitRestatementTests.cs
@@ -1,0 +1,232 @@
+using Equibles.CorporateActions.BusinessLogic;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Integrations.Yahoo.Models;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+public class YahooPriceImportServiceSplitRestatementTests
+{
+    private static readonly DateOnly Today = new(2026, 8, 18);
+
+    private static List<HistoricalPrice> StraddlingReverseSplitServe() =>
+        [
+            new()
+            {
+                Date = new DateOnly(2026, 8, 11),
+                Open = 0.4388m,
+                High = 0.45m,
+                Low = 0.41m,
+                Close = 0.4176m,
+                AdjustedClose = 0.418m,
+                Volume = 143_909_501,
+            },
+            new()
+            {
+                Date = new DateOnly(2026, 8, 14),
+                Open = 12.3m,
+                High = 13.5m,
+                Low = 12.1m,
+                Close = 13.47m,
+                AdjustedClose = 13.47m,
+                Volume = 4_100_000,
+            },
+            new()
+            {
+                Date = new DateOnly(2026, 8, 17),
+                Open = 13.4m,
+                High = 13.6m,
+                Low = 11.5m,
+                Close = 11.63m,
+                AdjustedClose = 11.63m,
+                Volume = 3_200_000,
+            },
+        ];
+
+    [Fact]
+    public void RestateHistoryAcrossKnownSplits_StraddlingReverseSplit_RestatesPreEffectiveRows()
+    {
+        var prices = StraddlingReverseSplitServe();
+        var splits = new[] { new SplitBasisDefinition(new DateOnly(2026, 8, 14), 1m, 30m) };
+
+        var restated = YahooPriceImportService.RestateHistoryAcrossKnownSplits(
+            prices,
+            splits,
+            Today
+        );
+
+        restated.Should().Be(1);
+        prices[0].Close.Should().Be(12.528m);
+        prices[0].Open.Should().Be(13.164m);
+        prices[0].AdjustedClose.Should().Be(12.54m);
+        prices[0].Volume.Should().Be(4_796_983); // 143,909,501 / 30, rounded
+        // Post-effective rows keep the served values untouched.
+        prices[1].Close.Should().Be(13.47m);
+        prices[2].Volume.Should().Be(3_200_000);
+
+        YahooPriceImportService
+            .HasSplitBasisDiscontinuity(prices, new DateOnly(2026, 8, 14), 1m, 30m)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void RestateHistoryAcrossKnownSplits_AlreadyAdjustedServe_TouchesNothing()
+    {
+        var prices = StraddlingReverseSplitServe();
+        // The provider already restated: pre-effective rows sit on the post-split basis.
+        prices[0].Close = 12.53m;
+        prices[0].Open = 13.16m;
+        var splits = new[] { new SplitBasisDefinition(new DateOnly(2026, 8, 14), 1m, 30m) };
+
+        var restated = YahooPriceImportService.RestateHistoryAcrossKnownSplits(
+            prices,
+            splits,
+            Today
+        );
+
+        restated.Should().Be(0);
+        prices[0].Close.Should().Be(12.53m);
+        prices[0].Volume.Should().Be(143_909_501);
+    }
+
+    [Fact]
+    public void RestateHistoryAcrossKnownSplits_FutureSplit_TouchesNothing()
+    {
+        var prices = StraddlingReverseSplitServe();
+        var splits = new[] { new SplitBasisDefinition(new DateOnly(2026, 8, 14), 1m, 30m) };
+
+        var restated = YahooPriceImportService.RestateHistoryAcrossKnownSplits(
+            prices,
+            splits,
+            today: new DateOnly(2026, 8, 13)
+        );
+
+        restated.Should().Be(0);
+        prices[0].Close.Should().Be(0.4176m);
+    }
+
+    [Fact]
+    public void RestateHistoryAcrossKnownSplits_JumpNotMatchingRatio_TouchesNothing()
+    {
+        var prices = StraddlingReverseSplitServe();
+        // A 2:1 captured ratio cannot explain a ~30x boundary jump; restating would corrupt.
+        var splits = new[] { new SplitBasisDefinition(new DateOnly(2026, 8, 14), 1m, 2m) };
+
+        var restated = YahooPriceImportService.RestateHistoryAcrossKnownSplits(
+            prices,
+            splits,
+            Today
+        );
+
+        restated.Should().Be(0);
+        prices[0].Close.Should().Be(0.4176m);
+    }
+
+    [Fact]
+    public void RestateHistoryAcrossKnownSplits_ForwardSplit_ScalesInTheOppositeDirection()
+    {
+        List<HistoricalPrice> prices =
+        [
+            new()
+            {
+                Date = new DateOnly(2026, 6, 1),
+                Open = 100m,
+                High = 104m,
+                Low = 98m,
+                Close = 102m,
+                AdjustedClose = 101m,
+                Volume = 1_000_000,
+            },
+            new()
+            {
+                Date = new DateOnly(2026, 6, 2),
+                Open = 25.2m,
+                High = 26m,
+                Low = 25m,
+                Close = 25.6m,
+                AdjustedClose = 25.6m,
+                Volume = 4_100_000,
+            },
+        ];
+        var splits = new[] { new SplitBasisDefinition(new DateOnly(2026, 6, 2), 4m, 1m) };
+
+        var restated = YahooPriceImportService.RestateHistoryAcrossKnownSplits(
+            prices,
+            splits,
+            Today
+        );
+
+        restated.Should().Be(1);
+        prices[0].Close.Should().Be(25.5m);
+        prices[0].Volume.Should().Be(4_000_000);
+        prices[1].Close.Should().Be(25.6m);
+    }
+
+    [Fact]
+    public void RestateHistoryAcrossKnownSplits_DuplicateBoundaryDefinitions_RestatesOnce()
+    {
+        var prices = StraddlingReverseSplitServe();
+        // The reconcile path merges captured DB splits with chart-reported events; the same
+        // boundary can arrive twice. The second pass finds no remaining jump and must skip.
+        var splits = new[]
+        {
+            new SplitBasisDefinition(new DateOnly(2026, 8, 14), 1m, 30m),
+            new SplitBasisDefinition(new DateOnly(2026, 8, 14), 1m, 30m),
+        };
+
+        var restated = YahooPriceImportService.RestateHistoryAcrossKnownSplits(
+            prices,
+            splits,
+            Today
+        );
+
+        restated.Should().Be(1);
+        prices[0].Close.Should().Be(12.528m);
+    }
+
+    [Fact]
+    public void CertifiableSplits_ServeEndingBeforeEffectiveDate_KeepsTheSplitPending()
+    {
+        var effective = new PendingSplitSnapshot(
+            Guid.NewGuid(),
+            new DateOnly(2026, 8, 10),
+            1m,
+            30m,
+            StockSplitSource.External
+        );
+        var notServedYet = new PendingSplitSnapshot(
+            Guid.NewGuid(),
+            new DateOnly(2026, 8, 14),
+            1m,
+            30m,
+            StockSplitSource.External
+        );
+
+        var certifiable = YahooPriceImportService.CertifiableSplits(
+            [effective, notServedYet],
+            lastServedDate: new DateOnly(2026, 8, 13)
+        );
+
+        certifiable.Should().ContainSingle().Which.Should().Be(effective);
+    }
+
+    [Fact]
+    public void CertifiableSplits_ServeReachingTheEffectiveDate_AllowsStamping()
+    {
+        var split = new PendingSplitSnapshot(
+            Guid.NewGuid(),
+            new DateOnly(2026, 8, 14),
+            1m,
+            30m,
+            StockSplitSource.External
+        );
+
+        var certifiable = YahooPriceImportService.CertifiableSplits(
+            [split],
+            lastServedDate: new DateOnly(2026, 8, 14)
+        );
+
+        certifiable.Should().ContainSingle();
+    }
+}


### PR DESCRIPTION
## Problem

A provider can serve an unrestated full history for **days** after a split becomes effective. BYND's 1-for-30 (effective 2026-08-14) surfaced two defects:

1. **The straddle rejection freezes the series indefinitely.** `ShouldRejectSplitBearingHistory` correctly refuses a mixed-basis serve, but with no fallback the store gets no rebase and no new bars for as long as the provider lingers — exactly when the name is most watched.
2. **A vacuous boundary check false-stamps the split applied.** `IsSplitBoundaryDiscontinuous` returns false when the serve has no bar on/after the effective date, so a serve ending *before* the split passed the check vacuously, replaced history on the old basis, and stamped `PriceAdjustmentAppliedTime` — parking the split outside the pending queue. The marker audit was equally blind: the store had no post-effective bar to reveal the jump.

## Fix

- **Restate instead of reject when the captured ratio explains the jump**: `RestateHistoryAcrossKnownSplits` scales the pre-effective segment (prices ×denominator/numerator, volumes ×numerator/denominator) before the normal atomic replacement, at every full-history acceptance site. Deterministic arithmetic off the captured effective ratio — it fires only when the observed jump already matches that ratio within the existing tolerance, so an already-adjusted serve is never double-applied and a future announced split never restates anything (#7254 semantics preserved). An unexplained straddle still rejects.
- **Stamp only certifiable splits**: `CertifiableSplits` drops splits whose effective date is after the serve's last bar from the stamp (and from the `SyncKeyStatistics` gate — a provider that has not served the first post-split bar is serving pre-split share counts too). They stay pending and the fair queue retries.

## Tests

8 new unit tests (`YahooPriceImportServiceSplitRestatementTests`): reverse + forward orientation, already-adjusted serve untouched, future split untouched, non-matching jump untouched, duplicate boundary definitions restate once, and the certifiable-split filter both ways. Full suite: 4403/4403 green.