### PR TITLE
fix(congress): parse null-padded House metadata

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -42,7 +42,7 @@ public class CongressionalTradeSyncService
 
     // Congressional trade disclosures are available from 2012 (STOCK Act).
     private static readonly DateOnly EarliestAvailableDate = new(2012, 4, 1);
-    private const int TradeParserVersion = 3;
+    private const int TradeParserVersion = 4;
     private const int ReprocessPerCycleLimit = 1_000;
 
     // A filing with a transaction whose ticker is not (yet) a tracked stock

--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -365,7 +365,10 @@ public partial class HouseDisclosureClient
         var lines = new List<string>(rawLines.Count);
         foreach (var rawLine in rawLines)
         {
-            var line = StripReprintedHeader(rawLine);
+            // Some official House PDFs encode the spaced field labels with null-padded
+            // glyphs (for example "S\0... O\0:"). Remove those source artifacts before
+            // any label or metadata regex runs; cleaning only at persistence is too late.
+            var line = StripReprintedHeader(rawLine.Replace("\0", "", StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(line))
                 lines.Add(line);
         }

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
@@ -162,6 +162,21 @@ public class HouseDisclosureClientTests
     }
 
     [Fact]
+    public void ParseTransactionLines_NullPaddedCompactSubholding_RetainsFiledIdentity()
+    {
+        var result = Parse(
+            "Procter & Gamble Company (PG) [ST] P 08/11/2026 08/20/2026 $1,001 - $15,000",
+            "F\0\0\0\0\0 S\0\0\0\0\0: New S\0\0\0\0\0\0\0\0\0 O\0: David Taylor Trust > Sardinia Ready Mix 401(k) - Dave"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.Ticker.Should().Be("PG");
+        tx.AssetType.Should().Be("ST");
+        tx.Subholding.Should().Be("David Taylor Trust > Sardinia Ready Mix 401(k) - Dave");
+        tx.AssetName.Should().Be("Procter & Gamble Company (PG)");
+    }
+
+    [Fact]
     public void ParseTransactionLines_SeriesDAssetNameWithoutSubholding_PreservesAssetName()
     {
         var result = Parse(


### PR DESCRIPTION
## Summary

- strips embedded NUL glyph artifacts before House PTR line classification and metadata parsing
- adds the exact null-padded compact subholding regression observed in official filing 20035289
- bumps the bounded congressional trade parser generation to v4 so v3 checkpoints replay

## Production evidence

- v3 replay completed successfully but left Subholding at 0 because PdfPig reconstructed official labels as null-padded text such as S\0... O\0:
- the official 2026 PDF passed end-to-end after source normalization
- no schema change is required

## Verification

- focused House parser tests: 26 passed
- focused Congress persistence integration tests: 17 passed
- OSS unit suite: 4,559 passed
- OSS integration suite: 2,684 passed
- CSharpier check: clean
- independent review: no findings
