### PR TITLE
feat(sec): optional excerpt-link seam for document-search renderings

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/IDocumentExcerptLinkBuilder.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/IDocumentExcerptLinkBuilder.cs
@@ -1,0 +1,22 @@
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.BusinessLogic.Search;
+
+/// <summary>
+/// Optional deployment seam: builds a public URL for one document excerpt so search
+/// renderers can attach a "view this passage" link. The framework registers no
+/// implementation — a deployment that has a public document viewer registers its own,
+/// and everything degrades to link-less rendering when none is registered (the
+/// consumers take this as an optional constructor dependency).
+/// </summary>
+public interface IDocumentExcerptLinkBuilder
+{
+    /// <summary>
+    /// Absolute URL for an excerpt of <paramref name="document"/>, or null when no link
+    /// applies (e.g. the document's stock has no public page). Line numbers are 1-based
+    /// positions in the document's normalized text content — approximate anchors the
+    /// viewer may refine with <paramref name="excerptText"/>, which is the excerpt's raw
+    /// text (implementations truncate and encode it themselves).
+    /// </summary>
+    string BuildExcerptUrl(Document document, int fromLine, int toLine, string excerptText);
+}

--- a/src/Equibles.Sec.BusinessLogic/Search/IRagManager.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/IRagManager.cs
@@ -38,6 +38,7 @@ public interface IRagManager
     public Task<string> BuildContext(
         List<Chunk> chunks,
         bool includeDocumentIds = false,
-        int maxExcerptChars = 0
+        int maxExcerptChars = 0,
+        bool includeExcerptLinks = false
     );
 }

--- a/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
@@ -17,16 +17,22 @@ public class RagManager : IRagManager
     private readonly HybridChunkSearcher _hybridChunkSearcher;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly ILogger<RagManager> _logger;
+    private readonly IDocumentExcerptLinkBuilder _excerptLinkBuilder;
 
+    // The link builder is an OPTIONAL dependency by design: the framework registers no
+    // implementation, and the DI container falls back to the default (null) when a
+    // deployment has not registered a public document viewer to link into.
     public RagManager(
         HybridChunkSearcher hybridChunkSearcher,
         CommonStockRepository commonStockRepository,
-        ILogger<RagManager> logger
+        ILogger<RagManager> logger,
+        IDocumentExcerptLinkBuilder excerptLinkBuilder = null
     )
     {
         _hybridChunkSearcher = hybridChunkSearcher;
         _commonStockRepository = commonStockRepository;
         _logger = logger;
+        _excerptLinkBuilder = excerptLinkBuilder;
     }
 
     public async Task<List<Chunk>> SearchRelevantChunks(
@@ -118,7 +124,8 @@ public class RagManager : IRagManager
     public Task<string> BuildContext(
         List<Chunk> chunks,
         bool includeDocumentIds = false,
-        int maxExcerptChars = 0
+        int maxExcerptChars = 0,
+        bool includeExcerptLinks = false
     )
     {
         if (!chunks.Any())
@@ -167,6 +174,11 @@ public class RagManager : IRagManager
                             : $"**Excerpt {chunk.Index + 1}:**"
                     );
                     context.AppendLine(content);
+                    var link = BuildExcerptLink(chunk, includeExcerptLinks);
+                    if (link != null)
+                    {
+                        context.AppendLine($"Link: {link}");
+                    }
                     context.AppendLine();
                 }
             }
@@ -176,6 +188,22 @@ public class RagManager : IRagManager
         }
 
         return Task.FromResult(context.ToString());
+    }
+
+    // The link anchors on the chunk's line span in the normalized text — the same
+    // (StartLineNumber, StartLineNumber + newline count) convention the excerpt header
+    // and ReadDocumentLines use — plus the chunk's raw text for viewers that refine the
+    // approximate line anchor by matching the passage itself.
+    private string BuildExcerptLink(Chunk chunk, bool includeExcerptLinks)
+    {
+        if (!includeExcerptLinks || _excerptLinkBuilder == null || chunk.StartLineNumber <= 0)
+        {
+            return null;
+        }
+
+        var fromLine = chunk.StartLineNumber;
+        var toLine = fromLine + (chunk.Content ?? string.Empty).Count(c => c == '\n');
+        return _excerptLinkBuilder.BuildExcerptUrl(chunk.Document, fromLine, toLine, chunk.Content);
     }
 
     // Markdown image references in chunk content (slide-deck captures embed one per slide)

--- a/src/Equibles.Sec.Mcp/Tools/DocumentKeywordScan.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentKeywordScan.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Equibles.Mcp.Helpers;
 using Equibles.Media.BusinessLogic;
+using Equibles.Sec.BusinessLogic.Search;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 
@@ -17,7 +18,8 @@ internal static class DocumentKeywordScan
         IFileManager fileManager,
         Guid documentId,
         string keyword,
-        int maxResults
+        int maxResults,
+        IDocumentExcerptLinkBuilder linkBuilder = null
     )
     {
         var (document, lines, error) = await LoadDocumentLines(
@@ -58,7 +60,7 @@ internal static class DocumentKeywordScan
         );
         result.AppendLine();
 
-        AppendMatchBlocks(result, lines, matches, keyword);
+        AppendMatchBlocks(result, lines, matches, keyword, document, linkBuilder);
 
         result.AppendLine(McpOutput.TruncationNote(matches.Count, allMatches.Count));
 
@@ -87,12 +89,15 @@ internal static class DocumentKeywordScan
 
     // Renders each match with one line of context on each side, merging overlapping and
     // adjacent blocks grep-style so a document line never prints twice; a blank line
-    // separates non-contiguous blocks.
+    // separates non-contiguous blocks. When a link builder is registered, each block ends
+    // with a link anchored on the block's line span and its first matched line's text.
     private static void AppendMatchBlocks(
         StringBuilder result,
         string[] lines,
         List<int> matches,
-        string keyword
+        string keyword,
+        Document document,
+        IDocumentExcerptLinkBuilder linkBuilder
     )
     {
         var matchSet = matches.ToHashSet();
@@ -107,19 +112,75 @@ internal static class DocumentKeywordScan
         }
 
         int? previous = null;
+        int? blockStart = null;
+        int? blockFirstMatch = null;
         foreach (var lineIndex in linesToPrint)
         {
             if (previous.HasValue && lineIndex > previous.Value + 1)
+            {
+                AppendBlockLink(
+                    result,
+                    lines,
+                    document,
+                    linkBuilder,
+                    blockStart,
+                    previous,
+                    blockFirstMatch
+                );
                 result.AppendLine();
+                blockStart = null;
+                blockFirstMatch = null;
+            }
 
-            var content = matchSet.Contains(lineIndex)
-                ? HighlightKeyword(lines[lineIndex], keyword)
-                : lines[lineIndex];
+            blockStart ??= lineIndex;
+            var isMatch = matchSet.Contains(lineIndex);
+            if (isMatch && blockFirstMatch == null)
+                blockFirstMatch = lineIndex;
+
+            var content = isMatch ? HighlightKeyword(lines[lineIndex], keyword) : lines[lineIndex];
             result.AppendLine(DocumentTextFormat.Line(lineIndex + 1, content));
             previous = lineIndex;
         }
 
+        AppendBlockLink(
+            result,
+            lines,
+            document,
+            linkBuilder,
+            blockStart,
+            previous,
+            blockFirstMatch
+        );
         result.AppendLine();
+    }
+
+    private static void AppendBlockLink(
+        StringBuilder result,
+        string[] lines,
+        Document document,
+        IDocumentExcerptLinkBuilder linkBuilder,
+        int? blockStart,
+        int? blockEnd,
+        int? blockFirstMatch
+    )
+    {
+        if (
+            linkBuilder == null
+            || blockStart == null
+            || blockEnd == null
+            || blockFirstMatch == null
+        )
+            return;
+
+        // Line numbers are rendered 1-based; the builder gets the same basis.
+        var url = linkBuilder.BuildExcerptUrl(
+            document,
+            blockStart.Value + 1,
+            blockEnd.Value + 1,
+            lines[blockFirstMatch.Value]
+        );
+        if (url != null)
+            result.AppendLine($"Link: {url}");
     }
 
     private static string HighlightKeyword(string line, string keyword)

--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -5,6 +5,7 @@ using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Mcp;
 using Equibles.Mcp.Helpers;
 using Equibles.Media.BusinessLogic;
+using Equibles.Sec.BusinessLogic.Search;
 using Equibles.Sec.Repositories;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -16,17 +17,22 @@ public class DocumentTextTools
 {
     private readonly DocumentRepository _documentRepository;
     private readonly IFileManager _fileManager;
+    private readonly IDocumentExcerptLinkBuilder _excerptLinkBuilder;
     private readonly McpToolRunner _runner;
 
+    // The excerpt link builder is optional by design — no framework registration exists,
+    // and the container falls back to null on deployments without a public viewer.
     public DocumentTextTools(
         DocumentRepository documentRepository,
         ErrorManager errorManager,
         IFileManager fileManager,
-        ILogger<DocumentTextTools> logger
+        ILogger<DocumentTextTools> logger,
+        IDocumentExcerptLinkBuilder excerptLinkBuilder = null
     )
     {
         _documentRepository = documentRepository;
         _fileManager = fileManager;
+        _excerptLinkBuilder = excerptLinkBuilder;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -52,7 +58,8 @@ public class DocumentTextTools
                     _fileManager,
                     documentId,
                     keyword,
-                    maxResults
+                    maxResults,
+                    _excerptLinkBuilder
                 ),
             "SearchDocumentKeyword",
             $"documentId: {documentId}, keyword: {keyword}",

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -44,8 +44,11 @@ public class RagSearchTools
     private readonly CommonStockRepository _commonStockRepository;
     private readonly DocumentRepository _documentRepository;
     private readonly IFileManager _fileManager;
+    private readonly IDocumentExcerptLinkBuilder _excerptLinkBuilder;
     private readonly McpToolRunner _runner;
 
+    // The excerpt link builder is optional by design — no framework registration exists,
+    // and the container falls back to null on deployments without a public viewer.
     public RagSearchTools(
         IRagManager ragManager,
         ISecDocumentService secDocumentService,
@@ -53,7 +56,8 @@ public class RagSearchTools
         DocumentRepository documentRepository,
         IFileManager fileManager,
         ErrorManager errorManager,
-        ILogger<RagSearchTools> logger
+        ILogger<RagSearchTools> logger,
+        IDocumentExcerptLinkBuilder excerptLinkBuilder = null
     )
     {
         _ragManager = ragManager;
@@ -61,6 +65,7 @@ public class RagSearchTools
         _commonStockRepository = commonStockRepository;
         _documentRepository = documentRepository;
         _fileManager = fileManager;
+        _excerptLinkBuilder = excerptLinkBuilder;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -118,7 +123,8 @@ public class RagSearchTools
                 var context = await _ragManager.BuildContext(
                     chunks,
                     includeDocumentIds: true,
-                    maxExcerptChars: maxExcerptChars
+                    maxExcerptChars: maxExcerptChars,
+                    includeExcerptLinks: true
                 );
                 return AppendShortfallNote(context, chunks.Count, maxResults);
             },
@@ -183,7 +189,8 @@ public class RagSearchTools
                 var context = await _ragManager.BuildContext(
                     chunks,
                     includeDocumentIds: true,
-                    maxExcerptChars: maxExcerptChars
+                    maxExcerptChars: maxExcerptChars,
+                    includeExcerptLinks: true
                 );
                 return AppendShortfallNote(context, chunks.Count, maxResults);
             },
@@ -229,7 +236,8 @@ public class RagSearchTools
                         _fileManager,
                         documentId,
                         query,
-                        maxResults
+                        maxResults,
+                        _excerptLinkBuilder
                     );
                 if (mode != "semantic")
                     return $"Unknown searchMode \"{searchMode}\" — pass 'semantic' (default) or 'exact'.";
@@ -254,7 +262,8 @@ public class RagSearchTools
                 var context = await _ragManager.BuildContext(
                     chunks,
                     includeDocumentIds: true,
-                    maxExcerptChars: maxExcerptChars
+                    maxExcerptChars: maxExcerptChars,
+                    includeExcerptLinks: true
                 );
                 return context
                     + $"_{chunks.Count} excerpt(s) returned (maxResults {maxResults}); excerpts are in document order — pass an excerpt's line number to ReadDocumentLines for surrounding context._";

--- a/tests/Equibles.UnitTests/Sec/DocumentKeywordScanBlockLinkTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentKeywordScanBlockLinkTests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.BusinessLogic.Search;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+// The keyword scan's per-block excerpt links: with a link builder present, each merged
+// grep-style block ends with ONE "Link: <url>" line anchored on the block's rendered line
+// span (1-based) and the block's first MATCHED line's text — never a context line's. With
+// no builder (the framework default) the rendering is byte-identical to before the seam
+// existed.
+public class DocumentKeywordScanBlockLinkTests
+{
+    private sealed class RecordingLinkBuilder : IDocumentExcerptLinkBuilder
+    {
+        public readonly List<(int FromLine, int ToLine, string ExcerptText)> Calls = [];
+
+        public string BuildExcerptUrl(
+            Document document,
+            int fromLine,
+            int toLine,
+            string excerptText
+        )
+        {
+            Calls.Add((fromLine, toLine, excerptText));
+            return $"https://example.com/{fromLine}-{toLine}";
+        }
+    }
+
+    private static string Render(
+        string[] lines,
+        List<int> matches,
+        string keyword,
+        IDocumentExcerptLinkBuilder linkBuilder
+    )
+    {
+        var method = typeof(DocumentKeywordScan).GetMethod(
+            "AppendMatchBlocks",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var result = new StringBuilder();
+        var document = new Document
+        {
+            CommonStock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." },
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 12, 31),
+        };
+        method!.Invoke(null, [result, lines, matches, keyword, document, linkBuilder]);
+        return result.ToString();
+    }
+
+    private static readonly string[] Lines =
+    [
+        "alpha",
+        "revenue grew strongly",
+        "beta",
+        "gamma",
+        "delta",
+        "epsilon",
+        "costs of revenue fell",
+        "zeta",
+    ];
+
+    [Fact]
+    public void AppendMatchBlocks_TwoSeparateBlocks_EachEndsWithItsOwnLink()
+    {
+        var builder = new RecordingLinkBuilder();
+
+        var rendered = Render(Lines, [1, 6], "revenue", builder);
+
+        builder.Calls.Should().HaveCount(2);
+        // Block one renders lines 1-3 (1-based): context, match, context.
+        builder.Calls[0].Should().Be((1, 3, "revenue grew strongly"));
+        // Block two renders lines 6-8.
+        builder.Calls[1].Should().Be((6, 8, "costs of revenue fell"));
+        rendered.Should().Contain("Link: https://example.com/1-3");
+        rendered.Should().Contain("Link: https://example.com/6-8");
+    }
+
+    [Fact]
+    public void AppendMatchBlocks_LinkNamesTheMatchedLine_NotAContextLine()
+    {
+        var builder = new RecordingLinkBuilder();
+
+        Render(Lines, [1], "revenue", builder);
+
+        builder.Calls.Should().ContainSingle();
+        builder.Calls[0].ExcerptText.Should().Be("revenue grew strongly");
+    }
+
+    [Fact]
+    public void AppendMatchBlocks_NoBuilder_RendersNoLinkLines()
+    {
+        var rendered = Render(Lines, [1, 6], "revenue", null);
+
+        rendered.Should().NotContain("Link:");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/RagManagerBuildContextExcerptLinkTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagManagerBuildContextExcerptLinkTests.cs
@@ -1,0 +1,133 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.BusinessLogic.Search;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+
+namespace Equibles.UnitTests.Sec;
+
+// The optional excerpt-link seam: when a deployment registers an IDocumentExcerptLinkBuilder
+// AND the caller opts in with includeExcerptLinks, each rendered excerpt gains a trailing
+// "Link: <url>" line anchored on the chunk's line span. Everything else must stay
+// byte-identical — the flag defaults to false and the builder to null, so existing callers
+// (and deployments without a public viewer) render exactly what they rendered before.
+public class RagManagerBuildContextExcerptLinkTests
+{
+    private sealed class RecordingLinkBuilder : IDocumentExcerptLinkBuilder
+    {
+        public Document Document;
+        public int FromLine;
+        public int ToLine;
+        public string ExcerptText;
+        public string Url = "https://example.com/doc";
+
+        public string BuildExcerptUrl(
+            Document document,
+            int fromLine,
+            int toLine,
+            string excerptText
+        )
+        {
+            Document = document;
+            FromLine = fromLine;
+            ToLine = toLine;
+            ExcerptText = excerptText;
+            return Url;
+        }
+    }
+
+    private static RagManager Sut(IDocumentExcerptLinkBuilder linkBuilder = null) =>
+        new(
+            hybridChunkSearcher: null,
+            commonStockRepository: null,
+            logger: null,
+            excerptLinkBuilder: linkBuilder
+        );
+
+    private static Document NewDocument() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommonStock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." },
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 12, 31),
+        };
+
+    private static Chunk NewChunk(Document document, string content, int startLineNumber = 10) =>
+        new()
+        {
+            Index = 0,
+            StartPosition = 0,
+            StartLineNumber = startLineNumber,
+            Content = content,
+            Document = document,
+        };
+
+    [Fact]
+    public async Task BuildContext_OptedInWithBuilder_AppendsLinkLineAfterExcerptContent()
+    {
+        var builder = new RecordingLinkBuilder();
+        var chunk = NewChunk(NewDocument(), "Revenue grew.");
+
+        var result = await Sut(builder).BuildContext([chunk], includeExcerptLinks: true);
+
+        result.Should().Contain("Revenue grew.\nLink: https://example.com/doc\n");
+    }
+
+    [Fact]
+    public async Task BuildContext_LineSpanCoversTheChunk_AndTextIsTheRawChunkContent()
+    {
+        var builder = new RecordingLinkBuilder();
+        var content = "line one\nline two\nline three";
+        var chunk = NewChunk(NewDocument(), content, startLineNumber: 42);
+
+        await Sut(builder).BuildContext([chunk], includeExcerptLinks: true);
+
+        builder.FromLine.Should().Be(42);
+        builder.ToLine.Should().Be(44, "toLine is the start line plus the content's newlines");
+        builder.ExcerptText.Should().Be(content, "the builder truncates and encodes itself");
+        builder.Document.Should().BeSameAs(chunk.Document);
+    }
+
+    [Fact]
+    public async Task BuildContext_DefaultArguments_StaysLinkFreeEvenWithABuilder()
+    {
+        var builder = new RecordingLinkBuilder();
+        var chunk = NewChunk(NewDocument(), "Revenue grew.");
+
+        var result = await Sut(builder).BuildContext([chunk]);
+
+        result.Should().NotContain("Link:");
+    }
+
+    [Fact]
+    public async Task BuildContext_OptedInWithoutABuilder_StaysLinkFree()
+    {
+        var chunk = NewChunk(NewDocument(), "Revenue grew.");
+
+        var result = await Sut().BuildContext([chunk], includeExcerptLinks: true);
+
+        result.Should().NotContain("Link:");
+    }
+
+    [Fact]
+    public async Task BuildContext_ChunkWithoutALineNumber_GetsNoLink()
+    {
+        var builder = new RecordingLinkBuilder();
+        var chunk = NewChunk(NewDocument(), "Revenue grew.", startLineNumber: 0);
+
+        var result = await Sut(builder).BuildContext([chunk], includeExcerptLinks: true);
+
+        result.Should().NotContain("Link:");
+    }
+
+    [Fact]
+    public async Task BuildContext_BuilderDeclines_GetsNoLinkLine()
+    {
+        var builder = new RecordingLinkBuilder { Url = null };
+        var chunk = NewChunk(NewDocument(), "Revenue grew.");
+
+        var result = await Sut(builder).BuildContext([chunk], includeExcerptLinks: true);
+
+        result.Should().NotContain("Link:");
+    }
+}


### PR DESCRIPTION
## What

Adds `IDocumentExcerptLinkBuilder` — an optional deployment seam that turns one document excerpt into a public "view this passage" URL — and wires it through the document-search renderings:

- `RagManager.BuildContext` gains `includeExcerptLinks` (default **false**). When a builder is registered and the caller opts in, each excerpt gains a trailing `Link: <url>` line anchored on the chunk's line span (`StartLineNumber .. StartLineNumber + content newlines`) plus the chunk's raw text, so a viewer can refine the approximate line anchor by matching the passage itself.
- `DocumentKeywordScan` emits one link per merged grep-style match block, anchored on the block's rendered 1-based line span and its first **matched** line's text (never a context line).
- The three semantic search tools opt in; `SearchDocumentKeyword` and `SearchDocument`'s exact mode pass the builder through.

## Why

A downstream deployment with a public document viewer wants search results that deep-link to the exact cited passage. The framework itself stays viewer-agnostic: **no implementation is registered here**, the builder is an optional constructor dependency (DI falls back to null), and with no builder every rendering is byte-identical to before this change.

## Tests

- `RagManagerBuildContextExcerptLinkTests`: link line placement, line-span arithmetic, raw text pass-through, and the three link-free paths (flag off, no builder, builder declines, no line number).
- `DocumentKeywordScanBlockLinkTests`: one link per block, span + matched-line anchoring, no-builder rendering unchanged.
- Full unit suite: 4420/4420 green.