### PR TITLE
feat(sec): let named fund series keep their whole NPORT schedule

### DIFF
--- a/src/Equibles.Sec.HostedService/Helpers/NportFullFidelitySeries.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/NportFullFidelitySeries.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Equibles.Sec.HostedService.Helpers;
+
+/// <summary>
+/// The SEC fund series whose NPORT-P schedule of investments is stored whole, opting them out of
+/// the daily-index sweep's narrowing to positions in tracked stocks.
+///
+/// The sweep exists to answer the reverse "who holds this stock" lookup, so it keeps only the rows
+/// whose CUSIP matches a stock we track and drops the rest of the portfolio before persisting.
+/// That narrowing is lossy and unrecoverable by query — the dropped rows are never written — so a
+/// consumer that needs a fund's complete schedule (reading an index tracker's portfolio as the
+/// index's constituent list, say) cannot be served from a narrowed filing at all. Listing a series
+/// here trades the storage of its whole portfolio for a complete schedule.
+///
+/// Empty by default: with nothing configured the sweep narrows exactly as it always has.
+/// </summary>
+public static class NportFullFidelitySeries
+{
+    /// <summary>Configuration key holding the opted-in SEC series identifiers.</summary>
+    public const string ConfigurationKey = "NportSweep:FullFidelitySeriesIds";
+
+    /// <summary>No series opted in — the default, and the sweep's historical behaviour.</summary>
+    public static readonly IReadOnlySet<string> None = new HashSet<string>(
+        StringComparer.OrdinalIgnoreCase
+    );
+
+    private static readonly char[] Separators = [',', ';', ' ', '\t', '\r', '\n'];
+
+    /// <summary>
+    /// Reads the opted-in series identifiers. Accepts either a configuration array (an appsettings
+    /// list, or indexed <c>NportSweep__FullFidelitySeriesIds__0</c> environment variables) or one
+    /// delimited scalar (<c>NportSweep__FullFidelitySeriesIds=S000030000,S000030003</c>) — the
+    /// shape a container deployment can express in a single variable. Blank entries are dropped and
+    /// matching is case-insensitive, so a hand-typed value still lines up with EDGAR's uppercase
+    /// identifiers.
+    /// </summary>
+    public static IReadOnlySet<string> FromConfiguration(IConfiguration configuration)
+    {
+        var section = configuration?.GetSection(ConfigurationKey);
+        if (section == null)
+            return None;
+
+        var seriesIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // The scalar form carries every id in one delimited value; the array form carries one per
+        // child. Both are read so a mixed configuration (an appsettings array overridden by a
+        // single environment variable) still resolves to the union rather than silently to one.
+        AddDelimited(seriesIds, section.Value);
+        foreach (var child in section.GetChildren())
+            AddDelimited(seriesIds, child.Value);
+
+        return seriesIds;
+    }
+
+    private static void AddDelimited(HashSet<string> seriesIds, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        foreach (var seriesId in value.Split(Separators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = seriesId.Trim();
+            if (trimmed.Length > 0)
+                seriesIds.Add(trimmed);
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/NportFilingReprocessWorker.cs
+++ b/src/Equibles.Sec.HostedService/NportFilingReprocessWorker.cs
@@ -1,7 +1,9 @@
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Worker;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -32,19 +34,29 @@ public class NportFilingReprocessWorker : BaseScraperWorker
     // starting at the same time.
     protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(5);
 
+    private readonly IConfiguration _configuration;
+
     public NportFilingReprocessWorker(
         ILogger<NportFilingReprocessWorker> logger,
         IServiceScopeFactory scopeFactory,
-        ErrorReporter errorReporter
+        ErrorReporter errorReporter,
+        IConfiguration configuration
     )
-        : base(logger, scopeFactory, errorReporter) { }
+        : base(logger, scopeFactory, errorReporter)
+    {
+        _configuration = configuration;
+    }
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
+        // Read from the sweep's own configuration: the two workers must agree on which series keep
+        // a whole schedule, or reprocess would re-narrow what the sweep just stored in full.
+        var fullFidelitySeriesIds = NportFullFidelitySeries.FromConfiguration(_configuration);
+
         await using var scope = ScopeFactory.CreateAsyncScope();
         var manager = scope.ServiceProvider.GetRequiredService<NportFilingReprocessManager>();
 
-        var result = await manager.Run(stoppingToken);
+        var result = await manager.Run(fullFidelitySeriesIds, stoppingToken);
 
         if (result.Processed > 0)
             Logger.LogInformation("NPORT-P filing reprocess cycle: {Summary}", result.Summary);

--- a/src/Equibles.Sec.HostedService/NportRealtimeWorker.cs
+++ b/src/Equibles.Sec.HostedService/NportRealtimeWorker.cs
@@ -1,5 +1,6 @@
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Worker;
 using Microsoft.Extensions.Configuration;
@@ -79,6 +80,7 @@ public class NportRealtimeWorker : BaseScraperWorker
             1,
             _configuration.GetValue("NportSweep:MaxFetchesPerCycle", DefaultMaxFetchesPerCycle)
         );
+        var fullFidelitySeriesIds = NportFullFidelitySeries.FromConfiguration(_configuration);
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
 
         await using var scope = ScopeFactory.CreateAsyncScope();
@@ -88,6 +90,7 @@ public class NportRealtimeWorker : BaseScraperWorker
             today,
             lookbackDays,
             maxFetches,
+            fullFidelitySeriesIds,
             stoppingToken
         );
 

--- a/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
@@ -75,8 +75,20 @@ public class NportFilingReprocessManager
         _logger = logger;
     }
 
-    public async Task<NportFilingReprocessResult> Run(CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Brings every filing below <see cref="NportFiling.CurrentParserVersion"/> up to date.
+    /// Filings of a series in <paramref name="fullFidelitySeriesIds"/> keep their whole schedule
+    /// rather than being re-narrowed to tracked-stock positions, and any of that series' filings
+    /// still holding a narrowed schedule are re-enrolled first so the opt-in heals history too.
+    /// </summary>
+    public async Task<NportFilingReprocessResult> Run(
+        IReadOnlySet<string> fullFidelitySeriesIds = null,
+        CancellationToken cancellationToken = default
+    )
     {
+        fullFidelitySeriesIds ??= NportFullFidelitySeries.None;
+        await ReenrollNarrowedFullFidelityFilings(fullFidelitySeriesIds, cancellationToken);
+
         var result = new NportFilingReprocessResult
         {
             Total = await _filingRepository
@@ -128,7 +140,11 @@ public class NportFilingReprocessManager
 
                 try
                 {
-                    result.HoldingsAdded += await ReprocessFiling(filing, cancellationToken);
+                    result.HoldingsAdded += await ReprocessFiling(
+                        filing,
+                        fullFidelitySeriesIds,
+                        cancellationToken
+                    );
                     result.Processed++;
                 }
                 catch (DbUpdateException ex) when (IsUniqueViolation(ex))
@@ -189,6 +205,62 @@ public class NportFilingReprocessManager
         return result;
     }
 
+    // Drops the parser stamp on opted-in filings whose stored schedule is still narrowed, so the
+    // pass below re-derives them from EDGAR. Bumping CurrentParserVersion would do the same job for
+    // the whole table — a six-figure re-fetch through the shared SEC budget — where the opt-in only
+    // invalidates the series it names.
+    //
+    // Two guards keep it from looping. The selection is self-clearing: a filing re-derived at full
+    // fidelity ends with its schedule matching its reported count and stops being selected. And a
+    // filing EDGAR will never return advances to the current version at the attempt ceiling, so
+    // this skips it rather than resetting the stamp the ceiling just set.
+    private async Task ReenrollNarrowedFullFidelityFilings(
+        IReadOnlySet<string> fullFidelitySeriesIds,
+        CancellationToken cancellationToken
+    )
+    {
+        if (fullFidelitySeriesIds.Count == 0)
+            return;
+
+        var narrowed = await _filingRepository
+            .GetNarrowedBelowReportedCount(fullFidelitySeriesIds.ToList())
+            .Where(f => f.ParserVersion >= NportFiling.CurrentParserVersion)
+            .Where(f => f.ReprocessAttempts < MaxReprocessAttempts)
+            .Select(f => f.Id)
+            .ToListAsync(cancellationToken);
+
+        if (narrowed.Count == 0)
+            return;
+
+        // Version 0 is the pre-versioning marker the reprocess pass already treats as "re-derive
+        // me", so it needs no separate sentinel.
+        if (_dbContext.Database.IsRelational())
+        {
+            await _filingRepository
+                .GetAll()
+                .Where(f => narrowed.Contains(f.Id))
+                .ExecuteUpdateAsync(s => s.SetProperty(f => f.ParserVersion, 0), cancellationToken);
+        }
+        else
+        {
+            // The in-memory provider (tests) has no ExecuteUpdate; the seeded set is tiny.
+            var filings = await _filingRepository
+                .GetAll()
+                .Where(f => narrowed.Contains(f.Id))
+                .ToListAsync(cancellationToken);
+            foreach (var filing in filings)
+                filing.ParserVersion = 0;
+            await _filingRepository.SaveChanges();
+        }
+
+        _dbContext.ChangeTracker.Clear();
+
+        _logger.LogInformation(
+            "NPORT-P reprocess: re-enrolled {Count} filings of full-fidelity series still holding a narrowed schedule",
+            narrowed.Count
+        );
+    }
+
     // Only a unique violation is trusted as "another writer got there first" and retried without
     // burning an attempt; every other database failure (e.g. a length or constraint violation) is
     // deterministic for the filing and must count toward the ceiling.
@@ -198,7 +270,11 @@ public class NportFilingReprocessManager
     // Returns the number of holdings parsed onto the filing. Throws on any fetch/parse failure so
     // the caller can record the attempt and retry the filing on a later run. The EDGAR fetch and
     // parse run before any database write, so a failure never leaves the filing half-replaced.
-    private async Task<int> ReprocessFiling(NportFiling filing, CancellationToken cancellationToken)
+    private async Task<int> ReprocessFiling(
+        NportFiling filing,
+        IReadOnlySet<string> fullFidelitySeriesIds,
+        CancellationToken cancellationToken
+    )
     {
         // A sweep-discovered filing has no tracked stock; its registrant CIK is the one to re-fetch
         // from. A feed-crawled filing carries no registrant CIK and re-fetches via its stock's.
@@ -245,9 +321,16 @@ public class NportFilingReprocessManager
         // Sweep-discovered (registrant-only) filings keep only positions in stocks we track — they
         // exist solely to answer the reverse "who holds this stock" lookup. Re-derive that same
         // filtered schedule so reprocess doesn't re-inflate the filing with the fund's full
-        // portfolio of bonds, derivatives and untracked equities.
+        // portfolio of bonds, derivatives and untracked equities. A series opted into full fidelity
+        // is the exception and keeps everything — re-narrowing it here would silently undo the
+        // opt-in on the next parser-version bump. The freshly parsed id wins over the stored one so
+        // a filing whose series id was never captured can still be recognised.
+        var seriesId = string.IsNullOrEmpty(parsed.SeriesId) ? filing.SeriesId : parsed.SeriesId;
+        var fullFidelity =
+            !string.IsNullOrEmpty(seriesId) && fullFidelitySeriesIds.Contains(seriesId);
+
         var reparsedHoldings = parsed.Holdings;
-        if (filing.CommonStockId == null)
+        if (filing.CommonStockId == null && !fullFidelity)
         {
             var trackedCusips = await GetTrackedCusips();
             reparsedHoldings = parsed

--- a/src/Equibles.Sec.HostedService/Services/NportRealtimeIngestionService.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportRealtimeIngestionService.cs
@@ -27,6 +27,10 @@ namespace Equibles.Sec.HostedService.Services;
 /// the only consumer is the reverse "who holds this stock" lookup. A registrant that is itself a
 /// tracked stock is left to the issuer-feed crawler, which stores its reports at full fidelity, so
 /// the two paths never produce the same series twice.
+///
+/// A series named in <see cref="NportFullFidelitySeries"/> is exempt from that narrowing and keeps
+/// its whole schedule — for consumers that need a fund's complete portfolio rather than its overlap
+/// with our universe.
 /// </summary>
 [Service]
 public class NportRealtimeIngestionService
@@ -69,14 +73,19 @@ public class NportRealtimeIngestionService
     /// <paramref name="today"/>) for NPORT-P submissions, ingesting the trust-only ones that hold a
     /// stock we track. At most <paramref name="maxFetchesPerCycle"/> submissions are downloaded per
     /// cycle; when more remain the result flags it so the worker drains the rest promptly.
+    /// Filings of a series in <paramref name="fullFidelitySeriesIds"/> keep their whole schedule
+    /// instead of being narrowed to tracked-stock positions.
     /// </summary>
     public async Task<NportRealtimeResult> IngestRecentFilings(
         DateOnly today,
         int lookbackDays,
         int maxFetchesPerCycle,
+        IReadOnlySet<string> fullFidelitySeriesIds,
         CancellationToken cancellationToken
     )
     {
+        fullFidelitySeriesIds ??= NportFullFidelitySeries.None;
+
         var trackedCusips = await LoadTrackedCusips(cancellationToken);
         if (trackedCusips.Count == 0)
         {
@@ -124,7 +133,12 @@ public class NportRealtimeIngestionService
                 }
 
                 fetched++;
-                var outcome = await ProcessTrustFiling(entry, trackedCusips, cancellationToken);
+                var outcome = await ProcessTrustFiling(
+                    entry,
+                    trackedCusips,
+                    fullFidelitySeriesIds,
+                    cancellationToken
+                );
                 if (outcome == FilingOutcome.Stored)
                     stored++;
                 if (outcome != FilingOutcome.TransientFailure)
@@ -167,6 +181,7 @@ public class NportRealtimeIngestionService
     private async Task<FilingOutcome> ProcessTrustFiling(
         EdgarDailyIndexEntry entry,
         HashSet<string> trackedCusips,
+        IReadOnlySet<string> fullFidelitySeriesIds,
         CancellationToken cancellationToken
     )
     {
@@ -228,6 +243,19 @@ public class NportRealtimeIngestionService
         }
 
         filing.RegistrantCik = Truncate(entry.Cik, 16);
+
+        // An opted-in series keeps its whole schedule and is stored unconditionally: its consumer
+        // reads the fund's complete portfolio, so narrowing it to our universe would not merely
+        // shrink the row count — it would answer the wrong question. Storing it even when it holds
+        // nothing we track is what lets the series' latest report keep advancing.
+        if (
+            !string.IsNullOrEmpty(filing.SeriesId)
+            && fullFidelitySeriesIds.Contains(filing.SeriesId)
+        )
+        {
+            _nportFilingRepository.Add(filing);
+            return FilingOutcome.Stored;
+        }
 
         var trackedHoldings = filing
             .Holdings.Where(h => !string.IsNullOrEmpty(h.Cusip) && trackedCusips.Contains(h.Cusip))

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -103,6 +103,33 @@ public class NportFilingRepository : BaseRepository<NportFiling>
     }
 
     /// <summary>
+    /// Sweep-discovered filings of the given series whose stored schedule is shorter than the row
+    /// count the filing reported — that is, ones persisted while the series was still being
+    /// narrowed to tracked-stock positions. The reprocess pass re-enrolls exactly these so an
+    /// opted-in series heals its own history from EDGAR instead of needing a manual replay.
+    ///
+    /// The count comparison is the whole test and it is self-clearing: the parser stamps
+    /// <see cref="NportFiling.ReportedHoldingCount"/> from the same list it returns, so a filing
+    /// re-derived at full fidelity ends with the two equal and drops out. Filings whose reported
+    /// count was never captured (null, pre-versioning) are left alone rather than guessed at.
+    ///
+    /// Series ids are compared upper-cased on both sides: EDGAR writes them uppercase, but a
+    /// hand-typed configuration value must not silently match nothing.
+    /// </summary>
+    public IQueryable<NportFiling> GetNarrowedBelowReportedCount(
+        IReadOnlyCollection<string> seriesIds
+    )
+    {
+        var wanted = seriesIds.Select(s => s.ToUpperInvariant()).ToList();
+
+        return GetAll()
+            .Where(f => f.CommonStockId == null)
+            .Where(f => f.SeriesId != null && wanted.Contains(f.SeriesId.ToUpper()))
+            .Where(f => f.ReportedHoldingCount != null)
+            .Where(f => f.Holdings.Count < f.ReportedHoldingCount);
+    }
+
+    /// <summary>
     /// Each fund series' most recent NPORT report whose portfolio is as of the floor date or
     /// later. Series identity never compares name text — the same fund's name varies across
     /// filings ("and"/"&amp;", "Inc"/"Inc.", stray spaces, legal renames), which would freeze a

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
@@ -173,7 +173,118 @@ public class NportFilingReprocessManagerTests
         await secClient.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task Run_FullFidelitySeries_KeepsTheWholeScheduleInsteadOfNarrowing()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        // No tracked stock carries either CUSIP in the submission, so the narrowing a sweep-
+        // discovered filing normally gets would leave the schedule empty.
+        var filing = SeedSweepFiling(dbContext, parserVersion: 0);
+        secClient
+            .GetDocumentContent(filing.AccessionNumber, Arg.Any<string>())
+            .Returns(ValidNportSubmission);
+
+        var result = await manager.Run(SeriesSet("S000087771"));
+
+        result.HoldingsAdded.Should().Be(2);
+        var reprocessed = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        reprocessed.Holdings.Should().HaveCount(2);
+        reprocessed.ParserVersion.Should().Be(NportFiling.CurrentParserVersion);
+    }
+
+    [Fact]
+    public async Task Run_SweepFilingOfAnUnlistedSeries_IsStillNarrowed()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        var filing = SeedSweepFiling(dbContext, parserVersion: 0);
+        secClient
+            .GetDocumentContent(filing.AccessionNumber, Arg.Any<string>())
+            .Returns(ValidNportSubmission);
+
+        // An opt-in for some other series must not widen this one.
+        var result = await manager.Run(SeriesSet("S000030003"));
+
+        result.HoldingsAdded.Should().Be(0);
+        var reprocessed = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        reprocessed.Holdings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Run_OptedInFilingStillNarrowed_IsReenrolledAndHealed()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        // Already at the current parser version, so the version-driven pass would never select it —
+        // but its stored schedule is one row against the two the filing reported, the fingerprint of
+        // a filing persisted while the series was still being narrowed.
+        var filing = SeedSweepFiling(
+            dbContext,
+            parserVersion: NportFiling.CurrentParserVersion,
+            reportedHoldingCount: 2
+        );
+        SeedHolding(dbContext, filing, "AT&T Inc", "00206R102");
+        secClient
+            .GetDocumentContent(filing.AccessionNumber, Arg.Any<string>())
+            .Returns(ValidNportSubmission);
+
+        var result = await manager.Run(SeriesSet("S000087771"));
+
+        result.Processed.Should().Be(1);
+        var healed = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        healed.Holdings.Should().HaveCount(2);
+        healed.ParserVersion.Should().Be(NportFiling.CurrentParserVersion);
+
+        // Self-clearing: a healed filing matches its reported count, so a second pass leaves it be.
+        dbContext.ChangeTracker.Clear();
+        secClient.ClearReceivedCalls();
+        var second = await manager.Run(SeriesSet("S000087771"));
+
+        second.Total.Should().Be(0);
+        await secClient.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Run_OptedInFilingAtTheAttemptCeiling_IsNotReenrolled()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        // EDGAR will never return this submission; the ceiling already stamped it current. Re-
+        // enrolling it would undo that and retry forever, one cycle at a time.
+        var filing = SeedSweepFiling(
+            dbContext,
+            parserVersion: NportFiling.CurrentParserVersion,
+            reportedHoldingCount: 2,
+            reprocessAttempts: NportFilingReprocessManager.MaxReprocessAttempts
+        );
+        SeedHolding(dbContext, filing, "AT&T Inc", "00206R102");
+
+        var result = await manager.Run(SeriesSet("S000087771"));
+
+        result.Total.Should().Be(0);
+        await secClient.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
+        var untouched = await dbContext.Set<NportFiling>().SingleAsync();
+        untouched.ParserVersion.Should().Be(NportFiling.CurrentParserVersion);
+    }
+
+    [Fact]
+    public async Task Run_NarrowedFilingOfAnUnlistedSeries_IsNotReenrolled()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        var filing = SeedSweepFiling(
+            dbContext,
+            parserVersion: NportFiling.CurrentParserVersion,
+            reportedHoldingCount: 2
+        );
+        SeedHolding(dbContext, filing, "AT&T Inc", "00206R102");
+
+        var result = await manager.Run(SeriesSet("S000030003"));
+
+        result.Total.Should().Be(0);
+        await secClient.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
+    }
+
     // ── Helpers ──
+
+    private static IReadOnlySet<string> SeriesSet(params string[] seriesIds) =>
+        new HashSet<string>(seriesIds, StringComparer.OrdinalIgnoreCase);
 
     private static (
         NportFilingReprocessManager manager,
@@ -247,6 +358,55 @@ public class NportFilingReprocessManagerTests
         dbContext.SaveChanges();
         dbContext.ChangeTracker.Clear();
         return filing;
+    }
+
+    // A sweep-discovered filing: no tracked stock, identified by its registrant CIK. Its schedule
+    // is the one the tracked-CUSIP narrowing applies to.
+    private static NportFiling SeedSweepFiling(
+        Equibles.Data.EquiblesFinancialDbContext dbContext,
+        int parserVersion,
+        int? reportedHoldingCount = null,
+        int reprocessAttempts = 0
+    )
+    {
+        var filing = new NportFiling
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = null,
+            RegistrantCik = "0001100663",
+            SeriesId = "S000087771",
+            AccessionNumber = "0001104659-26-000099",
+            FilingDate = new DateOnly(2026, 3, 30),
+            ReportPeriodDate = new DateOnly(2026, 2, 28),
+            ReportPeriodEnd = new DateOnly(2026, 2, 28),
+            ParserVersion = parserVersion,
+            ReportedHoldingCount = reportedHoldingCount,
+            ReprocessAttempts = reprocessAttempts,
+        };
+        dbContext.Add(filing);
+        dbContext.SaveChanges();
+        dbContext.ChangeTracker.Clear();
+        return filing;
+    }
+
+    private static void SeedHolding(
+        Equibles.Data.EquiblesFinancialDbContext dbContext,
+        NportFiling filing,
+        string name,
+        string cusip
+    )
+    {
+        dbContext.Add(
+            new NportHolding
+            {
+                Id = Guid.NewGuid(),
+                NportFilingId = filing.Id,
+                Name = name,
+                Cusip = cusip,
+            }
+        );
+        dbContext.SaveChanges();
+        dbContext.ChangeTracker.Clear();
     }
 
     // A trimmed NPORT-P submission with two holdings, laid out as real EDGAR filings are —

--- a/tests/Equibles.IntegrationTests/Sec/NportRealtimeIngestionServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportRealtimeIngestionServiceTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -50,6 +51,7 @@ public class NportRealtimeIngestionServiceTests
             new DateOnly(2026, 3, 1),
             lookbackDays: 1,
             maxFetchesPerCycle: 100,
+            NportFullFidelitySeries.None,
             CancellationToken.None
         );
 
@@ -80,6 +82,7 @@ public class NportRealtimeIngestionServiceTests
             new DateOnly(2026, 3, 1),
             lookbackDays: 1,
             maxFetchesPerCycle: 100,
+            NportFullFidelitySeries.None,
             CancellationToken.None
         );
 
@@ -116,6 +119,7 @@ public class NportRealtimeIngestionServiceTests
             new DateOnly(2026, 3, 1),
             lookbackDays: 1,
             maxFetchesPerCycle: 100,
+            NportFullFidelitySeries.None,
             CancellationToken.None
         );
 
@@ -150,12 +154,19 @@ public class NportRealtimeIngestionServiceTests
             NportXml("SOME BOND TRUST", "S000099999", (BondCusip, "US TREASURY NOTE", 1m))
         );
 
-        await service.IngestRecentFilings(new DateOnly(2026, 3, 1), 1, 100, CancellationToken.None);
+        await service.IngestRecentFilings(
+            new DateOnly(2026, 3, 1),
+            1,
+            100,
+            NportFullFidelitySeries.None,
+            CancellationToken.None
+        );
         dbContext.ChangeTracker.Clear();
         var second = await service.IngestRecentFilings(
             new DateOnly(2026, 3, 1),
             1,
             100,
+            NportFullFidelitySeries.None,
             CancellationToken.None
         );
 
@@ -201,6 +212,7 @@ public class NportRealtimeIngestionServiceTests
             new DateOnly(2026, 3, 1),
             lookbackDays: 1,
             maxFetchesPerCycle: 100,
+            NportFullFidelitySeries.None,
             CancellationToken.None
         );
 
@@ -209,7 +221,113 @@ public class NportRealtimeIngestionServiceTests
         stored.Holdings.Should().ContainSingle().Which.Cusip.Should().Be(AppleCusip);
     }
 
+    [Fact]
+    public async Task IngestRecentFilings_FullFidelitySeries_StoresTheWholeSchedule()
+    {
+        var (service, dbContext, secClient) = CreateServiceWithDeps();
+        SeedStock(dbContext, "AAPL", cik: "0000320193", cusip: AppleCusip);
+
+        var entry = Entry("0000036405-26-000001", cik: "36405");
+        StubDailyIndex(secClient, entry);
+        StubContent(
+            secClient,
+            entry,
+            NportXml(
+                "VANGUARD INDEX FUNDS",
+                "S000030003",
+                (AppleCusip, "APPLE INC", 170_000_000m),
+                (BondCusip, "US TREASURY NOTE", 5_000_000m),
+                // A foreign-domiciled issuer whose CUSIP the filer masks — the row a narrowed
+                // schedule can never recover, and the reason the opt-in exists.
+                ("000000000", "LINDE PLC", 2_600_000m)
+            )
+        );
+
+        var result = await service.IngestRecentFilings(
+            new DateOnly(2026, 3, 1),
+            lookbackDays: 1,
+            maxFetchesPerCycle: 100,
+            SeriesSet("S000030003"),
+            CancellationToken.None
+        );
+
+        result.Stored.Should().Be(1);
+        var stored = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        stored.Holdings.Should().HaveCount(3);
+        stored
+            .Holdings.Should()
+            .HaveCount(
+                stored.ReportedHoldingCount.Value,
+                "a whole schedule matches the count the filing reported — the signal reprocess re-enrolls on"
+            );
+    }
+
+    [Fact]
+    public async Task IngestRecentFilings_FullFidelitySeriesHoldingNothingTracked_StillStores()
+    {
+        var (service, dbContext, secClient) = CreateServiceWithDeps();
+        SeedStock(dbContext, "AAPL", cik: "0000320193", cusip: AppleCusip);
+
+        var entry = Entry("0000036405-26-000002", cik: "36405");
+        StubDailyIndex(secClient, entry);
+        StubContent(
+            secClient,
+            entry,
+            NportXml("VANGUARD INDEX FUNDS", "S000030003", (BondCusip, "US TREASURY NOTE", 1m))
+        );
+
+        // Without the opt-in this filing is skip-recorded (it holds nothing we track and the series
+        // is unknown); with it the series' report must land so its latest period keeps advancing.
+        var result = await service.IngestRecentFilings(
+            new DateOnly(2026, 3, 1),
+            lookbackDays: 1,
+            maxFetchesPerCycle: 100,
+            SeriesSet("S000030003"),
+            CancellationToken.None
+        );
+
+        result.Stored.Should().Be(1);
+        var stored = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        stored.Holdings.Should().ContainSingle().Which.Cusip.Should().Be(BondCusip);
+    }
+
+    [Fact]
+    public async Task IngestRecentFilings_SeriesNotOptedIn_StillNarrows()
+    {
+        var (service, dbContext, secClient) = CreateServiceWithDeps();
+        SeedStock(dbContext, "AAPL", cik: "0000320193", cusip: AppleCusip);
+
+        var entry = Entry("0000036405-26-000003", cik: "36405");
+        StubDailyIndex(secClient, entry);
+        StubContent(
+            secClient,
+            entry,
+            NportXml(
+                "VANGUARD INDEX FUNDS",
+                "S000002277",
+                (AppleCusip, "APPLE INC", 1m),
+                (BondCusip, "US TREASURY NOTE", 1m)
+            )
+        );
+
+        // An opt-in elsewhere must not widen every other series the sweep meets.
+        await service.IngestRecentFilings(
+            new DateOnly(2026, 3, 1),
+            lookbackDays: 1,
+            maxFetchesPerCycle: 100,
+            SeriesSet("S000030003"),
+            CancellationToken.None
+        );
+
+        var stored = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        stored.Holdings.Should().ContainSingle().Which.Cusip.Should().Be(AppleCusip);
+        stored.ReportedHoldingCount.Should().Be(2);
+    }
+
     // ── Helpers ──
+
+    private static IReadOnlySet<string> SeriesSet(params string[] seriesIds) =>
+        new HashSet<string>(seriesIds, StringComparer.OrdinalIgnoreCase);
 
     private static (
         NportRealtimeIngestionService service,

--- a/tests/Equibles.UnitTests/Sec/NportFilingRepositoryQueryTranslationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/NportFilingRepositoryQueryTranslationTests.cs
@@ -54,6 +54,25 @@ public class NportFilingRepositoryQueryTranslationTests
     }
 
     [Fact]
+    public void GetNarrowedBelowReportedCount_TranslatesTheHoldingCountComparisonToSql()
+    {
+        using var ctx = CreateContext();
+        var repository = new NportFilingRepository(ctx);
+
+        // The whole re-enrollment selector is a correlated count against a nullable column. If a
+        // provider change stops translating it the query throws at runtime in the worker — a place
+        // no other test reaches — so pin that it reaches SQL at all, and that the null guard rides
+        // along rather than being optimised into a comparison that swallows unknown counts.
+        var sql = repository
+            .GetNarrowedBelowReportedCount(["S000030000", "S000030003"])
+            .ToQueryString();
+        var flat = System.Text.RegularExpressions.Regex.Replace(sql, @"\s+", " ");
+
+        flat.ToUpperInvariant().Should().Contain("SELECT COUNT(*)");
+        flat.Should().Contain("\"ReportedHoldingCount\" IS NOT NULL");
+    }
+
+    [Fact]
     public void GetLatestPerSeries_TranslatesToPartitionedBranches_WithHashableIdentityKeys()
     {
         using var ctx = CreateContext();

--- a/tests/Equibles.UnitTests/Sec/NportFullFidelitySeriesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/NportFullFidelitySeriesTests.cs
@@ -1,0 +1,66 @@
+using Equibles.Sec.HostedService.Helpers;
+using Microsoft.Extensions.Configuration;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Reading the opt-in list. Getting this wrong fails silently in the worst way: an unparsed value
+/// yields an empty set, the sweep keeps narrowing, and the only symptom is a fund's schedule being
+/// quietly short — so both configuration shapes a deployment can express are pinned here.
+/// </summary>
+public class NportFullFidelitySeriesTests
+{
+    [Fact]
+    public void FromConfiguration_Missing_IsEmpty()
+    {
+        Read().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FromConfiguration_ArrayForm_ReadsEveryElement()
+    {
+        var seriesIds = Read(
+            ("NportSweep:FullFidelitySeriesIds:0", "S000030000"),
+            ("NportSweep:FullFidelitySeriesIds:1", "S000030003")
+        );
+
+        seriesIds.Should().BeEquivalentTo(["S000030000", "S000030003"]);
+    }
+
+    [Fact]
+    public void FromConfiguration_DelimitedScalar_ReadsEveryEntry()
+    {
+        // The shape a container deployment can express in one environment variable.
+        var seriesIds = Read(
+            ("NportSweep:FullFidelitySeriesIds", "S000030000, S000030003 ;S000030017")
+        );
+
+        seriesIds.Should().BeEquivalentTo(["S000030000", "S000030003", "S000030017"]);
+    }
+
+    [Fact]
+    public void FromConfiguration_BlankEntries_AreDropped()
+    {
+        var seriesIds = Read(("NportSweep:FullFidelitySeriesIds", " , S000030000 ,, "));
+
+        seriesIds.Should().ContainSingle().Which.Should().Be("S000030000");
+    }
+
+    [Fact]
+    public void FromConfiguration_MatchesCaseInsensitively()
+    {
+        // EDGAR writes series ids uppercase; a hand-typed configuration value must still match.
+        var seriesIds = Read(("NportSweep:FullFidelitySeriesIds", "s000030000"));
+
+        seriesIds.Contains("S000030000").Should().BeTrue();
+    }
+
+    private static IReadOnlySet<string> Read(params (string key, string value)[] settings) =>
+        NportFullFidelitySeries.FromConfiguration(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    settings.Select(s => new KeyValuePair<string, string>(s.key, s.value))
+                )
+                .Build()
+        );
+}


### PR DESCRIPTION
## Problem

The daily-index NPORT-P sweep narrows every filing to positions whose CUSIP matches a tracked stock, because its only consumer is the reverse "who holds this stock" lookup. That narrowing is **lossy and unrecoverable by query** — the dropped rows are never written, so recovering them means re-fetching from EDGAR.

A consumer that needs a fund's *complete* schedule therefore cannot be served from a swept filing at all. Reading an index tracker's portfolio as the index's constituent list is exactly that consumer: iShares Russell 2000 stores 1807 of the 1946 rows it reported, and the 139 missing names are precisely the ones we cannot see.

## Change

- **`NportSweep:FullFidelitySeriesIds`** — an opt-in list of SEC series ids whose filings keep every row. Empty by default, so a deployment that does not opt in behaves exactly as before. Accepts either a configuration array or one delimited scalar (the shape a container can express in a single environment variable).
- **Reprocess learns the same list, twice over:**
  - It re-derives the narrowed schedule for sweep-discovered filings, which would have silently undone the opt-in on the next parser-version bump.
  - It **re-enrolls an opted-in series' already-narrowed filings**, so history heals itself from EDGAR. Bumping `CurrentParserVersion` would do that too, at the cost of re-fetching all ~124k filings through the shared SEC budget; the opt-in only invalidates the series it names.

## Why the re-enrollment terminates

Two guards, both load-bearing:

1. **Self-clearing selector.** `ParseEntity` stamps `ReportedHoldingCount` from the same list it returns, so a filing re-derived at full fidelity ends with `Holdings.Count == ReportedHoldingCount` and stops being selected. `null` reported counts are left alone rather than guessed at.
2. **Attempt ceiling respected.** A filing EDGAR will never return is advanced to the current version at `MaxReprocessAttempts`; re-enrollment skips those rather than resetting the stamp the ceiling just set.

## Tests

- `NportFullFidelitySeriesTests` — both configuration shapes, blank entries, case-insensitive matching.
- `NportRealtimeIngestionServiceTests` — whole schedule stored (including a `000000000`-CUSIP foreign issuer a narrowed filing can never recover); an opted-in series holding nothing tracked still stores; a series **not** opted in still narrows.
- `NportFilingReprocessManagerTests` — full-fidelity replay keeps everything; unlisted series still narrowed; a narrowed filing is re-enrolled and healed, and a second pass leaves it alone; the attempt ceiling and unlisted series are never re-enrolled.
- `NportFilingRepositoryQueryTranslationTests` — pins that the correlated count comparison reaches SQL, since the worker is the only place that query runs.

Full OSS suite green locally: 4436 unit, 457 Sec integration.