### PR TITLE
docs: stop publishing an unverifiable hosted count

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Equibles is a self-hosted, open-source financial data MCP server** — an open-source alternative to a Bloomberg Terminal, built for AI agents rather than humans. It scrapes, stores, and serves SEC filings and XBRL financials, 13F institutional holdings, insider and congressional trades, FINRA/SEC short data, FRED economic indicators, CFTC and CBOE positioning, fund filings, government contracts, and daily stock prices — and exposes all of it over the Model Context Protocol, so Claude, ChatGPT, Cursor, or any agent can query it directly. Runs on your own hardware with Docker, for free, forever.
 
-**This is the open-source core of [Equibles](https://equibles.com).** [Equibles Cloud](https://equibles.com/mcp) runs this exact core and adds 44 more tools, 108 in total — earnings call transcripts and audio, real-time quotes, options chains with Greeks, LLM-extracted KPIs and guidance, buybacks, IPO filings, executive changes, valuation multiples, index composition, portfolio tracking, and a full US-market screener. Same protocol, same tool names, nothing to run — see [what's included](#whats-included).
+**This is the open-source core of [Equibles](https://equibles.com).** [Equibles Cloud](https://equibles.com/mcp) runs this exact core and adds more tools on top — earnings call transcripts and audio, real-time quotes, options chains with Greeks, LLM-extracted KPIs and guidance, buybacks, IPO filings, executive changes, valuation multiples, index composition, portfolio tracking, and a full US-market screener. Same protocol, same tool names, nothing to run — see [what's included](#whats-included).
 
 > **Don't want to run anything?** Point your AI assistant at `https://mcp.equibles.com/mcp` and get a free API key at [equibles.com/mcp](https://equibles.com/mcp) — 100 requests/day, no card. Per-client setup guides live at [daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server).
 
@@ -19,7 +19,7 @@ See [`docs/`](docs/README.md) for the user guide and technical documentation.
 
 ## What's Included
 
-Everything marked **Self-hosted** is scraped, stored, and served by this repo — **64 MCP tools**, no account, no key. [Equibles Cloud](https://equibles.com) runs this exact core over the same protocol with the same tool names, and adds 44 more tools, 108 in total.
+Everything marked **Self-hosted** is scraped, stored, and served by this repo — **64 MCP tools**, no account, no key. [Equibles Cloud](https://equibles.com) runs this exact core over the same protocol with the same tool names, and adds more tools on top.
 
 | Domain | Data Source | Self-hosted | [Equibles Cloud](https://equibles.com) | Description |
 |--------|------------|:---:|:---:|-------------|
@@ -284,7 +284,7 @@ Any MCP-compatible client can connect to `http://localhost:8081/mcp` (HTTP trans
 
 ## Tools
 
-This self-hosted build exposes 64 tools over MCP. The hosted server at `https://mcp.equibles.com/mcp` exposes 108 — the same 64 plus [44 more](#whats-included). Full catalog and client setup: [daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server).
+This self-hosted build exposes 64 tools over MCP. The hosted server at `https://mcp.equibles.com/mcp` runs this same core and [adds more on top](#whats-included). Full catalog and client setup: [daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server).
 
 **13F institutional holdings**
 

--- a/tests/Equibles.UnitTests/Mcp/McpToolAnnotationsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpToolAnnotationsTests.cs
@@ -98,7 +98,7 @@ public class McpToolAnnotationsTests
         EnumerateTools().Should().HaveCountGreaterThan(50);
     }
 
-    private static List<(McpServerToolAttribute Attribute, MethodInfo Method)> EnumerateTools()
+    internal static List<(McpServerToolAttribute Attribute, MethodInfo Method)> EnumerateTools()
     {
         return ToolAssemblyMarkers
             .Select(marker => marker.Assembly)

--- a/tests/Equibles.UnitTests/Mcp/PublishedToolCountTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/PublishedToolCountTests.cs
@@ -1,0 +1,47 @@
+using Xunit;
+
+namespace Equibles.UnitTests.Mcp;
+
+// The README's tool count is the number this project gets compared on: every "best MCP server for
+// stock data" roundup ranks entrants by it, and the AI assistants that answer that question read
+// the README to do it. Written out as a literal it silently stops being true the day a tool lands.
+//
+// Only the SELF-HOSTED count is asserted, because it is the only one this repo can prove. The README
+// used to also state the hosted server's total and the difference between the two; both drifted, so
+// it now says Cloud "adds more on top" rather than quoting a number nothing here can keep honest.
+public class PublishedToolCountTests
+{
+    [Fact]
+    public void Readme_StatesTheNumberOfToolsThisBuildActuallyServes()
+    {
+        var served = McpToolAnnotationsTests.EnumerateTools().Count;
+        var readme = File.ReadAllText(Path.Combine(RepositoryRoot(), "README.md"));
+
+        // Both places the figure is published. Update them together with the tool that changed it.
+        readme
+            .Should()
+            .Contain(
+                $"**{served} MCP tools**",
+                "the README badge line publishes this build's tool count"
+            )
+            .And.Contain(
+                $"exposes {served} tools over MCP",
+                "the Tools section publishes this build's tool count"
+            );
+    }
+
+    private static string RepositoryRoot()
+    {
+        // Anchored on the solution file, not on README.md: tests/README.md sits between the test
+        // binaries and the root, so a walk looking for any README stops one directory too early.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Equibles.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        dir.Should()
+            .NotBeNull("the test must run from inside the repository so it can read the README");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
The README stated the hosted server's total (108) and the difference between it and this build (44 more). Both had drifted: the hosted server is at 111 today, so the stated gap was wrong too. Three numbers were published and only the self-hosted 64 was still right.

- State only the **self-hosted** count, which this repo can prove by reflection.
- Describe Equibles Cloud as adding more tools on top, instead of quoting a total that lives in another repository and moves independently.
- Add `PublishedToolCountTests`, which counts the tools reflection actually finds and asserts the README publishes that number in both places it appears. Mutation-tested: bumping the README to 65 fails the test.

`EnumerateTools` in `McpToolAnnotationsTests` is widened to `internal` so the new guard reuses the existing enumerator rather than growing a second one.

4,440 unit tests pass.