### PR TITLE
fix(prices): stop rescaling an ADS market cap onto the issuer's ordinary share count

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ListedSecurityClassifier.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ListedSecurityClassifier.cs
@@ -84,6 +84,43 @@ public static class ListedSecurityClassifier
             RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled
         );
 
+    // The listed unit is a depositary receipt. Deliberately matched against the RAW title, not
+    // the rider-stripped one Classify uses: the question here is only whether the issuer names
+    // an American Depositary Share anywhere in the title it registered, and a title can put that
+    // phrase inside a parenthetical ("Ordinary Shares (represented by American Depositary
+    // Shares)") that Classify strips before choosing a kind.
+    //
+    // "Deposit[ao]ry" spells the issuer's own typo into the pattern rather than around it. The
+    // canonical word is "depositary"; a handful of filers register "American Depository Shares"
+    // instead, and because this is the title THEY filed there is nothing upstream to normalize
+    // it. "American" is required either way, so the far commoner preferred-stock form
+    // ("Depositary Shares, each representing a 1/1,000th interest in a share of Series A
+    // Preferred Stock") cannot match: that one is a fractional interest in the issuer's OWN
+    // preferred, counted on the same basis as the cover page, and there is no unit mismatch.
+    // A Global Depositary Share carries the same mismatch and is deliberately left out: every GDS
+    // issuer on record files as a foreign private issuer, so the form-based guard already answers
+    // for them, and one unexercised alternation is a rule nothing pins.
+    private static readonly Regex AmericanDepositary = Pattern(
+        "american deposit[ao]ry (shares?|receipts?)"
+    );
+
+    /// <summary>
+    /// True when the issuer's own registered title says the LISTED security is an American
+    /// Depositary Share or Receipt.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// A separate question from <see cref="Classify"/>, which answers what KIND of security is
+    /// listed (an ADS over ordinary shares is common equity, and classifies as such). This one
+    /// answers what UNIT the listing is quoted in, which is what a share count has to agree with:
+    /// the depositary receipt is priced per receipt while the issuer's SEC cover page counts
+    /// ordinary shares, and the two differ by the deposit ratio. Callers use it to refuse to mix
+    /// the bases, never to derive the ratio — the ratio is stated in prose and reading a number
+    /// out of prose is exactly what the registered title is authoritative INSTEAD of.
+    /// </remarks>
+    public static bool IsAmericanDepositary(string securityTitle) =>
+        !string.IsNullOrWhiteSpace(securityTitle) && AmericanDepositary.IsMatch(securityTitle);
+
     public static ListedSecurityType Classify(string securityTitle)
     {
         if (string.IsNullOrWhiteSpace(securityTitle))

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ShareBasisPlausibility.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ShareBasisPlausibility.cs
@@ -11,9 +11,15 @@ namespace Equibles.Sec.FinancialFacts.BusinessLogic;
 /// another unit entirely. The form-based foreign-private-issuer guard catches 20-F/40-F filers,
 /// but a former FPI that lost the status keeps filing 10-K/10-Q while its US listing is still an
 /// ADS — AKTX files 10-Q covers of 91.6B ordinary shares against ~1.1M listed ADSs (80,000
-/// ordinary per ADS since 2026-03-31). No API the importers ingest exposes the registered
-/// security's title (the SEC companyfacts endpoint serves numeric facts only, and the submissions
-/// feed has no security section), so the mismatch is detected from the figures themselves.
+/// ordinary per ADS since 2026-03-31).
+///
+/// Where the issuer's registered 12(b) title IS on record, callers ask it first
+/// (<see cref="ListedSecurityClassifier.IsAmericanDepositary"/>) — it says what unit the listing
+/// is quoted in, which no ratio can. This class is what remains when no title is on record, or
+/// when the two counts disagree for a reason no title would explain (a dropped digit, a
+/// thousands-scaled entry, a nominal placeholder): the mismatch is then detected from the figures
+/// themselves. Deposit ratios are small enough to hide inside that tolerance, which is exactly
+/// why the title has to be asked first rather than instead.
 /// </summary>
 public static class ShareBasisPlausibility
 {

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -183,6 +183,15 @@ public class FinancialFactsImportService
         if (await sharesProvider.IsForeignPrivateIssuer(stock, cancellationToken))
             return;
 
+        // Same unit problem, one step further out: a company that lost foreign private issuer
+        // status files 10-K/10-Q while its US listing stays a depositary receipt, so the form
+        // says domestic and the cover page still counts ordinary shares. Its registered 12(b)
+        // title says what it listed, so ask that before writing. Without this the count goes back
+        // onto the ordinary base every facts cycle while the Yahoo importer keeps the market cap
+        // on the ADS base, and the two writers undo each other forever.
+        if (ListedSecurityClassifier.IsAmericanDepositary(stock.ListedSecurityTitle))
+            return;
+
         var stockRepository = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var tracked = await stockRepository
             .GetByIds([stock.Id])

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -1960,15 +1960,30 @@ public class YahooPriceImportService
             edgarShares = null;
 
         // The form-based guard above can't see a DOMESTIC filer whose US listing is still an ADS:
-        // a former foreign private issuer that lost FPI status files 10-K/10-Q while its cover
-        // page keeps counting ordinary shares — AKTX filed 10-Q covers of 91.6B ordinary shares
-        // against ~1.1M listed ADSs (80,000 ordinary per ADS). Rescaling onto that base inflates
-        // market cap by the full ADS ratio, and the damage is undetectable downstream because the
-        // stored pair stays self-consistent (cap ÷ shares == the close). No ingested API exposes
-        // the registered security's title to flag these issuers authoritatively, so detect the
-        // unit mismatch from the figures themselves: when the EDGAR count and Yahoo's own share
-        // base are too far apart to be statements of the same unit, keep Yahoo's self-consistent
-        // listed-security figures verbatim, exactly like the FPI path. Also stops a garbage EDGAR
+        // a company that lost foreign-private-issuer status files 10-K/10-Q while its cover page
+        // keeps counting ordinary shares. So ask what it LISTED rather than what it files. The
+        // 12(b) registration title for the stock's own ticker is already materialized on the
+        // stock from that same cover page ("American Depositary Shares, each representing 13
+        // Ordinary Shares"), and a depositary receipt is a different unit from the ordinary
+        // shares counted beside it — so drop the EDGAR count exactly like the FPI path.
+        //
+        // This has to run BEFORE the ratio guard below and cannot be left to it: real deposit
+        // ratios are small (ONC 13x, SNY and AZN 2x) and sit far inside the band where two counts
+        // are still credible statements of the same unit, so the figures alone can never expose
+        // them. ONC stored a $557B market cap against a true ~$42.9B for exactly this reason, and
+        // the damage is invisible downstream because the stored pair stays self-consistent
+        // (cap ÷ shares == the close). The ratio itself is never read out of the title — only the
+        // fact that the listing is a receipt — so the repair is to stop rescaling, not to divide.
+        if (
+            edgarShares != null
+            && ListedSecurityClassifier.IsAmericanDepositary(stock.ListedSecurityTitle)
+        )
+            edgarShares = null;
+
+        // A last guard for issuers the two authoritative statements above miss: detect the unit
+        // mismatch from the figures themselves, when the EDGAR count and Yahoo's own share base
+        // are too far apart to be statements of the same unit. This catches an ADS issuer with no
+        // registered title on record (AKTX, 80,000 ordinary per ADS) and stops a garbage EDGAR
         // count (ABTC 458x, CNDA 768x off any real basis) from poisoning the rescale. The
         // threshold is deliberately far above any corporate-action lag (see
         // MaxPlausibleSameUnitRatio), so a lagging reverse split — where EDGAR is right and the
@@ -2060,12 +2075,13 @@ public class YahooPriceImportService
     // cap onto the EDGAR base (== EDGAR shares × the same implied price) so market cap stays
     // consistent with SharesOutStanding and the screener's derived price (market cap ÷ shares)
     // holds. Falls back to Yahoo's figure when there is no EDGAR count or no usable Yahoo share
-    // base to rescale from. The caller passes edgarShares == null for foreign private issuers
-    // (20-F/40-F), whose EDGAR count is in ordinary shares — a different unit from the US-listed
-    // ADR — so they keep Yahoo's self-consistent ADR market cap rather than being rescaled onto
-    // the ordinary base, and likewise whenever the EDGAR count and Yahoo's share base are too far
-    // apart to be statements of the same unit (a domestic filer still listing ADSs, a garbage
-    // cover-page count — see ShareBasisPlausibility).
+    // base to rescale from. The caller passes edgarShares == null whenever the EDGAR count is in a
+    // different unit from the listing Yahoo prices — a foreign private issuer (20-F/40-F) or a
+    // domestic filer whose registered 12(b) title says it listed American Depositary Shares, both
+    // of which count ordinary shares on the cover page, and any issuer whose EDGAR count and
+    // Yahoo share base are too far apart to be statements of the same unit at all (see
+    // ShareBasisPlausibility). Those keep Yahoo's self-consistent listed-security market cap
+    // rather than being rescaled onto the ordinary base.
     //
     // The rescale must divide by the share base Yahoo actually built its market cap on. That is
     // impliedSharesOutstanding (the entity-wide count, all classes) when Yahoo provides it — NOT

--- a/tests/Equibles.UnitTests/Sec/ListedSecurityClassifierDepositaryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ListedSecurityClassifierDepositaryTests.cs
@@ -1,0 +1,116 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins <see cref="ListedSecurityClassifier.IsAmericanDepositary"/>, which answers what UNIT a
+/// listing is quoted in — a different question from <c>Classify</c>'s what KIND of security it is
+/// (an ADS over ordinary shares is common equity and classifies as such). Both writers of
+/// <c>CommonStock.SharesOutStanding</c> ask it before mixing an EDGAR cover-page count with a
+/// price feed's share base: the cover page counts ordinary shares while the price is per ADS, and
+/// the deposit ratio between them (13x for ONC, 2x for AZN/SNY, 2,160x for ARBK) is small enough
+/// to sit inside <c>ShareBasisPlausibility</c>'s same-unit tolerance, so nothing but the issuer's
+/// own registered title can catch it.
+///
+/// Every title below is a verbatim <c>dei:Security12bTitle</c> read from the production store, so
+/// the shapes are the ones filers actually register rather than the ones a pattern was written
+/// for.
+/// </summary>
+public class ListedSecurityClassifierDepositaryTests
+{
+    [Theory]
+    // The three that motivated the guard: all list ADSs while filing domestic forms, so the
+    // form-based foreign-private-issuer check never sees them.
+    [InlineData(
+        "American Depositary Shares, each representing 13 Ordinary Shares, par value $0.0001 per share"
+    )]
+    [InlineData(
+        "American Depositary Shares, each representing one half of an Ordinary Share of 25¢ each"
+    )]
+    [InlineData(
+        "American Depositary Shares, each representing one half of one ordinary share, par value €2 per share"
+    )]
+    // Singular "Share", and the bare title with no ratio clause at all.
+    [InlineData(
+        "American Depositary Share representing 100 Series B Shares, par value 50 Rupiah per share"
+    )]
+    [InlineData("American Depositary Shares")]
+    // Receipts rather than shares.
+    [InlineData("American Depositary Receipts, each representing one B Share")]
+    // The issuer's own misspelling. "Depository" is not the canonical word, but it is the title
+    // THEY registered and nothing upstream normalizes it.
+    [InlineData("American Depository Shares, each representing 2,160 ordinary shares")]
+    [InlineData("American depository shares (the “ADSs”), each of which represents one share")]
+    // Case and quoting vary freely across filers.
+    [InlineData(
+        "American depositary shares, each ADS represents 15 ordinary shares, par valueUS$0.001 per share"
+    )]
+    [InlineData("American Depositary Shares (“ADS”), each representing 10 ordinary shares")]
+    [InlineData("American Depositary Shares (ADSs)")]
+    // The phrase inside a parenthetical, which Classify strips before choosing a kind — matching
+    // the RAW title is what keeps this one visible.
+    [InlineData(
+        "American Depositary Shares (as evidenced by American Depositary Receipts), each representing one ordinary share"
+    )]
+    public void IsAmericanDepositary_RegisteredAdsTitle_IsTrue(string title)
+    {
+        ListedSecurityClassifier.IsAmericanDepositary(title).Should().BeTrue();
+    }
+
+    [Theory]
+    // Ordinary domestic equity: the cover page and the listing count the same unit.
+    [InlineData("Common Stock, $0.001 par value per share")]
+    [InlineData("Common stock")]
+    [InlineData("Class A Ordinary Shares")]
+    // The far commoner depositary form, and the one that must NOT fire: a fractional interest in
+    // the issuer's OWN preferred stock. Treating it as a foreign-unit mismatch would throw away
+    // the authoritative EDGAR count for every bank that lists preferred this way.
+    [InlineData(
+        "Depositary Shares, each representing a 1/1,000th interest in a share of 7.375% Fixed-Rate Non-Cumulative Preferred Stock, Series D"
+    )]
+    // A Global Depositary Share carries the same unit mismatch but is deliberately out of scope —
+    // every GDS issuer on record files as a foreign private issuer, so the form-based guard
+    // answers for them first.
+    [InlineData("Global Depositary Shares")]
+    // Exchange-traded debt from an ADS issuer: same company, different listed security, and the
+    // share-count question does not arise.
+    [InlineData("4.875% Notes due 2033")]
+    // Word-boundary sanity: neither the adjective nor a longer word containing it counts.
+    [InlineData("American Insurance Common Stock")]
+    [InlineData("Depositary")]
+    public void IsAmericanDepositary_OtherTitle_IsFalse(string title)
+    {
+        ListedSecurityClassifier.IsAmericanDepositary(title).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsAmericanDepositary_MissingTitle_IsFalse(string title)
+    {
+        // Absence of a registered title is not evidence of a depositary listing. Stocks whose
+        // 12(b) title was never materialized must keep their existing behaviour rather than
+        // silently lose the authoritative EDGAR count.
+        ListedSecurityClassifier.IsAmericanDepositary(title).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAmericanDepositary_AdsTitle_StillClassifiesAsCommonEquity()
+    {
+        // The two questions are independent and both answers matter: the listing is common equity
+        // (so it belongs in every equity surface) AND it is quoted per receipt (so its share count
+        // must not be mixed with the cover page's). A future change that made the ADS test a
+        // Classify branch would silently drop these companies out of the equity universe.
+        const string title =
+            "American Depositary Shares, each representing 13 Ordinary Shares, par value $0.0001 per share";
+
+        ListedSecurityClassifier.IsAmericanDepositary(title).Should().BeTrue();
+        ListedSecurityClassifier
+            .Classify(title)
+            .Should()
+            .Be(Equibles.CommonStocks.Data.Models.ListedSecurityType.CommonShares);
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceAdsMarketCapTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceAdsMarketCapTests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Yahoo.HostedService.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// The regression behind the depositary guard, worked in the real figures that exposed it. BeOne
+/// Medicines (ONC) lists American Depositary Shares, each representing 13 ordinary shares, and
+/// files 10-K/10-Q — so the form-based foreign-private-issuer guard never fires, its cover page
+/// counts ordinary shares, and the price feed quotes ADSs.
+///
+/// <see cref="YahooPriceImportService.ReconcileMarketCap"/> rescales the feed's market cap onto
+/// the EDGAR share base. That is right when both are the same unit and catastrophic when they are
+/// not: it multiplied a correct ~$42.9B by the deposit ratio and stored $557.0B. The damage hides
+/// because the stored pair stays internally consistent — cap ÷ shares still equals the real ADS
+/// close of $376.86 — so no downstream sanity check on the pair can see it, and the inflated cap
+/// flows into every surface that ranks on market capitalization.
+/// </summary>
+public class YahooPriceImportServiceAdsMarketCapTests
+{
+    private static readonly MethodInfo ReconcileMarketCapMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "ReconcileMarketCap",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static double ReconcileMarketCap(long? edgarShares) =>
+        (double)
+            ReconcileMarketCapMethod.Invoke(
+                null,
+                [edgarShares, YahooAdsShareBase, 0L, YahooAdsMarketCap, null]
+            );
+
+    // ONC as its own SEC cover page reports it: ordinary shares, 13 per ADS.
+    private const long EdgarOrdinaryShares = 1_478_124_405L;
+
+    // What production stored for ONC while the defect was live, and the ADS close of the same
+    // session. 557,045,957,486.84 / 1,478,124,405 == 376.86 exactly, which is the point: the
+    // stored pair looks like a correctly priced company.
+    private const double StoredInflatedMarketCap = 557_045_957_486.84d;
+    private const double AdsClose = 376.86d;
+
+    // ONC as the price feed reports it, derived from the two above rather than invented: the ADS
+    // count is the ordinary count over the deposit ratio, and the feed's market cap is that count
+    // at the ADS close. This is the pair the rescale started from.
+    private const long YahooAdsShareBase = EdgarOrdinaryShares / 13;
+    private const double YahooAdsMarketCap = YahooAdsShareBase * AdsClose;
+
+    private const string AdsTitle =
+        "American Depositary Shares, each representing 13 Ordinary Shares, par value $0.0001 per share";
+
+    [Fact]
+    public void OrdinaryCoverPageCount_RescalesTheAdsMarketCapByTheDepositRatio()
+    {
+        // Not an assertion that this is desirable — it is the defect, pinned so the guard below is
+        // measured against something real. Feeding the ordinary count in multiplies the correct
+        // cap by 13 and produces the $557B that was live in production.
+        var inflated = ReconcileMarketCap(EdgarOrdinaryShares);
+
+        // Reproduces the stored figure to within a rounding error of the ADS close, and the shape
+        // of the error is exactly the deposit ratio.
+        inflated
+            .Should()
+            .BeApproximately(StoredInflatedMarketCap, StoredInflatedMarketCap * 1e-6);
+        (inflated / YahooAdsMarketCap).Should().BeApproximately(13d, 0.001);
+    }
+
+    [Fact]
+    public void DepositaryTitle_WithholdsTheCoverPageCount_SoTheFeedsMarketCapStands()
+    {
+        // The guard in SyncKeyStatistics: an issuer whose registered 12(b) title names an American
+        // Depositary Share has a cover-page count in a different unit from the quote, so the count
+        // is withheld from the rescale. The feed's figure is already on the listed unit and is
+        // kept verbatim — repairing the value rather than abstaining from it.
+        ListedSecurityClassifier.IsAmericanDepositary(AdsTitle).Should().BeTrue();
+
+        var reconciled = ReconcileMarketCap(null);
+
+        reconciled.Should().Be(YahooAdsMarketCap);
+    }
+
+    [Fact]
+    public void DepositRatio_SitsFarInsideTheSameUnitTolerance()
+    {
+        // Why the figures alone cannot catch this, and why the guard has to run BEFORE the ratio
+        // check rather than instead of it: 13x is nowhere near the 300x that separates same-unit
+        // divergences from different-unit ones, and no real deposit ratio would be — AZN and SNY
+        // are 2x. Only the issuer's own registered title distinguishes the two cases.
+        ShareBasisPlausibility
+            .IsUnitMismatch(EdgarOrdinaryShares, YahooAdsShareBase)
+            .Should()
+            .BeFalse();
+    }
+}


### PR DESCRIPTION
## Problem

A company whose US listing is an **American Depositary Share** has an SEC cover page counting **ordinary** shares, while its price is quoted **per receipt**. `YahooPriceImportService` rescales the feed's market cap onto the EDGAR share base, so for these issuers it multiplied a correct figure by the deposit ratio.

BeOne Medicines (`ONC`, 13 ordinary per ADS) in production:

| | stored | true |
|---|---|---|
| MarketCapitalization | `557,045,957,486.84` | `~42.85e9` |
| SharesOutStanding | `1,478,124,405` (ordinary) | `113,701,877` (ADS) |

`557,045,957,486.84 / 1,478,124,405 = 376.86`, which is the real ADS close that session. That is what makes it dangerous: the stored pair is internally consistent, so nothing that inspects the pair can tell it apart from a correctly priced company, and the inflated cap flows into every surface that ranks on market capitalization.

Neither existing guard sees it:

- `IsForeignPrivateIssuer` is **form-based**, and ONC files 10-K/10-Q.
- `ShareBasisPlausibility.MaxPlausibleSameUnitRatio` is **300x**, far above any real deposit ratio (ONC 13x, SNY and AZN 2x), so the figures alone can never expose it.

## Fix

Ask the issuer's own registered **12(b) title**, which states the listed unit outright and is already materialized on `CommonStock.ListedSecurityTitle` by `XbrlFactExtractionService` for the stock's own ticker.

- New `ListedSecurityClassifier.IsAmericanDepositary(title)`, a separate question from `Classify` (an ADS over ordinary shares is still common equity and still classifies as such). Matched against the **raw** title, because a filer can bury the phrase in a parenthetical that `Classify` strips.
- Consulted by **both** writers of `CommonStock.SharesOutStanding`. Only guarding the price lane would leave the facts importer putting the count back on the ordinary base every cycle while the price lane kept the cap on the ADS base, and the two would undo each other forever.
- It runs **before** the ratio guard, not instead of it: the ratio guard still catches an ADS issuer with no title on record (AKTX, 80,000 ordinary per ADS) and a garbage cover-page count (ABTC 458x, CNDA 768x).
- The ratio is **never read out of the title**, only the fact that the listing is a receipt. So the repair is to stop rescaling rather than to divide: the feed's figure is already on the listed unit and now stands verbatim, exactly as it does for a 20-F filer.

The pattern accepts the `Depository` misspelling four filers actually registered (`ARBK`, `IX`, `ALAR`, `NICM`), and requires `American` so the far commoner preferred form (`Depositary Shares, each representing a 1/1,000th interest in ... Preferred Stock`) cannot match. Global Depositary Shares are deliberately out of scope and documented as such: the one GDS issuer on record files as an FPI, so the form-based guard answers for it.

## Tests

`+27` tests, all values read from the production store rather than invented:

- `ListedSecurityClassifierDepositaryTests` (26) works real `dei:Security12bTitle` strings, both spellings, singular/plural, receipts, parenthetical-embedded, and the negatives that must not fire.
- `YahooPriceImportServiceAdsMarketCapTests` (3) pins the defect in ONC's own numbers (reproducing the `$557.0B` to within a rounding error of the close), pins that withholding the count leaves the feed's cap verbatim, and pins that `13x` sits far inside the same-unit tolerance, which is why the title has to be asked first.

`dotnet csharpier check .` clean, `dotnet build Equibles.sln -c Release` 0 errors, full unit suite **4,466 passed / 0 failed**.

## Rollout

Additive, no migration. Self-heals on the next enrichment rotation for each affected stock, so no manual data fix.

Blast radius in production: 332 stocks carry an ADS title and a non-zero market cap.

A.L.V.I.S.