### PR TITLE
fix(sec): restate per-share facts after stock splits

### DIFF
--- a/src/Equibles.CorporateActions.Data/SplitAdjustment.cs
+++ b/src/Equibles.CorporateActions.Data/SplitAdjustment.cs
@@ -73,4 +73,22 @@ public static class SplitAdjustment
         var f = ShareCountFactor(asOf, splits);
         return f == 0m ? 1m : 1m / f;
     }
+
+    /// <summary>
+    /// Restates a per-share value filed on <paramref name="filedDate"/> onto today's share
+    /// basis. Filings issued after a split already restate comparative per-share figures, so
+    /// only splits effective strictly after the filing date move the value.
+    /// </summary>
+    public static decimal AdjustPerShareValue(
+        decimal value,
+        DateOnly filedDate,
+        IEnumerable<StockSplit> splits
+    ) => AdjustPerShareValue(value, ShareCountFactor(filedDate, splits));
+
+    /// <summary>
+    /// Restates a per-share value using an already-computed share-count factor. A zero factor
+    /// leaves the value unchanged rather than dividing by zero.
+    /// </summary>
+    public static decimal AdjustPerShareValue(decimal value, decimal shareCountFactor) =>
+        shareCountFactor == 0m ? value : value / shareCountFactor;
 }

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Equibles.Sec.FinancialFacts.Mcp.csproj
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Equibles.Sec.FinancialFacts.Mcp.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.BusinessLogic\Equibles.Sec.FinancialFacts.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Repositories\Equibles.Sec.FinancialFacts.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CorporateActions.Repositories\Equibles.CorporateActions.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FinancialFactSplitAdjustment.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FinancialFactSplitAdjustment.cs
@@ -1,0 +1,32 @@
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+internal static class FinancialFactSplitAdjustment
+{
+    internal const string Note =
+        "Per-share values are split-adjusted to today's share basis using splits effective "
+        + "strictly after each fact's Filed date.";
+
+    internal static bool IsPerShare(FinancialFact fact) =>
+        fact.Unit?.Contains('/', StringComparison.Ordinal) == true;
+
+    internal static decimal Restate(
+        FinancialFact fact,
+        IReadOnlyList<StockSplit> splits,
+        out bool adjusted
+    )
+    {
+        if (!IsPerShare(fact))
+        {
+            adjusted = false;
+            return fact.Value;
+        }
+
+        var factor = SplitAdjustment.ShareCountFactor(fact.FiledDate, splits);
+        adjusted = factor != 0m && factor != 1m;
+        return SplitAdjustment.AdjustPerShareValue(fact.Value, factor);
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -6,6 +6,8 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -34,12 +36,14 @@ public class FinancialFactsTools
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
     private readonly McpToolRunner _runner;
 
     public FinancialFactsTools(
         FinancialFactRepository financialFactRepository,
         FinancialConceptRepository financialConceptRepository,
         CommonStockRepository commonStockRepository,
+        StockSplitRepository stockSplitRepository,
         ErrorManager errorManager,
         ILogger<FinancialFactsTools> logger
     )
@@ -47,6 +51,7 @@ public class FinancialFactsTools
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
         _commonStockRepository = commonStockRepository;
+        _stockSplitRepository = stockSplitRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -193,13 +198,20 @@ public class FinancialFactsTools
                 if (shown.Count == 0)
                     return $"No '{concept}' data found for {stock.Ticker} with the given filters.";
 
+                var splits = shown.Any(FinancialFactSplitAdjustment.IsPerShare)
+                    ? await _stockSplitRepository
+                        .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                        .ToListAsync()
+                    : [];
+
                 return RenderFactHistoryTable(
                     concept,
                     stock,
                     asOriginallyReported,
                     shown,
                     perPeriod.Count,
-                    coverageNote
+                    coverageNote,
+                    splits
                 );
             },
             "GetFinancialFact",
@@ -321,8 +333,32 @@ public class FinancialFactsTools
                     .ToDictionary(item => item.StockId, item => item.Fact);
 
                 var (rows, skipped) = BuildComparisonRows(requested, stockByTicker, bestByStock);
+                var splitAdjustedStockIds = rows.Where(row =>
+                        FinancialFactSplitAdjustment.IsPerShare(row.Fact)
+                    )
+                    .Select(row => row.Fact.CommonStockId)
+                    .Distinct()
+                    .ToList();
+                var splitsByStock =
+                    splitAdjustedStockIds.Count == 0
+                        ? new Dictionary<Guid, List<StockSplit>>()
+                        : (
+                            await _stockSplitRepository
+                                .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
+                                .Where(split => splitAdjustedStockIds.Contains(split.CommonStockId))
+                                .ToListAsync()
+                        )
+                            .GroupBy(split => split.CommonStockId)
+                            .ToDictionary(group => group.Key, group => group.ToList());
 
-                return RenderComparisonTable(concept, fiscalYear, period, rows, skipped);
+                return RenderComparisonTable(
+                    concept,
+                    fiscalYear,
+                    period,
+                    rows,
+                    skipped,
+                    splitsByStock
+                );
             },
             "CompareFinancialFact",
             $"tickers: {FactMarkdown.Clean(tickers)}, concept: {FactMarkdown.Clean(concept)}, "
@@ -336,7 +372,8 @@ public class FinancialFactsTools
         bool asOriginallyReported,
         List<FinancialFact> perPeriod,
         int totalPeriods,
-        string coverageNote
+        string coverageNote,
+        IReadOnlyList<StockSplit> splits
     )
     {
         var basis = asOriginallyReported ? "as originally reported" : "latest restated";
@@ -345,17 +382,25 @@ public class FinancialFactsTools
             "| Period Start | Period End | FY | Period | Value | Unit | Form | Filed | Accession |",
             "|--------------|------------|---:|--------|------:|------|------|-------|-----------|"
         );
+        var splitAdjusted = false;
         result.AppendRows(
             perPeriod,
             f =>
-                $"| {f.PeriodStart:yyyy-MM-dd} | {f.PeriodEnd:yyyy-MM-dd} | {f.FiscalYear} | "
-                + $"{f.FiscalPeriod.NameForHumans()} | "
-                + $"{FactMarkdown.Value(f.Value, f.Unit)} | "
-                + $"{FactMarkdown.Cell(f.Unit)} | "
-                + $"{FactMarkdown.Cell(f.Form?.DisplayName)} | "
-                + $"{f.FiledDate:yyyy-MM-dd} | "
-                + $"{FactMarkdown.Cell(f.AccessionNumber)} |"
+            {
+                var value = FinancialFactSplitAdjustment.Restate(f, splits, out var adjusted);
+                splitAdjusted |= adjusted;
+                return $"| {f.PeriodStart:yyyy-MM-dd} | {f.PeriodEnd:yyyy-MM-dd} | {f.FiscalYear} | "
+                    + $"{f.FiscalPeriod.NameForHumans()} | "
+                    + $"{FactMarkdown.Value(value, f.Unit)} | "
+                    + $"{FactMarkdown.Cell(f.Unit)} | "
+                    + $"{FactMarkdown.Cell(f.Form?.DisplayName)} | "
+                    + $"{f.FiledDate:yyyy-MM-dd} | "
+                    + $"{FactMarkdown.Cell(f.AccessionNumber)} |";
+            }
         );
+
+        if (splitAdjusted)
+            result.AppendLine($"\n_{FinancialFactSplitAdjustment.Note}_");
 
         // Rows are newest first, so "first N" reads correctly; a no-op empty
         // line when nothing was cut off.
@@ -504,7 +549,8 @@ public class FinancialFactsTools
         int fiscalYear,
         SecFiscalPeriod period,
         List<(string Ticker, string Name, FinancialFact Fact)> rows,
-        List<string> skipped
+        List<string> skipped,
+        IReadOnlyDictionary<Guid, List<StockSplit>> splitsByStock
     )
     {
         var result = MarkdownTable.Start(
@@ -512,16 +558,25 @@ public class FinancialFactsTools
             "| Ticker | Company | Value | Unit | Period End | Form | Filed |",
             "|--------|---------|------:|------|-----------|------|-------|"
         );
+        var splitAdjusted = false;
         result.AppendRows(
             rows,
             r =>
-                $"| {FactMarkdown.Cell(r.Ticker)} | {FactMarkdown.Cell(r.Name)} | "
-                + $"{FactMarkdown.Value(r.Fact.Value, r.Fact.Unit)} | "
-                + $"{FactMarkdown.Cell(r.Fact.Unit)} | "
-                + $"{r.Fact.PeriodEnd:yyyy-MM-dd} | "
-                + $"{FactMarkdown.Cell(r.Fact.Form?.DisplayName)} | "
-                + $"{r.Fact.FiledDate:yyyy-MM-dd} |"
+            {
+                var splits = splitsByStock.GetValueOrDefault(r.Fact.CommonStockId) ?? [];
+                var value = FinancialFactSplitAdjustment.Restate(r.Fact, splits, out var adjusted);
+                splitAdjusted |= adjusted;
+                return $"| {FactMarkdown.Cell(r.Ticker)} | {FactMarkdown.Cell(r.Name)} | "
+                    + $"{FactMarkdown.Value(value, r.Fact.Unit)} | "
+                    + $"{FactMarkdown.Cell(r.Fact.Unit)} | "
+                    + $"{r.Fact.PeriodEnd:yyyy-MM-dd} | "
+                    + $"{FactMarkdown.Cell(r.Fact.Form?.DisplayName)} | "
+                    + $"{r.Fact.FiledDate:yyyy-MM-dd} |";
+            }
         );
+
+        if (splitAdjusted)
+            result.AppendLine($"\n_{FinancialFactSplitAdjustment.Note}_");
 
         if (rows.Count == 0)
             result.AppendLine(

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -3,6 +3,8 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -25,12 +27,14 @@ public class FinancialStatementTools
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
     private readonly McpToolRunner _runner;
 
     public FinancialStatementTools(
         FinancialFactRepository financialFactRepository,
         FinancialConceptRepository financialConceptRepository,
         CommonStockRepository commonStockRepository,
+        StockSplitRepository stockSplitRepository,
         ErrorManager errorManager,
         ILogger<FinancialStatementTools> logger
     )
@@ -38,6 +42,7 @@ public class FinancialStatementTools
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
         _commonStockRepository = commonStockRepository;
+        _stockSplitRepository = stockSplitRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -168,6 +173,11 @@ public class FinancialStatementTools
                     facts,
                     selectedPeriod
                 );
+                var splits = latestByConcept.Values.Any(FinancialFactSplitAdjustment.IsPerShare)
+                    ? await _stockSplitRepository
+                        .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                        .ToListAsync()
+                    : [];
 
                 return RenderStatementTable(
                     stock,
@@ -176,7 +186,8 @@ public class FinancialStatementTools
                     selectedPeriod,
                     statementLines,
                     conceptIdByKey,
-                    latestByConcept
+                    latestByConcept,
+                    splits
                 );
             },
             "GetFinancialStatement",
@@ -192,7 +203,8 @@ public class FinancialStatementTools
         SecFiscalPeriod selectedPeriod,
         IReadOnlyList<StatementLine> statementLines,
         Dictionary<(FactTaxonomy Taxonomy, string Tag), Guid> conceptIdByKey,
-        Dictionary<Guid, FinancialFact> latestByConcept
+        Dictionary<Guid, FinancialFact> latestByConcept,
+        IReadOnlyList<StockSplit> splits
     )
     {
         var result = MarkdownTable.Start(
@@ -205,6 +217,7 @@ public class FinancialStatementTools
 
         var rendered = 0;
         var omitted = 0;
+        var splitAdjusted = false;
         DateOnly? earliestFiled = null;
         DateOnly? latestFiled = null;
         foreach (var line in statementLines)
@@ -219,9 +232,11 @@ public class FinancialStatementTools
                 continue;
             }
 
+            var value = FinancialFactSplitAdjustment.Restate(fact, splits, out var adjusted);
+            splitAdjusted |= adjusted;
             result.AppendLine(
                 $"| {FactMarkdown.Cell(line.Label)} | "
-                    + $"{FactMarkdown.Value(fact.Value, fact.Unit)} | "
+                    + $"{FactMarkdown.Value(value, fact.Unit)} | "
                     + $"{FactMarkdown.Cell(fact.Unit)} | "
                     + $"{fact.PeriodStart:yyyy-MM-dd} | "
                     + $"{fact.PeriodEnd:yyyy-MM-dd} | "
@@ -244,6 +259,9 @@ public class FinancialStatementTools
             result.AppendLine(
                 "\n_Line items the filer did not report for this period are omitted._"
             );
+
+        if (splitAdjusted)
+            result.AppendLine($"\n_{FinancialFactSplitAdjustment.Note}_");
 
         if (
             selectedPeriod != SecFiscalPeriod.FullYear

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsCompareToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsCompareToolsTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
@@ -21,6 +23,7 @@ public class FinancialFactsCompareToolsTests : ParadeDbMcpTestBase
             new FinancialFactRepository(DbContext),
             new FinancialConceptRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<FinancialFactsTools>()
         );
@@ -122,6 +125,7 @@ public class FinancialFactsCompareToolsTests : ParadeDbMcpTestBase
             new FinancialFactRepository(null),
             new FinancialConceptRepository(null),
             new CommonStockRepository(null),
+            new StockSplitRepository(null),
             new Equibles.Errors.BusinessLogic.ErrorManager(null),
             NullLogger<FinancialFactsTools>()
         );
@@ -152,6 +156,57 @@ public class FinancialFactsCompareToolsTests : ParadeDbMcpTestBase
         result.Should().Contain("Skipped:");
         result.Should().Contain("GOOGL (no data)");
         result.Should().Contain("ZZZZ (not found in the tracked SEC issuer set)");
+    }
+
+    [Fact]
+    public async Task CompareFinancialFact_PerShareValue_RestatesEachCompanyAcrossItsSplits()
+    {
+        var alphabet = AddStock("GOOGL", "Alphabet Inc.");
+        var dilutedEps = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "EarningsPerShareDiluted",
+            Label = "Diluted EPS",
+        };
+        DbContext.Set<FinancialConcept>().Add(dilutedEps);
+        DbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStockId = alphabet.Id,
+                    EffectiveDate = new DateOnly(2022, 7, 18),
+                    Numerator = 20m,
+                    Denominator = 1m,
+                }
+            );
+        DbContext
+            .Set<FinancialFact>()
+            .Add(
+                new FinancialFact
+                {
+                    CommonStockId = alphabet.Id,
+                    FinancialConceptId = dilutedEps.Id,
+                    Unit = "USD/shares",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(2021, 1, 1),
+                    PeriodEnd = new DateOnly(2021, 12, 31),
+                    Value = 20m,
+                    FiscalYear = 2021,
+                    FiscalPeriod = SecFiscalPeriod.FullYear,
+                    Form = DocumentType.TenK,
+                    FiledDate = new DateOnly(2022, 2, 2),
+                    AccessionNumber = "googl-fy21",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().CompareFinancialFact("GOOGL", "eps-diluted", 2021);
+
+        result.Should().Contain("| GOOGL | Alphabet Inc. | $1.00 | USD/shares |");
+        result.Should().NotContain("| $20.00 | USD/shares |");
+        result.Should().Contain("Per-share values are split-adjusted");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsComparativeWindowLeakTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsComparativeWindowLeakTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
@@ -29,6 +30,7 @@ public class FinancialFactsToolsComparativeWindowLeakTests : ParadeDbMcpTestBase
             new FinancialFactRepository(DbContext),
             new FinancialConceptRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<FinancialFactsTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
@@ -21,6 +23,7 @@ public class FinancialFactsToolsTests : ParadeDbMcpTestBase
             new FinancialFactRepository(DbContext),
             new FinancialConceptRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<FinancialFactsTools>()
         );
@@ -109,6 +112,75 @@ public class FinancialFactsToolsTests : ParadeDbMcpTestBase
         var result = await Sut().GetFinancialFact("AAPL", "revenue");
 
         result.Should().Contain("No 'revenue' data has been ingested for AAPL");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_PerShareHistory_RestatesValuesFiledBeforeSplit()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "GOOGL",
+            Name = "Alphabet Inc.",
+            Cik = "0001652044",
+        };
+        var dilutedEps = AddConcept("EarningsPerShareDiluted");
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStockId = stock.Id,
+                    EffectiveDate = new DateOnly(2022, 7, 18),
+                    Numerator = 20m,
+                    Denominator = 1m,
+                }
+            );
+        DbContext
+            .Set<FinancialFact>()
+            .AddRange(
+                new FinancialFact
+                {
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = dilutedEps.Id,
+                    Unit = "USD/shares",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(2022, 1, 1),
+                    PeriodEnd = new DateOnly(2022, 3, 31),
+                    Value = 24.62m,
+                    FiscalYear = 2022,
+                    FiscalPeriod = SecFiscalPeriod.Q1,
+                    Form = DocumentType.TenQ,
+                    FiledDate = new DateOnly(2022, 4, 26),
+                    AccessionNumber = "googl-q1",
+                },
+                new FinancialFact
+                {
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = dilutedEps.Id,
+                    Unit = "USD/shares",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(2022, 7, 1),
+                    PeriodEnd = new DateOnly(2022, 9, 30),
+                    Value = 1.06m,
+                    FiscalYear = 2022,
+                    FiscalPeriod = SecFiscalPeriod.Q3,
+                    Form = DocumentType.TenQ,
+                    FiledDate = new DateOnly(2022, 10, 26),
+                    AccessionNumber = "googl-q3",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("GOOGL", "eps-diluted");
+
+        result
+            .Should()
+            .Contain("| $1.23 | USD/shares |", "24.62 is restated across the 20:1 split");
+        result.Should().Contain("| $1.06 | USD/shares |", "the post-split filing stays unchanged");
+        result.Should().NotContain("| $24.62 | USD/shares |");
+        result.Should().Contain("Per-share values are split-adjusted");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsFullYearOutranksQ4Tests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsFullYearOutranksQ4Tests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
@@ -33,6 +34,7 @@ public class FinancialStatementToolsFullYearOutranksQ4Tests : ParadeDbMcpTestBas
             new FinancialFactRepository(DbContext),
             new FinancialConceptRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<FinancialStatementTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsQ4AndScopingTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsQ4AndScopingTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
@@ -29,6 +30,7 @@ public class FinancialStatementToolsQ4AndScopingTests : ParadeDbMcpTestBase
             new FinancialFactRepository(DbContext),
             new FinancialConceptRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<FinancialStatementTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
@@ -1,5 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
@@ -22,6 +24,7 @@ public class FinancialStatementToolsTests : ParadeDbMcpTestBase
             new FinancialFactRepository(DbContext),
             new FinancialConceptRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<FinancialStatementTools>()
         );
@@ -257,6 +260,64 @@ public class FinancialStatementToolsTests : ParadeDbMcpTestBase
         var result = await Sut().GetFinancialStatement("AAPL", statement: "income");
 
         result.Should().Contain("| EPS (Diluted) | $6.13 | USD/shares |");
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_PerShareLine_RestatesAcrossSplitWithoutChangingDollarLines()
+    {
+        var stock = Apple();
+        var revenue = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenue",
+        };
+        var dilutedEps = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "EarningsPerShareDiluted",
+            Label = "Diluted EPS",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<FinancialConcept>().AddRange(revenue, dilutedEps);
+        DbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStockId = stock.Id,
+                    EffectiveDate = new DateOnly(2022, 6, 1),
+                    Numerator = 4m,
+                    Denominator = 1m,
+                }
+            );
+        await SeedRevenue(
+            stock,
+            revenue,
+            2021,
+            SecFiscalPeriod.FullYear,
+            100_000_000m,
+            "USD",
+            "revenue"
+        );
+        await SeedRevenue(
+            stock,
+            dilutedEps,
+            2021,
+            SecFiscalPeriod.FullYear,
+            8m,
+            "USD/shares",
+            "eps"
+        );
+
+        var result = await Sut().GetFinancialStatement("AAPL", statement: "income", year: 2021);
+
+        result.Should().Contain("| Revenue | $100,000,000 | USD |");
+        result.Should().Contain("| EPS (Diluted) | $2.00 | USD/shares |");
+        result.Should().NotContain("| EPS (Diluted) | $8.00 | USD/shares |");
+        result.Should().Contain("Per-share values are split-adjusted");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/CorporateActions/SplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/SplitAdjustmentTests.cs
@@ -64,6 +64,24 @@ public class SplitAdjustmentTests
     }
 
     [Fact]
+    public void AdjustPerShareValue_FilingBeforeSplits_DividesByCompoundedShareFactor()
+    {
+        SplitAdjustment
+            .AdjustPerShareValue(120m, new DateOnly(2021, 1, 1), NvdaSplits)
+            .Should()
+            .Be(3m);
+    }
+
+    [Fact]
+    public void AdjustPerShareValue_FilingOnSplitDate_TreatsValueAsAlreadyRestated()
+    {
+        SplitAdjustment
+            .AdjustPerShareValue(3m, new DateOnly(2024, 6, 10), NvdaSplits)
+            .Should()
+            .Be(3m);
+    }
+
+    [Fact]
     public void ShareCountFactor_ReverseSplit_ShrinksPreSplitCount()
     {
         StockSplit[] splits =

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderComparisonTableEmptyWithSkippedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderComparisonTableEmptyWithSkippedTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Mcp.Tools;
@@ -44,7 +45,17 @@ public class FinancialFactsToolsRenderComparisonTableEmptyWithSkippedTests
         var skipped = new List<string> { "AAPL", "MSFT" };
 
         var result = (string)
-            method.Invoke(null, ["Revenues", 2024, SecFiscalPeriod.FullYear, rows, skipped]);
+            method.Invoke(
+                null,
+                [
+                    "Revenues",
+                    2024,
+                    SecFiscalPeriod.FullYear,
+                    rows,
+                    skipped,
+                    new Dictionary<Guid, List<StockSplit>>(),
+                ]
+            );
 
         result.Should().Contain("No company reported");
         result.Should().Contain("AAPL");

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderComparisonTablePeriodEndTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderComparisonTablePeriodEndTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
@@ -43,7 +44,14 @@ public class FinancialFactsToolsRenderComparisonTablePeriodEndTests
         return (string)
             method.Invoke(
                 null,
-                ["eps-diluted", 2025, SecFiscalPeriod.Q2, tableRows, new List<string>()]
+                [
+                    "eps-diluted",
+                    2025,
+                    SecFiscalPeriod.Q2,
+                    tableRows,
+                    new List<string>(),
+                    new Dictionary<Guid, List<StockSplit>>(),
+                ]
             );
     }
 

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableLatestRestatedLabelTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableLatestRestatedLabelTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Mcp.Tools;
 
@@ -57,7 +58,11 @@ public class FinancialFactsToolsRenderFactHistoryTableLatestRestatedLabelTests
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
         var perPeriod = new List<FinancialFact>();
 
-        var result = (string)method.Invoke(null, ["Revenues", stock, false, perPeriod, 0, null]);
+        var result = (string)
+            method.Invoke(
+                null,
+                ["Revenues", stock, false, perPeriod, 0, null, Array.Empty<StockSplit>()]
+            );
 
         result.Should().Contain("latest restated");
         result.Should().NotContain("as originally reported");

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableOriginallyReportedLabelTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableOriginallyReportedLabelTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Mcp.Tools;
 
@@ -41,7 +42,11 @@ public class FinancialFactsToolsRenderFactHistoryTableOriginallyReportedLabelTes
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
         var perPeriod = new List<FinancialFact>();
 
-        var result = (string)method.Invoke(null, ["Revenues", stock, true, perPeriod, 0, null]);
+        var result = (string)
+            method.Invoke(
+                null,
+                ["Revenues", stock, true, perPeriod, 0, null, Array.Empty<StockSplit>()]
+            );
 
         result.Should().Contain("as originally reported");
         result.Should().NotContain("latest restated");

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableTruncationNoteTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsRenderFactHistoryTableTruncationNoteTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
@@ -39,7 +40,11 @@ public class FinancialFactsToolsRenderFactHistoryTableTruncationNoteTests
             })
             .ToList();
 
-        return (string)method.Invoke(null, ["revenue", stock, false, perPeriod, total, null]);
+        return (string)
+            method.Invoke(
+                null,
+                ["revenue", stock, false, perPeriod, total, null, Array.Empty<StockSplit>()]
+            );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Restate SEC per-share fact responses to the current split basis.
- Preserve total-dollar values and disclose adjusted output.

## Code changes

- Added filed-date-aware per-share adjustment using effective stock splits.
- Applied the adjustment to fact history, peer comparisons, and financial statements.
- Added unit and integration regression coverage for GOOGL-like splits.

Fixes #4082