### PR TITLE
fix(sec): preserve filing tables and rebuild stored text

### DIFF
--- a/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
@@ -21,7 +21,11 @@ public interface ISecEdgarClient
         DateOnly? fromDate = null,
         DateOnly? toDate = null
     );
-    Task<string> GetDocumentContent(string accessionNumber, string cik);
+    Task<string> GetDocumentContent(
+        string accessionNumber,
+        string cik,
+        CancellationToken cancellationToken = default
+    );
     Task<string> GetDocumentContent(FilingData filing);
 
     /// <summary>

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -451,7 +451,11 @@ public class SecEdgarClient : ISecEdgarClient
         return await GetDocumentContent(filing.AccessionNumber, filing.Cik);
     }
 
-    public async Task<string> GetDocumentContent(string accessionNumber, string cik)
+    public async Task<string> GetDocumentContent(
+        string accessionNumber,
+        string cik,
+        CancellationToken cancellationToken = default
+    )
     {
         try
         {
@@ -459,13 +463,17 @@ public class SecEdgarClient : ISecEdgarClient
 
             _logger.LogInformation("Requesting document: {Url}", url);
 
-            var content = await FetchStringAsync(url);
+            var content = await FetchStringAsync(url, cancellationToken);
 
             _logger.LogInformation(
                 "Successfully retrieved document content ({Length} characters)",
                 content.Length
             );
             return content;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -833,11 +841,14 @@ public class SecEdgarClient : ISecEdgarClient
     }
 
     // Send a retrying GET, throw on a non-success status, and return the fully-buffered body.
-    private async Task<string> FetchStringAsync(string url)
+    private async Task<string> FetchStringAsync(
+        string url,
+        CancellationToken cancellationToken = default
+    )
     {
-        using var response = await SendWithRetryAsync(url);
+        using var response = await SendWithRetryAsync(url, cancellationToken);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync();
+        return await response.Content.ReadAsStringAsync(cancellationToken);
     }
 
     private Task<HttpResponseMessage> SendWithRetryAsync(

--- a/src/Equibles.Migrations/Migrations/20260823011742_NormalizeStoredDocumentTables.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260823011742_NormalizeStoredDocumentTables.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823011742_NormalizeStoredDocumentTables")]
+    partial class NormalizeStoredDocumentTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260823011742_NormalizeStoredDocumentTables.cs
+++ b/src/Equibles.Migrations/Migrations/20260823011742_NormalizeStoredDocumentTables.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class NormalizeStoredDocumentTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "NormalizedContentAttempts",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "NormalizedContentVersion",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Document_NormalizationBackfill",
+                table: "Document",
+                columns: new[] { "DocumentType", "NormalizedContentVersion", "NormalizedContentAttempts", "ReportingDate", "Id" },
+                descending: new[] { false, false, false, true, false });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Document_NormalizationBackfill",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "NormalizedContentAttempts",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "NormalizedContentVersion",
+                table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
@@ -58,6 +58,9 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
         var maxCols = rows.Max(row => HtmlElementExtensions.DirectChildCells(row).Count);
         var columnsToProcess = new List<int>();
         var currencySymbols = new HashSet<string>();
+        var hasRejectedCurrencySymbol = rows.SelectMany(HtmlElementExtensions.DirectChildCells)
+            .Select(cell => cell.TextContent.Trim())
+            .Any(text => DetectCurrency(text) == null && ContainsAnyCurrencySymbol(text));
 
         for (int colIndex = 0; colIndex < maxCols - 1; colIndex++)
         {
@@ -71,7 +74,9 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
 
         ProcessCurrencyColumnsForConsolidation(rows, columnsToProcess);
 
-        return currencySymbols.Count == 1 ? currencySymbols.Single() : null;
+        return !hasRejectedCurrencySymbol && currencySymbols.Count == 1
+            ? currencySymbols.Single()
+            : null;
     }
 
     private bool ShouldConsolidateColumn(
@@ -81,7 +86,6 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
     )
     {
         var shouldConsolidate = false;
-
         foreach (var row in rows)
         {
             var cells = HtmlElementExtensions.DirectChildCells(row);
@@ -94,10 +98,24 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
 
             var detectedCurrency = DetectCurrency(currentCell);
             var nextCell = cells[colIndex + 1].TextContent.Trim();
-            if (
-                detectedCurrency == null
-                || (!IsStandaloneCurrencyCell(currentCell) && !IsEmptyCell(nextCell))
-            )
+            if (detectedCurrency == null)
+            {
+                // A raw symbol that was deliberately rejected by DetectCurrency is a foreign
+                // prefixed symbol such as C$ or A$. Treat it as conflicting currency evidence:
+                // shifting it as a Workiva header would later strip the symbol and mislabel the
+                // whole table as USD.
+                if (ContainsAnyCurrencySymbol(currentCell))
+                    return false;
+
+                // Workiva colspans put both leading headers and values from symbol-less rows in
+                // the same physical column as standalone currency cells. Preserve that content
+                // by shifting it into the empty cell to the right before removing the column.
+                if (!IsEmptyCell(nextCell))
+                    return false;
+                continue;
+            }
+
+            if (!IsStandaloneCurrencyCell(currentCell) && !IsEmptyCell(nextCell))
                 return false;
 
             currencySymbols.Add(detectedCurrency);
@@ -127,6 +145,11 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
         }
         return null;
     }
+
+    private static bool ContainsAnyCurrencySymbol(string text) =>
+        CurrencyMap.Values.Any(currency =>
+            text.Contains(currency.Symbol, StringComparison.Ordinal)
+        );
 
     // A symbol immediately preceded by a letter is a different currency's
     // prefixed symbol (e.g. "C$", "A$", "HK$", "NZ$"), not this one — so a
@@ -180,9 +203,6 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
 
                 var currentCell = cells[colIndex];
                 var currentText = currentCell.TextContent.Trim();
-
-                if (!IsEmptyCell(currentText) && DetectCurrency(currentText) == null)
-                    continue;
 
                 var cleanTitle = RemoveCurrencySymbols(currentText);
                 if (cleanTitle.Length > 0 && (colIndex + 1) >= cells.Count)

--- a/src/Equibles.Sec.BusinessLogic/Processing/ChunkingStrategy.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/ChunkingStrategy.cs
@@ -102,11 +102,13 @@ public class ChunkingStrategy
         // TextContent concatenates descendant text with NO separator, so adjacent
         // block-level cells (a table label and its figure, or sibling <p>/<div>/<li>)
         // glue into one junk token ("Net income1000") that never matches a search
-        // query. Join the remaining text nodes with a space instead; the \s+ collapse
-        // below removes any extra space introduced between inline runs of one word.
+        // query. Join distinct text nodes with a space, but preserve line breaks already
+        // present in Markdown so filing-table rows remain independently readable.
         text = string.Join(" ", document.Body.Descendants<IText>().Select(node => node.Data));
 
-        text = Regex.Replace(text, @"\s+", " ");
+        text = Regex.Replace(text, @"[^\S\r\n]+", " ");
+        text = Regex.Replace(text, @" *\r?\n *", "\n");
+        text = Regex.Replace(text, @"\n{3,}", "\n\n");
         return text.Trim();
     }
 

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -14,6 +14,15 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(XbrlStatus), IsUnique = false)]
 [Index(nameof(XbrlStatus), nameof(XbrlFactsVersion))]
 [Index(nameof(DocumentType), nameof(AsFiledHtmlVersion))]
+[Index(
+    nameof(DocumentType),
+    nameof(NormalizedContentVersion),
+    nameof(NormalizedContentAttempts),
+    nameof(ReportingDate),
+    nameof(Id),
+    IsDescending = new[] { false, false, false, true, false },
+    Name = "IX_Document_NormalizationBackfill"
+)]
 [Index(nameof(ReportedStatementsStatus), IsUnique = false)]
 [Index(nameof(ReportedStatementsStatus), nameof(ReportedStatementsParseVersion))]
 [Index(nameof(CreationTime), IsUnique = false)]
@@ -48,6 +57,30 @@ public class Document
     public DateOnly ReportingForDate { get; set; }
 
     public int LineCount { get; set; }
+
+    /// <summary>
+    /// Version of the HTML-normalization and Markdown-conversion pipeline that produced
+    /// <see cref="Content"/>. Existing rows default to 0; the backfill re-fetches their EDGAR
+    /// submission and replaces the stored text when this is below
+    /// <see cref="NormalizedContentBuilderVersion"/>.
+    /// </summary>
+    public int NormalizedContentVersion { get; set; }
+
+    /// <summary>
+    /// How many times re-normalizing this document has failed. The backfill stops selecting it
+    /// at <see cref="MaxNormalizedContentAttempts"/> so one unavailable filing cannot starve the
+    /// corpus sweep.
+    /// </summary>
+    public int NormalizedContentAttempts { get; set; }
+
+    /// <summary>Retry ceiling for <see cref="NormalizedContentAttempts"/>.</summary>
+    public const int MaxNormalizedContentAttempts = 5;
+
+    /// <summary>
+    /// Current stored-text pipeline version. Bump after a normalization or conversion change
+    /// that must be applied to already-ingested EDGAR documents.
+    /// </summary>
+    public const int NormalizedContentBuilderVersion = 1;
 
     [MaxLength(500)]
     public string SourceUrl { get; set; }

--- a/src/Equibles.Sec.HostedService/Configuration/DocumentNormalizationBackfillOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentNormalizationBackfillOptions.cs
@@ -1,0 +1,25 @@
+namespace Equibles.Sec.HostedService.Configuration;
+
+/// <summary>
+/// Controls the self-draining sweep that re-derives stored filing text after a normalization
+/// pipeline version bump.
+/// </summary>
+public class DocumentNormalizationBackfillOptions
+{
+    public bool Enabled { get; set; }
+
+    public int BatchSize { get; set; } = 16;
+
+    public int DrainIntervalSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// The staged default handles periodic reports first because their fiscal tables feed RAG.
+    /// Enable this only after the 10-K/10-Q stage drains.
+    /// </summary>
+    public bool IncludeAllDocumentTypes { get; set; }
+
+    /// <summary>
+    /// Accessions that must run before the staged queue, used to verify a known filing safely.
+    /// </summary>
+    public List<string> PriorityAccessions { get; set; } = [];
+}

--- a/src/Equibles.Sec.HostedService/DocumentNormalizationBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/DocumentNormalizationBackfillWorker.cs
@@ -1,0 +1,83 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Worker;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Sec.HostedService;
+
+/// <summary>
+/// Self-draining historical sweep for stored filing text. A pipeline-version bump refills the
+/// work-set; once every refetchable EDGAR document is current, cycles become a cheap empty query.
+/// </summary>
+public class DocumentNormalizationBackfillWorker : BaseScraperWorker
+{
+    private readonly IConfiguration _configuration;
+    private readonly DocumentNormalizationBackfillOptions _options;
+
+    protected override string WorkerName => "Document normalization backfill";
+
+    protected override TimeSpan SleepInterval => TimeSpan.FromMinutes(5);
+
+    protected override TimeSpan ContinuationInterval =>
+        TimeSpan.FromSeconds(_options.DrainIntervalSeconds);
+
+    protected override ErrorSource ErrorSource => ErrorSource.DocumentScraper;
+
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(10);
+
+    public DocumentNormalizationBackfillWorker(
+        ILogger<DocumentNormalizationBackfillWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<DocumentNormalizationBackfillOptions> options,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        _options = options.Value;
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(
+            _configuration,
+            "Document normalization backfill",
+            treatWhitespaceAsAbsent: true
+        );
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            Logger.LogDebug("Document normalization backfill disabled; skipping cycle.");
+            return;
+        }
+
+        var batchSize = _options.BatchSize;
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var service =
+            scope.ServiceProvider.GetRequiredService<DocumentNormalizationBackfillService>();
+        var result = await service.Backfill(
+            batchSize,
+            _options.IncludeAllDocumentTypes,
+            _options.PriorityAccessions,
+            stoppingToken
+        );
+
+        if (batchSize > 0 && result.Processed >= batchSize && result.Failed < result.Processed)
+        {
+            RequestImmediateContinuation();
+        }
+
+        Logger.LogInformation(
+            "Document normalization backfill cycle complete. Processed: {Processed}, Replaced: {Replaced}, Unchanged: {Unchanged}, Failed: {Failed}",
+            result.Processed,
+            result.Replaced,
+            result.Unchanged,
+            result.Failed
+        );
+    }
+}

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<XbrlEnvelopeCaptureService>();
         services.AddScoped<AsFiledHtmlCaptureService>();
         services.AddScoped<AsFiledHtmlBackfillService>();
+        services.AddScoped<DocumentNormalizationBackfillService>();
         services.AddScoped<DocumentImageService>();
         services.AddScoped<FilingItemsBackfillService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();
@@ -38,6 +39,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<FtdScraperWorker>();
         services.AddHostedService<FormAdvScraperWorker>();
         services.AddHostedService<AsFiledHtmlBackfillWorker>();
+        services.AddHostedService<DocumentNormalizationBackfillWorker>();
         services.AddHostedService<FilingItemsBackfillWorker>();
         services.AddHostedService<InsiderFilingReprocessWorker>();
         services.AddHostedService<Form144FilerCikBackfillWorker>();

--- a/src/Equibles.Sec.HostedService/Models/DocumentNormalizationBackfillResult.cs
+++ b/src/Equibles.Sec.HostedService/Models/DocumentNormalizationBackfillResult.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Sec.HostedService.Models;
+
+public class DocumentNormalizationBackfillResult
+{
+    public int Processed { get; set; }
+
+    public int Replaced { get; set; }
+
+    public int Unchanged { get; set; }
+
+    public int Failed { get; set; }
+}

--- a/src/Equibles.Sec.HostedService/Services/DocumentNormalizationBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentNormalizationBackfillService.cs
@@ -1,0 +1,263 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Media.BusinessLogic;
+using Equibles.Sec.BusinessLogic;
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Re-fetches and re-normalizes EDGAR documents whose stored Markdown predates the current
+/// normalization pipeline. Each successful replacement keeps the document id, removes stale
+/// chunks, and immediately recreates chunks from the corrected body.
+/// </summary>
+public class DocumentNormalizationBackfillService
+{
+    private static readonly Regex EdgarSourceUrlAccession = new(
+        @"/Archives/edgar/data/\d+/(\d{10}-\d{2}-\d{6})\.txt$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
+
+    private readonly DocumentRepository _documentRepository;
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly ISecDocumentHtmlNormalizer _normalizer;
+    private readonly ISecDocumentHtmlToMarkdownConverter _converter;
+    private readonly IFileManager _fileManager;
+    private readonly IDocumentPersistenceService _persistenceService;
+    private readonly IDocumentProcessor _documentProcessor;
+    private readonly ILogger<DocumentNormalizationBackfillService> _logger;
+
+    public DocumentNormalizationBackfillService(
+        DocumentRepository documentRepository,
+        ISecEdgarClient secEdgarClient,
+        ISecDocumentHtmlNormalizer normalizer,
+        ISecDocumentHtmlToMarkdownConverter converter,
+        IFileManager fileManager,
+        IDocumentPersistenceService persistenceService,
+        IDocumentProcessor documentProcessor,
+        ILogger<DocumentNormalizationBackfillService> logger
+    )
+    {
+        _documentRepository = documentRepository;
+        _secEdgarClient = secEdgarClient;
+        _normalizer = normalizer;
+        _converter = converter;
+        _fileManager = fileManager;
+        _persistenceService = persistenceService;
+        _documentProcessor = documentProcessor;
+        _logger = logger;
+    }
+
+    public async Task<DocumentNormalizationBackfillResult> Backfill(
+        int batchSize,
+        bool includeAllDocumentTypes = false,
+        IReadOnlyCollection<string> priorityAccessions = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = new DocumentNormalizationBackfillResult();
+        if (batchSize <= 0)
+            return result;
+
+        var pending = _documentRepository.GetPendingNormalizedContent();
+        var priorities =
+            priorityAccessions
+                ?.Where(accession => !string.IsNullOrWhiteSpace(accession))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList()
+            ?? [];
+
+        var priorityIds = new List<Guid>();
+        foreach (var accession in priorities.Take(batchSize))
+        {
+            var sourceSuffix = $"/{accession}.txt";
+            var priorityId = await pending
+                .Where(d =>
+                    !priorityIds.Contains(d.Id)
+                    && (
+                        d.AccessionNumber == accession
+                        || (
+                            (d.AccessionNumber == null || d.AccessionNumber == "")
+                            && d.SourceUrl != null
+                            && d.SourceUrl.EndsWith(sourceSuffix)
+                        )
+                    )
+                )
+                .Select(d => (Guid?)d.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+            if (priorityId.HasValue)
+            {
+                priorityIds.Add(priorityId.Value);
+            }
+        }
+
+        var remaining = batchSize - priorityIds.Count;
+        var stagedIds = new List<Guid>();
+        if (remaining > 0)
+        {
+            stagedIds = await _documentRepository
+                .GetOrderedPendingNormalizedContent(includeAllDocumentTypes)
+                .Where(d => !priorityIds.Contains(d.Id))
+                .Take(remaining)
+                .Select(d => d.Id)
+                .ToListAsync(cancellationToken);
+        }
+
+        var batchIds = priorityIds.Concat(stagedIds);
+
+        foreach (var documentId in batchIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var document = await _documentRepository.GetWithContent(documentId, cancellationToken);
+            if (document == null)
+                continue;
+
+            result.Processed++;
+            document.NormalizedContentAttempts++;
+            var currentAttempt = document.NormalizedContentAttempts;
+            if (string.IsNullOrEmpty(document.AccessionNumber))
+            {
+                document.AccessionNumber = DeriveAccessionNumber(document.SourceUrl);
+            }
+
+            if (document.AccessionNumber == null)
+            {
+                result.Failed++;
+                _logger.LogWarning(
+                    "Document normalization backfill cannot derive an accession number from SourceUrl {SourceUrl} for document {DocumentId}.",
+                    document.SourceUrl,
+                    document.Id
+                );
+                await RevertAndPersistAttempt(document, cancellationToken);
+                continue;
+            }
+
+            try
+            {
+                var source = await _secEdgarClient.GetDocumentContent(
+                    document.AccessionNumber,
+                    document.CommonStock.Cik,
+                    cancellationToken
+                );
+                var normalizedHtml = _normalizer.Normalize(source);
+                var markdown = _converter.Convert(normalizedHtml);
+                if (string.IsNullOrWhiteSpace(markdown))
+                {
+                    throw new InvalidOperationException(
+                        $"Normalization produced no content for document {document.Id}."
+                    );
+                }
+
+                var normalizedContent = Encoding.UTF8.GetBytes(markdown);
+                document.NormalizedContentVersion = Document.NormalizedContentBuilderVersion;
+                document.NormalizedContentAttempts = 0;
+
+                if (await ContentMatches(document, normalizedContent))
+                {
+                    await _persistenceService.ResetChunks(document, cancellationToken);
+                    result.Unchanged++;
+                    await Rechunk(document, cancellationToken);
+                    continue;
+                }
+
+                await _persistenceService.ReplaceContent(
+                    document,
+                    normalizedContent,
+                    cancellationToken
+                );
+                result.Replaced++;
+
+                await Rechunk(document, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                result.Failed++;
+                // Success bookkeeping is applied before persistence so it commits atomically with
+                // the corrected content. Restore this run's attempt if comparison or persistence
+                // fails, otherwise deterministic storage failures can retry forever.
+                document.NormalizedContentAttempts = currentAttempt;
+                _logger.LogWarning(
+                    ex,
+                    "Document normalization backfill failed for document {DocumentId} ({Accession}); will retry.",
+                    document.Id,
+                    document.AccessionNumber
+                );
+                await RevertAndPersistAttempt(document, cancellationToken);
+            }
+        }
+
+        return result;
+    }
+
+    private async Task Rechunk(Document document, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _documentProcessor.ProcessDocuments([document], cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Corrected document {DocumentId} was stored but could not be re-chunked immediately; the document processor will retry it.",
+                document.Id
+            );
+        }
+    }
+
+    private async Task<bool> ContentMatches(Document document, byte[] normalizedContent)
+    {
+        if (document.Content == null)
+            return false;
+
+        var storedContent = await _fileManager.GetContent(document.Content);
+        return storedContent.AsSpan().SequenceEqual(normalizedContent);
+    }
+
+    private static string DeriveAccessionNumber(string sourceUrl)
+    {
+        if (string.IsNullOrEmpty(sourceUrl))
+            return null;
+
+        var match = EdgarSourceUrlAccession.Match(sourceUrl);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    private async Task RevertAndPersistAttempt(
+        Document document,
+        CancellationToken cancellationToken
+    )
+    {
+        _documentRepository.ClearChangeTracker();
+        try
+        {
+            await _documentRepository.PersistNormalizedContentAttempt(document, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to persist document normalization backfill attempt count."
+            );
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -106,6 +106,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
             AccessionNumber = accessionNumber,
             Items = items,
             LineCount = lineCount,
+            NormalizedContentVersion = Document.NormalizedContentBuilderVersion,
         };
 
         await ApplyXbrlCapture(document, xbrl ?? XbrlCaptureResult.NotChecked);
@@ -171,22 +172,42 @@ public class DocumentPersistenceService : IDocumentPersistenceService
 
         // Swap in a new content file and recount lines. The document keeps its id, so every soft
         // reference to it (e.g. an earnings call's TranscriptDocumentId) stays valid with no re-link.
-        var fileName = document.Content?.NameWithExtension ?? $"{document.Id}.txt";
+        var oldContent = document.Content;
+        var fileName = oldContent?.NameWithExtension ?? $"{document.Id}.txt";
         var file = await SaveTextContent(content, fileName);
         document.Content = file;
         document.LineCount = CountLines(content);
-        _documentRepository.Update(document);
+
+        // Remove the superseded File row in the same transaction. Filesystem bytes are queued
+        // for the reference-checked deletion sweep, so content-addressed blobs shared with the
+        // replacement or another File row are never unlinked prematurely.
+        _fileManager.DeleteFile(oldContent);
 
         // Drop the stale chunks (their embeddings cascade at the DB level) so the chunking worker,
         // which polls for documents that have no chunks, re-chunks the new body on its next pass.
-        await _chunkRepository
-            .GetAll()
-            .Where(c => c.DocumentId == document.Id)
-            .ExecuteDeleteAsync(cancellationToken);
+        await DeleteChunks(document.Id, cancellationToken);
 
         await _documentRepository.SaveChanges();
         await transaction.CommitAsync(cancellationToken);
     }
+
+    public async Task ResetChunks(Document document, CancellationToken cancellationToken = default)
+    {
+        await using var transaction = await _documentRepository.CreateTransaction(
+            IsolationLevel.ReadCommitted,
+            cancellationToken
+        );
+
+        await DeleteChunks(document.Id, cancellationToken);
+        await _documentRepository.SaveChanges();
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    private Task<int> DeleteChunks(Guid documentId, CancellationToken cancellationToken) =>
+        _chunkRepository
+            .GetAll()
+            .Where(c => c.DocumentId == documentId)
+            .ExecuteDeleteAsync(cancellationToken);
 
     // Line count = newline bytes + 1 — identical to the previous
     // GetString(content).Split('\n').Length, without decoding a multi-MB filing

--- a/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
@@ -73,4 +73,10 @@ public interface IDocumentPersistenceService
         byte[] content,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Persists document bookkeeping and removes stale chunks without rewriting an unchanged
+    /// content file. Used when a chunking-only pipeline change must rebuild the search corpus.
+    /// </summary>
+    Task ResetChunks(Document document, CancellationToken cancellationToken = default);
 }

--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -108,6 +108,47 @@ public class DocumentRepository : BaseRepository<Document>
     }
 
     /// <summary>
+    /// EDGAR documents whose stored Markdown predates the current normalization pipeline and
+    /// can be re-fetched safely. This is the single definition of the normalized-content
+    /// backfill work-set.
+    /// </summary>
+    public IQueryable<Document> GetPendingNormalizedContent()
+    {
+        return GetAll()
+            .Where(d =>
+                d.NormalizedContentVersion < Document.NormalizedContentBuilderVersion
+                && d.NormalizedContentAttempts < Document.MaxNormalizedContentAttempts
+                && (
+                    (d.AccessionNumber != null && d.AccessionNumber != "")
+                    || (d.SourceUrl != null && d.SourceUrl.Contains("/Archives/edgar/data/"))
+                )
+                && d.CommonStock.Cik != null
+            );
+    }
+
+    /// <summary>
+    /// Ordered normalized-content work set aligned with IX_Document_NormalizationBackfill.
+    /// The periodic stage drains 10-K/10-Q first; the all-types stage reuses the same order.
+    /// </summary>
+    public IQueryable<Document> GetOrderedPendingNormalizedContent(bool includeAllDocumentTypes)
+    {
+        var pending = GetPendingNormalizedContent();
+        if (!includeAllDocumentTypes)
+        {
+            pending = pending.Where(d =>
+                d.DocumentType == DocumentType.TenK || d.DocumentType == DocumentType.TenQ
+            );
+        }
+
+        return pending
+            .OrderBy(d => d.DocumentType)
+            .ThenBy(d => d.NormalizedContentVersion)
+            .ThenBy(d => d.NormalizedContentAttempts)
+            .ThenByDescending(d => d.ReportingDate)
+            .ThenBy(d => d.Id);
+    }
+
+    /// <summary>
     /// One-batch dedup lookup for a (company, type) scrape pass: the subset of
     /// <paramref name="accessionNumbers"/> already stored, plus the (filing date,
     /// report date) keys of legacy rows stored before accession stamping. Together
@@ -177,7 +218,32 @@ public class DocumentRepository : BaseRepository<Document>
             );
     }
 
-    public virtual async Task<Document> GetWithContent(Guid id)
+    /// <summary>
+    /// Persists only normalized-content retry bookkeeping after a failed attempt whose tracked
+    /// normalization and file mutations have been discarded.
+    /// </summary>
+    public Task PersistNormalizedContentAttempt(
+        Document document,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return GetAll()
+            .Where(d => d.Id == document.Id)
+            .ExecuteUpdateAsync(
+                s =>
+                    s.SetProperty(
+                            x => x.NormalizedContentAttempts,
+                            document.NormalizedContentAttempts
+                        )
+                        .SetProperty(x => x.AccessionNumber, document.AccessionNumber),
+                cancellationToken
+            );
+    }
+
+    public virtual async Task<Document> GetWithContent(
+        Guid id,
+        CancellationToken cancellationToken = default
+    )
     {
         // The content bytes ride along eagerly: leaving File.FileContent to a lazy load
         // lets an aborted or transient load mid-request corrupt the navigation's loaded
@@ -187,7 +253,7 @@ public class DocumentRepository : BaseRepository<Document>
             .Include(d => d.Content)
                 .ThenInclude(f => f.FileContent)
             .Include(d => d.CommonStock)
-            .FirstOrDefaultAsync(d => d.Id == id);
+            .FirstOrDefaultAsync(d => d.Id == id, cancellationToken);
     }
 
     public IQueryable<Document> GetByDateRange(DateOnly? fromDate = null, DateOnly? toDate = null)

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -87,6 +87,9 @@ builder.Services.Configure<Equibles.Sec.HostedService.Configuration.XbrlCaptureO
 builder.Services.Configure<Equibles.Sec.HostedService.Configuration.AsFiledHtmlCaptureOptions>(
     builder.Configuration.GetSection("AsFiledHtml")
 );
+builder.Services.Configure<Equibles.Sec.HostedService.Configuration.DocumentNormalizationBackfillOptions>(
+    builder.Configuration.GetSection("DocumentNormalizationBackfill")
+);
 builder.Services.Configure<Equibles.Sec.HostedService.Configuration.FilingItemsBackfillOptions>(
     builder.Configuration.GetSection("FilingItemsBackfill")
 );

--- a/tests/Equibles.IntegrationTests/Sec/DocumentNormalizationBackfillPostgresTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentNormalizationBackfillPostgresTests.cs
@@ -1,0 +1,340 @@
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Repositories;
+using Equibles.Sec.BusinessLogic;
+using Equibles.Sec.BusinessLogic.Embeddings;
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.BusinessLogic.Tokenization;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+[Collection(ParadeDbCollection.Name)]
+public class DocumentNormalizationBackfillPostgresTests : ParadeDbMcpTestBase
+{
+    private const string Accession = "0001045810-26-000021";
+    private const string SourceUrl =
+        "https://www.sec.gov/Archives/edgar/data/1045810/0001045810-26-000021.txt";
+
+    public DocumentNormalizationBackfillPostgresTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Backfill_ReplacesFileDeletesStaleChunksAndRechunksInOneRun()
+    {
+        var document = await SeedLegacyDocument("NVDA");
+        var oldContentId = document.ContentId;
+        DbContext
+            .Set<Chunk>()
+            .Add(
+                new Chunk
+                {
+                    DocumentId = document.Id,
+                    Index = 0,
+                    StartPosition = 0,
+                    EndPosition = 3,
+                    StartLineNumber = 1,
+                    Content = "old",
+                    DocumentType = DocumentType.TenK,
+                    Ticker = "NVDA",
+                    ReportingDate = new DateTime(2026, 2, 25, 0, 0, 0, DateTimeKind.Utc),
+                }
+            );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var secClient = Substitute.For<ISecEdgarClient>();
+        secClient
+            .GetDocumentContent(Accession, "0001045810", Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                await using var concurrent = Fixture.CreateDbContext();
+                await concurrent
+                    .Set<Document>()
+                    .Where(d => d.Id == document.Id)
+                    .ExecuteUpdateAsync(setters =>
+                        setters.SetProperty(d => d.Items, "concurrent-enrichment")
+                    );
+                return NvidiaSubmission;
+            });
+
+        var result = await BuildSut(secClient).Backfill(batchSize: 1);
+
+        result.Replaced.Should().Be(1);
+        await using var verify = Fixture.CreateDbContext();
+        var saved = await verify
+            .Set<Document>()
+            .Include(d => d.Content)
+                .ThenInclude(f => f.FileContent)
+            .SingleAsync(d => d.Id == document.Id);
+        saved.AccessionNumber.Should().Be(Accession);
+        saved.NormalizedContentVersion.Should().Be(Document.NormalizedContentBuilderVersion);
+        saved.ContentId.Should().NotBe(oldContentId);
+        saved.Items.Should().Be("concurrent-enrichment");
+        Encoding
+            .UTF8.GetString(saved.Content.FileContent.Bytes)
+            .Should()
+            .Contain("| Compute & Networking | 193,479 | 116,193 | 77,286 | 67 | % |");
+        (await verify.Set<Equibles.Media.Data.Models.File>().AnyAsync(f => f.Id == oldContentId))
+            .Should()
+            .BeFalse();
+        var chunks = await verify
+            .Set<Chunk>()
+            .Where(c => c.DocumentId == document.Id)
+            .OrderBy(c => c.Index)
+            .ToListAsync();
+        chunks.Should().NotBeEmpty();
+        chunks[0].Content.Should().Contain("77,286 | 67 | % |\n| Graphics | 22,459");
+    }
+
+    [Fact]
+    public async Task Backfill_FailurePersistsDerivedAccessionAndStopsAtRetryCeiling()
+    {
+        var document = await SeedLegacyDocument("NVDAF");
+        var secClient = Substitute.For<ISecEdgarClient>();
+        secClient
+            .GetDocumentContent(Accession, "0001045810", Arg.Any<CancellationToken>())
+            .Returns<Task<string>>(_ => throw new HttpRequestException("SEC unavailable"));
+        var sut = BuildSut(secClient);
+
+        for (var attempt = 0; attempt < Document.MaxNormalizedContentAttempts; attempt++)
+        {
+            var result = await sut.Backfill(batchSize: 1);
+            result.Failed.Should().Be(1);
+        }
+
+        var terminal = await sut.Backfill(batchSize: 1);
+
+        terminal.Processed.Should().Be(0);
+        await using var verify = Fixture.CreateDbContext();
+        var saved = await verify.Set<Document>().SingleAsync(d => d.Id == document.Id);
+        saved.AccessionNumber.Should().Be(Accession);
+        saved.NormalizedContentAttempts.Should().Be(Document.MaxNormalizedContentAttempts);
+        saved.NormalizedContentVersion.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Backfill_PersistenceFailurePersistsAttemptsAndStopsAtRetryCeiling()
+    {
+        var document = await SeedLegacyDocument("NVDAP");
+        var secClient = Substitute.For<ISecEdgarClient>();
+        secClient
+            .GetDocumentContent(Accession, "0001045810", Arg.Any<CancellationToken>())
+            .Returns(NvidiaSubmission);
+        var persistence = Substitute.For<IDocumentPersistenceService>();
+        persistence
+            .ReplaceContent(Arg.Any<Document>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new IOException("content store unavailable"));
+        var sut = BuildSut(secClient, persistence);
+
+        for (var attempt = 0; attempt < Document.MaxNormalizedContentAttempts; attempt++)
+        {
+            var result = await sut.Backfill(batchSize: 1);
+            result.Failed.Should().Be(1);
+        }
+
+        var terminal = await sut.Backfill(batchSize: 1);
+
+        terminal.Processed.Should().Be(0);
+        await using var verify = Fixture.CreateDbContext();
+        var saved = await verify.Set<Document>().SingleAsync(d => d.Id == document.Id);
+        saved.NormalizedContentAttempts.Should().Be(Document.MaxNormalizedContentAttempts);
+        saved.NormalizedContentVersion.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Backfill_UnchangedFileKeepsBlobButRebuildsFlattenedChunks()
+    {
+        var normalized = new SecDocumentHtmlToMarkdownConverter().Convert(
+            new SecDocumentHtmlNormalizer().Normalize(NvidiaSubmission)
+        );
+        var document = await SeedLegacyDocument("NVDAU", Encoding.UTF8.GetBytes(normalized));
+        var originalContentId = document.ContentId;
+        DbContext
+            .Set<Chunk>()
+            .Add(
+                new Chunk
+                {
+                    DocumentId = document.Id,
+                    Index = 0,
+                    StartPosition = 0,
+                    EndPosition = normalized.Length,
+                    StartLineNumber = 1,
+                    Content = normalized.Replace('\n', ' '),
+                    DocumentType = DocumentType.TenK,
+                    Ticker = "NVDAU",
+                    ReportingDate = new DateTime(2026, 2, 25, 0, 0, 0, DateTimeKind.Utc),
+                }
+            );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+        var secClient = Substitute.For<ISecEdgarClient>();
+        secClient
+            .GetDocumentContent(Accession, "0001045810", Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                await using var concurrent = Fixture.CreateDbContext();
+                await concurrent
+                    .Set<Document>()
+                    .Where(d => d.Id == document.Id)
+                    .ExecuteUpdateAsync(setters =>
+                        setters.SetProperty(d => d.Items, "concurrent-enrichment")
+                    );
+                return NvidiaSubmission;
+            });
+
+        var result = await BuildSut(secClient).Backfill(batchSize: 1);
+
+        result.Unchanged.Should().Be(1);
+        result.Replaced.Should().Be(0);
+        await using var verify = Fixture.CreateDbContext();
+        var saved = await verify.Set<Document>().SingleAsync(d => d.Id == document.Id);
+        saved.ContentId.Should().Be(originalContentId);
+        saved.Items.Should().Be("concurrent-enrichment");
+        var chunks = await verify
+            .Set<Chunk>()
+            .Where(c => c.DocumentId == document.Id)
+            .OrderBy(c => c.Index)
+            .ToListAsync();
+        chunks.Should().NotBeEmpty();
+        chunks[0].Content.Should().Contain("77,286 | 67 | % |\n| Graphics | 22,459");
+    }
+
+    private async Task<Document> SeedLegacyDocument(string ticker, byte[] content = null)
+    {
+        var company = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = "NVIDIA Corporation",
+            Cik = "0001045810",
+        };
+        DbContext.Set<CommonStock>().Add(company);
+        await DbContext.SaveChangesAsync();
+
+        var fileManager = CreateFileManager();
+        await CreatePersistence(fileManager)
+            .Save(
+                company,
+                content ?? "legacy table body"u8.ToArray(),
+                $"{ticker}-2026-10k.txt",
+                DocumentType.TenK,
+                new DateOnly(2026, 2, 25),
+                new DateOnly(2026, 1, 25),
+                SourceUrl,
+                accessionNumber: ""
+            );
+
+        var document = await DbContext
+            .Set<Document>()
+            .SingleAsync(d => d.CommonStockId == company.Id);
+        document.NormalizedContentVersion = 0;
+        await DbContext.SaveChangesAsync();
+        return document;
+    }
+
+    private DocumentNormalizationBackfillService BuildSut(
+        ISecEdgarClient secClient,
+        IDocumentPersistenceService persistenceService = null
+    )
+    {
+        var fileManager = CreateFileManager();
+        var processor = new DocumentProcessor(
+            new ChunkRepository(DbContext),
+            new EmbeddingRepository(DbContext),
+            Substitute.For<IEmbeddingClient>(),
+            new ChunkingStrategy(new TokenCounter()),
+            Options.Create(new EmbeddingConfig()),
+            fileManager,
+            Substitute.For<ILogger<DocumentProcessor>>()
+        );
+
+        return new DocumentNormalizationBackfillService(
+            new DocumentRepository(DbContext),
+            secClient,
+            new SecDocumentHtmlNormalizer(),
+            new SecDocumentHtmlToMarkdownConverter(),
+            fileManager,
+            persistenceService ?? CreatePersistence(fileManager),
+            processor,
+            Substitute.For<ILogger<DocumentNormalizationBackfillService>>()
+        );
+    }
+
+    private FileManager CreateFileManager() =>
+        FileManagerTestFactory.Create(
+            new FileRepository(DbContext),
+            pendingBlobDeletionRepository: new PendingBlobDeletionRepository(DbContext)
+        );
+
+    private DocumentPersistenceService CreatePersistence(FileManager fileManager) =>
+        new(
+            new DocumentRepository(DbContext),
+            new ChunkRepository(DbContext),
+            fileManager,
+            new DocumentImageService(
+                new DocumentImageRepository(DbContext),
+                new FileRepository(DbContext),
+                fileManager
+            ),
+            Substitute.For<IBus>()
+        );
+
+    [Fact]
+    public void OrderedWorkSet_MatchesTheBackfillIndex()
+    {
+        var sql = new DocumentRepository(DbContext)
+            .GetOrderedPendingNormalizedContent(includeAllDocumentTypes: false)
+            .Take(16)
+            .ToQueryString();
+
+        sql.Should()
+            .Contain(
+                "ORDER BY d.\"DocumentType\", d.\"NormalizedContentVersion\", d.\"NormalizedContentAttempts\", d.\"ReportingDate\" DESC, d.\"Id\""
+            );
+
+        var entity = DbContext
+            .GetService<IDesignTimeModel>()
+            .Model.FindEntityType(typeof(Document));
+        var index = entity.GetIndexes().Single(i => i.Name == "IX_Document_NormalizationBackfill");
+        index
+            .Properties.Select(property => property.Name)
+            .Should()
+            .Equal(
+                nameof(Document.DocumentType),
+                nameof(Document.NormalizedContentVersion),
+                nameof(Document.NormalizedContentAttempts),
+                nameof(Document.ReportingDate),
+                nameof(Document.Id)
+            );
+        index.IsDescending.Should().Equal(false, false, false, true, false);
+    }
+
+    private const string NvidiaSubmission = """
+        <DOCUMENT>
+        <TYPE>10-K
+        <FILENAME>nvda-20260125.htm
+        <TEXT>
+        <html><body><table>
+        <tr><td></td><td>Jan 25, 2026</td><td></td><td>Jan 26, 2025</td><td></td><td>$ Change</td><td></td><td>% Change</td><td></td></tr>
+        <tr><td>Compute &amp; Networking</td><td>$</td><td>193,479</td><td>$</td><td>116,193</td><td>$</td><td>77,286</td><td>67</td><td>%</td></tr>
+        <tr><td>Graphics</td><td></td><td>22,459</td><td></td><td>14,304</td><td></td><td>8,155</td><td>57</td><td>%</td></tr>
+        <tr><td>Total</td><td>$</td><td>215,938</td><td>$</td><td>130,497</td><td>$</td><td>85,441</td><td>65</td><td>%</td></tr>
+        </table></body></html>
+        </TEXT>
+        </DOCUMENT>
+        """;
+}

--- a/tests/Equibles.IntegrationTests/Sec/DocumentNormalizationBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentNormalizationBackfillServiceTests.cs
@@ -1,0 +1,308 @@
+using System.Text;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Data;
+using Equibles.Sec.BusinessLogic;
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class DocumentNormalizationBackfillServiceTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly ISecEdgarClient _secEdgarClient = Substitute.For<ISecEdgarClient>();
+    private readonly IFileManager _fileManager = Substitute.For<IFileManager>();
+    private readonly IDocumentPersistenceService _persistenceService =
+        Substitute.For<IDocumentPersistenceService>();
+    private readonly IDocumentProcessor _documentProcessor = Substitute.For<IDocumentProcessor>();
+    private readonly CommonStock _company;
+
+    public DocumentNormalizationBackfillServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        _dbContext = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new MediaModuleConfiguration(),
+                new SecTestModuleConfiguration(),
+            }
+        );
+        _dbContext.Database.EnsureCreated();
+
+        _company = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "NVDA",
+            Name = "NVIDIA Corporation",
+            Cik = "0001045810",
+        };
+        _dbContext.Add(_company);
+        _dbContext.SaveChanges();
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task Backfill_PendingNvidiaFiling_ReplacesContentAndRechunksAtCurrentVersion()
+    {
+        var document = SeedDocument(normalizedContentVersion: 0);
+        _secEdgarClient
+            .GetDocumentContent(
+                document.AccessionNumber,
+                _company.Cik,
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(NvidiaSubmission);
+
+        var result = await BuildSut().Backfill(batchSize: 10);
+
+        result.Processed.Should().Be(1);
+        result.Replaced.Should().Be(1);
+        result.Failed.Should().Be(0);
+        await _persistenceService
+            .Received(1)
+            .ReplaceContent(
+                Arg.Is<Document>(d =>
+                    d.Id == document.Id
+                    && d.NormalizedContentVersion == Document.NormalizedContentBuilderVersion
+                    && d.NormalizedContentAttempts == 0
+                ),
+                Arg.Is<byte[]>(bytes => CorrectedTable(Encoding.UTF8.GetString(bytes))),
+                Arg.Any<CancellationToken>()
+            );
+        await _documentProcessor
+            .Received(1)
+            .ProcessDocuments(
+                Arg.Is<List<Document>>(documents =>
+                    documents.Count == 1 && documents[0].Id == document.Id
+                ),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task Backfill_CurrentDocument_DoesNotRefetchOrReplace()
+    {
+        SeedDocument(Document.NormalizedContentBuilderVersion);
+
+        var result = await BuildSut().Backfill(batchSize: 10);
+
+        result.Processed.Should().Be(0);
+        await _secEdgarClient
+            .DidNotReceiveWithAnyArgs()
+            .GetDocumentContent(default, default, default);
+        await _persistenceService
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceContent(default, default, default);
+    }
+
+    [Fact]
+    public async Task Backfill_EmptyLegacyAccession_DerivesItFromSourceUrl()
+    {
+        var document = SeedDocument(normalizedContentVersion: 0);
+        document.DocumentType = DocumentType.EightK;
+        document.AccessionNumber = "";
+        _dbContext.SaveChanges();
+        _secEdgarClient
+            .GetDocumentContent("0001045810-26-000021", _company.Cik, Arg.Any<CancellationToken>())
+            .Returns(NvidiaSubmission);
+
+        var result = await BuildSut()
+            .Backfill(batchSize: 1, priorityAccessions: ["0001045810-26-000021"]);
+
+        result.Replaced.Should().Be(1);
+        await _secEdgarClient
+            .Received(1)
+            .GetDocumentContent("0001045810-26-000021", _company.Cik, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Backfill_NonPeriodicDocument_IsOnlySelectedWhenPrioritized()
+    {
+        var document = SeedDocument(normalizedContentVersion: 0);
+        document.DocumentType = DocumentType.EightK;
+        _dbContext.SaveChanges();
+        _secEdgarClient
+            .GetDocumentContent(
+                document.AccessionNumber,
+                _company.Cik,
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(NvidiaSubmission);
+
+        var stagedResult = await BuildSut().Backfill(batchSize: 1);
+        var priorityResult = await BuildSut()
+            .Backfill(batchSize: 1, priorityAccessions: [document.AccessionNumber]);
+
+        stagedResult.Processed.Should().Be(0);
+        priorityResult.Replaced.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Backfill_WhenNormalizedBytesAreUnchanged_RechunksWithoutReplacingFile()
+    {
+        var document = SeedDocument(normalizedContentVersion: 0);
+        _secEdgarClient
+            .GetDocumentContent(
+                document.AccessionNumber,
+                _company.Cik,
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(NvidiaSubmission);
+        var normalized = new SecDocumentHtmlToMarkdownConverter().Convert(
+            new SecDocumentHtmlNormalizer().Normalize(NvidiaSubmission)
+        );
+        _fileManager
+            .GetContent(Arg.Is<Equibles.Media.Data.Models.File>(f => f.Id == document.ContentId))
+            .Returns(Encoding.UTF8.GetBytes(normalized));
+
+        var result = await BuildSut().Backfill(batchSize: 1);
+
+        result.Unchanged.Should().Be(1);
+        result.Replaced.Should().Be(0);
+        document.NormalizedContentVersion.Should().Be(Document.NormalizedContentBuilderVersion);
+        await _persistenceService
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceContent(default, default, default);
+        await _persistenceService
+            .Received(1)
+            .ResetChunks(Arg.Is<Document>(d => d.Id == document.Id), Arg.Any<CancellationToken>());
+        await _documentProcessor
+            .Received(1)
+            .ProcessDocuments(
+                Arg.Is<List<Document>>(documents => documents.Single().Id == document.Id),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task Backfill_ShutdownCancellation_StopsTheSecRequestWithoutRecordingFailure()
+    {
+        var document = SeedDocument(normalizedContentVersion: 0);
+        using var cancellation = new CancellationTokenSource();
+        _secEdgarClient
+            .GetDocumentContent(
+                document.AccessionNumber,
+                _company.Cik,
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(async call =>
+            {
+                var token = call.ArgAt<CancellationToken>(2);
+                cancellation.Cancel();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return "unreachable";
+            });
+
+        var act = () => BuildSut().Backfill(batchSize: 1, cancellationToken: cancellation.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        document.NormalizedContentAttempts.Should().Be(1);
+        document.NormalizedContentVersion.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Backfill_CancellationDuringRechunk_PropagatesAfterProcessorReturns()
+    {
+        var document = SeedDocument(normalizedContentVersion: 0);
+        using var cancellation = new CancellationTokenSource();
+        _secEdgarClient
+            .GetDocumentContent(
+                document.AccessionNumber,
+                _company.Cik,
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(NvidiaSubmission);
+        _documentProcessor
+            .ProcessDocuments(Arg.Any<List<Document>>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                cancellation.Cancel();
+                return Task.CompletedTask;
+            });
+
+        var act = () => BuildSut().Backfill(batchSize: 1, cancellationToken: cancellation.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private DocumentNormalizationBackfillService BuildSut() =>
+        new(
+            new DocumentRepository(_dbContext),
+            _secEdgarClient,
+            new SecDocumentHtmlNormalizer(),
+            new SecDocumentHtmlToMarkdownConverter(),
+            _fileManager,
+            _persistenceService,
+            _documentProcessor,
+            Substitute.For<ILogger<DocumentNormalizationBackfillService>>()
+        );
+
+    private Document SeedDocument(int normalizedContentVersion)
+    {
+        var document = new Document
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = _company.Id,
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2026, 2, 25),
+            ReportingForDate = new DateOnly(2026, 1, 25),
+            AccessionNumber = "0001045810-26-000021",
+            SourceUrl = "https://www.sec.gov/Archives/edgar/data/1045810/0001045810-26-000021.txt",
+            NormalizedContentVersion = normalizedContentVersion,
+            Content = new Equibles.Media.Data.Models.File
+            {
+                Name = "nvda-20260125",
+                Extension = "txt",
+                ContentType = "text/plain",
+                FileContent = new Equibles.Media.Data.Models.FileContent
+                {
+                    Bytes = "old normalized filing"u8.ToArray(),
+                },
+            },
+        };
+        _dbContext.Add(document);
+        _dbContext.SaveChanges();
+        return document;
+    }
+
+    private static bool CorrectedTable(string markdown) =>
+        markdown.Contains(
+            "| Compute & Networking | 193,479 | 116,193 | 77,286 | 67 | % |",
+            StringComparison.Ordinal
+        )
+        && markdown.Contains(
+            "116,193 | 77,286 | 67 | % |\n| Graphics | 22,459 | 14,304",
+            StringComparison.Ordinal
+        );
+
+    private const string NvidiaSubmission = """
+        <DOCUMENT>
+        <TYPE>10-K
+        <FILENAME>nvda-20260125.htm
+        <TEXT>
+        <html><body><table>
+        <tr><td></td><td>Jan 25, 2026</td><td></td><td>Jan 26, 2025</td><td></td><td>$ Change</td><td></td><td>% Change</td><td></td></tr>
+        <tr><td>Compute &amp; Networking</td><td>$</td><td>193,479</td><td>$</td><td>116,193</td><td>$</td><td>77,286</td><td>67</td><td>%</td></tr>
+        <tr><td>Graphics</td><td></td><td>22,459</td><td></td><td>14,304</td><td></td><td>8,155</td><td>57</td><td>%</td></tr>
+        <tr><td>Total</td><td>$</td><td>215,938</td><td>$</td><td>130,497</td><td>$</td><td>85,441</td><td>65</td><td>%</td></tr>
+        </table></body></html>
+        </TEXT>
+        </DOCUMENT>
+        """;
+}

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceReplaceContentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceReplaceContentTests.cs
@@ -1,6 +1,8 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.BusinessLogic;
+using Equibles.Media.BusinessLogic.Configuration;
+using Equibles.Media.Data.Models;
 using Equibles.Media.Repositories;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Data.Models.Chunks;
@@ -21,8 +23,13 @@ namespace Equibles.IntegrationTests.Sec;
 /// chunks are deleted so the chunking worker re-chunks the new body on its next pass.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
-public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase
+public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase, IDisposable
 {
+    private readonly string _storageRoot = Path.Combine(
+        Path.GetTempPath(),
+        $"equibles-replace-content-{Guid.NewGuid():N}"
+    );
+
     public DocumentPersistenceServiceReplaceContentTests(ParadeDbFixture fixture)
         : base(fixture) { }
 
@@ -44,18 +51,34 @@ public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase
         return await DbContext.Set<CommonStock>().SingleAsync(s => s.Id == apple.Id);
     }
 
-    private DocumentPersistenceService BuildSut() =>
-        new(
+    private DocumentPersistenceService BuildSut()
+    {
+        var storageOptions = new FileStorageOptions { Enabled = true, RootPath = _storageRoot };
+        var pendingDeletions = new PendingBlobDeletionRepository(DbContext);
+        var fileManager = FileManagerTestFactory.Create(
+            new FileRepository(DbContext),
+            storageOptions,
+            pendingDeletions
+        );
+
+        return new(
             new DocumentRepository(DbContext),
             new ChunkRepository(DbContext),
-            FileManagerTestFactory.Create(new FileRepository(DbContext)),
+            fileManager,
             new DocumentImageService(
                 new DocumentImageRepository(DbContext),
                 new FileRepository(DbContext),
-                FileManagerTestFactory.Create(new FileRepository(DbContext))
+                fileManager
             ),
             Substitute.For<IBus>()
         );
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_storageRoot))
+            Directory.Delete(_storageRoot, recursive: true);
+    }
 
     [Fact]
     public async Task ReplaceContent_SwapsBodyAndLineCount_AndDeletesStaleChunks()
@@ -75,10 +98,18 @@ public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase
             );
 
         Guid documentId;
+        Guid oldContentId;
+        string oldContentHash;
+        string oldRelativePath;
         await using (var seed = Fixture.CreateDbContext())
         {
-            var document = await seed.Set<Document>().SingleAsync(d => d.CommonStockId == apple.Id);
+            var document = await seed.Set<Document>()
+                .Include(d => d.Content)
+                .SingleAsync(d => d.CommonStockId == apple.Id);
             documentId = document.Id;
+            oldContentId = document.ContentId;
+            oldContentHash = document.Content.ContentHash;
+            oldRelativePath = document.Content.RelativePath;
             seed.Set<Chunk>()
                 .Add(
                     new Chunk
@@ -99,6 +130,13 @@ public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase
 
         DbContext.ChangeTracker.Clear();
         var tracked = await new DocumentRepository(DbContext).Get(documentId);
+        await using (var concurrent = Fixture.CreateDbContext())
+        {
+            await concurrent
+                .Set<Document>()
+                .Where(d => d.Id == documentId)
+                .ExecuteUpdateAsync(setters => setters.SetProperty(d => d.Items, "7.01"));
+        }
         var newBody = "new line 1\nnew line 2\nnew line 3"u8.ToArray();
 
         await BuildSut().ReplaceContent(tracked, newBody);
@@ -106,9 +144,20 @@ public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase
         await using var verify = Fixture.CreateDbContext();
         var saved = await verify.Set<Document>().SingleAsync(d => d.Id == documentId);
         saved.LineCount.Should().Be(3);
+        saved.Items.Should().Be("7.01");
+        saved.NormalizedContentVersion.Should().Be(Document.NormalizedContentBuilderVersion);
 
         var bodyFile = await verify.Set<File>().SingleAsync(f => f.Id == saved.ContentId);
-        bodyFile.FileContent.Bytes.Should().Equal(newBody);
+        bodyFile.StorageProvider.Should().Be(StorageProvider.FileSystem);
+        var bodyBytes = await System.IO.File.ReadAllBytesAsync(
+            Path.Combine(_storageRoot, bodyFile.RelativePath)
+        );
+        bodyBytes.Should().Equal(newBody);
+
+        (await verify.Set<File>().AnyAsync(f => f.Id == oldContentId)).Should().BeFalse();
+        var queuedDeletion = await verify.Set<PendingBlobDeletion>().SingleAsync();
+        queuedDeletion.ContentHash.Should().Be(oldContentHash);
+        queuedDeletion.RelativePath.Should().Be(oldRelativePath);
 
         var remainingChunks = await verify.Set<Chunk>().CountAsync(c => c.DocumentId == documentId);
         remainingChunks.Should().Be(0);

--- a/tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextBlockBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextBlockBoundaryTests.cs
@@ -24,4 +24,18 @@ public class ChunkingStrategyCleanTextBlockBoundaryTests
 
         result.Should().Be("Net income 1000");
     }
+
+    [Fact]
+    public void CleanText_AdjacentMarkdownTableRows_PreservesRowBoundaries()
+    {
+        var result = _strategy.CleanText(
+            "| Segment | 2026 | 2025 |\n"
+                + "| --- | --- | --- |\n"
+                + "| Compute & Networking | 193,479 | 116,193 |\n"
+                + "| Graphics | 22,459 | 14,304 |"
+        );
+
+        result.Split('\n').Should().HaveCount(4);
+        result.Should().Contain("116,193 |\n| Graphics");
+    }
 }

--- a/tests/Equibles.UnitTests/Sec/DocumentNormalizationBackfillOptionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentNormalizationBackfillOptionsTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Sec.HostedService.Configuration;
+
+namespace Equibles.UnitTests.Sec;
+
+public class DocumentNormalizationBackfillOptionsTests
+{
+    [Fact]
+    public void Defaults_AreDisabledAndLeaveHeadroomForLiveIngestion()
+    {
+        var options = new DocumentNormalizationBackfillOptions();
+
+        options.Enabled.Should().BeFalse();
+        options.IncludeAllDocumentTypes.Should().BeFalse();
+        options.BatchSize.Should().Be(16);
+        options.DrainIntervalSeconds.Should().Be(60);
+        options.PriorityAccessions.Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepLeadingHeaderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepLeadingHeaderTests.cs
@@ -1,0 +1,83 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class CurrencyConsolidationStepLeadingHeaderTests
+{
+    [Fact]
+    public void Execute_LeadingPeriodHeaderInCurrencyColumn_ShiftsHeaderAndRemovesWholeColumn()
+    {
+        var parser = new HtmlParser();
+        var step = new CurrencyConsolidationStep();
+        var doc = parser.ParseDocument(
+            "<html><body><table>"
+                + "<tr><td>Jan 25, 2026</td><td></td><td>Jan 26, 2025</td><td></td></tr>"
+                + "<tr><td>$</td><td>193,479</td><td>$</td><td>116,193</td></tr>"
+                + "<tr><td></td><td>22,459</td><td></td><td>14,304</td></tr>"
+                + "</table></body></html>"
+        );
+
+        step.Execute(doc);
+
+        var rows = doc.QuerySelectorAll("tr");
+        rows.Should().AllSatisfy(row => row.QuerySelectorAll("td").Should().HaveCount(2));
+        rows[0]
+            .QuerySelectorAll("td")
+            .Select(cell => cell.TextContent.Trim())
+            .Should()
+            .Equal("Jan 25, 2026", "Jan 26, 2025");
+        rows[1]
+            .QuerySelectorAll("td")
+            .Select(cell => cell.TextContent.Trim())
+            .Should()
+            .Equal("193,479", "116,193");
+        rows[2]
+            .QuerySelectorAll("td")
+            .Select(cell => cell.TextContent.Trim())
+            .Should()
+            .Equal("22,459", "14,304");
+    }
+
+    [Fact]
+    public void Execute_MixedForeignDollarSymbol_PreservesColumnAndDoesNotAddUsdNote()
+    {
+        var parser = new HtmlParser();
+        var step = new CurrencyConsolidationStep();
+        var doc = parser.ParseDocument(
+            "<html><body><table>"
+                + "<tr><td>$</td><td>100</td></tr>"
+                + "<tr><td>C$</td><td></td></tr>"
+                + "</table></body></html>"
+        );
+
+        step.Execute(doc);
+
+        var rows = doc.QuerySelectorAll("tr");
+        rows.Should().AllSatisfy(row => row.QuerySelectorAll("td").Should().HaveCount(2));
+        rows[0].QuerySelectorAll("td")[0].TextContent.Should().Be("$");
+        rows[1].QuerySelectorAll("td")[0].TextContent.Should().Be("C$");
+        doc.Body.TextContent.Should().NotContain("All values are in US Dollars");
+    }
+
+    [Fact]
+    public void Execute_SeparateUsdAndForeignDollarColumns_DoesNotAddTableWideUsdNote()
+    {
+        var parser = new HtmlParser();
+        var step = new CurrencyConsolidationStep();
+        var doc = parser.ParseDocument(
+            "<html><body><table>"
+                + "<tr><td>$</td><td>100</td><td>C$</td><td></td></tr>"
+                + "<tr><td>$</td><td>200</td><td>C$</td><td></td></tr>"
+                + "</table></body></html>"
+        );
+
+        step.Execute(doc);
+
+        var rows = doc.QuerySelectorAll("tr");
+        rows.Should().AllSatisfy(row => row.QuerySelectorAll("td").Should().HaveCount(3));
+        rows.Should()
+            .AllSatisfy(row => row.QuerySelectorAll("td")[1].TextContent.Should().Be("C$"));
+        doc.Body.TextContent.Should().NotContain("All values are in US Dollars");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SecDocumentTablePipelineTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentTablePipelineTests.cs
@@ -1,0 +1,35 @@
+using Equibles.Sec.BusinessLogic;
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.BusinessLogic.Tokenization;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentTablePipelineTests
+{
+    [Fact]
+    public void NormalizeAndConvert_NvidiaSegmentTable_PreservesRowsAndPeriodColumns()
+    {
+        var submission = File.ReadAllText(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "TestAssets",
+                "Sec",
+                "nvda-2026-segment-table.html"
+            )
+        );
+
+        var normalized = new SecDocumentHtmlNormalizer().Normalize(submission);
+        var markdown = new SecDocumentHtmlToMarkdownConverter().Convert(normalized);
+        var tableLines = markdown.Split('\n').Where(line => line.StartsWith('|')).ToList();
+
+        tableLines.Should().HaveCount(7);
+        tableLines[2].Should().Contain("Jan 25, 2026").And.Contain("Jan 26, 2025");
+        tableLines[4].Should().Be("| Compute & Networking | 193,479 | 116,193 | 77,286 | 67 | % |");
+        tableLines[5].Should().Be("| Graphics | 22,459 | 14,304 | 8,155 | 57 | % |");
+        tableLines[6].Should().Be("| Total | 215,938 | 130,497 | 85,441 | 65 | % |");
+
+        var chunks = new ChunkingStrategy(new TokenCounter()).SplitIntoChunks(markdown);
+        chunks.Should().ContainSingle();
+        chunks[0].Content.Should().Contain("77,286 | 67 | % |\n| Graphics | 22,459");
+    }
+}

--- a/tests/Equibles.UnitTests/TestAssets/Sec/nvda-2026-segment-table.html
+++ b/tests/Equibles.UnitTests/TestAssets/Sec/nvda-2026-segment-table.html
@@ -1,0 +1,17 @@
+<!-- Trimmed from NVIDIA 2026 10-K accession 0001045810-26-000021. Non-structural styles removed. -->
+<DOCUMENT>
+<TYPE>10-K
+<FILENAME>nvda-20260125.htm
+<TEXT>
+<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL"><body><table>
+<tr><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td colspan="3"></td><td colspan="21">Year Ended</td></tr>
+<tr><td colspan="3"></td><td colspan="3">Jan 25, 2026</td><td colspan="3"></td><td colspan="3">Jan 26, 2025</td><td colspan="3"></td><td colspan="3">$<br/>Change</td><td colspan="3"></td><td colspan="3">%<br/>Change</td></tr>
+<tr style="height:3pt"><td colspan="3"></td><td colspan="3"></td><td colspan="3"></td><td colspan="3"></td><td colspan="3"></td><td colspan="3"></td><td colspan="3"></td><td colspan="3"></td></tr>
+<tr><td colspan="3"></td><td colspan="21">($ in millions)</td></tr>
+<tr><td colspan="3"><div>Compute &amp; Networking</div></td><td>$</td><td><ix:nonFraction contextRef="c-1" name="nvda:Revenue">193,479&#160;</ix:nonFraction></td><td></td><td colspan="3"></td><td>$</td><td><ix:nonFraction contextRef="c-9" name="nvda:Revenue">116,193&#160;</ix:nonFraction></td><td></td><td colspan="3"></td><td>$</td><td>77,286&#160;</td><td></td><td colspan="3"></td><td colspan="2">67&#160;</td><td>%</td></tr>
+<tr><td colspan="3">Graphics</td><td colspan="2"><ix:nonFraction contextRef="c-1" name="nvda:Revenue">22,459&#160;</ix:nonFraction></td><td></td><td colspan="3"></td><td colspan="2"><ix:nonFraction contextRef="c-9" name="nvda:Revenue">14,304&#160;</ix:nonFraction></td><td></td><td colspan="3"></td><td colspan="2">8,155&#160;</td><td></td><td colspan="3"></td><td colspan="2">57&#160;</td><td>%</td></tr>
+<tr><td colspan="3">Total</td><td>$</td><td>215,938&#160;</td><td></td><td colspan="3"></td><td>$</td><td>130,497&#160;</td><td></td><td colspan="3"></td><td>$</td><td>85,441&#160;</td><td></td><td colspan="3"></td><td colspan="2">65&#160;</td><td>%</td></tr>
+</table></body></html>
+</TEXT>
+</DOCUMENT>


### PR DESCRIPTION
## Summary

- preserve Workiva table cells and fiscal-period alignment during currency-column normalization
- retain Markdown row boundaries in generated RAG chunks
- add an opt-in, bounded, retry-capped backfill for stored EDGAR text and chunks
- add financial-schema migration and real PostgreSQL coverage for replacement, rechunking, cleanup, retry, and concurrency

## Verification

- dotnet build Equibles.sln -c Release
- 4,565 unit tests passed
- 499 SEC integration tests passed
- CSharpier check passed
- EF pending-model check passed
- independent review passed

Refs #4174