### PR TITLE
test(sec): cover document search service activation

### DIFF
--- a/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
@@ -25,7 +25,6 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Npgsql;
 using Respawn;
 using Testcontainers.PostgreSql;
@@ -100,16 +99,6 @@ public class McpServerAppFixture : IAsyncLifetime
         );
 
         builder.Configuration["ConnectionStrings:DefaultConnection"] = _db.GetConnectionString();
-
-        // Production MCP server doesn't opt in to validate-on-build; EmbeddingClient pulls
-        // IHttpClientFactory lazily on first use and isn't registered at composition time.
-        // Match that behaviour so the fixture's host build doesn't reject the composition
-        // before any request is served.
-        builder.Host.UseDefaultServiceProvider(o =>
-        {
-            o.ValidateOnBuild = false;
-            o.ValidateScopes = false;
-        });
 
         Program.ConfigureServices(builder);
         _app = builder.Build();

--- a/tests/Equibles.IntegrationTests/Mcp/Server/McpServerFixture.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Server/McpServerFixture.cs
@@ -31,19 +31,7 @@ public class McpServerFixture : WebApplicationFactory<Program>, IAsyncLifetime
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseSetting("ConnectionStrings:DefaultConnection", _paradeDb.ConnectionString);
-
-        // Match production: WebApplicationFactory enables ValidateOnBuild + ValidateScopes in
-        // the Development environment, which the production MCP server (running under
-        // ASP.NET Core's default options without explicit opt-in) does not. EmbeddingClient
-        // pulls IHttpClientFactory only when an embeddings tool is actually invoked, and the
-        // MCP server doesn't register AddHttpClient at composition time; the validation
-        // would reject the host before any test runs even though the production startup
-        // tolerates this lazy resolution.
-        builder.UseDefaultServiceProvider(o =>
-        {
-            o.ValidateOnBuild = false;
-            o.ValidateScopes = false;
-        });
+        builder.UseSetting("Embedding:Enabled", "false");
     }
 
     public async Task InitializeAsync()

--- a/tests/Equibles.IntegrationTests/Mcp/Server/McpServerToolInvocationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Server/McpServerToolInvocationTests.cs
@@ -129,4 +129,40 @@ public class McpServerToolInvocationTests : IAsyncLifetime
                 "the F2-formatted close should round-trip through the JSON content block"
             );
     }
+
+    [Fact]
+    public async Task CallTool_ListCompanyDocuments_EmbeddingsDisabled_ActivatesSecSearchGraph()
+    {
+        var httpClient = _serverFixture.CreateClient();
+        httpClient.BaseAddress = new Uri("http://localhost/");
+
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri("http://localhost/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+            },
+            httpClient
+        );
+
+        await using var client = await McpClient.CreateAsync(transport);
+        var result = await client.CallToolAsync(
+            toolName: "ListCompanyDocuments",
+            arguments: new Dictionary<string, object> { ["ticker"] = "ZZZZ" }
+        );
+
+        result
+            .IsError.Should()
+            .NotBe(
+                true,
+                "the SEC search dependency graph should activate when embeddings are disabled"
+            );
+
+        var text = string.Concat(result.Content.OfType<TextContentBlock>().Select(b => b.Text));
+        text.Should()
+            .Contain(
+                "Stock 'ZZZZ' not found.",
+                "the tool should reach its normal unknown-ticker response after DI activation"
+            );
+    }
 }


### PR DESCRIPTION
## Summary
Add a regression that exercises SEC document search through the public server with embeddings disabled, preventing missing service registrations from returning.

## Code changes
- Invoke `ListCompanyDocuments` over HTTP and assert the normal unknown-ticker response.
- Restore default dependency validation in the integration fixture.
- Remove obsolete validation overrides from the functional fixture.