### PR TITLE
fix(sec): poll latest filings every ten seconds

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -20,8 +20,10 @@ Equibles scrapes several public and free-tier data sources automatically. Each s
 
 | Source | What it provides | Default sync interval |
 |--------|-----------------|----------------------|
-| **SEC EDGAR** | Company filings (10-K, 10-Q, 8-K, …), financial facts (XBRL), and Failure-to-Deliver data | ~15 seconds (continuous) |
-| **SEC EDGAR 13F** | Institutional holdings (who owns what) | Every 24 hours (daily backfill) plus a 6-hour realtime check |
+| **SEC EDGAR filings** | Company filings (10-K, 10-Q, 8-K, …) | Ten-second default minimum between latest-filings polling attempts; active scrape cycles add latency |
+| **SEC EDGAR financial facts** | Company facts reported in XBRL | Every 24 hours |
+| **SEC EDGAR FTD** | Failure-to-Deliver data | Every 24 hours |
+| **SEC EDGAR 13F** | Institutional holdings (who owns what) | Every 24 hours (daily backfill) plus a 6-hour incremental check |
 | **Yahoo Finance** | Historical stock prices (OHLCV) | Every 24 hours |
 | **FRED** | U.S. economic indicators (GDP, unemployment, CPI, …) | Every 24 hours (requires a [free API key](how-to-set-up-fred-api-key.md)) |
 | **FINRA** | Short-sale volume data | Every 24 hours (requires a [free API key](how-to-set-up-finra-api-key.md)) |
@@ -31,7 +33,7 @@ Equibles scrapes several public and free-tier data sources automatically. Each s
 | **USAspending.gov** | Federal government contract awards won by public companies | Every 24 hours |
 | **FDA.gov** | FDA advisory-committee (AdComm) meeting calendar — regulatory catalyst dates for biotech and pharma stocks | Every 24 hours |
 
-The SEC filing and document-processing scrapers run nearly continuously (every 15 seconds) to pick up new filings as they appear on EDGAR. All other scrapers default to a 24-hour cycle. You don't need API keys for SEC, Yahoo, Congress, CBOE, CFTC, USAspending, or FDA — those work out of the box. FRED and FINRA require free API keys; without them those scrapers are simply skipped.
+The SEC latest-filings feed uses a ten-second default minimum polling interval, and document processing checks for queued work every 15 seconds. Financial-facts and Failure-to-Deliver imports run on separate daily schedules. You don't need API keys for SEC, Yahoo, Congress, CBOE, CFTC, USAspending, or FDA — those work out of the box. FRED and FINRA require free API keys; without them those scrapers are simply skipped.
 
 ## I started the stack but the web portal is nearly empty — is something wrong?
 
@@ -98,4 +100,4 @@ Not currently. All data sources are U.S.-focused: SEC EDGAR for filings and hold
 
 ## Does Equibles provide real-time data?
 
-No — Equibles is designed for research and analysis, not live trading. Stock prices from Yahoo Finance are end-of-day and update once every 24 hours. SEC filings appear within minutes of being published on EDGAR (the scraper polls every ~15 seconds), but the filings themselves are not real-time market data. Institutional holdings from 13F filings are quarterly and arrive with a 45-day lag. Short volume from FINRA and economic indicators from FRED are published daily or less frequently by those agencies. For the exact sync cadence of each data source, see [What data sources does Equibles pull from?](#what-data-sources-does-equibles-pull-from-and-how-often-do-they-update).
+No — Equibles is designed for research and analysis, not live trading. Stock prices from Yahoo Finance are end-of-day and update once every 24 hours. SEC filing discovery uses a ten-second default minimum between polling attempts, but active scrape cycles, SEC publication timing, and downstream processing mean a filing can take minutes to become available in Equibles. Institutional holdings from 13F filings are quarterly and arrive with a 45-day lag. Short volume from FINRA and economic indicators from FRED are published daily or less frequently by those agencies. For the exact sync cadence of each data source, see [What data sources does Equibles pull from?](#what-data-sources-does-equibles-pull-from-and-how-often-do-they-update).

--- a/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
@@ -39,7 +39,7 @@ public class DocumentScraperOptions
     // Minimum seconds between "Latest Filings" ATOM feed polls. The feed holds
     // ~100 entries per page and peak dissemination bursts run tens of filings a
     // minute, so the poll interval bounds the realtime layer's blind window.
-    public int RecentFeedPollSeconds { get; set; } = 60;
+    public int RecentFeedPollSeconds { get; set; } = 10;
 
     // Max ATOM pages (100 entries each) walked per poll when every entry is
     // still unseen (first poll after a boot, or a heavy burst).

--- a/src/Equibles.Sec.HostedService/SecScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/SecScraperWorker.cs
@@ -11,7 +11,7 @@ public class SecScraperWorker : BaseScraperWorker
     private readonly IConfiguration _configuration;
 
     protected override string WorkerName => "SEC filing scraper";
-    protected override TimeSpan SleepInterval => TimeSpan.FromSeconds(15);
+    protected override TimeSpan SleepInterval => TimeSpan.FromSeconds(10);
     protected override ErrorSource ErrorSource => ErrorSource.DocumentScraper;
 
     // Staggered so the SEC scrapers don't drain the shared EDGAR request budget at

--- a/src/Equibles.Sec.HostedService/Services/IFilingDiscoveryService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IFilingDiscoveryService.cs
@@ -7,7 +7,8 @@ public interface IFilingDiscoveryService
     /// <summary>
     /// Returns the tracked companies that likely have new filings since the
     /// last cycle, discovered from EDGAR's centralized feeds: the real-time
-    /// "Latest Filings" ATOM stream (minutes of latency, lossy under bursts)
+    /// "Latest Filings" ATOM stream (a configurable interval with a ten-second
+    /// default minimum, lossy under bursts)
     /// plus the immutable per-day master index (complete, hours of latency,
     /// watermarked so downtime is caught up without loss). Both layers are
     /// best-effort — the periodic per-company reconciliation sweep is the

--- a/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
+++ b/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
@@ -176,6 +176,14 @@ public class ConfigurationTests
         options.DocumentTypesToSync.Should().ContainSingle().Which.Should().Be(DocumentType.EightK);
     }
 
+    [Fact]
+    public void DocumentScraperOptions_RecentFeedPollSeconds_DefaultsToTenSeconds()
+    {
+        var options = new DocumentScraperOptions();
+
+        options.RecentFeedPollSeconds.Should().Be(10);
+    }
+
     // ── FinraOptions (integration) ───────────────────────────────────
 
     [Fact]

--- a/tests/Equibles.UnitTests/Sec/SecScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecScraperWorkerTests.cs
@@ -77,11 +77,11 @@ public class SecScraperWorkerTests
     }
 
     [Fact]
-    public void SleepInterval_IsFifteenSeconds()
+    public void SleepInterval_IsTenSeconds()
     {
         // SecScraperWorker is the only scraper in the pipeline that polls the SEC
         // submissions API at sub-minute cadence (the other workers — FTD, Holdings,
-        // InsiderTrading, etc. — sleep for hours per cycle). The 15-second interval
+        // InsiderTrading, etc. — sleep for hours per cycle). The 10-second interval
         // sits well inside SEC EDGAR's documented 10 req/second / 600 req/minute
         // limit even with concurrent cycles, but a refactor that "tightened the loop"
         // to e.g. `TimeSpan.FromSeconds(1)` (a plausible copy-paste from a unit-test
@@ -101,7 +101,7 @@ public class SecScraperWorkerTests
             new ConfigurationBuilder().Build()
         );
 
-        sut.InvokeSleepInterval().Should().Be(TimeSpan.FromSeconds(15));
+        sut.InvokeSleepInterval().Should().Be(TimeSpan.FromSeconds(10));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Reduce the default SEC Latest Filings discovery delay from 60 seconds to a ten-second minimum after completed scrape cycles.

## Code changes

- Set the recent-feed poll and SEC worker sleep defaults to ten seconds.
- Add regression tests for both defaults.
- Document the distinction between discovery cadence, processing cadence, and end-to-end availability.
- Keep all EDGAR traffic behind the existing shared five-requests-per-second limiter.

## Verification

- Release solution build passed.
- 4,467 unit tests passed.
- 32 focused tests passed after documentation fixes.
- CSharpier and git diff checks passed.
- Independent audit passed with no blocking or high-confidence findings.