### PR TITLE
feat(fred): triple the curated series list to the codes people actually search

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/CuratedSeriesRegistry.cs
+++ b/src/Equibles.Fred.HostedService/Services/CuratedSeriesRegistry.cs
@@ -2,6 +2,17 @@ using Equibles.Fred.Data.Models;
 
 namespace Equibles.Fred.HostedService.Services;
 
+// The FRED series this deployment tracks. Every entry becomes a stored series with its full
+// observation history, one public page, and one sitemap URL.
+//
+// Curated rather than swept: FRED publishes around 800,000 series and almost all of them are a
+// county-level or vintage-specific slice nobody asks for. The list below is the set a reader
+// (or a model answering about the US economy) actually names, chosen against FRED's own
+// popularity score with a floor of 50, and it deliberately fills out the families already here
+// rather than opening new ones. Two series that cleared the floor are excluded on purpose:
+// USSLIND stopped updating in April 2020, and FPCPITOTLZGUSA is an annual World Bank restatement
+// of CPI that lags the series we already carry. A frozen series is worse than a missing one; it
+// renders a current-looking page over a stale number, which is the same trap STLFSI2 sprang.
 public static class CuratedSeriesRegistry
 {
     public static readonly IReadOnlyList<CuratedSeries> Series =
@@ -63,6 +74,96 @@ public static class CuratedSeriesRegistry
         // STLFSI4 supersedes the discontinued STLFSI2 (frozen at 2022-01-07), whose
         // stale value polluted the "current macro conditions" snapshot.
         new("STLFSI4", FredSeriesCategory.Market),
+        // The rest of the Treasury constant-maturity curve plus the Fed's own administered
+        // rates. A curve with only the 2s, 10s and 30s cannot answer a question about the front end.
+        new("DGS5", FredSeriesCategory.InterestRates),
+        new("DFF", FredSeriesCategory.InterestRates),
+        new("DGS1", FredSeriesCategory.InterestRates),
+        new("IORB", FredSeriesCategory.InterestRates),
+        new("DGS3MO", FredSeriesCategory.InterestRates),
+        new("DGS20", FredSeriesCategory.InterestRates),
+        new("DGS1MO", FredSeriesCategory.InterestRates),
+        new("TB3MS", FredSeriesCategory.InterestRates),
+        new("DGS3", FredSeriesCategory.InterestRates),
+        new("DGS6MO", FredSeriesCategory.InterestRates),
+        new("DGS7", FredSeriesCategory.InterestRates),
+        // The rating buckets under the aggregate high-yield and investment-grade spreads: BB, B
+        // and CCC separate a risk-on rally from a genuine credit event, which BAMLH0A0HYM2 alone cannot.
+        new("BAMLC0A4CBBB", FredSeriesCategory.CorporateBondSpreads),
+        new("BAMLH0A3HYC", FredSeriesCategory.CorporateBondSpreads),
+        new("DBAA", FredSeriesCategory.CorporateBondSpreads),
+        new("BAMLH0A1HYBB", FredSeriesCategory.CorporateBondSpreads),
+        new("DAAA", FredSeriesCategory.CorporateBondSpreads),
+        new("BAMLH0A2HYB", FredSeriesCategory.CorporateBondSpreads),
+        new("BAMLC0A1CAAAEY", FredSeriesCategory.CorporateBondSpreads),
+        // The unadjusted CPI everyone quotes, the PCE price level, the market-implied and survey
+        // expectation measures, and the three component indices (food, shelter, energy) that
+        // explain a headline print the aggregate only reports.
+        new("T5YIE", FredSeriesCategory.Inflation),
+        new("PCEPI", FredSeriesCategory.Inflation),
+        new("CPIAUCNS", FredSeriesCategory.Inflation),
+        new("MICH", FredSeriesCategory.Inflation),
+        new("CPIUFDSL", FredSeriesCategory.Inflation),
+        new("CUSR0000SEHA", FredSeriesCategory.Inflation),
+        new("CPIENGSL", FredSeriesCategory.Inflation),
+        // The rest of the household survey. The headline unemployment rate is the one number whose
+        // meaning changes once participation, U-6, hourly earnings and the demographic breakdowns
+        // are next to it, and the JOLTS hires and quits behind the openings series already here.
+        new("CIVPART", FredSeriesCategory.Employment),
+        new("CES0500000003", FredSeriesCategory.Employment),
+        new("U6RATE", FredSeriesCategory.Employment),
+        new("CCSA", FredSeriesCategory.Employment),
+        new("EMRATIO", FredSeriesCategory.Employment),
+        new("UNEMPLOY", FredSeriesCategory.Employment),
+        new("LNS14000006", FredSeriesCategory.Employment),
+        new("AWHAETP", FredSeriesCategory.Employment),
+        new("JTSHIL", FredSeriesCategory.Employment),
+        // The demand and capacity side of the same accounts GDP already covers.
+        new("PCE", FredSeriesCategory.GdpAndOutput),
+        new("A191RL1Q225SBEA", FredSeriesCategory.GdpAndOutput),
+        new("GDPPOT", FredSeriesCategory.GdpAndOutput),
+        new("TCU", FredSeriesCategory.GdpAndOutput),
+        new("DGORDER", FredSeriesCategory.GdpAndOutput),
+        new("GPDI", FredSeriesCategory.GdpAndOutput),
+        new("BUSINV", FredSeriesCategory.GdpAndOutput),
+        new("NETEXP", FredSeriesCategory.GdpAndOutput),
+        // Reserve-side plumbing. The overnight reverse repo facility is the most-watched of these
+        // and was missing entirely.
+        new("RRPONTSYD", FredSeriesCategory.MoneySupply),
+        new("WRESBAL", FredSeriesCategory.MoneySupply),
+        new("M2V", FredSeriesCategory.MoneySupply),
+        new("M1SL", FredSeriesCategory.MoneySupply),
+        new("BOGMBASE", FredSeriesCategory.MoneySupply),
+        new("TOTRESNS", FredSeriesCategory.MoneySupply),
+        // Prices, supply and the 15-year mortgage. Housing had starts and the 30-year rate and
+        // nothing that says what a house costs.
+        new("MSPUS", FredSeriesCategory.Housing),
+        new("MORTGAGE15US", FredSeriesCategory.Housing),
+        new("EXHOSLUSM495S", FredSeriesCategory.Housing),
+        new("HSN1F", FredSeriesCategory.Housing),
+        new("RHORUSQ156N", FredSeriesCategory.Housing),
+        new("PERMIT", FredSeriesCategory.Housing),
+        new("MSACSR", FredSeriesCategory.Housing),
+        // The major bilateral pairs behind the trade-weighted dollar index we already carry.
+        new("DEXJPUS", FredSeriesCategory.ExchangeRates),
+        new("DEXCHUS", FredSeriesCategory.ExchangeRates),
+        new("DEXUSUK", FredSeriesCategory.ExchangeRates),
+        new("DEXCAUS", FredSeriesCategory.ExchangeRates),
+        new("DEXKOUS", FredSeriesCategory.ExchangeRates),
+        new("DEXINUS", FredSeriesCategory.ExchangeRates),
+        new("DEXMXUS", FredSeriesCategory.ExchangeRates),
+        new("DTWEXAFEGS", FredSeriesCategory.ExchangeRates),
+        new("DEXSZUS", FredSeriesCategory.ExchangeRates),
+        new("DEXBZUS", FredSeriesCategory.ExchangeRates),
+        // The other two headline indices, both crude benchmarks, retail gasoline, and the
+        // adjusted financial-conditions index that pairs with NFCI.
+        new("DCOILWTICO", FredSeriesCategory.Market),
+        new("DCOILBRENTEU", FredSeriesCategory.Market),
+        new("GASREGW", FredSeriesCategory.Market),
+        new("NASDAQCOM", FredSeriesCategory.Market),
+        new("DJIA", FredSeriesCategory.Market),
+        new("NASDAQ100", FredSeriesCategory.Market),
+        new("ANFCI", FredSeriesCategory.Market),
     ];
 }
 

--- a/tests/Equibles.UnitTests/Fred/CuratedSeriesRegistryTests.cs
+++ b/tests/Equibles.UnitTests/Fred/CuratedSeriesRegistryTests.cs
@@ -96,6 +96,57 @@ public class CuratedSeriesRegistryTests
     }
 
     [Fact]
+    public void Series_ExcludesTheSeriesFredHasStoppedUpdating()
+    {
+        // The rule STLFSI2 taught, written so it survives the next curation pass. Both of these
+        // clear the popularity floor the list is chosen against, and both would render a
+        // current-looking page over a number that is not current: USSLIND stopped updating in
+        // April 2020, and FPCPITOTLZGUSA is an annual World Bank restatement of US CPI that lags
+        // CPIAUCSL by a year. Popularity alone must never be enough to get a series in.
+        CuratedSeriesRegistry.Series.Should().NotContain(s => s.SeriesId == "USSLIND");
+        CuratedSeriesRegistry.Series.Should().NotContain(s => s.SeriesId == "FPCPITOTLZGUSA");
+    }
+
+    [Fact]
+    public void InterestRates_CoverTheWholeTreasuryCurve()
+    {
+        // A yield curve with holes cannot answer a question about its own shape: the front end
+        // is where policy expectations show up, and the list used to start at the 2-year.
+        var maturities = CuratedSeriesRegistry
+            .Series.Where(s => s.Category == FredSeriesCategory.InterestRates)
+            .Select(s => s.SeriesId)
+            .ToList();
+
+        maturities
+            .Should()
+            .Contain([
+                "DGS1MO",
+                "DGS3MO",
+                "DGS6MO",
+                "DGS1",
+                "DGS2",
+                "DGS3",
+                "DGS5",
+                "DGS7",
+                "DGS10",
+                "DGS20",
+                "DGS30",
+            ]);
+    }
+
+    [Fact]
+    public void CorporateBondSpreads_SeparateTheRatingBuckets()
+    {
+        // BAMLH0A0HYM2 is the aggregate. Without BB, B and CCC underneath it, a widening cannot
+        // be told apart from a rotation within high yield.
+        CuratedSeriesRegistry
+            .Series.Where(s => s.Category == FredSeriesCategory.CorporateBondSpreads)
+            .Select(s => s.SeriesId)
+            .Should()
+            .Contain(["BAMLH0A1HYBB", "BAMLH0A2HYB", "BAMLH0A3HYC"]);
+    }
+
+    [Fact]
     public void AllCategories_HaveAtLeastOneSeries()
     {
         var allCategories = Enum.GetValues<FredSeriesCategory>();


### PR DESCRIPTION
## Why

The economic-data pages are the best-ranking template on the deployment that consumes this module: Search Console puts `/EconomicData/*` at **average position 5.4** over the 28 days to 2026-08-17. They are also the smallest surface we publish, **42 series out of the roughly 800,000 FRED carries**.

This is the one place where the query *is* the identifier. Somebody types `BAMLH0A0HYM2` and wants exactly that series, and that one code drew **1,064 impressions and 9 clicks** in those 28 days. The constraint on the template is codes carried, not ranking.

## What changes

The curated list goes from 42 to **114**. Selection rule, now written into the file's header comment:

- chosen against **FRED's own `popularity` score**, floor of 50;
- confined to the categories already present, so no new taxonomy;
- **every id resolved through the FRED series API before being written down**. The first draft contained `WILL5000INDFC`, which does not exist. None of these are from memory.

What was missing was mostly structural:

| Family | Gap |
|---|---|
| Interest rates | The curve started at the 2-year, so nothing could answer a question about the front end. Adds 1M through 20Y plus DFF, IORB, TB3MS. |
| Corporate bond spreads | The high-yield aggregate had no rating buckets under it, so a widening could not be told apart from a rotation within high yield. Adds BB, B, CCC, BBB, and the Moody's yields. |
| Housing | Starts and the 30-year rate, but no price. Adds MSPUS, HSN1F, PERMIT, MORTGAGE15US, existing-home sales, months' supply, homeownership. |
| Exchange rates | A trade-weighted index with no bilateral pairs beneath it. Adds the nine majors. |
| Money supply | No reverse repo facility, which is the most-watched item in that category. |
| Inflation, employment, output | The component and household-survey series that give the headline print its meaning. |

## Deliberate exclusions

Two series cleared the popularity floor and are kept out, with a test to keep them out:

- **USSLIND** stopped updating in April 2020.
- **FPCPITOTLZGUSA** is an annual World Bank restatement of US CPI that lags `CPIAUCSL` by a year.

A frozen series is worse than a missing one: it renders a current-looking page over a stale number, which is exactly the trap `STLFSI2` sprang. That rule was a comment about one series; it is now `Series_ExcludesTheSeriesFredHasStoppedUpdating`, so the next curation pass cannot reintroduce a dead series on popularity alone.

## Tests

Existing coverage already pins uniqueness, valid categories and every category being represented, so the additions are covered by it. New:

- `Series_ExcludesTheSeriesFredHasStoppedUpdating`
- `InterestRates_CoverTheWholeTreasuryCurve` (1M, 3M, 6M, 1, 2, 3, 5, 7, 10, 20, 30)
- `CorporateBondSpreads_SeparateTheRatingBuckets` (BB, B, CCC)

`dotnet csharpier check .` clean, `dotnet build Equibles.sln -c Release` 0 errors, `dotnet test tests/Equibles.UnitTests` **4,439 passed, 0 failed**. Mutation-checked after committing: swapping one curve member for USSLIND failed both new guards, and the change was restored.

## Cost

72 more series is 72 more rows in the daily refresh, well inside FRED's rate limit, and the observation history is fetched once.