### PR TITLE
fix(congress): separate account-aware trade identities

### DIFF
--- a/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
+++ b/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
@@ -8,9 +8,8 @@ public class CongressModuleConfiguration : Equibles.Data.IFinancialModule
     public void ConfigureEntities(ModelBuilder builder)
     {
         builder.Entity<CongressMember>();
-        // These values are written by the scraper. The defaults make the additive migration safe
-        // for existing rows; ValueGeneratedNever keeps FlexLabs free to use them in a later
-        // account-aware conflict key after the expand release is deployed.
+        // These values are written by the scraper. The defaults made the additive migration safe
+        // for existing rows; ValueGeneratedNever makes them usable in FlexLabs' conflict key.
         ConfigureRequiredTradeText(builder, t => t.OwnerType);
         ConfigureRequiredTradeText(builder, t => t.AssetType);
         ConfigureRequiredTradeText(builder, t => t.Subholding);

--- a/src/Equibles.Congress.Data/Models/CongressionalTrade.cs
+++ b/src/Equibles.Congress.Data/Models/CongressionalTrade.cs
@@ -10,7 +10,8 @@ namespace Equibles.Congress.Data.Models;
 // The trade identity / upsert key (see CongressionalTradeSyncService.PersistTrades). OwnerType
 // and the amount bracket are part of a trade's identity: a member can file two same-day
 // purchases of the same stock that differ only in bracket or in who holds them (self vs.
-// spouse vs. dependent child), and without those columns the second one is silently dropped.
+// spouse vs. dependent child), asset type, or disclosed account/subholding, and without those
+// columns the second one is silently dropped.
 // FilingDate is deliberately EXCLUDED — the disclosure feeds re-date the same filing between
 // scrapes, so keying on it would re-insert existing trades as duplicates.
 [Index(
@@ -22,6 +23,9 @@ namespace Equibles.Congress.Data.Models;
     nameof(OwnerType),
     nameof(AmountFrom),
     nameof(AmountTo),
+    nameof(AssetType),
+    nameof(Subholding),
+    Name = "UX_CongressionalTrade_FilingIdentity",
     IsUnique = true
 )]
 [Index(nameof(FilingDate))]

--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -42,7 +42,7 @@ public class CongressionalTradeSyncService
 
     // Congressional trade disclosures are available from 2012 (STOCK Act).
     private static readonly DateOnly EarliestAvailableDate = new(2012, 4, 1);
-    private const int TradeParserVersion = 2;
+    private const int TradeParserVersion = 3;
     private const int ReprocessPerCycleLimit = 1_000;
 
     // A filing with a transaction whose ticker is not (yet) a tracked stock
@@ -533,37 +533,20 @@ public class CongressionalTradeSyncService
         }
 
         var repairs = new List<CongressionalTrade>();
-        foreach (var legacyGroup in legacyCandidates.GroupBy(candidate => candidate.Identity))
+        foreach (var legacyCandidate in legacyCandidates)
         {
-            if (!incomingByIdentity.TryGetValue(legacyGroup.Key, out var candidates))
+            if (!incomingByIdentity.TryGetValue(legacyCandidate.Identity, out var candidates))
                 continue;
-            var activeCandidates = candidates.Where(incoming.Contains).ToList();
-            if (activeCandidates.Count == 0)
-                continue;
-
-            var groupedLegacy = legacyGroup.ToList();
-            if (groupedLegacy.Count != 1)
-            {
-                incoming.RemoveAll(candidate => activeCandidates.Contains(candidate));
-                _logger.LogWarning(
-                    "Deferred congressional trade inline-metadata repair because {Count} legacy rows share the deployed identity",
-                    groupedLegacy.Count
-                );
-                continue;
-            }
-
-            var legacyCandidate = groupedLegacy[0];
             var legacy = legacyCandidate.Trade;
             if (legacy.Subholding != "" && legacy.Subholding != legacyCandidate.CleanedSubholding)
             {
-                incoming.RemoveAll(candidate => activeCandidates.Contains(candidate));
                 _logger.LogWarning(
                     "Deferred congressional trade inline-metadata repair because stored and filed subholdings conflict"
                 );
                 continue;
             }
 
-            var matchingSubholding = activeCandidates
+            var matchingSubholding = candidates
                 .Where(candidate => candidate.Subholding == legacyCandidate.CleanedSubholding)
                 .ToList();
             List<CongressionalTrade> selectedCandidates;
@@ -584,16 +567,12 @@ public class CongressionalTradeSyncService
 
             if (selectedCandidates.Count == 0)
             {
-                incoming.RemoveAll(candidate => activeCandidates.Contains(candidate));
                 _logger.LogWarning(
                     "Deferred congressional trade inline-metadata repair because replay did not supply one authoritative account and asset type"
                 );
                 continue;
             }
 
-            incoming.RemoveAll(candidate =>
-                activeCandidates.Contains(candidate) && !selectedCandidates.Contains(candidate)
-            );
             repairs.Add(legacy);
         }
 
@@ -614,11 +593,14 @@ public class CongressionalTradeSyncService
         CancellationToken ct
     )
     {
+        if (trades.Count == 0)
+            return;
+
         await using var transaction = await dbContext.Database.BeginTransactionAsync(ct);
         await RepairLegacyInlineSubholdingNames(trades, dbContext, ct);
+        await RepairLegacyEmptyFiledMetadata(trades, dbContext, ct);
         await RepairLegacyZeroFloorAmounts(trades, dbContext, ct);
-        var expandCompatibleTrades = CollapseExpandPhaseCollisions(trades);
-        await WarnOnPersistedExpandPhaseCollisions(expandCompatibleTrades, dbContext, ct);
+        RemoveUnidentifiedMetadataDuplicates(trades);
 
         // Must match the unique index on CongressionalTrade exactly (see the identity note on
         // the entity) or ON CONFLICT has no arbiter and the upsert throws. AssetName
@@ -626,7 +608,7 @@ public class CongressionalTradeSyncService
         // CleanAssetName output — see the invariant note on CleanAssetName.
         await dbContext
             .Set<CongressionalTrade>()
-            .UpsertRange(expandCompatibleTrades)
+            .UpsertRange(trades)
             .On(t => new
             {
                 t.CommonStockId,
@@ -637,24 +619,10 @@ public class CongressionalTradeSyncService
                 t.OwnerType,
                 t.AmountFrom,
                 t.AmountTo,
+                t.AssetType,
+                t.Subholding,
             })
-            // Phase 1 of the account-aware rollout keeps the old conflict target so a worker
-            // from the preceding release remains compatible while the additive columns deploy.
-            // Replays still enrich existing rows with the newly retained filed facts.
-            .WhenMatched(
-                (existing, incoming) =>
-                    new CongressionalTrade
-                    {
-                        AssetType =
-                            existing.AssetType != "" || existing.Subholding != ""
-                                ? existing.AssetType
-                                : incoming.AssetType,
-                        Subholding =
-                            existing.AssetType != "" || existing.Subholding != ""
-                                ? existing.Subholding
-                                : incoming.Subholding,
-                    }
-            )
+            .NoUpdate()
             .RunAsync(ct);
 
         await transaction.CommitAsync(ct);
@@ -664,6 +632,65 @@ public class CongressionalTradeSyncService
             trades.Count
         );
     }
+
+    private async Task RepairLegacyEmptyFiledMetadata(
+        IReadOnlyList<CongressionalTrade> incoming,
+        EquiblesFinancialDbContext dbContext,
+        CancellationToken ct
+    )
+    {
+        var authoritativeIdentities = incoming
+            .Where(HasFiledMetadata)
+            .Select(InlineMetadataRepairIdentity.From)
+            .ToHashSet();
+        if (authoritativeIdentities.Count == 0)
+            return;
+
+        var stockIds = incoming.Select(t => t.CommonStockId).Distinct().ToList();
+        var memberIds = incoming.Select(t => t.CongressMemberId).Distinct().ToList();
+        var firstDate = incoming.Min(t => t.TransactionDate);
+        var lastDate = incoming.Max(t => t.TransactionDate);
+        var legacyRows = await dbContext
+            .Set<CongressionalTrade>()
+            .Where(t =>
+                stockIds.Contains(t.CommonStockId)
+                && memberIds.Contains(t.CongressMemberId)
+                && t.TransactionDate >= firstDate
+                && t.TransactionDate <= lastDate
+                && t.AssetType == ""
+                && t.Subholding == ""
+            )
+            .ToListAsync(ct);
+        var repairs = legacyRows
+            .Where(legacy =>
+                authoritativeIdentities.Contains(InlineMetadataRepairIdentity.From(legacy))
+            )
+            .ToList();
+        if (repairs.Count == 0)
+            return;
+
+        dbContext.RemoveRange(repairs);
+        await dbContext.SaveChangesAsync(ct);
+        _logger.LogInformation(
+            "Removed {Count} legacy congressional trades whose empty filed metadata was supplied by source replay",
+            repairs.Count
+        );
+    }
+
+    private static void RemoveUnidentifiedMetadataDuplicates(List<CongressionalTrade> trades)
+    {
+        var authoritativeIdentities = trades
+            .Where(HasFiledMetadata)
+            .Select(InlineMetadataRepairIdentity.From)
+            .ToHashSet();
+        trades.RemoveAll(trade =>
+            !HasFiledMetadata(trade)
+            && authoritativeIdentities.Contains(InlineMetadataRepairIdentity.From(trade))
+        );
+    }
+
+    private static bool HasFiledMetadata(CongressionalTrade trade) =>
+        !string.IsNullOrEmpty(trade.AssetType) || !string.IsNullOrEmpty(trade.Subholding);
 
     private async Task RepairLegacyZeroFloorAmounts(
         List<CongressionalTrade> incoming,
@@ -718,81 +745,6 @@ public class CongressionalTradeSyncService
         );
     }
 
-    private List<CongressionalTrade> CollapseExpandPhaseCollisions(List<CongressionalTrade> trades)
-    {
-        var collapsed = new List<CongressionalTrade>();
-        foreach (var group in trades.GroupBy(TradeCurrentIdentity.From))
-        {
-            var selected = group
-                .OrderByDescending(t => !string.IsNullOrEmpty(t.Subholding))
-                .ThenByDescending(t => !string.IsNullOrEmpty(t.AssetType))
-                .First();
-            collapsed.Add(selected);
-            if (
-                group.Any(t =>
-                    t.Subholding != selected.Subholding || t.AssetType != selected.AssetType
-                )
-            )
-            {
-                _logger.LogWarning(
-                    "Deferred {Count} congressional trades distinguished only by asset type or subholding until the account-aware uniqueness contract is deployed",
-                    group.Count() - 1
-                );
-            }
-        }
-
-        return collapsed;
-    }
-
-    private async Task WarnOnPersistedExpandPhaseCollisions(
-        IReadOnlyList<CongressionalTrade> incoming,
-        EquiblesFinancialDbContext dbContext,
-        CancellationToken ct
-    )
-    {
-        if (incoming.Count == 0)
-            return;
-
-        var stockIds = incoming.Select(t => t.CommonStockId).Distinct().ToList();
-        var memberIds = incoming.Select(t => t.CongressMemberId).Distinct().ToList();
-        var firstDate = incoming.Min(t => t.TransactionDate);
-        var lastDate = incoming.Max(t => t.TransactionDate);
-        var persisted = await dbContext
-            .Set<CongressionalTrade>()
-            .AsNoTracking()
-            .Where(t =>
-                stockIds.Contains(t.CommonStockId)
-                && memberIds.Contains(t.CongressMemberId)
-                && t.TransactionDate >= firstDate
-                && t.TransactionDate <= lastDate
-            )
-            .ToListAsync(ct);
-        var persistedByIdentity = persisted.ToDictionary(TradeCurrentIdentity.From);
-
-        var collisionCount = incoming.Count(candidate =>
-            persistedByIdentity.TryGetValue(TradeCurrentIdentity.From(candidate), out var existing)
-            && MetadataPairConflicts(existing, candidate)
-        );
-        if (collisionCount > 0)
-        {
-            _logger.LogWarning(
-                "Deferred {Count} congressional trades distinguished from stored rows only by asset type or subholding until the account-aware uniqueness contract is deployed",
-                collisionCount
-            );
-        }
-    }
-
-    private static bool MetadataPairConflicts(
-        CongressionalTrade existing,
-        CongressionalTrade incoming
-    ) =>
-        (!string.IsNullOrEmpty(existing.AssetType) || !string.IsNullOrEmpty(existing.Subholding))
-        && (!string.IsNullOrEmpty(incoming.AssetType) || !string.IsNullOrEmpty(incoming.Subholding))
-        && (
-            !string.Equals(existing.AssetType, incoming.AssetType, StringComparison.Ordinal)
-            || !string.Equals(existing.Subholding, incoming.Subholding, StringComparison.Ordinal)
-        );
-
     private sealed record TradeBaseIdentity(
         Guid CommonStockId,
         Guid CongressMemberId,
@@ -811,16 +763,6 @@ public class CongressionalTradeSyncService
                 trade.AssetName,
                 trade.OwnerType
             );
-    }
-
-    private sealed record TradeCurrentIdentity(
-        TradeBaseIdentity Base,
-        long AmountFrom,
-        long AmountTo
-    )
-    {
-        public static TradeCurrentIdentity From(CongressionalTrade trade) =>
-            new(TradeBaseIdentity.From(trade), trade.AmountFrom, trade.AmountTo);
     }
 
     private sealed record TradeAmountRange(long AmountFrom, long AmountTo, DateOnly FilingDate);

--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -424,9 +424,9 @@ public partial class HouseDisclosureClient
             if (TransactionAnchorRegex().IsMatch(lines[i]))
                 break;
 
-            var match = SubholdingRegex().Match(lines[i]);
-            if (match.Success)
-                return match.Groups[1].Value.Trim();
+            var details = ExtractInlineAssetDetails(lines[i]);
+            if (details.Subholding != null)
+                return details.Subholding;
         }
 
         return null;

--- a/src/Equibles.Migrations/Migrations/20260822220823_MakeCongressionalTradeAccountAware.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260822220823_MakeCongressionalTradeAccountAware.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260822220823_MakeCongressionalTradeAccountAware")]
+    partial class MakeCongressionalTradeAccountAware
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260822220823_MakeCongressionalTradeAccountAware.cs
+++ b/src/Equibles.Migrations/Migrations/20260822220823_MakeCongressionalTradeAccountAware.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeCongressionalTradeAccountAware : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CongressionalTrade_CommonStockId_CongressMemberId_Transacti~",
+                table: "CongressionalTrade");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_CongressionalTrade_FilingIdentity",
+                table: "CongressionalTrade",
+                columns: new[] { "CommonStockId", "CongressMemberId", "TransactionDate", "TransactionType", "AssetName", "OwnerType", "AmountFrom", "AmountTo", "AssetType", "Subholding" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_CongressionalTrade_FilingIdentity",
+                table: "CongressionalTrade");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CongressionalTrade_CommonStockId_CongressMemberId_Transacti~",
+                table: "CongressionalTrade",
+                columns: new[] { "CommonStockId", "CongressMemberId", "TransactionDate", "TransactionType", "AssetName", "OwnerType", "AmountFrom", "AmountTo" },
+                unique: true);
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
@@ -159,6 +159,37 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task ProcessTransactions_SameDaySameAssetDifferentAccounts_AllPersistOnce()
+    {
+        DbContext.Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc." });
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var transactions = new List<DisclosureTransaction>
+        {
+            Txn("Jane Doe", "AAPL", assetType: "ST", subholding: "Brokerage Account"),
+            Txn("Jane Doe", "AAPL", assetType: "ST", subholding: "Retirement Account"),
+            Txn("Jane Doe", "AAPL", assetType: "OP", subholding: "Brokerage Account"),
+        };
+        var sut = BuildSut();
+
+        await (Task)ProcessTransactionsMethod.Invoke(sut, [transactions, CancellationToken.None]);
+        await (Task)ProcessTransactionsMethod.Invoke(sut, [transactions, CancellationToken.None]);
+
+        await using var verify = Fixture.CreateDbContext();
+        var trades = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
+        trades.Should().HaveCount(3);
+        trades
+            .Select(t => (t.AssetType, t.Subholding))
+            .Should()
+            .BeEquivalentTo([
+                ("ST", "Brokerage Account"),
+                ("ST", "Retirement Account"),
+                ("OP", "Brokerage Account"),
+            ]);
+    }
+
+    [Fact]
     public async Task ProcessTransactions_NoTickerMatchesTrackedStock_WritesNothing()
     {
         DbContext.Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc." });
@@ -391,14 +422,16 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
             );
 
         await using var verify = Fixture.CreateDbContext();
-        var repaired = await verify.Set<CongressionalTrade>().AsNoTracking().SingleAsync();
+        var stored = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
+        stored.Should().HaveCount(3);
+        var repaired = stored.Single(trade =>
+            trade.AssetType == "OP" && trade.Subholding == subholding
+        );
         repaired.AssetName.Should().Be("Broadcom Inc. (AVGO)");
-        repaired.AssetType.Should().Be("OP");
-        repaired.Subholding.Should().Be(subholding);
     }
 
     [Fact]
-    public async Task ProcessTransactions_TwoPollutedLegacyAccounts_SharedIdentityAbstainsAtomically()
+    public async Task ProcessTransactions_TwoPollutedLegacyAccounts_ReplaySeparatesBothAccounts()
     {
         const string firstSubholding = "Brokerage Account A";
         const string secondSubholding = "Brokerage Account B";
@@ -422,15 +455,26 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
                             subholding: firstSubholding,
                             assetName: "Broadcom Inc. (AVGO)"
                         ),
+                        Txn(
+                            "Jane Doe",
+                            "AVGO",
+                            assetType: "OP",
+                            subholding: secondSubholding,
+                            assetName: "Broadcom Inc. (AVGO)"
+                        ),
                     },
                     CancellationToken.None,
                 ]
             );
 
         await using var verify = Fixture.CreateDbContext();
-        var preserved = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
-        preserved.Should().HaveCount(2);
-        preserved.Should().OnlyContain(trade => trade.AssetName.Contains("S O:"));
+        var repaired = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
+        repaired.Should().HaveCount(2);
+        repaired.Should().OnlyContain(trade => trade.AssetName == "Broadcom Inc. (AVGO)");
+        repaired
+            .Select(trade => trade.Subholding)
+            .Should()
+            .BeEquivalentTo(firstSubholding, secondSubholding);
 
         CongressionalTrade LegacyTrade(string subholding) =>
             new()
@@ -453,7 +497,7 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task ProcessTransactions_DifferentAccountArrivesLater_PreservesFirstStoredAccount()
+    public async Task ProcessTransactions_DifferentAccountArrivesLater_PersistsBothAccounts()
     {
         DbContext.Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc." });
         await DbContext.SaveChangesAsync();
@@ -484,12 +528,13 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
             );
 
         await using var verify = Fixture.CreateDbContext();
-        var stored = await verify.Set<CongressionalTrade>().AsNoTracking().SingleAsync();
-        stored.Subholding.Should().Be("Account A");
+        var stored = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
+        stored.Should().HaveCount(2);
+        stored.Select(trade => trade.Subholding).Should().BeEquivalentTo("Account A", "Account B");
     }
 
     [Fact]
-    public async Task ProcessTransactions_PartialStoredMetadata_DoesNotCreateHybridFiledIdentity()
+    public async Task ProcessTransactions_PartialStoredMetadata_PreservesBothFiledIdentities()
     {
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
         var member = new CongressMember { Name = "Jane Doe", Position = CongressPosition.Senator };
@@ -514,11 +559,9 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
         );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
-        var logger = Substitute.For<ILogger<CongressionalTradeSyncService>>();
-
         await (Task)
             ProcessTransactionsMethod.Invoke(
-                BuildSut(logger),
+                BuildSut(),
                 [
                     new List<DisclosureTransaction>
                     {
@@ -529,28 +572,23 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
             );
 
         await using var verify = Fixture.CreateDbContext();
-        var stored = await verify.Set<CongressionalTrade>().AsNoTracking().SingleAsync();
-        stored.AssetType.Should().Be("ST");
-        stored.Subholding.Should().BeEmpty();
-        var messages = logger
-            .ReceivedCalls()
-            .Where(call => call.GetArguments().Length > 2)
-            .Select(call => call.GetArguments()[2]?.ToString() ?? "")
-            .ToList();
-        messages.Should().Contain(message => message.Contains("Deferred 1 congressional trade"));
+        var stored = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
+        stored.Should().HaveCount(2);
+        stored
+            .Select(trade => (trade.AssetType, trade.Subholding))
+            .Should()
+            .BeEquivalentTo(new[] { ("ST", ""), ("OP", "Brokerage IRA") });
     }
 
     [Fact]
-    public async Task ProcessTransactions_SameCycleMetadataCollision_IsLogged()
+    public async Task ProcessTransactions_SameCycleEmptyMetadataDuplicate_PrefersFiledMetadata()
     {
         DbContext.Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc." });
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
-        var logger = Substitute.For<ILogger<CongressionalTradeSyncService>>();
-
         await (Task)
             ProcessTransactionsMethod.Invoke(
-                BuildSut(logger),
+                BuildSut(),
                 [
                     new List<DisclosureTransaction>
                     {
@@ -561,12 +599,10 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
                 ]
             );
 
-        var messages = logger
-            .ReceivedCalls()
-            .Where(call => call.GetArguments().Length > 2)
-            .Select(call => call.GetArguments()[2]?.ToString() ?? "")
-            .ToList();
-        messages.Should().Contain(message => message.Contains("Deferred 1 congressional trade"));
+        await using var verify = Fixture.CreateDbContext();
+        var stored = await verify.Set<CongressionalTrade>().AsNoTracking().SingleAsync();
+        stored.AssetType.Should().Be("OP");
+        stored.Subholding.Should().Be("Brokerage IRA");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
@@ -147,6 +147,21 @@ public class HouseDisclosureClientTests
     }
 
     [Fact]
+    public void ParseTransactionLines_CompactSubholdingOnMetadataLine_RetainsFiledIdentity()
+    {
+        var result = Parse(
+            "Comfort Systems USA, Inc. Common Stock (FIX) [ST] P 01/13/2025 02/13/2025 $1,001 - $15,000",
+            "F S: New S O: Joint Ownership LPL Account"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.Ticker.Should().Be("FIX");
+        tx.AssetType.Should().Be("ST");
+        tx.Subholding.Should().Be("Joint Ownership LPL Account");
+        tx.AssetName.Should().Be("Comfort Systems USA, Inc. Common Stock (FIX)");
+    }
+
+    [Fact]
     public void ParseTransactionLines_SeriesDAssetNameWithoutSubholding_PreservesAssetName()
     {
         var result = Parse(


### PR DESCRIPTION
## Summary
- include asset type and subholding in congressional-trade uniqueness and upsert identity
- replay parser v3 and safely replace legacy empty/polluted metadata rows
- parse compact standalone House `F S: ... S O: ...` metadata lines
- add the matching financial migration and PostgreSQL regression coverage

## Verification
- `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --no-restore` (4558 passed)
- `dotnet test tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj --no-restore` (2684 passed)
- focused Congress integration tests (17 passed)
- `dotnet ef migrations has-pending-model-changes --project src/Equibles.Migrations`
- CSharpier and `git diff --check`
- independent audit: no findings

Together with #4433, #4435, and #4436, this completes the fixes for the reported amount, history, identity, and filed-type defects.

Closes #4306
Closes #4307
Closes #4308
Closes #4309