### PR TITLE
refactor(sec): make GetWithContent virtual like every other repository read

### DIFF
--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -177,7 +177,7 @@ public class DocumentRepository : BaseRepository<Document>
             );
     }
 
-    public async Task<Document> GetWithContent(Guid id)
+    public virtual async Task<Document> GetWithContent(Guid id)
     {
         // The content bytes ride along eagerly: leaving File.FileContent to a lazy load
         // lets an aborted or transient load mid-request corrupt the navigation's loaded


### PR DESCRIPTION
One-word change: `DocumentRepository.GetWithContent` gains `virtual`, matching the `BaseRepository` convention (`Get`, `GetAll`, `Add`, … are all virtual). A downstream consumer needs to stub it to pin controller wiring in a unit test; today it is the only read on the type that cannot be overridden. No behavior change. OSS unit suite 4430/4430 via vstest.