### PR TITLE
chore(deps): upgrade safe runtime and test packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="PdfPig" Version="0.1.15" />
-    <PackageVersion Include="ReverseMarkdown" Version="5.3.0" />
+    <PackageVersion Include="ReverseMarkdown" Version="6.2.1" />
     <!-- Validation -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
@@ -48,7 +48,7 @@
     <!-- Pinned to remediate the transitive 9.0.4 high-severity advisory
          GHSA-73j8-2gch-69rq (NU1903); referenced directly in
          Equibles.Sec.BusinessLogic to override the vulnerable transitive. -->
-    <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.11" />
     <!-- Microsoft.Extensions -->
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
@@ -91,7 +91,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Testcontainers" Version="4.14.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />

--- a/src/Equibles.Sec.BusinessLogic/SecDocumentHtmlToMarkdownConverter.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentHtmlToMarkdownConverter.cs
@@ -38,9 +38,9 @@ public class SecDocumentHtmlToMarkdownConverter : ISecDocumentHtmlToMarkdownConv
         var config = new Config
         {
             GithubFlavored = true,
-            RemoveComments = true,
-            SmartHrefHandling = true,
-            UnknownTags = Config.UnknownTagsOption.Bypass,
+            Formatting = { RemoveComments = true },
+            Links = { SmartHref = true },
+            Tags = { Unknown = Config.UnknownTagsOption.Bypass },
         };
 
         return new Converter(config);

--- a/src/Equibles.Web/package-lock.json
+++ b/src/Equibles.Web/package-lock.json
@@ -1624,9 +1624,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {
@@ -1650,9 +1650,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1663,9 +1663,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "dev": true,
             "funding": [
                 {
@@ -1683,7 +1683,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -1809,9 +1809,9 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/tests/Equibles.UnitTests/Sec/SecDocumentHtmlToMarkdownConverterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentHtmlToMarkdownConverterTests.cs
@@ -47,6 +47,38 @@ public class SecDocumentHtmlToMarkdownConverterTests
     }
 
     [Fact]
+    public void Convert_GithubFormatting_ProducesCleanMarkdown()
+    {
+        var result = _converter.Convert("<strong>bold</strong><br><em>italic</em>");
+
+        result.Should().Be("**bold**  \n*italic*");
+    }
+
+    [Fact]
+    public void Convert_UnknownTag_UnwrapsTag()
+    {
+        var result = _converter.Convert("<custom-element>content</custom-element>");
+
+        result.Should().Be("content");
+    }
+
+    [Fact]
+    public void Convert_Comment_RemovesComment()
+    {
+        var result = _converter.Convert("before<!--hidden-->after");
+
+        result.Should().Be("beforeafter");
+    }
+
+    [Fact]
+    public void Convert_LinkMatchingHref_UsesSmartHref()
+    {
+        var result = _converter.Convert("<a href=\"https://example.com\">https://example.com</a>");
+
+        result.Should().Be("https://example.com");
+    }
+
+    [Fact]
     public void Convert_DuplicateStyleAttributes_DoesNotThrow()
     {
         var html = """<p style="font-weight:bold;font-weight:bold">styled text</p>""";


### PR DESCRIPTION
## Summary
- upgrade ReverseMarkdown, Microsoft.Bcl.Memory, and NSubstitute to current permissively licensed releases
- migrate the SEC HTML converter to the ReverseMarkdown 6 configuration surface with exact regression coverage
- patch vulnerable frontend build dependencies without changing production dependencies

## Verification
- Release build: passed with zero warnings
- formatting check: passed
- unit tests: 4,530 passed
- integration tests: 2,662 passed
- functional tests: 118 passed
- NuGet vulnerability scan: zero findings
- npm audit: zero findings
- independent review: no findings

## Deferred
- MassTransit 9, ImageSharp 4, Playwright, and xUnit migration remain unchanged for dedicated compatibility work