### PR TITLE
fix(insider-trading): clear cross-family replay claims

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -85,6 +85,8 @@ public class InsiderFilingReprocessManager
         CancellationToken cancellationToken = default
     )
     {
+        await ClearProvenCrossFamilyClaims(cancellationToken);
+
         // Snapshot of the work-set for the progress bar. The live ingest worker may
         // stamp new rows at the current version while this runs; harmless — Processed
         // can briefly nudge past Total and self-corrects.
@@ -105,116 +107,153 @@ public class InsiderFilingReprocessManager
 
         _dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
 
-        await ReprocessRowlessFilingForms(result, onProgress, cancellationToken);
-
-        // No DB cursor: a reprocessed filing's rows advance to the current version and
-        // drop out of the filter, so each pass takes the next batch of unprocessed
-        // accessions. Drain one exact parser version at a time so the composite
-        // (ParserVersion, AccessionNumber) index can stream DISTINCT accessions directly
-        // into LIMIT instead of filtering current rows from the accession index (#4374).
-        // Filings that fail this run are held in-memory and excluded so the run still
-        // terminates; they're retried on the next run. The textual order is local to one
-        // batch, not a persisted keyset boundary, so database collation cannot skip work.
-        var failedThisRun = new HashSet<string>();
-        while (!cancellationToken.IsCancellationRequested)
+        try
         {
-            var pending = _transactionRepository
-                .GetAll()
-                .Where(t => t.ParserVersion < InsiderTransaction.CurrentParserVersion)
-                .Where(t => !failedThisRun.Contains(t.AccessionNumber));
-            var oldestParserVersion = await pending
-                .Select(t => (int?)t.ParserVersion)
-                .MinAsync(cancellationToken);
+            await ReprocessRowlessFilingForms(result, onProgress, cancellationToken);
 
-            if (oldestParserVersion == null)
-                break;
-
-            var accessions = await pending
-                .Where(t => t.ParserVersion == oldestParserVersion.Value)
-                .Select(t => t.AccessionNumber)
-                .Distinct()
-                .OrderBy(accession => accession)
-                .Take(BatchSize)
-                .ToListAsync(cancellationToken);
-
-            if (accessions.Count == 0)
-                continue;
-
-            var attempted = 0;
-            foreach (var accession in accessions)
+            // No DB cursor: a reprocessed filing's rows advance to the current version and
+            // drop out of the filter, so each pass takes the next batch of unprocessed
+            // accessions. Drain one exact parser version at a time so the composite
+            // (ParserVersion, AccessionNumber) index can stream DISTINCT accessions directly
+            // into LIMIT instead of filtering current rows from the accession index (#4374).
+            // Filings that fail this run are held in-memory and excluded so the run still
+            // terminates; they're retried on the next run. The textual order is local to one
+            // batch, not a persisted keyset boundary, so database collation cannot skip work.
+            var failedThisRun = new HashSet<string>();
+            while (!cancellationToken.IsCancellationRequested)
             {
-                if (cancellationToken.IsCancellationRequested)
+                var pending = _transactionRepository
+                    .GetAll()
+                    .Where(t => t.ParserVersion < InsiderTransaction.CurrentParserVersion)
+                    .Where(t => !failedThisRun.Contains(t.AccessionNumber));
+                var oldestParserVersion = await pending
+                    .Select(t => (int?)t.ParserVersion)
+                    .MinAsync(cancellationToken);
+
+                if (oldestParserVersion == null)
                     break;
-                attempted++;
+
+                var accessions = await pending
+                    .Where(t => t.ParserVersion == oldestParserVersion.Value)
+                    .Select(t => t.AccessionNumber)
+                    .Distinct()
+                    .OrderBy(accession => accession)
+                    .Take(BatchSize)
+                    .ToListAsync(cancellationToken);
+
+                if (accessions.Count == 0)
+                    continue;
+
+                var attempted = 0;
+                foreach (var accession in accessions)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                        break;
+                    attempted++;
+                    try
+                    {
+                        await ReprocessFiling(accession, result);
+                    }
+                    catch (Exception ex)
+                    {
+                        // One bad filing (e.g. a transient EDGAR 429/timeout) must not abort
+                        // the whole batch. Skip it this run; it's retried on the next.
+                        _logger.LogWarning(
+                            ex,
+                            "Insider filing reprocess failed for {AccessionNumber}; skipping this run",
+                            accession
+                        );
+                        failedThisRun.Add(accession);
+                        result.Failed++;
+                    }
+                }
+
                 try
                 {
-                    await ReprocessFiling(accession, result);
-                }
-                catch (Exception ex)
-                {
-                    // One bad filing (e.g. a transient EDGAR 429/timeout) must not abort
-                    // the whole batch. Skip it this run; it's retried on the next.
-                    _logger.LogWarning(
-                        ex,
-                        "Insider filing reprocess failed for {AccessionNumber}; skipping this run",
-                        accession
-                    );
-                    failedThisRun.Add(accession);
-                    result.Failed++;
-                }
-            }
-
-            try
-            {
-                await _transactionRepository.SaveChanges();
-                // Count only filings actually attempted this batch (successes + failures).
-                // Cancellation can break the loop early, so the remaining accessions were
-                // never tried and must not be credited as processed.
-                result.Processed += attempted;
-            }
-            catch (DbUpdateException ex)
-            {
-                // A concurrent ingest or reprocess run inserted one of these filings' cache
-                // rows first, so this batch's duplicate-accession insert is rejected by the
-                // unique index. That cache write is best-effort, but the batch's transaction
-                // updates (parser-version advances, reclassifications, price repairs) are
-                // not — detaching the pending filing/file inserts and re-saving lets the
-                // transaction work commit instead of being discarded with the conflict (#2454).
-                if (await TryCommitWithoutPendingCacheInserts())
-                {
+                    await _transactionRepository.SaveChanges();
+                    // Count only filings actually attempted this batch (successes + failures).
+                    // Cancellation can break the loop early, so the remaining accessions were
+                    // never tried and must not be credited as processed.
                     result.Processed += attempted;
                 }
-                else
+                catch (DbUpdateException ex)
                 {
-                    _logger.LogWarning(
-                        ex,
-                        "Insider filing reprocess batch save failed; retrying next run"
-                    );
-                    foreach (var accession in accessions)
-                        failedThisRun.Add(accession);
+                    // A concurrent ingest or reprocess run inserted one of these filings' cache
+                    // rows first, so this batch's duplicate-accession insert is rejected by the
+                    // unique index. That cache write is best-effort, but the batch's transaction
+                    // updates (parser-version advances, reclassifications, price repairs) are
+                    // not — detaching the pending filing/file inserts and re-saving lets the
+                    // transaction work commit instead of being discarded with the conflict (#2454).
+                    if (await TryCommitWithoutPendingCacheInserts())
+                    {
+                        result.Processed += attempted;
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Insider filing reprocess batch save failed; retrying next run"
+                        );
+                        foreach (var accession in accessions)
+                            failedThisRun.Add(accession);
+                    }
                 }
-            }
-            finally
-            {
-                _dbContext.ChangeTracker.Clear();
-            }
+                finally
+                {
+                    _dbContext.ChangeTracker.Clear();
+                }
 
-            _logger.LogInformation(
-                "Insider filing reprocess: {Processed}/{Total} filings, reclassified={Reclassified}, repaired={Repaired}, dates corrected={DatesCorrected}, 10b5-1 stamped={Rule10b5Stamped}, failed={Failed}",
-                result.Processed,
-                result.Total,
-                result.Reclassified,
-                result.Repaired,
-                result.DatesCorrected,
-                result.Rule10b5Stamped,
-                result.Failed
-            );
+                _logger.LogInformation(
+                    "Insider filing reprocess: {Processed}/{Total} filings, reclassified={Reclassified}, repaired={Repaired}, dates corrected={DatesCorrected}, 10b5-1 stamped={Rule10b5Stamped}, failed={Failed}",
+                    result.Processed,
+                    result.Total,
+                    result.Reclassified,
+                    result.Repaired,
+                    result.DatesCorrected,
+                    result.Rule10b5Stamped,
+                    result.Failed
+                );
 
-            if (onProgress != null)
-                await onProgress(result);
+                if (onProgress != null)
+                    await onProgress(result);
+            }
+        }
+        finally
+        {
+            await ClearProvenCrossFamilyClaims(CancellationToken.None);
         }
 
         return result;
+    }
+
+    private async Task ClearProvenCrossFamilyClaims(CancellationToken cancellationToken)
+    {
+        var filingRows = _filingRepository.GetAll();
+        var cleared = await _transactionRepository
+            .GetAll()
+            .Where(transaction =>
+                transaction.SupersededAccessionNumber != null
+                && transaction.FilingForm != InsiderOwnershipForm.Unknown
+                && filingRows.Any(original =>
+                    original.AccessionNumber == transaction.SupersededAccessionNumber
+                    && original.FilingForm != InsiderOwnershipForm.Unknown
+                    && original.FilingForm != transaction.FilingForm
+                )
+            )
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters.SetProperty(
+                        transaction => transaction.SupersededAccessionNumber,
+                        (string)null
+                    ),
+                cancellationToken
+            );
+
+        if (cleared > 0)
+            _logger.LogInformation(
+                "Cleared {Count} proven cross-family insider supersession claims",
+                cleared
+            );
     }
 
     // Supersession deliberately deletes an original filing's transaction rows but

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerClaimCleanupTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerClaimCleanupTests.cs
@@ -1,0 +1,223 @@
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+using FileContent = Equibles.Media.Data.Models.FileContent;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+[Collection(ParadeDbCollection.Name)]
+public class InsiderFilingReprocessManagerClaimCleanupTests : ParadeDbMcpTestBase
+{
+    public InsiderFilingReprocessManagerClaimCleanupTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Run_CurrentRows_ClearsOnlyProvenCrossFamilyClaims()
+    {
+        const string mismatchedTarget = "0000000001-24-000001";
+        const string matchingTarget = "0000000001-24-000002";
+        const string unknownTarget = "0000000001-24-000005";
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "TEST",
+            Name = "Test Company",
+            Cik = "0000000001",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0000000002",
+            Name = "Test Owner",
+        };
+        var mismatchedClaim = BuildClaim(stock, owner, "0000000001-24-000003", mismatchedTarget);
+        var matchingClaim = BuildClaim(stock, owner, "0000000001-24-000004", matchingTarget);
+        var knownClaimOfUnknownTarget = BuildClaim(
+            stock,
+            owner,
+            "0000000001-24-000006",
+            unknownTarget
+        );
+        var unknownClaimOfKnownTarget = BuildClaim(
+            stock,
+            owner,
+            "0000000001-24-000007",
+            mismatchedTarget,
+            InsiderOwnershipForm.Unknown
+        );
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        DbContext.AddRange(
+            new InsiderFiling
+            {
+                AccessionNumber = mismatchedTarget,
+                FilingForm = InsiderOwnershipForm.Form4,
+            },
+            new InsiderFiling
+            {
+                AccessionNumber = matchingTarget,
+                FilingForm = InsiderOwnershipForm.Form3,
+            },
+            new InsiderFiling { AccessionNumber = unknownTarget },
+            mismatchedClaim,
+            matchingClaim,
+            knownClaimOfUnknownTarget,
+            unknownClaimOfKnownTarget
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var runContext = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runContext),
+            new InsiderFilingRepository(runContext),
+            new DailyStockPriceRepository(runContext),
+            new StockSplitRepository(runContext),
+            new InsiderTransactionPriceValidator(),
+            Substitute.For<ISecEdgarClient>(),
+            Substitute.For<IFileManager>(),
+            runContext,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Total.Should().Be(0);
+        await using var verify = Fixture.CreateDbContext();
+        var persistedMismatch = await verify
+            .Set<InsiderTransaction>()
+            .SingleAsync(t => t.Id == mismatchedClaim.Id);
+        var persistedMatch = await verify
+            .Set<InsiderTransaction>()
+            .SingleAsync(t => t.Id == matchingClaim.Id);
+        var persistedKnownClaimOfUnknownTarget = await verify
+            .Set<InsiderTransaction>()
+            .SingleAsync(t => t.Id == knownClaimOfUnknownTarget.Id);
+        var persistedUnknownClaimOfKnownTarget = await verify
+            .Set<InsiderTransaction>()
+            .SingleAsync(t => t.Id == unknownClaimOfKnownTarget.Id);
+        persistedMismatch.SupersededAccessionNumber.Should().BeNull();
+        persistedMatch.SupersededAccessionNumber.Should().Be(matchingTarget);
+        persistedKnownClaimOfUnknownTarget.SupersededAccessionNumber.Should().Be(unknownTarget);
+        persistedUnknownClaimOfKnownTarget.SupersededAccessionNumber.Should().Be(mismatchedTarget);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Run_RowlessTargetClassifiedAsDifferentFamily_ClearsClaimInSameRun(
+        bool cancelAfterClassification
+    )
+    {
+        const string targetAccession = "0000000001-24-000011";
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "TEST",
+            Name = "Test Company",
+            Cik = "0000000001",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0000000002",
+            Name = "Test Owner",
+        };
+        var claim = BuildClaim(stock, owner, "0000000001-24-000012", targetAccession);
+        var rawBytes = Encoding.UTF8.GetBytes(
+            "<ownershipDocument><documentType>4</documentType></ownershipDocument>"
+        );
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        DbContext.Add(claim);
+        DbContext.Add(
+            new InsiderFiling
+            {
+                AccessionNumber = targetAccession,
+                CaptureStatus = InsiderFilingCaptureStatus.Captured,
+                UncompressedSize = rawBytes.Length,
+                Content = new File
+                {
+                    Name = targetAccession,
+                    Extension = "gz",
+                    ContentType = "application/gzip",
+                    FileContent = new FileContent { Bytes = GzipCompressor.Compress(rawBytes) },
+                },
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var runContext = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runContext),
+            new InsiderFilingRepository(runContext),
+            new DailyStockPriceRepository(runContext),
+            new StockSplitRepository(runContext),
+            new InsiderTransactionPriceValidator(),
+            Substitute.For<ISecEdgarClient>(),
+            InsiderReprocessTestSupport.NewFileManager(),
+            runContext,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        using var cancellation = new CancellationTokenSource();
+        var result = await manager.Run(
+            _ =>
+            {
+                if (cancelAfterClassification)
+                    cancellation.Cancel();
+                return Task.CompletedTask;
+            },
+            cancellation.Token
+        );
+
+        result.Total.Should().Be(1);
+        result.Processed.Should().Be(1);
+        await using var verify = Fixture.CreateDbContext();
+        var persistedClaim = await verify
+            .Set<InsiderTransaction>()
+            .SingleAsync(t => t.Id == claim.Id);
+        var persistedTarget = await verify
+            .Set<InsiderFiling>()
+            .SingleAsync(f => f.AccessionNumber == targetAccession);
+        persistedTarget.FilingForm.Should().Be(InsiderOwnershipForm.Form4);
+        persistedClaim.SupersededAccessionNumber.Should().BeNull();
+    }
+
+    private static InsiderTransaction BuildClaim(
+        CommonStock stock,
+        InsiderOwner owner,
+        string accessionNumber,
+        string supersededAccessionNumber,
+        InsiderOwnershipForm filingForm = InsiderOwnershipForm.Form3
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            InsiderOwnerId = owner.Id,
+            AccessionNumber = accessionNumber,
+            TransactionOrder = 0,
+            FilingDate = new DateOnly(2024, 1, 2),
+            TransactionDate = new DateOnly(2024, 1, 2),
+            TransactionCode = TransactionCode.Holding,
+            SecurityTitle = "Common Stock",
+            FilingForm = filingForm,
+            ParserVersion = InsiderTransaction.CurrentParserVersion,
+            SupersededAccessionNumber = supersededAccessionNumber,
+        };
+}


### PR DESCRIPTION
## Summary

Clear proven cross-family insider supersession links after authoritative form-family replay so completed backfills cannot leave stale Form 3/4/5 relationships behind.

## Code changes

- Run a predicate-guarded atomic cleanup before and after replay, including graceful cancellation.
- Preserve same-family and unknown-family claims until SEC XML proves a mismatch.
- Add PostgreSQL integration coverage for completed backlogs, unknown families, rowless classification, and cancellation.