### PR TITLE
fix(finra): backfill newly tracked stocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- FINRA daily short-volume completeness now includes the resolved stock universe, so stocks added after a date was marked complete receive a bounded historical backfill. Issue #4316.
+
 ## [1.6.0] — 2026-08-22
 
 ### Added

--- a/src/Equibles.Finra.HostedService/Services/FinraImportScope.cs
+++ b/src/Equibles.Finra.HostedService/Services/FinraImportScope.cs
@@ -23,4 +23,18 @@ public static class FinraImportScope
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
         return $"tickers:{Convert.ToHexString(hash).ToLowerInvariant()}";
     }
+
+    public static string ResolveStockUniverse(IReadOnlyDictionary<string, Guid> stocks)
+    {
+        ArgumentNullException.ThrowIfNull(stocks);
+
+        var payload = string.Join(
+            '\n',
+            stocks
+                .OrderBy(stock => stock.Key, StringComparer.Ordinal)
+                .Select(stock => $"{stock.Key}\0{stock.Value:N}")
+        );
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return $"stocks:{Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
 }

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -80,7 +80,23 @@ public class ShortVolumeImportService
             return;
         }
 
-        var scopeKey = FinraImportScope.Resolve(_workerOptions.TickersToSync);
+        // The resolved universe is part of completeness identity. A date checked before a stock
+        // was added is not complete for that stock, so a universe change gets a fresh bounded,
+        // newest-first pass instead of inheriting the old global "all" markers.
+        var tickerMap = await _tickerMapService.Build(
+            _workerOptions.TickersToSync,
+            cancellationToken,
+            StringComparer.Ordinal
+        );
+        if (tickerMap.Count == 0)
+        {
+            _logger.LogInformation(
+                "No common stocks resolved for FINRA daily short-volume import; leaving partitions retryable"
+            );
+            return;
+        }
+
+        var scopeKey = FinraImportScope.ResolveStockUniverse(tickerMap);
         var completed = await _partitionTracker.GetCompleted(
             Dataset,
             scopeKey,
@@ -101,13 +117,6 @@ public class ShortVolumeImportService
             scopeKey
         );
 
-        // Ordinal: FINRA symbol casing is identity (lowercase suffix = preferred/when-issued,
-        // a different security) — a case-insensitive map merges two securities' volumes.
-        var tickerMap = await _tickerMapService.Build(
-            _workerOptions.TickersToSync,
-            cancellationToken,
-            StringComparer.Ordinal
-        );
         foreach (var date in dates)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/tests/Equibles.IntegrationTests/Finra/FinraImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraImportServiceTests.cs
@@ -33,6 +33,7 @@ public class ShortVolumeImportServiceTests : IDisposable
     private readonly IFinraClient _finraClient;
     private readonly ErrorReporter _errorReporter;
     private readonly WorkerOptions _workerOptions;
+    private readonly FinraScraperOptions _finraOptions;
     private readonly TimeProvider _timeProvider;
     private readonly ShortVolumeImportService _service;
 
@@ -53,6 +54,7 @@ public class ShortVolumeImportServiceTests : IDisposable
         );
 
         _workerOptions = new WorkerOptions();
+        _finraOptions = new FinraScraperOptions();
         _timeProvider = Substitute.For<TimeProvider>();
         _timeProvider.GetUtcNow().Returns(Now);
 
@@ -70,7 +72,7 @@ public class ShortVolumeImportServiceTests : IDisposable
             tickerMapService,
             _errorReporter,
             Options.Create(_workerOptions),
-            Options.Create(new FinraScraperOptions()),
+            Options.Create(_finraOptions),
             new FinraImportPartitionTracker(_partitionRepo),
             _timeProvider
         );
@@ -135,6 +137,13 @@ public class ShortVolumeImportServiceTests : IDisposable
         );
         await _partitionRepo.SaveChanges();
         _dbContext.ChangeTracker.Clear();
+    }
+
+    private static string ResolveStockUniverse(params CommonStock[] stocks)
+    {
+        return FinraImportScope.ResolveStockUniverse(
+            stocks.ToDictionary(stock => stock.Ticker, stock => stock.Id, StringComparer.Ordinal)
+        );
     }
 
     private static List<ShortVolumeRecord> CreateVolumeRecords(
@@ -267,7 +276,7 @@ public class ShortVolumeImportServiceTests : IDisposable
         var today = DateOnly.FromDateTime(Now.UtcDateTime);
         _workerOptions.MinSyncDate = today.ToDateTime(TimeOnly.MinValue);
         await SeedVolume(apple, today);
-        await SeedCompletedPartition(today);
+        await SeedCompletedPartition(today, ResolveStockUniverse(apple));
 
         await _service.Import(CancellationToken.None);
 
@@ -289,7 +298,7 @@ public class ShortVolumeImportServiceTests : IDisposable
 
         await _finraClient.Received(1).GetDailyShortVolume(today);
         _partitionRepo
-            .GetPartition("daily-short-volume-files-v2", "all", today)
+            .GetPartition("daily-short-volume-files-v2", ResolveStockUniverse(apple), today)
             .Should()
             .ContainSingle();
     }
@@ -326,13 +335,74 @@ public class ShortVolumeImportServiceTests : IDisposable
         volumes.Should().Contain(v => v.CommonStockId == apple.Id && v.ShortVolume == 200_000);
         volumes.Should().Contain(v => v.CommonStockId == microsoft.Id && v.ShortVolume == 300_000);
         _partitionRepo
-            .GetPartition("daily-short-volume-files-v2", "all", existingDate)
+            .GetPartition(
+                "daily-short-volume-files-v2",
+                ResolveStockUniverse(apple, microsoft),
+                existingDate
+            )
             .Should()
             .ContainSingle();
 
         _finraClient.ClearReceivedCalls();
         await _service.Import(CancellationToken.None);
         await _finraClient.DidNotReceive().GetDailyShortVolume(existingDate);
+    }
+
+    [Fact]
+    public async Task Import_StockAddedAfterPartitionsComplete_BackfillsOutsideCorrectionLookback()
+    {
+        var apple = CreateStock("AAPL", "Apple Inc.");
+        await SeedStocks(apple);
+
+        var historicalDate = new DateOnly(2026, 3, 20);
+        _workerOptions.MinSyncDate = historicalDate.ToDateTime(TimeOnly.MinValue);
+        _finraClient
+            .GetDailyShortVolume(Arg.Any<DateOnly>())
+            .Returns(new List<ShortVolumeRecord>());
+
+        await _service.Import(CancellationToken.None);
+        _finraClient.ClearReceivedCalls();
+
+        var microsoft = CreateStock("MSFT", "Microsoft Corp.");
+        await SeedStocks(microsoft);
+        _finraClient
+            .GetDailyShortVolume(historicalDate)
+            .Returns(CreateVolumeRecords(("MSFT", 300_000, 3_000, 900_000)));
+
+        await _service.Import(CancellationToken.None);
+
+        await _finraClient.Received(1).GetDailyShortVolume(historicalDate);
+        _volumeRepo
+            .GetByDate(historicalDate)
+            .Should()
+            .ContainSingle(volume =>
+                volume.CommonStockId == microsoft.Id && volume.ShortVolume == 300_000
+            );
+    }
+
+    [Fact]
+    public async Task Import_StockUniverseChange_HonorsBackfillDateCap()
+    {
+        var apple = CreateStock("AAPL", "Apple Inc.");
+        await SeedStocks(apple);
+
+        var floor = new DateOnly(2026, 3, 20);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        _finraClient
+            .GetDailyShortVolume(Arg.Any<DateOnly>())
+            .Returns(new List<ShortVolumeRecord>());
+        await _service.Import(CancellationToken.None);
+        _finraClient.ClearReceivedCalls();
+
+        await SeedStocks(CreateStock("MSFT", "Microsoft Corp."));
+        _finraOptions.ShortVolumeBackfillDatesPerCycle = 2;
+
+        await _service.Import(CancellationToken.None);
+
+        _finraClient.ReceivedCalls().Should().HaveCount(2);
+        await _finraClient.Received(1).GetDailyShortVolume(new DateOnly(2026, 3, 30));
+        await _finraClient.Received(1).GetDailyShortVolume(new DateOnly(2026, 3, 27));
+        await _finraClient.DidNotReceive().GetDailyShortVolume(new DateOnly(2026, 3, 26));
     }
 
     // ── Handles empty API response ───────────────────────────────────
@@ -625,6 +695,8 @@ public class ShortVolumeImportServiceTests : IDisposable
 
         var volumes = _volumeRepo.GetAll().ToList();
         volumes.Should().BeEmpty();
+        await _finraClient.DidNotReceive().GetDailyShortVolume(Arg.Any<DateOnly>());
+        _partitionRepo.GetAll().Should().BeEmpty();
     }
 }
 

--- a/tests/Equibles.UnitTests/Finra/FinraImportScopeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraImportScopeTests.cs
@@ -27,4 +27,60 @@ public class FinraImportScopeTests
     {
         FinraImportScope.Resolve(["AAPL"]).Should().NotBe(FinraImportScope.Resolve(["MSFT"]));
     }
+
+    [Fact]
+    public void ResolveStockUniverse_SameStocksInDifferentOrder_UsesSameScope()
+    {
+        var appleId = Guid.NewGuid();
+        var microsoftId = Guid.NewGuid();
+        var canonical = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            ["AAPL"] = appleId,
+            ["MSFT"] = microsoftId,
+        };
+        var reordered = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            ["MSFT"] = microsoftId,
+            ["AAPL"] = appleId,
+        };
+
+        FinraImportScope
+            .ResolveStockUniverse(reordered)
+            .Should()
+            .Be(FinraImportScope.ResolveStockUniverse(canonical))
+            .And.StartWith("stocks:");
+    }
+
+    [Fact]
+    public void ResolveStockUniverse_AddedOrReplacedStock_UsesDifferentScope()
+    {
+        var appleId = Guid.NewGuid();
+        var original = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["AAPL"] = appleId };
+        var added = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            ["AAPL"] = appleId,
+            ["MSFT"] = Guid.NewGuid(),
+        };
+        var replaced = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        {
+            ["AAPL"] = Guid.NewGuid(),
+        };
+
+        var originalScope = FinraImportScope.ResolveStockUniverse(original);
+        FinraImportScope.ResolveStockUniverse(added).Should().NotBe(originalScope);
+        FinraImportScope.ResolveStockUniverse(replaced).Should().NotBe(originalScope);
+    }
+
+    [Fact]
+    public void ResolveStockUniverse_ExactTickerCasing_IsPartOfIdentity()
+    {
+        var stockId = Guid.NewGuid();
+        var common = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TPC"] = stockId };
+        var preferred = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TpC"] = stockId };
+
+        FinraImportScope
+            .ResolveStockUniverse(preferred)
+            .Should()
+            .NotBe(FinraImportScope.ResolveStockUniverse(common));
+    }
 }


### PR DESCRIPTION
## Summary

- Make daily short-volume completeness depend on the exact resolved stock universe
- Reconcile newly added stocks across bounded historical batches
- Keep issue #4316 open until the fix is deployed and verified

## Code changes

- Hash ordinal ticker and stock identity into the daily FINRA partition scope
- Skip fetches and markers when no stock universe resolves
- Add regression coverage for historical healing, cap ordering, casing identity, and empty-universe safety
- Document the fix in the changelog

Refs #4316