### PR TITLE
fix(sec): index pending document chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- SEC document chunking now reads an indexed pending-state queue instead of scanning every stored document and probing the chunk corpus on each drained poll. Closes #3823.
+
 ## [1.6.1] — 2026-08-22
 
 ### Fixed

--- a/src/Equibles.Migrations/Migrations/20260823091141_AddDocumentChunkedAt.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260823091141_AddDocumentChunkedAt.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823091141_AddDocumentChunkedAt")]
+    partial class AddDocumentChunkedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -2695,11 +2698,6 @@ namespace Equibles.Migrations.Migrations
                     b.HasIndex("XbrlStatus");
 
                     b.HasIndex("CommonStockId", "DocumentType");
-
-                    b.HasIndex("CreationTime", "Id")
-                        .HasDatabaseName("IX_Document_PendingChunking")
-                        .HasFilter("\"ChunkedAt\" IS NULL")
-                        .HasAnnotation("Npgsql:CreatedConcurrently", true);
 
                     b.HasIndex("DocumentType", "AsFiledHtmlVersion");
 

--- a/src/Equibles.Migrations/Migrations/20260823091141_AddDocumentChunkedAt.cs
+++ b/src/Equibles.Migrations/Migrations/20260823091141_AddDocumentChunkedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentChunkedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ChunkedAt",
+                table: "Document",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ChunkedAt",
+                table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260823091158_AddPendingDocumentChunkingIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260823091158_AddPendingDocumentChunkingIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823091158_AddPendingDocumentChunkingIndex")]
+    partial class AddPendingDocumentChunkingIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260823091158_AddPendingDocumentChunkingIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260823091158_AddPendingDocumentChunkingIndex.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <summary>
+    /// Adds the partial FIFO index used by the pending-document chunk queue. The build is
+    /// restart-safe because PostgreSQL can retain an invalid index after an interrupted concurrent
+    /// build, and a crash can occur after a successful build but before EF records the migration.
+    /// </summary>
+    public partial class AddPendingDocumentChunkingIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DO $$ BEGIN "
+                    + "IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                    + "WHERE c.relname = 'IX_Document_PendingChunking' AND NOT i.indisvalid) THEN "
+                    + "EXECUTE 'DROP INDEX \"IX_Document_PendingChunking\"'; END IF; END $$;",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_Document_PendingChunking\" "
+                    + "ON \"Document\" (\"CreationTime\", \"Id\") WHERE \"ChunkedAt\" IS NULL;",
+                suppressTransaction: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_Document_PendingChunking\";",
+                suppressTransaction: true
+            );
+        }
+    }
+}

--- a/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
@@ -61,7 +61,7 @@ public class DocumentProcessor : IDocumentProcessor
             attempted++;
             try
             {
-                await ChunkDocument(document);
+                await ProcessDocument(document, cancellationToken);
                 progressed++;
             }
             catch (Exception ex)
@@ -86,6 +86,9 @@ public class DocumentProcessor : IDocumentProcessor
             );
         }
     }
+
+    public Task ProcessDocument(Document document, CancellationToken cancellationToken = default) =>
+        ChunkDocument(document);
 
     public async Task GenerateEmbeddings(List<Chunk> chunks, CancellationToken cancellationToken)
     {
@@ -156,6 +159,7 @@ public class DocumentProcessor : IDocumentProcessor
         if (document.Chunks.Any())
         {
             _logger.LogInformation("Document {DocumentId} already chunked, skipping", document.Id);
+            await MarkChunked(document);
             return;
         }
 
@@ -170,10 +174,12 @@ public class DocumentProcessor : IDocumentProcessor
         if (string.IsNullOrWhiteSpace(content))
         {
             _logger.LogWarning("Document {DocumentId} has no content", document.Id);
+            await MarkChunked(document);
             return;
         }
 
-        var chunks = await CreateChunks(document, content);
+        var chunks = CreateChunks(document, content);
+        await MarkChunked(document);
         _logger.LogInformation(
             "Created {ChunkCount} chunks for document {DocumentId}",
             chunks.Count,
@@ -191,7 +197,7 @@ public class DocumentProcessor : IDocumentProcessor
         return Encoding.UTF8.GetString(await _fileManager.GetContent(document.Content));
     }
 
-    private async Task<List<Chunk>> CreateChunks(Document document, string content)
+    private List<Chunk> CreateChunks(Document document, string content)
     {
         var allChunks = new List<Chunk>();
         var currentTime = DateTime.UtcNow;
@@ -224,8 +230,13 @@ public class DocumentProcessor : IDocumentProcessor
             allChunks.Add(chunk);
         }
 
-        await _chunkRepository.SaveChanges();
         return allChunks;
+    }
+
+    private async Task MarkChunked(Document document)
+    {
+        document.ChunkedAt = DateTime.UtcNow;
+        await _chunkRepository.SaveChanges();
     }
 
     /// <summary>

--- a/src/Equibles.Sec.BusinessLogic/Processing/IDocumentProcessor.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/IDocumentProcessor.cs
@@ -9,6 +9,7 @@ public interface IDocumentProcessor
         List<Document> documents,
         CancellationToken cancellationToken = default
     );
+    public Task ProcessDocument(Document document, CancellationToken cancellationToken = default);
     public Task GenerateEmbeddings(
         List<Chunk> chunks,
         CancellationToken cancellationToken = default

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -59,6 +59,13 @@ public class Document
     public int LineCount { get; set; }
 
     /// <summary>
+    /// When chunking completed, including deterministic zero-chunk outcomes such as blank text.
+    /// Null means the document still needs chunking. Content replacement and explicit chunk resets
+    /// clear this marker so the document returns to the pending queue.
+    /// </summary>
+    public DateTime? ChunkedAt { get; set; }
+
+    /// <summary>
     /// Version of the HTML-normalization and Markdown-conversion pipeline that produced
     /// <see cref="Content"/>. Existing rows default to 0; the backfill re-fetches their EDGAR
     /// submission and replaces the stored text when this is below

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -16,6 +16,10 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<Document>(b =>
         {
             b.Property(e => e.DocumentType).HasConversion(docTypeConversion);
+            b.HasIndex(e => new { e.CreationTime, e.Id })
+                .HasDatabaseName("IX_Document_PendingChunking")
+                .HasFilter("\"ChunkedAt\" IS NULL")
+                .IsCreatedConcurrently();
         });
 
         builder.Entity<Models.Chunks.Chunk>(b =>

--- a/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
+++ b/src/Equibles.Sec.HostedService/DocumentProcessorWorker.cs
@@ -21,11 +21,9 @@ public class DocumentProcessorWorker : BaseScraperWorker
     // visibility comes from the System Health probe + activity feed, not these rows.
     protected override int ErrorReportThreshold => 20;
 
-    // Backfill frontiers for the two phases. They live on the worker (a singleton) because the
-    // DocumentManager is re-resolved from a fresh scope per batch; each hydrates from its
-    // persisted BackfillState row on first use, so a process restart resumes at the frontier
-    // instead of paying the unfloored corpus scan.
-    private readonly BackfillCursor _chunkCursor = new("document-chunking");
+    // The embedding frontier lives on the worker (a singleton) because the DocumentManager is
+    // re-resolved from a fresh scope per batch. Chunking no longer needs a frontier: its partial
+    // pending index makes every FIFO lookup bounded by the actual backlog.
     private readonly BackfillCursor _embeddingCursor = new("chunk-embedding");
 
     public DocumentProcessorWorker(
@@ -42,7 +40,7 @@ public class DocumentProcessorWorker : BaseScraperWorker
         {
             await using var chunkScope = ScopeFactory.CreateAsyncScope();
             var documentManager = chunkScope.ServiceProvider.GetRequiredService<DocumentManager>();
-            var workDone = await documentManager.ChunkDocumentBatch(_chunkCursor, stoppingToken);
+            var workDone = await documentManager.ChunkDocumentBatch(stoppingToken);
             if (!workDone)
                 break;
         }

--- a/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Sec.BusinessLogic.Embeddings;
@@ -40,47 +41,78 @@ public class DocumentManager
         _logger = logger;
     }
 
-    // Both batch loaders anti-join a huge table ("no chunks yet" / "no embeddings yet") ordered
-    // by CreationTime. Unfloored, that anti-join hashes the entire table on every poll — minutes
-    // of I/O each time on the chunk corpus. The caller-owned cursor floors each poll at the
-    // backfill frontier so the CreationTime index seeks straight to the pending rows; the
-    // rate-limited full-rescan fallback in LoadBatch catches rows left behind the frontier.
+    // The chunk loader reads the partial pending index. Existing installations initially have a
+    // null marker on every document, so a bounded compatibility update marks legacy rows that
+    // already have chunks while holding their document row locks. This drains the corpus without
+    // an unbounded anti-join and makes concurrent reset/replacement authoritative.
 
-    public async Task<bool> ChunkDocumentBatch(
-        BackfillCursor cursor,
-        CancellationToken cancellationToken
-    )
+    public async Task<bool> ChunkDocumentBatch(CancellationToken cancellationToken)
     {
-        var pendingDocuments = await LoadBatch(
-            floor =>
-            {
-                var query = _documentRepository
-                    .GetAll()
-                    .Include(d => d.CommonStock)
-                    .Include(d => d.Content)
-                    .Where(d => !d.Chunks.Any() && d.Content != null);
-                if (floor is { } f)
-                    query = query.Where(d => d.CreationTime >= f);
-                return query
-                    .OrderBy(d => d.CreationTime)
-                    .Take(_loadSize)
-                    .ToListAsync(cancellationToken);
-            },
-            cursor
-        );
+        if (await BackfillChunkedAtBatch(cancellationToken) > 0)
+            return true;
 
-        if (pendingDocuments.Count == 0)
+        var pendingDocumentIds = await _documentRepository
+            .GetAll()
+            .Where(d => d.ChunkedAt == null && d.Content != null)
+            .OrderBy(d => d.CreationTime)
+            .ThenBy(d => d.Id)
+            .Select(d => d.Id)
+            .Take(_loadSize)
+            .ToListAsync(cancellationToken);
+
+        if (pendingDocumentIds.Count == 0)
             return false;
 
-        _logger.LogInformation("Chunking {Count} documents", pendingDocuments.Count);
-        await ProcessOrRewind(
-            () => _documentProcessor.ProcessDocuments(pendingDocuments, cancellationToken),
-            cursor
-        );
-        cursor.Advance(pendingDocuments[^1].CreationTime);
-        await PersistCursor(cursor);
-        return true;
+        _logger.LogInformation("Chunking {Count} documents", pendingDocumentIds.Count);
+        var attempted = 0;
+        var progressed = 0;
+        foreach (var documentId in pendingDocumentIds)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            await using var transaction = await _documentRepository.CreateTransaction(
+                IsolationLevel.ReadCommitted,
+                cancellationToken
+            );
+            try
+            {
+                var document = await _documentRepository.GetPendingForUpdate(
+                    documentId,
+                    cancellationToken
+                );
+                if (document == null)
+                    continue;
+
+                attempted++;
+                await _documentProcessor.ProcessDocument(document, cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+                progressed++;
+            }
+            catch (Exception ex)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                _logger.LogError(ex, "Error chunking document {DocumentId}", documentId);
+            }
+            finally
+            {
+                _documentRepository.ClearChangeTracker();
+            }
+        }
+
+        if (!cancellationToken.IsCancellationRequested && attempted > 0 && progressed == 0)
+        {
+            throw new InvalidOperationException(
+                $"Chunking failed for all {attempted} documents in the batch — the content "
+                    + "store is likely unavailable. Backing off this cycle."
+            );
+        }
+
+        return progressed > 0;
     }
+
+    private Task<int> BackfillChunkedAtBatch(CancellationToken cancellationToken) =>
+        _documentRepository.BackfillLegacyChunked(_loadSize, DateTime.UtcNow, cancellationToken);
 
     public async Task<bool> GenerateEmbeddingBatch(
         BackfillCursor cursor,

--- a/src/Equibles.Sec.HostedService/Services/DocumentNormalizationBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentNormalizationBackfillService.cs
@@ -3,7 +3,6 @@ using System.Text.RegularExpressions;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Media.BusinessLogic;
 using Equibles.Sec.BusinessLogic;
-using Equibles.Sec.BusinessLogic.Processing;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Models;
 using Equibles.Sec.Repositories;
@@ -14,7 +13,7 @@ namespace Equibles.Sec.HostedService.Services;
 /// <summary>
 /// Re-fetches and re-normalizes EDGAR documents whose stored Markdown predates the current
 /// normalization pipeline. Each successful replacement keeps the document id, removes stale
-/// chunks, and immediately recreates chunks from the corrected body.
+/// chunks, and returns it to the indexed pending queue for locked reprocessing.
 /// </summary>
 public class DocumentNormalizationBackfillService
 {
@@ -29,7 +28,6 @@ public class DocumentNormalizationBackfillService
     private readonly ISecDocumentHtmlToMarkdownConverter _converter;
     private readonly IFileManager _fileManager;
     private readonly IDocumentPersistenceService _persistenceService;
-    private readonly IDocumentProcessor _documentProcessor;
     private readonly ILogger<DocumentNormalizationBackfillService> _logger;
 
     public DocumentNormalizationBackfillService(
@@ -39,7 +37,6 @@ public class DocumentNormalizationBackfillService
         ISecDocumentHtmlToMarkdownConverter converter,
         IFileManager fileManager,
         IDocumentPersistenceService persistenceService,
-        IDocumentProcessor documentProcessor,
         ILogger<DocumentNormalizationBackfillService> logger
     )
     {
@@ -49,7 +46,6 @@ public class DocumentNormalizationBackfillService
         _converter = converter;
         _fileManager = fileManager;
         _persistenceService = persistenceService;
-        _documentProcessor = documentProcessor;
         _logger = logger;
     }
 
@@ -162,7 +158,6 @@ public class DocumentNormalizationBackfillService
                 {
                     await _persistenceService.ResetChunks(document, cancellationToken);
                     result.Unchanged++;
-                    await Rechunk(document, cancellationToken);
                     continue;
                 }
 
@@ -172,8 +167,6 @@ public class DocumentNormalizationBackfillService
                     cancellationToken
                 );
                 result.Replaced++;
-
-                await Rechunk(document, cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -197,27 +190,6 @@ public class DocumentNormalizationBackfillService
         }
 
         return result;
-    }
-
-    private async Task Rechunk(Document document, CancellationToken cancellationToken)
-    {
-        try
-        {
-            await _documentProcessor.ProcessDocuments([document], cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Corrected document {DocumentId} was stored but could not be re-chunked immediately; the document processor will retry it.",
-                document.Id
-            );
-        }
     }
 
     private async Task<bool> ContentMatches(Document document, byte[] normalizedContent)

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -177,14 +177,15 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         var file = await SaveTextContent(content, fileName);
         document.Content = file;
         document.LineCount = CountLines(content);
+        await ClearChunkedAt(document, cancellationToken);
 
         // Remove the superseded File row in the same transaction. Filesystem bytes are queued
         // for the reference-checked deletion sweep, so content-addressed blobs shared with the
         // replacement or another File row are never unlinked prematurely.
         _fileManager.DeleteFile(oldContent);
 
-        // Drop the stale chunks (their embeddings cascade at the DB level) so the chunking worker,
-        // which polls for documents that have no chunks, re-chunks the new body on its next pass.
+        // Drop the stale chunks (their embeddings cascade at the DB level). Clearing ChunkedAt
+        // above returns the document to the worker's indexed pending queue after commit.
         await DeleteChunks(document.Id, cancellationToken);
 
         await _documentRepository.SaveChanges();
@@ -198,6 +199,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
             cancellationToken
         );
 
+        await ClearChunkedAt(document, cancellationToken);
         await DeleteChunks(document.Id, cancellationToken);
         await _documentRepository.SaveChanges();
         await transaction.CommitAsync(cancellationToken);
@@ -208,6 +210,18 @@ public class DocumentPersistenceService : IDocumentPersistenceService
             .GetAll()
             .Where(c => c.DocumentId == documentId)
             .ExecuteDeleteAsync(cancellationToken);
+
+    private async Task ClearChunkedAt(Document document, CancellationToken cancellationToken)
+    {
+        document.ChunkedAt = null;
+        await _documentRepository
+            .GetAll()
+            .Where(d => d.Id == document.Id)
+            .ExecuteUpdateAsync(
+                setters => setters.SetProperty(d => d.ChunkedAt, (DateTime?)null),
+                cancellationToken
+            );
+    }
 
     // Line count = newline bytes + 1 — identical to the previous
     // GetString(content).Split('\n').Length, without decoding a multi-MB filing

--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -72,6 +72,72 @@ public class DocumentRepository : BaseRepository<Document>
         return GetAll().Where(d => d.DocumentType == documentType);
     }
 
+    /// <summary>
+    /// Locks one bounded FIFO batch of legacy rows that already have chunks but predate the
+    /// completion marker. The pending partial index bounds candidate discovery; the chunk probe
+    /// uses the DocumentId index and disappears once compatibility draining finishes.
+    /// </summary>
+    public Task<int> BackfillLegacyChunked(
+        int batchSize,
+        DateTime chunkedAt,
+        CancellationToken cancellationToken = default
+    ) =>
+        DbContext.Database.ExecuteSqlInterpolatedAsync(
+            $"""
+            WITH candidates AS MATERIALIZED (
+                SELECT d."Id"
+                FROM "Document" AS d
+                WHERE d."ChunkedAt" IS NULL
+                  AND EXISTS (
+                      SELECT 1
+                      FROM "Chunk" AS c
+                      WHERE c."DocumentId" = d."Id"
+                  )
+                ORDER BY d."CreationTime", d."Id"
+                LIMIT {batchSize}
+                FOR UPDATE OF d SKIP LOCKED
+            )
+            UPDATE "Document" AS d
+            SET "ChunkedAt" = {chunkedAt}
+            FROM candidates AS c
+            WHERE d."Id" = c."Id";
+            """,
+            cancellationToken
+        );
+
+    /// <summary>
+    /// Claims one pending document for the current transaction. SKIP LOCKED keeps a concurrent
+    /// content replacement or chunk reset authoritative: the worker skips that document until the
+    /// reset commits instead of waiting and then writing a stale completion marker over it.
+    /// </summary>
+    public async Task<Document> GetPendingForUpdate(
+        Guid documentId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var documents = await GetDbSet()
+            .FromSqlInterpolated(
+                $"""
+                SELECT d.*
+                FROM "Document" AS d
+                WHERE d."Id" = {documentId}
+                  AND d."ChunkedAt" IS NULL
+                  AND d."ContentId" IS NOT NULL
+                FOR UPDATE OF d SKIP LOCKED
+                """
+            )
+            .ToListAsync(cancellationToken);
+
+        var document = documents.SingleOrDefault();
+        if (document == null)
+            return null;
+
+        await DbContext.Entry(document).Reference(d => d.CommonStock).LoadAsync(cancellationToken);
+        await DbContext.Entry(document).Reference(d => d.Content).LoadAsync(cancellationToken);
+        await DbContext.Entry(document).Collection(d => d.Chunks).LoadAsync(cancellationToken);
+        return document;
+    }
+
     public IQueryable<Document> GetByXbrlStatus(XbrlCaptureStatus status)
     {
         return GetAll().Where(d => d.XbrlStatus == status);

--- a/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
@@ -1,5 +1,7 @@
+using System.Data.Common;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.BusinessLogic.Processing;
@@ -7,7 +9,9 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.Data.Models.Chunks;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Pgvector;
@@ -19,13 +23,9 @@ namespace Equibles.IntegrationTests.Sec;
 /// <summary>
 /// The unit-tier <c>DocumentManagerTests</c> in <c>Equibles.UnitTests.Sec</c> explicitly
 /// leaves <see cref="DocumentManager.ChunkDocumentBatch"/> uncovered (see its XML doc):
-/// the query <c>.Include(d =&gt; d.Chunks).Where(d =&gt; !d.Chunks.Any() &amp;&amp; d.Content != null)</c>
-/// only behaves correctly against real Postgres — EF Core's InMemory provider has
-/// different semantics for navigation-property predicates, so a regression in how that
-/// "pending document" query is shaped would slip past the unit suite. With a real
-/// ParadeDB container, this test pins the production filter: a document that already
-/// has chunks must be excluded, and a document without content must also be excluded —
-/// so the Phase 1 worker only chunks documents that genuinely need it.
+/// uses a filtered PostgreSQL index over <see cref="Document.ChunkedAt"/>. These tests pin the
+/// production filter and the bounded compatibility drain for rows created before that marker
+/// existed.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class DocumentManagerTests : ParadeDbMcpTestBase
@@ -54,8 +54,8 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
             createdAt: DateTime.UtcNow.AddMinutes(-5)
         );
 
-        // Already chunked: has Content AND at least one Chunk — must be excluded by
-        // the !d.Chunks.Any() predicate so the worker doesn't re-chunk it on every tick.
+        // Already chunked: has a completion marker and must be excluded by the partial queue
+        // predicate even though its historical chunk rows also remain present.
         var chunkedFile = MakeFile();
         var chunkedDoc = MakeDocument(
             stock,
@@ -63,6 +63,7 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
             contentId: chunkedFile.Id,
             createdAt: DateTime.UtcNow.AddMinutes(-10)
         );
+        chunkedDoc.ChunkedAt = DateTime.UtcNow.AddMinutes(-9);
         var existingChunk = new Chunk
         {
             Id = Guid.NewGuid(),
@@ -98,10 +99,7 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
             NullLogger<DocumentManager>()
         );
 
-        var workDone = await sut.ChunkDocumentBatch(
-            new BackfillCursor("document-chunking"),
-            CancellationToken.None
-        );
+        var workDone = await sut.ChunkDocumentBatch(CancellationToken.None);
 
         workDone
             .Should()
@@ -110,17 +108,277 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
         var passed =
             _processor
                 .ReceivedCalls()
-                .Single(c => c.GetMethodInfo().Name == nameof(IDocumentProcessor.ProcessDocuments))
-                .GetArguments()[0] as IReadOnlyCollection<Document>;
+                .Single(c => c.GetMethodInfo().Name == nameof(IDocumentProcessor.ProcessDocument))
+                .GetArguments()[0] as Document;
 
         passed.Should().NotBeNull();
-        passed!
-            .Select(d => d.Id)
-            .Should()
-            .ContainSingle(
-                id => id == pendingDoc.Id,
-                "only the chunkless-with-content document survives the !Chunks.Any() && Content != null filter"
+        passed!.Id.Should().Be(pendingDoc.Id);
+    }
+
+    [Fact]
+    public async Task ChunkDocumentBatch_LegacyChunkedDocument_BackfillsMarkerWithoutProcessing()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+        };
+        var file = MakeFile();
+        var document = MakeDocument(
+            stock,
+            file,
+            contentId: file.Id,
+            createdAt: DateTime.UtcNow.AddMinutes(-5)
+        );
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<File>().Add(file);
+        DbContext.Set<Document>().Add(document);
+        DbContext
+            .Set<Chunk>()
+            .Add(
+                new Chunk
+                {
+                    DocumentId = document.Id,
+                    Content = "already chunked",
+                    Index = 0,
+                    DocumentType = document.DocumentType,
+                    Ticker = stock.Ticker,
+                    ReportingDate = document.ReportingDate.ToDateTime(
+                        TimeOnly.MinValue,
+                        DateTimeKind.Utc
+                    ),
+                }
             );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var sut = new DocumentManager(
+            new DocumentRepository(DbContext),
+            new ChunkRepository(DbContext),
+            new BackfillStateRepository(DbContext),
+            _processor,
+            Options.Create(new EmbeddingConfig { Enabled = false }),
+            NullLogger<DocumentManager>()
+        );
+
+        var workDone = await sut.ChunkDocumentBatch(CancellationToken.None);
+
+        workDone.Should().BeTrue();
+        await _processor.DidNotReceiveWithAnyArgs().ProcessDocument(default, default);
+        DbContext.ChangeTracker.Clear();
+        var saved = await DbContext.Set<Document>().SingleAsync(d => d.Id == document.Id);
+        saved.ChunkedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ChunkDocumentBatch_ConcurrentReset_SkipsLockedDocumentUntilResetCommits()
+    {
+        var documentId = Guid.NewGuid();
+        await using (var seed = Fixture.CreateDbContext())
+        {
+            var stock = new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = "AAPL",
+                Name = "Apple Inc.",
+            };
+            var file = MakeFile();
+            var document = MakeDocument(
+                stock,
+                file,
+                contentId: file.Id,
+                createdAt: DateTime.UtcNow.AddMinutes(-5)
+            );
+            document.Id = documentId;
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<File>().Add(file);
+            seed.Set<Document>().Add(document);
+            seed.Set<Chunk>()
+                .Add(
+                    new Chunk
+                    {
+                        DocumentId = document.Id,
+                        Content = "legacy chunk",
+                        Index = 0,
+                        DocumentType = document.DocumentType,
+                        Ticker = stock.Ticker,
+                        ReportingDate = document.ReportingDate.ToDateTime(
+                            TimeOnly.MinValue,
+                            DateTimeKind.Utc
+                        ),
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var resetInterceptor = new ChunkMarkerResetInterceptor(pauseAfterMarkerClear: true);
+        await using var resetContext = Fixture.CreateDbContext(options =>
+            options.AddInterceptors(resetInterceptor)
+        );
+        var resetDocument = await resetContext.Set<Document>().SingleAsync(d => d.Id == documentId);
+        var resetTask = NewResetService(resetContext).ResetChunks(resetDocument);
+        await resetInterceptor.MarkerCleared.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await using var workerContext = Fixture.CreateDbContext();
+        var sut = new DocumentManager(
+            new DocumentRepository(workerContext),
+            new ChunkRepository(workerContext),
+            new BackfillStateRepository(workerContext),
+            _processor,
+            Options.Create(new EmbeddingConfig { Enabled = false }),
+            NullLogger<DocumentManager>()
+        );
+
+        try
+        {
+            (await sut.ChunkDocumentBatch(CancellationToken.None)).Should().BeFalse();
+            await _processor.DidNotReceiveWithAnyArgs().ProcessDocument(default, default);
+        }
+        finally
+        {
+            resetInterceptor.ReleaseMarkerClear.SetResult();
+        }
+        await resetTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        _processor
+            .ProcessDocument(Arg.Any<Document>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var document = call.ArgAt<Document>(0);
+                workerContext
+                    .Set<Chunk>()
+                    .Add(
+                        new Chunk
+                        {
+                            Document = document,
+                            Content = "fresh chunk",
+                            Index = 0,
+                            DocumentType = document.DocumentType,
+                            Ticker = document.CommonStock.Ticker,
+                            ReportingDate = document.ReportingDate.ToDateTime(
+                                TimeOnly.MinValue,
+                                DateTimeKind.Utc
+                            ),
+                        }
+                    );
+                document.ChunkedAt = DateTime.UtcNow;
+                await workerContext.SaveChangesAsync();
+            });
+
+        (await sut.ChunkDocumentBatch(CancellationToken.None)).Should().BeTrue();
+        await _processor
+            .Received(1)
+            .ProcessDocument(
+                Arg.Is<Document>(d => d.Id == documentId),
+                Arg.Any<CancellationToken>()
+            );
+
+        await using var verify = Fixture.CreateDbContext();
+        var saved = await verify.Set<Document>().SingleAsync(d => d.Id == documentId);
+        saved.ChunkedAt.Should().NotBeNull();
+        (await verify.Set<Chunk>().CountAsync(c => c.DocumentId == documentId)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ChunkDocumentBatch_WorkerOwnsLock_ResetWaitsAndWinsFinalState()
+    {
+        var documentId = Guid.NewGuid();
+        await using (var seed = Fixture.CreateDbContext())
+        {
+            var stock = new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = "AAPL",
+                Name = "Apple Inc.",
+            };
+            var file = MakeFile();
+            var document = MakeDocument(
+                stock,
+                file,
+                contentId: file.Id,
+                createdAt: DateTime.UtcNow.AddMinutes(-5)
+            );
+            document.Id = documentId;
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<File>().Add(file);
+            seed.Set<Document>().Add(document);
+            await seed.SaveChangesAsync();
+        }
+
+        await using var workerContext = Fixture.CreateDbContext();
+        var workerEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var releaseWorker = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        _processor
+            .ProcessDocument(Arg.Any<Document>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var document = call.ArgAt<Document>(0);
+                workerContext
+                    .Set<Chunk>()
+                    .Add(
+                        new Chunk
+                        {
+                            Document = document,
+                            Content = "fresh chunk",
+                            Index = 0,
+                            DocumentType = document.DocumentType,
+                            Ticker = document.CommonStock.Ticker,
+                            ReportingDate = document.ReportingDate.ToDateTime(
+                                TimeOnly.MinValue,
+                                DateTimeKind.Utc
+                            ),
+                        }
+                    );
+                document.ChunkedAt = DateTime.UtcNow;
+                await workerContext.SaveChangesAsync();
+                workerEntered.SetResult();
+                await releaseWorker.Task;
+            });
+
+        var sut = new DocumentManager(
+            new DocumentRepository(workerContext),
+            new ChunkRepository(workerContext),
+            new BackfillStateRepository(workerContext),
+            _processor,
+            Options.Create(new EmbeddingConfig { Enabled = false }),
+            NullLogger<DocumentManager>()
+        );
+        var workerTask = sut.ChunkDocumentBatch(CancellationToken.None);
+        await workerEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var resetInterceptor = new ChunkMarkerResetInterceptor(pauseAfterMarkerClear: false);
+        await using var resetContext = Fixture.CreateDbContext(options =>
+            options.AddInterceptors(resetInterceptor)
+        );
+        var resetDocument = await resetContext.Set<Document>().SingleAsync(d => d.Id == documentId);
+        var resetTask = NewResetService(resetContext).ResetChunks(resetDocument);
+        await resetInterceptor.MarkerClearStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            var completed = await Task.WhenAny(
+                resetTask,
+                Task.Delay(TimeSpan.FromMilliseconds(250))
+            );
+            completed.Should().NotBe(resetTask, "the reset must wait for the worker's row lock");
+        }
+        finally
+        {
+            releaseWorker.SetResult();
+        }
+
+        (await workerTask).Should().BeTrue();
+        await resetTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await using var verify = Fixture.CreateDbContext();
+        var saved = await verify.Set<Document>().SingleAsync(d => d.Id == documentId);
+        saved.ChunkedAt.Should().BeNull();
+        (await verify.Set<Chunk>().AnyAsync(c => c.DocumentId == documentId)).Should().BeFalse();
     }
 
     [Fact]
@@ -403,6 +661,64 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
             ),
             NullLogger<DocumentManager>()
         );
+
+    private static DocumentPersistenceService NewResetService(
+        Equibles.Data.EquiblesFinancialDbContext dbContext
+    ) =>
+        new(
+            new DocumentRepository(dbContext),
+            new ChunkRepository(dbContext),
+            Substitute.For<IFileManager>(),
+            null,
+            Substitute.For<IBus>()
+        );
+
+    private sealed class ChunkMarkerResetInterceptor(bool pauseAfterMarkerClear)
+        : DbCommandInterceptor
+    {
+        public TaskCompletionSource MarkerClearStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource MarkerCleared { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseMarkerClear { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (IsMarkerClear(command))
+                MarkerClearStarted.TrySetResult();
+
+            return ValueTask.FromResult(result);
+        }
+
+        public override async ValueTask<int> NonQueryExecutedAsync(
+            DbCommand command,
+            CommandExecutedEventData eventData,
+            int result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (!IsMarkerClear(command))
+                return result;
+
+            MarkerCleared.TrySetResult();
+            if (pauseAfterMarkerClear)
+                await ReleaseMarkerClear.Task.WaitAsync(cancellationToken);
+
+            return result;
+        }
+
+        private static bool IsMarkerClear(DbCommand command) =>
+            command.CommandText.Contains("UPDATE \"Document\"", StringComparison.Ordinal)
+            && command.CommandText.Contains("\"ChunkedAt\"", StringComparison.Ordinal);
+    }
 
     private static Chunk MakeChunk(
         Document document,

--- a/tests/Equibles.IntegrationTests/Sec/DocumentNormalizationBackfillPostgresTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentNormalizationBackfillPostgresTests.cs
@@ -5,9 +5,6 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.BusinessLogic;
 using Equibles.Media.Repositories;
 using Equibles.Sec.BusinessLogic;
-using Equibles.Sec.BusinessLogic.Embeddings;
-using Equibles.Sec.BusinessLogic.Processing;
-using Equibles.Sec.BusinessLogic.Tokenization;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Data.Models.Chunks;
 using Equibles.Sec.HostedService.Services;
@@ -17,7 +14,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using NSubstitute;
 
 namespace Equibles.IntegrationTests.Sec;
@@ -33,7 +29,7 @@ public class DocumentNormalizationBackfillPostgresTests : ParadeDbMcpTestBase
         : base(fixture) { }
 
     [Fact]
-    public async Task Backfill_ReplacesFileDeletesStaleChunksAndRechunksInOneRun()
+    public async Task Backfill_ReplacesFileDeletesStaleChunksAndQueuesLockedRechunking()
     {
         var document = await SeedLegacyDocument("NVDA");
         var oldContentId = document.ContentId;
@@ -96,8 +92,8 @@ public class DocumentNormalizationBackfillPostgresTests : ParadeDbMcpTestBase
             .Where(c => c.DocumentId == document.Id)
             .OrderBy(c => c.Index)
             .ToListAsync();
-        chunks.Should().NotBeEmpty();
-        chunks[0].Content.Should().Contain("77,286 | 67 | % |\n| Graphics | 22,459");
+        chunks.Should().BeEmpty();
+        saved.ChunkedAt.Should().BeNull();
     }
 
     [Fact]
@@ -156,7 +152,7 @@ public class DocumentNormalizationBackfillPostgresTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task Backfill_UnchangedFileKeepsBlobButRebuildsFlattenedChunks()
+    public async Task Backfill_UnchangedFileKeepsBlobAndQueuesLockedRechunking()
     {
         var normalized = new SecDocumentHtmlToMarkdownConverter().Convert(
             new SecDocumentHtmlNormalizer().Normalize(NvidiaSubmission)
@@ -209,8 +205,8 @@ public class DocumentNormalizationBackfillPostgresTests : ParadeDbMcpTestBase
             .Where(c => c.DocumentId == document.Id)
             .OrderBy(c => c.Index)
             .ToListAsync();
-        chunks.Should().NotBeEmpty();
-        chunks[0].Content.Should().Contain("77,286 | 67 | % |\n| Graphics | 22,459");
+        chunks.Should().BeEmpty();
+        saved.ChunkedAt.Should().BeNull();
     }
 
     private async Task<Document> SeedLegacyDocument(string ticker, byte[] content = null)
@@ -252,16 +248,6 @@ public class DocumentNormalizationBackfillPostgresTests : ParadeDbMcpTestBase
     )
     {
         var fileManager = CreateFileManager();
-        var processor = new DocumentProcessor(
-            new ChunkRepository(DbContext),
-            new EmbeddingRepository(DbContext),
-            Substitute.For<IEmbeddingClient>(),
-            new ChunkingStrategy(new TokenCounter()),
-            Options.Create(new EmbeddingConfig()),
-            fileManager,
-            Substitute.For<ILogger<DocumentProcessor>>()
-        );
-
         return new DocumentNormalizationBackfillService(
             new DocumentRepository(DbContext),
             secClient,
@@ -269,7 +255,6 @@ public class DocumentNormalizationBackfillPostgresTests : ParadeDbMcpTestBase
             new SecDocumentHtmlToMarkdownConverter(),
             fileManager,
             persistenceService ?? CreatePersistence(fileManager),
-            processor,
             Substitute.For<ILogger<DocumentNormalizationBackfillService>>()
         );
     }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentNormalizationBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentNormalizationBackfillServiceTests.cs
@@ -7,7 +7,6 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data;
 using Equibles.Sec.BusinessLogic;
-using Equibles.Sec.BusinessLogic.Processing;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
@@ -24,7 +23,6 @@ public class DocumentNormalizationBackfillServiceTests : IDisposable
     private readonly IFileManager _fileManager = Substitute.For<IFileManager>();
     private readonly IDocumentPersistenceService _persistenceService =
         Substitute.For<IDocumentPersistenceService>();
-    private readonly IDocumentProcessor _documentProcessor = Substitute.For<IDocumentProcessor>();
     private readonly CommonStock _company;
 
     public DocumentNormalizationBackfillServiceTests()
@@ -58,7 +56,7 @@ public class DocumentNormalizationBackfillServiceTests : IDisposable
     public void Dispose() => _dbContext.Dispose();
 
     [Fact]
-    public async Task Backfill_PendingNvidiaFiling_ReplacesContentAndRechunksAtCurrentVersion()
+    public async Task Backfill_PendingNvidiaFiling_ReplacesContentForIndexedRechunking()
     {
         var document = SeedDocument(normalizedContentVersion: 0);
         _secEdgarClient
@@ -83,14 +81,6 @@ public class DocumentNormalizationBackfillServiceTests : IDisposable
                     && d.NormalizedContentAttempts == 0
                 ),
                 Arg.Is<byte[]>(bytes => CorrectedTable(Encoding.UTF8.GetString(bytes))),
-                Arg.Any<CancellationToken>()
-            );
-        await _documentProcessor
-            .Received(1)
-            .ProcessDocuments(
-                Arg.Is<List<Document>>(documents =>
-                    documents.Count == 1 && documents[0].Id == document.Id
-                ),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -154,7 +144,7 @@ public class DocumentNormalizationBackfillServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Backfill_WhenNormalizedBytesAreUnchanged_RechunksWithoutReplacingFile()
+    public async Task Backfill_WhenNormalizedBytesAreUnchanged_ResetsChunksWithoutReplacingFile()
     {
         var document = SeedDocument(normalizedContentVersion: 0);
         _secEdgarClient
@@ -182,12 +172,6 @@ public class DocumentNormalizationBackfillServiceTests : IDisposable
         await _persistenceService
             .Received(1)
             .ResetChunks(Arg.Is<Document>(d => d.Id == document.Id), Arg.Any<CancellationToken>());
-        await _documentProcessor
-            .Received(1)
-            .ProcessDocuments(
-                Arg.Is<List<Document>>(documents => documents.Single().Id == document.Id),
-                Arg.Any<CancellationToken>()
-            );
     }
 
     [Fact]
@@ -216,31 +200,6 @@ public class DocumentNormalizationBackfillServiceTests : IDisposable
         document.NormalizedContentVersion.Should().Be(0);
     }
 
-    [Fact]
-    public async Task Backfill_CancellationDuringRechunk_PropagatesAfterProcessorReturns()
-    {
-        var document = SeedDocument(normalizedContentVersion: 0);
-        using var cancellation = new CancellationTokenSource();
-        _secEdgarClient
-            .GetDocumentContent(
-                document.AccessionNumber,
-                _company.Cik,
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(NvidiaSubmission);
-        _documentProcessor
-            .ProcessDocuments(Arg.Any<List<Document>>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
-            {
-                cancellation.Cancel();
-                return Task.CompletedTask;
-            });
-
-        var act = () => BuildSut().Backfill(batchSize: 1, cancellationToken: cancellation.Token);
-
-        await act.Should().ThrowAsync<OperationCanceledException>();
-    }
-
     private DocumentNormalizationBackfillService BuildSut() =>
         new(
             new DocumentRepository(_dbContext),
@@ -249,7 +208,6 @@ public class DocumentNormalizationBackfillServiceTests : IDisposable
             new SecDocumentHtmlToMarkdownConverter(),
             _fileManager,
             _persistenceService,
-            _documentProcessor,
             Substitute.For<ILogger<DocumentNormalizationBackfillService>>()
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceReplaceContentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceReplaceContentTests.cs
@@ -135,8 +135,13 @@ public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase
             await concurrent
                 .Set<Document>()
                 .Where(d => d.Id == documentId)
-                .ExecuteUpdateAsync(setters => setters.SetProperty(d => d.Items, "7.01"));
+                .ExecuteUpdateAsync(setters =>
+                    setters
+                        .SetProperty(d => d.Items, "7.01")
+                        .SetProperty(d => d.ChunkedAt, DateTime.UtcNow)
+                );
         }
+        tracked.ChunkedAt.Should().BeNull("the replacement context loaded the legacy marker");
         var newBody = "new line 1\nnew line 2\nnew line 3"u8.ToArray();
 
         await BuildSut().ReplaceContent(tracked, newBody);
@@ -146,6 +151,7 @@ public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase
         saved.LineCount.Should().Be(3);
         saved.Items.Should().Be("7.01");
         saved.NormalizedContentVersion.Should().Be(Document.NormalizedContentBuilderVersion);
+        saved.ChunkedAt.Should().BeNull();
 
         var bodyFile = await verify.Set<File>().SingleAsync(f => f.Id == saved.ContentId);
         bodyFile.StorageProvider.Should().Be(StorageProvider.FileSystem);
@@ -161,5 +167,60 @@ public class DocumentPersistenceServiceReplaceContentTests : ParadeDbMcpTestBase
 
         var remainingChunks = await verify.Set<Chunk>().CountAsync(c => c.DocumentId == documentId);
         remainingChunks.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResetChunks_ClearsChunkedMarkerAndDeletesChunks()
+    {
+        var apple = await SeedCompany();
+        await BuildSut()
+            .Save(
+                company: apple,
+                content: "stored body"u8.ToArray(),
+                fileName: "AAPL-10k.txt",
+                documentType: DocumentType.TenK,
+                reportingDate: new DateOnly(2024, 3, 15),
+                reportingForDate: new DateOnly(2023, 12, 31),
+                sourceUrl: "https://example.test/filing"
+            );
+
+        var document = await DbContext
+            .Set<Document>()
+            .SingleAsync(d => d.CommonStockId == apple.Id);
+        DbContext
+            .Set<Chunk>()
+            .Add(
+                new Chunk
+                {
+                    DocumentId = document.Id,
+                    Index = 0,
+                    Content = "stored body",
+                    DocumentType = document.DocumentType,
+                    Ticker = apple.Ticker,
+                    ReportingDate = document.ReportingDate.ToDateTime(
+                        TimeOnly.MinValue,
+                        DateTimeKind.Utc
+                    ),
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        await using (var concurrent = Fixture.CreateDbContext())
+        {
+            await concurrent
+                .Set<Document>()
+                .Where(d => d.Id == document.Id)
+                .ExecuteUpdateAsync(setters =>
+                    setters.SetProperty(d => d.ChunkedAt, DateTime.UtcNow)
+                );
+        }
+        document.ChunkedAt.Should().BeNull("the reset context loaded the legacy marker");
+
+        await BuildSut().ResetChunks(document);
+
+        await using var verify = Fixture.CreateDbContext();
+        var saved = await verify.Set<Document>().SingleAsync(d => d.Id == document.Id);
+        saved.ChunkedAt.Should().BeNull();
+        (await verify.Set<Chunk>().AnyAsync(c => c.DocumentId == document.Id)).Should().BeFalse();
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorCreateChunksTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorCreateChunksTests.cs
@@ -94,6 +94,7 @@ public class DocumentProcessorCreateChunksTests
         // Index must be assigned sequentially — a regression that reused i or shuffled
         // the order would silently corrupt downstream search/retrieval ordering.
         addedChunks.Select(c => c.Index).Should().Equal(Enumerable.Range(0, addedChunks.Count));
+        document.ChunkedAt.Should().NotBeNull();
         await chunkRepository.Received(1).SaveChanges();
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
@@ -61,9 +61,8 @@ public class DocumentProcessorTests
     [Fact]
     public async Task ProcessDocuments_DocumentWithNullContent_LogsErrorAndContinuesBatch()
     {
-        // DocumentProcessor.ProcessDocuments is the worker's main loop —
-        // SecScraperWorker hands it the whole queue of newly-fetched filings
-        // each cycle. If a single document is missing its File envelope
+        // ProcessDocuments is the processor's batch-isolation wrapper. If a single document is
+        // missing its File envelope
         // (Content == null), GetDocumentContent throws Exception("Document
         // content is null"); ProcessDocuments catches that under `catch
         // (Exception ex)` and logs an error so the rest of the batch can
@@ -148,6 +147,7 @@ public class DocumentProcessorTests
         var act = () => sut.ProcessDocuments(documents, CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Chunking failed*");
+        documents.Should().OnlyContain(d => d.ChunkedAt == null);
     }
 
     [Fact]
@@ -162,20 +162,19 @@ public class DocumentProcessorTests
             .GetContent(Arg.Any<Equibles.Media.Data.Models.File>())
             .Returns(System.Text.Encoding.UTF8.GetBytes("   \n\t  "));
         var sut = CreateSut(Substitute.For<IEmbeddingClient>(), fileManager: fileManager);
-        var documents = new List<Document>
+        var document = new Document
         {
-            new()
-            {
-                Id = Guid.NewGuid(),
-                DocumentType = DocumentType.TenK,
-                CommonStock = new CommonStock { Name = "Test Co", Ticker = "TEST" },
-                Content = new Equibles.Media.Data.Models.File(),
-            },
+            Id = Guid.NewGuid(),
+            DocumentType = DocumentType.TenK,
+            CommonStock = new CommonStock { Name = "Test Co", Ticker = "TEST" },
+            Content = new Equibles.Media.Data.Models.File(),
         };
+        var documents = new List<Document> { document };
 
         var act = () => sut.ProcessDocuments(documents, CancellationToken.None);
 
         await act.Should().NotThrowAsync();
+        document.ChunkedAt.Should().NotBeNull();
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentManagerTests.cs
@@ -11,8 +11,8 @@ namespace Equibles.UnitTests.Sec;
 
 /// <summary>
 /// Tests for <see cref="DocumentManager"/>.
-/// ChunkDocumentBatch uses .Include(d => d.Chunks) which requires PostgreSQL (pgvector),
-/// so we focus on the embedding configuration logic and GenerateEmbeddingBatch guard clauses.
+/// ChunkDocumentBatch uses PostgreSQL row locks, so this unit tier focuses on the embedding
+/// configuration logic and GenerateEmbeddingBatch guard clauses.
 /// </summary>
 public class DocumentManagerTests
 {

--- a/tests/Equibles.UnitTests/Sec/SecModulePendingChunkingIndexTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecModulePendingChunkingIndexTests.cs
@@ -1,0 +1,37 @@
+using Equibles.CommonStocks.Data;
+using Equibles.Data;
+using Equibles.Media.Data;
+using Equibles.Sec.Data;
+using Equibles.Sec.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecModulePendingChunkingIndexTests
+{
+    [Fact]
+    public void PendingChunkingIndex_IsFilteredAndOrdered()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=model-only", o => o.UseVector())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        using var db = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new MediaModuleConfiguration(),
+                new SecModuleConfiguration(),
+            }
+        );
+
+        var entity = db.Model.FindEntityType(typeof(Document));
+        var index = entity!
+            .GetIndexes()
+            .Single(i => i.GetDatabaseName() == "IX_Document_PendingChunking");
+
+        index.Properties.Select(p => p.Name).Should().Equal("CreationTime", "Id");
+        index.GetFilter().Should().Be("\"ChunkedAt\" IS NULL");
+    }
+}


### PR DESCRIPTION
## Problem

`DocumentManager.ChunkDocumentBatch` used a corpus-wide `NOT EXISTS` chunk anti-join that scanned more than one million documents and probed the chunk corpus on every drained poll, timing out in production.

## What changed

- add a persisted `Document.ChunkedAt` completion marker and partial FIFO pending index
- drain legacy chunked rows in bounded, lock-safe batches
- claim pending documents with `FOR UPDATE SKIP LOCKED` so reset and replacement races remain correct
- atomically save chunks and the completion marker, including terminal zero-chunk outcomes
- requeue normalization replacements through the same locked worker path
- split the column and retry-safe concurrent index migrations
- cover both reset-first and worker-first PostgreSQL race orderings

## Verification

- `dotnet csharpier check .`
- `dotnet ef migrations has-pending-model-changes --project src/Equibles.Migrations --startup-project src/Equibles.Web`
- `dotnet build Equibles.sln -c Release --no-restore -m:1`
- 4,566 unit tests
- 2,699 PostgreSQL integration tests
- independent audit: no findings

Closes #3823