### PR TITLE
fix(imports): close Yahoo and FINRA race gaps

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -50,7 +50,8 @@ public class ShortInterestImportService
 
         var tickerMap = await _tickerMapService.Build(
             _workerOptions.TickersToSync,
-            cancellationToken
+            cancellationToken,
+            StringComparer.Ordinal
         );
         if (tickerMap.Count == 0)
         {
@@ -67,7 +68,7 @@ public class ShortInterestImportService
         // stocks on the next cycle.
         var compressedIndex = FinraClassShareSymbols.BuildCompressedIndex(
             tickerMap,
-            StringComparer.OrdinalIgnoreCase
+            StringComparer.Ordinal
         );
 
         HashSet<DateOnly> knownDates;

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -1896,6 +1896,25 @@ public class YahooPriceImportService
             return;
         }
 
+        // Another price writer can add a date after PersistPrices' optimistic read and before
+        // this series lock. Rechecking while locked turns that collision into an idempotent skip
+        // instead of rolling back every later row in this batch.
+        var batchDates = batch.Select(price => price.Date).ToList();
+        var existingDates = await repo.GetAllSeries()
+            .Where(p =>
+                p.CommonStockId == first.CommonStockId
+                && p.ListedTicker == first.ListedTicker
+                && batchDates.Contains(p.Date)
+            )
+            .Select(p => p.Date)
+            .ToListAsync();
+        batch.RemoveAll(price => existingDates.Contains(price.Date));
+        if (batch.Count == 0)
+        {
+            await transaction.CommitAsync();
+            return;
+        }
+
         repo.AddRange(batch);
         await repo.SaveChanges();
         await transaction.CommitAsync();

--- a/tests/Equibles.IntegrationTests/Finra/ShortInterestImportServicePipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortInterestImportServicePipelineTests.cs
@@ -107,6 +107,100 @@ public class ShortInterestImportServicePipelineTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task Import_CaseVariantSymbols_PersistsEachSecurity()
+    {
+        var common = new CommonStock
+        {
+            Cik = "0000000889",
+            Ticker = "TPC",
+            Name = "Tutor Perini Corporation",
+        };
+        var preferred = new CommonStock
+        {
+            Cik = "0000000890",
+            Ticker = "TpC",
+            Name = "Tutor Perini Preferred",
+        };
+        DbContext.AddRange(common, preferred);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var settlementDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
+        var finraClient = Substitute.For<IFinraClient>();
+        finraClient.GetShortInterestSettlementDates().Returns([settlementDate]);
+        finraClient
+            .GetShortInterest(settlementDate)
+            .Returns(
+                new List<ShortInterestRecord>
+                {
+                    new() { Symbol = "TPC", CurrentShortPosition = 100 },
+                    new() { Symbol = "TpC", CurrentShortPosition = 200 },
+                }
+            );
+
+        await BuildService(finraClient).Import(CancellationToken.None);
+
+        await using var verify = Fixture.CreateDbContext();
+        var rows = await verify
+            .Set<ShortInterest>()
+            .AsNoTracking()
+            .Where(s => s.SettlementDate == settlementDate)
+            .ToListAsync();
+        rows.Should().HaveCount(2);
+        rows.Single(row => row.CommonStockId == common.Id).CurrentShortPosition.Should().Be(100);
+        rows.Single(row => row.CommonStockId == preferred.Id).CurrentShortPosition.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task Import_CaseVariantCompressedClassSymbols_PersistsEachSecurity()
+    {
+        var commonClass = new CommonStock
+        {
+            Cik = "0000000891",
+            Ticker = "TPC-A",
+            Name = "Tutor Perini Class A",
+        };
+        var preferredClass = new CommonStock
+        {
+            Cik = "0000000892",
+            Ticker = "TpC-A",
+            Name = "Tutor Perini Preferred Class A",
+        };
+        DbContext.AddRange(commonClass, preferredClass);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var settlementDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
+        var finraClient = Substitute.For<IFinraClient>();
+        finraClient.GetShortInterestSettlementDates().Returns([settlementDate]);
+        finraClient
+            .GetShortInterest(settlementDate)
+            .Returns(
+                new List<ShortInterestRecord>
+                {
+                    new() { Symbol = "TPCA", CurrentShortPosition = 300 },
+                    new() { Symbol = "TpCA", CurrentShortPosition = 400 },
+                }
+            );
+
+        await BuildService(finraClient).Import(CancellationToken.None);
+
+        await using var verify = Fixture.CreateDbContext();
+        var rows = await verify
+            .Set<ShortInterest>()
+            .AsNoTracking()
+            .Where(s => s.SettlementDate == settlementDate)
+            .ToListAsync();
+        rows.Should().HaveCount(2);
+        rows.Single(row => row.CommonStockId == commonClass.Id)
+            .CurrentShortPosition.Should()
+            .Be(300);
+        rows.Single(row => row.CommonStockId == preferredClass.Id)
+            .CurrentShortPosition.Should()
+            .Be(400);
+    }
+
+    [Fact]
     public async Task Import_SettlementDateDiscoveryThrows_ReportsErrorAndReturns()
     {
         await SeedStock();

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceConcurrentWriterTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceConcurrentWriterTests.cs
@@ -1,0 +1,141 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Yahoo.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Worker;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.HostedService.Configuration;
+using Equibles.Yahoo.HostedService.Services;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Yahoo;
+
+[Collection(ParadeDbCollection.Name)]
+public class YahooPriceImportServiceConcurrentWriterTests : ParadeDbMcpTestBase
+{
+    private static readonly MethodInfo FlushPriceBatchMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "FlushPriceBatch",
+            BindingFlags.Instance | BindingFlags.NonPublic
+        )!;
+
+    public YahooPriceImportServiceConcurrentWriterTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task FlushPriceBatch_ConcurrentDateAlreadyCommitted_SkipsItAndCommitsRemainingRows()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Cik = "0000000991",
+            Ticker = "RACE",
+            Name = "Concurrent Writer Test",
+        };
+        DbContext.Add(stock);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var collisionDate = new DateOnly(2026, 8, 20);
+        var remainingDate = collisionDate.AddDays(1);
+        var staleBatch = new List<DailyStockPrice>
+        {
+            Price(stock.Id, collisionDate, 99m),
+            Price(stock.Id, remainingDate, 101m),
+        };
+
+        await using var flushContext = Fixture.CreateDbContext();
+        await using var concurrentWriter = Fixture.CreateDbContext();
+        await using var writerTransaction = await concurrentWriter.Database.BeginTransactionAsync();
+        var writerStockRepo = new CommonStockRepository(concurrentWriter);
+        var writerPriceRepo = new DailyStockPriceRepository(concurrentWriter);
+        await writerStockRepo.GetForUpdate(stock.Id);
+        writerPriceRepo.Add(Price(stock.Id, collisionDate, 100m));
+        await writerPriceRepo.SaveChanges();
+        var writerPid = ((NpgsqlConnection)concurrentWriter.Database.GetDbConnection()).ProcessID;
+
+        var service = BuildService(flushContext);
+        var flushTask = (Task)FlushPriceBatchMethod.Invoke(service, [staleBatch])!;
+        await WaitUntilBlockedBy(writerPid);
+        await writerTransaction.CommitAsync();
+        await flushTask;
+
+        await using var verify = Fixture.CreateDbContext();
+        var stored = await verify
+            .Set<DailyStockPrice>()
+            .AsNoTracking()
+            .Where(price => price.CommonStockId == stock.Id && price.ListedTicker == stock.Ticker)
+            .OrderBy(price => price.Date)
+            .ToListAsync();
+        stored.Select(price => price.Date).Should().Equal(collisionDate, remainingDate);
+        stored.Select(price => price.Close).Should().Equal(100m, 101m);
+    }
+
+    private YahooPriceImportService BuildService(EquiblesFinancialDbContext context)
+    {
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(CommonStockRepository), new CommonStockRepository(context)),
+            (typeof(DailyStockPriceRepository), new DailyStockPriceRepository(context))
+        );
+        return new YahooPriceImportService(
+            scopeFactory,
+            Substitute.For<ILogger<YahooPriceImportService>>(),
+            Substitute.For<IYahooFinanceClient>(),
+            new TickerMapService(scopeFactory),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions()),
+            Options.Create(new YahooPriceScraperOptions())
+        );
+    }
+
+    private async Task WaitUntilBlockedBy(int writerPid)
+    {
+        await using var observer = Fixture.CreateDbContext();
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            var blocked = await observer
+                .Database.SqlQuery<int>(
+                    $"""
+                    SELECT count(*)::int AS "Value"
+                    FROM pg_stat_activity
+                    WHERE {writerPid} = ANY(pg_blocking_pids(pid))
+                    """
+                )
+                .SingleAsync();
+            if (blocked > 0)
+                return;
+            await Task.Delay(20);
+        }
+
+        throw new TimeoutException("Yahoo flush did not block on the concurrent writer's lock.");
+    }
+
+    private static DailyStockPrice Price(Guid stockId, DateOnly date, decimal close) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stockId,
+            ListedTicker = "RACE",
+            Date = date,
+            Open = close - 1m,
+            High = close + 1m,
+            Low = close - 2m,
+            Close = close,
+            AdjustedClose = close,
+            Volume = 1_000,
+        };
+}

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -1012,9 +1012,10 @@ public class YahooPriceImportServiceTests : IDisposable
         var stock = CreateStock("AEHL", "Antelope Enterprise Holdings");
         await SeedStocks(stock);
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
-        var effectiveDate = today.AddDays(-4);
-        var beforeDate = effectiveDate.AddDays(-1);
-        var afterDate = effectiveDate.AddDays(1);
+        var latestSettled = UsMarketCalendar.PreviousTradingDay(today);
+        var afterDate = UsMarketCalendar.PreviousTradingDay(latestSettled);
+        var effectiveDate = UsMarketCalendar.PreviousTradingDay(afterDate);
+        var beforeDate = UsMarketCalendar.PreviousTradingDay(effectiveDate);
         await SeedPrices(
             CreatePrice(stock, beforeDate, 3.00m),
             CreatePrice(stock, afterDate, 57.10m)
@@ -1022,7 +1023,7 @@ public class YahooPriceImportServiceTests : IDisposable
 
         var incremental = new YahooChartData
         {
-            Prices = CreateHistoricalPrices((today.AddDays(-1), 56.00m)),
+            Prices = CreateHistoricalPrices((latestSettled, 56.00m)),
             Splits =
             [
                 new StockSplitEvent
@@ -1036,7 +1037,7 @@ public class YahooPriceImportServiceTests : IDisposable
         var mixedFullHistory = CreateChartData(
             (beforeDate, 3.20m),
             (afterDate, 58.00m),
-            (today.AddDays(-1), 57.00m)
+            (latestSettled, 57.00m)
         );
         var floor = new DateOnly(2020, 1, 1);
         _yahooClient


### PR DESCRIPTION
## Summary

- Make the Yahoo split-boundary fixture independent of Mondays.
- Make Yahoo price inserts tolerate a competing writer for the same listed date.
- Preserve exact FINRA symbol casing throughout short-interest resolution.

Closes #4403
Closes #4320
Closes #4319

## Code changes

- Re-query existing listed-price dates after acquiring the per-stock lock, skip collisions, and commit the remaining batch.
- Build both direct and compressed FINRA short-interest maps with ordinal identity.
- Add PostgreSQL lock-contention, direct case-variant, compressed case-variant, and trading-calendar regressions.

## Tests

- `dotnet vstest tests/Equibles.IntegrationTests/bin/Debug/net10.0/Equibles.IntegrationTests.dll --Tests:"Equibles.IntegrationTests.Yahoo.YahooPriceImportServiceTests,Equibles.IntegrationTests.Yahoo.YahooPriceImportServiceConcurrentWriterTests,Equibles.IntegrationTests.Finra.ShortInterestImportServicePipelineTests"` — 56 passed.
- Full OSS unit suite — 4,530 passed.
- `dotnet csharpier check .`
- `git diff --check`