### PR TITLE
fix(insider-trading): persist Form 144 backfill retries

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/Form144FilerCikBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Form144FilerCikBackfillManager.cs
@@ -17,10 +17,10 @@ namespace Equibles.InsiderTrading.BusinessLogic;
 /// only way to tell whether a proposed sale was ever executed. Without it the seller is free
 /// text, and matching on a name resolves only about half of the corpus.
 ///
-/// <see cref="Form144Filing.FilerCik"/> being null is the single selector, so the run drains,
-/// terminates and resumes: an interrupted run continues where it left off. Notices EDGAR will
-/// not serve are parked with <see cref="UnavailableMarker"/> after
-/// <see cref="MaxAttempts"/> tries so one bad document cannot stall the backlog forever.
+/// Never-attempted notices run before retries, and failed fetches wait between persisted attempts,
+/// so a temporary EDGAR outage cannot consume the retry budget or starve later notices. Notices
+/// EDGAR will not serve are parked with <see cref="UnavailableMarker"/> after
+/// <see cref="MaxAttempts"/> tries.
 /// </summary>
 [Service]
 public class Form144FilerCikBackfillManager
@@ -35,6 +35,7 @@ public class Form144FilerCikBackfillManager
     // Committed per batch, so a throttled or interrupted run keeps what it fetched.
     private const int BatchSize = 64;
     private const int MaxAttempts = 3;
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromHours(6);
 
     // One full batch parked for missing credentials is already past coincidence.
     private const int ParkedWithoutCredentialsAlarm = BatchSize;
@@ -42,16 +43,19 @@ public class Form144FilerCikBackfillManager
     private readonly Form144FilingRepository _repository;
     private readonly ISecEdgarClient _secEdgarClient;
     private readonly ILogger<Form144FilerCikBackfillManager> _logger;
+    private readonly TimeProvider _timeProvider;
 
     public Form144FilerCikBackfillManager(
         Form144FilingRepository repository,
         ISecEdgarClient secEdgarClient,
-        ILogger<Form144FilerCikBackfillManager> logger
+        ILogger<Form144FilerCikBackfillManager> logger,
+        TimeProvider timeProvider
     )
     {
         _repository = repository;
         _secEdgarClient = secEdgarClient;
         _logger = logger;
+        _timeProvider = timeProvider;
     }
 
     /// <summary>
@@ -59,19 +63,31 @@ public class Form144FilerCikBackfillManager
     /// </summary>
     public async Task<int> Run(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var resolved = 0;
         var parkedNoIssuerCik = 0;
         var parkedNoCredentials = 0;
         var parkedAttemptsExhausted = 0;
-        var attempts = new Dictionary<Guid, int>();
+        var retryBefore = (_timeProvider.GetUtcNow() - RetryDelay).UtcDateTime;
 
-        while (!cancellationToken.IsCancellationRequested)
+        while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var batch = await _repository
                 .GetAll()
-                .Where(f => f.FilerCik == null)
+                .Where(f =>
+                    f.FilerCik == null
+                    && (
+                        f.FilerCikBackfillAttemptedAt == null
+                        || f.FilerCikBackfillAttemptedAt <= retryBefore
+                    )
+                )
                 .Include(f => f.CommonStock)
-                .OrderBy(f => f.FilingDate)
+                .OrderBy(f => f.FilerCikBackfillAttemptedAt != null)
+                .ThenBy(f => f.FilerCikBackfillAttemptedAt)
+                .ThenBy(f => f.FilingDate)
                 .ThenBy(f => f.Id)
                 .Take(BatchSize)
                 .ToListAsync(cancellationToken);
@@ -79,12 +95,14 @@ public class Form144FilerCikBackfillManager
             if (batch.Count == 0)
                 break;
 
-            var progressed = false;
-
             foreach (var filing in batch)
             {
                 if (cancellationToken.IsCancellationRequested)
-                    break;
+                {
+                    await _repository.SaveChanges();
+                    _repository.ClearChangeTracker();
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
 
                 var issuerCik = filing.CommonStock?.Cik;
                 if (string.IsNullOrEmpty(issuerCik))
@@ -93,22 +111,17 @@ public class Form144FilerCikBackfillManager
                     // be addressed on EDGAR at all. Park it rather than retrying forever.
                     filing.FilerCik = UnavailableMarker;
                     parkedNoIssuerCik++;
-                    progressed = true;
                     continue;
                 }
 
-                if (!TryRecordAttempt(attempts, filing.Id))
+                if (filing.FilerCikBackfillAttempts >= MaxAttempts)
                 {
-                    filing.FilerCik = UnavailableMarker;
-                    parkedAttemptsExhausted++;
-                    progressed = true;
-                    _logger.LogWarning(
-                        "Parking Form 144 {AccessionNumber} after {Attempts} failed attempts",
-                        filing.AccessionNumber,
-                        MaxAttempts
-                    );
+                    ParkIfAttemptsExhausted(filing, ref parkedAttemptsExhausted);
                     continue;
                 }
+
+                filing.FilerCikBackfillAttempts++;
+                filing.FilerCikBackfillAttemptedAt = _timeProvider.GetUtcNow().UtcDateTime;
 
                 string xml;
                 try
@@ -118,6 +131,12 @@ public class Form144FilerCikBackfillManager
                         issuerCik
                     );
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    await _repository.SaveChanges();
+                    _repository.ClearChangeTracker();
+                    throw;
+                }
                 catch (Exception exception)
                 {
                     _logger.LogWarning(
@@ -125,11 +144,15 @@ public class Form144FilerCikBackfillManager
                         "Failed to fetch Form 144 {AccessionNumber}",
                         filing.AccessionNumber
                     );
+                    ParkIfAttemptsExhausted(filing, ref parkedAttemptsExhausted);
                     continue;
                 }
 
                 if (string.IsNullOrWhiteSpace(xml))
+                {
+                    ParkIfAttemptsExhausted(filing, ref parkedAttemptsExhausted);
                     continue;
+                }
 
                 var parsed = ParseIdentity(xml);
                 if (parsed.FilerCik == null)
@@ -138,25 +161,16 @@ public class Form144FilerCikBackfillManager
                     // that, so park it immediately rather than burning the attempt budget.
                     filing.FilerCik = UnavailableMarker;
                     parkedNoCredentials++;
-                    progressed = true;
                     continue;
                 }
 
                 filing.FilerCik = parsed.FilerCik;
                 filing.PlanAdoptionDate = parsed.PlanAdoptionDate;
                 resolved++;
-                progressed = true;
             }
 
             await _repository.SaveChanges();
-
-            // Every notice in the batch failed transiently and none was parked, so the same
-            // batch would be re-read forever. Stop and let the next cycle retry.
-            if (!progressed)
-            {
-                _logger.LogWarning("Form 144 filer-CIK backfill made no progress; stopping cycle");
-                break;
-            }
+            _repository.ClearChangeTracker();
         }
 
         var parked = parkedNoIssuerCik + parkedNoCredentials + parkedAttemptsExhausted;
@@ -194,11 +208,18 @@ public class Form144FilerCikBackfillManager
         return resolved;
     }
 
-    private static bool TryRecordAttempt(Dictionary<Guid, int> attempts, Guid id)
+    private void ParkIfAttemptsExhausted(Form144Filing filing, ref int parkedAttemptsExhausted)
     {
-        attempts.TryGetValue(id, out var count);
-        attempts[id] = count + 1;
-        return count < MaxAttempts;
+        if (filing.FilerCikBackfillAttempts < MaxAttempts)
+            return;
+
+        filing.FilerCik = UnavailableMarker;
+        parkedAttemptsExhausted++;
+        _logger.LogWarning(
+            "Parking Form 144 {AccessionNumber} after {Attempts} failed attempts",
+            filing.AccessionNumber,
+            MaxAttempts
+        );
     }
 
     /// <summary>

--- a/src/Equibles.InsiderTrading.Data/Models/Form144Filing.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/Form144Filing.cs
@@ -49,6 +49,18 @@ public class Form144Filing
     public string FilerCik { get; set; }
 
     /// <summary>
+    /// Number of EDGAR fetches attempted by the filer-CIK backfill. Persisted so worker restarts
+    /// cannot reset the retry budget and let one bad filing starve the backlog forever.
+    /// </summary>
+    public int FilerCikBackfillAttempts { get; set; }
+
+    /// <summary>
+    /// UTC time of the latest filer-CIK fetch attempt. Failed notices wait for the retry interval
+    /// while never-attempted notices continue through the backlog.
+    /// </summary>
+    public DateTime? FilerCikBackfillAttemptedAt { get; set; }
+
+    /// <summary>
     /// The seller's relationship(s) to the issuer (e.g. "Director", "Officer"). A filing can
     /// list several — joined with ", ".
     /// </summary>

--- a/src/Equibles.Migrations/Migrations/20260820141759_AddForm144FilerCikBackfillAttempts.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260820141759_AddForm144FilerCikBackfillAttempts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820141759_AddForm144FilerCikBackfillAttempts")]
+    partial class AddForm144FilerCikBackfillAttempts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260820141759_AddForm144FilerCikBackfillAttempts.cs
+++ b/src/Equibles.Migrations/Migrations/20260820141759_AddForm144FilerCikBackfillAttempts.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddForm144FilerCikBackfillAttempts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "FilerCikBackfillAttemptedAt",
+                table: "Form144Filing",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "FilerCikBackfillAttempts",
+                table: "Form144Filing",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FilerCikBackfillAttemptedAt",
+                table: "Form144Filing");
+
+            migrationBuilder.DropColumn(
+                name: "FilerCikBackfillAttempts",
+                table: "Form144Filing");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Equibles.Core.AutoWiring;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Equibles.Sec.HostedService.Extensions;
 
@@ -10,6 +11,7 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddSecWorker(this IServiceCollection services)
     {
+        services.TryAddSingleton(TimeProvider.System);
         services.AutoWireServicesFrom<DocumentManager>();
         services.AutoWireServicesFrom<Equibles.Integrations.Sec.SecEdgarClient>();
 

--- a/tests/Equibles.IntegrationTests/InsiderTrading/Form144FilerCikBackfillManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/Form144FilerCikBackfillManagerTests.cs
@@ -1,0 +1,223 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+public class Form144FilerCikBackfillManagerTests : IDisposable
+{
+    private const string SuccessfulAccession = "0000000001-26-000065";
+
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly Form144FilingRepository _repository;
+
+    public Form144FilerCikBackfillManagerTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new InsiderTradingModuleConfiguration()
+        );
+        _repository = new Form144FilingRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Fact]
+    public async Task Run_PermanentFailureBatch_RetriesAcrossManagersAndReachesLaterNotice()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "TEST",
+            Name = "Test Issuer",
+            Cik = "0000000001",
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+
+        for (var index = 1; index <= 64; index++)
+        {
+            _repository.Add(
+                Filing(stock, $"0000000001-26-{index:000000}", new DateOnly(2026, 8, 1))
+            );
+        }
+        _repository.Add(Filing(stock, SuccessfulAccession, new DateOnly(2026, 8, 2)));
+        await _repository.SaveChanges();
+
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar
+            .GetDocumentContent(Arg.Any<string>(), stock.Cik)
+            .Returns(call =>
+                call.ArgAt<string>(0) == SuccessfulAccession
+                    ? "<edgarSubmission><headerData><filerInfo><filer><filerCredentials><cik>0000000065</cik></filerCredentials></filer></filerInfo></headerData></edgarSubmission>"
+                    : throw new HttpRequestException("permanent test failure")
+            );
+        var now = new DateTimeOffset(2026, 8, 20, 6, 0, 0, TimeSpan.Zero);
+        var timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(_ => now);
+
+        var firstResolved = await Manager().Run();
+
+        firstResolved.Should().Be(1);
+        await edgar.Received(65).GetDocumentContent(Arg.Any<string>(), stock.Cik);
+        _dbContext.ChangeTracker.Entries().Should().BeEmpty();
+
+        now = now.AddHours(6);
+        var secondResolved = await Manager().Run();
+
+        secondResolved.Should().Be(0);
+        await edgar.Received(129).GetDocumentContent(Arg.Any<string>(), stock.Cik);
+
+        now = now.AddHours(6);
+        var thirdResolved = await Manager().Run();
+
+        thirdResolved.Should().Be(0);
+        var filings = await _repository
+            .GetAll()
+            .AsNoTracking()
+            .OrderBy(f => f.FilingDate)
+            .ToListAsync();
+        filings
+            .Take(64)
+            .Should()
+            .OnlyContain(f => f.FilerCik == Form144FilerCikBackfillManager.UnavailableMarker);
+        filings[^1].FilerCik.Should().Be("0000000065");
+        filings.Take(64).Should().OnlyContain(f => f.FilerCikBackfillAttempts == 3);
+        await edgar.Received(193).GetDocumentContent(Arg.Any<string>(), stock.Cik);
+
+        Form144FilerCikBackfillManager Manager() =>
+            new(
+                _repository,
+                edgar,
+                NullLogger<Form144FilerCikBackfillManager>.Instance,
+                timeProvider
+            );
+    }
+
+    [Fact]
+    public async Task Run_CancelledMidBatch_PersistsEarlierSuccessAndCurrentAttempt()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "TEST",
+            Name = "Test Issuer",
+            Cik = "0000000001",
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+        var first = Filing(stock, "0000000001-26-000001", new DateOnly(2026, 8, 1));
+        var second = Filing(stock, "0000000001-26-000002", new DateOnly(2026, 8, 2));
+        second.FilerCikBackfillAttempts = 2;
+        _repository.Add(first);
+        _repository.Add(second);
+        await _repository.SaveChanges();
+
+        using var cancellation = new CancellationTokenSource();
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar
+            .GetDocumentContent(first.AccessionNumber, stock.Cik)
+            .Returns(
+                "<edgarSubmission><headerData><filerInfo><filer><filerCredentials><cik>0000000002</cik></filerCredentials></filer></filerInfo></headerData></edgarSubmission>"
+            );
+        edgar
+            .GetDocumentContent(second.AccessionNumber, stock.Cik)
+            .Returns(
+                (Func<NSubstitute.Core.CallInfo, Task<string>>)(
+                    _ =>
+                    {
+                        cancellation.Cancel();
+                        return Task.FromCanceled<string>(cancellation.Token);
+                    }
+                )
+            );
+        var now = new DateTimeOffset(2026, 8, 20, 6, 0, 0, TimeSpan.Zero);
+        var timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(_ => now);
+        var manager = new Form144FilerCikBackfillManager(
+            _repository,
+            edgar,
+            NullLogger<Form144FilerCikBackfillManager>.Instance,
+            timeProvider
+        );
+
+        var run = () => manager.Run(cancellation.Token);
+
+        await run.Should().ThrowAsync<OperationCanceledException>();
+        var filings = await _repository
+            .GetAll()
+            .AsNoTracking()
+            .OrderBy(f => f.AccessionNumber)
+            .ToListAsync();
+        filings[0].FilerCik.Should().Be("0000000002");
+        filings[0].FilerCikBackfillAttempts.Should().Be(1);
+        filings[1].FilerCik.Should().BeNull();
+        filings[1].FilerCikBackfillAttempts.Should().Be(3);
+        filings[1].FilerCikBackfillAttemptedAt.Should().NotBeNull();
+        _dbContext.ChangeTracker.Entries().Should().BeEmpty();
+
+        edgar
+            .GetDocumentContent(second.AccessionNumber, stock.Cik)
+            .Returns(
+                "<edgarSubmission><headerData><filerInfo><filer><filerCredentials><cik>0000000003</cik></filerCredentials></filer></filerInfo></headerData></edgarSubmission>"
+            );
+        now = now.AddHours(6);
+        var resumedManager = new Form144FilerCikBackfillManager(
+            _repository,
+            edgar,
+            NullLogger<Form144FilerCikBackfillManager>.Instance,
+            timeProvider
+        );
+
+        (await resumedManager.Run()).Should().Be(0);
+        var resumed = await _repository.GetAll().AsNoTracking().SingleAsync(f => f.Id == second.Id);
+        resumed.FilerCik.Should().Be(Form144FilerCikBackfillManager.UnavailableMarker);
+        resumed.FilerCikBackfillAttempts.Should().Be(3);
+        await edgar.Received(1).GetDocumentContent(second.AccessionNumber, stock.Cik);
+    }
+
+    [Fact]
+    public async Task Run_PreCancelled_ThrowsWithoutFetching()
+    {
+        var edgar = Substitute.For<ISecEdgarClient>();
+        var manager = new Form144FilerCikBackfillManager(
+            _repository,
+            edgar,
+            NullLogger<Form144FilerCikBackfillManager>.Instance,
+            TimeProvider.System
+        );
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var run = () => manager.Run(cancellation.Token);
+
+        await run.Should().ThrowAsync<OperationCanceledException>();
+        await edgar.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    private static Form144Filing Filing(
+        CommonStock stock,
+        string accessionNumber,
+        DateOnly filingDate
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            CommonStock = stock,
+            AccessionNumber = accessionNumber,
+            FilingDate = filingDate,
+            SellerName = "Test Seller",
+            RelationshipToIssuer = "Officer",
+            SecurityClassTitle = "Common Stock",
+        };
+}


### PR DESCRIPTION
## Summary
- persist filer-CIK retry attempts and timestamps across worker lifetimes
- prioritize fresh backlog rows and back off failed EDGAR fetches
- preserve bounded progress across cancellation and clear EF tracking per batch
- add the additive schema migration and restart/cancellation coverage

## Verification
- dotnet ef migrations has-pending-model-changes --project src/Equibles.Migrations
- dotnet vstest tests/Equibles.IntegrationTests/bin/Release/net10.0/Equibles.IntegrationTests.dll --Tests:Equibles.IntegrationTests.InsiderTrading.Form144FilerCikBackfillManagerTests (3/3)
- dotnet vstest tests/Equibles.IntegrationTests/bin/Release/net10.0/Equibles.IntegrationTests.dll (2642/2642)