### PR TITLE
fix(congress): extract inline House subholdings

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -42,7 +42,7 @@ public class CongressionalTradeSyncService
 
     // Congressional trade disclosures are available from 2012 (STOCK Act).
     private static readonly DateOnly EarliestAvailableDate = new(2012, 4, 1);
-    private const int TradeParserVersion = 1;
+    private const int TradeParserVersion = 2;
     private const int ReprocessPerCycleLimit = 1_000;
 
     // A filing with a transaction whose ticker is not (yet) a tracked stock
@@ -486,6 +486,128 @@ public class CongressionalTradeSyncService
     private static string CleanStoredText(string value) =>
         value?.Replace("\0", "", StringComparison.Ordinal).Trim() ?? "";
 
+    private async Task RepairLegacyInlineSubholdingNames(
+        List<CongressionalTrade> incoming,
+        EquiblesFinancialDbContext dbContext,
+        CancellationToken ct
+    )
+    {
+        if (incoming.Count == 0)
+            return;
+
+        var incomingByIdentity = incoming
+            .GroupBy(InlineMetadataRepairIdentity.From)
+            .ToDictionary(group => group.Key, group => group.ToList());
+        var stockIds = incoming.Select(t => t.CommonStockId).Distinct().ToList();
+        var memberIds = incoming.Select(t => t.CongressMemberId).Distinct().ToList();
+        var firstDate = incoming.Min(t => t.TransactionDate);
+        var lastDate = incoming.Max(t => t.TransactionDate);
+        var legacyRows = await dbContext
+            .Set<CongressionalTrade>()
+            .Where(t =>
+                stockIds.Contains(t.CommonStockId)
+                && memberIds.Contains(t.CongressMemberId)
+                && t.TransactionDate >= firstDate
+                && t.TransactionDate <= lastDate
+                && t.AssetName.Contains(":")
+            )
+            .ToListAsync(ct);
+        var legacyCandidates = new List<LegacyInlineMetadataCandidate>();
+        foreach (var legacy in legacyRows)
+        {
+            var details = HouseDisclosureClient.ExtractInlineAssetDetails(legacy.AssetName);
+            if (details.Subholding == null)
+                continue;
+
+            var cleanedName = DisclosureParsingHelper.CleanAssetName(details.AssetName);
+            var cleanedSubholding = CleanStoredText(
+                DisclosureParsingHelper.Truncate(details.Subholding, 256)
+            );
+            legacyCandidates.Add(
+                new LegacyInlineMetadataCandidate(
+                    legacy,
+                    InlineMetadataRepairIdentity.From(legacy, cleanedName),
+                    cleanedSubholding
+                )
+            );
+        }
+
+        var repairs = new List<CongressionalTrade>();
+        foreach (var legacyGroup in legacyCandidates.GroupBy(candidate => candidate.Identity))
+        {
+            if (!incomingByIdentity.TryGetValue(legacyGroup.Key, out var candidates))
+                continue;
+            var activeCandidates = candidates.Where(incoming.Contains).ToList();
+            if (activeCandidates.Count == 0)
+                continue;
+
+            var groupedLegacy = legacyGroup.ToList();
+            if (groupedLegacy.Count != 1)
+            {
+                incoming.RemoveAll(candidate => activeCandidates.Contains(candidate));
+                _logger.LogWarning(
+                    "Deferred congressional trade inline-metadata repair because {Count} legacy rows share the deployed identity",
+                    groupedLegacy.Count
+                );
+                continue;
+            }
+
+            var legacyCandidate = groupedLegacy[0];
+            var legacy = legacyCandidate.Trade;
+            if (legacy.Subholding != "" && legacy.Subholding != legacyCandidate.CleanedSubholding)
+            {
+                incoming.RemoveAll(candidate => activeCandidates.Contains(candidate));
+                _logger.LogWarning(
+                    "Deferred congressional trade inline-metadata repair because stored and filed subholdings conflict"
+                );
+                continue;
+            }
+
+            var matchingSubholding = activeCandidates
+                .Where(candidate => candidate.Subholding == legacyCandidate.CleanedSubholding)
+                .ToList();
+            List<CongressionalTrade> selectedCandidates;
+            if (!string.IsNullOrEmpty(legacy.AssetType))
+            {
+                selectedCandidates = matchingSubholding
+                    .Where(candidate => candidate.AssetType == legacy.AssetType)
+                    .ToList();
+            }
+            else
+            {
+                var candidateAssetTypes = matchingSubholding
+                    .Select(candidate => candidate.AssetType)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList();
+                selectedCandidates = candidateAssetTypes.Count == 1 ? matchingSubholding : [];
+            }
+
+            if (selectedCandidates.Count == 0)
+            {
+                incoming.RemoveAll(candidate => activeCandidates.Contains(candidate));
+                _logger.LogWarning(
+                    "Deferred congressional trade inline-metadata repair because replay did not supply one authoritative account and asset type"
+                );
+                continue;
+            }
+
+            incoming.RemoveAll(candidate =>
+                activeCandidates.Contains(candidate) && !selectedCandidates.Contains(candidate)
+            );
+            repairs.Add(legacy);
+        }
+
+        if (repairs.Count == 0)
+            return;
+
+        dbContext.RemoveRange(repairs);
+        await dbContext.SaveChangesAsync(ct);
+        _logger.LogInformation(
+            "Removed {Count} legacy congressional trades whose inline House metadata was separated by source replay",
+            repairs.Count
+        );
+    }
+
     private async Task PersistTrades(
         List<CongressionalTrade> trades,
         EquiblesFinancialDbContext dbContext,
@@ -493,6 +615,7 @@ public class CongressionalTradeSyncService
     )
     {
         await using var transaction = await dbContext.Database.BeginTransactionAsync(ct);
+        await RepairLegacyInlineSubholdingNames(trades, dbContext, ct);
         await RepairLegacyZeroFloorAmounts(trades, dbContext, ct);
         var expandCompatibleTrades = CollapseExpandPhaseCollisions(trades);
         await WarnOnPersistedExpandPhaseCollisions(expandCompatibleTrades, dbContext, ct);
@@ -701,4 +824,40 @@ public class CongressionalTradeSyncService
     }
 
     private sealed record TradeAmountRange(long AmountFrom, long AmountTo, DateOnly FilingDate);
+
+    private sealed record InlineMetadataRepairIdentity(
+        Guid CommonStockId,
+        Guid CongressMemberId,
+        DateOnly TransactionDate,
+        CongressTransactionType TransactionType,
+        string AssetName,
+        string OwnerType,
+        long AmountFrom,
+        long AmountTo
+    )
+    {
+        public static InlineMetadataRepairIdentity From(CongressionalTrade trade) =>
+            From(trade, trade.AssetName);
+
+        public static InlineMetadataRepairIdentity From(
+            CongressionalTrade trade,
+            string assetName
+        ) =>
+            new(
+                trade.CommonStockId,
+                trade.CongressMemberId,
+                trade.TransactionDate,
+                trade.TransactionType,
+                assetName,
+                trade.OwnerType,
+                trade.AmountFrom,
+                trade.AmountTo
+            );
+    }
+
+    private sealed record LegacyInlineMetadataCandidate(
+        CongressionalTrade Trade,
+        InlineMetadataRepairIdentity Identity,
+        string CleanedSubholding
+    );
 }

--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -525,6 +525,16 @@ public partial class HouseDisclosureClient
             : null;
         assetText = AssetTypeCodeRegex().Replace(assetText, " ").Trim();
 
+        // Some House PTRs place the abbreviated detail fields on the transaction's visual
+        // line instead of separate lines ("F S:", "S O:", "D:"). Preserve the filed
+        // subholding before removing that metadata suffix from the asset name.
+        var inlineDetails = ExtractInlineAssetDetails(assetText);
+        if (inlineDetails.Subholding != null)
+        {
+            subholding = inlineDetails.Subholding;
+            assetText = inlineDetails.AssetName;
+        }
+
         // The PDF's row checkboxes extract as "gfedc"/"gfedcb" glued onto the asset name — strip
         // them before the name is stored or mined for a ticker (see CleanAssetName).
         assetText = CleanAssetName(assetText);
@@ -633,6 +643,32 @@ public partial class HouseDisclosureClient
     [GeneratedRegex(@"^\s*Subholding\s+Of\s*:\s*(.+?)\s*$", RegexOptions.IgnoreCase)]
     private static partial Regex SubholdingRegex();
 
+    [GeneratedRegex(
+        @"(?:^|\s)(?:S\s+O|Subholding\s+Of)\s*:\s*(.+?)(?=\s+(?:D|Description|F\s+S|Filing\s+Status)\s*:|$)",
+        RegexOptions.IgnoreCase
+    )]
+    private static partial Regex InlineSubholdingRegex();
+
+    [GeneratedRegex(@"(?:^|\s)(?:F\s+S|Filing\s+Status)\s*:", RegexOptions.IgnoreCase)]
+    private static partial Regex InlineFilingStatusRegex();
+
+    internal static HouseInlineAssetDetails ExtractInlineAssetDetails(string assetText)
+    {
+        var subholdingMatch = InlineSubholdingRegex().Match(assetText);
+        if (!subholdingMatch.Success)
+            return new HouseInlineAssetDetails(assetText, null);
+
+        var metadataStart = subholdingMatch.Index;
+        var filingStatusMatch = InlineFilingStatusRegex().Match(assetText);
+        if (filingStatusMatch.Success && filingStatusMatch.Index < metadataStart)
+            metadataStart = filingStatusMatch.Index;
+
+        return new HouseInlineAssetDetails(
+            assetText[..metadataStart].Trim(),
+            subholdingMatch.Groups[1].Value.Trim()
+        );
+    }
+
     [GeneratedRegex(@"\b\d{1,2}/\d{1,2}/\d{4}\b")]
     private static partial Regex DateTokenRegex();
 
@@ -667,6 +703,8 @@ public partial class HouseDisclosureClient
         DateOnly FilingDate,
         string StateDst
     );
+
+    internal sealed record HouseInlineAssetDetails(string AssetName, string Subholding);
 
     internal sealed record HousePtrParseResult(
         List<DisclosureTransaction> Transactions,

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
@@ -80,6 +80,7 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
         long amountTo = 15_000,
         string assetType = "ST",
         string subholding = "",
+        string assetName = "Apple Inc.",
         DateOnly? transactionDate = null,
         DateOnly? filingDate = null,
         string sourceId = null
@@ -89,7 +90,7 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
             MemberName = member,
             Position = CongressPosition.Senator,
             Ticker = ticker,
-            AssetName = "Apple Inc.",
+            AssetName = assetName,
             TransactionDate = transactionDate ?? new DateOnly(2024, 6, 1),
             FilingDate = filingDate ?? new DateOnly(2024, 6, 15),
             TransactionType = CongressTransactionType.Purchase,
@@ -317,6 +318,138 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
         var enriched = await verify.Set<CongressionalTrade>().AsNoTracking().SingleAsync();
         enriched.AssetType.Should().Be("OP");
         enriched.Subholding.Should().Be("Brokerage IRA");
+    }
+
+    [Fact]
+    public async Task ProcessTransactions_RedatedDuplicateInlineSubholdingReplay_ReplacesPollutedLegacyName()
+    {
+        const string subholding =
+            "150 Main Street Trust > Pershing Advisor Solutions LLC Brokerage";
+        const string otherSubholding = "Different Brokerage Account";
+        var stock = new CommonStock { Ticker = "AVGO", Name = "Broadcom Inc." };
+        var member = new CongressMember { Name = "Jane Doe", Position = CongressPosition.Senator };
+        DbContext.AddRange(stock, member);
+        DbContext.Add(
+            new CongressionalTrade
+            {
+                CongressMember = member,
+                CongressMemberId = member.Id,
+                CommonStock = stock,
+                CommonStockId = stock.Id,
+                TransactionDate = new DateOnly(2024, 6, 1),
+                FilingDate = new DateOnly(2024, 6, 14),
+                TransactionType = CongressTransactionType.Purchase,
+                OwnerType = "self",
+                AssetName =
+                    $"Broadcom Inc. (AVGO) F S: New S O: {subholding} D: Put option, strike price",
+                AssetType = "OP",
+                Subholding = "",
+                AmountFrom = 1_001,
+                AmountTo = 15_000,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await (Task)
+            ProcessTransactionsMethod.Invoke(
+                BuildSut(),
+                [
+                    new List<DisclosureTransaction>
+                    {
+                        Txn(
+                            "Jane Doe",
+                            "AVGO",
+                            assetType: "OP",
+                            subholding: otherSubholding,
+                            assetName: "Broadcom Inc. (AVGO)"
+                        ),
+                        Txn(
+                            "Jane Doe",
+                            "AVGO",
+                            assetType: "ST",
+                            subholding: subholding,
+                            assetName: "Broadcom Inc. (AVGO)"
+                        ),
+                        Txn(
+                            "Jane Doe",
+                            "AVGO",
+                            assetType: "OP",
+                            subholding: subholding,
+                            assetName: "Broadcom Inc. (AVGO)"
+                        ),
+                        Txn(
+                            "Jane Doe",
+                            "AVGO",
+                            assetType: "OP",
+                            subholding: subholding,
+                            assetName: "Broadcom Inc. (AVGO)"
+                        ),
+                    },
+                    CancellationToken.None,
+                ]
+            );
+
+        await using var verify = Fixture.CreateDbContext();
+        var repaired = await verify.Set<CongressionalTrade>().AsNoTracking().SingleAsync();
+        repaired.AssetName.Should().Be("Broadcom Inc. (AVGO)");
+        repaired.AssetType.Should().Be("OP");
+        repaired.Subholding.Should().Be(subholding);
+    }
+
+    [Fact]
+    public async Task ProcessTransactions_TwoPollutedLegacyAccounts_SharedIdentityAbstainsAtomically()
+    {
+        const string firstSubholding = "Brokerage Account A";
+        const string secondSubholding = "Brokerage Account B";
+        var stock = new CommonStock { Ticker = "AVGO", Name = "Broadcom Inc." };
+        var member = new CongressMember { Name = "Jane Doe", Position = CongressPosition.Senator };
+        DbContext.AddRange(stock, member);
+        DbContext.AddRange(LegacyTrade(firstSubholding), LegacyTrade(secondSubholding));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await (Task)
+            ProcessTransactionsMethod.Invoke(
+                BuildSut(),
+                [
+                    new List<DisclosureTransaction>
+                    {
+                        Txn(
+                            "Jane Doe",
+                            "AVGO",
+                            assetType: "OP",
+                            subholding: firstSubholding,
+                            assetName: "Broadcom Inc. (AVGO)"
+                        ),
+                    },
+                    CancellationToken.None,
+                ]
+            );
+
+        await using var verify = Fixture.CreateDbContext();
+        var preserved = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
+        preserved.Should().HaveCount(2);
+        preserved.Should().OnlyContain(trade => trade.AssetName.Contains("S O:"));
+
+        CongressionalTrade LegacyTrade(string subholding) =>
+            new()
+            {
+                CongressMember = member,
+                CongressMemberId = member.Id,
+                CommonStock = stock,
+                CommonStockId = stock.Id,
+                TransactionDate = new DateOnly(2024, 6, 1),
+                FilingDate = new DateOnly(2024, 6, 14),
+                TransactionType = CongressTransactionType.Purchase,
+                OwnerType = "self",
+                AssetName =
+                    $"Broadcom Inc. (AVGO) F S: New S O: {subholding} D: Put option, strike price",
+                AssetType = "OP",
+                Subholding = "",
+                AmountFrom = 1_001,
+                AmountTo = 15_000,
+            };
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
@@ -132,6 +132,34 @@ public class HouseDisclosureClientTests
     }
 
     [Fact]
+    public void ParseTransactionLines_InlineAbbreviatedSubholding_RetainsFiledIdentity()
+    {
+        var result = Parse(
+            "Broadcom Inc. - Common Stock (AVGO) [OP] F S: New S O: 150 Main Street Trust > Pershing Advisor Solutions LLC Brokerage D: Put option, strike price P 03/03/2025 03/05/2025 $15,001 - $50,000"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.Ticker.Should().Be("AVGO");
+        tx.AssetType.Should().Be("OP");
+        tx.Subholding.Should()
+            .Be("150 Main Street Trust > Pershing Advisor Solutions LLC Brokerage");
+        tx.AssetName.Should().Be("Broadcom Inc. - Common Stock (AVGO)");
+    }
+
+    [Fact]
+    public void ParseTransactionLines_SeriesDAssetNameWithoutSubholding_PreservesAssetName()
+    {
+        var result = Parse(
+            "Acme Series D: Preferred Stock (ACME) [ST] P 03/03/2025 03/05/2025 $15,001 - $50,000"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.Ticker.Should().Be("ACME");
+        tx.Subholding.Should().BeNull();
+        tx.AssetName.Should().Be("Acme Series D: Preferred Stock (ACME)");
+    }
+
+    [Fact]
     public void ParseTransactionLines_HeaderFieldLabelAndFooterLines_ProduceNoTransactions()
     {
         // None of these lines is a transaction row. The "Digitally Signed … ,


### PR DESCRIPTION
- Parse official inline `S O:` / `Subholding Of:` House PTR fields
- Remove filed inline metadata from asset names without truncating legitimate `Series D:` names
- Replay parser version 2 and transactionally replace exact polluted legacy rows
- Preserve phase-1 commercial compatibility and abstain on identities the legacy key cannot represent safely

Tests:
- 4,557 OSS unit tests passed
- 2,683 OSS PostgreSQL integration tests passed
- Independent review: clean