### PR TITLE
fix(congress): strip null bytes from trade text

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -463,15 +463,17 @@ public class CongressionalTradeSyncService
                     TransactionType = tx.TransactionType,
                     // '' rather than null: OwnerType is part of the upsert key, and Postgres
                     // treats NULLs as distinct in unique indexes, which would disable dedup.
-                    OwnerType = tx.OwnerType ?? "",
+                    OwnerType = CleanStoredText(tx.OwnerType),
                     // The stored name is part of the trade upsert key (see PersistTrades), so it
                     // must be normalized here no matter which scraper emitted the transaction —
                     // an unnormalized variant would re-insert the same trade as a new row. Every
                     // source already cleans at emission; doing it here too makes this the single
                     // choke point, mirroring NormalizeMemberName above (GH-3374).
-                    AssetName = DisclosureParsingHelper.CleanAssetName(tx.AssetName) ?? "",
-                    AssetType = tx.AssetType?.Trim() ?? "",
-                    Subholding = tx.Subholding?.Trim() ?? "",
+                    AssetName = DisclosureParsingHelper.CleanAssetName(
+                        CleanStoredText(tx.AssetName)
+                    ),
+                    AssetType = CleanStoredText(tx.AssetType),
+                    Subholding = CleanStoredText(tx.Subholding),
                     AmountFrom = tx.AmountFrom,
                     AmountTo = tx.AmountTo,
                 }
@@ -480,6 +482,9 @@ public class CongressionalTradeSyncService
 
         return trades;
     }
+
+    private static string CleanStoredText(string value) =>
+        value?.Replace("\0", "", StringComparison.Ordinal).Trim() ?? "";
 
     private async Task PersistTrades(
         List<CongressionalTrade> trades,

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
@@ -103,6 +103,39 @@ public class CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests
         trades.Should().ContainSingle().Which.OwnerType.Should().Be("");
     }
 
+    [Fact]
+    public void BuildTrades_SourceTextContainsNullBytes_RemovesThemBeforePersistence()
+    {
+        var sut = CreateService();
+        var member = new CongressMember { Name = "Jane Doe" };
+        var transaction = new DisclosureTransaction
+        {
+            MemberName = "Jane Doe",
+            Ticker = "WY",
+            AssetName = "Weyer\0haeuser Company (WY)",
+            AssetType = "Stock\0",
+            OwnerType = "S\0P",
+            Subholding = "Brokerage\0 IRA",
+            TransactionDate = new DateOnly(2026, 6, 18),
+            FilingDate = new DateOnly(2026, 7, 2),
+            TransactionType = CongressTransactionType.Purchase,
+            AmountFrom = 1001,
+            AmountTo = 15000,
+        };
+
+        var trades = sut.BuildTrades(
+            [transaction],
+            new Dictionary<string, CongressMember> { ["Jane Doe"] = member },
+            new Dictionary<string, CommonStock> { ["WY"] = new CommonStock() }
+        );
+
+        var trade = trades.Should().ContainSingle().Which;
+        trade.AssetName.Should().Be("Weyerhaeuser Company (WY)");
+        trade.AssetType.Should().Be("Stock");
+        trade.OwnerType.Should().Be("SP");
+        trade.Subholding.Should().Be("Brokerage IRA");
+    }
+
     private static CongressionalTradeSyncService CreateService()
     {
         var scope = Substitute.For<IServiceScope>();


### PR DESCRIPTION
## Summary

The phase-1 production replay exposed an embedded NUL byte in a filed asset type. PostgreSQL rejects NULs in text parameters, so the transactional upsert rolled back and the archive partition remained uncheckpointed.

## Code changes

- sanitize NUL bytes from AssetName, AssetType, OwnerType, and Subholding at the BuildTrades persistence boundary
- retain the existing eight-column upsert identity and empty-string null semantics
- add a regression test covering all four stored disclosure text fields

## Verification

- 4,555 OSS unit tests passed
- focused independent verification passed 6 tests
- CSharpier check passed
- git diff --check passed
- independent review found no actionable issues