### PR TITLE
docs(insiders): distinguish ownership from transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ This self-hosted build exposes 64 tools over MCP. The hosted server at `https://
 
 **Insider trading**
 
-- GetInsiderTransactions — insider transactions from Form 3/4/5
+- GetInsiderTransactions — insider transactions from Forms 4/5
 - GetInsiderOwnership — insider ownership ranked by shares
 - GetProposedSales — proposed sales from Form 144
 - SearchInsiders — strict-first whole-word filed-name search with verified public-name aliases

--- a/docs/guide/how-to-ask-about-insider-trading.md
+++ b/docs/guide/how-to-ask-about-insider-trading.md
@@ -1,6 +1,6 @@
 # Ask your AI assistant about a company's insider trading
 
-Equibles tracks the Form 3, Form 4, Form 5, and Form 144 filings that company insiders — directors, officers, and 10%-or-more owners — submit to the SEC, and exposes them through the MCP server, so you can ask your AI assistant who is buying or selling a stock, what each insider owns, and which sales are coming up.
+Equibles tracks the Form 3, Form 4, Form 5, and Form 144 filings that company insiders — directors, officers, and 10%-or-more owners — submit to the SEC, and exposes them through the MCP server, so you can ask your AI assistant who is buying or selling a stock, what each insider owns, and which sales have been proposed.
 
 ## Before you start
 
@@ -14,7 +14,7 @@ Name a company and ask about its insider activity:
 - "What insider buying and selling has there been at AAPL recently?"
 - "Have any Tesla executives sold shares in the last few months?"
 
-The assistant calls the `GetInsiderTransactions` tool and replies with recent purchases, sales, and awards from Forms 3, 4, and 5 — each with the insider's name and role, the transaction type, the number of shares and price, and the holding left afterward.
+The assistant calls the `GetInsiderTransactions` tool and replies with recent purchases, sales, and awards from Forms 4 and 5 — each with the insider's name and role, the transaction type, the number of shares and price, and the holding left afterward. Form 3 supplies initial ownership rather than a transaction.
 
 ## Ask who owns what
 
@@ -24,9 +24,9 @@ To see the insider ownership structure rather than individual trades:
 
 The assistant uses `GetInsiderOwnership`, which lists each insider, their role, total shares held, and their most recent transaction.
 
-## Ask about upcoming sales
+## Ask about proposed sales
 
-A Form 144 is an affiliate's declared intent to sell, filed before the trade — an early signal that often precedes an executed Form 4:
+A Form 144 is an affiliate's declared intent to sell, not evidence that a trade will occur. A completed sale may later appear on Form 4 or 5 when it is reportable there:
 
 - "Are there any proposed insider sales pending at NVDA?"
 

--- a/docs/guide/how-to-ask-about-proposed-sales.md
+++ b/docs/guide/how-to-ask-about-proposed-sales.md
@@ -1,6 +1,6 @@
 # Ask your AI assistant about proposed insider sales (Form 144)
 
-Equibles imports SEC Form 144 notices — an affiliate's declaration of intent to sell restricted or control shares — and exposes them through the MCP server, so you can ask your AI assistant about a company's upcoming insider selling before it executes. Form 144 is the forward-looking complement to executed Form 4 trades — to ask about those, see [Ask about a company's insider trading](how-to-ask-about-insider-trading.md). To browse the same notices on the web portal, see [View proposed insider sales](how-to-view-proposed-sales.md).
+Equibles imports SEC Form 144 notices — an affiliate's declaration of intent to sell restricted or control shares — and exposes them through the MCP server, so you can ask your AI assistant about proposed insider selling before any trade occurs. A proposed sale may never execute; when one does and is reportable there, it may later appear on Form 4 or 5 — to ask about reported transactions, see [Ask about a company's insider trading](how-to-ask-about-insider-trading.md). To browse the same notices on the web portal, see [View proposed insider sales](how-to-view-proposed-sales.md).
 
 ## Before you start
 
@@ -21,6 +21,6 @@ The assistant picks the `GetProposedSales` tool and returns the company's recent
 
 A table of recent Form 144 notices, each showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the sale as a percent of shares outstanding, the approximate sale date, the broker, and filed remarks such as a stated 10b5-1 plan.
 
-Remember that a Form 144 is a *declaration of intent*, not a completed trade — the actual sale, if it happens, later appears as an executed [Form 4 insider transaction](how-to-ask-about-insider-trading.md).
+Remember that a Form 144 is a *declaration of intent*, not a completed trade — the actual sale, if it happens and is reportable there, may later appear as an executed [Form 4 or 5 insider transaction](how-to-ask-about-insider-trading.md).
 
 If the reply says there are no proposed sales, the company may simply have no recent Form 144 filings — confirm the worker has run, then try a large, actively-traded ticker such as AAPL.

--- a/docs/guide/how-to-view-insider-activity.md
+++ b/docs/guide/how-to-view-insider-activity.md
@@ -20,7 +20,7 @@ Each table shows the insider's name, the stock ticker, the transaction value, an
 - **Red values** in the Top Sells card indicate sales.
 - In the Biggest Transactions table, a green **Buy** or red **Sell** badge marks each row's direction.
 
-Insider activity comes from SEC Forms 3, 4, and 5. Form 4 normally reports a trade within two business days; Form 5 is the annual statement that can report transactions eligible for deferred reporting.
+Transactions come from SEC Forms 4 and 5; Form 3 supplies initial ownership. Form 4 normally reports a trade within two business days, while Form 5 is the annual statement that can report transactions eligible for deferred reporting.
 
 ## Drill into an insider or stock
 
@@ -29,4 +29,4 @@ Insider activity comes from SEC Forms 3, 4, and 5. Form 4 normally reports a tra
 
 ## If the dashboard is empty
 
-The dashboard shows "No insider transactions yet" until the worker has ingested Forms 3, 4, and 5. After a fresh install, give the scrapers at least an hour to begin populating insider data. You can check ingestion progress on the [status page](how-to-view-status-and-errors.md).
+The dashboard shows "No insider transactions yet" until the worker has ingested Forms 4 and 5. After a fresh install, give the scrapers at least an hour to begin populating insider data. You can check ingestion progress on the [status page](how-to-view-status-and-errors.md).

--- a/docs/guide/how-to-view-proposed-sales.md
+++ b/docs/guide/how-to-view-proposed-sales.md
@@ -26,5 +26,5 @@ Each row is one Form 144 notice. The columns are:
 
 ## Related
 
-- For completed insider transactions (Forms 3, 4, and 5), see the **Insider Trading** tab on the same profile.
+- For completed insider transactions (Forms 4 and 5), see the **Insider Trading** tab on the same profile. Form 3 supplies initial ownership.
 - To walk through every tab on a stock profile, see [Explore a company's data on the web portal](tutorial-explore-stock.md).

--- a/docs/guide/tutorial-explore-stock.md
+++ b/docs/guide/tutorial-explore-stock.md
@@ -50,7 +50,7 @@ Click **SEC Filings**. Here you'll find every filing the company has made with t
 
 ## Insider Trades
 
-Click **Insider Trades**. This tab lists stock transactions by company insiders (officers, directors, and large shareholders) as reported on SEC Forms 3, 4, and 5. You'll see who traded, when, how many shares, at what price, and whether it was a buy or a sell.
+Click **Insider Trades**. This tab lists stock transactions by company insiders (officers, directors, and large shareholders) as reported on SEC Forms 4 and 5. Form 3 supplies initial ownership rather than a trade. You'll see who traded, when, how many shares, at what price, and whether it was a buy or a sell.
 
 ## Proposed Sales
 

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -80,11 +80,11 @@ public class InsiderTradingTools
 
     [McpServerTool(
         Name = "GetInsiderTransactions",
-        Title = "Insider Transactions (Forms 3/4/5)",
+        Title = "Insider Transactions (Forms 4/5)",
         ReadOnly = true
     )]
     [Description(
-        "Get recent insider trading transactions for a stock from SEC Form 3/4/5 filings, newest first. The Type column carries the SEC transaction code meaning: 'Buy'/'Sell' are open-market purchases/sales only, while Award, Conversion, Exercise, Tax Payment, Expiration, Gift, Inheritance, Discretionary and Other are compensation or derivative mechanics — not conviction trades. The 10b5-1 column marks trades made under a pre-arranged Rule 10b5-1 plan ('-' = filing predates the 2023 checkbox). Per-row Shares/Price/Value are as filed; Owned After is the post-transaction balance restated onto today's split basis, tracked per security kind and ownership form. Supports optional date-range, transaction-type and insider-name filters to reach history beyond the newest rows. Use this to understand insider buying/selling activity."
+        "Get recent insider trading transactions for a stock from SEC Forms 4 and 5, newest first. Form 3 supplies initial ownership rather than a transaction. The Type column carries the SEC transaction code meaning: 'Buy'/'Sell' are open-market purchases/sales only, while Award, Conversion, Exercise, Tax Payment, Expiration, Gift, Inheritance, Discretionary and Other are compensation or derivative mechanics — not conviction trades. The 10b5-1 column marks trades made under a pre-arranged Rule 10b5-1 plan ('-' = filing predates the 2023 checkbox). Per-row Shares/Price/Value are as filed; Owned After is the post-transaction balance restated onto today's split basis, tracked per security kind and ownership form. Supports optional date-range, transaction-type and insider-name filters to reach history beyond the newest rows. Use this to understand insider buying/selling activity."
     )]
     public Task<string> GetInsiderTransactions(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -394,7 +394,7 @@ public class InsiderTradingTools
         ReadOnly = true
     )]
     [Description(
-        "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the proposed sale as a share of the issuer's current shares outstanding, the approximate sale date, the broker, and the filer's remarks (including any stated 10b5-1 plan). Results are the most recent notices first and a note flags when more exist than were returned; use fromDate/toDate to scope a period (heavy 10b5-1 filers can flood the recency window with small daily notices). Use this to anticipate upcoming insider selling before it shows up as an executed Form 4."
+        "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the proposed sale as a share of the issuer's current shares outstanding, the approximate sale date, the broker, and the filer's remarks (including any stated 10b5-1 plan). Results are the most recent notices first and a note flags when more exist than were returned; use fromDate/toDate to scope a period (heavy 10b5-1 filers can flood the recency window with small daily notices). A proposal may never execute; a completed sale may later appear on Form 4 or 5 only when it is reportable there."
     )]
     public Task<string> GetProposedSales(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,

--- a/src/Equibles.Web/Views/Home/Index.cshtml
+++ b/src/Equibles.Web/Views/Home/Index.cshtml
@@ -37,7 +37,7 @@
         <a href="~/insider-trading/dashboard" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">
             <div class="card-body">
                 <h2 class="card-title text-lg">Insider Trading</h2>
-                <p class="text-sm text-base-content/70">Director, officer, and 10% owner activity from SEC Forms 3, 4, and 5.</p>
+                <p class="text-sm text-base-content/70">Initial ownership from Form 3 and director, officer, and 10% owner transactions from Forms 4 and 5.</p>
             </div>
         </a>
         <a asp-controller="Search" asp-action="Index" asp-route-category="Congress" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">

--- a/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
+++ b/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
@@ -3,16 +3,16 @@
 
 @{
     ViewData["Title"] = "Insider Trading Dashboard";
-    ViewData["Description"] = "Market-wide insider trading activity — top buys, top sells, and biggest transactions from SEC Forms 3, 4, and 5.";
+    ViewData["Description"] = "Market-wide insider trading activity — top buys, top sells, and biggest transactions from SEC Forms 4 and 5.";
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
     <page-header title="Insider Trading Dashboard">
-            Top insider transactions from the last 90 days (SEC Forms 3, 4, and 5)
+            Top insider transactions from the last 90 days (SEC Forms 4 and 5)
         </page-header>
 
     @if (Model.TopBuys.Count == 0 && Model.TopSells.Count == 0) {
-        <partial name="_EmptyStateCard" model='(IconName: "user-group", Heading: "No insider transactions yet", Message: "Once Forms 3, 4, and 5 have been ingested, the insider dashboard appears here.")' />
+        <partial name="_EmptyStateCard" model='(IconName: "user-group", Heading: "No insider transactions yet", Message: "Once Forms 4 and 5 have been ingested, the insider dashboard appears here.")' />
     } else {
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
             <!-- Top Buys -->

--- a/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
@@ -1,7 +1,7 @@
 @using Equibles.InsiderTrading.Data.Models
 @model Equibles.Web.ViewModels.Stocks.InsiderTradingTabViewModel
 
-<partial name="_TabIntro" model="@("Trades by corporate insiders — officers, directors and holders of more than 10% of the shares — disclosed to the SEC on Forms 3, 4 and 5. Form 4 must be filed within two business days of the trade.")" />
+<partial name="_TabIntro" model="@("Trades by corporate insiders — officers, directors and holders of more than 10% of the shares — disclosed to the SEC on Forms 4 and 5. Form 3 supplies initial ownership rather than a trade; Form 4 must be filed within two business days of the trade.")" />
 
 @if (Model.Transactions.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "user", Heading: "No Insider Trading Data", Message: "No insider transactions are available for this stock yet.")' />


### PR DESCRIPTION
## Summary
- describe Form 3 as initial ownership and Forms 4/5 as transaction sources
- keep Form 144 execution and later reporting explicitly conditional
- align MCP metadata, guides, and OSS web surfaces

## Verification
- `dotnet csharpier format src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs`
- `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release` (4514 passed)
- independent review: approved