### PR TITLE
fix(sec): sanitize the Form 144 submission before reading the filer CIK from it

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/Form144FilerCikBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Form144FilerCikBackfillManager.cs
@@ -36,6 +36,9 @@ public class Form144FilerCikBackfillManager
     private const int BatchSize = 64;
     private const int MaxAttempts = 3;
 
+    // One full batch parked for missing credentials is already past coincidence.
+    private const int ParkedWithoutCredentialsAlarm = BatchSize;
+
     private readonly Form144FilingRepository _repository;
     private readonly ISecEdgarClient _secEdgarClient;
     private readonly ILogger<Form144FilerCikBackfillManager> _logger;
@@ -57,6 +60,9 @@ public class Form144FilerCikBackfillManager
     public async Task<int> Run(CancellationToken cancellationToken = default)
     {
         var resolved = 0;
+        var parkedNoIssuerCik = 0;
+        var parkedNoCredentials = 0;
+        var parkedAttemptsExhausted = 0;
         var attempts = new Dictionary<Guid, int>();
 
         while (!cancellationToken.IsCancellationRequested)
@@ -86,6 +92,7 @@ public class Form144FilerCikBackfillManager
                     // The notice is attributed to an issuer with no CIK, so its document cannot
                     // be addressed on EDGAR at all. Park it rather than retrying forever.
                     filing.FilerCik = UnavailableMarker;
+                    parkedNoIssuerCik++;
                     progressed = true;
                     continue;
                 }
@@ -93,6 +100,7 @@ public class Form144FilerCikBackfillManager
                 if (!TryRecordAttempt(attempts, filing.Id))
                 {
                     filing.FilerCik = UnavailableMarker;
+                    parkedAttemptsExhausted++;
                     progressed = true;
                     _logger.LogWarning(
                         "Parking Form 144 {AccessionNumber} after {Attempts} failed attempts",
@@ -129,6 +137,7 @@ public class Form144FilerCikBackfillManager
                     // Fetched cleanly but carries no filer credentials. Retrying cannot change
                     // that, so park it immediately rather than burning the attempt budget.
                     filing.FilerCik = UnavailableMarker;
+                    parkedNoCredentials++;
                     progressed = true;
                     continue;
                 }
@@ -150,6 +159,38 @@ public class Form144FilerCikBackfillManager
             }
         }
 
+        var parked = parkedNoIssuerCik + parkedNoCredentials + parkedAttemptsExhausted;
+        if (parked > 0)
+        {
+            _logger.LogInformation(
+                "Form 144 filer-CIK backfill parked {Parked} notice(s): {NoIssuerCik} with no "
+                    + "issuer CIK, {NoCredentials} carrying no filer credentials, {Exhausted} after "
+                    + "{MaxAttempts} failed fetches. Resolved {Resolved}.",
+                parked,
+                parkedNoIssuerCik,
+                parkedNoCredentials,
+                parkedAttemptsExhausted,
+                MaxAttempts,
+                resolved
+            );
+        }
+
+        // Notices EDGAR serves but that carry no filer credentials are the exception, not the
+        // rule: every electronically filed Form 144 has them. A cycle that parks far more than
+        // it resolves is a fault in THIS lane (a document shape it cannot read), not a corpus
+        // of bad filings, and parking is silent enough to burn the whole backlog unnoticed.
+        if (parkedNoCredentials > resolved && parkedNoCredentials >= ParkedWithoutCredentialsAlarm)
+        {
+            _logger.LogWarning(
+                "Form 144 filer-CIK backfill parked {NoCredentials} notice(s) for missing filer "
+                    + "credentials while resolving only {Resolved}. Expect nearly every notice to "
+                    + "carry credentials, so this points at the document shape this lane reads, not "
+                    + "at the filings. Investigate before the backlog is exhausted.",
+                parkedNoCredentials,
+                resolved
+            );
+        }
+
         return resolved;
     }
 
@@ -165,12 +206,25 @@ public class Form144FilerCikBackfillManager
     /// Kept here rather than on the processor because the backfill runs from a raw document
     /// with no surrounding filing metadata.
     /// </summary>
+    /// <summary>
+    /// Reads the filer CIK and earliest plan adoption date out of a notice's RAW EDGAR
+    /// submission.
+    ///
+    /// The document arrives as the full <c>.txt</c> submission, which opens with an SGML
+    /// envelope (<c>SEC-DOCUMENT</c>, <c>SEC-HEADER</c>) and is NOT well-formed XML, so it must
+    /// be sanitized exactly as the import path sanitizes it before it can be parsed. Parsing the
+    /// raw text instead throws on every notice, which reads here as "carries no filer
+    /// credentials" and quietly parks the entire corpus.
+    /// </summary>
     internal static (string FilerCik, DateOnly? PlanAdoptionDate) ParseIdentity(string xml)
     {
+        if (string.IsNullOrWhiteSpace(xml))
+            return (null, null);
+
         XElement root;
         try
         {
-            root = XDocument.Parse(xml).Root;
+            root = XDocument.Parse(InsiderFilingParser.SanitizeXml(xml)).Root;
         }
         catch (System.Xml.XmlException)
         {

--- a/tests/Equibles.IntegrationTests/Sec/Form144FilingProcessorFilerCikTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/Form144FilingProcessorFilerCikTests.cs
@@ -147,8 +147,10 @@ public class Form144FilingProcessorFilerCikTests
         Parse(Document(Header("0001780525"))).PlanAdoptionDate.Should().BeNull();
     }
 
-    // The backfill reads a raw document with no surrounding filing metadata, so it parses the
-    // same two fields independently. The two paths must agree, or history and new ingest diverge.
+    // The backfill parses the same two fields independently of the import path, so the two must
+    // agree or history and new ingest diverge. This case feeds the ALREADY-SANITIZED payload;
+    // BackfillParseIdentity_RawSgmlSubmissionAsEdgarServesIt covers what the backfill is actually
+    // handed, which is not this.
     [Fact]
     public void BackfillParseIdentity_AgreesWithTheProcessor()
     {
@@ -172,5 +174,59 @@ public class Form144FilingProcessorFilerCikTests
 
         parsed.FilerCik.Should().BeNull();
         parsed.PlanAdoptionDate.Should().BeNull();
+    }
+
+    // The exact bytes EDGAR serves for accession 0001959173-23-000915 (trimmed), which is what
+    // the backfill is handed: GetDocumentContent fetches `{accession}.txt`, the FULL submission.
+    // It opens with an SGML envelope and is NOT well-formed XML, and the payload is namespaced.
+    //
+    // This is the regression. The backfill shipped parsing this text directly, so XDocument threw
+    // on every notice, every notice looked like it "carries no filer credentials", and the lane
+    // parked the corpus instead of filling it: 1,854 notices parked and 0 resolved in production
+    // before it was caught. The old agreement test passed throughout because it fed the payload
+    // post-sanitize, a shape the backfill never sees.
+    private const string RawSgmlSubmission =
+        "<SEC-DOCUMENT>0001959173-23-000915.txt : 20230508\n"
+        + "<SEC-HEADER>0001959173-23-000915.hdr.sgml : 20230508\n"
+        + "<ACCEPTANCE-DATETIME>20230508153241\n"
+        + "ACCESSION NUMBER:\t\t0001959173-23-000915\n"
+        + "CONFORMED SUBMISSION TYPE:\t144\n"
+        + "</SEC-HEADER>\n"
+        + "<DOCUMENT>\n<TYPE>144\n<SEQUENCE>1\n<FILENAME>primary_doc.xml\n<TEXT>\n"
+        + "<XML>\n"
+        + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<edgarSubmission xmlns=\"http://www.sec.gov/edgar/ownership\" "
+        + "xmlns:com=\"http://www.sec.gov/edgar/common\">"
+        + "<headerData><filerInfo><filer><filerCredentials>"
+        + "<cik>0001914614</cik><ccc>XXXXXXXX</ccc>"
+        + "</filerCredentials></filer></filerInfo></headerData>"
+        + "<formData><noticeSignature><planAdoptionDates>"
+        + "<planAdoptionDate>11/28/2022</planAdoptionDate>"
+        + "</planAdoptionDates></noticeSignature></formData>"
+        + "</edgarSubmission>\n"
+        + "</XML>\n</TEXT>\n</DOCUMENT>\n</SEC-DOCUMENT>\n";
+
+    [Fact]
+    public void BackfillParseIdentity_RawSgmlSubmissionAsEdgarServesIt_ReadsFilerCikAndPlanDate()
+    {
+        var parsed = Form144FilerCikBackfillManager.ParseIdentity(RawSgmlSubmission);
+
+        // Zero-padded verbatim, so it joins InsiderOwner.OwnerCik without transformation.
+        parsed.FilerCik.Should().Be("0001914614");
+        parsed.PlanAdoptionDate.Should().Be(new DateOnly(2022, 11, 28));
+    }
+
+    // A document EDGAR serves that genuinely carries no credentials must still park, so the fix
+    // above cannot be mistaken for "never park anything".
+    [Fact]
+    public void BackfillParseIdentity_SgmlSubmissionWithoutFilerCredentials_ReturnsNothing()
+    {
+        var withoutCredentials =
+            "<SEC-DOCUMENT>x.txt : 20230508\n<SEC-HEADER>x</SEC-HEADER>\n<XML>\n"
+            + "<edgarSubmission xmlns=\"http://www.sec.gov/edgar/ownership\">"
+            + "<headerData><filerInfo><filer /></filerInfo></headerData>"
+            + "</edgarSubmission>\n</XML>\n</SEC-DOCUMENT>\n";
+
+        Form144FilerCikBackfillManager.ParseIdentity(withoutCredentials).FilerCik.Should().BeNull();
     }
 }


### PR DESCRIPTION
## The fault

`Form144FilerCikBackfillManager` fetches each notice with `GetDocumentContent(accession, issuerCik)`, which returns the **full EDGAR submission** (`{accession}.txt`). That document opens with an SGML envelope:

```
<SEC-DOCUMENT>0001959173-23-000915.txt : 20230508
<SEC-HEADER>...
<DOCUMENT><TYPE>144 ... <XML>
<?xml version="1.0"?><edgarSubmission xmlns="...">
```

It is not well-formed XML, so `XDocument.Parse` threw on **every** notice. The throw was caught and folded into the `FilerCik == null` branch, which is a *park-immediately* condition, so the lane parked the corpus instead of filling it.

Measured in production before this was caught:

| | |
|---|---|
| parked `unavailable` | **1,854** |
| resolved by the backfill | **0** |
| pending | 109,458 |

(The 10 rows that do carry a CIK came from the live import path, which sanitizes correctly. The backfill resolved nothing.)

## The fix

Sanitize before parsing, using the sanitizer already in this assembly. The documents are fine: all three sampled carry `filerCredentials/cik` zero-padded, and one carries a `planAdoptionDate`.

## Parking was silent

Two of the three park paths logged nothing, which is why a total failure produced no log line. Each reason is now counted and reported per cycle, and a cycle that parks a full batch for missing credentials while resolving fewer warns explicitly, because near enough every electronically filed Form 144 carries credentials.

## Why the tests missed it

`BackfillParseIdentity_AgreesWithTheProcessor` fed the payload **post-sanitize**, a shape the backfill never receives. Pinned now with the real bytes EDGAR serves, envelope and namespace included. Mutation-checked: reverting the one-line fix fails the new guard with the exact production symptom (`FilerCik` null) while the other 11 stay green.

Follows #4411.