### PR TITLE
fix(insider-trading): scope amendments to form family

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -56,6 +56,7 @@ public static class InsiderFilingParser
             tx.TransactionOrder = transactions.Count;
             tx.IsRule10b5One = rule10b5One;
             tx.OriginalFilingDate = originalFilingDate;
+            tx.FilingForm = ParseOwnershipForm(filing.Form);
             transactions.Add(tx);
         }
 
@@ -148,6 +149,19 @@ public static class InsiderFilingParser
     }
 
     /// <summary>
+    /// Maps the SEC's authoritative ownership form label to its base family.
+    /// Unknown labels stay unknown rather than being inferred from row contents.
+    /// </summary>
+    public static InsiderOwnershipForm ParseOwnershipForm(string form) =>
+        form?.Trim().ToUpperInvariant() switch
+        {
+            "3" or "3/A" => InsiderOwnershipForm.Form3,
+            "4" or "4/A" => InsiderOwnershipForm.Form4,
+            "5" or "5/A" => InsiderOwnershipForm.Form5,
+            _ => InsiderOwnershipForm.Unknown,
+        };
+
+    /// <summary>
     /// The transaction-period anchor declared by the ownership document. Null when
     /// absent or unparseable, so callers can retain existing data rather than infer a
     /// financial date.
@@ -193,6 +207,7 @@ public static class InsiderFilingParser
             TransactionCode = TransactionCode.Other,
             AccessionNumber = filing.AccessionNumber,
             SecurityTitle = "No Securities Owned",
+            FilingForm = ParseOwnershipForm(filing.Form),
             IsPriceValid = true,
             ParserVersion = InsiderTransaction.CurrentParserVersion,
         };

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -88,20 +88,24 @@ public class InsiderFilingReprocessManager
         // Snapshot of the work-set for the progress bar. The live ingest worker may
         // stamp new rows at the current version while this runs; harmless — Processed
         // can briefly nudge past Total and self-corrects.
+        var staleTransactionFilingCount = await _transactionRepository
+            .GetAll()
+            .Where(t => t.ParserVersion < InsiderTransaction.CurrentParserVersion)
+            .Select(t => t.AccessionNumber)
+            .Distinct()
+            .CountAsync();
+        var rowlessUnknownFilingCount = await RowlessUnknownCapturedFilings().CountAsync();
         var result = new InsiderFilingReprocessResult
         {
-            Total = await _transactionRepository
-                .GetAll()
-                .Where(t => t.ParserVersion < InsiderTransaction.CurrentParserVersion)
-                .Select(t => t.AccessionNumber)
-                .Distinct()
-                .CountAsync(),
+            Total = staleTransactionFilingCount + rowlessUnknownFilingCount,
         };
 
         if (result.Total == 0)
             return result;
 
         _dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+
+        await ReprocessRowlessFilingForms(result, onProgress, cancellationToken);
 
         // No DB cursor: a reprocessed filing's rows advance to the current version and
         // drop out of the filter, so each pass takes the next batch of unprocessed
@@ -213,6 +217,89 @@ public class InsiderFilingReprocessManager
         return result;
     }
 
+    // Supersession deliberately deletes an original filing's transaction rows but
+    // retains its cached XML. Those rowless filings are absent from the parser-version
+    // workset, so stamp their authoritative form family in a separate bounded pass.
+    private IQueryable<InsiderFiling> RowlessUnknownCapturedFilings()
+    {
+        return _filingRepository
+            .GetAll()
+            .Where(f =>
+                f.FilingForm == InsiderOwnershipForm.Unknown
+                && f.CaptureStatus == InsiderFilingCaptureStatus.Captured
+                && f.ContentId != null
+                && !_transactionRepository.GetAll().Any(t => t.AccessionNumber == f.AccessionNumber)
+            );
+    }
+
+    private async Task ReprocessRowlessFilingForms(
+        InsiderFilingReprocessResult result,
+        Func<InsiderFilingReprocessResult, Task> onProgress,
+        CancellationToken cancellationToken
+    )
+    {
+        var failedThisRun = new HashSet<string>();
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var accessions = await RowlessUnknownCapturedFilings()
+                .Where(f => !failedThisRun.Contains(f.AccessionNumber))
+                .Select(f => f.AccessionNumber)
+                .OrderBy(accession => accession)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken);
+            if (accessions.Count == 0)
+                break;
+
+            foreach (var accession in accessions)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
+                try
+                {
+                    var filing = await _filingRepository
+                        .GetByAccessionNumber(accession)
+                        .Include(f => f.Content)
+                            .ThenInclude(content => content.FileContent)
+                        .SingleAsync(cancellationToken);
+                    var raw = GzipCompressor.Decompress(
+                        await _fileManager.GetContent(filing.Content)
+                    );
+                    var root = InsiderFilingParser.TryGetOwnershipRoot(
+                        Encoding.UTF8.GetString(raw)
+                    );
+                    var filingForm = InsiderFilingParser.ParseOwnershipForm(
+                        root?.Element("documentType")?.Value
+                    );
+                    if (filingForm == InsiderOwnershipForm.Unknown)
+                    {
+                        failedThisRun.Add(accession);
+                        result.Failed++;
+                        continue;
+                    }
+
+                    filing.FilingForm = filingForm;
+                    result.Processed++;
+                }
+                catch (Exception ex)
+                {
+                    failedThisRun.Add(accession);
+                    result.Failed++;
+                    _logger.LogWarning(
+                        ex,
+                        "Insider filing family replay failed for rowless filing {AccessionNumber}; skipping this run",
+                        accession
+                    );
+                }
+            }
+
+            await _filingRepository.SaveChanges();
+            _dbContext.ChangeTracker.Clear();
+            if (onProgress != null)
+                await onProgress(result);
+        }
+    }
+
     // Re-saves the batch after detaching the best-effort filing/file cache inserts that a
     // concurrent run beat us to (the unique-accession conflict). Those cache rows are
     // regenerable — re-fetched on a later pass — but the batch's transaction updates are the
@@ -265,11 +352,24 @@ public class InsiderFilingReprocessManager
         {
             AccessionNumber = accession,
             FilingDate = first.FilingDate,
+            Form = root.Element("documentType")?.Value?.Trim(),
             // periodOfReport is the authoritative fallback used by the parser when a
             // filer keyed an impossible transaction date. Falling back to the stored
             // date preserves legacy behavior only for malformed documents that omit it.
             ReportDate = InsiderFilingParser.ParsePeriodOfReport(root) ?? first.TransactionDate,
         };
+        var filingForm = InsiderFilingParser.ParseOwnershipForm(filing.Form);
+
+        // The family is a document-level fact, so stamp every stored row even
+        // when the current parser produces fewer rows than an older version.
+        foreach (var row in rows)
+            row.FilingForm = filingForm;
+
+        var storedFiling = await _filingRepository
+            .GetByAccessionNumber(accession)
+            .FirstOrDefaultAsync();
+        if (storedFiling != null)
+            storedFiling.FilingForm = filingForm;
 
         // Re-parse in the same document order the ingest used; map back onto the
         // stored rows by TransactionOrder so a kind lands on the right row even if
@@ -426,6 +526,9 @@ public class InsiderFilingReprocessManager
     {
         var rawBytes = Encoding.UTF8.GetBytes(root.ToString(SaveOptions.DisableFormatting));
         var compressed = GzipCompressor.Compress(rawBytes);
+        var filingForm = InsiderFilingParser.ParseOwnershipForm(
+            root.Element("documentType")?.Value
+        );
         var file = await _fileManager.SaveInternalFile(
             compressed,
             accession,
@@ -439,6 +542,7 @@ public class InsiderFilingReprocessManager
                 new InsiderFiling
                 {
                     AccessionNumber = accession,
+                    FilingForm = filingForm,
                     Content = file,
                     UncompressedSize = rawBytes.Length,
                     CaptureStatus = InsiderFilingCaptureStatus.Captured,
@@ -447,6 +551,7 @@ public class InsiderFilingReprocessManager
         }
         else
         {
+            filing.FilingForm = filingForm;
             filing.Content = file;
             filing.UncompressedSize = rawBytes.Length;
             filing.CaptureStatus = InsiderFilingCaptureStatus.Captured;

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderFiling.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderFiling.cs
@@ -30,6 +30,13 @@ public class InsiderFiling
     public string AccessionNumber { get; set; }
 
     /// <summary>
+    /// SEC ownership-report family declared by this filing's documentType.
+    /// Stored independently of transaction rows so a superseded original remains
+    /// classifiable after its transactions are removed.
+    /// </summary>
+    public InsiderOwnershipForm FilingForm { get; set; } = InsiderOwnershipForm.Unknown;
+
+    /// <summary>
     /// The file holding the gzip-compressed ownership XML. Null when no XML was
     /// captured (status <see cref="InsiderFilingCaptureStatus.NotChecked"/> or
     /// <see cref="InsiderFilingCaptureStatus.NotPresent"/>). The stored

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderOwnershipForm.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderOwnershipForm.cs
@@ -1,0 +1,13 @@
+namespace Equibles.InsiderTrading.Data.Models;
+
+/// <summary>
+/// The SEC ownership-report family that produced an insider row. Derived from
+/// the filing's authoritative form type, never from transaction contents.
+/// </summary>
+public enum InsiderOwnershipForm
+{
+    Unknown = 0,
+    Form3 = 3,
+    Form4 = 4,
+    Form5 = 5,
+}

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -38,9 +38,10 @@ public class InsiderTransaction
     /// anchoring source typos to the filing's period of report; v7 re-copies the
     /// Rule 10b5-1 checkbox during reprocess — the v4 capture parsed it but the
     /// reprocess copy-loop never wrote it, so pre-capture rows (1.4M checkbox-era
-    /// rows) stayed null (#7164, EquiblesCommercial).
+    /// rows) stayed null (#7164, EquiblesCommercial); v8 stamps the authoritative
+    /// Form 3/4/5 family so amendments cannot supersede a different ownership form.
     /// </summary>
-    public const int CurrentParserVersion = 7;
+    public const int CurrentParserVersion = 8;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 
@@ -99,6 +100,14 @@ public class InsiderTransaction
     public int TransactionOrder { get; set; }
 
     public bool IsAmendment { get; set; }
+
+    /// <summary>
+    /// SEC ownership-report family that produced this row. Amendments retain the
+    /// base family (for example, Form 5/A stores <see cref="InsiderOwnershipForm.Form5"/>).
+    /// <see cref="InsiderOwnershipForm.Unknown"/> marks legacy rows awaiting the
+    /// parser-version reprocess.
+    /// </summary>
+    public InsiderOwnershipForm FilingForm { get; set; } = InsiderOwnershipForm.Unknown;
 
     /// <summary>
     /// For rows from a Form 3/A, 4/A, or 5/A: the filing date of the ORIGINAL report the

--- a/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
@@ -48,18 +48,21 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
     /// <summary>
     /// Rows from any amendment that restates the original report an owner filed for
     /// this company on <paramref name="originalFilingDate"/> (the filer-entered
-    /// <c>dateOfOriginalSubmission</c>, stable across chained amendments).
+    /// <c>dateOfOriginalSubmission</c>, stable across chained amendments), within
+    /// the same authoritative Form 3/4/5 family.
     /// </summary>
     public IQueryable<InsiderTransaction> GetAmendmentsOfOriginal(
         InsiderOwner owner,
         Guid commonStockId,
-        DateOnly originalFilingDate
+        DateOnly originalFilingDate,
+        InsiderOwnershipForm filingForm
     )
     {
         return GetAll()
             .Where(t =>
                 t.InsiderOwnerId == owner.Id
                 && t.CommonStockId == commonStockId
+                && t.FilingForm == filingForm
                 && t.OriginalFilingDate == originalFilingDate
             );
     }
@@ -69,9 +72,15 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
     /// original it replaces — the durable guard that stops a late-arriving (or
     /// re-listed) original from re-inserting rows its amendment already superseded.
     /// </summary>
-    public IQueryable<InsiderTransaction> GetAmendmentsClaiming(string accessionNumber)
+    public IQueryable<InsiderTransaction> GetAmendmentsClaiming(
+        string accessionNumber,
+        InsiderOwnershipForm filingForm
+    )
     {
-        return GetAll().Where(t => t.SupersededAccessionNumber == accessionNumber);
+        return GetAll()
+            .Where(t =>
+                t.SupersededAccessionNumber == accessionNumber && t.FilingForm == filingForm
+            );
     }
 
     /// <summary>
@@ -80,19 +89,22 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
     /// [<paramref name="windowStart"/>, <paramref name="windowEnd"/>]. The window
     /// absorbs EDGAR's date shift: an after-17:30 submission is indexed the next
     /// business day, so the feed FilingDate of the original can trail the
-    /// filer-entered <c>dateOfOriginalSubmission</c> by up to a weekend.
+    /// filer-entered <c>dateOfOriginalSubmission</c> by up to a weekend. Matching
+    /// is restricted to the incoming original's Form 3/4/5 family.
     /// </summary>
     public IQueryable<InsiderTransaction> GetUnresolvedAmendments(
         InsiderOwner owner,
         Guid commonStockId,
         DateOnly windowStart,
-        DateOnly windowEnd
+        DateOnly windowEnd,
+        InsiderOwnershipForm filingForm
     )
     {
         return GetAll()
             .Where(t =>
                 t.InsiderOwnerId == owner.Id
                 && t.CommonStockId == commonStockId
+                && t.FilingForm == filingForm
                 && t.IsAmendment
                 && t.SupersededAccessionNumber == null
                 && t.OriginalFilingDate != null
@@ -107,18 +119,21 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
     /// [<paramref name="windowStart"/>, <paramref name="windowEnd"/>] (the
     /// filer-entered original date plus the EDGAR indexing shift). The caller
     /// resolves the single original accession from these before deleting anything.
+    /// Candidates from another Form 3/4/5 family are never returned.
     /// </summary>
     public IQueryable<InsiderTransaction> GetOriginalCandidates(
         InsiderOwner owner,
         Guid commonStockId,
         DateOnly windowStart,
-        DateOnly windowEnd
+        DateOnly windowEnd,
+        InsiderOwnershipForm filingForm
     )
     {
         return GetAll()
             .Where(t =>
                 t.InsiderOwnerId == owner.Id
                 && t.CommonStockId == commonStockId
+                && t.FilingForm == filingForm
                 && !t.IsAmendment
                 && t.FilingDate >= windowStart
                 && t.FilingDate <= windowEnd

--- a/src/Equibles.Migrations/Migrations/20260821230132_ScopeInsiderAmendmentsToFormFamily.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260821230132_ScopeInsiderAmendmentsToFormFamily.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260821230132_ScopeInsiderAmendmentsToFormFamily")]
+    partial class ScopeInsiderAmendmentsToFormFamily
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260821230132_ScopeInsiderAmendmentsToFormFamily.cs
+++ b/src/Equibles.Migrations/Migrations/20260821230132_ScopeInsiderAmendmentsToFormFamily.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class ScopeInsiderAmendmentsToFormFamily : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FilingForm",
+                table: "InsiderTransaction",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "FilingForm",
+                table: "InsiderFiling",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FilingForm",
+                table: "InsiderTransaction");
+
+            migrationBuilder.DropColumn(
+                name: "FilingForm",
+                table: "InsiderFiling");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -63,42 +63,47 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         await using var scope = _scopeFactory.CreateAsyncScope();
         var transactionRepository =
             scope.ServiceProvider.GetRequiredService<InsiderTransactionRepository>();
+        var filingRepository = scope.ServiceProvider.GetRequiredService<InsiderFilingRepository>();
 
         // An accession is "known" both when its own rows exist and when an
         // amendment has superseded (or claimed) it — a superseded original has
         // no rows of its own, and without the claim column every sweep would
         // re-fetch it from EDGAR forever just to re-skip it.
         //
-        // Deliberately TWO single-column probes instead of one cross-column OR:
-        // EF translates the OR (plus null-compensation branches for the nullable
-        // columns) into a shape Postgres plans as a bitmap heap scan — ~230 ms
-        // per call at the sweep's batch rate, the single largest query cost on
-        // the box — while each single-column ANY probe walks its own index in
-        // well under a millisecond. The union is semantically identical: feed
-        // accession numbers are never null, so the dropped null-match branches
-        // could never fire.
+        // Keep own-accession and superseded-claim probes separate instead of one
+        // cross-column OR: Postgres plans the OR as a costly bitmap heap scan.
+        // Claims additionally join the captured original's tiny, indexed filing
+        // row so a legacy cross-family link cannot suppress the real accession.
         var candidates = accessionNumbers.ToList();
         var knownByOwnRows = await transactionRepository
             .GetAll()
             .Where(t => candidates.Contains(t.AccessionNumber))
-            .Select(t => new { t.AccessionNumber, t.SupersededAccessionNumber })
+            .Select(t => t.AccessionNumber)
+            .Distinct()
             .ToListAsync();
-        var knownBySupersededClaim = await transactionRepository
-            .GetAll()
-            .Where(t =>
-                t.SupersededAccessionNumber != null
-                && candidates.Contains(t.SupersededAccessionNumber)
-            )
-            .Select(t => new { t.AccessionNumber, t.SupersededAccessionNumber })
+        // A legacy claim is authoritative only when both the amendment row and
+        // the captured original have a known, matching Form 3/4/5 family. Before
+        // v8, same-day filings from different families could be linked; treating
+        // that stale link as known would permanently suppress the real original.
+        var knownBySupersededClaim = await (
+            from transaction in transactionRepository.GetAll()
+            join original in filingRepository.GetAll()
+                on transaction.SupersededAccessionNumber equals original.AccessionNumber
+            where
+                transaction.SupersededAccessionNumber != null
+                && candidates.Contains(transaction.SupersededAccessionNumber)
+                && transaction.FilingForm != InsiderOwnershipForm.Unknown
+                && transaction.FilingForm == original.FilingForm
+            select transaction.SupersededAccessionNumber
+        )
+            .Distinct()
             .ToListAsync();
 
         var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var row in knownByOwnRows.Concat(knownBySupersededClaim))
-        {
-            result.Add(row.AccessionNumber);
-            if (row.SupersededAccessionNumber != null)
-                result.Add(row.SupersededAccessionNumber);
-        }
+        foreach (var accession in knownByOwnRows)
+            result.Add(accession);
+        foreach (var accession in knownBySupersededClaim)
+            result.Add(accession);
         return result;
     }
 
@@ -193,6 +198,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         }
 
         var isAmendment = filing.Form.Contains("/A", StringComparison.OrdinalIgnoreCase);
+        var ownershipForm = InsiderFilingParser.ParseOwnershipForm(filing.Form);
+        await StampFilingForm(filingRepository, filing.AccessionNumber, ownershipForm);
 
         // A late-arriving original whose amendment already ingested must not
         // re-insert the rows that amendment replaced (EDGAR lists newest-first,
@@ -201,9 +208,12 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             !isAmendment
             && await TrySkipSupersededOriginal(
                 transactionRepository,
+                filingRepository,
+                fileManager,
                 owner,
                 companyId,
                 filing,
+                ownershipForm,
                 companyTicker
             )
         )
@@ -216,13 +226,32 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         if (isAmendment && originalFilingDate.HasValue)
         {
+            // The v8 migration initializes legacy rows to Unknown. Resolve only the
+            // relevant original/amendment candidates from their captured SEC XML before
+            // the family-scoped queries run, or a live amendment racing the replay could
+            // leave a same-family legacy row permanently duplicated.
+            await ResolveLegacyAmendmentCandidates(
+                transactionRepository,
+                filingRepository,
+                fileManager,
+                owner,
+                companyId,
+                originalFilingDate.Value,
+                _logger
+            );
+
             // Stale amendment: a NEWER amendment of the same original already
             // ingested — its rows are the current truth, so skip this one.
             // Same-day chains break the tie on accession number (SEC assigns
             // them monotonically per filer agent).
             if (
                 await transactionRepository
-                    .GetAmendmentsOfOriginal(owner, companyId, originalFilingDate.Value)
+                    .GetAmendmentsOfOriginal(
+                        owner,
+                        companyId,
+                        originalFilingDate.Value,
+                        ownershipForm
+                    )
                     .AnyAsync(t =>
                         t.FilingDate > filing.FilingDate
                         || (
@@ -255,10 +284,12 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
             supersededAccession = await SupersedeOriginal(
                 transactionRepository,
+                filingRepository,
                 owner,
                 companyId,
                 filing,
                 originalFilingDate.Value,
+                ownershipForm,
                 companyTicker
             );
         }
@@ -351,13 +382,37 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
     // prefilter drops the original from every future sweep without a fetch.
     private async Task<bool> TrySkipSupersededOriginal(
         InsiderTransactionRepository transactionRepository,
+        InsiderFilingRepository filingRepository,
+        IFileManager fileManager,
         InsiderOwner owner,
         Guid companyId,
         FilingData filing,
+        InsiderOwnershipForm ownershipForm,
         string companyTicker
     )
     {
-        if (await transactionRepository.GetAmendmentsClaiming(filing.AccessionNumber).AnyAsync())
+        await ResolveLegacyClaimForms(
+            transactionRepository,
+            filingRepository,
+            fileManager,
+            filing.AccessionNumber,
+            _logger
+        );
+        await PrepareLegacyOriginalCandidates(
+            transactionRepository,
+            filingRepository,
+            fileManager,
+            owner,
+            companyId,
+            filing.FilingDate,
+            _logger
+        );
+
+        if (
+            await transactionRepository
+                .GetAmendmentsClaiming(filing.AccessionNumber, ownershipForm)
+                .AnyAsync()
+        )
         {
             _logger.LogInformation(
                 "Skipping {Form} {AccessionNumber} for {Ticker}: an amendment already claimed and superseded it",
@@ -370,7 +425,13 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         var windowStart = filing.FilingDate.AddDays(-OriginalDateShiftToleranceDays);
         var orphans = await transactionRepository
-            .GetUnresolvedAmendments(owner, companyId, windowStart, filing.FilingDate)
+            .GetUnresolvedAmendments(
+                owner,
+                companyId,
+                windowStart,
+                filing.FilingDate,
+                ownershipForm
+            )
             .ToListAsync();
         if (orphans.Count == 0)
             return false;
@@ -401,6 +462,258 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         return true;
     }
 
+    // v8 introduced FilingForm after claims already existed. Resolve an unknown
+    // claimant from its captured SEC ownership XML before deciding whether it
+    // suppresses an incoming original. An unreadable claimant stays unknown and
+    // is ignored: a visible duplicate is safer than deleting the wrong family.
+    private static async Task ResolveLegacyClaimForms(
+        InsiderTransactionRepository transactionRepository,
+        InsiderFilingRepository filingRepository,
+        IFileManager fileManager,
+        string supersededAccessionNumber,
+        ILogger<InsiderTradingFilingProcessor> logger
+    )
+    {
+        var accessions = await transactionRepository
+            .GetAll()
+            .Where(t =>
+                t.SupersededAccessionNumber == supersededAccessionNumber
+                && t.FilingForm == InsiderOwnershipForm.Unknown
+            )
+            .Select(t => t.AccessionNumber)
+            .Distinct()
+            .ToListAsync();
+        await ResolveLegacyFilingForms(
+            transactionRepository,
+            filingRepository,
+            fileManager,
+            accessions,
+            logger
+        );
+    }
+
+    private static async Task ResolveLegacyAmendmentCandidates(
+        InsiderTransactionRepository transactionRepository,
+        InsiderFilingRepository filingRepository,
+        IFileManager fileManager,
+        InsiderOwner owner,
+        Guid companyId,
+        DateOnly originalFilingDate,
+        ILogger<InsiderTradingFilingProcessor> logger
+    )
+    {
+        var windowEnd = originalFilingDate.AddDays(OriginalDateShiftToleranceDays);
+        var accessions = await transactionRepository
+            .GetAll()
+            .Where(t =>
+                t.InsiderOwnerId == owner.Id
+                && t.CommonStockId == companyId
+                && (
+                    (
+                        !t.IsAmendment
+                        && t.FilingDate >= originalFilingDate
+                        && t.FilingDate <= windowEnd
+                    ) || (t.IsAmendment && t.OriginalFilingDate == originalFilingDate)
+                )
+            )
+            .Select(t => t.AccessionNumber)
+            .Distinct()
+            .ToListAsync();
+        await ResolveLegacyFilingForms(
+            transactionRepository,
+            filingRepository,
+            fileManager,
+            accessions,
+            logger
+        );
+        await ClearProvenCrossFamilyClaims(transactionRepository, filingRepository, accessions);
+    }
+
+    private static async Task PrepareLegacyOriginalCandidates(
+        InsiderTransactionRepository transactionRepository,
+        InsiderFilingRepository filingRepository,
+        IFileManager fileManager,
+        InsiderOwner owner,
+        Guid companyId,
+        DateOnly filingDate,
+        ILogger<InsiderTradingFilingProcessor> logger
+    )
+    {
+        var windowStart = filingDate.AddDays(-OriginalDateShiftToleranceDays);
+        var accessions = await transactionRepository
+            .GetAll()
+            .Where(t =>
+                t.InsiderOwnerId == owner.Id
+                && t.CommonStockId == companyId
+                && t.IsAmendment
+                && t.OriginalFilingDate != null
+                && t.OriginalFilingDate >= windowStart
+                && t.OriginalFilingDate <= filingDate
+            )
+            .Select(t => t.AccessionNumber)
+            .Distinct()
+            .ToListAsync();
+        await ResolveLegacyFilingForms(
+            transactionRepository,
+            filingRepository,
+            fileManager,
+            accessions,
+            logger
+        );
+        await ClearProvenCrossFamilyClaims(transactionRepository, filingRepository, accessions);
+    }
+
+    // Pre-v8 same-day matching could attach an amendment to a sibling form family.
+    // Clear only claims disproved by both authoritative documentType stamps; an
+    // unknown target remains untouched until its cached XML can prove the mismatch.
+    private static async Task ClearProvenCrossFamilyClaims(
+        InsiderTransactionRepository transactionRepository,
+        InsiderFilingRepository filingRepository,
+        IReadOnlyCollection<string> amendmentAccessions
+    )
+    {
+        if (amendmentAccessions.Count == 0)
+            return;
+
+        var claimedRows = await transactionRepository
+            .GetAll()
+            .Where(t =>
+                amendmentAccessions.Contains(t.AccessionNumber)
+                && t.SupersededAccessionNumber != null
+                && t.FilingForm != InsiderOwnershipForm.Unknown
+            )
+            .ToListAsync();
+        var targetAccessions = claimedRows
+            .Select(t => t.SupersededAccessionNumber)
+            .Distinct()
+            .ToList();
+        var targetFamilies = await filingRepository
+            .GetAll()
+            .Where(f => targetAccessions.Contains(f.AccessionNumber))
+            .Select(f => new { f.AccessionNumber, f.FilingForm })
+            .ToDictionaryAsync(f => f.AccessionNumber, f => f.FilingForm);
+
+        foreach (var row in claimedRows)
+        {
+            if (
+                targetFamilies.TryGetValue(row.SupersededAccessionNumber, out var targetFamily)
+                && targetFamily != InsiderOwnershipForm.Unknown
+                && targetFamily != row.FilingForm
+            )
+            {
+                row.SupersededAccessionNumber = null;
+            }
+        }
+
+        await transactionRepository.SaveChanges();
+    }
+
+    // A pre-v8 family is trusted only when it was already stamped from documentType
+    // or can be recovered from the gzip-compressed SEC ownership XML. Names, dates,
+    // accession shape, and transaction content never infer a form family.
+    private static async Task ResolveLegacyFilingForms(
+        InsiderTransactionRepository transactionRepository,
+        InsiderFilingRepository filingRepository,
+        IFileManager fileManager,
+        IReadOnlyCollection<string> accessionNumbers,
+        ILogger<InsiderTradingFilingProcessor> logger
+    )
+    {
+        if (accessionNumbers.Count == 0)
+            return;
+
+        foreach (var accessionNumber in accessionNumbers)
+        {
+            var unresolved = await transactionRepository
+                .GetByAccessionNumber(accessionNumber)
+                .Where(t => t.FilingForm == InsiderOwnershipForm.Unknown)
+                .ToListAsync();
+            if (unresolved.Count == 0)
+                continue;
+
+            var stored = await filingRepository
+                .GetByAccessionNumber(accessionNumber)
+                .Include(f => f.Content)
+                    .ThenInclude(content => content.FileContent)
+                .FirstOrDefaultAsync();
+            if (stored == null)
+            {
+                logger.LogWarning(
+                    "Could not resolve legacy insider filing family for {AccessionNumber}: no cached filing row; leaving it unknown",
+                    accessionNumber
+                );
+                continue;
+            }
+
+            var filingForm = stored.FilingForm;
+            if (filingForm == InsiderOwnershipForm.Unknown)
+            {
+                if (
+                    stored
+                    is not {
+                        CaptureStatus: InsiderFilingCaptureStatus.Captured,
+                        ContentId: not null
+                    }
+                )
+                {
+                    logger.LogWarning(
+                        "Could not resolve legacy insider filing family for {AccessionNumber}: cached XML is unavailable; leaving it unknown",
+                        accessionNumber
+                    );
+                    continue;
+                }
+
+                try
+                {
+                    var compressed = await fileManager.GetContent(stored.Content);
+                    if (compressed == null || compressed.Length == 0)
+                    {
+                        logger.LogWarning(
+                            "Could not resolve legacy insider filing family for {AccessionNumber}: cached XML is empty; leaving it unknown",
+                            accessionNumber
+                        );
+                        continue;
+                    }
+
+                    var raw = GzipCompressor.Decompress(compressed);
+                    var root = InsiderFilingParser.TryGetOwnershipRoot(
+                        Encoding.UTF8.GetString(raw)
+                    );
+                    filingForm = InsiderFilingParser.ParseOwnershipForm(
+                        root?.Element("documentType")?.Value
+                    );
+                    if (filingForm == InsiderOwnershipForm.Unknown)
+                    {
+                        logger.LogWarning(
+                            "Could not resolve legacy insider filing family for {AccessionNumber}: cached XML has no supported ownership documentType; leaving it unknown",
+                            accessionNumber
+                        );
+                        continue;
+                    }
+
+                    stored.FilingForm = filingForm;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Could not resolve legacy insider filing family from cached XML for {AccessionNumber}; leaving it unknown",
+                        accessionNumber
+                    );
+                    continue;
+                }
+            }
+
+            if (filingForm == InsiderOwnershipForm.Unknown)
+                continue;
+
+            foreach (var row in unresolved)
+                row.FilingForm = filingForm;
+        }
+
+        await transactionRepository.SaveChanges();
+    }
+
     // Replaces what an incoming amendment restates: the original filing's rows —
     // resolved to a SINGLE accession via the filer-entered original date plus the
     // indexing-shift window — and any older amendment of the same original.
@@ -412,16 +725,18 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
     // legitimate sibling filing.
     private async Task<string> SupersedeOriginal(
         InsiderTransactionRepository transactionRepository,
+        InsiderFilingRepository filingRepository,
         InsiderOwner owner,
         Guid companyId,
         FilingData filing,
         DateOnly originalFilingDate,
+        InsiderOwnershipForm ownershipForm,
         string companyTicker
     )
     {
         var windowEnd = originalFilingDate.AddDays(OriginalDateShiftToleranceDays);
         var candidates = await transactionRepository
-            .GetOriginalCandidates(owner, companyId, originalFilingDate, windowEnd)
+            .GetOriginalCandidates(owner, companyId, originalFilingDate, windowEnd, ownershipForm)
             .Select(t => new { t.AccessionNumber, t.FilingDate })
             .Distinct()
             .ToListAsync();
@@ -467,7 +782,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         // wholesale, and its resolution (which original accession it consumed or
         // claimed) is inherited so the prefilter keeps dropping that original.
         var olderAmendments = await transactionRepository
-            .GetAmendmentsOfOriginal(owner, companyId, originalFilingDate)
+            .GetAmendmentsOfOriginal(owner, companyId, originalFilingDate, ownershipForm)
             .Where(t =>
                 t.AccessionNumber != filing.AccessionNumber
                 && (
@@ -481,9 +796,19 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             .ToListAsync();
         if (olderAmendments.Count > 0)
         {
-            resolvedAccession ??= olderAmendments
+            var claimedAccessions = olderAmendments
                 .Select(t => t.SupersededAccessionNumber)
-                .FirstOrDefault(a => a != null);
+                .Where(a => a != null)
+                .Distinct()
+                .ToList();
+            var validatedClaims = await filingRepository
+                .GetAll()
+                .Where(f =>
+                    claimedAccessions.Contains(f.AccessionNumber) && f.FilingForm == ownershipForm
+                )
+                .Select(f => f.AccessionNumber)
+                .ToHashSetAsync();
+            resolvedAccession ??= claimedAccessions.FirstOrDefault(validatedClaims.Contains);
             transactionRepository.Delete(olderAmendments);
             _logger.LogInformation(
                 "Amendment {AccessionNumber} replaces {Count} row(s) from older amendment(s) of the same original for {Ticker}",
@@ -494,6 +819,32 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         }
 
         return resolvedAccession;
+    }
+
+    // Persist the authoritative form family before any supersession early-return.
+    // The filing row survives deletion of its transaction rows, which lets the
+    // known-accession prefilter validate both sides of a legacy claim.
+    private static async Task StampFilingForm(
+        InsiderFilingRepository filingRepository,
+        string accessionNumber,
+        InsiderOwnershipForm filingForm
+    )
+    {
+        var stored = await filingRepository
+            .GetByAccessionNumber(accessionNumber)
+            .FirstOrDefaultAsync();
+        if (stored == null)
+        {
+            filingRepository.Add(
+                new InsiderFiling { AccessionNumber = accessionNumber, FilingForm = filingForm }
+            );
+        }
+        else
+        {
+            stored.FilingForm = filingForm;
+        }
+
+        await filingRepository.SaveChanges();
     }
 
     // Stores the parsed ownership XML as a gzip-compressed internal File so the
@@ -509,13 +860,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         IFileManager fileManager
     )
     {
-        // A filing is only processed when its transactions don't yet exist, but
-        // guard against a duplicate filing row so the unique accession index
-        // can't be violated by a re-run.
-        var alreadyCaptured = await filingRepository
+        var stored = await filingRepository
             .GetByAccessionNumber(filing.AccessionNumber)
-            .AnyAsync();
-        if (alreadyCaptured)
+            .FirstOrDefaultAsync();
+        if (stored is { CaptureStatus: InsiderFilingCaptureStatus.Captured, ContentId: not null })
             return;
 
         var rawBytes = Encoding.UTF8.GetBytes(root.ToString(SaveOptions.DisableFormatting));
@@ -527,15 +875,26 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             "application/gzip"
         );
 
-        filingRepository.Add(
-            new InsiderFiling
-            {
-                AccessionNumber = filing.AccessionNumber,
-                Content = file,
-                UncompressedSize = rawBytes.Length,
-                CaptureStatus = InsiderFilingCaptureStatus.Captured,
-            }
-        );
+        if (stored == null)
+        {
+            filingRepository.Add(
+                new InsiderFiling
+                {
+                    AccessionNumber = filing.AccessionNumber,
+                    FilingForm = InsiderFilingParser.ParseOwnershipForm(filing.Form),
+                    Content = file,
+                    UncompressedSize = rawBytes.Length,
+                    CaptureStatus = InsiderFilingCaptureStatus.Captured,
+                }
+            );
+        }
+        else
+        {
+            stored.FilingForm = InsiderFilingParser.ParseOwnershipForm(filing.Form);
+            stored.Content = file;
+            stored.UncompressedSize = rawBytes.Length;
+            stored.CaptureStatus = InsiderFilingCaptureStatus.Captured;
+        }
     }
 
     // Returns the parsed ownership root, or (null, reason) when the content is
@@ -749,6 +1108,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 SecurityTitle = "No Securities Owned",
                 TransactionOrder = 0,
                 IsAmendment = isAmendment,
+                FilingForm = InsiderFilingParser.ParseOwnershipForm(filing.Form),
                 OriginalFilingDate = originalFilingDate,
                 SupersededAccessionNumber = supersededAccessionNumber,
                 // 0-price holding sentinel: nothing to validate or repair.

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
@@ -74,13 +74,14 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
                 OwnershipNature = OwnershipNature.Direct,
                 SecurityTitle = "Common Stock",
                 SecurityKind = InsiderSecurityKind.Derivative,
+                FilingForm = InsiderOwnershipForm.Unknown,
                 ParserVersion = 0,
             };
         var matched = MakeStale(0);
         var unmatched = MakeStale(1);
 
         var ownershipXml =
-            "<ownershipDocument>"
+            "<ownershipDocument><documentType>5</documentType>"
             + "<nonDerivativeTable><nonDerivativeTransaction>"
             + "<securityTitle><value>Common Stock</value></securityTitle>"
             + "<transactionDate><value>2024-06-14</value></transactionDate>"
@@ -152,11 +153,72 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
         var unmatchedAfter = await verify.Set<InsiderTransaction>().FindAsync(unmatched.Id);
 
         matchedAfter!.SecurityKind.Should().Be(InsiderSecurityKind.NonDerivative);
+        matchedAfter.FilingForm.Should().Be(InsiderOwnershipForm.Form5);
         matchedAfter.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
 
         // The unmatched row keeps its prior kind but must still advance, or it would be
         // re-selected forever.
         unmatchedAfter!.SecurityKind.Should().Be(InsiderSecurityKind.Derivative);
+        unmatchedAfter.FilingForm.Should().Be(InsiderOwnershipForm.Form5);
         unmatchedAfter.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
+
+        var filingAfter = await verify
+            .Set<InsiderFiling>()
+            .SingleAsync(f => f.AccessionNumber == accession);
+        filingAfter.FilingForm.Should().Be(InsiderOwnershipForm.Form5);
+    }
+
+    [Fact]
+    public async Task Run_RowlessCachedLegacyFiling_StampsFamilyFromDocumentType()
+    {
+        var accession = "0000320193-24-000051";
+        var rawBytes = Encoding.UTF8.GetBytes(
+            "<ownershipDocument><documentType>5/A</documentType></ownershipDocument>"
+        );
+        DbContext.Add(
+            new InsiderFiling
+            {
+                AccessionNumber = accession,
+                FilingForm = InsiderOwnershipForm.Unknown,
+                CaptureStatus = InsiderFilingCaptureStatus.Captured,
+                UncompressedSize = rawBytes.Length,
+                Content = new File
+                {
+                    Name = accession,
+                    Extension = "gz",
+                    ContentType = "application/gzip",
+                    FileContent = new FileContent { Bytes = GzipCompressor.Compress(rawBytes) },
+                },
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runCtx),
+            new InsiderFilingRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            Substitute.For<ISecEdgarClient>(),
+            InsiderReprocessTestSupport.NewFileManager(),
+            runCtx,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Total.Should().Be(1);
+        result.Processed.Should().Be(1);
+        result.Failed.Should().Be(0);
+        await using var verify = Fixture.CreateDbContext();
+        var filing = await verify
+            .Set<InsiderFiling>()
+            .SingleAsync(f => f.AccessionNumber == accession);
+        filing.FilingForm.Should().Be(InsiderOwnershipForm.Form5);
+        (await verify.Set<InsiderTransaction>().AnyAsync(t => t.AccessionNumber == accession))
+            .Should()
+            .BeFalse();
     }
 }

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRetagHoldingTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerRetagHoldingTests.cs
@@ -24,6 +24,7 @@ namespace Equibles.IntegrationTests.InsiderTrading;
 /// reprocess re-parses from the cached ownership XML — where the source element is a
 /// <c>nonDerivativeHolding</c> — and re-tags the row to <see cref="TransactionCode.Holding"/>,
 /// authoritatively (from the element, never a DB heuristic), then stamps the version.
+/// It also pins v8's ownership-form family stamp from the SEC documentType.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class InsiderFilingReprocessManagerRetagHoldingTests : ParadeDbMcpTestBase
@@ -75,13 +76,14 @@ public class InsiderFilingReprocessManagerRetagHoldingTests : ParadeDbMcpTestBas
             OwnershipNature = OwnershipNature.Direct,
             SecurityTitle = "Common Stock",
             SecurityKind = InsiderSecurityKind.NonDerivative,
+            FilingForm = InsiderOwnershipForm.Unknown,
             ParserVersion = 4,
         };
 
         // Source is a holding element (no transaction), so the re-parse routes through
         // ParseHolding and tags the row Holding.
         var ownershipXml =
-            "<ownershipDocument>"
+            "<ownershipDocument><documentType>5</documentType>"
             + "<nonDerivativeTable><nonDerivativeHolding>"
             + "<securityTitle><value>Common Stock</value></securityTitle>"
             + "<postTransactionAmounts>"
@@ -148,6 +150,7 @@ public class InsiderFilingReprocessManagerRetagHoldingTests : ParadeDbMcpTestBas
         await using var verify = Fixture.CreateDbContext();
         var reprocessed = await verify.Set<InsiderTransaction>().FindAsync(stale.Id);
         reprocessed!.TransactionCode.Should().Be(TransactionCode.Holding);
+        reprocessed.FilingForm.Should().Be(InsiderOwnershipForm.Form5);
         reprocessed.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CorporateActions.Data;
@@ -7,6 +8,7 @@ using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
 using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
@@ -18,26 +20,31 @@ using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using MediaFile = Equibles.Media.Data.Models.File;
+using MediaFileContent = Equibles.Media.Data.Models.FileContent;
 
 namespace Equibles.IntegrationTests.Sec;
 
-// Form 4/A / 3/A supersession: an amendment restates its original filing in full,
+// Form 3/A, 4/A, and 5/A supersession: an amendment restates its original filing in full,
 // so the pipeline must (1) replace the original's transactions when the amendment
 // ingests, (2) skip a late-arriving original whose amendment already ingested
 // (EDGAR lists newest-first, so that order is the COMMON one during history
 // sweeps), and (3) skip an older amendment when a newer one of the same original
-// is already in. Without these, enabling 4/A sync would double count insider
-// trades — the erroneous original and its correction summed together.
+// is already in, and (4) never crosses the Form 3/4/5 family boundary. Without
+// these, amendments can double count a correction or delete a same-day sibling form.
 public class InsiderTradingFilingProcessorAmendmentTests
 {
     private const string OriginalAccession = "0001-24-000100";
     private const string AmendmentAccession = "0001-24-000200";
+    private const string FormFiveOriginalAccession = "0001-24-000300";
+    private const string FormFiveAmendmentAccession = "0001-24-000400";
     private static readonly DateOnly OriginalFilingDate = new(2024, 3, 16);
     private static readonly DateOnly AmendmentFilingDate = new(2024, 4, 2);
 
     private static readonly string OriginalForm4Xml = BuildOwnershipXml(
         shares: 1000,
-        dateOfOriginalSubmission: null
+        dateOfOriginalSubmission: null,
+        form: "4"
     );
 
     // The amendment corrects the share count and names its original via
@@ -45,16 +52,22 @@ public class InsiderTradingFilingProcessorAmendmentTests
     // ownership filings.
     private static readonly string AmendmentForm4Xml = BuildOwnershipXml(
         shares: 250,
-        dateOfOriginalSubmission: OriginalFilingDate
+        dateOfOriginalSubmission: OriginalFilingDate,
+        form: "4/A"
     );
 
-    private static string BuildOwnershipXml(long shares, DateOnly? dateOfOriginalSubmission)
+    private static string BuildOwnershipXml(
+        long shares,
+        DateOnly? dateOfOriginalSubmission,
+        string form = "4/A"
+    )
     {
         var originalSubmission = dateOfOriginalSubmission.HasValue
             ? $"<dateOfOriginalSubmission>{dateOfOriginalSubmission:yyyy-MM-dd}</dateOfOriginalSubmission>"
             : string.Empty;
         return $"""
             <ownershipDocument>
+                <documentType>{form}</documentType>
                 {originalSubmission}
                 <reportingOwner>
                     <reportingOwnerId>
@@ -90,8 +103,9 @@ public class InsiderTradingFilingProcessorAmendmentTests
     private static (
         InsiderTradingFilingProcessor Processor,
         InsiderTransactionRepository TxRepo,
-        ISecEdgarClient SecClient
-    ) CreateProcessorWithDeps()
+        ISecEdgarClient SecClient,
+        InsiderFilingRepository FilingRepo
+    ) CreateProcessorWithDeps(ILogger<InsiderTradingFilingProcessor> logger = null)
     {
         var dbContext = TestDbContextFactory.Create(
             new InsiderTradingModuleConfiguration(),
@@ -107,6 +121,32 @@ public class InsiderTradingFilingProcessorAmendmentTests
         var errorManager = new ErrorManager(new ErrorRepository(dbContext));
         var dailyStockPriceRepo = new DailyStockPriceRepository(dbContext);
         var secClient = Substitute.For<ISecEdgarClient>();
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager
+            .SaveInternalFile(
+                Arg.Any<byte[]>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            )
+            .Returns(call =>
+            {
+                var bytes = call.ArgAt<byte[]>(0);
+                var file = new MediaFile
+                {
+                    Name = call.ArgAt<string>(1),
+                    Extension = call.ArgAt<string>(2),
+                    ContentType = call.ArgAt<string>(3),
+                    Size = bytes.Length,
+                    FileContent = new MediaFileContent { Bytes = bytes },
+                };
+                dbContext.Add(file);
+                return file;
+            });
+        fileManager
+            .GetContent(Arg.Any<MediaFile>())
+            .Returns(call => call.ArgAt<MediaFile>(0).FileContent.Bytes);
 
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(ISecEdgarClient), secClient),
@@ -114,7 +154,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
             (typeof(InsiderTransactionRepository), txRepo),
             (typeof(InsiderFilingRepository), filingRepo),
             (typeof(FailedFilingIngestRepository), new FailedFilingIngestRepository(dbContext)),
-            (typeof(IFileManager), Substitute.For<IFileManager>()),
+            (typeof(IFileManager), fileManager),
             (typeof(ErrorManager), errorManager),
             (typeof(DailyStockPriceRepository), dailyStockPriceRepo),
             (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator()),
@@ -123,11 +163,11 @@ public class InsiderTradingFilingProcessorAmendmentTests
 
         var processor = new InsiderTradingFilingProcessor(
             scopeFactory,
-            Substitute.For<ILogger<InsiderTradingFilingProcessor>>(),
+            logger ?? Substitute.For<ILogger<InsiderTradingFilingProcessor>>(),
             new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>())
         );
 
-        return (processor, txRepo, secClient);
+        return (processor, txRepo, secClient, filingRepo);
     }
 
     private static FilingData MakeOriginal() =>
@@ -150,6 +190,26 @@ public class InsiderTradingFilingProcessorAmendmentTests
             Cik = "0000320193",
         };
 
+    private static FilingData MakeFormFiveOriginal() =>
+        new()
+        {
+            AccessionNumber = FormFiveOriginalAccession,
+            Form = "5",
+            FilingDate = OriginalFilingDate,
+            ReportDate = new DateOnly(2024, 3, 15),
+            Cik = "0000320193",
+        };
+
+    private static FilingData MakeFormFiveAmendment() =>
+        new()
+        {
+            AccessionNumber = FormFiveAmendmentAccession,
+            Form = "5/A",
+            FilingDate = AmendmentFilingDate,
+            ReportDate = new DateOnly(2024, 3, 15),
+            Cik = "0000320193",
+        };
+
     private static CommonStock MakeCompany() =>
         new()
         {
@@ -161,7 +221,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
     [Fact]
     public async Task Process_AmendmentAfterOriginal_ReplacesTheOriginalsTransactions()
     {
-        var (processor, txRepo, secClient) = CreateProcessorWithDeps();
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
         var company = MakeCompany();
         secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
         (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
@@ -184,11 +244,55 @@ public class InsiderTradingFilingProcessorAmendmentTests
     }
 
     [Fact]
+    public async Task Process_AmendmentAgainstLegacyUnknownOriginal_ResolvesFamilyBeforeSuperseding()
+    {
+        var (processor, txRepo, secClient, filingRepo) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+        txRepo.GetByAccessionNumber(OriginalAccession).Single().FilingForm =
+            InsiderOwnershipForm.Unknown;
+        filingRepo.GetByAccessionNumber(OriginalAccession).Single().FilingForm =
+            InsiderOwnershipForm.Unknown;
+        await txRepo.SaveChanges();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        txRepo.GetAll().Should().ContainSingle();
+        txRepo.GetAll().Single().AccessionNumber.Should().Be(AmendmentAccession);
+    }
+
+    [Fact]
+    public async Task Process_NewerAmendmentAgainstLegacyUnknownOlderAmendment_ReplacesIt()
+    {
+        var (processor, txRepo, secClient, filingRepo) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        var olderAmendment = MakeAmendment();
+        olderAmendment.AccessionNumber = "0001-24-000150";
+        olderAmendment.FilingDate = AmendmentFilingDate.AddDays(-1);
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(olderAmendment, company)).Should().BeTrue();
+        txRepo.GetByAccessionNumber(olderAmendment.AccessionNumber).Single().FilingForm =
+            InsiderOwnershipForm.Unknown;
+        filingRepo.GetByAccessionNumber(olderAmendment.AccessionNumber).Single().FilingForm =
+            InsiderOwnershipForm.Unknown;
+        await txRepo.SaveChanges();
+
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        txRepo.GetAll().Should().ContainSingle();
+        txRepo.GetAll().Single().AccessionNumber.Should().Be(AmendmentAccession);
+    }
+
+    [Fact]
     public async Task Process_OriginalAfterItsAmendment_IsSkipped()
     {
         // EDGAR's submissions feed lists newest-first, so during a history sweep
         // the 4/A routinely processes BEFORE its Form 4.
-        var (processor, txRepo, secClient) = CreateProcessorWithDeps();
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
         var company = MakeCompany();
         secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
         (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
@@ -210,13 +314,402 @@ public class InsiderTradingFilingProcessorAmendmentTests
     }
 
     [Fact]
+    public async Task Process_OriginalAfterLegacyUnknownOrphanAmendment_ResolvesAndClaimsIt()
+    {
+        var (processor, txRepo, secClient, filingRepo) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+        var amendment = txRepo.GetByAccessionNumber(AmendmentAccession).Single();
+        amendment.FilingForm = InsiderOwnershipForm.Unknown;
+        amendment.SupersededAccessionNumber = null;
+        filingRepo.GetByAccessionNumber(AmendmentAccession).Single().FilingForm =
+            InsiderOwnershipForm.Unknown;
+        await txRepo.SaveChanges();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company))
+            .Should()
+            .BeFalse("the cached Form 4/A proves the legacy orphan superseded this original");
+
+        txRepo.GetAll().Should().ContainSingle();
+        var remaining = txRepo.GetAll().Single();
+        remaining.AccessionNumber.Should().Be(AmendmentAccession);
+        remaining.FilingForm.Should().Be(InsiderOwnershipForm.Form4);
+        remaining.SupersededAccessionNumber.Should().Be(OriginalAccession);
+    }
+
+    [Fact]
+    public async Task Process_OriginalAfterLegacyUnknownAmendmentWithCorruptCache_StillIngests()
+    {
+        var (processor, txRepo, secClient, filingRepo) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+        var amendment = txRepo.GetByAccessionNumber(AmendmentAccession).Single();
+        amendment.FilingForm = InsiderOwnershipForm.Unknown;
+        amendment.SupersededAccessionNumber = null;
+        var stored = filingRepo.GetByAccessionNumber(AmendmentAccession).Single();
+        stored.FilingForm = InsiderOwnershipForm.Unknown;
+        stored.Content.FileContent.Bytes = [1, 2, 3];
+        await txRepo.SaveChanges();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company))
+            .Should()
+            .BeTrue("an unreadable legacy cache cannot block live ingestion");
+
+        txRepo
+            .GetAll()
+            .Select(t => t.AccessionNumber)
+            .Should()
+            .BeEquivalentTo([AmendmentAccession, OriginalAccession]);
+        amendment.FilingForm.Should().Be(InsiderOwnershipForm.Unknown);
+    }
+
+    [Fact]
+    public async Task Process_OriginalAfterLegacyUnknownAmendmentWithoutCache_LogsAndStillIngests()
+    {
+        var logger = Substitute.For<ILogger<InsiderTradingFilingProcessor>>();
+        var (processor, txRepo, secClient, filingRepo) = CreateProcessorWithDeps(logger);
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+        txRepo.GetByAccessionNumber(AmendmentAccession).Single().FilingForm =
+            InsiderOwnershipForm.Unknown;
+        filingRepo.Delete(filingRepo.GetByAccessionNumber(AmendmentAccession).Single());
+        await txRepo.SaveChanges();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        ShouldHaveFamilyResolutionWarning(logger, AmendmentAccession);
+        txRepo.GetAll().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Process_OriginalAfterLegacyUnknownAmendmentWithNonOwnershipCache_LogsAndStillIngests()
+    {
+        var logger = Substitute.For<ILogger<InsiderTradingFilingProcessor>>();
+        var (processor, txRepo, secClient, filingRepo) = CreateProcessorWithDeps(logger);
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+        txRepo.GetByAccessionNumber(AmendmentAccession).Single().FilingForm =
+            InsiderOwnershipForm.Unknown;
+        var stored = filingRepo.GetByAccessionNumber(AmendmentAccession).Single();
+        stored.FilingForm = InsiderOwnershipForm.Unknown;
+        stored.Content.FileContent.Bytes = GzipCompressor.Compress(
+            Encoding.UTF8.GetBytes("<html><body>not an ownership filing</body></html>")
+        );
+        await txRepo.SaveChanges();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        ShouldHaveFamilyResolutionWarning(logger, AmendmentAccession);
+        txRepo.GetAll().Should().HaveCount(2);
+    }
+
+    private static void ShouldHaveFamilyResolutionWarning(
+        ILogger<InsiderTradingFilingProcessor> logger,
+        string accessionNumber
+    )
+    {
+        logger
+            .ReceivedCalls()
+            .Should()
+            .Contain(call =>
+                call.GetMethodInfo().Name == nameof(ILogger.Log)
+                && Equals(call.GetArguments()[0], LogLevel.Warning)
+                && call.GetArguments()[2].ToString()!.Contains(accessionNumber)
+            );
+    }
+
+    [Fact]
+    public async Task Process_FormFiveAmendmentAfterSameDayFormFourAndFive_ReplacesOnlyFormFive()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(500, null, "5"));
+        (await processor.Process(MakeFormFiveOriginal(), company)).Should().BeTrue();
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(550, OriginalFilingDate, "5/A"));
+        (await processor.Process(MakeFormFiveAmendment(), company)).Should().BeTrue();
+
+        var transactions = txRepo.GetAll().OrderBy(t => t.AccessionNumber).ToList();
+        transactions.Should().HaveCount(2);
+        transactions
+            .Select(t => t.AccessionNumber)
+            .Should()
+            .Equal(OriginalAccession, FormFiveAmendmentAccession);
+        transactions
+            .Single(t => t.FilingForm == InsiderOwnershipForm.Form4)
+            .Shares.Should()
+            .Be(1000);
+        transactions
+            .Single(t => t.FilingForm == InsiderOwnershipForm.Form5)
+            .Shares.Should()
+            .Be(550);
+    }
+
+    [Fact]
+    public async Task Process_FormFiveAmendmentBeforeSameDayFormFourAndFive_ClaimsOnlyFormFive()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(550, OriginalFilingDate, "5/A"));
+        (await processor.Process(MakeFormFiveAmendment(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(500, null, "5"));
+        (await processor.Process(MakeFormFiveOriginal(), company))
+            .Should()
+            .BeFalse("the already-ingested Form 5/A superseded this Form 5");
+
+        var transactions = txRepo.GetAll().OrderBy(t => t.AccessionNumber).ToList();
+        transactions.Should().HaveCount(2);
+        transactions
+            .Select(t => t.AccessionNumber)
+            .Should()
+            .Equal(OriginalAccession, FormFiveAmendmentAccession);
+        transactions
+            .Single(t => t.FilingForm == InsiderOwnershipForm.Form4)
+            .Shares.Should()
+            .Be(1000);
+        transactions
+            .Single(t => t.FilingForm == InsiderOwnershipForm.Form5)
+            .SupersededAccessionNumber.Should()
+            .Be(FormFiveOriginalAccession);
+    }
+
+    [Fact]
+    public async Task Process_OlderFormFourAmendmentAfterNewerFormFiveAmendment_IsNotStale()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(550, OriginalFilingDate, "5/A"));
+        (await processor.Process(MakeFormFiveAmendment(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company))
+            .Should()
+            .BeTrue("a newer Form 5/A cannot make a Form 4/A stale");
+
+        txRepo
+            .GetAll()
+            .Select(t => t.FilingForm)
+            .ToList()
+            .Should()
+            .BeEquivalentTo([InsiderOwnershipForm.Form4, InsiderOwnershipForm.Form5]);
+    }
+
+    [Fact]
+    public async Task Process_NewerFormFiveAmendment_ReplacesOnlyOlderFormFiveAmendment()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var olderFormFiveAmendment = MakeFormFiveAmendment();
+        olderFormFiveAmendment.AccessionNumber = "0001-24-000350";
+        olderFormFiveAmendment.FilingDate = AmendmentFilingDate.AddDays(-1);
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(525, OriginalFilingDate, "5/A"));
+        (await processor.Process(olderFormFiveAmendment, company)).Should().BeTrue();
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(550, OriginalFilingDate, "5/A"));
+        (await processor.Process(MakeFormFiveAmendment(), company)).Should().BeTrue();
+
+        var transactions = txRepo.GetAll().OrderBy(t => t.AccessionNumber).ToList();
+        transactions.Should().HaveCount(2);
+        transactions
+            .Select(t => t.AccessionNumber)
+            .Should()
+            .Equal(AmendmentAccession, FormFiveAmendmentAccession);
+    }
+
+    [Fact]
+    public async Task Process_FormFiveOriginalAfterBadCrossFamilyClaim_ReassignsTheClaim()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(550, OriginalFilingDate, "5/A"));
+        (await processor.Process(MakeFormFiveAmendment(), company)).Should().BeTrue();
+        var amendment = txRepo.GetByAccessionNumber(FormFiveAmendmentAccession).Single();
+        amendment.SupersededAccessionNumber = OriginalAccession;
+        await txRepo.SaveChanges();
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(500, null, "5"));
+        (await processor.Process(MakeFormFiveOriginal(), company))
+            .Should()
+            .BeFalse("the Form 5/A is reassigned from its disproved Form 4 claim");
+
+        txRepo.GetByAccessionNumber(FormFiveOriginalAccession).Should().BeEmpty();
+        txRepo
+            .GetByAccessionNumber(FormFiveAmendmentAccession)
+            .Single()
+            .SupersededAccessionNumber.Should()
+            .Be(FormFiveOriginalAccession);
+    }
+
+    [Fact]
+    public async Task Process_NewerFormFiveAmendment_DoesNotInheritBadCrossFamilyClaim()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        var olderAmendment = MakeFormFiveAmendment();
+        olderAmendment.AccessionNumber = "0001-24-000350";
+        olderAmendment.FilingDate = AmendmentFilingDate.AddDays(-1);
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(525, OriginalFilingDate, "5/A"));
+        (await processor.Process(olderAmendment, company)).Should().BeTrue();
+        txRepo
+            .GetByAccessionNumber(olderAmendment.AccessionNumber)
+            .Single()
+            .SupersededAccessionNumber = OriginalAccession;
+        await txRepo.SaveChanges();
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(550, OriginalFilingDate, "5/A"));
+        (await processor.Process(MakeFormFiveAmendment(), company)).Should().BeTrue();
+
+        txRepo.GetByAccessionNumber(olderAmendment.AccessionNumber).Should().BeEmpty();
+        txRepo
+            .GetByAccessionNumber(FormFiveAmendmentAccession)
+            .Single()
+            .SupersededAccessionNumber.Should()
+            .BeNull("the stored target is authoritatively Form 4, not Form 5");
+    }
+
+    [Fact]
+    public async Task Process_LegacyCrossFamilyClaim_DoesNotHideOrSuppressOriginal()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(500, null, "5"));
+        (await processor.Process(MakeFormFiveOriginal(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var formFiveRows = txRepo.GetByAccessionNumber(FormFiveOriginalAccession).ToList();
+        txRepo.Delete(formFiveRows);
+        var formFourAmendment = txRepo.GetByAccessionNumber(AmendmentAccession).Single();
+        formFourAmendment.SupersededAccessionNumber = FormFiveOriginalAccession;
+        await txRepo.SaveChanges();
+
+        var known = await processor.FilterKnownAccessions([
+            AmendmentAccession,
+            FormFiveOriginalAccession,
+        ]);
+        known
+            .Should()
+            .Equal(
+                [AmendmentAccession],
+                "the amendment is known by its own row but cannot carry a cross-family target"
+            );
+
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildOwnershipXml(500, null, "5"));
+        (await processor.Process(MakeFormFiveOriginal(), company))
+            .Should()
+            .BeTrue("a cross-family claim cannot suppress the real original");
+
+        txRepo.GetByAccessionNumber(FormFiveOriginalAccession).Should().ContainSingle();
+        txRepo.GetByAccessionNumber(AmendmentAccession).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Process_ValidLegacyUnknownClaim_ResolvesFromCachedXmlAndStillSuppressesOriginal()
+    {
+        var (processor, txRepo, secClient, filingRepo) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var amendment = txRepo.GetByAccessionNumber(AmendmentAccession).Single();
+        amendment.FilingForm = InsiderOwnershipForm.Unknown;
+        filingRepo.GetByAccessionNumber(OriginalAccession).Single().FilingForm =
+            InsiderOwnershipForm.Unknown;
+        filingRepo.GetByAccessionNumber(AmendmentAccession).Single().FilingForm =
+            InsiderOwnershipForm.Unknown;
+        await txRepo.SaveChanges();
+
+        var before = await processor.FilterKnownAccessions([OriginalAccession, AmendmentAccession]);
+        before.Should().Equal(AmendmentAccession);
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company))
+            .Should()
+            .BeFalse("the cached Form 4/A proves this same-family legacy claim is valid");
+
+        txRepo.GetByAccessionNumber(OriginalAccession).Should().BeEmpty();
+        txRepo
+            .GetByAccessionNumber(AmendmentAccession)
+            .Single()
+            .FilingForm.Should()
+            .Be(InsiderOwnershipForm.Form4);
+
+        var after = await processor.FilterKnownAccessions([OriginalAccession, AmendmentAccession]);
+        after.Should().BeEquivalentTo([OriginalAccession, AmendmentAccession]);
+    }
+
+    [Fact]
     public async Task Process_AmendmentWithDateShiftedOriginal_StillSupersedesIt()
     {
         // EDGAR indexes an after-17:30 submission the NEXT business day, so the
         // original's feed FilingDate can trail the amendment's filer-entered
         // dateOfOriginalSubmission. The window resolution must still find and
         // replace it — exact-date-only matching would leave both rows counted.
-        var (processor, txRepo, secClient) = CreateProcessorWithDeps();
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
         var company = MakeCompany();
 
         var shiftedOriginal = MakeOriginal();
@@ -240,7 +733,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
         // A superseded original has no rows of its own; without the claim column
         // every sweep would pass it through the prefilter and re-fetch it from
         // EDGAR forever just to re-skip it.
-        var (processor, _, secClient) = CreateProcessorWithDeps();
+        var (processor, _, secClient, _) = CreateProcessorWithDeps();
         var company = MakeCompany();
         secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
         (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
@@ -259,7 +752,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
     [Fact]
     public async Task Process_OlderAmendmentAfterNewer_IsSkipped()
     {
-        var (processor, txRepo, secClient) = CreateProcessorWithDeps();
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
         var company = MakeCompany();
         secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
         (await processor.Process(MakeAmendment(), company)).Should().BeTrue();

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
@@ -200,6 +200,7 @@ public class InsiderTradingFilingProcessorSkipTombstoneTests
                     SecurityTitle = "Common Stock",
                     TransactionOrder = 1,
                     IsAmendment = true,
+                    FilingForm = InsiderOwnershipForm.Form4,
                     OriginalFilingDate = new DateOnly(2023, 5, 25),
                     IsPriceValid = true,
                     Notes = [],


### PR DESCRIPTION
## Summary
- persist the authoritative Form 3/4/5 family on ownership filings and transactions
- scope original, orphan, stale, and chained amendment supersession to that family
- safely repair legacy claims and rowless cached filings from SEC `documentType`
- keep corrupt or missing legacy caches fail-open with warning diagnostics

## Verification
- `dotnet build Equibles.sln -c Release`
- `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release --no-build` (4514 passed)
- focused amendment/replay integration tests (23 passed)
- `dotnet csharpier check .`
- EF pending-model check clean
- independent review approved
