### PR TITLE
fix(financial-facts): restate the cover-page share count onto today's split basis

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Equibles.Sec.FinancialFacts.BusinessLogic.csproj
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Equibles.Sec.FinancialFacts.BusinessLogic.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Data\Equibles.Sec.FinancialFacts.Data.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Repositories\Equibles.Sec.FinancialFacts.Repositories.csproj" />
   </ItemGroup>

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ISharesOutstandingProvider.cs
@@ -43,6 +43,10 @@ public interface ISharesOutstandingProvider
     /// collapse by both the issuer's previous cover-page count and the same filing's
     /// balance-sheet count — in which case EDGAR abstains and the caller's fallback source (the
     /// price feed's listed-security count) stands.
+    /// The count is restated onto today's split basis: a captured primary-series split effective
+    /// after the fact's as-of date rescales it (a 1-for-30 reverse split divides it by 30), so
+    /// the months between a split and the issuer's next cover page do not serve a stale-basis
+    /// count. The first post-split cover page makes the restatement a natural no-op.
     /// </summary>
     Task<long?> GetCurrentSharesOutstanding(
         CommonStock stock,

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Statements;
@@ -66,19 +68,25 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
 
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
 
     public SharesOutstandingProvider(
         FinancialFactRepository financialFactRepository,
-        FinancialConceptRepository financialConceptRepository
+        FinancialConceptRepository financialConceptRepository,
+        StockSplitRepository stockSplitRepository
     )
     {
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
+        _stockSplitRepository = stockSplitRepository;
     }
 
-    // The current entity share count together with the filing that stated it.
+    // The current entity share count together with the filing that stated it. AsOf is the
+    // instant the count was stated for (the fact's PeriodEnd), which trails the filed date —
+    // a 10-Q cover states "shares outstanding as of <a few days before filing>".
     private sealed record SharesFact(
         long Shares,
+        DateOnly AsOf,
         DateOnly Filed,
         DocumentType Form,
         string AccessionNumber
@@ -139,7 +147,44 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
     public async Task<long?> GetCurrentSharesOutstanding(
         CommonStock stock,
         CancellationToken cancellationToken = default
-    ) => (await ResolveCurrentSharesFact(stock, cancellationToken))?.Shares;
+    )
+    {
+        var fact = await ResolveCurrentSharesFact(stock, cancellationToken);
+        if (fact == null)
+            return null;
+        return await RestateToCurrentSplitBasis(stock, fact, cancellationToken);
+    }
+
+    // A cover-page count is stated as-of a date inside its filing window, and the NEXT cover page
+    // is typically a quarter away — so a split effective in between leaves this figure on the
+    // pre-split basis for months (BYND's 1-for-30 kept every market-cap and ownership surface 30x
+    // wrong until its next 10-Q). Restate the count onto today's basis with the captured splits,
+    // the same read-time contract every other share-count consumer applies (SplitAdjustment):
+    // only splits already effective apply (never an announced future one), and the strict
+    // after-AsOf comparison makes the first post-split cover page a natural no-op — no flag to
+    // clear, no double application. Scoped to the primary price series (exact primary ticker plus
+    // legacy null attribution): the entity total moves with the issuer's common stock, and a
+    // split attributed only to a sibling listing must not rescale it.
+    private async Task<long> RestateToCurrentSplitBasis(
+        CommonStock stock,
+        SharesFact fact,
+        CancellationToken cancellationToken
+    )
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var splits = await _stockSplitRepository
+            .GetEffectiveByStock(stock.Id, today)
+            .Where(split =>
+                split.PriceSeriesTicker == null || split.PriceSeriesTicker == stock.Ticker
+            )
+            .ToListAsync(cancellationToken);
+
+        var factor = SplitAdjustment.ShareCountFactor(fact.AsOf, splits);
+        // Defensive: a corrupt split row (zero/negative numerator) zeroes the factor, and a zeroed
+        // count is a worse answer than the stale one — leave the count as filed, like every other
+        // non-positive-factor fallback in the split-adjustment family.
+        return factor <= 0m ? fact.Shares : SplitAdjustment.AdjustShareCount(fact.Shares, factor);
+    }
 
     // True when the fact backing GetCurrentSharesOutstanding — the latest consolidated cover-page
     // fact or the latest per-class filing, whichever wins the pick — is a foreign-private-issuer
@@ -314,6 +359,7 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
                 true,
                 new SharesFact(
                     (long)sameFilingBalanceSheet.Value,
+                    latest.AsOf,
                     latest.Filed,
                     latest.Form,
                     latest.AccessionNumber
@@ -418,6 +464,7 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
             .Select(f => new
             {
                 f.Value,
+                f.PeriodEnd,
                 f.FiledDate,
                 f.Form,
                 f.AccessionNumber,
@@ -430,7 +477,13 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         // decimal->long cast would throw, crashing the caller. Treat an unrepresentable figure as
         // none on record (null), matching how every other decimal->long cast here is range-checked.
         return match.Value >= long.MinValue && match.Value <= long.MaxValue
-            ? new SharesFact((long)match.Value, match.FiledDate, match.Form, match.AccessionNumber)
+            ? new SharesFact(
+                (long)match.Value,
+                match.PeriodEnd,
+                match.FiledDate,
+                match.Form,
+                match.AccessionNumber
+            )
             : null;
     }
 
@@ -486,7 +539,13 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         // Same range-check: a corrupt per-class count can push the sum past Int64; degrade to null
         // rather than let the decimal->long cast throw.
         return total > 0 && total <= long.MaxValue
-            ? new SharesFact((long)total, latest.FiledDate, latest.Form, latest.AccessionNumber)
+            ? new SharesFact(
+                (long)total,
+                latest.PeriodEnd,
+                latest.FiledDate,
+                latest.Form,
+                latest.AccessionNumber
+            )
             : null;
     }
 

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderComparativePeriodTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderComparativePeriodTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.BusinessLogic;
@@ -36,6 +38,7 @@ public class SharesOutstandingProviderComparativePeriodTests
             {
                 new CommonStocksModuleConfiguration(),
                 new FinancialFactsTestModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
             }
         );
         ctx.Database.EnsureCreated();
@@ -110,7 +113,8 @@ public class SharesOutstandingProviderComparativePeriodTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetSummedPerClassSharesOutstanding(stock);

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderCoverPageIntegrityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderCoverPageIntegrityTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.BusinessLogic;
@@ -50,6 +52,7 @@ public class SharesOutstandingProviderCoverPageIntegrityTests
             {
                 new CommonStocksModuleConfiguration(),
                 new FinancialFactsTestModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
             }
         );
         ctx.Database.EnsureCreated();
@@ -57,7 +60,11 @@ public class SharesOutstandingProviderCoverPageIntegrityTests
     }
 
     private static SharesOutstandingProvider NewProvider(EquiblesFinancialDbContext db) =>
-        new(new FinancialFactRepository(db), new FinancialConceptRepository(db));
+        new(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
+        );
 
     private static CommonStock Stock(string ticker) =>
         new()

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderReportedSharesOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderReportedSharesOverflowTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.BusinessLogic;
@@ -35,6 +37,7 @@ public class SharesOutstandingProviderReportedSharesOverflowTests
             {
                 new CommonStocksModuleConfiguration(),
                 new FinancialFactsTestModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
             }
         );
         ctx.Database.EnsureCreated();
@@ -73,7 +76,8 @@ public class SharesOutstandingProviderReportedSharesOverflowTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetReportedSharesOutstanding(stock);
@@ -114,7 +118,8 @@ public class SharesOutstandingProviderReportedSharesOverflowTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetSummedPerClassSharesOutstanding(stock);

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderSplitRestatementTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderSplitRestatementTests.cs
@@ -1,0 +1,278 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.Data;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+// Pins the split restatement in GetCurrentSharesOutstanding: a cover-page count is stated as-of
+// a date inside its filing window, so a captured split effective AFTER that date must rescale it
+// — otherwise every market-cap and ownership surface stays on the pre-split basis until the
+// issuer's next cover page, a whole quarter away (BYND's 1-for-30 served a ~$6.2B market cap on
+// a ~$210M company). The first post-split cover page makes the restatement a natural no-op.
+public class SharesOutstandingProviderSplitRestatementTests
+{
+    private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new FinancialFactsTestModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static SharesOutstandingProvider NewProvider(EquiblesFinancialDbContext db) =>
+        new(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
+        );
+
+    private static CommonStock Stock() =>
+        new()
+        {
+            Ticker = "BYND",
+            Name = "Beyond Meat",
+            Cik = "0001655210",
+        };
+
+    private static FinancialConcept CoverPageConcept() =>
+        new() { Taxonomy = FactTaxonomy.Dei, Tag = "EntityCommonStockSharesOutstanding" };
+
+    private static FinancialFact Fact(
+        CommonStock stock,
+        FinancialConcept concept,
+        decimal value,
+        DateOnly filed,
+        DateOnly asOf,
+        string dimensionsKey = ""
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Unit = "shares",
+            PeriodType = FactPeriodType.Instant,
+            PeriodStart = asOf,
+            PeriodEnd = asOf,
+            Value = value,
+            FiscalYear = asOf.Year,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            Form = DocumentType.TenQ,
+            FiledDate = filed,
+            AccessionNumber = $"ACC-{Guid.NewGuid():N}"[..20],
+            DimensionsKey = dimensionsKey,
+        };
+
+    private static FinancialFact ClassFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        decimal value,
+        DateOnly filed,
+        DateOnly asOf,
+        string member
+    )
+    {
+        const string axis = "us-gaap:StatementClassOfStockAxis";
+        var fact = Fact(stock, concept, value, filed, asOf, dimensionsKey: $"{axis}={member}");
+        fact.AccessionNumber = "ACC-SAME-FILING";
+        fact.Dimensions.Add(new FinancialFactDimension { Axis = axis, Member = member });
+        return fact;
+    }
+
+    private static StockSplit Split(
+        CommonStock stock,
+        DateOnly effective,
+        decimal numerator,
+        decimal denominator,
+        string priceSeriesTicker
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            EffectiveDate = effective,
+            Numerator = numerator,
+            Denominator = denominator,
+            Source = StockSplitSource.External,
+            PriceSeriesTicker = priceSeriesTicker,
+        };
+
+    [Fact]
+    public async Task ReverseSplitEffectiveAfterTheFactsAsOfDate_RestatesTheCount()
+    {
+        await using var db = NewDb();
+        var stock = Stock();
+        var concept = CoverPageConcept();
+        db.AddRange(stock, concept);
+        // The BYND shape: 10-Q filed Aug 6 with the count as of Aug 1; 1-for-30 effective Aug 14.
+        db.Add(Fact(stock, concept, 515_818_978m, Today.AddDays(-12), Today.AddDays(-17)));
+        db.Add(Split(stock, Today.AddDays(-4), 1m, 30m, "BYND"));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(17_193_966); // 515,818,978 / 30, rounded
+    }
+
+    [Fact]
+    public async Task FactStatedOnTheEffectiveDate_IsAlreadyPostSplit_NotRestated()
+    {
+        await using var db = NewDb();
+        var stock = Stock();
+        var concept = CoverPageConcept();
+        db.AddRange(stock, concept);
+        var effective = Today.AddDays(-4);
+        // The first post-split cover page: stated ON the effective date or later — restating it
+        // again would double-apply, so the strict after-AsOf comparison must exclude it.
+        db.Add(Fact(stock, concept, 17_200_000m, Today.AddDays(-1), effective));
+        db.Add(Split(stock, effective, 1m, 30m, "BYND"));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(17_200_000);
+    }
+
+    [Fact]
+    public async Task AnnouncedFutureSplit_DoesNotRestateAnything()
+    {
+        await using var db = NewDb();
+        var stock = Stock();
+        var concept = CoverPageConcept();
+        db.AddRange(stock, concept);
+        db.Add(Fact(stock, concept, 515_818_978m, Today.AddDays(-12), Today.AddDays(-17)));
+        // Captured at announcement, effective next week — today's count must not move.
+        db.Add(Split(stock, Today.AddDays(7), 1m, 30m, "BYND"));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(515_818_978);
+    }
+
+    [Fact]
+    public async Task SplitAttributedToASiblingSeries_DoesNotRescaleTheEntityCount()
+    {
+        await using var db = NewDb();
+        var stock = Stock();
+        var concept = CoverPageConcept();
+        db.AddRange(stock, concept);
+        db.Add(Fact(stock, concept, 515_818_978m, Today.AddDays(-12), Today.AddDays(-17)));
+        db.Add(Split(stock, Today.AddDays(-4), 1m, 30m, "BYND-B"));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(515_818_978);
+    }
+
+    [Fact]
+    public async Task LegacyNullAttributedSplit_RestatesLikeThePrimarySeries()
+    {
+        await using var db = NewDb();
+        var stock = Stock();
+        var concept = CoverPageConcept();
+        db.AddRange(stock, concept);
+        db.Add(Fact(stock, concept, 100_000_000m, Today.AddDays(-12), Today.AddDays(-17)));
+        // Forward 2:1 with legacy null series attribution: the count doubles.
+        db.Add(Split(stock, Today.AddDays(-4), 2m, 1m, null));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(200_000_000);
+    }
+
+    [Fact]
+    public async Task PerClassSum_IsRestatedByTheSameRule()
+    {
+        await using var db = NewDb();
+        var stock = Stock();
+        var concept = CoverPageConcept();
+        db.AddRange(stock, concept);
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                200_000_000m,
+                Today.AddDays(-12),
+                Today.AddDays(-17),
+                "bynd:ClassAMember"
+            )
+        );
+        db.Add(
+            ClassFact(
+                stock,
+                concept,
+                100_000_000m,
+                Today.AddDays(-12),
+                Today.AddDays(-17),
+                "bynd:ClassBMember"
+            )
+        );
+        db.Add(Split(stock, Today.AddDays(-4), 1m, 30m, "BYND"));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(10_000_000); // (200M + 100M) / 30
+    }
+
+    [Fact]
+    public async Task CorruptSplitRatio_LeavesTheCountAsFiled()
+    {
+        await using var db = NewDb();
+        var stock = Stock();
+        var concept = CoverPageConcept();
+        db.AddRange(stock, concept);
+        db.Add(Fact(stock, concept, 515_818_978m, Today.AddDays(-12), Today.AddDays(-17)));
+        // A zero numerator would zero the count — worse than the stale figure; leave it as filed.
+        db.Add(Split(stock, Today.AddDays(-4), 0m, 30m, "BYND"));
+        await db.SaveChangesAsync();
+
+        var shares = await NewProvider(db).GetCurrentSharesOutstanding(stock);
+
+        shares.Should().Be(515_818_978);
+    }
+
+    [Fact]
+    public async Task GetReportedSharesOutstanding_StaysAsFiled()
+    {
+        await using var db = NewDb();
+        var stock = Stock();
+        var concept = CoverPageConcept();
+        db.AddRange(stock, concept);
+        db.Add(Fact(stock, concept, 515_818_978m, Today.AddDays(-12), Today.AddDays(-17)));
+        db.Add(Split(stock, Today.AddDays(-4), 1m, 30m, "BYND"));
+        await db.SaveChangesAsync();
+
+        // The as-reported accessor documents the filing verbatim; only the "current entity
+        // total" contract restates onto today's basis.
+        var shares = await NewProvider(db).GetReportedSharesOutstanding(stock);
+
+        shares.Should().Be(515_818_978);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.BusinessLogic;
@@ -32,6 +34,7 @@ public class SharesOutstandingProviderTests
             {
                 new CommonStocksModuleConfiguration(),
                 new FinancialFactsTestModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
             }
         );
         ctx.Database.EnsureCreated();
@@ -83,7 +86,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetReportedSharesOutstanding(stock);
@@ -134,7 +138,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetReportedSharesOutstanding(stock);
@@ -230,7 +235,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetSummedPerClassSharesOutstanding(stock);
@@ -269,7 +275,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetSummedPerClassSharesOutstanding(stock);
@@ -311,7 +318,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetSummedPerClassSharesOutstanding(stock);
@@ -386,7 +394,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetSummedPerClassSharesOutstanding(stock);
@@ -452,7 +461,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetCurrentSharesOutstanding(stock);
@@ -496,7 +506,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var isForeign = await provider.IsForeignPrivateIssuer(stock);
@@ -534,7 +545,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var isForeign = await provider.IsForeignPrivateIssuer(stock);
@@ -557,7 +569,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var isForeign = await provider.IsForeignPrivateIssuer(stock);
@@ -607,7 +620,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var isForeign = await provider.IsForeignPrivateIssuer(stock);
@@ -671,7 +685,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetCurrentSharesOutstanding(stock);
@@ -703,7 +718,8 @@ public class SharesOutstandingProviderTests
 
         var provider = new SharesOutstandingProvider(
             new FinancialFactRepository(db),
-            new FinancialConceptRepository(db)
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
         );
 
         var shares = await provider.GetCurrentSharesOutstanding(stock);


### PR DESCRIPTION
## Problem

For a domestic filer the entity share count comes from the SEC cover-page fact (`dei:EntityCommonStockSharesOutstanding`), preferred over the price feed by design (#3575/#2503). That count is stated as-of a date inside its filing window, and the next cover page is a quarter away — so a split effective in between leaves the count on the pre-split basis for months. BYND's 1-for-30 (effective 2026-08-14, latest cover page 2026-08-06) served a ~$6.2B market cap on a ~$210M company, and the unit-mismatch guard cannot catch it: it deliberately tolerates corporate-action-sized gaps (`MaxPlausibleSameUnitRatio = 300`) so a *current* EDGAR count can correct a *lagging* price feed — here the direction is inverted.

## Fix

`GetCurrentSharesOutstanding` restates the resolved count with the captured primary-series splits effective **after the fact's as-of date** (`SplitAdjustment.ShareCountFactor`, the same read-time contract every other share-count consumer applies):

- Announced future splits never apply (`GetEffectiveByStock` as-of today).
- A fact stated on/after the effective date is already post-split (strict `>` in the factor), so the first post-split cover page makes the restatement a **natural no-op** — nothing to unwind at the next filing.
- Scoped to the primary series (exact primary ticker + legacy null attribution); a sibling-listing split never rescales the entity total.
- A corrupt ratio (non-positive factor) leaves the count as filed.
- Both writers — the Yahoo key-statistics sync and the financial-facts importer — read through this provider, so one change covers both. `ReconcileMarketCap` then rescales the provider cap onto the corrected base, which lands right whether the price feed has processed the split yet or not.
- The as-reported accessors (`GetReportedSharesOutstanding`, `GetSummedPerClassSharesOutstanding`) stay verbatim.

## Tests

8 new tests (`SharesOutstandingProviderSplitRestatementTests`): the BYND shape restates ÷30, on-effective-date fact untouched, future split untouched, sibling-series split untouched, legacy null attribution restates, per-class sum restates, corrupt ratio falls back, as-reported stays verbatim. Full suites green: 4411 unit / 2617 integration.