### PR TITLE
fix(deps): update Testcontainers for SSH.NET advisory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -93,8 +93,8 @@
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
-    <PackageVersion Include="Testcontainers" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>

--- a/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
@@ -48,8 +48,7 @@ namespace Equibles.FunctionalTests.Fixtures;
 /// </summary>
 public class McpServerAppFixture : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _db = new PostgreSqlBuilder()
-        .WithImage("paradedb/paradedb:latest")
+    private readonly PostgreSqlContainer _db = new PostgreSqlBuilder("paradedb/paradedb:latest")
         .WithDatabase("equibles_functional_mcp")
         .WithUsername("postgres")
         .WithPassword("postgres")

--- a/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
@@ -29,8 +29,7 @@ namespace Equibles.FunctionalTests.Fixtures;
 /// </summary>
 public class WebAppFixture : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _db = new PostgreSqlBuilder()
-        .WithImage("paradedb/paradedb:latest")
+    private readonly PostgreSqlContainer _db = new PostgreSqlBuilder("paradedb/paradedb:latest")
         .WithDatabase("equibles_functional")
         .WithUsername("postgres")
         .WithPassword("postgres")

--- a/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
@@ -39,8 +39,9 @@ namespace Equibles.IntegrationTests.Helpers;
 /// </summary>
 public class ParadeDbFixture : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("paradedb/paradedb:latest")
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder(
+        "paradedb/paradedb:latest"
+    )
         .WithDatabase("equibles_integration")
         .WithUsername("postgres")
         .WithPassword("postgres")

--- a/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
@@ -29,8 +29,7 @@ namespace Equibles.IntegrationTests.Helpers;
 /// </summary>
 public class WebHostFixture : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _db = new PostgreSqlBuilder()
-        .WithImage("paradedb/paradedb:latest")
+    private readonly PostgreSqlContainer _db = new PostgreSqlBuilder("paradedb/paradedb:latest")
         .WithDatabase("equibles_webint")
         .WithUsername("postgres")
         .WithPassword("postgres")


### PR DESCRIPTION
## Summary
- Updates Testcontainers to 4.14.0 so test projects resolve SSH.NET 2026.0.0 instead of the vulnerable 2025.1.0 release.
- Resolves GHSA-q939-rpr3-3284.

## Code changes
- Bumps the Testcontainers package pair to 4.14.0.
- Uses the supported PostgreSQL builder constructor in integration and functional fixtures.
- Verifies the solution has no known vulnerable NuGet dependencies.