### PR TITLE
fix(web): restate share balances onto today's split basis on the web read surfaces

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -2409,6 +2409,11 @@ public class InstitutionalHoldingsTools
     // Restates the quarterly-activity diff onto today's split basis, then re-classifies the
     // movement buckets from the restated counts. A zero side is preserved by restatement, so
     // Initiated/Exited stay put; only Increased/Reduced/Unchanged can flip.
+    //
+    // MIRROR: the commercial repo's ALVIS runtime carries a deliberate, test-pinned copy of
+    // this logic (Equibles.Agent.BusinessLogic.QuarterlyActivitySplitRestater) because this
+    // method is private and the host references the tool modules, not the reverse. A change
+    // to the rebucketing contract here must be mirrored there in the same change.
     private async Task RestateAndRebucketQuarterlyActivity(
         Dictionary<StockPositionChangeType, List<StockPositionChange>> grouped,
         DateOnly currentDate,

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -1446,12 +1446,22 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     // round trip, joins CommonStock + Industry for display columns and the % of float
     // calculation, and applies each non-null criterion as a server-side filter so result
     // pagination stays cheap. Caller materializes with ToListAsync.
+    //
+    // splitAffectedStockIds: stocks with a split effective after `current` — their as-filed
+    // CurrentShares sits on a different basis than today's SharesOutStanding, so the SQL
+    // % of float predicates PASS them THROUGH instead of judging them on a wrong ratio;
+    // ScreenRestated re-judges them in memory on the restated count. Null/empty keeps the
+    // pure-SQL behaviour.
     public IQueryable<ScreenerRow> Screen(
         ScreenerCriteria criteria,
         DateOnly current,
-        DateOnly previous
+        DateOnly previous,
+        IReadOnlyCollection<Guid> splitAffectedStockIds = null
     )
     {
+        var pctPassthroughIds = splitAffectedStockIds is { Count: > 0 }
+            ? splitAffectedStockIds.ToList()
+            : null;
         var aggregated = BothQuarters(current, previous)
             .GroupBy(h => h.CommonStockId)
             .Select(g => new
@@ -1554,18 +1564,38 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             // SharesOutStanding == 0 means "unknown" in the current schema; any % filter
             // excludes those stocks rather than treating them as 100% held (false positive).
             .WhereIf(
-                criteria.MinPctFloat.HasValue,
+                criteria.MinPctFloat.HasValue && pctPassthroughIds == null,
                 j =>
                     j.cs.SharesOutStanding > 0
                     && (double)j.agg.CurrentShares / j.cs.SharesOutStanding * 100.0
                         >= criteria.MinPctFloat.Value
             )
             .WhereIf(
-                criteria.MaxPctFloat.HasValue,
+                criteria.MinPctFloat.HasValue && pctPassthroughIds != null,
+                j =>
+                    pctPassthroughIds.Contains(j.agg.CommonStockId)
+                    || (
+                        j.cs.SharesOutStanding > 0
+                        && (double)j.agg.CurrentShares / j.cs.SharesOutStanding * 100.0
+                            >= criteria.MinPctFloat.Value
+                    )
+            )
+            .WhereIf(
+                criteria.MaxPctFloat.HasValue && pctPassthroughIds == null,
                 j =>
                     j.cs.SharesOutStanding > 0
                     && (double)j.agg.CurrentShares / j.cs.SharesOutStanding * 100.0
                         <= criteria.MaxPctFloat.Value
+            )
+            .WhereIf(
+                criteria.MaxPctFloat.HasValue && pctPassthroughIds != null,
+                j =>
+                    pctPassthroughIds.Contains(j.agg.CommonStockId)
+                    || (
+                        j.cs.SharesOutStanding > 0
+                        && (double)j.agg.CurrentShares / j.cs.SharesOutStanding * 100.0
+                            <= criteria.MaxPctFloat.Value
+                    )
             );
 
         return joined.Select(j => new ScreenerRow
@@ -1588,6 +1618,83 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
                     ? (double?)((double)j.agg.CurrentShares / j.cs.SharesOutStanding * 100.0)
                     : null,
         });
+    }
+
+    // Split-aware screener entry point: runs Screen with % of float passthrough for stocks
+    // that split after `current`, restates those stocks' CurrentShares / PercentOfFloat onto
+    // today's basis from their exact per-listing sums, re-applies the % filters on the
+    // restated ratio, and caps the ordered result. Ordering is by CurrentValue (a dollar
+    // figure, split-invariant), so the SQL Take fast path stays correct whenever no
+    // in-memory % re-judgement is needed.
+    //
+    // splitsSinceCurrent: splits effective strictly after `current` and on or before today
+    // (load via StockSplitRepository.GetEffective(today) — announced-but-not-effective rows
+    // must never restate anything).
+    public async Task<List<ScreenerRow>> ScreenRestated(
+        ScreenerCriteria criteria,
+        DateOnly current,
+        DateOnly previous,
+        IReadOnlyList<StockSplit> splitsSinceCurrent,
+        int? rowCap,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var splitsByStock = (splitsSinceCurrent ?? [])
+            .Where(s => s.Numerator > 0 && s.Denominator > 0)
+            .GroupBy(s => s.CommonStockId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<StockSplit>)g.ToList());
+
+        var query = Screen(criteria, current, previous, splitsByStock.Keys.ToList())
+            .OrderByDescending(r => r.CurrentValue);
+
+        // The SQL % predicates passed affected stocks through un-judged, so the cap can
+        // only apply after the in-memory re-judgement; without an active % filter the
+        // passthrough changes nothing and the SQL Take fast path is exact.
+        var pctFilterActive = criteria.MinPctFloat.HasValue || criteria.MaxPctFloat.HasValue;
+        var needsInMemoryPctPass = splitsByStock.Count > 0 && pctFilterActive;
+
+        var rows =
+            rowCap.HasValue && !needsInMemoryPctPass
+                ? await query.Take(rowCap.Value).ToListAsync(cancellationToken)
+                : await query.ToListAsync(cancellationToken);
+
+        var affectedRows = rows.Where(r => splitsByStock.ContainsKey(r.CommonStockId)).ToList();
+        if (affectedRows.Count > 0)
+        {
+            var affectedIds = affectedRows.Select(r => r.CommonStockId).Distinct().ToList();
+            var listingShares = await BothQuarters(current, previous)
+                .Where(h => h.ReportDate == current && affectedIds.Contains(h.CommonStockId))
+                .GroupBy(h => new { h.CommonStockId, h.ListedTicker })
+                .Select(g => new ScreenerListingShares
+                {
+                    CommonStockId = g.Key.CommonStockId,
+                    ListedTicker = g.Key.ListedTicker,
+                    Shares = g.Sum(h => h.Shares),
+                })
+                .ToListAsync(cancellationToken);
+            var listingSharesByStock = listingShares
+                .GroupBy(s => s.CommonStockId)
+                .ToDictionary(g => g.Key, g => (IReadOnlyList<ScreenerListingShares>)g.ToList());
+
+            foreach (var row in affectedRows)
+                ScreenerSplitRestatement.RestateRow(
+                    row,
+                    listingSharesByStock.GetValueOrDefault(row.CommonStockId) ?? [],
+                    splitsByStock[row.CommonStockId],
+                    current
+                );
+
+            if (needsInMemoryPctPass)
+                rows = rows.Where(r =>
+                        !splitsByStock.ContainsKey(r.CommonStockId)
+                        || ScreenerSplitRestatement.PassesPctFloat(r, criteria)
+                    )
+                    .ToList();
+        }
+
+        return rowCap.HasValue && rows.Count > rowCap.Value
+            ? rows.Take(rowCap.Value).ToList()
+            : rows;
     }
 
     public IQueryable<FilingActivitySummary> GetFilingActivitySummary(

--- a/src/Equibles.Holdings.Repositories/ScreenerSplitRestatement.cs
+++ b/src/Equibles.Holdings.Repositories/ScreenerSplitRestatement.cs
@@ -1,0 +1,73 @@
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+/// <summary>
+/// One stock's current-quarter share sum for one exact listed series
+/// (<c>ListedTicker == null</c> is the primary listing), feeding the screener's
+/// per-listing split restatement.
+/// </summary>
+public sealed class ScreenerListingShares
+{
+    public Guid CommonStockId { get; set; }
+    public string ListedTicker { get; set; }
+    public long Shares { get; set; }
+}
+
+/// <summary>
+/// In-memory half of the split-aware screener: restates a split-affected row's
+/// share count and % of float onto today's basis. Pure so it stays unit-testable
+/// without a database.
+/// </summary>
+public static class ScreenerSplitRestatement
+{
+    /// <summary>
+    /// Restates <see cref="ScreenerRow.CurrentShares"/> from the exact per-listing sums
+    /// (a split attributed to one share class must never multiply a sibling listing's
+    /// count) and recomputes <see cref="ScreenerRow.PercentOfFloat"/> against today's
+    /// <see cref="ScreenerRow.SharesOutStanding"/>. Dollar values stay as filed.
+    /// </summary>
+    public static void RestateRow(
+        ScreenerRow row,
+        IReadOnlyList<ScreenerListingShares> currentListingShares,
+        IReadOnlyList<StockSplit> splitsSinceCurrent,
+        DateOnly current
+    )
+    {
+        long restated = 0;
+        foreach (var slice in currentListingShares)
+        {
+            var scoped = PriceSeriesSplitScope.ForListing(
+                splitsSinceCurrent,
+                row.Ticker,
+                slice.ListedTicker ?? row.Ticker
+            );
+            restated += SplitAdjustment.AdjustShareCount(slice.Shares, current, scoped);
+        }
+        row.CurrentShares = restated;
+        row.PercentOfFloat =
+            row.SharesOutStanding > 0 ? (double)restated / row.SharesOutStanding * 100.0 : null;
+    }
+
+    /// <summary>
+    /// The % of float criteria as the SQL predicates apply them: an absent %
+    /// (unknown SharesOutStanding) fails any active bound rather than passing.
+    /// </summary>
+    public static bool PassesPctFloat(ScreenerRow row, ScreenerCriteria criteria) =>
+        (
+            !criteria.MinPctFloat.HasValue
+            || (
+                row.PercentOfFloat.HasValue
+                && row.PercentOfFloat.Value >= criteria.MinPctFloat.Value
+            )
+        )
+        && (
+            !criteria.MaxPctFloat.HasValue
+            || (
+                row.PercentOfFloat.HasValue
+                && row.PercentOfFloat.Value <= criteria.MaxPctFloat.Value
+            )
+        );
+}

--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
 using Equibles.Web.Controllers.Abstract;
@@ -18,17 +20,31 @@ public class HoldingsScreenerController : BaseController
 
     private readonly InstitutionalHoldingRepository _holdingRepository;
     private readonly IndustryRepository _industryRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
 
     public HoldingsScreenerController(
         InstitutionalHoldingRepository holdingRepository,
         IndustryRepository industryRepository,
+        StockSplitRepository stockSplitRepository,
         ILogger<HoldingsScreenerController> logger
     )
         : base(logger)
     {
         _holdingRepository = holdingRepository;
         _industryRepository = industryRepository;
+        _stockSplitRepository = stockSplitRepository;
     }
+
+    // Splits effective after the screened quarter (and on or before today): those stocks'
+    // as-filed 13F counts sit on a different basis than today's SharesOutStanding, so
+    // ScreenRestated restates them before the % of float judgement. GetEffective already
+    // excludes announced-but-not-yet-effective rows.
+    private Task<List<StockSplit>> LoadSplitsSince(DateOnly current) =>
+        _stockSplitRepository
+            .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
+            .AsNoTracking()
+            .Where(s => s.EffectiveDate > current)
+            .ToListAsync();
 
     [HttpGet("~/holdings/screener")]
     public async Task<IActionResult> Screener(
@@ -70,11 +86,13 @@ public class HoldingsScreenerController : BaseController
         viewModel.ComparisonDate = comparisonDate.Value;
 
         var criteria = ToCriteria(filters);
-        var rows = await _holdingRepository
-            .Screen(criteria, selectedDate.Value, comparisonDate.Value)
-            .OrderByDescending(r => r.CurrentValue)
-            .Take(RowCap)
-            .ToListAsync();
+        var rows = await _holdingRepository.ScreenRestated(
+            criteria,
+            selectedDate.Value,
+            comparisonDate.Value,
+            await LoadSplitsSince(selectedDate.Value),
+            RowCap
+        );
 
         viewModel.Rows = rows.Select(r => new ScreenerResultRow
             {
@@ -116,10 +134,13 @@ public class HoldingsScreenerController : BaseController
         // matching row, not the first 200. Materializing the full result set here is fine:
         // the Screen query is already filtered server-side, so the row count is bounded by
         // the user's criteria rather than the universe.
-        var rows = await _holdingRepository
-            .Screen(criteria, selectedDate.Value, comparisonDate.Value)
-            .OrderByDescending(r => r.CurrentValue)
-            .ToListAsync();
+        var rows = await _holdingRepository.ScreenRestated(
+            criteria,
+            selectedDate.Value,
+            comparisonDate.Value,
+            await LoadSplitsSince(selectedDate.Value),
+            rowCap: null
+        );
 
         var csv = BuildCsv(rows);
         var filename =

--- a/src/Equibles.Web/Services/HoldingShareRestatement.cs
+++ b/src/Equibles.Web/Services/HoldingShareRestatement.cs
@@ -1,0 +1,37 @@
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Web.Services;
+
+/// <summary>
+/// Restates a 13F row's share count onto today's post-split basis, from the row's own
+/// <see cref="InstitutionalHolding.ReportDate"/> (a combined-quarter view mixes report dates,
+/// so a page-wide date would miss carried rows). Restatement is per exact listed series:
+/// a split attributed to one share class must never multiply a sibling listing's count
+/// (see <see cref="PriceSeriesSplitScope.ForListing"/>). Dollar values stay as filed —
+/// they are split-invariant.
+/// </summary>
+public static class HoldingShareRestatement
+{
+    /// <param name="effectiveSplits">
+    /// The stock's splits already filtered to effective-as-of-today
+    /// (<c>StockSplitRepository.GetEffectiveByStock</c>) — an announced but not yet
+    /// effective split must never restate anything.
+    /// </param>
+    public static long RestateToToday(
+        InstitutionalHolding holding,
+        IReadOnlyList<StockSplit> effectiveSplits,
+        string primaryTicker
+    )
+    {
+        if (effectiveSplits == null || effectiveSplits.Count == 0)
+            return holding.Shares;
+        var scoped = PriceSeriesSplitScope.ForListing(
+            effectiveSplits,
+            primaryTicker,
+            holding.ListedTicker ?? primaryTicker
+        );
+        return SplitAdjustment.AdjustShareCount(holding.Shares, holding.ReportDate, scoped);
+    }
+}

--- a/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
+++ b/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
@@ -1,8 +1,15 @@
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Web.ViewModels.Stocks;
 
 namespace Equibles.Web.Services;
 
+// The commercial repo carries a deliberate fork of this class
+// (Equibles.Web.Providers.Services.HoldingsPositionGrouper). Their split-restatement
+// behaviour must stay equivalent, but the classification contracts intentionally
+// diverge: this copy keeps a 0-share-both-quarters holder as an Unchanged row
+// (pinned by HoldingsPositionGrouperZeroSharesBothQuartersTests) while the
+// commercial copy skips those rows entirely. Never blind-copy either direction.
 public static class HoldingsPositionGrouper
 {
     /// <param name="filersWithCurrentQuarterFilings">
@@ -19,10 +26,27 @@ public static class HoldingsPositionGrouper
         IReadOnlyList<InstitutionalHolding> currentHoldings,
         IReadOnlyList<InstitutionalHolding> previousHoldings,
         IReadOnlySet<Guid> filersWithCurrentQuarterFilings
+    ) => Group(currentHoldings, previousHoldings, filersWithCurrentQuarterFilings, [], null);
+
+    /// <param name="effectiveSplits">
+    /// The stock's splits effective as of today. Every share count is restated onto
+    /// today's post-split basis from its row's own report date before aggregation and
+    /// bucket classification — a split between the two quarters otherwise reads as a
+    /// phantom Increased (forward) or Reduced (reverse) row for every unchanged holder.
+    /// Restatement is per exact listed series (see <see cref="HoldingShareRestatement"/>);
+    /// dollar values stay as filed. Pass an empty list for as-filed behaviour.
+    /// </param>
+    /// <param name="primaryTicker">The stock's primary ticker, scoping split attribution.</param>
+    public static Dictionary<PositionChangeType, List<HolderPositionChange>> Group(
+        IReadOnlyList<InstitutionalHolding> currentHoldings,
+        IReadOnlyList<InstitutionalHolding> previousHoldings,
+        IReadOnlySet<Guid> filersWithCurrentQuarterFilings,
+        IReadOnlyList<StockSplit> effectiveSplits,
+        string primaryTicker
     )
     {
-        var currentByHolder = AggregateByHolder(currentHoldings);
-        var previousByHolder = AggregateByHolder(previousHoldings);
+        var currentByHolder = AggregateByHolder(currentHoldings, effectiveSplits, primaryTicker);
+        var previousByHolder = AggregateByHolder(previousHoldings, effectiveSplits, primaryTicker);
 
         var result = new Dictionary<PositionChangeType, List<HolderPositionChange>>
         {
@@ -98,7 +122,9 @@ public static class HoldingsPositionGrouper
     }
 
     private static Dictionary<Guid, HolderAggregate> AggregateByHolder(
-        IReadOnlyList<InstitutionalHolding> holdings
+        IReadOnlyList<InstitutionalHolding> holdings,
+        IReadOnlyList<StockSplit> effectiveSplits,
+        string primaryTicker
     )
     {
         return holdings
@@ -114,7 +140,13 @@ public static class HoldingsPositionGrouper
                     LatestHolding = g.OrderBy(h => h.ListedTicker == null ? 0 : 1)
                         .ThenByDescending(h => h.FilingDate)
                         .First(),
-                    TotalShares = g.Sum(h => h.Shares),
+                    // Restate per ROW, not per aggregate: a holder's total can mix share
+                    // classes, and a sibling-class count only moves on its own series'
+                    // splits — one factor over the mixed sum would restate the sibling's
+                    // part by the primary's ratio.
+                    TotalShares = g.Sum(h =>
+                        HoldingShareRestatement.RestateToToday(h, effectiveSplits, primaryTicker)
+                    ),
                     TotalValue = g.Sum(h => h.Value),
                 }
             );

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -6,6 +6,9 @@ using Equibles.Congress.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Core.Extensions;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data.Extensions;
 using Equibles.Finra.Repositories;
 using Equibles.Holdings.BusinessLogic;
@@ -48,6 +51,7 @@ public class StockTabService
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly MarketActivityShareRestater _marketActivityShareRestater;
+    private readonly StockSplitRepository _stockSplitRepository;
 
     // Data before the configured sync floor is partial — the scrapers only
     // backfill from it — so historical series clamp to it rather than render
@@ -80,7 +84,8 @@ public class StockTabService
         FinancialConceptRepository financialConceptRepository,
         CommonStockRepository commonStockRepository,
         IOptions<WorkerOptions> workerOptions = null,
-        MarketActivityShareRestater marketActivityShareRestater = null
+        MarketActivityShareRestater marketActivityShareRestater = null,
+        StockSplitRepository stockSplitRepository = null
     )
     {
         _minSyncDate = workerOptions?.Value.MinSyncDate is { } floor
@@ -103,6 +108,20 @@ public class StockTabService
         _financialConceptRepository = financialConceptRepository;
         _commonStockRepository = commonStockRepository;
         _marketActivityShareRestater = marketActivityShareRestater;
+        _stockSplitRepository = stockSplitRepository;
+    }
+
+    // The stock's splits effective as of today, for restating share balances onto today's
+    // post-split basis at read time (stored rows stay as filed). Empty when the optional
+    // repository is absent (test constructors), which keeps every consumer as-filed.
+    private async Task<IReadOnlyList<StockSplit>> LoadEffectiveSplits(CommonStock stock)
+    {
+        if (_stockSplitRepository == null)
+            return [];
+        return await _stockSplitRepository
+            .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+            .AsNoTracking()
+            .ToListAsync();
     }
 
     // Whether the holdings tab should OPEN in the combined view: the newest quarter's filing
@@ -150,10 +169,13 @@ public class StockTabService
             selectedDate
         );
 
+        var effectiveSplits = await LoadEffectiveSplits(stock);
         var grouped = HoldingsPositionGrouper.Group(
             allCurrent,
             allPrevious,
-            filersWithCurrentQuarterFilings
+            filersWithCurrentQuarterFilings,
+            effectiveSplits,
+            stock.Ticker
         );
 
         var allChanges = grouped.SelectMany(g => g.Value).ToList();
@@ -171,7 +193,12 @@ public class StockTabService
             SelectedDate = selectedDate,
             Ticker = stock.Ticker,
             TotalValue = allCurrent.Sum(h => h.Value),
-            TotalShares = allCurrent.Sum(h => h.Shares),
+            // Restated onto today's split basis so the header stat matches the ownership
+            // trend's latest point (the trend is restated by MarketActivityShareRestater)
+            // and stays comparable to today's SharesOutStanding.
+            TotalShares = allCurrent.Sum(h =>
+                HoldingShareRestatement.RestateToToday(h, effectiveSplits, stock.Ticker)
+            ),
             HolderCount = allCurrent.Select(h => h.InstitutionalHolderId).Distinct().Count(),
             SharesOutstanding = stock.SharesOutStanding,
             OwnershipTrend = await LoadOwnershipTrend(stock),
@@ -209,6 +236,11 @@ public class StockTabService
             .Include(h => h.InstitutionalHolder)
             .ToListAsync();
 
+        // Restate from each ROW's own report date: carried-forward rows keep the previous
+        // quarter's date, so a split between the two quarters only rescales the rows that
+        // actually predate it.
+        var effectiveSplits = await LoadEffectiveSplits(stock);
+
         var holders = allCombined
             .GroupBy(h => h.InstitutionalHolderId)
             .Select(g =>
@@ -223,7 +255,9 @@ public class StockTabService
                     CurrentHolding = g.OrderBy(h => h.ListedTicker == null ? 0 : 1)
                         .ThenByDescending(h => h.FilingDate)
                         .First(),
-                    CurrentShares = g.Sum(h => h.Shares),
+                    CurrentShares = g.Sum(h =>
+                        HoldingShareRestatement.RestateToToday(h, effectiveSplits, stock.Ticker)
+                    ),
                     CurrentValue = g.Sum(h => h.Value),
                     ChangeType = PositionChangeType.Unchanged,
                     LatestReportDate = latestDate,
@@ -248,7 +282,9 @@ public class StockTabService
             SelectedDate = current,
             Ticker = stock.Ticker,
             TotalValue = allCombined.Sum(h => h.Value),
-            TotalShares = allCombined.Sum(h => h.Shares),
+            TotalShares = allCombined.Sum(h =>
+                HoldingShareRestatement.RestateToToday(h, effectiveSplits, stock.Ticker)
+            ),
             HolderCount = holders.Count,
             SharesOutstanding = stock.SharesOutStanding,
             OwnershipTrend = await LoadOwnershipTrend(stock),
@@ -261,27 +297,77 @@ public class StockTabService
 
     public async Task<ShortVolumeTabViewModel> LoadShortVolumeTab(CommonStock stock)
     {
+        // AsNoTracking: the rows are mutated below for display (restated onto today's
+        // split basis) and must never flush back through a tracked context.
         var shortVolumes = await FetchMostRecentAscending(
-            _dailyShortVolumeRepository.GetHistoryByStock(stock),
+            _dailyShortVolumeRepository.GetHistoryByStock(stock).AsNoTracking(),
             d => d.Date,
             90
         );
+        var primarySplits = await LoadPrimarySeriesSplits(stock);
+        foreach (var row in shortVolumes)
+        {
+            var factor = SplitAdjustment.ShareCountFactor(row.Date, primarySplits);
+            if (factor == 1m)
+                continue;
+            row.ShortVolume = SplitAdjustment.AdjustShareCount(row.ShortVolume, factor);
+            row.ShortExemptVolume = SplitAdjustment.AdjustShareCount(row.ShortExemptVolume, factor);
+            // TotalVolume restates by the same factor, so the short-of-total ratio stays
+            // exactly as filed (same-observation ratios are split-invariant).
+            row.TotalVolume = SplitAdjustment.AdjustShareCount(row.TotalVolume, factor);
+        }
         return new ShortVolumeTabViewModel { ShortVolumes = shortVolumes, Ticker = stock.Ticker };
     }
 
     public async Task<ShortInterestTabViewModel> LoadShortInterestTab(CommonStock stock)
     {
         var shortInterests = await FetchMostRecentAscending(
-            _shortInterestRepository.GetHistoryByStock(stock),
+            _shortInterestRepository.GetHistoryByStock(stock).AsNoTracking(),
             s => s.SettlementDate,
             24
         );
+        var primarySplits = await LoadPrimarySeriesSplits(stock);
+        foreach (var row in shortInterests)
+        {
+            var factor = SplitAdjustment.ShareCountFactor(row.SettlementDate, primarySplits);
+            if (factor == 1m)
+                continue;
+            row.CurrentShortPosition = SplitAdjustment.AdjustShareCount(
+                row.CurrentShortPosition,
+                factor
+            );
+            row.PreviousShortPosition = SplitAdjustment.AdjustShareCount(
+                row.PreviousShortPosition,
+                factor
+            );
+            row.ChangeInShortPosition = SplitAdjustment.AdjustShareCount(
+                row.ChangeInShortPosition,
+                factor
+            );
+            // ADV restates with the position so the stored DaysToCover (position ÷ ADV, a
+            // same-observation ratio) stays consistent with both printed magnitudes.
+            if (row.AverageDailyVolume.HasValue)
+                row.AverageDailyVolume = SplitAdjustment.AdjustShareCount(
+                    row.AverageDailyVolume.Value,
+                    factor
+                );
+        }
         return new ShortInterestTabViewModel
         {
             ShortInterests = shortInterests,
             Ticker = stock.Ticker,
         };
     }
+
+    // FINRA report magnitudes belong to the stock's PRIMARY listed series, so restatement
+    // uses only splits attributed to that exact series (a sibling share class's split must
+    // never rescale them).
+    private async Task<List<StockSplit>> LoadPrimarySeriesSplits(CommonStock stock) =>
+        PriceSeriesSplitScope.ForListing(
+            await LoadEffectiveSplits(stock),
+            stock.Ticker,
+            stock.Ticker
+        );
 
     public async Task<FtdTabViewModel> LoadFtdTab(CommonStock stock)
     {
@@ -768,12 +854,29 @@ public class StockTabService
         InstitutionalHolder holder
     )
     {
+        // AsNoTracking: rows are mutated below for display and must never flush back.
         var holdings = await _institutionalHoldingRepository
             .GetHistoryByStock(stock)
             .Where(h => h.InstitutionalHolderId == holder.Id)
             .OrderByDescending(h => h.ReportDate)
             .Take(50)
+            .AsNoTracking()
             .ToListAsync();
+
+        // Restate every quarter's count onto today's split basis so the position-over-time
+        // chart is continuous across a split and the quarter-over-quarter change compares
+        // like with like (as filed, an unchanged position reads as a 10x jump across a
+        // 10:1 forward split). Values stay as filed.
+        var effectiveSplits = await LoadEffectiveSplits(stock);
+        if (effectiveSplits.Count > 0)
+        {
+            foreach (var holding in holdings)
+                holding.Shares = HoldingShareRestatement.RestateToToday(
+                    holding,
+                    effectiveSplits,
+                    stock.Ticker
+                );
+        }
 
         return new HolderDetailViewModel
         {

--- a/tests/Equibles.UnitTests/Holdings/ScreenerSplitRestatementTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/ScreenerSplitRestatementTests.cs
@@ -1,0 +1,143 @@
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// The in-memory half of the split-aware screener: a stock that split after the screened
+/// quarter gets its CurrentShares and % of float restated onto today's basis from exact
+/// per-listing sums, and the % filters re-judge the restated ratio (the SQL predicates
+/// passed such stocks through un-judged).
+/// </summary>
+public class ScreenerSplitRestatementTests
+{
+    private static readonly DateOnly Current = new(2026, 6, 30);
+
+    [Fact]
+    public void RestateRow_ReverseSplitAfterTheQuarter_ShrinksSharesAndPercent()
+    {
+        // The BYND shape: 1-for-30 reverse split after the screened quarter. The as-filed
+        // 30M count over the post-split 2M float would read 1500%; restated it is 50%.
+        var row = new ScreenerRow
+        {
+            Ticker = "BYND",
+            SharesOutStanding = 2_000_000,
+            CurrentShares = 30_000_000,
+            PercentOfFloat = 1_500.0,
+        };
+        List<StockSplit> splits =
+        [
+            new StockSplit
+            {
+                EffectiveDate = Current.AddDays(20),
+                Numerator = 1m,
+                Denominator = 30m,
+                PriceSeriesTicker = "BYND",
+            },
+        ];
+
+        ScreenerSplitRestatement.RestateRow(
+            row,
+            [new ScreenerListingShares { ListedTicker = null, Shares = 30_000_000 }],
+            splits,
+            Current
+        );
+
+        row.CurrentShares.Should().Be(1_000_000);
+        row.PercentOfFloat.Should().Be(50.0);
+    }
+
+    [Fact]
+    public void RestateRow_SiblingListingSlice_IsNeverRescaledByThePrimarySplit()
+    {
+        var row = new ScreenerRow
+        {
+            Ticker = "GOOGL",
+            SharesOutStanding = 100_000,
+            CurrentShares = 1_700,
+        };
+        List<StockSplit> splits =
+        [
+            new StockSplit
+            {
+                EffectiveDate = Current.AddDays(5),
+                Numerator = 10m,
+                Denominator = 1m,
+                PriceSeriesTicker = "GOOGL",
+            },
+        ];
+
+        ScreenerSplitRestatement.RestateRow(
+            row,
+            [
+                new ScreenerListingShares { ListedTicker = null, Shares = 1_000 },
+                new ScreenerListingShares { ListedTicker = "GOOG", Shares = 700 },
+            ],
+            splits,
+            Current
+        );
+
+        // Primary 1,000 → 10,000; the sibling class's 700 stays as filed.
+        row.CurrentShares.Should().Be(10_700);
+        row.PercentOfFloat.Should().Be(10.7);
+    }
+
+    [Fact]
+    public void RestateRow_UnknownSharesOutstanding_AnswersNullPercent()
+    {
+        var row = new ScreenerRow
+        {
+            Ticker = "TINY",
+            SharesOutStanding = 0,
+            PercentOfFloat = null,
+        };
+
+        ScreenerSplitRestatement.RestateRow(
+            row,
+            [new ScreenerListingShares { ListedTicker = null, Shares = 5_000 }],
+            [
+                new StockSplit
+                {
+                    EffectiveDate = Current.AddDays(1),
+                    Numerator = 2m,
+                    Denominator = 1m,
+                    PriceSeriesTicker = "TINY",
+                },
+            ],
+            Current
+        );
+
+        row.CurrentShares.Should().Be(10_000);
+        row.PercentOfFloat.Should().BeNull();
+    }
+
+    [Fact]
+    public void PassesPctFloat_MirrorsTheSqlPredicates()
+    {
+        var criteria = new ScreenerCriteria { MinPctFloat = 10.0, MaxPctFloat = 60.0 };
+
+        ScreenerSplitRestatement
+            .PassesPctFloat(new ScreenerRow { PercentOfFloat = 25.0 }, criteria)
+            .Should()
+            .BeTrue();
+        ScreenerSplitRestatement
+            .PassesPctFloat(new ScreenerRow { PercentOfFloat = 5.0 }, criteria)
+            .Should()
+            .BeFalse();
+        ScreenerSplitRestatement
+            .PassesPctFloat(new ScreenerRow { PercentOfFloat = 75.0 }, criteria)
+            .Should()
+            .BeFalse();
+        // Unknown SharesOutStanding (null %) fails any active bound, matching SQL.
+        ScreenerSplitRestatement
+            .PassesPctFloat(new ScreenerRow { PercentOfFloat = null }, criteria)
+            .Should()
+            .BeFalse();
+        // No bounds set: everything passes.
+        ScreenerSplitRestatement
+            .PassesPctFloat(new ScreenerRow { PercentOfFloat = null }, new ScreenerCriteria())
+            .Should()
+            .BeTrue();
+    }
+}

--- a/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperSplitRestatementTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperSplitRestatementTests.cs
@@ -1,0 +1,223 @@
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Web.Services;
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.UnitTests.Web;
+
+/// <summary>
+/// The split-aware Group overload restates every share count onto today's post-split
+/// basis from the row's own report date before aggregation and classification. A split
+/// between the two quarters otherwise reads as a phantom Increased (forward) or Reduced
+/// (reverse) row for every unchanged holder. Restatement is per exact listed series: a
+/// split attributed to the primary class must never rescale a sibling listing's count.
+/// </summary>
+public class HoldingsPositionGrouperSplitRestatementTests
+{
+    private const string PrimaryTicker = "NVDA";
+    private static readonly DateOnly PreviousQuarter = new(2024, 3, 31);
+    private static readonly DateOnly CurrentQuarter = new(2024, 6, 30);
+
+    // 10:1 forward split between the quarters, attributed to the primary series.
+    private static List<StockSplit> ForwardSplitBetweenQuarters() =>
+        [
+            new StockSplit
+            {
+                EffectiveDate = new DateOnly(2024, 6, 10),
+                Numerator = 10m,
+                Denominator = 1m,
+                PriceSeriesTicker = PrimaryTicker,
+            },
+        ];
+
+    private static InstitutionalHolding MakeHolding(
+        Guid holderId,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value,
+        string listedTicker = null
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            InstitutionalHolderId = holderId,
+            InstitutionalHolder = holder,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(30),
+            Shares = shares,
+            Value = value,
+            ListedTicker = listedTicker,
+        };
+
+    [Fact]
+    public void UnchangedHolderAcrossAForwardSplit_ClassifiesAsUnchanged()
+    {
+        // 1,000 shares held through the 10:1 split: filed as 1,000 then 10,000. As filed
+        // that buckets Increased with a phantom +9,000 delta.
+        var holderId = Guid.NewGuid();
+        var holder = new InstitutionalHolder { Id = holderId, Name = "Steady Fund" };
+        var previous = MakeHolding(holderId, holder, PreviousQuarter, shares: 1_000, value: 90);
+        var current = MakeHolding(holderId, holder, CurrentQuarter, shares: 10_000, value: 100);
+
+        var grouped = HoldingsPositionGrouper.Group(
+            [current],
+            [previous],
+            null,
+            ForwardSplitBetweenQuarters(),
+            PrimaryTicker
+        );
+
+        grouped[PositionChangeType.Increased].Should().BeEmpty();
+        var change = grouped[PositionChangeType.Unchanged].Should().ContainSingle().Subject;
+        change.CurrentShares.Should().Be(10_000);
+        change.PreviousShares.Should().Be(10_000);
+    }
+
+    [Fact]
+    public void UnchangedHolderAcrossAReverseSplit_ClassifiesAsUnchanged()
+    {
+        // 30,000 shares through a 1-for-30 reverse split: filed as 30,000 then 1,000 —
+        // as filed that reads as a near-total sell.
+        var holderId = Guid.NewGuid();
+        var holder = new InstitutionalHolder { Id = holderId, Name = "Patient Fund" };
+        var previous = MakeHolding(holderId, holder, PreviousQuarter, shares: 30_000, value: 90);
+        var current = MakeHolding(holderId, holder, CurrentQuarter, shares: 1_000, value: 100);
+        List<StockSplit> reverse =
+        [
+            new StockSplit
+            {
+                EffectiveDate = new DateOnly(2024, 6, 10),
+                Numerator = 1m,
+                Denominator = 30m,
+                PriceSeriesTicker = PrimaryTicker,
+            },
+        ];
+
+        var grouped = HoldingsPositionGrouper.Group(
+            [current],
+            [previous],
+            null,
+            reverse,
+            PrimaryTicker
+        );
+
+        grouped[PositionChangeType.Reduced].Should().BeEmpty();
+        var change = grouped[PositionChangeType.Unchanged].Should().ContainSingle().Subject;
+        change.PreviousShares.Should().Be(1_000);
+    }
+
+    [Fact]
+    public void RealTrimAcrossTheSplit_StaysReducedWithRestatedCounts()
+    {
+        // Sold half through the 10:1 split: 1,000 pre-split → 5,000 post-split shares.
+        // As filed that reads +4,000 (Increased).
+        var holderId = Guid.NewGuid();
+        var holder = new InstitutionalHolder { Id = holderId, Name = "Trimming Fund" };
+        var previous = MakeHolding(holderId, holder, PreviousQuarter, shares: 1_000, value: 90);
+        var current = MakeHolding(holderId, holder, CurrentQuarter, shares: 5_000, value: 50);
+
+        var grouped = HoldingsPositionGrouper.Group(
+            [current],
+            [previous],
+            null,
+            ForwardSplitBetweenQuarters(),
+            PrimaryTicker
+        );
+
+        var change = grouped[PositionChangeType.Reduced].Should().ContainSingle().Subject;
+        change.PreviousShares.Should().Be(10_000);
+        change.CurrentShares.Should().Be(5_000);
+    }
+
+    [Fact]
+    public void SiblingListingRow_IsNeverRescaledByThePrimarySeriesSplit()
+    {
+        // The holder owns 1,000 primary shares plus 700 of a sibling class in both
+        // quarters. The 10:1 split is attributed to the PRIMARY series only, so the
+        // sibling's 700 must survive as-filed on both sides — an unscoped factor over
+        // the mixed sum would read 700 as 7,000.
+        var holderId = Guid.NewGuid();
+        var holder = new InstitutionalHolder { Id = holderId, Name = "Two-Class Fund" };
+        List<InstitutionalHolding> previous =
+        [
+            MakeHolding(holderId, holder, PreviousQuarter, shares: 1_000, value: 90),
+            MakeHolding(
+                holderId,
+                holder,
+                PreviousQuarter,
+                shares: 700,
+                value: 60,
+                listedTicker: "NVDA-B"
+            ),
+        ];
+        List<InstitutionalHolding> current =
+        [
+            MakeHolding(holderId, holder, CurrentQuarter, shares: 10_000, value: 100),
+            MakeHolding(
+                holderId,
+                holder,
+                CurrentQuarter,
+                shares: 700,
+                value: 70,
+                listedTicker: "NVDA-B"
+            ),
+        ];
+
+        var grouped = HoldingsPositionGrouper.Group(
+            current,
+            previous,
+            null,
+            ForwardSplitBetweenQuarters(),
+            PrimaryTicker
+        );
+
+        var change = grouped[PositionChangeType.Unchanged].Should().ContainSingle().Subject;
+        change.CurrentShares.Should().Be(10_700);
+        change.PreviousShares.Should().Be(10_700);
+    }
+
+    [Fact]
+    public void LegacyNullAttributedSplit_RestatesThePrimarySeries()
+    {
+        // Older captured splits carry no PriceSeriesTicker; they belong to the primary
+        // series (PriceSeriesSplitScope's legacy-null rule).
+        var holderId = Guid.NewGuid();
+        var holder = new InstitutionalHolder { Id = holderId, Name = "Legacy Fund" };
+        var previous = MakeHolding(holderId, holder, PreviousQuarter, shares: 1_000, value: 90);
+        var current = MakeHolding(holderId, holder, CurrentQuarter, shares: 10_000, value: 100);
+        List<StockSplit> legacy =
+        [
+            new StockSplit
+            {
+                EffectiveDate = new DateOnly(2024, 6, 10),
+                Numerator = 10m,
+                Denominator = 1m,
+                PriceSeriesTicker = null,
+            },
+        ];
+
+        var grouped = HoldingsPositionGrouper.Group(
+            [current],
+            [previous],
+            null,
+            legacy,
+            PrimaryTicker
+        );
+
+        grouped[PositionChangeType.Unchanged].Should().ContainSingle();
+    }
+
+    [Fact]
+    public void ThreeArgOverload_KeepsAsFiledBehaviour()
+    {
+        var holderId = Guid.NewGuid();
+        var holder = new InstitutionalHolder { Id = holderId, Name = "As-Filed Fund" };
+        var previous = MakeHolding(holderId, holder, PreviousQuarter, shares: 1_000, value: 90);
+        var current = MakeHolding(holderId, holder, CurrentQuarter, shares: 10_000, value: 100);
+
+        var grouped = HoldingsPositionGrouper.Group([current], [previous], null);
+
+        grouped[PositionChangeType.Increased].Should().ContainSingle();
+    }
+}


### PR DESCRIPTION
## Problem

Stored 13F and FINRA rows are as-filed by design, but the web tier printed share balances on their filing-date basis. Across a split that renders phantom magnitudes: an unchanged 13F position reads as a 10x buy (10:1 forward) or a near-total sell (1-for-30 reverse), the holder-detail chart shows a step, and % of float pairs an old-basis count with today's SharesOutStanding.

## What changed (read-path only, no stored row changes)

- **HoldingsPositionGrouper**: new split-aware `Group` overload restates every count from its row's own report date, per exact listed series via `PriceSeriesSplitScope.ForListing` (a primary-attributed split never rescales a sibling class). The 3-arg overload delegates with no splits, so existing behaviour and tests stand. Note: this class has a deliberate commercial fork; classification contracts intentionally diverge (documented in the header).
- **StockTabService**: holdings tab and combined view feed the grouper the stock's effective splits; header `TotalShares` restates (now consistent with the ownership trend, which `MarketActivityShareRestater` already restated); short-volume and short-interest tabs restate magnitudes on the primary series (stored same-observation ratios like DaysToCover stay as filed); holder-detail history restates each quarter so the position chart is continuous and the QoQ change compares like with like.
- **Holdings screener**: the SQL % of float predicates pass split-affected stocks through, and the new `ScreenRestated` re-judges them in memory on exact per-listing sums restated to today (`ScreenerSplitRestatement`, pure and unit-tested). Without an active % filter the SQL `Take` fast path is unchanged. `Screen` keeps its `IQueryable` shape (new optional passthrough parameter).
- **InstitutionalHoldingsTools**: cross-reference comment on `RestateAndRebucketQuarterlyActivity` naming its commercial mirror.

## Deliberate skips

- FTD surfaces stay as-filed (quantity × price is internally consistent; one cross-surface decision, deferred).
- Announced-but-not-yet-effective splits never restate (`GetEffectiveByStock`/`GetEffective` inputs only).

## Tests

- `HoldingsPositionGrouperSplitRestatementTests` (6): forward/reverse phantom kill, real trim keeps Reduced with restated delta, sibling-listing invariance, legacy null attribution, 3-arg as-filed.
- `ScreenerSplitRestatementTests` (4): reverse-split % recompute, sibling slice invariance, unknown-float null %, predicate parity with SQL.
- Full unit suite: 4,430 passed / 0 failed. `dotnet csharpier check .` clean. `dotnet build -c Release` 0 errors.