### PR TITLE
fix(finra): disclose unreliable weekly history

### DIFF
--- a/docs/guide/how-to-ask-about-off-exchange-volume.md
+++ b/docs/guide/how-to-ask-about-off-exchange-volume.md
@@ -23,6 +23,8 @@ If you don't give dates, the assistant defaults to the last six months (about 26
 
 The FINRA file reports only the off-exchange numbers — it does not include consolidated tape (total market) volume, so the assistant cannot tell you what *share* of a stock's overall volume traded off-exchange. To compute that share, compare these figures against a total-volume source such as the stock's daily price history.
 
+Weeks before 2025-08-11 may include volume from a case-variant sibling security. Those weeks predate the ordinal FINRA symbol-map fix and have aged out of FINRA's rolling source window, so they cannot be re-imported. The tool adds this caveat whenever a response includes an affected week.
+
 ## What you should see
 
 A Markdown table in the assistant's reply, one row per week, oldest to newest. If it comes back empty, either the stock has no reported off-exchange activity in that window or the FINRA scraper hasn't imported it yet — confirm your FINRA API key is set and give the worker time to finish its first sync.

--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -145,7 +145,7 @@ never substitutes `BRK-B`; dot share-class spelling such as `BRK.A` resolves to 
 
 `OffExchangeVolumeTools`:
 
-- `GetOffExchangeVolume` — weekly off-exchange (dark-pool / OTC) volume per ticker from FINRA OTC/ATS Transparency data: ATS volume and trade count, non-ATS OTC volume and trade count, and the ATS + non-ATS OTC total.
+- `GetOffExchangeVolume` — weekly off-exchange (dark-pool / OTC) volume per ticker from FINRA OTC/ATS Transparency data: ATS volume and trade count, non-ATS OTC volume and trade count, and the ATS + non-ATS OTC total. Responses containing a week before 2025-08-11 warn that the historical row may include volume from a case-variant sibling security that can no longer be re-imported.
 
 ### `mcp.AddCftc()` — CFTC Commitments of Traders
 

--- a/src/Equibles.Finra.Data/Models/OffExchangeVolumeCoverage.cs
+++ b/src/Equibles.Finra.Data/Models/OffExchangeVolumeCoverage.cs
@@ -1,0 +1,23 @@
+using System.Globalization;
+
+namespace Equibles.Finra.Data.Models;
+
+public static class OffExchangeVolumeCoverage
+{
+    // The ordinal symbol-map fix first re-imported the rolling FINRA window beginning here.
+    // Older weeks had already aged out and cannot be repaired from the source.
+    public const string CorrectedSymbolResolutionStartWeekIso = "2025-08-11";
+    public static readonly DateOnly CorrectedSymbolResolutionStartWeek = DateOnly.ParseExact(
+        CorrectedSymbolResolutionStartWeekIso,
+        "yyyy-MM-dd",
+        CultureInfo.InvariantCulture
+    );
+
+    public const string HistoricalCaseFoldCaveat =
+        "Weeks before "
+        + CorrectedSymbolResolutionStartWeekIso
+        + " may include volume from a case-variant sibling security because they predate the ordinal FINRA symbol-map fix and can no longer be re-imported from FINRA's rolling source window.";
+
+    public static bool MayIncludeCaseFoldedSiblingVolume(DateOnly weekStartDate) =>
+        weekStartDate < CorrectedSymbolResolutionStartWeek;
+}

--- a/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
@@ -42,6 +42,8 @@ public class OffExchangeVolumeTools
             + "Each week shows ATS (alternative trading system / dark pool) volume and trade count, non-ATS OTC volume and trade count, "
             + "and the total off-exchange volume (ATS + non-ATS OTC). The FINRA file does not include consolidated tape volume, so the "
             + "off-exchange share of total market volume is not reported here; compute that share elsewhere against a consolidated-volume source. "
+            + OffExchangeVolumeCoverage.HistoricalCaseFoldCaveat
+            + " "
             + "FINRA publishes each week on a delay (2 weeks for Tier 1 NMS stocks, longer for other tiers), so the latest week lags today."
     )]
     public Task<string> GetOffExchangeVolume(
@@ -92,7 +94,12 @@ public class OffExchangeVolumeTools
                     r => RenderOffExchangeRow($"{r.WeekStartDate:yyyy-MM-dd}", r)
                 );
 
-                return AppendNote(table, NewestKeptNote(records.Count, total, "weeks"));
+                var notes = new[]
+                {
+                    HistoricalCoverageNote(records),
+                    NewestKeptNote(records.Count, total, "weeks"),
+                };
+                return AppendNotes(table, notes);
             },
             "GetOffExchangeVolume",
             $"ticker: {ticker}"
@@ -151,10 +158,20 @@ public class OffExchangeVolumeTools
             ? string.Empty
             : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
 
-    // Appends a note line under a rendered table (blank line first so strict CommonMark
-    // renderers keep the table intact); a no-op for the empty note or an empty-state message.
-    private static string AppendNote(string table, string note) =>
-        note.Length == 0 ? table : $"{table}\n{note}\n";
+    private static string HistoricalCoverageNote(IReadOnlyCollection<OffExchangeVolume> records) =>
+        records.Any(record =>
+            OffExchangeVolumeCoverage.MayIncludeCaseFoldedSiblingVolume(record.WeekStartDate)
+        )
+            ? $"_Historical data caveat: {OffExchangeVolumeCoverage.HistoricalCaseFoldCaveat}_"
+            : string.Empty;
+
+    // Appends note lines under a rendered table (blank line first so strict CommonMark
+    // renderers keep the table intact); a no-op when every note is empty.
+    private static string AppendNotes(string table, IEnumerable<string> notes)
+    {
+        var renderedNotes = notes.Where(note => note.Length > 0).ToList();
+        return renderedNotes.Count == 0 ? table : $"{table}\n{string.Join("\n", renderedNotes)}\n";
+    }
 
     // Render with InvariantCulture so the MCP markdown does not fork the separators by host
     // locale (e.g. de-DE would render 5.000.000 instead of 5,000,000). Total off-exchange

--- a/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsStrictDatesAndTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsStrictDatesAndTruncationTests.cs
@@ -118,4 +118,50 @@ public class OffExchangeVolumeToolsStrictDatesAndTruncationTests : ParadeDbMcpTe
 
         result.Should().NotContain("Showing the newest");
     }
+
+    [Fact]
+    public async Task GetOffExchangeVolume_AffectedHistoricalWeek_AppendsCoverageCaveat()
+    {
+        var stock = AddGme();
+        AddWeek(stock, OffExchangeVolumeCoverage.CorrectedSymbolResolutionStartWeek.AddDays(-7));
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOffExchangeVolume("GME", startDate: "2025-08-01", endDate: "2025-08-10");
+
+        result.Should().Contain(OffExchangeVolumeCoverage.HistoricalCaseFoldCaveat);
+    }
+
+    [Fact]
+    public async Task GetOffExchangeVolume_CorrectedBoundaryWeek_HasNoCoverageCaveat()
+    {
+        var stock = AddGme();
+        AddWeek(stock, OffExchangeVolumeCoverage.CorrectedSymbolResolutionStartWeek);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOffExchangeVolume("GME", startDate: "2025-08-11", endDate: "2025-08-17");
+
+        result.Should().NotContain("Historical data caveat");
+    }
+
+    [Fact]
+    public async Task GetOffExchangeVolume_AffectedWeekExcludedByLimit_HasNoCoverageCaveat()
+    {
+        var stock = AddGme();
+        AddWeek(stock, OffExchangeVolumeCoverage.CorrectedSymbolResolutionStartWeek.AddDays(-7));
+        AddWeek(stock, OffExchangeVolumeCoverage.CorrectedSymbolResolutionStartWeek);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOffExchangeVolume(
+                "GME",
+                startDate: "2025-08-01",
+                endDate: "2025-08-17",
+                maxResults: 1
+            );
+
+        result.Should().NotContain("Historical data caveat");
+        result.Should().Contain("Showing the newest 1 of 2 weeks");
+    }
 }

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeCoverageTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeCoverageTests.cs
@@ -1,0 +1,26 @@
+using Equibles.Finra.Data.Models;
+using Xunit;
+
+namespace Equibles.UnitTests.Finra;
+
+public class OffExchangeVolumeCoverageTests
+{
+    [Fact]
+    public void MayIncludeCaseFoldedSiblingVolume_WeekBeforeBoundary_ReturnsTrue()
+    {
+        var week = OffExchangeVolumeCoverage.CorrectedSymbolResolutionStartWeek.AddDays(-7);
+
+        OffExchangeVolumeCoverage.MayIncludeCaseFoldedSiblingVolume(week).Should().BeTrue();
+    }
+
+    [Fact]
+    public void MayIncludeCaseFoldedSiblingVolume_BoundaryWeek_ReturnsFalse()
+    {
+        OffExchangeVolumeCoverage
+            .MayIncludeCaseFoldedSiblingVolume(
+                OffExchangeVolumeCoverage.CorrectedSymbolResolutionStartWeek
+            )
+            .Should()
+            .BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Disclose the unrecoverable case-fold risk on weekly off-exchange rows before 2025-08-11. This is the OSS foundation for #4311; the commercial surfaces will consume the same coverage contract before the issue is closed.

## Code changes

- Centralize the corrected-history boundary and caveat in `OffExchangeVolumeCoverage`.
- Append the warning only when returned MCP rows include an affected week.
- Document the historical limitation in the guide and technical reference.
- Cover the cutoff boundary and truncated-result behavior with unit and integration tests.