### PR TITLE
fix(insider-trading): scope amendment supersession

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -119,7 +119,7 @@ public static class InsiderFilingParser
         // it the reprocess pipeline, which replays this parse, re-derives zero rows and
         // logs a phantom "stored 1 but re-parsed 0" divergence for every such filing.
         if (transactions.Count == 0 && DeclaresNoSecuritiesOwned(root))
-            AddParsed(BuildNoSecuritiesOwnedSentinel(owner, companyId, filing));
+            AddParsed(BuildNoSecuritiesOwnedSentinel(owner, companyId, filing, isAmendment));
 
         return transactions;
     }
@@ -196,7 +196,8 @@ public static class InsiderFilingParser
     internal static InsiderTransaction BuildNoSecuritiesOwnedSentinel(
         InsiderOwner owner,
         Guid companyId,
-        FilingData filing
+        FilingData filing,
+        bool isAmendment
     ) =>
         new()
         {
@@ -204,9 +205,10 @@ public static class InsiderFilingParser
             CommonStockId = companyId,
             FilingDate = filing.FilingDate,
             TransactionDate = filing.ReportDate,
-            TransactionCode = TransactionCode.Other,
+            TransactionCode = TransactionCode.Holding,
             AccessionNumber = filing.AccessionNumber,
             SecurityTitle = "No Securities Owned",
+            IsAmendment = isAmendment,
             FilingForm = ParseOwnershipForm(filing.Form),
             IsPriceValid = true,
             ParserVersion = InsiderTransaction.CurrentParserVersion,

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -92,7 +92,10 @@ public class InsiderFilingReprocessManager
         // can briefly nudge past Total and self-corrects.
         var staleTransactionFilingCount = await _transactionRepository
             .GetAll()
-            .Where(t => t.ParserVersion < InsiderTransaction.CurrentParserVersion)
+            .Where(t =>
+                t.TransactionCode != TransactionCode.IngestMarker
+                && t.ParserVersion < InsiderTransaction.CurrentParserVersion
+            )
             .Select(t => t.AccessionNumber)
             .Distinct()
             .CountAsync();
@@ -124,7 +127,10 @@ public class InsiderFilingReprocessManager
             {
                 var pending = _transactionRepository
                     .GetAll()
-                    .Where(t => t.ParserVersion < InsiderTransaction.CurrentParserVersion)
+                    .Where(t =>
+                        t.TransactionCode != TransactionCode.IngestMarker
+                        && t.ParserVersion < InsiderTransaction.CurrentParserVersion
+                    )
                     .Where(t => !failedThisRun.Contains(t.AccessionNumber));
                 var oldestParserVersion = await pending
                     .Select(t => (int?)t.ParserVersion)
@@ -398,11 +404,20 @@ public class InsiderFilingReprocessManager
             ReportDate = InsiderFilingParser.ParsePeriodOfReport(root) ?? first.TransactionDate,
         };
         var filingForm = InsiderFilingParser.ParseOwnershipForm(filing.Form);
+        var isAmendment = filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+        var originalFilingDate = isAmendment
+            ? InsiderFilingParser.ParseDateOfOriginalSubmission(root)
+            : null;
 
-        // The family is a document-level fact, so stamp every stored row even
-        // when the current parser produces fewer rows than an older version.
+        // Family and amendment identity are document-level facts, so stamp every
+        // stored row even when the current parser produces fewer rows than an
+        // older version and some rows cannot be mapped by order.
         foreach (var row in rows)
+        {
             row.FilingForm = filingForm;
+            row.IsAmendment = isAmendment;
+            row.OriginalFilingDate = originalFilingDate;
+        }
 
         var storedFiling = await _filingRepository
             .GetByAccessionNumber(accession)
@@ -418,11 +433,28 @@ public class InsiderFilingReprocessManager
             new InsiderOwner { Id = first.InsiderOwnerId },
             first.CommonStockId,
             filing,
-            first.IsAmendment
+            isAmendment
         );
         // TransactionOrder is unique within a parse by construction, so a direct
         // dictionary is safe; a duplicate would be a parser bug worth surfacing.
         var parsedByOrder = parsed.ToDictionary(t => t.TransactionOrder);
+
+        // Older ingest code manufactured an Other/"No Securities Owned" row for
+        // every valid zero-row parse. When the cached XML confirms there are still
+        // no rows, convert that fake holding into the versioned non-section marker
+        // and clear any wholesale-era claim it carried.
+        if (parsed.Count == 0 && rows.All(IsLegacyEmptyParseMarker))
+        {
+            foreach (var row in rows)
+            {
+                row.TransactionCode = TransactionCode.IngestMarker;
+                row.SecurityTitle = null;
+                row.SupersededAccessionNumber = null;
+                row.ParserVersion = InsiderTransaction.CurrentParserVersion;
+                result.Reclassified++;
+            }
+            return;
+        }
 
         // The re-parse should reproduce the stored rows exactly. If the counts
         // diverge, some stored rows won't map to a parsed row — they keep their
@@ -515,6 +547,13 @@ public class InsiderFilingReprocessManager
 
             row.ParserVersion = InsiderTransaction.CurrentParserVersion;
         }
+    }
+
+    private static bool IsLegacyEmptyParseMarker(InsiderTransaction row)
+    {
+        return row.TransactionCode == TransactionCode.Other
+            && row.SecurityTitle == "No Securities Owned"
+            && row.Shares == 0;
     }
 
     // Returns the parsed ownership root for a filing — from the cached XML when

--- a/src/Equibles.InsiderTrading.Data/Extensions/InsiderTransactionQueryableExtensions.cs
+++ b/src/Equibles.InsiderTrading.Data/Extensions/InsiderTransactionQueryableExtensions.cs
@@ -5,8 +5,9 @@ namespace Equibles.InsiderTrading.Data.Extensions;
 public static class InsiderTransactionQueryableExtensions
 {
     /// <summary>
-    /// Drops position-snapshot rows (<see cref="TransactionCode.Holding"/>) from a
-    /// transaction query. Holdings are parsed from Form 3/4/5 holding elements and
+    /// Drops non-transaction rows (<see cref="TransactionCode.Holding"/> and
+    /// <see cref="TransactionCode.IngestMarker"/>) from a transaction query.
+    /// Holdings are parsed from Form 3/4/5 holding elements and
     /// carry the insider's whole position in <see cref="InsiderTransaction.Shares"/>
     /// with no price, so listing them next to trades reads as a phantom acquisition
     /// of the entire stake. Apply on transaction lists and dollar-volume boards;
@@ -18,6 +19,9 @@ public static class InsiderTransactionQueryableExtensions
         this IQueryable<InsiderTransaction> query
     )
     {
-        return query.Where(t => t.TransactionCode != TransactionCode.Holding);
+        return query.Where(t =>
+            t.TransactionCode != TransactionCode.Holding
+            && t.TransactionCode != TransactionCode.IngestMarker
+        );
     }
 }

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -7,9 +7,8 @@ namespace Equibles.InsiderTrading.Data.Models;
 [Index(nameof(CommonStockId), nameof(TransactionDate))]
 [Index(nameof(InsiderOwnerId), nameof(TransactionDate))]
 [Index(nameof(AccessionNumber), nameof(TransactionOrder), IsUnique = true)]
-// The scraper's known-accession prefilter probes SupersededAccessionNumber with the same
-// candidate list as AccessionNumber; without its own index that arm falls back to a
-// sequential scan of the table on every sweep batch.
+// Late-original amendment resolution probes SupersededAccessionNumber for each
+// accession; without its own index that lookup scans the table on every replay.
 [Index(nameof(SupersededAccessionNumber))]
 [Index(nameof(FilingDate))]
 [Index(nameof(TransactionDate))]
@@ -39,9 +38,11 @@ public class InsiderTransaction
     /// Rule 10b5-1 checkbox during reprocess — the v4 capture parsed it but the
     /// reprocess copy-loop never wrote it, so pre-capture rows (1.4M checkbox-era
     /// rows) stayed null (#7164, EquiblesCommercial); v8 stamps the authoritative
-    /// Form 3/4/5 family so amendments cannot supersede a different ownership form.
+    /// Form 3/4/5 family so amendments cannot supersede a different ownership form;
+    /// v9 tags the no-securities-owned sentinel as a holding so it participates only
+    /// in holding-section supersession.
     /// </summary>
-    public const int CurrentParserVersion = 8;
+    public const int CurrentParserVersion = 9;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 
@@ -112,10 +113,10 @@ public class InsiderTransaction
     /// <summary>
     /// For rows from a Form 3/A, 4/A, or 5/A: the filing date of the ORIGINAL report the
     /// amendment restates (the XML's <c>dateOfOriginalSubmission</c>). Drives
-    /// supersession — an amendment replaces the original filing's rows, and a
-    /// late-arriving original (or an older chained amendment) is skipped when a row
-    /// referencing its filing date already exists. Null on non-amendment rows and
-    /// on amendments whose XML omits the element.
+    /// section-scoped supersession: transaction rows replace transactions and
+    /// holding snapshots replace holdings. A late-arriving original or older
+    /// chained amendment retains any section the amendment did not restate. Null
+    /// on non-amendment rows and on amendments whose XML omits the element.
     /// </summary>
     public DateOnly? OriginalFilingDate { get; set; }
 
@@ -125,9 +126,10 @@ public class InsiderTransaction
     /// amendment (EDGAR lists newest-first). Resolved at ingest rather than
     /// parsed: the XML only names the original's submission DATE, which can trail
     /// the feed's filing date (an after-17:30 submission indexes the next
-    /// business day), so the accession is the durable link. Also feeds the
-    /// scraper's known-accession prefilter, so a superseded original stops being
-    /// re-fetched from EDGAR every cycle. Null until resolved.
+    /// business day), so the accession is the durable link. It never makes the
+    /// original known by itself: only the original's own parsed row or current
+    /// ingest marker may stop replay, so legacy wholesale deletion can heal.
+    /// Null until resolved.
     /// </summary>
     [MaxLength(32)]
     public string SupersededAccessionNumber { get; set; }

--- a/src/Equibles.InsiderTrading.Data/Models/TransactionCode.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/TransactionCode.cs
@@ -48,4 +48,14 @@ public enum TransactionCode
     /// </summary>
     [Display(Name = "Holding")]
     Holding,
+
+    /// <summary>
+    /// Internal versioned marker for a valid ownership filing that contributes no
+    /// current rows, either because it parsed none or every section was superseded.
+    /// It is not a transaction or holding and claims no supersession section. A
+    /// stale marker lets a later parser version retry the filing from the SEC feed
+    /// without introducing a schema-level parser version.
+    /// </summary>
+    [Display(Name = "Ingest marker")]
+    IngestMarker,
 }

--- a/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
@@ -46,8 +46,9 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
     }
 
     /// <summary>
-    /// Rows from any amendment that restates the original report an owner filed for
-    /// this company on <paramref name="originalFilingDate"/> (the filer-entered
+    /// Rows from any amendment that restates transaction and/or holding sections
+    /// of the original report an owner filed for this company on
+    /// <paramref name="originalFilingDate"/> (the filer-entered
     /// <c>dateOfOriginalSubmission</c>, stable across chained amendments), within
     /// the same authoritative Form 3/4/5 family.
     /// </summary>
@@ -64,6 +65,12 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
                 && t.CommonStockId == commonStockId
                 && t.FilingForm == filingForm
                 && t.OriginalFilingDate == originalFilingDate
+                && t.TransactionCode != TransactionCode.IngestMarker
+                && !(
+                    t.TransactionCode == TransactionCode.Other
+                    && t.SecurityTitle == "No Securities Owned"
+                    && t.Shares == 0
+                )
             );
     }
 
@@ -79,7 +86,14 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
     {
         return GetAll()
             .Where(t =>
-                t.SupersededAccessionNumber == accessionNumber && t.FilingForm == filingForm
+                t.SupersededAccessionNumber == accessionNumber
+                && t.FilingForm == filingForm
+                && t.TransactionCode != TransactionCode.IngestMarker
+                && !(
+                    t.TransactionCode == TransactionCode.Other
+                    && t.SecurityTitle == "No Securities Owned"
+                    && t.Shares == 0
+                )
             );
     }
 
@@ -106,6 +120,12 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
                 && t.CommonStockId == commonStockId
                 && t.FilingForm == filingForm
                 && t.IsAmendment
+                && t.TransactionCode != TransactionCode.IngestMarker
+                && !(
+                    t.TransactionCode == TransactionCode.Other
+                    && t.SecurityTitle == "No Securities Owned"
+                    && t.Shares == 0
+                )
                 && t.SupersededAccessionNumber == null
                 && t.OriginalFilingDate != null
                 && t.OriginalFilingDate >= windowStart
@@ -135,6 +155,12 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
                 && t.CommonStockId == commonStockId
                 && t.FilingForm == filingForm
                 && !t.IsAmendment
+                && t.TransactionCode != TransactionCode.IngestMarker
+                && !(
+                    t.TransactionCode == TransactionCode.Other
+                    && t.SecurityTitle == "No Securities Owned"
+                    && t.Shares == 0
+                )
                 && t.FilingDate >= windowStart
                 && t.FilingDate <= windowEnd
             );

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -63,46 +63,27 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         await using var scope = _scopeFactory.CreateAsyncScope();
         var transactionRepository =
             scope.ServiceProvider.GetRequiredService<InsiderTransactionRepository>();
-        var filingRepository = scope.ServiceProvider.GetRequiredService<InsiderFilingRepository>();
 
-        // An accession is "known" both when its own rows exist and when an
-        // amendment has superseded (or claimed) it — a superseded original has
-        // no rows of its own, and without the claim column every sweep would
-        // re-fetch it from EDGAR forever just to re-skip it.
-        //
-        // Keep own-accession and superseded-claim probes separate instead of one
-        // cross-column OR: Postgres plans the OR as a costly bitmap heap scan.
-        // Claims additionally join the captured original's tiny, indexed filing
-        // row so a legacy cross-family link cannot suppress the real accession.
+        // An accession is "known" when its own parsed rows or a current-version
+        // non-section marker exists. A supersession claim never makes the whole
+        // original known: older wholesale deletion may have removed a section the
+        // amendment did not restate, so replay must be allowed to restore it.
         var candidates = accessionNumbers.ToList();
         var knownByOwnRows = await transactionRepository
             .GetAll()
-            .Where(t => candidates.Contains(t.AccessionNumber))
+            .Where(t =>
+                candidates.Contains(t.AccessionNumber)
+                && (
+                    t.TransactionCode != TransactionCode.IngestMarker
+                    || t.ParserVersion >= InsiderTransaction.CurrentParserVersion
+                )
+            )
             .Select(t => t.AccessionNumber)
-            .Distinct()
-            .ToListAsync();
-        // A legacy claim is authoritative only when both the amendment row and
-        // the captured original have a known, matching Form 3/4/5 family. Before
-        // v8, same-day filings from different families could be linked; treating
-        // that stale link as known would permanently suppress the real original.
-        var knownBySupersededClaim = await (
-            from transaction in transactionRepository.GetAll()
-            join original in filingRepository.GetAll()
-                on transaction.SupersededAccessionNumber equals original.AccessionNumber
-            where
-                transaction.SupersededAccessionNumber != null
-                && candidates.Contains(transaction.SupersededAccessionNumber)
-                && transaction.FilingForm != InsiderOwnershipForm.Unknown
-                && transaction.FilingForm == original.FilingForm
-            select transaction.SupersededAccessionNumber
-        )
             .Distinct()
             .ToListAsync();
 
         var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var accession in knownByOwnRows)
-            result.Add(accession);
-        foreach (var accession in knownBySupersededClaim)
             result.Add(accession);
         return result;
     }
@@ -128,10 +109,16 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             scope.ServiceProvider.GetRequiredService<InsiderTransactionPriceValidator>();
         var stockSplitRepository = scope.ServiceProvider.GetRequiredService<StockSplitRepository>();
 
-        var existing = await transactionRepository
+        var existingRows = await transactionRepository
             .GetByAccessionNumber(filing.AccessionNumber)
-            .AnyAsync();
-        if (existing)
+            .ToListAsync();
+        var staleIngestMarkers = existingRows
+            .Where(row =>
+                row.TransactionCode == TransactionCode.IngestMarker
+                && row.ParserVersion < InsiderTransaction.CurrentParserVersion
+            )
+            .ToList();
+        if (existingRows.Count != staleIngestMarkers.Count)
             return false;
 
         var xmlContent = await secEdgarClient.GetDocumentContent(filing);
@@ -201,12 +188,20 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var ownershipForm = InsiderFilingParser.ParseOwnershipForm(filing.Form);
         await StampFilingForm(filingRepository, filing.AccessionNumber, ownershipForm);
 
-        // A late-arriving original whose amendment already ingested must not
-        // re-insert the rows that amendment replaced (EDGAR lists newest-first,
-        // so during history sweeps the 4/A routinely lands before its Form 4).
-        if (
-            !isAmendment
-            && await TrySkipSupersededOriginal(
+        var transactions = InsiderFilingParser.ParseTransactions(
+            root,
+            owner,
+            companyId,
+            filing,
+            isAmendment
+        );
+
+        // EDGAR lists newest-first, so an amendment routinely lands before its
+        // original. Drop only the original sections that the amendment actually
+        // restated; an ownership-only amendment cannot suppress transaction rows.
+        if (!isAmendment)
+        {
+            var removedCount = await RemoveSupersededOriginalSections(
                 transactionRepository,
                 filingRepository,
                 fileManager,
@@ -214,10 +209,29 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 companyId,
                 filing,
                 ownershipForm,
-                companyTicker
-            )
-        )
-            return false;
+                companyTicker,
+                transactions
+            );
+            if (removedCount > 0 && transactions.Count == 0)
+            {
+                await CaptureFilingXml(root, filing, filingRepository, fileManager);
+                await SaveIngestMarker(
+                    transactionRepository,
+                    staleIngestMarkers,
+                    owner,
+                    companyId,
+                    filing,
+                    isAmendment: false,
+                    originalFilingDate: null
+                );
+                await FilingIngestTombstones.Clear(
+                    tombstoneRepository,
+                    filing.AccessionNumber,
+                    _logger
+                );
+                return false;
+            }
+        }
 
         var originalFilingDate = isAmendment
             ? InsiderFilingParser.ParseDateOfOriginalSubmission(root)
@@ -240,29 +254,25 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 _logger
             );
 
-            // Stale amendment: a NEWER amendment of the same original already
-            // ingested — its rows are the current truth, so skip this one.
-            // Same-day chains break the tie on accession number (SEC assigns
-            // them monotonically per filer agent).
-            if (
-                await transactionRepository
-                    .GetAmendmentsOfOriginal(
-                        owner,
-                        companyId,
-                        originalFilingDate.Value,
-                        ownershipForm
+            // A newer amendment wins only for sections it also carries. An older
+            // transaction correction still matters when the newer amendment
+            // restates holdings alone.
+            var newerAmendmentRows = await transactionRepository
+                .GetAmendmentsOfOriginal(owner, companyId, originalFilingDate.Value, ownershipForm)
+                .Where(t =>
+                    t.FilingDate > filing.FilingDate
+                    || (
+                        t.FilingDate == filing.FilingDate
+                        && string.Compare(t.AccessionNumber, filing.AccessionNumber) > 0
                     )
-                    .AnyAsync(t =>
-                        t.FilingDate > filing.FilingDate
-                        || (
-                            t.FilingDate == filing.FilingDate
-                            && string.Compare(t.AccessionNumber, filing.AccessionNumber) > 0
-                        )
-                    )
-            )
+                )
+                .ToListAsync();
+            var parsedSectionCount = transactions.Count;
+            RemoveSupersededSections(transactions, newerAmendmentRows);
+            if (parsedSectionCount > 0 && newerAmendmentRows.Count > 0 && transactions.Count == 0)
             {
                 _logger.LogInformation(
-                    "Skipping {Form} {AccessionNumber} for {Ticker}: a newer amendment of the same original is already ingested",
+                    "Skipping {Form} {AccessionNumber} for {Ticker}: a newer amendment already restated all of its sections",
                     filing.Form,
                     filing.AccessionNumber,
                     companyTicker
@@ -276,22 +286,26 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                     tombstoneRepository,
                     companyOutContext.Cik,
                     filing,
-                    "superseded by a newer ingested amendment of the same original",
+                    "superseded by a newer ingested amendment covering the same sections",
                     _logger
                 );
                 return false;
             }
 
-            supersededAccession = await SupersedeOriginal(
-                transactionRepository,
-                filingRepository,
-                owner,
-                companyId,
-                filing,
-                originalFilingDate.Value,
-                ownershipForm,
-                companyTicker
-            );
+            if (transactions.Any(row => GetSupersessionSection(row) != SupersessionSection.None))
+            {
+                supersededAccession = await SupersedeOriginal(
+                    transactionRepository,
+                    filingRepository,
+                    owner,
+                    companyId,
+                    filing,
+                    originalFilingDate.Value,
+                    ownershipForm,
+                    companyTicker,
+                    transactions
+                );
+            }
         }
         else if (isAmendment)
         {
@@ -307,25 +321,16 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         // when the parser changes, without re-fetching from EDGAR.
         await CaptureFilingXml(root, filing, filingRepository, fileManager);
 
-        var transactions = InsiderFilingParser.ParseTransactions(
-            root,
-            owner,
-            companyId,
-            filing,
-            isAmendment
-        );
-
         if (transactions.Count == 0)
         {
-            await SaveNoSecuritiesOwnedSentinel(
+            await SaveIngestMarker(
                 transactionRepository,
+                staleIngestMarkers,
                 owner,
                 companyId,
                 filing,
-                companyTicker,
                 isAmendment,
-                originalFilingDate,
-                supersededAccession
+                originalFilingDate
             );
             await FilingIngestTombstones.Clear(
                 tombstoneRepository,
@@ -344,6 +349,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             stockSplitRepository,
             priceValidator
         );
+
+        transactionRepository.Delete(staleIngestMarkers);
 
         // No in-memory dedup needed: every parsed row got a unique TransactionOrder from its
         // XML position, so the (AccessionNumber, TransactionOrder) unique index can't collide
@@ -374,13 +381,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
     // dateOfOriginalSubmission by a weekend (+ a holiday).
     private const int OriginalDateShiftToleranceDays = 4;
 
-    // Whether an incoming ORIGINAL was already replaced by an ingested amendment.
-    // Two signals, strongest first: an amendment that explicitly claimed this
-    // accession (re-listed original), or an unresolved amendment whose
-    // filer-entered original date falls within the indexing-shift window of this
-    // filing date — which then claims it, so the scraper's known-accession
-    // prefilter drops the original from every future sweep without a fetch.
-    private async Task<bool> TrySkipSupersededOriginal(
+    // Removes the sections of an incoming original that an already-ingested
+    // amendment restated. The amendment either explicitly claimed this accession
+    // or is paired by its filer-entered original date and the indexing-shift window.
+    private async Task<int> RemoveSupersededOriginalSections(
         InsiderTransactionRepository transactionRepository,
         InsiderFilingRepository filingRepository,
         IFileManager fileManager,
@@ -388,7 +392,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         Guid companyId,
         FilingData filing,
         InsiderOwnershipForm ownershipForm,
-        string companyTicker
+        string companyTicker,
+        List<InsiderTransaction> originalRows
     )
     {
         await ResolveLegacyClaimForms(
@@ -408,23 +413,11 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             _logger
         );
 
-        if (
-            await transactionRepository
-                .GetAmendmentsClaiming(filing.AccessionNumber, ownershipForm)
-                .AnyAsync()
-        )
-        {
-            _logger.LogInformation(
-                "Skipping {Form} {AccessionNumber} for {Ticker}: an amendment already claimed and superseded it",
-                filing.Form,
-                filing.AccessionNumber,
-                companyTicker
-            );
-            return true;
-        }
-
+        var claimingRows = await transactionRepository
+            .GetAmendmentsClaiming(filing.AccessionNumber, ownershipForm)
+            .ToListAsync();
         var windowStart = filing.FilingDate.AddDays(-OriginalDateShiftToleranceDays);
-        var orphans = await transactionRepository
+        var unresolvedRows = await transactionRepository
             .GetUnresolvedAmendments(
                 owner,
                 companyId,
@@ -433,33 +426,56 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 ownershipForm
             )
             .ToListAsync();
-        if (orphans.Count == 0)
-            return false;
-
-        // Several unresolved amendments (of DIFFERENT originals) can sit in the
-        // window; pair this original with exactly one group — the exact-date
-        // match when present, else the closest original date — so a sibling
-        // amendment stays unresolved for ITS original instead of being consumed
-        // by the wrong one.
-        var targetDate = orphans.Any(t => t.OriginalFilingDate == filing.FilingDate)
-            ? filing.FilingDate
-            : orphans.Max(t => t.OriginalFilingDate!.Value);
-        var claimed = orphans.Where(t => t.OriginalFilingDate == targetDate).ToList();
-
-        foreach (var row in claimed)
+        List<InsiderTransaction> newlyClaimedRows;
+        if (claimingRows.Count > 0)
         {
-            row.SupersededAccessionNumber = filing.AccessionNumber;
+            // A legacy wholesale deletion may leave one section claimed while a
+            // disjoint amendment of the same original remains unresolved. Merge
+            // only rows sharing the claimant's authoritative original date; an
+            // arbitrary nearby date could belong to a sibling filing.
+            var claimedOriginalDates = claimingRows
+                .Where(row => row.OriginalFilingDate.HasValue)
+                .Select(row => row.OriginalFilingDate!.Value)
+                .ToHashSet();
+            newlyClaimedRows = unresolvedRows
+                .Where(row =>
+                    row.OriginalFilingDate.HasValue
+                    && claimedOriginalDates.Contains(row.OriginalFilingDate.Value)
+                )
+                .ToList();
         }
-        await transactionRepository.SaveChanges();
+        else
+        {
+            if (unresolvedRows.Count == 0)
+                return 0;
 
-        _logger.LogInformation(
-            "Skipping {Form} {AccessionNumber} for {Ticker}: claimed by the already-ingested amendment dated {OriginalDate:yyyy-MM-dd}",
-            filing.Form,
-            filing.AccessionNumber,
-            companyTicker,
-            targetDate
-        );
-        return true;
+            // Several unresolved amendments (of DIFFERENT originals) can sit in
+            // the window. Pair this original with exactly one date group so a
+            // sibling amendment stays unresolved for its own original.
+            var targetDate = unresolvedRows.Any(t => t.OriginalFilingDate == filing.FilingDate)
+                ? filing.FilingDate
+                : unresolvedRows.Max(t => t.OriginalFilingDate!.Value);
+            newlyClaimedRows = unresolvedRows
+                .Where(t => t.OriginalFilingDate == targetDate)
+                .ToList();
+        }
+
+        foreach (var row in newlyClaimedRows)
+            row.SupersededAccessionNumber = filing.AccessionNumber;
+        claimingRows.AddRange(newlyClaimedRows);
+
+        var removedCount = RemoveSupersededSections(originalRows, claimingRows);
+        if (removedCount > 0)
+        {
+            _logger.LogInformation(
+                "Removed {Count} row(s) from {Form} {AccessionNumber} for {Ticker} because an amendment restated those sections",
+                removedCount,
+                filing.Form,
+                filing.AccessionNumber,
+                companyTicker
+            );
+        }
+        return removedCount;
     }
 
     // v8 introduced FilingForm after claims already existed. Resolve an unknown
@@ -714,15 +730,14 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         await transactionRepository.SaveChanges();
     }
 
-    // Replaces what an incoming amendment restates: the original filing's rows —
-    // resolved to a SINGLE accession via the filer-entered original date plus the
-    // indexing-shift window — and any older amendment of the same original.
+    // Replaces the transaction and/or holding sections an incoming amendment
+    // restates. The original resolves to a SINGLE accession via the filer-entered
+    // original date plus the indexing-shift window.
     // Returns the accession this amendment now supersedes (its own resolution, or
     // one inherited from a replaced older amendment), or null when the original
-    // is not ingested (pre-MinSyncDate history, or it arrives later and is
-    // claimed by TrySkipSupersededOriginal). Ambiguity (several candidate
-    // accessions) deletes nothing: a visible duplicate beats silently deleting a
-    // legitimate sibling filing.
+    // is not ingested yet. Ambiguity (several candidate accessions) deletes
+    // nothing: a visible duplicate beats silently deleting a legitimate sibling
+    // filing.
     private async Task<string> SupersedeOriginal(
         InsiderTransactionRepository transactionRepository,
         InsiderFilingRepository filingRepository,
@@ -731,7 +746,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         FilingData filing,
         DateOnly originalFilingDate,
         InsiderOwnershipForm ownershipForm,
-        string companyTicker
+        string companyTicker,
+        IReadOnlyCollection<InsiderTransaction> amendmentRows
     )
     {
         var windowEnd = originalFilingDate.AddDays(OriginalDateShiftToleranceDays);
@@ -758,11 +774,15 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             var originalRows = await transactionRepository
                 .GetByAccessionNumber(resolvedAccession)
                 .ToListAsync();
-            transactionRepository.Delete(originalRows);
+            var supersededCount = DeleteSupersededSections(
+                transactionRepository,
+                originalRows,
+                amendmentRows
+            );
             _logger.LogInformation(
-                "Amendment {AccessionNumber} supersedes {Count} transaction(s) of original {OriginalAccession} for {Ticker}",
+                "Amendment {AccessionNumber} supersedes {Count} row(s) in matching sections of original {OriginalAccession} for {Ticker}",
                 filing.AccessionNumber,
-                originalRows.Count,
+                supersededCount,
                 resolvedAccession,
                 companyTicker
             );
@@ -778,9 +798,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             );
         }
 
-        // Chained amendments: an older amendment of the same original is replaced
-        // wholesale, and its resolution (which original accession it consumed or
-        // claimed) is inherited so the prefilter keeps dropping that original.
+        // Chained amendments replace only overlapping sections. A holdings-only
+        // amendment must leave an older amendment's transaction rows intact.
         var olderAmendments = await transactionRepository
             .GetAmendmentsOfOriginal(owner, companyId, originalFilingDate, ownershipForm)
             .Where(t =>
@@ -794,9 +813,12 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 )
             )
             .ToListAsync();
-        if (olderAmendments.Count > 0)
+        var replacedOlderAmendments = olderAmendments
+            .Where(row => IsSectionSuperseded(row, amendmentRows))
+            .ToList();
+        if (replacedOlderAmendments.Count > 0)
         {
-            var claimedAccessions = olderAmendments
+            var claimedAccessions = replacedOlderAmendments
                 .Select(t => t.SupersededAccessionNumber)
                 .Where(a => a != null)
                 .Distinct()
@@ -809,11 +831,11 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 .Select(f => f.AccessionNumber)
                 .ToHashSetAsync();
             resolvedAccession ??= claimedAccessions.FirstOrDefault(validatedClaims.Contains);
-            transactionRepository.Delete(olderAmendments);
+            transactionRepository.Delete(replacedOlderAmendments);
             _logger.LogInformation(
-                "Amendment {AccessionNumber} replaces {Count} row(s) from older amendment(s) of the same original for {Ticker}",
+                "Amendment {AccessionNumber} replaces {Count} row(s) in matching sections from older amendment(s) of the same original for {Ticker}",
                 filing.AccessionNumber,
-                olderAmendments.Count,
+                replacedOlderAmendments.Count,
                 companyTicker
             );
         }
@@ -821,9 +843,85 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         return resolvedAccession;
     }
 
+    private static int DeleteSupersededSections(
+        InsiderTransactionRepository transactionRepository,
+        IReadOnlyCollection<InsiderTransaction> storedRows,
+        IReadOnlyCollection<InsiderTransaction> replacementRows
+    )
+    {
+        var supersededRows = storedRows
+            .Where(row => IsSectionSuperseded(row, replacementRows))
+            .ToList();
+        if (supersededRows.Count == storedRows.Count && supersededRows.Count > 0)
+        {
+            // Preserve one own-accession marker when every current section is
+            // superseded. The known-accession filter can then distinguish a
+            // genuinely empty current filing from legacy wholesale deletion.
+            var marker = supersededRows.MinBy(row => row.TransactionOrder)!;
+            ConvertToIngestMarker(marker, isAmendment: false, originalFilingDate: null);
+            transactionRepository.Delete(supersededRows.Where(row => row != marker));
+        }
+        else
+        {
+            transactionRepository.Delete(supersededRows);
+        }
+
+        return supersededRows.Count;
+    }
+
+    private static int RemoveSupersededSections(
+        List<InsiderTransaction> rows,
+        IReadOnlyCollection<InsiderTransaction> replacementRows
+    )
+    {
+        return rows.RemoveAll(row => IsSectionSuperseded(row, replacementRows));
+    }
+
+    private static bool IsSectionSuperseded(
+        InsiderTransaction row,
+        IReadOnlyCollection<InsiderTransaction> replacementRows
+    )
+    {
+        var section = GetSupersessionSection(row);
+        return section != SupersessionSection.None
+            && replacementRows.Any(replacement => GetSupersessionSection(replacement) == section);
+    }
+
+    private static SupersessionSection GetSupersessionSection(InsiderTransaction row)
+    {
+        if (row.TransactionCode == TransactionCode.IngestMarker)
+            return SupersessionSection.None;
+
+        if (row.TransactionCode == TransactionCode.Holding)
+            return SupersessionSection.Holding;
+
+        // Before parser v5, holding snapshots and genuine "Other" transactions
+        // shared TransactionCode.Other. Refuse to classify those rows rather than
+        // delete the wrong section. Reprocessing their captured XML resolves them.
+        if (
+            row.TransactionCode == TransactionCode.Other
+            && (
+                row.ParserVersion < 5
+                || (row.SecurityTitle == "No Securities Owned" && row.Shares == 0)
+            )
+        )
+        {
+            return SupersessionSection.None;
+        }
+
+        return SupersessionSection.Transaction;
+    }
+
+    private enum SupersessionSection
+    {
+        None,
+        Transaction,
+        Holding,
+    }
+
     // Persist the authoritative form family before any supersession early-return.
-    // The filing row survives deletion of its transaction rows, which lets the
-    // known-accession prefilter validate both sides of a legacy claim.
+    // The filing row survives deletion of its transaction rows and remains the
+    // source of truth for family-scoped amendment resolution and local replay.
     private static async Task StampFilingForm(
         InsiderFilingRepository filingRepository,
         string accessionNumber,
@@ -1077,48 +1175,65 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         return owner;
     }
 
-    // Form 3 with noSecuritiesOwned — save a 0-shares record so the accession-number
-    // short-circuit at the top of Process() prevents re-fetching this filing every cycle.
-    private async Task SaveNoSecuritiesOwnedSentinel(
+    private static async Task SaveIngestMarker(
         InsiderTransactionRepository transactionRepository,
+        IReadOnlyList<InsiderTransaction> staleMarkers,
         InsiderOwner owner,
         Guid companyId,
         FilingData filing,
-        string companyTicker,
-        bool isAmendment = false,
-        DateOnly? originalFilingDate = null,
-        string supersededAccessionNumber = null
+        bool isAmendment,
+        DateOnly? originalFilingDate
     )
     {
-        _logger.LogDebug(
-            "No transactions found for {Ticker} - {AccessionNumber}, saving 0-shares holding",
-            companyTicker,
-            filing.AccessionNumber
-        );
-
-        transactionRepository.Add(
-            new InsiderTransaction
+        var marker = staleMarkers.FirstOrDefault();
+        if (marker == null)
+        {
+            marker = new InsiderTransaction
             {
                 InsiderOwnerId = owner.Id,
                 CommonStockId = companyId,
-                FilingDate = filing.FilingDate,
-                TransactionDate = filing.ReportDate,
-                TransactionCode = TransactionCode.Other,
                 AccessionNumber = filing.AccessionNumber,
-                SecurityTitle = "No Securities Owned",
                 TransactionOrder = 0,
-                IsAmendment = isAmendment,
-                FilingForm = InsiderFilingParser.ParseOwnershipForm(filing.Form),
-                OriginalFilingDate = originalFilingDate,
-                SupersededAccessionNumber = supersededAccessionNumber,
-                // 0-price holding sentinel: nothing to validate or repair.
-                IsPriceValid = true,
-                // No security exists on a noSecuritiesOwned filing, so SecurityKind
-                // stays Unknown by design — there is no table to classify it from.
-                ParserVersion = InsiderTransaction.CurrentParserVersion,
-            }
-        );
+            };
+            transactionRepository.Add(marker);
+        }
+        else
+        {
+            transactionRepository.Delete(staleMarkers.Skip(1));
+        }
+
+        marker.FilingForm = InsiderFilingParser.ParseOwnershipForm(filing.Form);
+        marker.FilingDate = filing.FilingDate;
+        marker.TransactionDate = filing.ReportDate;
+        ConvertToIngestMarker(marker, isAmendment, originalFilingDate);
+
         await transactionRepository.SaveChanges();
+    }
+
+    private static void ConvertToIngestMarker(
+        InsiderTransaction marker,
+        bool isAmendment,
+        DateOnly? originalFilingDate
+    )
+    {
+        marker.TransactionOrder = 0;
+        marker.TransactionCode = TransactionCode.IngestMarker;
+        marker.Shares = 0;
+        marker.PricePerShare = 0;
+        marker.ReportedPricePerShare = 0;
+        marker.PriceWasRepaired = false;
+        marker.AcquiredDisposed = default;
+        marker.SharesOwnedAfter = 0;
+        marker.OwnershipNature = default;
+        marker.SecurityTitle = null;
+        marker.SecurityKind = InsiderSecurityKind.Unknown;
+        marker.IsAmendment = isAmendment;
+        marker.OriginalFilingDate = originalFilingDate;
+        marker.SupersededAccessionNumber = null;
+        marker.Notes = [];
+        marker.IsRule10b5One = null;
+        marker.IsPriceValid = true;
+        marker.ParserVersion = InsiderTransaction.CurrentParserVersion;
     }
 
     // Filer-reported transactionPricePerShare is unvalidated by EDGAR — some

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
@@ -30,11 +30,16 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
     public InsiderFilingReprocessManagerDivergenceTests(ParadeDbFixture fixture)
         : base(fixture) { }
 
-    [Fact]
-    public async Task Run_CachedXmlReparsesFewerRowsThanStored_AdvancesUnmatchedRowKeepingPriorData()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Run_CachedXmlReparsesFewerRowsThanStored_StampsDocumentIdentityOnEveryRow(
+        bool isAmendment
+    )
     {
         var date = new DateOnly(2024, 6, 14);
-        var accession = "0000320193-24-000050";
+        var originalFilingDate = new DateOnly(2024, 5, 31);
+        var accession = isAmendment ? "0000320193-24-000053" : "0000320193-24-000050";
 
         var stock = new CommonStock
         {
@@ -80,8 +85,12 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
         var matched = MakeStale(0);
         var unmatched = MakeStale(1);
 
+        var documentType = isAmendment ? "5/A" : "5";
+        var originalSubmission = isAmendment
+            ? $"<dateOfOriginalSubmission>{originalFilingDate:yyyy-MM-dd}</dateOfOriginalSubmission>"
+            : string.Empty;
         var ownershipXml =
-            "<ownershipDocument><documentType>5</documentType>"
+            $"<ownershipDocument><documentType>{documentType}</documentType>{originalSubmission}"
             + "<nonDerivativeTable><nonDerivativeTransaction>"
             + "<securityTitle><value>Common Stock</value></securityTitle>"
             + "<transactionDate><value>2024-06-14</value></transactionDate>"
@@ -154,12 +163,16 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
 
         matchedAfter!.SecurityKind.Should().Be(InsiderSecurityKind.NonDerivative);
         matchedAfter.FilingForm.Should().Be(InsiderOwnershipForm.Form5);
+        matchedAfter.IsAmendment.Should().Be(isAmendment);
+        matchedAfter.OriginalFilingDate.Should().Be(isAmendment ? originalFilingDate : null);
         matchedAfter.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
 
         // The unmatched row keeps its prior kind but must still advance, or it would be
         // re-selected forever.
         unmatchedAfter!.SecurityKind.Should().Be(InsiderSecurityKind.Derivative);
         unmatchedAfter.FilingForm.Should().Be(InsiderOwnershipForm.Form5);
+        unmatchedAfter.IsAmendment.Should().Be(isAmendment);
+        unmatchedAfter.OriginalFilingDate.Should().Be(isAmendment ? originalFilingDate : null);
         unmatchedAfter.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
 
         var filingAfter = await verify
@@ -220,5 +233,181 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
         (await verify.Set<InsiderTransaction>().AnyAsync(t => t.AccessionNumber == accession))
             .Should()
             .BeFalse();
+    }
+
+    [Fact]
+    public async Task Run_LegacyEmptyParseMarker_ConvertsToNonSectionMarkerAndClearsClaim()
+    {
+        var date = new DateOnly(2024, 6, 14);
+        var accession = "0000320193-24-000052";
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0001",
+            Name = "Jane Insider",
+        };
+        var marker = new InsiderTransaction
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            InsiderOwnerId = owner.Id,
+            AccessionNumber = accession,
+            TransactionOrder = 0,
+            FilingDate = date,
+            TransactionDate = date,
+            TransactionCode = TransactionCode.Other,
+            SecurityTitle = "No Securities Owned",
+            IsAmendment = true,
+            OriginalFilingDate = date,
+            SupersededAccessionNumber = "0000320193-24-000051",
+            FilingForm = InsiderOwnershipForm.Form4,
+            ParserVersion = 8,
+        };
+        var rawBytes = Encoding.UTF8.GetBytes(
+            "<ownershipDocument><documentType>4/A</documentType>"
+                + "<dateOfOriginalSubmission>2024-06-14</dateOfOriginalSubmission>"
+                + "<nonDerivativeTable/><derivativeTable/></ownershipDocument>"
+        );
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        DbContext.Add(marker);
+        DbContext.Add(
+            new InsiderFiling
+            {
+                AccessionNumber = accession,
+                FilingForm = InsiderOwnershipForm.Form4,
+                CaptureStatus = InsiderFilingCaptureStatus.Captured,
+                UncompressedSize = rawBytes.Length,
+                Content = new File
+                {
+                    Name = accession,
+                    Extension = "gz",
+                    ContentType = "application/gzip",
+                    FileContent = new FileContent { Bytes = GzipCompressor.Compress(rawBytes) },
+                },
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runCtx),
+            new InsiderFilingRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            Substitute.For<ISecEdgarClient>(),
+            InsiderReprocessTestSupport.NewFileManager(),
+            runCtx,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Failed.Should().Be(0);
+        result.Processed.Should().Be(1);
+        await using var verify = Fixture.CreateDbContext();
+        var converted = await verify.Set<InsiderTransaction>().SingleAsync(t => t.Id == marker.Id);
+        converted.TransactionCode.Should().Be(TransactionCode.IngestMarker);
+        converted.SecurityTitle.Should().BeNull();
+        converted.SupersededAccessionNumber.Should().BeNull();
+        converted.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
+    }
+
+    [Fact]
+    public async Task Run_LegacyNoSecuritiesAmendment_RestoresAmendmentIdentity()
+    {
+        var originalDate = new DateOnly(2024, 6, 14);
+        var accession = "0000320193-24-000053";
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0001",
+            Name = "Jane Insider",
+        };
+        var sentinel = new InsiderTransaction
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            InsiderOwnerId = owner.Id,
+            AccessionNumber = accession,
+            TransactionOrder = 0,
+            FilingDate = originalDate.AddDays(1),
+            TransactionDate = originalDate,
+            TransactionCode = TransactionCode.Other,
+            SecurityTitle = "No Securities Owned",
+            IsAmendment = false,
+            FilingForm = InsiderOwnershipForm.Form3,
+            ParserVersion = 8,
+        };
+        var rawBytes = Encoding.UTF8.GetBytes(
+            "<ownershipDocument><documentType>3/A</documentType>"
+                + "<periodOfReport>2024-06-14</periodOfReport>"
+                + "<dateOfOriginalSubmission>2024-06-14</dateOfOriginalSubmission>"
+                + "<noSecuritiesOwned>1</noSecuritiesOwned>"
+                + "<nonDerivativeTable/><derivativeTable/></ownershipDocument>"
+        );
+
+        DbContext.Add(stock);
+        DbContext.Add(owner);
+        DbContext.Add(sentinel);
+        DbContext.Add(
+            new InsiderFiling
+            {
+                AccessionNumber = accession,
+                FilingForm = InsiderOwnershipForm.Form3,
+                CaptureStatus = InsiderFilingCaptureStatus.Captured,
+                UncompressedSize = rawBytes.Length,
+                Content = new File
+                {
+                    Name = accession,
+                    Extension = "gz",
+                    ContentType = "application/gzip",
+                    FileContent = new FileContent { Bytes = GzipCompressor.Compress(rawBytes) },
+                },
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(runCtx),
+            new InsiderFilingRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new StockSplitRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            Substitute.For<ISecEdgarClient>(),
+            InsiderReprocessTestSupport.NewFileManager(),
+            runCtx,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Failed.Should().Be(0);
+        result.Processed.Should().Be(1);
+        await using var verify = Fixture.CreateDbContext();
+        var restored = await verify.Set<InsiderTransaction>().SingleAsync(t => t.Id == sentinel.Id);
+        restored.TransactionCode.Should().Be(TransactionCode.Holding);
+        restored.IsAmendment.Should().BeTrue();
+        restored.OriginalFilingDate.Should().Be(originalDate);
+        restored.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorAmendmentTests.cs
@@ -25,13 +25,10 @@ using MediaFileContent = Equibles.Media.Data.Models.FileContent;
 
 namespace Equibles.IntegrationTests.Sec;
 
-// Form 3/A, 4/A, and 5/A supersession: an amendment restates its original filing in full,
-// so the pipeline must (1) replace the original's transactions when the amendment
-// ingests, (2) skip a late-arriving original whose amendment already ingested
-// (EDGAR lists newest-first, so that order is the COMMON one during history
-// sweeps), and (3) skip an older amendment when a newer one of the same original
-// is already in, and (4) never crosses the Form 3/4/5 family boundary. Without
-// these, amendments can double count a correction or delete a same-day sibling form.
+// Form 3/A, 4/A, and 5/A supersession is section-scoped: transaction rows replace
+// transactions and holding snapshots replace holdings. The pipeline also handles
+// amendments arriving before originals, newer amendment chains, and Form 3/4/5
+// family boundaries without double-counting or deleting a sibling filing.
 public class InsiderTradingFilingProcessorAmendmentTests
 {
     private const string OriginalAccession = "0001-24-000100";
@@ -54,6 +51,20 @@ public class InsiderTradingFilingProcessorAmendmentTests
         shares: 250,
         dateOfOriginalSubmission: OriginalFilingDate,
         form: "4/A"
+    );
+
+    private static readonly string OriginalForm4WithHoldingXml = AddHolding(
+        OriginalForm4Xml,
+        shares: 5000
+    );
+
+    private static readonly string HoldingsOnlyAmendmentForm4Xml = BuildHoldingOnlyOwnershipXml(
+        shares: 4500,
+        dateOfOriginalSubmission: OriginalFilingDate
+    );
+
+    private static readonly string EmptyAmendmentForm4Xml = BuildEmptyAmendmentOwnershipXml(
+        OriginalFilingDate
     );
 
     private static string BuildOwnershipXml(
@@ -100,12 +111,133 @@ public class InsiderTradingFilingProcessorAmendmentTests
             """;
     }
 
+    private static string AddHolding(string xml, long shares)
+    {
+        var holding = $"""
+                    <nonDerivativeHolding>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>{shares}</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                        <ownershipNature>
+                            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                        </ownershipNature>
+                    </nonDerivativeHolding>
+            """;
+        return xml.Replace("</nonDerivativeTable>", $"{holding}</nonDerivativeTable>");
+    }
+
+    private static string BuildHoldingOnlyOwnershipXml(
+        long shares,
+        DateOnly dateOfOriginalSubmission
+    )
+    {
+        return $"""
+            <ownershipDocument>
+                <documentType>4/A</documentType>
+                <dateOfOriginalSubmission>{dateOfOriginalSubmission:yyyy-MM-dd}</dateOfOriginalSubmission>
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>0001234567</rptOwnerCik>
+                        <rptOwnerName>John Doe</rptOwnerName>
+                    </reportingOwnerId>
+                    <reportingOwnerRelationship>
+                        <isDirector>1</isDirector>
+                    </reportingOwnerRelationship>
+                </reportingOwner>
+                <nonDerivativeTable>
+                    <nonDerivativeHolding>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>{shares}</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                        <ownershipNature>
+                            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                        </ownershipNature>
+                    </nonDerivativeHolding>
+                </nonDerivativeTable>
+            </ownershipDocument>
+            """;
+    }
+
+    private static string BuildEmptyAmendmentOwnershipXml(DateOnly dateOfOriginalSubmission)
+    {
+        return $"""
+            <ownershipDocument>
+                <documentType>4/A</documentType>
+                <dateOfOriginalSubmission>{dateOfOriginalSubmission:yyyy-MM-dd}</dateOfOriginalSubmission>
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>0001234567</rptOwnerCik>
+                        <rptOwnerName>John Doe</rptOwnerName>
+                    </reportingOwnerId>
+                </reportingOwner>
+                <nonDerivativeTable/>
+                <derivativeTable/>
+            </ownershipDocument>
+            """;
+    }
+
+    private static string BuildNoSecuritiesOwnedAmendmentXml(DateOnly originalFilingDate)
+    {
+        return $"""
+            <ownershipDocument>
+                <documentType>3/A</documentType>
+                <dateOfOriginalSubmission>{originalFilingDate:yyyy-MM-dd}</dateOfOriginalSubmission>
+                <noSecuritiesOwned>1</noSecuritiesOwned>
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>0001234567</rptOwnerCik>
+                        <rptOwnerName>John Doe</rptOwnerName>
+                    </reportingOwnerId>
+                </reportingOwner>
+                <nonDerivativeTable/>
+                <derivativeTable/>
+            </ownershipDocument>
+            """;
+    }
+
+    private static string BuildFormThreeHoldingXml(long shares)
+    {
+        return $"""
+            <ownershipDocument>
+                <documentType>3</documentType>
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>0001234567</rptOwnerCik>
+                        <rptOwnerName>John Doe</rptOwnerName>
+                    </reportingOwnerId>
+                </reportingOwner>
+                <nonDerivativeTable>
+                    <nonDerivativeHolding>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>{shares}</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                    </nonDerivativeHolding>
+                </nonDerivativeTable>
+            </ownershipDocument>
+            """;
+    }
+
     private static (
         InsiderTradingFilingProcessor Processor,
         InsiderTransactionRepository TxRepo,
         ISecEdgarClient SecClient,
         InsiderFilingRepository FilingRepo
-    ) CreateProcessorWithDeps(ILogger<InsiderTradingFilingProcessor> logger = null)
+    ) CreateProcessorWithDeps(ILogger<InsiderTradingFilingProcessor> logger = null) =>
+        CreateProcessorWithDeps(out _, out _, logger);
+
+    private static (
+        InsiderTradingFilingProcessor Processor,
+        InsiderTransactionRepository TxRepo,
+        ISecEdgarClient SecClient,
+        InsiderFilingRepository FilingRepo
+    ) CreateProcessorWithDeps(
+        out IFileManager fileManager,
+        out Action restoreFileManager,
+        ILogger<InsiderTradingFilingProcessor> logger = null
+    )
     {
         var dbContext = TestDbContextFactory.Create(
             new InsiderTradingModuleConfiguration(),
@@ -121,32 +253,40 @@ public class InsiderTradingFilingProcessorAmendmentTests
         var errorManager = new ErrorManager(new ErrorRepository(dbContext));
         var dailyStockPriceRepo = new DailyStockPriceRepository(dbContext);
         var secClient = Substitute.For<ISecEdgarClient>();
-        var fileManager = Substitute.For<IFileManager>();
-        fileManager
-            .SaveInternalFile(
-                Arg.Any<byte[]>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>()
-            )
-            .Returns(call =>
-            {
-                var bytes = call.ArgAt<byte[]>(0);
-                var file = new MediaFile
+        var configuredFileManager = Substitute.For<IFileManager>();
+
+        void ConfigureFileManager()
+        {
+            configuredFileManager
+                .SaveInternalFile(
+                    Arg.Any<byte[]>(),
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<string>()
+                )
+                .Returns(call =>
                 {
-                    Name = call.ArgAt<string>(1),
-                    Extension = call.ArgAt<string>(2),
-                    ContentType = call.ArgAt<string>(3),
-                    Size = bytes.Length,
-                    FileContent = new MediaFileContent { Bytes = bytes },
-                };
-                dbContext.Add(file);
-                return file;
-            });
-        fileManager
-            .GetContent(Arg.Any<MediaFile>())
-            .Returns(call => call.ArgAt<MediaFile>(0).FileContent.Bytes);
+                    var bytes = call.ArgAt<byte[]>(0);
+                    var file = new MediaFile
+                    {
+                        Name = call.ArgAt<string>(1),
+                        Extension = call.ArgAt<string>(2),
+                        ContentType = call.ArgAt<string>(3),
+                        Size = bytes.Length,
+                        FileContent = new MediaFileContent { Bytes = bytes },
+                    };
+                    dbContext.Add(file);
+                    return file;
+                });
+            configuredFileManager
+                .GetContent(Arg.Any<MediaFile>())
+                .Returns(call => call.ArgAt<MediaFile>(0).FileContent.Bytes);
+        }
+
+        ConfigureFileManager();
+        fileManager = configuredFileManager;
+        restoreFileManager = ConfigureFileManager;
 
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(ISecEdgarClient), secClient),
@@ -154,7 +294,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
             (typeof(InsiderTransactionRepository), txRepo),
             (typeof(InsiderFilingRepository), filingRepo),
             (typeof(FailedFilingIngestRepository), new FailedFilingIngestRepository(dbContext)),
-            (typeof(IFileManager), fileManager),
+            (typeof(IFileManager), configuredFileManager),
             (typeof(ErrorManager), errorManager),
             (typeof(DailyStockPriceRepository), dailyStockPriceRepo),
             (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator()),
@@ -218,6 +358,23 @@ public class InsiderTradingFilingProcessorAmendmentTests
             Cik = "0000320193",
         };
 
+    private static List<InsiderTransaction> CurrentRows(InsiderTransactionRepository repository) =>
+        repository.GetAll().Where(t => t.TransactionCode != TransactionCode.IngestMarker).ToList();
+
+    private static void AssertCurrentMarker(
+        InsiderTransactionRepository repository,
+        string accessionNumber
+    )
+    {
+        repository
+            .GetByAccessionNumber(accessionNumber)
+            .Should()
+            .ContainSingle(t =>
+                t.TransactionCode == TransactionCode.IngestMarker
+                && t.ParserVersion == InsiderTransaction.CurrentParserVersion
+            );
+    }
+
     [Fact]
     public async Task Process_AmendmentAfterOriginal_ReplacesTheOriginalsTransactions()
     {
@@ -230,7 +387,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
         var result = await processor.Process(MakeAmendment(), company);
 
         result.Should().BeTrue();
-        var transactions = txRepo.GetAll().ToList();
+        var transactions = CurrentRows(txRepo);
         transactions
             .Should()
             .ContainSingle("the amendment replaces, never sums with, its original");
@@ -241,6 +398,374 @@ public class InsiderTradingFilingProcessorAmendmentTests
         transactions[0]
             .SupersededAccessionNumber.Should()
             .Be(OriginalAccession, "the amendment records which original it replaced");
+        AssertCurrentMarker(txRepo, OriginalAccession);
+    }
+
+    [Fact]
+    public async Task Process_HoldingsOnlyAmendmentAfterOriginal_PreservesOriginalTransactions()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(HoldingsOnlyAmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var rows = txRepo.GetAll().OrderBy(t => t.AccessionNumber).ToList();
+        rows.Should().HaveCount(2);
+        rows.Single(t => t.TransactionCode != TransactionCode.Holding)
+            .AccessionNumber.Should()
+            .Be(OriginalAccession);
+        var holding = rows.Single(t => t.TransactionCode == TransactionCode.Holding);
+        holding.AccessionNumber.Should().Be(AmendmentAccession);
+        holding.Shares.Should().Be(4500);
+        holding.SupersededAccessionNumber.Should().Be(OriginalAccession);
+    }
+
+    [Fact]
+    public async Task Process_LegacyWholesaleDeletion_ReplaysOriginalAndRestoresUntouchedSection()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(HoldingsOnlyAmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        // Recreate the pre-fix production state: the holdings-only amendment
+        // claimed the original after wholesale deletion removed its transaction.
+        txRepo.Delete(txRepo.GetByAccessionNumber(OriginalAccession));
+        await txRepo.SaveChanges();
+
+        var knownBeforeReplay = await processor.FilterKnownAccessions([
+            OriginalAccession,
+            AmendmentAccession,
+        ]);
+        knownBeforeReplay.Should().Equal(AmendmentAccession);
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        var rows = txRepo
+            .GetAll()
+            .Where(t => t.TransactionCode != TransactionCode.IngestMarker)
+            .ToList();
+        rows.Should().HaveCount(2);
+        rows.Should()
+            .ContainSingle(t =>
+                t.AccessionNumber == OriginalAccession
+                && t.TransactionCode != TransactionCode.Holding
+            );
+        rows.Should()
+            .ContainSingle(t =>
+                t.AccessionNumber == AmendmentAccession
+                && t.TransactionCode == TransactionCode.Holding
+            );
+    }
+
+    [Fact]
+    public async Task Process_LegacyClaimAndUnresolvedAmendment_ReplayAppliesBothSections()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(HoldingsOnlyAmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var transactionAmendment = MakeAmendment();
+        transactionAmendment.AccessionNumber = "0001-24-000300";
+        transactionAmendment.FilingDate = AmendmentFilingDate.AddDays(1);
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(transactionAmendment, company)).Should().BeTrue();
+
+        // Recreate a mixed legacy state: wholesale deletion attached the holding
+        // claim, while the disjoint transaction correction stayed unresolved.
+        var holdingAmendment = txRepo.GetByAccessionNumber(AmendmentAccession).Single();
+        holdingAmendment.SupersededAccessionNumber = OriginalAccession;
+        await txRepo.SaveChanges();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company))
+            .Should()
+            .BeFalse("both amended sections leave the original with no current rows");
+
+        var rows = CurrentRows(txRepo);
+        rows.Should().HaveCount(2);
+        rows.Should()
+            .ContainSingle(t =>
+                t.AccessionNumber == AmendmentAccession
+                && t.TransactionCode == TransactionCode.Holding
+            );
+        rows.Should()
+            .ContainSingle(t =>
+                t.AccessionNumber == transactionAmendment.AccessionNumber
+                && t.TransactionCode != TransactionCode.Holding
+            );
+        rows.Should().OnlyContain(t => t.SupersededAccessionNumber == OriginalAccession);
+        AssertCurrentMarker(txRepo, OriginalAccession);
+    }
+
+    [Fact]
+    public async Task Process_OriginalAfterHoldingsOnlyAmendment_PreservesOriginalTransactions()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(HoldingsOnlyAmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        var rows = txRepo.GetAll().OrderBy(t => t.AccessionNumber).ToList();
+        rows.Should().HaveCount(2);
+        rows.Single(t => t.TransactionCode != TransactionCode.Holding)
+            .AccessionNumber.Should()
+            .Be(OriginalAccession);
+        rows.Single(t => t.TransactionCode == TransactionCode.Holding)
+            .AccessionNumber.Should()
+            .Be(AmendmentAccession);
+    }
+
+    [Fact]
+    public async Task Process_OriginalAfterEmptyAmendment_PreservesEveryOriginalSection()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(EmptyAmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        txRepo
+            .GetAll()
+            .Should()
+            .ContainSingle(t =>
+                t.TransactionCode == TransactionCode.IngestMarker
+                && t.SupersededAccessionNumber == null
+            );
+        (await processor.FilterKnownAccessions([AmendmentAccession]))
+            .Should()
+            .Equal(AmendmentAccession);
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        var rows = txRepo
+            .GetAll()
+            .Where(t => t.TransactionCode != TransactionCode.IngestMarker)
+            .ToList();
+        rows.Should().HaveCount(2);
+        rows.Should().OnlyContain(t => t.AccessionNumber == OriginalAccession);
+        rows.Should().ContainSingle(t => t.TransactionCode == TransactionCode.Holding);
+        rows.Should().ContainSingle(t => t.TransactionCode != TransactionCode.Holding);
+    }
+
+    [Fact]
+    public async Task Process_EmptyNewerAmendment_DoesNotSuppressOlderAmendmentSections()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(HoldingsOnlyAmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var emptyNewerAmendment = MakeAmendment();
+        emptyNewerAmendment.AccessionNumber = "0001-24-000300";
+        emptyNewerAmendment.FilingDate = AmendmentFilingDate.AddDays(1);
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(EmptyAmendmentForm4Xml);
+        (await processor.Process(emptyNewerAmendment, company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        var rows = txRepo
+            .GetAll()
+            .Where(t => t.TransactionCode != TransactionCode.IngestMarker)
+            .ToList();
+        rows.Should().HaveCount(2);
+        rows.Single(t => t.TransactionCode == TransactionCode.Holding)
+            .AccessionNumber.Should()
+            .Be(AmendmentAccession);
+        rows.Single(t => t.TransactionCode != TransactionCode.Holding)
+            .AccessionNumber.Should()
+            .Be(OriginalAccession);
+    }
+
+    [Fact]
+    public async Task Process_FormThreeOriginalAfterNoSecuritiesOwnedAmendment_IsSuperseded()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        var amendment = MakeAmendment();
+        amendment.Form = "3/A";
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildNoSecuritiesOwnedAmendmentXml(OriginalFilingDate));
+        (await processor.Process(amendment, company)).Should().BeTrue();
+
+        var original = MakeOriginal();
+        original.Form = "3";
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(BuildFormThreeHoldingXml(5000));
+        (await processor.Process(original, company)).Should().BeFalse();
+
+        var sentinel = CurrentRows(txRepo).Should().ContainSingle().Subject;
+        sentinel.AccessionNumber.Should().Be(AmendmentAccession);
+        sentinel.TransactionCode.Should().Be(TransactionCode.Holding);
+        sentinel.IsAmendment.Should().BeTrue();
+        sentinel.OriginalFilingDate.Should().Be(OriginalFilingDate);
+        sentinel.SupersededAccessionNumber.Should().Be(OriginalAccession);
+        AssertCurrentMarker(txRepo, OriginalAccession);
+    }
+
+    [Fact]
+    public async Task Process_TransactionAmendment_PreservesAmbiguousPreV5Holding()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        var legacyHolding = txRepo
+            .GetByAccessionNumber(OriginalAccession)
+            .Single(t => t.TransactionCode == TransactionCode.Holding);
+        legacyHolding.TransactionCode = TransactionCode.Other;
+        legacyHolding.ParserVersion = 4;
+        await txRepo.SaveChanges();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var rows = txRepo.GetAll().ToList();
+        rows.Should().HaveCount(2);
+        rows.Should().Contain(legacyHolding);
+        rows.Should().ContainSingle(t => t.AccessionNumber == AmendmentAccession);
+    }
+
+    [Fact]
+    public async Task Process_HoldingsAmendment_PreservesAmbiguousPreV5Holding()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        var legacyHolding = txRepo
+            .GetByAccessionNumber(OriginalAccession)
+            .Single(t => t.TransactionCode == TransactionCode.Holding);
+        legacyHolding.TransactionCode = TransactionCode.Other;
+        legacyHolding.ParserVersion = 4;
+        await txRepo.SaveChanges();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(HoldingsOnlyAmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var rows = txRepo.GetAll().ToList();
+        rows.Should().HaveCount(3);
+        rows.Should().Contain(legacyHolding);
+        rows.Should()
+            .ContainSingle(t =>
+                t.AccessionNumber == AmendmentAccession
+                && t.TransactionCode == TransactionCode.Holding
+            );
+    }
+
+    [Fact]
+    public async Task Process_NewerHoldingsAmendment_PreservesOlderAmendmentTransactions()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        var newerAmendment = MakeAmendment();
+        newerAmendment.AccessionNumber = "0001-24-000300";
+        newerAmendment.FilingDate = AmendmentFilingDate.AddDays(1);
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(HoldingsOnlyAmendmentForm4Xml);
+        (await processor.Process(newerAmendment, company)).Should().BeTrue();
+
+        var rows = CurrentRows(txRepo).OrderBy(t => t.AccessionNumber).ToList();
+        rows.Should().HaveCount(2);
+        rows.Single(t => t.TransactionCode != TransactionCode.Holding)
+            .AccessionNumber.Should()
+            .Be(AmendmentAccession);
+        rows.Single(t => t.TransactionCode == TransactionCode.Holding)
+            .AccessionNumber.Should()
+            .Be(newerAmendment.AccessionNumber);
+    }
+
+    [Fact]
+    public async Task Process_OlderTransactionAmendmentAfterNewerHoldingsAmendment_PreservesBoth()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+        var newerAmendment = MakeAmendment();
+        newerAmendment.AccessionNumber = "0001-24-000300";
+        newerAmendment.FilingDate = AmendmentFilingDate.AddDays(1);
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(HoldingsOnlyAmendmentForm4Xml);
+        (await processor.Process(newerAmendment, company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeFalse();
+
+        var rows = CurrentRows(txRepo).OrderBy(t => t.AccessionNumber).ToList();
+        rows.Should().HaveCount(2);
+        rows.Single(t => t.TransactionCode != TransactionCode.Holding)
+            .AccessionNumber.Should()
+            .Be(AmendmentAccession);
+        rows.Single(t => t.TransactionCode == TransactionCode.Holding)
+            .AccessionNumber.Should()
+            .Be(newerAmendment.AccessionNumber);
+        rows.Should().OnlyContain(t => t.SupersededAccessionNumber == OriginalAccession);
+    }
+
+    [Fact]
+    public async Task Process_PartialLateOriginalFailure_DoesNotPersistClaimAndCanRetry()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps(
+            out var fileManager,
+            out var restoreFileManager
+        );
+        var company = MakeCompany();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(HoldingsOnlyAmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        fileManager
+            .SaveInternalFile(
+                Arg.Any<byte[]>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            )
+            .Returns(Task.FromException<MediaFile>(new IOException("simulated capture failure")));
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4WithHoldingXml);
+
+        var act = () => processor.Process(MakeOriginal(), company);
+        await act.Should().ThrowAsync<IOException>();
+
+        txRepo.ClearChangeTracker();
+        var knownAfterFailure = await processor.FilterKnownAccessions([
+            AmendmentAccession,
+            OriginalAccession,
+        ]);
+        knownAfterFailure.Should().Equal(AmendmentAccession);
+
+        restoreFileManager();
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+        txRepo
+            .GetByAccessionNumber(OriginalAccession)
+            .Should()
+            .ContainSingle(t => t.TransactionCode != TransactionCode.Holding);
+        txRepo
+            .GetByAccessionNumber(AmendmentAccession)
+            .Single()
+            .SupersededAccessionNumber.Should()
+            .Be(OriginalAccession);
     }
 
     [Fact]
@@ -260,8 +785,8 @@ public class InsiderTradingFilingProcessorAmendmentTests
         secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
         (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
 
-        txRepo.GetAll().Should().ContainSingle();
-        txRepo.GetAll().Single().AccessionNumber.Should().Be(AmendmentAccession);
+        CurrentRows(txRepo).Should().ContainSingle();
+        CurrentRows(txRepo).Single().AccessionNumber.Should().Be(AmendmentAccession);
     }
 
     [Fact]
@@ -301,7 +826,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
         var result = await processor.Process(MakeOriginal(), company);
 
         result.Should().BeFalse("the original's rows were already superseded");
-        var transactions = txRepo.GetAll().ToList();
+        var transactions = CurrentRows(txRepo);
         transactions.Should().ContainSingle();
         transactions[0].AccessionNumber.Should().Be(AmendmentAccession);
         transactions[0].Shares.Should().Be(250);
@@ -311,6 +836,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
                 OriginalAccession,
                 "the orphaned amendment claims the original so future sweeps drop it without a fetch"
             );
+        AssertCurrentMarker(txRepo, OriginalAccession);
     }
 
     [Fact]
@@ -333,11 +859,12 @@ public class InsiderTradingFilingProcessorAmendmentTests
             .Should()
             .BeFalse("the cached Form 4/A proves the legacy orphan superseded this original");
 
-        txRepo.GetAll().Should().ContainSingle();
-        var remaining = txRepo.GetAll().Single();
+        CurrentRows(txRepo).Should().ContainSingle();
+        var remaining = CurrentRows(txRepo).Single();
         remaining.AccessionNumber.Should().Be(AmendmentAccession);
         remaining.FilingForm.Should().Be(InsiderOwnershipForm.Form4);
         remaining.SupersededAccessionNumber.Should().Be(OriginalAccession);
+        AssertCurrentMarker(txRepo, OriginalAccession);
     }
 
     [Fact]
@@ -449,7 +976,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
             .Returns(BuildOwnershipXml(550, OriginalFilingDate, "5/A"));
         (await processor.Process(MakeFormFiveAmendment(), company)).Should().BeTrue();
 
-        var transactions = txRepo.GetAll().OrderBy(t => t.AccessionNumber).ToList();
+        var transactions = CurrentRows(txRepo).OrderBy(t => t.AccessionNumber).ToList();
         transactions.Should().HaveCount(2);
         transactions
             .Select(t => t.AccessionNumber)
@@ -486,7 +1013,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
             .Should()
             .BeFalse("the already-ingested Form 5/A superseded this Form 5");
 
-        var transactions = txRepo.GetAll().OrderBy(t => t.AccessionNumber).ToList();
+        var transactions = CurrentRows(txRepo).OrderBy(t => t.AccessionNumber).ToList();
         transactions.Should().HaveCount(2);
         transactions
             .Select(t => t.AccessionNumber)
@@ -579,7 +1106,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
             .Should()
             .BeFalse("the Form 5/A is reassigned from its disproved Form 4 claim");
 
-        txRepo.GetByAccessionNumber(FormFiveOriginalAccession).Should().BeEmpty();
+        AssertCurrentMarker(txRepo, FormFiveOriginalAccession);
         txRepo
             .GetByAccessionNumber(FormFiveAmendmentAccession)
             .Single()
@@ -665,6 +1192,62 @@ public class InsiderTradingFilingProcessorAmendmentTests
     }
 
     [Fact]
+    public async Task Process_LegacyEmptyParseMarkerClaim_DoesNotHideOriginal()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        txRepo.Delete(txRepo.GetByAccessionNumber(OriginalAccession));
+        await txRepo.SaveChanges();
+
+        var legacyMarker = txRepo.GetByAccessionNumber(AmendmentAccession).Single();
+        legacyMarker.TransactionCode = TransactionCode.Other;
+        legacyMarker.SecurityTitle = "No Securities Owned";
+        legacyMarker.Shares = 0;
+        legacyMarker.ParserVersion = 8;
+        await txRepo.SaveChanges();
+
+        var known = await processor.FilterKnownAccessions([OriginalAccession, AmendmentAccession]);
+        known.Should().Equal(AmendmentAccession);
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+        txRepo.GetByAccessionNumber(OriginalAccession).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Process_AmbiguousPreV5OtherClaim_DoesNotHideOriginal()
+    {
+        var (processor, txRepo, secClient, _) = CreateProcessorWithDeps();
+        var company = MakeCompany();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
+        (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        txRepo.Delete(txRepo.GetByAccessionNumber(OriginalAccession));
+        await txRepo.SaveChanges();
+
+        var legacyOther = txRepo.GetByAccessionNumber(AmendmentAccession).Single();
+        legacyOther.TransactionCode = TransactionCode.Other;
+        legacyOther.ParserVersion = 4;
+        await txRepo.SaveChanges();
+
+        var known = await processor.FilterKnownAccessions([OriginalAccession, AmendmentAccession]);
+        known.Should().Equal(AmendmentAccession);
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);
+        (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
+        txRepo.GetByAccessionNumber(OriginalAccession).Should().ContainSingle();
+    }
+
+    [Fact]
     public async Task Process_ValidLegacyUnknownClaim_ResolvesFromCachedXmlAndStillSuppressesOriginal()
     {
         var (processor, txRepo, secClient, filingRepo) = CreateProcessorWithDeps();
@@ -674,6 +1257,9 @@ public class InsiderTradingFilingProcessorAmendmentTests
         (await processor.Process(MakeOriginal(), company)).Should().BeTrue();
         secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentForm4Xml);
         (await processor.Process(MakeAmendment(), company)).Should().BeTrue();
+
+        txRepo.Delete(txRepo.GetByAccessionNumber(OriginalAccession));
+        await txRepo.SaveChanges();
 
         var amendment = txRepo.GetByAccessionNumber(AmendmentAccession).Single();
         amendment.FilingForm = InsiderOwnershipForm.Unknown;
@@ -691,7 +1277,7 @@ public class InsiderTradingFilingProcessorAmendmentTests
             .Should()
             .BeFalse("the cached Form 4/A proves this same-family legacy claim is valid");
 
-        txRepo.GetByAccessionNumber(OriginalAccession).Should().BeEmpty();
+        AssertCurrentMarker(txRepo, OriginalAccession);
         txRepo
             .GetByAccessionNumber(AmendmentAccession)
             .Single()
@@ -721,18 +1307,19 @@ public class InsiderTradingFilingProcessorAmendmentTests
         var result = await processor.Process(MakeAmendment(), company);
 
         result.Should().BeTrue();
-        var transactions = txRepo.GetAll().ToList();
+        var transactions = CurrentRows(txRepo);
         transactions.Should().ContainSingle("the date-shifted original must still be replaced");
         transactions[0].AccessionNumber.Should().Be(AmendmentAccession);
         transactions[0].SupersededAccessionNumber.Should().Be(OriginalAccession);
+        AssertCurrentMarker(txRepo, OriginalAccession);
     }
 
     [Fact]
     public async Task FilterKnownAccessions_SupersededOriginal_CountsAsKnown()
     {
-        // A superseded original has no rows of its own; without the claim column
-        // every sweep would pass it through the prefilter and re-fetch it from
-        // EDGAR forever just to re-skip it.
+        // A fully superseded original retains a non-section marker of its own.
+        // Claims cannot make an original known because a legacy claim may have
+        // been paired with wholesale deletion of sections it never restated.
         var (processor, _, secClient, _) = CreateProcessorWithDeps();
         var company = MakeCompany();
         secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(OriginalForm4Xml);

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -602,7 +602,7 @@ public class InsiderTradingFilingProcessorTests
     }
 
     [Fact]
-    public async Task Process_NoTransactions_SavesMarkerAndReturnsTrue()
+    public async Task Process_NoTransactions_SavesVersionedNonSectionMarker()
     {
         var xml = """
             <ownershipDocument>
@@ -617,12 +617,48 @@ public class InsiderTradingFilingProcessorTests
         var (processor, _, txRepo, secClient) = CreateProcessorWithDeps();
         secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(xml);
 
-        var result = await processor.Process(MakeFiling(), MakeCompany());
+        var filing = MakeFiling();
+        var result = await processor.Process(filing, MakeCompany());
 
         result.Should().BeTrue();
-        var markers = txRepo.GetAll().ToList();
-        markers.Should().HaveCount(1);
-        markers[0].SecurityTitle.Should().Be("No Securities Owned");
+        var marker = txRepo.GetAll().Should().ContainSingle().Subject;
+        marker.TransactionCode.Should().Be(TransactionCode.IngestMarker);
+        marker.ParserVersion.Should().Be(InsiderTransaction.CurrentParserVersion);
+        marker.SupersededAccessionNumber.Should().BeNull();
+        (await processor.FilterKnownAccessions([filing.AccessionNumber]))
+            .Should()
+            .Equal(filing.AccessionNumber);
+    }
+
+    [Fact]
+    public async Task Process_StaleEmptyParseMarker_RetriesWithCurrentParser()
+    {
+        const string emptyXml = """
+            <ownershipDocument>
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>0001234567</rptOwnerCik>
+                        <rptOwnerName>John Doe</rptOwnerName>
+                    </reportingOwnerId>
+                </reportingOwner>
+            </ownershipDocument>
+            """;
+        var (processor, _, txRepo, secClient) = CreateProcessorWithDeps();
+        var filing = MakeFiling();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(emptyXml);
+        (await processor.Process(filing, MakeCompany())).Should().BeTrue();
+
+        var marker = txRepo.GetAll().Single();
+        marker.ParserVersion = InsiderTransaction.CurrentParserVersion - 1;
+        await txRepo.SaveChanges();
+        (await processor.FilterKnownAccessions([filing.AccessionNumber])).Should().BeEmpty();
+
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(ValidForm4Xml);
+        (await processor.Process(filing, MakeCompany())).Should().BeTrue();
+
+        var row = txRepo.GetAll().Should().ContainSingle().Subject;
+        row.TransactionCode.Should().Be(TransactionCode.Purchase);
+        row.AccessionNumber.Should().Be(filing.AccessionNumber);
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserNoSecuritiesOwnedSentinelTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserNoSecuritiesOwnedSentinelTests.cs
@@ -72,7 +72,7 @@ public class InsiderFilingParserNoSecuritiesOwnedSentinelTests
         sentinel.SharesOwnedAfter.Should().Be(0);
         sentinel.PricePerShare.Should().Be(0);
         sentinel.TransactionOrder.Should().Be(0);
-        sentinel.TransactionCode.Should().Be(TransactionCode.Other);
+        sentinel.TransactionCode.Should().Be(TransactionCode.Holding);
         sentinel.TransactionDate.Should().Be(filing.ReportDate);
         sentinel.SecurityKind.Should().Be(InsiderSecurityKind.Unknown);
         sentinel.IsPriceValid.Should().BeTrue();
@@ -110,5 +110,42 @@ public class InsiderFilingParserNoSecuritiesOwnedSentinelTests
         );
 
         result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseTransactions_NoSecuritiesOwnedAmendment_PreservesAmendmentIdentity()
+    {
+        var root = InsiderFilingParser.TryGetOwnershipRoot(
+            NoSecuritiesOwnedForm3
+                .Replace("<documentType>3</documentType>", "<documentType>3/A</documentType>")
+                .Replace(
+                    "<periodOfReport>2023-10-03</periodOfReport>",
+                    "<periodOfReport>2023-10-03</periodOfReport><dateOfOriginalSubmission>2023-10-03</dateOfOriginalSubmission>"
+                )
+        );
+        var filing = new FilingData
+        {
+            AccessionNumber = "0001466258-23-000204",
+            Form = "3/A",
+            FilingDate = new DateOnly(2023, 10, 6),
+            ReportDate = new DateOnly(2023, 10, 3),
+        };
+
+        var sentinel = InsiderFilingParser
+            .ParseTransactions(
+                root,
+                new InsiderOwner { Id = Guid.NewGuid() },
+                Guid.NewGuid(),
+                filing,
+                isAmendment: true
+            )
+            .Should()
+            .ContainSingle()
+            .Subject;
+
+        sentinel.IsAmendment.Should().BeTrue();
+        sentinel.OriginalFilingDate.Should().Be(new DateOnly(2023, 10, 3));
+        sentinel.FilingForm.Should().Be(InsiderOwnershipForm.Form3);
+        sentinel.TransactionCode.Should().Be(TransactionCode.Holding);
     }
 }

--- a/tests/Equibles.UnitTests/Models/InsiderTradingEnumTests.cs
+++ b/tests/Equibles.UnitTests/Models/InsiderTradingEnumTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Equibles.Core.Extensions;
+using Equibles.InsiderTrading.Data.Extensions;
 using Equibles.InsiderTrading.Data.Models;
 
 namespace Equibles.UnitTests.Models;
@@ -32,12 +33,29 @@ public class InsiderTradingEnumTests
     [InlineData(TransactionCode.Discretionary, "Discretionary")]
     [InlineData(TransactionCode.Other, "Other")]
     [InlineData(TransactionCode.Holding, "Holding")]
+    [InlineData(TransactionCode.IngestMarker, "Ingest marker")]
     public void TransactionCode_AllValues_HaveCorrectDisplayName(
         TransactionCode code,
         string expected
     )
     {
         code.NameForHumans().Should().Be(expected);
+    }
+
+    [Fact]
+    public void ExcludeHoldings_RemovesHoldingsAndIngestMarkers()
+    {
+        var rows = new[]
+        {
+            new InsiderTransaction { TransactionCode = TransactionCode.Purchase },
+            new InsiderTransaction { TransactionCode = TransactionCode.Holding },
+            new InsiderTransaction { TransactionCode = TransactionCode.IngestMarker },
+        };
+
+        rows.AsQueryable()
+            .ExcludeHoldings()
+            .Should()
+            .ContainSingle(t => t.TransactionCode == TransactionCode.Purchase);
     }
 
     [Fact]
@@ -68,7 +86,7 @@ public class InsiderTradingEnumTests
     public void TransactionCode_AllValues_HaveDisplayAttribute()
     {
         var values = Enum.GetValues<TransactionCode>();
-        values.Should().HaveCount(12);
+        values.Should().HaveCount(13);
 
         foreach (var value in values)
         {

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSkipTombstoneTests.cs
@@ -118,7 +118,8 @@ public class InsiderTradingFilingProcessorSkipTombstoneTests
         string issuerCik = IssuerCik,
         string documentType = "4",
         string dateOfOriginalSubmission = null,
-        bool includeOwner = true
+        bool includeOwner = true,
+        bool includeTransaction = false
     )
     {
         var original =
@@ -135,6 +136,21 @@ public class InsiderTradingFilingProcessorSkipTombstoneTests
                 </reportingOwner>
                 """
             : "<reportingOwner></reportingOwner>";
+        var transactionTable = includeTransaction
+            ? """
+                <nonDerivativeTable>
+                    <nonDerivativeTransaction>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <transactionDate><value>2023-05-30</value></transactionDate>
+                        <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+                        <transactionAmounts>
+                            <transactionShares><value>100</value></transactionShares>
+                            <transactionPricePerShare><value>10</value></transactionPricePerShare>
+                        </transactionAmounts>
+                    </nonDerivativeTransaction>
+                </nonDerivativeTable>
+                """
+            : string.Empty;
         return $"""
             <ownershipDocument>
                 <schemaVersion>X0306</schemaVersion>
@@ -147,6 +163,7 @@ public class InsiderTradingFilingProcessorSkipTombstoneTests
                     <issuerTradingSymbol>QXO</issuerTradingSymbol>
                 </issuer>
                 {owner}
+                {transactionTable}
             </ownershipDocument>
             """;
     }
@@ -211,7 +228,11 @@ public class InsiderTradingFilingProcessorSkipTombstoneTests
 
         var processor = BuildProcessor(
             ctx,
-            OwnershipXml(documentType: "4/A", dateOfOriginalSubmission: "2023-05-25")
+            OwnershipXml(
+                documentType: "4/A",
+                dateOfOriginalSubmission: "2023-05-25",
+                includeTransaction: true
+            )
         );
 
         var processed = await processor.Process(Filing(form: "4/A"), issuer);
@@ -270,8 +291,8 @@ public class InsiderTradingFilingProcessorSkipTombstoneTests
             );
         await ctx.SaveChangesAsync();
 
-        // Valid ownership XML with no transaction tables → the 0-transaction
-        // sentinel path, which is a successful ingest (returns true).
+        // Valid ownership XML with no transaction tables → the non-section
+        // marker path, which is a successful ingest (returns true).
         var processor = BuildProcessor(ctx, OwnershipXml());
 
         var processed = await processor.Process(Filing(), Issuer());


### PR DESCRIPTION
## Summary
- Scope Form 3/A, 4/A, and 5/A supersession to parsed transaction and holding sections.
- Restore untouched sections in either ingest order and repair legacy wholesale deletions on replay.
- Keep empty and fully superseded filings retryable through versioned non-section markers.
- Closes #4312

## Code changes
- Parse before supersession and apply section-aware filtering and deletion.
- Preserve atomic claims and cached replay metadata across amendment chains.
- Combine claimed and unresolved amendments only on matching original-submission dates.
- Add reverse-order, legacy repair, failure/retry, and parser-version regression coverage.

## Verification
- Release unit and integration builds passed.
- 56 parser/model tests passed.
- 108 filing processor tests passed.
- 20 reprocessing tests passed.
- Independent review approved with no findings.