### PR TITLE
feat(sec): capture the Form 144 filer CIK and 10b5-1 plan adoption date

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/Form144FilerCikBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Form144FilerCikBackfillManager.cs
@@ -1,0 +1,223 @@
+using System.Xml.Linq;
+using Equibles.Core.AutoWiring;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// Fills <see cref="Form144Filing.FilerCik"/> and <see cref="Form144Filing.PlanAdoptionDate"/>
+/// on notices imported before those fields were captured, by re-reading each notice's XML from
+/// EDGAR.
+///
+/// The filer CIK is what makes a notice joinable to the filer's Forms 3/4/5, and therefore the
+/// only way to tell whether a proposed sale was ever executed. Without it the seller is free
+/// text, and matching on a name resolves only about half of the corpus.
+///
+/// <see cref="Form144Filing.FilerCik"/> being null is the single selector, so the run drains,
+/// terminates and resumes: an interrupted run continues where it left off. Notices EDGAR will
+/// not serve are parked with <see cref="UnavailableMarker"/> after
+/// <see cref="MaxAttempts"/> tries so one bad document cannot stall the backlog forever.
+/// </summary>
+[Service]
+public class Form144FilerCikBackfillManager
+{
+    /// <summary>
+    /// Parked value for a notice whose XML EDGAR will not serve, or which carries no filer
+    /// credentials. It is not a CIK and cannot collide with one, so it drops the notice out of
+    /// the work set without ever matching an <see cref="InsiderOwner"/>.
+    /// </summary>
+    public const string UnavailableMarker = "unavailable";
+
+    // Committed per batch, so a throttled or interrupted run keeps what it fetched.
+    private const int BatchSize = 64;
+    private const int MaxAttempts = 3;
+
+    private readonly Form144FilingRepository _repository;
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly ILogger<Form144FilerCikBackfillManager> _logger;
+
+    public Form144FilerCikBackfillManager(
+        Form144FilingRepository repository,
+        ISecEdgarClient secEdgarClient,
+        ILogger<Form144FilerCikBackfillManager> logger
+    )
+    {
+        _repository = repository;
+        _secEdgarClient = secEdgarClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Drains notices missing a filer CIK. Returns the number of notices resolved to a real CIK.
+    /// </summary>
+    public async Task<int> Run(CancellationToken cancellationToken = default)
+    {
+        var resolved = 0;
+        var attempts = new Dictionary<Guid, int>();
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var batch = await _repository
+                .GetAll()
+                .Where(f => f.FilerCik == null)
+                .Include(f => f.CommonStock)
+                .OrderBy(f => f.FilingDate)
+                .ThenBy(f => f.Id)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken);
+
+            if (batch.Count == 0)
+                break;
+
+            var progressed = false;
+
+            foreach (var filing in batch)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
+                var issuerCik = filing.CommonStock?.Cik;
+                if (string.IsNullOrEmpty(issuerCik))
+                {
+                    // The notice is attributed to an issuer with no CIK, so its document cannot
+                    // be addressed on EDGAR at all. Park it rather than retrying forever.
+                    filing.FilerCik = UnavailableMarker;
+                    progressed = true;
+                    continue;
+                }
+
+                if (!TryRecordAttempt(attempts, filing.Id))
+                {
+                    filing.FilerCik = UnavailableMarker;
+                    progressed = true;
+                    _logger.LogWarning(
+                        "Parking Form 144 {AccessionNumber} after {Attempts} failed attempts",
+                        filing.AccessionNumber,
+                        MaxAttempts
+                    );
+                    continue;
+                }
+
+                string xml;
+                try
+                {
+                    xml = await _secEdgarClient.GetDocumentContent(
+                        filing.AccessionNumber,
+                        issuerCik
+                    );
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogWarning(
+                        exception,
+                        "Failed to fetch Form 144 {AccessionNumber}",
+                        filing.AccessionNumber
+                    );
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(xml))
+                    continue;
+
+                var parsed = ParseIdentity(xml);
+                if (parsed.FilerCik == null)
+                {
+                    // Fetched cleanly but carries no filer credentials. Retrying cannot change
+                    // that, so park it immediately rather than burning the attempt budget.
+                    filing.FilerCik = UnavailableMarker;
+                    progressed = true;
+                    continue;
+                }
+
+                filing.FilerCik = parsed.FilerCik;
+                filing.PlanAdoptionDate = parsed.PlanAdoptionDate;
+                resolved++;
+                progressed = true;
+            }
+
+            await _repository.SaveChanges();
+
+            // Every notice in the batch failed transiently and none was parked, so the same
+            // batch would be re-read forever. Stop and let the next cycle retry.
+            if (!progressed)
+            {
+                _logger.LogWarning("Form 144 filer-CIK backfill made no progress; stopping cycle");
+                break;
+            }
+        }
+
+        return resolved;
+    }
+
+    private static bool TryRecordAttempt(Dictionary<Guid, int> attempts, Guid id)
+    {
+        attempts.TryGetValue(id, out var count);
+        attempts[id] = count + 1;
+        return count < MaxAttempts;
+    }
+
+    /// <summary>
+    /// Reads the filer CIK and any Rule 10b5-1 plan adoption date out of a notice's XML.
+    /// Kept here rather than on the processor because the backfill runs from a raw document
+    /// with no surrounding filing metadata.
+    /// </summary>
+    internal static (string FilerCik, DateOnly? PlanAdoptionDate) ParseIdentity(string xml)
+    {
+        XElement root;
+        try
+        {
+            root = XDocument.Parse(xml).Root;
+        }
+        catch (System.Xml.XmlException)
+        {
+            return (null, null);
+        }
+
+        if (root == null)
+            return (null, null);
+
+        var filer = Child(Child(Child(root, "headerData"), "filerInfo"), "filer");
+        var cik = Value(Child(filer, "filerCredentials"), "cik");
+
+        var adoptionDates = Children(
+                Child(Child(Child(root, "formData"), "noticeSignature"), "planAdoptionDates"),
+                "planAdoptionDate"
+            )
+            .Select(e => ParseUsDate(e.Value))
+            .Where(d => d != null)
+            .ToList();
+
+        return (
+            string.IsNullOrEmpty(cik) ? null : cik,
+            adoptionDates.Count == 0 ? null : adoptionDates.Min()
+        );
+    }
+
+    // Namespace-agnostic navigation: Form 144 documents carry the edgar/ownership namespace on
+    // some elements and a common namespace on others.
+    private static XElement Child(XElement parent, string name) =>
+        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
+
+    private static IEnumerable<XElement> Children(XElement parent, string name) =>
+        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
+
+    private static string Value(XElement parent, string name) =>
+        Child(parent, name)?.Value?.Trim();
+
+    private static DateOnly? ParseUsDate(string value)
+    {
+        return DateOnly.TryParseExact(
+            value?.Trim(),
+            ["MM/dd/yyyy", "M/d/yyyy"],
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None,
+            out var parsed
+        )
+            ? parsed
+            : null;
+    }
+}

--- a/src/Equibles.InsiderTrading.BusinessLogic/Form144FilerCikBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Form144FilerCikBackfillManager.cs
@@ -205,8 +205,7 @@ public class Form144FilerCikBackfillManager
     private static IEnumerable<XElement> Children(XElement parent, string name) =>
         parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
 
-    private static string Value(XElement parent, string name) =>
-        Child(parent, name)?.Value?.Trim();
+    private static string Value(XElement parent, string name) => Child(parent, name)?.Value?.Trim();
 
     private static DateOnly? ParseUsDate(string value)
     {

--- a/src/Equibles.InsiderTrading.Data/Models/Form144Filing.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/Form144Filing.cs
@@ -14,6 +14,7 @@ namespace Equibles.InsiderTrading.Data.Models;
 [Index(nameof(CommonStockId), nameof(FilingDate))]
 [Index(nameof(AccessionNumber), IsUnique = true)]
 [Index(nameof(FilingDate))]
+[Index(nameof(FilerCik), nameof(FilingDate))]
 public class Form144Filing
 {
     public Guid Id { get; set; } = Guid.NewGuid();
@@ -27,12 +28,25 @@ public class Form144Filing
     public DateOnly FilingDate { get; set; }
 
     /// <summary>
-    /// Person for whose account the securities are to be sold (the affiliate). Form 144 XML
-    /// carries the seller's name but not a CIK, so this is stored as free text rather than
-    /// resolved to an <see cref="InsiderOwner"/>.
+    /// Person for whose account the securities are to be sold (the affiliate), as free text.
+    /// Use <see cref="FilerCik"/> to identify them; names are not unique and not stable.
     /// </summary>
     [MaxLength(512)]
     public string SellerName { get; set; }
+
+    /// <summary>
+    /// CIK of the natural person who filed the notice, taken from the submission's
+    /// <c>filerCredentials</c> block. This is the same identifier that person's Forms 3/4/5
+    /// are filed under, so it joins directly to <see cref="InsiderOwner.OwnerCik"/> and is the
+    /// only reliable way to tell whether a proposed sale was ever executed.
+    ///
+    /// Stored verbatim, zero-padded to ten characters exactly as EDGAR emits it and exactly as
+    /// <see cref="InsiderOwner.OwnerCik"/> stores it, so the two compare without normalisation.
+    ///
+    /// Null on notices imported before this field was captured; the backfill fills them in.
+    /// </summary>
+    [MaxLength(16)]
+    public string FilerCik { get; set; }
 
     /// <summary>
     /// The seller's relationship(s) to the issuer (e.g. "Director", "Officer"). A filing can
@@ -63,6 +77,20 @@ public class Form144Filing
 
     [MaxLength(2048)]
     public string Remarks { get; set; }
+
+    /// <summary>
+    /// Adoption date of the Rule 10b5-1 trading plan the sale is made under, when the notice
+    /// declares one. Its presence is the notice's own signal that the sale is pre-arranged
+    /// rather than discretionary.
+    ///
+    /// This matters most where the Form 4 side cannot help: an executed notice can borrow
+    /// <see cref="InsiderTransaction.IsRule10b5One"/> from the matching transaction, but a
+    /// notice that is never executed has no transaction to borrow from.
+    ///
+    /// Null when the notice declares no plan, and on notices imported before this field was
+    /// captured. The two are not distinguishable until the backfill has drained.
+    /// </summary>
+    public DateOnly? PlanAdoptionDate { get; set; }
 
     public virtual List<Form144PriorSale> PriorSales { get; set; } = [];
 

--- a/src/Equibles.Migrations/Migrations/20260819173909_AddForm144FilerCikAndPlanAdoptionDate.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260819173909_AddForm144FilerCikAndPlanAdoptionDate.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260819173909_AddForm144FilerCikAndPlanAdoptionDate")]
+    partial class AddForm144FilerCikAndPlanAdoptionDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260819173909_AddForm144FilerCikAndPlanAdoptionDate.cs
+++ b/src/Equibles.Migrations/Migrations/20260819173909_AddForm144FilerCikAndPlanAdoptionDate.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddForm144FilerCikAndPlanAdoptionDate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FilerCik",
+                table: "Form144Filing",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "PlanAdoptionDate",
+                table: "Form144Filing",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Form144Filing_FilerCik_FilingDate",
+                table: "Form144Filing",
+                columns: new[] { "FilerCik", "FilingDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Form144Filing_FilerCik_FilingDate",
+                table: "Form144Filing");
+
+            migrationBuilder.DropColumn(
+                name: "FilerCik",
+                table: "Form144Filing");
+
+            migrationBuilder.DropColumn(
+                name: "PlanAdoptionDate",
+                table: "Form144Filing");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<AsFiledHtmlBackfillWorker>();
         services.AddHostedService<FilingItemsBackfillWorker>();
         services.AddHostedService<InsiderFilingReprocessWorker>();
+        services.AddHostedService<Form144FilerCikBackfillWorker>();
         services.AddHostedService<NportFilingReprocessWorker>();
         services.AddHostedService<NportRealtimeWorker>();
         services.AddHostedService<FundSeriesRefreshWorker>();

--- a/src/Equibles.Sec.HostedService/Form144FilerCikBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/Form144FilerCikBackfillWorker.cs
@@ -42,8 +42,7 @@ public class Form144FilerCikBackfillWorker : BaseScraperWorker
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
         using var scope = ScopeFactory.CreateScope();
-        var manager =
-            scope.ServiceProvider.GetRequiredService<Form144FilerCikBackfillManager>();
+        var manager = scope.ServiceProvider.GetRequiredService<Form144FilerCikBackfillManager>();
 
         var resolved = await manager.Run(stoppingToken);
 

--- a/src/Equibles.Sec.HostedService/Form144FilerCikBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/Form144FilerCikBackfillWorker.cs
@@ -1,0 +1,53 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService;
+
+/// <summary>
+/// Backfills the filer CIK, and any Rule 10b5-1 plan adoption date, onto Form 144 notices
+/// imported before those fields were captured.
+///
+/// Selection is driven entirely by the column being null, so the run drains to nothing and
+/// then idles. Once history is filled the parser writes both fields at ingest and this worker
+/// has no work left to do.
+///
+/// Runs in the worker process so it shares the single SEC rate limiter with the other EDGAR
+/// scrapers rather than competing with them as a separate process, and starts on a stagger so
+/// the initial burst does not collide with them at deploy time.
+/// </summary>
+public class Form144FilerCikBackfillWorker : BaseScraperWorker
+{
+    protected override string WorkerName => "Form 144 filer CIK backfill";
+    protected override ErrorSource ErrorSource => ErrorSource.InsiderTradingReprocess;
+
+    // Once drained each cycle finds nothing; the periodic re-check only picks up notices left
+    // pending by a transient EDGAR failure.
+    protected override TimeSpan SleepInterval => TimeSpan.FromHours(6);
+
+    // Longer than the insider reprocess stagger so the two EDGAR backfills do not start
+    // together and split the request budget.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(9);
+
+    public Form144FilerCikBackfillWorker(
+        ILogger<Form144FilerCikBackfillWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter
+    )
+        : base(logger, scopeFactory, errorReporter) { }
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        using var scope = ScopeFactory.CreateScope();
+        var manager =
+            scope.ServiceProvider.GetRequiredService<Form144FilerCikBackfillManager>();
+
+        var resolved = await manager.Run(stoppingToken);
+
+        if (resolved > 0)
+            Logger.LogInformation("Resolved the filer CIK on {Count} Form 144 notices", resolved);
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
@@ -78,6 +78,8 @@ public class Form144FilingProcessor
             CommonStockId = companyId,
             AccessionNumber = filing.AccessionNumber,
             FilingDate = filing.FilingDate,
+            FilerCik = ParseFilerCik(root),
+            PlanAdoptionDate = ParsePlanAdoptionDate(formData),
             SellerName = Truncate(
                 Val(issuerInfo, "nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold"),
                 512
@@ -104,6 +106,51 @@ public class Form144FilingProcessor
         }
 
         return entity;
+    }
+
+    /// <summary>
+    /// CIK of the natural person the notice is filed for, from
+    /// <c>headerData/filerInfo/filer/filerCredentials/cik</c>. EDGAR indexes the notice under
+    /// this CIK as well as the issuer's, and it is the same CIK that person's Forms 3/4/5 use,
+    /// which is what makes a notice joinable to its executions.
+    ///
+    /// Kept verbatim (EDGAR zero-pads to ten characters) so it matches
+    /// <c>InsiderOwner.OwnerCik</c>, which stores the Form 4 value the same way.
+    /// </summary>
+    private string ParseFilerCik(XElement root)
+    {
+        var filerInfo = El(El(root, "headerData"), "filerInfo");
+
+        // A joint filing carries several <filer> elements. The first is the person the notice
+        // is filed for; log the rest rather than guessing between them.
+        var filers = Els(filerInfo, "filer").ToList();
+        if (filers.Count == 0)
+            return null;
+
+        if (filers.Count > 1)
+        {
+            Logger.LogWarning(
+                "Form 144 carries {Count} filer elements; taking the first CIK",
+                filers.Count
+            );
+        }
+
+        return Truncate(Val(El(filers[0], "filerCredentials"), "cik"), 16);
+    }
+
+    /// <summary>
+    /// Adoption date of the Rule 10b5-1 plan the sale is made under, when the notice declares
+    /// one, from <c>noticeSignature/planAdoptionDates/planAdoptionDate</c>. A notice may list
+    /// more than one adoption date; the earliest is taken as the plan's origin.
+    /// </summary>
+    private static DateOnly? ParsePlanAdoptionDate(XElement formData)
+    {
+        var dates = Els(El(El(formData, "noticeSignature"), "planAdoptionDates"), "planAdoptionDate")
+            .Select(e => ParseDate(e.Value))
+            .Where(d => d != null)
+            .ToList();
+
+        return dates.Count == 0 ? null : dates.Min();
     }
 
     private static Form144PriorSale ParsePriorSale(XElement element)

--- a/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
@@ -145,7 +145,10 @@ public class Form144FilingProcessor
     /// </summary>
     private static DateOnly? ParsePlanAdoptionDate(XElement formData)
     {
-        var dates = Els(El(El(formData, "noticeSignature"), "planAdoptionDates"), "planAdoptionDate")
+        var dates = Els(
+                El(El(formData, "noticeSignature"), "planAdoptionDates"),
+                "planAdoptionDate"
+            )
             .Select(e => ParseDate(e.Value))
             .Where(d => d != null)
             .ToList();

--- a/tests/Equibles.IntegrationTests/Sec/Form144FilingProcessorFilerCikTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/Form144FilingProcessorFilerCikTests.cs
@@ -1,0 +1,176 @@
+using System.Reflection;
+using System.Xml.Linq;
+using Equibles.Errors.BusinessLogic;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// The filer CIK is what makes a Form 144 joinable to the filer's Forms 3/4/5, and therefore
+/// the only way to tell whether a proposed sale was ever executed. Without it the seller is
+/// free text and a name match resolves only about half of the corpus.
+/// </summary>
+public class Form144FilingProcessorFilerCikTests
+{
+    private static Form144FilingProcessor Processor() =>
+        new(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<Form144FilingProcessor>>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+    private static Form144Filing Parse(string xml)
+    {
+        var method = typeof(Form144FilingProcessor).GetMethod(
+            "ParseFiling",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-26-000001",
+            FilingDate = new DateOnly(2026, 8, 11),
+            ReportDate = new DateOnly(2026, 8, 11),
+            Form = "144",
+        };
+
+        return (Form144Filing)
+            method.Invoke(Processor(), [XElement.Parse(xml), Guid.NewGuid(), filing]);
+    }
+
+    private static string Document(string headerData, string noticeSignature = "") =>
+        "<edgarSubmission>"
+        + headerData
+        + "<formData>"
+        + "<issuerInfo><nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>Jane Doe"
+        + "</nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold></issuerInfo>"
+        + "<securitiesInformation><securitiesClassTitle>Common</securitiesClassTitle></securitiesInformation>"
+        + noticeSignature
+        + "</formData></edgarSubmission>";
+
+    private static string Header(string cik) =>
+        "<headerData><filerInfo><filer><filerCredentials><cik>"
+        + cik
+        + "</cik><ccc>XXXXXXXX</ccc></filerCredentials></filer></filerInfo></headerData>";
+
+    // A notice filed through an agent still credits the natural person, not the agent. This is
+    // the shape behind the great majority of the corpus.
+    [Fact]
+    public void ParseFiling_AgentFiledNotice_TakesThePersonsCik()
+    {
+        Parse(Document(Header("0001780525"))).FilerCik.Should().Be("0001780525");
+    }
+
+    // A self-filer's accession prefix happens to be their own CIK; the field is read the same way.
+    [Fact]
+    public void ParseFiling_SelfFiledNotice_TakesTheFilerCredentialsCik()
+    {
+        Parse(Document(Header("0001786391"))).FilerCik.Should().Be("0001786391");
+    }
+
+    // THE JOIN INVARIANT. InsiderOwner.OwnerCik stores the Form 4 value verbatim, and EDGAR
+    // zero-pads to ten characters on both forms. Trimming the padding here, or padding it
+    // differently, makes every notice-to-execution join miss silently rather than fail loudly.
+    [Fact]
+    public void ParseFiling_LeadingZeros_ArePreservedSoTheCikMatchesInsiderOwner()
+    {
+        var entity = Parse(Document(Header("0000320193")));
+
+        entity.FilerCik.Should().Be("0000320193");
+        entity.FilerCik.Should().NotBe("320193");
+    }
+
+    [Fact]
+    public void ParseFiling_NoHeaderData_LeavesTheFilerCikNull()
+    {
+        Parse(Document(headerData: "")).FilerCik.Should().BeNull();
+    }
+
+    // Joint filings carry several <filer> elements. The first is the person the notice is filed
+    // for; the parser must pick one deterministically rather than concatenating or failing.
+    [Fact]
+    public void ParseFiling_MultipleFilers_TakesTheFirst()
+    {
+        var header =
+            "<headerData><filerInfo>"
+            + "<filer><filerCredentials><cik>0001111111</cik></filerCredentials></filer>"
+            + "<filer><filerCredentials><cik>0002222222</cik></filerCredentials></filer>"
+            + "</filerInfo></headerData>";
+
+        Parse(Document(header)).FilerCik.Should().Be("0001111111");
+    }
+
+    // A plan adoption date is the notice's own declaration that the sale is pre-arranged. It is
+    // the only 10b5-1 signal available for a notice that is never executed, because there is no
+    // Form 4 to borrow the flag from.
+    [Fact]
+    public void ParseFiling_PlanAdoptionDate_IsCaptured()
+    {
+        var signature =
+            "<noticeSignature><noticeDate>08/11/2026</noticeDate>"
+            + "<planAdoptionDates><planAdoptionDate>05/05/2026</planAdoptionDate></planAdoptionDates>"
+            + "</noticeSignature>";
+
+        Parse(Document(Header("0001780525"), signature))
+            .PlanAdoptionDate.Should()
+            .Be(new DateOnly(2026, 5, 5));
+    }
+
+    // Several adoption dates means an amended or layered plan; the earliest is the plan's origin.
+    [Fact]
+    public void ParseFiling_SeveralPlanAdoptionDates_TakesTheEarliest()
+    {
+        var signature =
+            "<noticeSignature><planAdoptionDates>"
+            + "<planAdoptionDate>09/01/2026</planAdoptionDate>"
+            + "<planAdoptionDate>05/05/2026</planAdoptionDate>"
+            + "</planAdoptionDates></noticeSignature>";
+
+        Parse(Document(Header("0001780525"), signature))
+            .PlanAdoptionDate.Should()
+            .Be(new DateOnly(2026, 5, 5));
+    }
+
+    // Most notices declare no plan. Null must mean "none declared", never a zero date.
+    [Fact]
+    public void ParseFiling_NoPlanAdoptionDate_LeavesItNull()
+    {
+        Parse(Document(Header("0001780525"))).PlanAdoptionDate.Should().BeNull();
+    }
+
+    // The backfill reads a raw document with no surrounding filing metadata, so it parses the
+    // same two fields independently. The two paths must agree, or history and new ingest diverge.
+    [Fact]
+    public void BackfillParseIdentity_AgreesWithTheProcessor()
+    {
+        var signature =
+            "<noticeSignature><planAdoptionDates>"
+            + "<planAdoptionDate>05/05/2026</planAdoptionDate>"
+            + "</planAdoptionDates></noticeSignature>";
+        var xml = Document(Header("0001780525"), signature);
+
+        var fromProcessor = Parse(xml);
+        var fromBackfill = Form144FilerCikBackfillManager.ParseIdentity(xml);
+
+        fromBackfill.FilerCik.Should().Be(fromProcessor.FilerCik);
+        fromBackfill.PlanAdoptionDate.Should().Be(fromProcessor.PlanAdoptionDate);
+    }
+
+    [Fact]
+    public void BackfillParseIdentity_MalformedXml_ReturnsNothingRatherThanThrowing()
+    {
+        var parsed = Form144FilerCikBackfillManager.ParseIdentity("<edgarSubmission");
+
+        parsed.FilerCik.Should().BeNull();
+        parsed.PlanAdoptionDate.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem

A Form 144 announces that an affiliate intends to sell. Whether the sale actually happened is only knowable by joining the notice to that person's Form 4 executions, and nothing in the codebase could do that.

The parser stored the seller as free text and dropped the identity entirely, with the model comment asserting that "Form 144 XML carries the seller's name but not a CIK". That is not correct. The CIK is in the submission header, and it is the same CIK the person's Forms 3/4/5 are filed under.

Falling back to name matching resolves about 55% of the corpus, and the unresolved remainder is not missing at random, so any analysis built on it is biased before it starts.

## What changed

`Form144Filing` gains two nullable columns:

- **`FilerCik`**, from `headerData/filerInfo/filer/filerCredentials/cik`. Stored **verbatim**, because EDGAR zero-pads to ten characters on both Form 4 and Form 144, and `InsiderOwner.OwnerCik` keeps the Form 4 value in exactly that shape. The two therefore compare without normalisation. A test pins the padding: trimming it would make every join miss silently rather than fail loudly.
- **`PlanAdoptionDate`**, from `noticeSignature/planAdoptionDates`. The 10b5-1 flag exists only on `InsiderTransaction`, so an executed notice can borrow it from the matching transaction while a never-executed notice has nothing to borrow from. The notice's own plan date is the only pre-arranged-versus-discretionary signal available for that cohort.

`Form144FilerCikBackfillWorker` fills history by re-reading each notice's XML. Selection is driven by `FilerCik IS NULL`, so the run drains, terminates and resumes. Documents EDGAR will not serve are parked after three attempts so one bad filing cannot stall the backlog, and a batch that makes no progress at all ends the cycle rather than looping on the same rows. It runs in the worker process to share the single SEC rate limiter, on a longer stagger than the insider reprocess so the two do not split the request budget.

## Verification

The identity claim was checked against EDGAR directly before writing any code:

- Every Form 144 is indexed **twice** in the quarterly `form.idx`, once under the issuer CIK and once under the natural person's. Across 17 quarters, **122,720 of 122,723** distinct accessions carry exactly two rows.
- On a 20-notice sample the CIK recovered from that index matched `filerCredentials/cik` inside the notice XML in **20 of 20** cases, across three different filing agents.

Tests: 10 new, covering agent-filed and self-filed shapes, the zero-padding invariant, missing header data, joint filings with several `<filer>` elements, plan-date capture including the several-dates and none cases, agreement between the processor and the backfill parse paths, and malformed XML. All 57 Form 144 tests pass.

## Migration

`AddForm144FilerCikAndPlanAdoptionDate` is additive only, two nullable columns and one index, so it is invisible to running code and safe under a migrate-before-rollout deploy.

## Not in this PR

`FilerCik` is deliberately not exposed on any DTO, MCP tool or portal surface. It is an internal identity key, and putting it on the public wire is a separate decision.