### PR TITLE
fix(congress): reconcile member identities

### DIFF
--- a/src/Equibles.Congress.Data/Models/CongressMember.cs
+++ b/src/Equibles.Congress.Data/Models/CongressMember.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.Congress.Data.Models;
 
 [Index(nameof(Name), IsUnique = true)]
+[Index(nameof(BioguideId), IsUnique = true)]
 public class CongressMember
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
@@ -12,6 +13,14 @@ public class CongressMember
 
     [MaxLength(256)]
     public string Name { get; set; }
+
+    /// <summary>
+    /// The member's stable identifier from the official Biographical Directory of the
+    /// United States Congress. Null only when the filing name has not been authoritatively
+    /// resolved; names alone never establish identity.
+    /// </summary>
+    [MaxLength(7)]
+    public string BioguideId { get; set; }
 
     public CongressPosition Position { get; set; }
 

--- a/src/Equibles.Congress.Data/Models/CongressMemberIdentity.cs
+++ b/src/Equibles.Congress.Data/Models/CongressMemberIdentity.cs
@@ -1,0 +1,7 @@
+namespace Equibles.Congress.Data.Models;
+
+public sealed record CongressMemberIdentity(
+    string BioguideId,
+    string CanonicalName,
+    IReadOnlyList<string> Aliases
+);

--- a/src/Equibles.Congress.Data/Models/CongressMemberIdentityCatalog.cs
+++ b/src/Equibles.Congress.Data/Models/CongressMemberIdentityCatalog.cs
@@ -1,0 +1,96 @@
+namespace Equibles.Congress.Data.Models;
+
+/// <summary>
+/// Reviewed, exact filing-name aliases backed by official BioGuide identities. This catalog is
+/// deliberately exact: an unknown spelling remains unresolved instead of being joined by name
+/// similarity. Add an alias only after verifying the member's BioGuide id against an official
+/// House Clerk or Congress.gov record.
+/// </summary>
+public static class CongressMemberIdentityCatalog
+{
+    private static readonly IReadOnlyList<CongressMemberIdentity> Identities =
+    [
+        Identity("S001150", "Adam Schiff", "Adam B Schiff", "Adam B. Schiff"),
+        Identity(
+            "O000172",
+            "Alexandria Ocasio-Cortez",
+            "Alexandria F Ocasio-Cortez",
+            "Alexandria F. Ocasio-Cortez"
+        ),
+        Identity("R000305", "Deborah Ross", "Deborah K Ross", "Deborah K. Ross"),
+        Identity("B001299", "James Banks", "James E Banks", "James E. Banks", "Jim Banks"),
+        Identity("C001114", "John Curtis", "John R Curtis", "John R. Curtis"),
+        Identity(
+            "M001239",
+            "John McGuire",
+            "John J McGuire",
+            "John J. McGuire",
+            "John McGuire III",
+            "John J. McGuire III"
+        ),
+        Identity("B001275", "Larry Bucshon", "Larry D Bucshon", "Larry D. Bucshon"),
+        Identity("M001136", "Lisa McClain", "Lisa C McClain", "Lisa C. McClain"),
+        Identity("M001211", "Mary Miller", "Mary E Miller", "Mary E. Miller"),
+        Identity(
+            "R000103",
+            "Matt Rosendale",
+            "Matt M Rosendale",
+            "Matt M. Rosendale",
+            "Matthew Rosendale"
+        ),
+        Identity("G000595", "Robert Good", "Robert G Good", "Robert G. Good"),
+        Identity("M001198", "Roger Marshall", "Roger W Marshall", "Roger W. Marshall"),
+        Identity(
+            "Y000067",
+            "Rudy Yakym",
+            "Rudy C Yakym",
+            "Rudy C. Yakym",
+            "Rudy Yakym III",
+            "Rudy C. Yakym III"
+        ),
+        Identity("F000471", "Scott Fitzgerald", "Scott L Fitzgerald", "Scott L. Fitzgerald"),
+        Identity("F000472", "Scott Franklin", "C Scott Franklin", "C. Scott Franklin"),
+        Identity("B001313", "Shontel Brown", "M Shontel Brown", "Shontel M. Brown"),
+        Identity("G000587", "Sylvia Garcia", "Sylvia R Garcia", "Sylvia R. Garcia"),
+        Identity("B001305", "Ted Budd", "Theodore Budd", "Theodore P Budd", "Theodore P. Budd"),
+        Identity("S001201", "Thomas Suozzi", "Thomas R Suozzi", "Thomas R. Suozzi"),
+    ];
+
+    private static readonly IReadOnlyDictionary<string, CongressMemberIdentity> ByAlias =
+        BuildAliasIndex();
+
+    public static IReadOnlyList<CongressMemberIdentity> All => Identities;
+
+    public static CongressMemberIdentity Resolve(string normalizedFilingName) =>
+        normalizedFilingName != null
+            ? ByAlias.GetValueOrDefault(normalizedFilingName.Trim())
+            : null;
+
+    private static CongressMemberIdentity Identity(
+        string bioguideId,
+        string canonicalName,
+        params string[] aliases
+    ) =>
+        new(
+            bioguideId,
+            canonicalName,
+            aliases.Prepend(canonicalName).Distinct(StringComparer.OrdinalIgnoreCase).ToArray()
+        );
+
+    private static IReadOnlyDictionary<string, CongressMemberIdentity> BuildAliasIndex()
+    {
+        var aliases = new Dictionary<string, CongressMemberIdentity>(
+            StringComparer.OrdinalIgnoreCase
+        );
+        foreach (var identity in Identities)
+        foreach (var alias in identity.Aliases)
+        {
+            if (!aliases.TryAdd(alias, identity))
+                throw new InvalidOperationException(
+                    $"Congress member alias '{alias}' is ambiguous"
+                );
+        }
+
+        return aliases;
+    }
+}

--- a/src/Equibles.Congress.HostedService/Models/CongressMemberObservation.cs
+++ b/src/Equibles.Congress.HostedService/Models/CongressMemberObservation.cs
@@ -1,0 +1,10 @@
+using Equibles.Congress.Data.Models;
+
+namespace Equibles.Congress.HostedService.Models;
+
+public sealed record CongressMemberObservation(
+    string FilingName,
+    CongressPosition Position,
+    string StateDistrict,
+    DateOnly ObservedAt
+);

--- a/src/Equibles.Congress.HostedService/Models/CongressionalTradeIdentity.cs
+++ b/src/Equibles.Congress.HostedService/Models/CongressionalTradeIdentity.cs
@@ -1,0 +1,29 @@
+using Equibles.Congress.Data.Models;
+
+namespace Equibles.Congress.HostedService.Models;
+
+internal sealed record CongressionalTradeIdentity(
+    Guid CommonStockId,
+    DateOnly TransactionDate,
+    CongressTransactionType TransactionType,
+    string AssetName,
+    string OwnerType,
+    long AmountFrom,
+    long AmountTo,
+    string AssetType,
+    string Subholding
+)
+{
+    public static CongressionalTradeIdentity From(CongressionalTrade trade) =>
+        new(
+            trade.CommonStockId,
+            trade.TransactionDate,
+            trade.TransactionType,
+            trade.AssetName,
+            trade.OwnerType,
+            trade.AmountFrom,
+            trade.AmountTo,
+            trade.AssetType,
+            trade.Subholding
+        );
+}

--- a/src/Equibles.Congress.HostedService/Models/ResolvedCongressMemberObservation.cs
+++ b/src/Equibles.Congress.HostedService/Models/ResolvedCongressMemberObservation.cs
@@ -1,0 +1,12 @@
+using Equibles.Congress.Data.Models;
+
+namespace Equibles.Congress.HostedService.Models;
+
+internal sealed record ResolvedCongressMemberObservation(
+    string FilingName,
+    string CanonicalName,
+    string BioguideId,
+    CongressPosition Position,
+    string StateDistrict,
+    DateOnly ObservedAt
+);

--- a/src/Equibles.Congress.HostedService/Services/CongressMemberHistoryMerger.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressMemberHistoryMerger.cs
@@ -1,0 +1,172 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Congress.HostedService.Services;
+
+internal sealed class CongressMemberHistoryMerger
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly ILogger<CongressMemberIdentityService> _logger;
+
+    public CongressMemberHistoryMerger(
+        EquiblesFinancialDbContext dbContext,
+        ILogger<CongressMemberIdentityService> logger
+    )
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task MergeMembers(
+        CongressMember survivor,
+        IReadOnlyCollection<CongressMember> retired,
+        CancellationToken ct
+    )
+    {
+        PreserveStateDistrict(survivor, retired);
+        var memberIds = retired.Select(member => member.Id).Append(survivor.Id).ToList();
+        var (reassignedTrades, duplicateTrades) = await MergeTrades(survivor.Id, memberIds, ct);
+        var (reassignedDisclosures, duplicateDisclosures) = await MergeDisclosures(
+            survivor.Id,
+            memberIds,
+            ct
+        );
+        await RewriteRedirectsAndRemoveMembers(survivor.Id, retired, ct);
+
+        _logger.LogInformation(
+            "Merged {RetiredCount} duplicate Congress members into {MemberId}; reassigned "
+                + "{TradeCount} trades and {DisclosureCount} annual disclosures, removed "
+                + "{DuplicateTradeCount} duplicate trades and {DuplicateDisclosureCount} superseded disclosures",
+            retired.Count,
+            survivor.Id,
+            reassignedTrades,
+            reassignedDisclosures,
+            duplicateTrades,
+            duplicateDisclosures
+        );
+    }
+
+    private static void PreserveStateDistrict(
+        CongressMember survivor,
+        IEnumerable<CongressMember> retired
+    )
+    {
+        survivor.StateDistrict ??= retired
+            .Where(member => !string.IsNullOrWhiteSpace(member.StateDistrict))
+            .OrderBy(member => member.CreationTime)
+            .LastOrDefault()
+            ?.StateDistrict;
+    }
+
+    private async Task<(int Reassigned, int Duplicates)> MergeTrades(
+        Guid survivorId,
+        IReadOnlyCollection<Guid> memberIds,
+        CancellationToken ct
+    )
+    {
+        var trades = await _dbContext
+            .Set<CongressionalTrade>()
+            .Where(trade => memberIds.Contains(trade.CongressMemberId))
+            .OrderByDescending(trade => trade.CongressMemberId == survivorId)
+            .ThenBy(trade => trade.CreationTime)
+            .ThenBy(trade => trade.Id)
+            .ToListAsync(ct);
+        var retainedKeys = new HashSet<CongressionalTradeIdentity>();
+        var duplicates = new List<CongressionalTrade>();
+        var reassigned = new List<CongressionalTrade>();
+        foreach (var trade in trades)
+        {
+            if (!retainedKeys.Add(CongressionalTradeIdentity.From(trade)))
+            {
+                duplicates.Add(trade);
+                continue;
+            }
+
+            if (trade.CongressMemberId != survivorId)
+                reassigned.Add(trade);
+        }
+
+        _dbContext.RemoveRange(duplicates);
+        await _dbContext.SaveChangesAsync(ct);
+        foreach (var trade in reassigned.Except(duplicates))
+            trade.CongressMemberId = survivorId;
+        await _dbContext.SaveChangesAsync(ct);
+        return (reassigned.Count, duplicates.Count);
+    }
+
+    private async Task<(int Reassigned, int Duplicates)> MergeDisclosures(
+        Guid survivorId,
+        IReadOnlyCollection<Guid> memberIds,
+        CancellationToken ct
+    )
+    {
+        var disclosures = await _dbContext
+            .Set<CongressionalAnnualDisclosure>()
+            .Where(disclosure => memberIds.Contains(disclosure.CongressMemberId))
+            .ToListAsync(ct);
+        var retained = disclosures
+            .GroupBy(disclosure => disclosure.Year)
+            .Select(group => SelectLatestDisclosure(group, survivorId))
+            .ToHashSet();
+        var duplicates = disclosures.Where(disclosure => !retained.Contains(disclosure)).ToList();
+        var reassigned = retained
+            .Where(disclosure => disclosure.CongressMemberId != survivorId)
+            .ToList();
+
+        _dbContext.RemoveRange(duplicates);
+        await _dbContext.SaveChangesAsync(ct);
+        foreach (var disclosure in reassigned)
+            disclosure.CongressMemberId = survivorId;
+        await _dbContext.SaveChangesAsync(ct);
+        return (reassigned.Count, duplicates.Count);
+    }
+
+    private static CongressionalAnnualDisclosure SelectLatestDisclosure(
+        IEnumerable<CongressionalAnnualDisclosure> disclosures,
+        Guid survivorId
+    ) =>
+        disclosures
+            .OrderByDescending(disclosure => disclosure.FiledDate)
+            .ThenByDescending(disclosure => disclosure.CreationTime)
+            .ThenByDescending(disclosure => disclosure.CongressMemberId == survivorId)
+            .ThenBy(disclosure => disclosure.Id)
+            .First();
+
+    private async Task RewriteRedirectsAndRemoveMembers(
+        Guid survivorId,
+        IReadOnlyCollection<CongressMember> retired,
+        CancellationToken ct
+    )
+    {
+        var retiredIds = retired.Select(member => member.Id).ToList();
+        var redirects = await _dbContext
+            .Set<CongressMemberRedirect>()
+            .Where(redirect =>
+                retiredIds.Contains(redirect.Id) || retiredIds.Contains(redirect.MergedIntoId)
+            )
+            .ToListAsync(ct);
+        foreach (
+            var redirect in redirects.Where(redirect => retiredIds.Contains(redirect.MergedIntoId))
+        )
+            redirect.MergedIntoId = survivorId;
+        foreach (var retiredMember in retired)
+        {
+            var redirect = redirects.FirstOrDefault(existing => existing.Id == retiredMember.Id);
+            if (redirect == null)
+            {
+                _dbContext.Add(
+                    new CongressMemberRedirect { Id = retiredMember.Id, MergedIntoId = survivorId }
+                );
+            }
+            else
+            {
+                redirect.MergedIntoId = survivorId;
+            }
+        }
+
+        _dbContext.RemoveRange(retired);
+        await _dbContext.SaveChangesAsync(ct);
+    }
+}

--- a/src/Equibles.Congress.HostedService/Services/CongressMemberIdentityService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressMemberIdentityService.cs
@@ -1,0 +1,212 @@
+using System.Data;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using FlexLabs.EntityFrameworkCore.Upsert;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.Congress.HostedService.Services;
+
+/// <summary>
+/// Resolves only reviewed BioGuide-backed aliases, then writes every affected member, filing,
+/// trade, and redirect in one transaction. Unknown names retain their own row; this service
+/// never infers identity from initials, punctuation, district, or name similarity.
+/// </summary>
+[Service(ServiceLifetime.Scoped, typeof(ICongressMemberIdentityService))]
+public class CongressMemberIdentityService : ICongressMemberIdentityService
+{
+    private const long ReconciliationLockId = 4305;
+
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly CongressMemberHistoryMerger _historyMerger;
+
+    public CongressMemberIdentityService(
+        EquiblesFinancialDbContext dbContext,
+        ILogger<CongressMemberIdentityService> logger
+    )
+    {
+        _dbContext = dbContext;
+        _historyMerger = new CongressMemberHistoryMerger(dbContext, logger);
+    }
+
+    public async Task ReconcileMembers(CancellationToken ct)
+    {
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(
+            IsolationLevel.ReadCommitted,
+            ct
+        );
+        await AcquireReconciliationLock(ct);
+        await ReconcileCatalog(ct);
+        await transaction.CommitAsync(ct);
+    }
+
+    public async Task<Dictionary<string, CongressMember>> UpsertMembers(
+        IReadOnlyCollection<CongressMemberObservation> observations,
+        CancellationToken ct
+    )
+    {
+        if (observations.Count == 0)
+            return new Dictionary<string, CongressMember>(StringComparer.OrdinalIgnoreCase);
+
+        var normalized = observations.Select(ResolveObservation).ToList();
+
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(
+            IsolationLevel.ReadCommitted,
+            ct
+        );
+        await AcquireReconciliationLock(ct);
+
+        await ReconcileCatalog(ct);
+
+        var members = BuildMembers(normalized);
+        await UpsertMemberRows(members, ct);
+        var persisted = await LoadPersistedMembers(members, ct);
+
+        await transaction.CommitAsync(ct);
+
+        return MapFilingNames(normalized, persisted);
+    }
+
+    private static ResolvedCongressMemberObservation ResolveObservation(
+        CongressMemberObservation observation
+    )
+    {
+        var filingName = DisclosureParsingHelper.NormalizeMemberName(observation.FilingName);
+        var identity = CongressMemberIdentityCatalog.Resolve(filingName);
+        return new ResolvedCongressMemberObservation(
+            filingName,
+            identity?.CanonicalName ?? filingName,
+            identity?.BioguideId,
+            observation.Position,
+            observation.StateDistrict,
+            observation.ObservedAt
+        );
+    }
+
+    private static List<CongressMember> BuildMembers(
+        IEnumerable<ResolvedCongressMemberObservation> observations
+    ) =>
+        observations
+            .GroupBy(observation => observation.CanonicalName, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var latest = group.OrderBy(observation => observation.ObservedAt).Last();
+                var latestSeat = group
+                    .Where(observation => !string.IsNullOrWhiteSpace(observation.StateDistrict))
+                    .OrderBy(observation => observation.ObservedAt)
+                    .LastOrDefault()
+                    ?.StateDistrict.Trim();
+                return new CongressMember
+                {
+                    Name = group.Key,
+                    BioguideId = group
+                        .Select(observation => observation.BioguideId)
+                        .FirstOrDefault(id => id != null),
+                    Position = latest.Position,
+                    StateDistrict = latestSeat,
+                };
+            })
+            .ToList();
+
+    private async Task UpsertMemberRows(
+        IReadOnlyCollection<CongressMember> members,
+        CancellationToken ct
+    )
+    {
+        await _dbContext
+            .Set<CongressMember>()
+            .UpsertRange(members)
+            .On(member => new { member.Name })
+            .WhenMatched(
+                (existing, incoming) =>
+                    new CongressMember
+                    {
+                        BioguideId = incoming.BioguideId ?? existing.BioguideId,
+                        Position = incoming.Position,
+                        StateDistrict = incoming.StateDistrict ?? existing.StateDistrict,
+                    }
+            )
+            .RunAsync(ct);
+    }
+
+    private async Task<Dictionary<string, CongressMember>> LoadPersistedMembers(
+        IEnumerable<CongressMember> members,
+        CancellationToken ct
+    )
+    {
+        var canonicalNames = members.Select(member => member.Name).ToList();
+        return await _dbContext
+            .Set<CongressMember>()
+            .Where(member => canonicalNames.Contains(member.Name))
+            .ToDictionaryAsync(member => member.Name, StringComparer.OrdinalIgnoreCase, ct);
+    }
+
+    private static Dictionary<string, CongressMember> MapFilingNames(
+        IEnumerable<ResolvedCongressMemberObservation> normalized,
+        IReadOnlyDictionary<string, CongressMember> persisted
+    ) =>
+        normalized
+            .GroupBy(observation => observation.FilingName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => persisted[group.First().CanonicalName],
+                StringComparer.OrdinalIgnoreCase
+            );
+
+    private Task<int> AcquireReconciliationLock(CancellationToken ct) =>
+        _dbContext.Database.ExecuteSqlRawAsync(
+            $"SELECT pg_advisory_xact_lock({ReconciliationLockId})",
+            cancellationToken: ct
+        );
+
+    private async Task ReconcileCatalog(CancellationToken ct)
+    {
+        foreach (var identity in CongressMemberIdentityCatalog.All)
+        {
+            var aliases = identity.Aliases.Select(alias => alias.ToLowerInvariant()).ToList();
+            var candidates = await _dbContext
+                .Set<CongressMember>()
+                .Where(member =>
+                    member.BioguideId == identity.BioguideId
+                    || aliases.Contains(member.Name.ToLower())
+                )
+                .OrderBy(member => member.CreationTime)
+                .ThenBy(member => member.Id)
+                .ToListAsync(ct);
+            if (candidates.Count == 0)
+                continue;
+
+            var conflicting = candidates.FirstOrDefault(member =>
+                member.BioguideId != null && member.BioguideId != identity.BioguideId
+            );
+            if (conflicting != null)
+            {
+                throw new InvalidOperationException(
+                    $"Congress member '{conflicting.Name}' is already assigned BioGuide id "
+                        + $"'{conflicting.BioguideId}', not '{identity.BioguideId}'"
+                );
+            }
+
+            var survivor =
+                candidates.FirstOrDefault(member =>
+                    string.Equals(
+                        member.Name,
+                        identity.CanonicalName,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                ?? candidates.FirstOrDefault(member => member.BioguideId == identity.BioguideId)
+                ?? candidates[0];
+            var retired = candidates.Where(member => member.Id != survivor.Id).ToList();
+
+            if (retired.Count > 0)
+                await _historyMerger.MergeMembers(survivor, retired, ct);
+
+            survivor.Name = identity.CanonicalName;
+            survivor.BioguideId = identity.BioguideId;
+            await _dbContext.SaveChangesAsync(ct);
+        }
+    }
+}

--- a/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
@@ -6,7 +6,6 @@ using Equibles.Core.Configuration;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
-using FlexLabs.EntityFrameworkCore.Upsert;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -29,6 +28,7 @@ public class CongressionalAnnualDisclosureSyncService
     private readonly WorkerOptions _workerOptions;
     private readonly ErrorReporter _errorReporter;
     private readonly CongressionalFilingLedger _filingLedger;
+    private readonly ICongressMemberIdentityService _memberIdentityService;
 
     // Electronic filing of congressional disclosures dates to the STOCK Act.
     private const int EarliestCoverageYear = 2012;
@@ -55,7 +55,8 @@ public class CongressionalAnnualDisclosureSyncService
         IOptions<WorkerOptions> workerOptions,
         ILogger<CongressionalAnnualDisclosureSyncService> logger,
         ErrorReporter errorReporter,
-        CongressionalFilingLedger filingLedger
+        CongressionalFilingLedger filingLedger,
+        ICongressMemberIdentityService memberIdentityService
     )
     {
         _scopeFactory = scopeFactory;
@@ -63,10 +64,13 @@ public class CongressionalAnnualDisclosureSyncService
         _logger = logger;
         _errorReporter = errorReporter;
         _filingLedger = filingLedger;
+        _memberIdentityService = memberIdentityService;
     }
 
     public async Task SyncAll(CancellationToken ct)
     {
+        await _memberIdentityService.ReconcileMembers(ct);
+
         var currentYear = DateTime.UtcNow.Year;
         var fromYear = Math.Max(
             _workerOptions.MinSyncDate?.Year ?? currentYear - DefaultCoverageYearsBack,
@@ -190,12 +194,23 @@ public class CongressionalAnnualDisclosureSyncService
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
-        var memberRepository = scope.ServiceProvider.GetRequiredService<CongressMemberRepository>();
+        var memberIdentityService =
+            scope.ServiceProvider.GetRequiredService<ICongressMemberIdentityService>();
         var disclosureRepository =
             scope.ServiceProvider.GetRequiredService<CongressionalAnnualDisclosureRepository>();
 
         var latest = SelectLatestReports(reports);
-        var members = await UpsertCongressMembers(latest, dbContext, memberRepository, ct);
+        var members = await memberIdentityService.UpsertMembers(
+            latest
+                .Select(report => new CongressMemberObservation(
+                    report.MemberName,
+                    report.Position,
+                    report.StateDistrict,
+                    report.FiledDate
+                ))
+                .ToList(),
+            ct
+        );
 
         var unpersistedReportIds = new HashSet<string>();
         int added = 0,
@@ -250,50 +265,6 @@ public class CongressionalAnnualDisclosureSyncService
         return unpersistedReportIds;
     }
 
-    private async Task<Dictionary<string, CongressMember>> UpsertCongressMembers(
-        List<AnnualDisclosureReport> reports,
-        EquiblesFinancialDbContext dbContext,
-        CongressMemberRepository memberRepository,
-        CancellationToken ct
-    )
-    {
-        // Canonicalise the name so cosmetic disclosure variants resolve to one
-        // CongressMember record (GH-3374) — the same identity key the trade
-        // sync uses, so the two pipelines converge on the same member.
-        var distinctMembers = reports
-            .GroupBy(r => DisclosureParsingHelper.NormalizeMemberName(r.MemberName))
-            .Select(g => new CongressMember
-            {
-                Name = g.Key,
-                Position = g.First().Position,
-                StateDistrict = SelectStateDistrict(g),
-            })
-            .ToList();
-
-        await dbContext
-            .Set<CongressMember>()
-            .UpsertRange(distinctMembers)
-            .On(m => new { m.Name })
-            .WhenMatched(
-                (existing, incoming) =>
-                    new CongressMember
-                    {
-                        Position = incoming.Position,
-                        // Only the House index publishes a seat, so a member's
-                        // Senate reports carry none — coalescing keeps a
-                        // recorded seat instead of blanking it on every cycle.
-                        StateDistrict = incoming.StateDistrict ?? existing.StateDistrict,
-                    }
-            )
-            .RunAsync(ct);
-
-        var memberNames = distinctMembers.Select(m => m.Name).ToList();
-        return await memberRepository
-            .GetAll()
-            .Where(m => memberNames.Contains(m.Name))
-            .ToDictionaryAsync(m => m.Name, ct);
-    }
-
     /// <summary>
     /// The seat to record for a member this cycle. Redistricting moves a member
     /// between districts, so the most recently filed report that states one
@@ -308,16 +279,27 @@ public class CongressionalAnnualDisclosureSyncService
             ?.StateDistrict.Trim();
 
     /// <summary>
-    /// One report per (member, position, year): the latest filed wins, and an
-    /// amendment beats the original on a same-day refiling.
+    /// One report per member and year: the latest filed wins, and an amendment beats the
+    /// original on a same-day refiling. Reviewed aliases group by BioGuide identity before
+    /// persistence; unresolved names retain position in their exact key so no identity is
+    /// inferred from a similar name.
     /// </summary>
     internal static List<AnnualDisclosureReport> SelectLatestReports(
         IEnumerable<AnnualDisclosureReport> reports
     ) =>
         reports
-            .GroupBy(r => (r.MemberName, r.Position, r.Year))
+            .GroupBy(r => (IdentityKey: SelectAnnualIdentityKey(r), r.Year))
             .Select(g => g.OrderBy(r => r.FiledDate).ThenBy(r => r.IsAmendment).Last())
             .ToList();
+
+    private static string SelectAnnualIdentityKey(AnnualDisclosureReport report)
+    {
+        var normalizedName = DisclosureParsingHelper.NormalizeMemberName(report.MemberName);
+        var identity = CongressMemberIdentityCatalog.Resolve(normalizedName);
+        return identity != null
+            ? $"bioguide:{identity.BioguideId}"
+            : $"name:{normalizedName}|position:{report.Position}";
+    }
 
     /// <summary>
     /// Amendments replace the stored report in place: a different source

--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -2,7 +2,6 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.HostedService.Models;
-using Equibles.Congress.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
@@ -22,6 +21,7 @@ public class CongressionalTradeSyncService
     private readonly ErrorReporter _errorReporter;
     private readonly CongressionalFilingLedger _filingLedger;
     private readonly CongressionalTradeImportLedger _importLedger;
+    private readonly ICongressMemberIdentityService _memberIdentityService;
 
     public CongressionalTradeSyncService(
         IServiceScopeFactory scopeFactory,
@@ -29,7 +29,8 @@ public class CongressionalTradeSyncService
         ILogger<CongressionalTradeSyncService> logger,
         ErrorReporter errorReporter,
         CongressionalFilingLedger filingLedger,
-        CongressionalTradeImportLedger importLedger
+        CongressionalTradeImportLedger importLedger,
+        ICongressMemberIdentityService memberIdentityService
     )
     {
         _scopeFactory = scopeFactory;
@@ -38,6 +39,7 @@ public class CongressionalTradeSyncService
         _errorReporter = errorReporter;
         _filingLedger = filingLedger;
         _importLedger = importLedger;
+        _memberIdentityService = memberIdentityService;
     }
 
     // Congressional trade disclosures are available from 2012 (STOCK Act).
@@ -54,6 +56,8 @@ public class CongressionalTradeSyncService
 
     public async Task SyncAll(CancellationToken ct)
     {
+        await _memberIdentityService.ReconcileMembers(ct);
+
         var fromDate = _workerOptions.MinSyncDate.HasValue
             ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
             : new DateOnly(DateTime.UtcNow.Year, 1, 1);
@@ -293,7 +297,8 @@ public class CongressionalTradeSyncService
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
-        var memberRepository = scope.ServiceProvider.GetRequiredService<CongressMemberRepository>();
+        var memberIdentityService =
+            scope.ServiceProvider.GetRequiredService<ICongressMemberIdentityService>();
         var commonStockRepository =
             scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
@@ -338,7 +343,17 @@ public class CongressionalTradeSyncService
         if (matched.Count == 0)
             return new TradePersistOutcome(unmatchedTickerSourceIds, unpersistedSourceIds);
 
-        var members = await UpsertCongressMembers(matched, dbContext, memberRepository, ct);
+        var members = await memberIdentityService.UpsertMembers(
+            matched
+                .Select(transaction => new CongressMemberObservation(
+                    transaction.MemberName,
+                    transaction.Position,
+                    transaction.StateDistrict,
+                    transaction.FilingDate
+                ))
+                .ToList(),
+            ct
+        );
 
         // Mirrors BuildTrades' member-not-found guard: those rows are parsed
         // but never stored, so their filings must not be recorded as ingested.
@@ -357,52 +372,6 @@ public class CongressionalTradeSyncService
         await PersistTrades(trades, dbContext, ct);
 
         return new TradePersistOutcome(unmatchedTickerSourceIds, unpersistedSourceIds);
-    }
-
-    private async Task<Dictionary<string, CongressMember>> UpsertCongressMembers(
-        List<DisclosureTransaction> matched,
-        EquiblesFinancialDbContext dbContext,
-        CongressMemberRepository memberRepository,
-        CancellationToken ct
-    )
-    {
-        // Key identity on the canonical name so cosmetic disclosure variants
-        // (mid-name honorific, doubled first name) resolve to one record no
-        // matter which scraper emitted the transaction (GH-3374). Every source
-        // already normalises at emission; doing it here too makes the upsert key
-        // the single source of truth for member identity.
-        var distinctMembers = matched
-            .GroupBy(t => DisclosureParsingHelper.NormalizeMemberName(t.MemberName))
-            .Select(g => new CongressMember
-            {
-                Name = g.Key,
-                Position = g.First().Position,
-                StateDistrict = SelectStateDistrict(g),
-            })
-            .ToList();
-
-        await dbContext
-            .Set<CongressMember>()
-            .UpsertRange(distinctMembers)
-            .On(m => new { m.Name })
-            .WhenMatched(
-                (existing, incoming) =>
-                    new CongressMember
-                    {
-                        Position = incoming.Position,
-                        // Coalesced, never overwritten with nothing: this lane sees the same
-                        // member through Senate transactions too, and those state no seat. A
-                        // straight assignment would wipe a recorded seat on the next cycle.
-                        StateDistrict = incoming.StateDistrict ?? existing.StateDistrict,
-                    }
-            )
-            .RunAsync(ct);
-
-        var memberNames = distinctMembers.Select(m => m.Name).ToList();
-        return await memberRepository
-            .GetAll()
-            .Where(m => memberNames.Contains(m.Name))
-            .ToDictionaryAsync(m => m.Name, ct);
     }
 
     /// <summary>

--- a/src/Equibles.Congress.HostedService/Services/ICongressMemberIdentityService.cs
+++ b/src/Equibles.Congress.HostedService/Services/ICongressMemberIdentityService.cs
@@ -1,0 +1,14 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+
+namespace Equibles.Congress.HostedService.Services;
+
+public interface ICongressMemberIdentityService
+{
+    Task ReconcileMembers(CancellationToken ct);
+
+    Task<Dictionary<string, CongressMember>> UpsertMembers(
+        IReadOnlyCollection<CongressMemberObservation> observations,
+        CancellationToken ct
+    );
+}

--- a/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
@@ -11,6 +11,15 @@ public class CongressMemberRepository : BaseRepository<CongressMember>
 
     public async Task<CongressMember> GetByName(string name)
     {
+        var identity = CongressMemberIdentityCatalog.Resolve(name);
+        if (identity != null)
+        {
+            var canonical = await GetAll()
+                .FirstOrDefaultAsync(m => m.Name.ToLower() == identity.CanonicalName.ToLower());
+            if (canonical != null)
+                return canonical;
+        }
+
         var exactName = name?.Trim().ToLowerInvariant();
         var exact = await GetAll().FirstOrDefaultAsync(m => m.Name.ToLower() == exactName);
         if (exact != null)
@@ -47,14 +56,21 @@ public class CongressMemberRepository : BaseRepository<CongressMember>
             exactName == null
                 ? GetAll().Where(_ => false)
                 : GetAll().Where(m => m.Name.ToLower() == exactName);
-        var canonicalName = CongressMemberSearchAliases.ResolveName(search);
+        var identity = CongressMemberIdentityCatalog.Resolve(search);
+        var preferredIdentity =
+            identity == null
+                ? exactIdentifier
+                : GetAll()
+                    .Where(m => m.Name.ToLower() == identity.CanonicalName.ToLowerInvariant());
+        var canonicalName =
+            identity == null ? CongressMemberSearchAliases.ResolveName(search) : null;
         var verifiedAlias =
             canonicalName == null
                 ? GetAll().Where(_ => false)
                 : GetAll().Where(m => m.Name.ToLower() == canonicalName.ToLowerInvariant());
         return SearchTerms.WithExclusiveResolutionTiers(
-            exactIdentifier,
-            verifiedAlias,
+            preferredIdentity,
+            identity == null ? verifiedAlias : exactIdentifier,
             matches,
             anyTokenMatches
         );
@@ -63,16 +79,20 @@ public class CongressMemberRepository : BaseRepository<CongressMember>
 
 internal static class CongressMemberSearchAliases
 {
-    private static readonly IReadOnlyDictionary<string, string> Names = new Dictionary<
-        string,
-        string
-    >(StringComparer.OrdinalIgnoreCase)
-    {
-        // The House roster files the member as Daniel Crenshaw, while the public and
-        // the tool examples use Dan Crenshaw.
-        ["dan crenshaw"] = "Daniel Crenshaw",
-    };
+    private static readonly IReadOnlyDictionary<string, string> Names = BuildNames();
 
     public static string ResolveName(string query) =>
         Names.GetValueOrDefault(SearchTerms.Normalize(query));
+
+    private static IReadOnlyDictionary<string, string> BuildNames()
+    {
+        var names = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // The House roster files the member as Daniel Crenshaw, while the public and
+            // the tool examples use Dan Crenshaw.
+            ["dan crenshaw"] = "Daniel Crenshaw",
+        };
+
+        return names;
+    }
 }

--- a/src/Equibles.Migrations/Migrations/20260823132654_AddCongressMemberBioguideIdentity.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260823132654_AddCongressMemberBioguideIdentity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823132654_AddCongressMemberBioguideIdentity")]
+    partial class AddCongressMemberBioguideIdentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260823132654_AddCongressMemberBioguideIdentity.cs
+++ b/src/Equibles.Migrations/Migrations/20260823132654_AddCongressMemberBioguideIdentity.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCongressMemberBioguideIdentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BioguideId",
+                table: "CongressMember",
+                type: "character varying(7)",
+                maxLength: 7,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CongressMember_BioguideId",
+                table: "CongressMember",
+                column: "BioguideId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CongressMember_BioguideId",
+                table: "CongressMember");
+
+            migrationBuilder.DropColumn(
+                name: "BioguideId",
+                table: "CongressMember");
+        }
+    }
+}

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -32,6 +32,7 @@ public class ProfilesController : BaseController
     private readonly InsiderOwnerRepository _insiderOwnerRepository;
     private readonly InsiderTransactionRepository _insiderTransactionRepository;
     private readonly CongressMemberRepository _congressMemberRepository;
+    private readonly CongressMemberRedirectRepository _congressMemberRedirectRepository;
     private readonly CongressionalTradeRepository _congressionalTradeRepository;
     private readonly HoldingsBacktestService _holdingsBacktestService;
     private readonly InstitutionPortfolioSummaryProvider _institutionPortfolioSummaryProvider;
@@ -43,6 +44,7 @@ public class ProfilesController : BaseController
         InsiderOwnerRepository insiderOwnerRepository,
         InsiderTransactionRepository insiderTransactionRepository,
         CongressMemberRepository congressMemberRepository,
+        CongressMemberRedirectRepository congressMemberRedirectRepository,
         CongressionalTradeRepository congressionalTradeRepository,
         HoldingsBacktestService holdingsBacktestService,
         InstitutionPortfolioSummaryProvider institutionPortfolioSummaryProvider,
@@ -56,6 +58,7 @@ public class ProfilesController : BaseController
         _insiderOwnerRepository = insiderOwnerRepository;
         _insiderTransactionRepository = insiderTransactionRepository;
         _congressMemberRepository = congressMemberRepository;
+        _congressMemberRedirectRepository = congressMemberRedirectRepository;
         _congressionalTradeRepository = congressionalTradeRepository;
         _holdingsBacktestService = holdingsBacktestService;
         _institutionPortfolioSummaryProvider = institutionPortfolioSummaryProvider;
@@ -381,7 +384,15 @@ public class ProfilesController : BaseController
     {
         var member = await _congressMemberRepository.Get(id);
         if (member == null)
-            return NotFound();
+        {
+            var mergedIntoId = await _congressMemberRedirectRepository
+                .GetByRetiredId(id)
+                .Select(redirect => (Guid?)redirect.MergedIntoId)
+                .SingleOrDefaultAsync();
+            return mergedIntoId.HasValue
+                ? RedirectToActionPermanent(nameof(Member), new { id = mergedIntoId.Value })
+                : NotFound();
+        }
 
         var trades = await _congressionalTradeRepository
             .GetByMember(member)

--- a/tests/Equibles.IntegrationTests/Congress/CongressMemberIdentityServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressMemberIdentityServiceTests.cs
@@ -1,0 +1,97 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Congress;
+
+[Collection(ParadeDbCollection.Name)]
+public class CongressMemberIdentityServiceTests : ParadeDbMcpTestBase
+{
+    public CongressMemberIdentityServiceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task ReconcileMembers_NoNewFilings_MergesReviewedAliases()
+    {
+        var survivor = new CongressMember { Name = "Scott Franklin" };
+        var retired = new CongressMember { Name = "C. Scott Franklin" };
+        DbContext.AddRange(survivor, retired);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await CreateSut().ReconcileMembers(CancellationToken.None);
+
+        await using var verify = Fixture.CreateDbContext();
+        var member = await verify.Set<CongressMember>().AsNoTracking().SingleAsync();
+        member.Id.Should().Be(survivor.Id);
+        member.BioguideId.Should().Be("F000472");
+        var redirect = await verify.Set<CongressMemberRedirect>().AsNoTracking().SingleAsync();
+        redirect.Id.Should().Be(retired.Id);
+        redirect.MergedIntoId.Should().Be(survivor.Id);
+    }
+
+    [Fact]
+    public async Task ReconcileMembers_AliasHasConflictingBioguideId_RefusesMerge()
+    {
+        var member = new CongressMember { Name = "James E. Banks", BioguideId = "X000001" };
+        DbContext.Add(member);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var act = async () => await CreateSut().ReconcileMembers(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        await using var verify = Fixture.CreateDbContext();
+        var persisted = await verify.Set<CongressMember>().AsNoTracking().SingleAsync();
+        persisted.Name.Should().Be("James E. Banks");
+        persisted.BioguideId.Should().Be("X000001");
+        (await verify.Set<CongressMemberRedirect>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ReconcileMembers_SameDayAnnualAliasAmendment_KeepsNewestStoredReport()
+    {
+        var survivor = new CongressMember { Name = "Scott Franklin" };
+        var retired = new CongressMember { Name = "C. Scott Franklin" };
+        var filedDate = new DateOnly(2025, 5, 15);
+        DbContext.AddRange(survivor, retired);
+        DbContext.AddRange(
+            new CongressionalAnnualDisclosure
+            {
+                CongressMember = survivor,
+                Year = 2024,
+                FiledDate = filedDate,
+                ReportId = "original",
+                CreationTime = new DateTime(2025, 5, 15, 9, 0, 0, DateTimeKind.Utc),
+            },
+            new CongressionalAnnualDisclosure
+            {
+                CongressMember = retired,
+                Year = 2024,
+                FiledDate = filedDate,
+                ReportId = "amendment",
+                CreationTime = new DateTime(2025, 5, 15, 10, 0, 0, DateTimeKind.Utc),
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await CreateSut().ReconcileMembers(CancellationToken.None);
+
+        await using var verify = Fixture.CreateDbContext();
+        var member = await verify.Set<CongressMember>().AsNoTracking().SingleAsync();
+        var disclosure = await verify
+            .Set<CongressionalAnnualDisclosure>()
+            .AsNoTracking()
+            .SingleAsync();
+        disclosure.CongressMemberId.Should().Be(member.Id);
+        disclosure.ReportId.Should().Be("amendment");
+    }
+
+    private CongressMemberIdentityService CreateSut() =>
+        new(DbContext, Substitute.For<ILogger<CongressMemberIdentityService>>());
+}

--- a/tests/Equibles.IntegrationTests/Congress/CongressMemberRepositoryPostgresSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressMemberRepositoryPostgresSearchTests.cs
@@ -96,4 +96,26 @@ public class CongressMemberRepositoryPostgresSearchTests : ParadeDbMcpTestBase
         resolved.Should().NotBeNull();
         resolved.Name.Should().Be("Dan Crenshaw");
     }
+
+    [Fact]
+    public async Task Search_ReviewedAliasRowStillExists_PrefersCanonicalMember()
+    {
+        DbContext.AddRange(
+            new CongressMember { Name = "James Banks", Position = CongressPosition.Senator },
+            new CongressMember
+            {
+                Name = "James E. Banks",
+                Position = CongressPosition.Representative,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var results = await new CongressMemberRepository(verify)
+            .Search("James E. Banks")
+            .ToListAsync();
+
+        results.Should().ContainSingle().Which.Name.Should().Be("James Banks");
+    }
 }

--- a/tests/Equibles.IntegrationTests/Congress/CongressRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressRepositoryTests.cs
@@ -85,6 +85,33 @@ public class CongressMemberRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task GetByName_ReviewedFormerFilingName_ReturnsCanonicalMember()
+    {
+        var member = CreateMember("James Banks", CongressPosition.Senator);
+        _dbContext.Set<CongressMember>().Add(member);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetByName("James E. Banks");
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be(member.Id);
+    }
+
+    [Fact]
+    public async Task GetByName_ReviewedAliasRowStillExists_PrefersCanonicalMember()
+    {
+        var canonical = CreateMember("James Banks", CongressPosition.Senator);
+        var staleAlias = CreateMember("James E. Banks", CongressPosition.Representative);
+        _dbContext.Set<CongressMember>().AddRange(canonical, staleAlias);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetByName("James E. Banks");
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be(canonical.Id);
+    }
+
+    [Fact]
     public async Task GetByName_EmptyDatabase_ReturnsNull()
     {
         var result = await _repository.GetByName("Nancy Pelosi");

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceOrchestrationTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceOrchestrationTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Congress;
+
+public class CongressionalAnnualDisclosureSyncServiceOrchestrationTests
+{
+    private sealed class EmptySenateSession : ISenateBrowserSession
+    {
+        public Task EnsureAuthenticated(CancellationToken ct) => Task.CompletedTask;
+
+        public Task<SenateFetchResult> Fetch(
+            string url,
+            Dictionary<string, string> formFields,
+            CancellationToken ct
+        ) => Task.FromResult(new SenateFetchResult { Status = 200, Body = "{\"data\":[]}" });
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class NotFoundHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+    }
+
+    [Fact]
+    public async Task SyncAll_NoReports_StillReconcilesReviewedMemberAliases()
+    {
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (
+                typeof(HouseAnnualReportClient),
+                new HouseAnnualReportClient(
+                    new HttpClient(new NotFoundHandler()),
+                    Substitute.For<ILogger<HouseAnnualReportClient>>()
+                )
+            ),
+            (
+                typeof(SenateAnnualReportClient),
+                new SenateAnnualReportClient(
+                    new EmptySenateSession(),
+                    Substitute.For<ILogger<SenateAnnualReportClient>>()
+                )
+            )
+        );
+        var filingLedger = Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null);
+        filingLedger
+            .GetProcessedSourceIds(
+                Arg.Any<CongressionalFilingKind>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<int>(),
+                Arg.Any<int>()
+            )
+            .Returns(new HashSet<string>());
+        var identityService = Substitute.For<ICongressMemberIdentityService>();
+        var sut = new CongressionalAnnualDisclosureSyncService(
+            scopeFactory,
+            Options.Create(new WorkerOptions { MinSyncDate = DateTime.UtcNow.Date }),
+            Substitute.For<ILogger<CongressionalAnnualDisclosureSyncService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            filingLedger,
+            identityService
+        );
+
+        await sut.SyncAll(CancellationToken.None);
+
+        await identityService.Received(1).ReconcileMembers(CancellationToken.None);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceProcessTests.cs
@@ -44,7 +44,13 @@ public class CongressionalAnnualDisclosureSyncServiceProcessTests : ParadeDbMcpT
     {
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(EquiblesFinancialDbContext), DbContext),
-            (typeof(CongressMemberRepository), new CongressMemberRepository(DbContext)),
+            (
+                typeof(ICongressMemberIdentityService),
+                new CongressMemberIdentityService(
+                    DbContext,
+                    Substitute.For<ILogger<CongressMemberIdentityService>>()
+                )
+            ),
             (
                 typeof(CongressionalAnnualDisclosureRepository),
                 new CongressionalAnnualDisclosureRepository(DbContext)
@@ -58,7 +64,8 @@ public class CongressionalAnnualDisclosureSyncServiceProcessTests : ParadeDbMcpT
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
-            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
     }
 
@@ -77,6 +84,22 @@ public class CongressionalAnnualDisclosureSyncServiceProcessTests : ParadeDbMcpT
             ReportId = reportId,
             IsAmendment = amendment,
             Lines = lines.ToList(),
+        };
+
+    private static AnnualDisclosureReport ReportForMember(
+        string memberName,
+        string reportId,
+        DateOnly filed,
+        bool amendment
+    ) =>
+        new()
+        {
+            MemberName = memberName,
+            Position = CongressPosition.Representative,
+            Year = 2024,
+            FiledDate = filed,
+            ReportId = reportId,
+            IsAmendment = amendment,
         };
 
     private static AnnualDisclosureLineItem Line(
@@ -202,5 +225,34 @@ public class CongressionalAnnualDisclosureSyncServiceProcessTests : ParadeDbMcpT
         (await verify.Set<CongressionalDisclosureLine>().AsNoTracking().CountAsync())
             .Should()
             .Be(1);
+    }
+
+    [Fact]
+    public async Task ProcessReports_ReviewedAliasesInOneBatch_StoresOnlyLatestMemberYear()
+    {
+        var original = ReportForMember(
+            "C. Scott Franklin",
+            "10066169",
+            new DateOnly(2025, 5, 15),
+            amendment: false
+        );
+        var amendment = ReportForMember(
+            "Scott Franklin",
+            "10074000",
+            new DateOnly(2025, 11, 4),
+            amendment: true
+        );
+
+        await ProcessReports(BuildSut(), [original, amendment]);
+
+        await using var verify = Fixture.CreateDbContext();
+        var member = await verify.Set<CongressMember>().AsNoTracking().SingleAsync();
+        member.Name.Should().Be("Scott Franklin");
+        member.BioguideId.Should().Be("F000472");
+        var disclosure = await verify
+            .Set<CongressionalAnnualDisclosure>()
+            .AsNoTracking()
+            .SingleAsync();
+        disclosure.ReportId.Should().Be("10074000");
     }
 }

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeScraperWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeScraperWorkerDoWorkTests.cs
@@ -72,7 +72,8 @@ public class CongressionalTradeScraperWorkerDoWorkTests
             Substitute.For<ILogger<CongressionalTradeSyncService>>(),
             errorReporter,
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
 
         var workerScope = ServiceScopeSubstitute.Create(

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceBothFailTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceBothFailTests.cs
@@ -43,7 +43,8 @@ public class CongressionalTradeSyncServiceBothFailTests
             Substitute.For<ILogger<CongressionalTradeSyncService>>(),
             errorReporter,
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
 
         // Must not throw — both fetches fail, allTransactions stays empty,

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceFetchTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceFetchTests.cs
@@ -84,6 +84,7 @@ public class CongressionalTradeSyncServiceFetchTests
                 Arg.Any<CancellationToken>()
             )
             .Returns(2018);
+        var memberIdentityService = Substitute.For<ICongressMemberIdentityService>();
 
         var sut = new CongressionalTradeSyncService(
             scopeFactory,
@@ -94,7 +95,8 @@ public class CongressionalTradeSyncServiceFetchTests
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            importLedger
+            importLedger,
+            memberIdentityService
         );
 
         // Both fetch helpers run their success path; with no transactions the
@@ -102,6 +104,7 @@ public class CongressionalTradeSyncServiceFetchTests
         var act = async () => await sut.SyncAll(CancellationToken.None);
 
         await act.Should().NotThrowAsync();
+        await memberIdentityService.Received(1).ReconcileMembers(CancellationToken.None);
         senateSession
             .FetchCount.Should()
             .Be(2, "Senate receives current plus the one archive partition");

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
@@ -44,7 +44,13 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
     {
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(EquiblesFinancialDbContext), DbContext),
-            (typeof(CongressMemberRepository), new CongressMemberRepository(DbContext)),
+            (
+                typeof(ICongressMemberIdentityService),
+                new CongressMemberIdentityService(
+                    DbContext,
+                    Substitute.For<ILogger<CongressMemberIdentityService>>()
+                )
+            ),
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext))
         );
         return new CongressionalTradeSyncService(
@@ -56,7 +62,8 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
     }
 
@@ -102,6 +109,42 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
             SourceId = sourceId,
         };
 
+    private static CongressionalTrade Trade(
+        CongressMember member,
+        CommonStock stock,
+        DateOnly transactionDate,
+        DateOnly filingDate
+    ) =>
+        new()
+        {
+            CongressMemberId = member.Id,
+            CommonStockId = stock.Id,
+            TransactionDate = transactionDate,
+            FilingDate = filingDate,
+            TransactionType = CongressTransactionType.Purchase,
+            OwnerType = "self",
+            AssetName = stock.Name,
+            AssetType = "ST",
+            Subholding = "",
+            AmountFrom = 1_001,
+            AmountTo = 15_000,
+        };
+
+    private static CongressionalAnnualDisclosure Disclosure(
+        CongressMember member,
+        string reportId,
+        DateOnly filedDate
+    ) =>
+        new()
+        {
+            CongressMemberId = member.Id,
+            Year = 2023,
+            FiledDate = filedDate,
+            ReportId = reportId,
+            NetWorthMinimum = 1_001,
+            NetWorthMaximum = 15_000,
+        };
+
     [Fact]
     public async Task ProcessTransactions_TickerMatchesTrackedStock_UpsertsMemberAndPersistsTrade()
     {
@@ -124,6 +167,82 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
         trades.Should().ContainSingle();
         trades[0].CongressMemberId.Should().Be(member.Id);
         trades[0].AssetType.Should().Be("ST");
+    }
+
+    [Fact]
+    public async Task ProcessTransactions_ReviewedBioguideAliases_MergesHistoryAndWritesRedirects()
+    {
+        var apple = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
+        var microsoft = new CommonStock { Ticker = "MSFT", Name = "Microsoft Corp." };
+        var survivor = new CongressMember
+        {
+            Name = "James Banks",
+            Position = CongressPosition.Senator,
+            CreationTime = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+        var retired = new CongressMember
+        {
+            Name = "James E. Banks",
+            Position = CongressPosition.Representative,
+            StateDistrict = "IN03",
+            CreationTime = new DateTime(2017, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+        var chainedRetiredId = Guid.NewGuid();
+
+        DbContext.AddRange(apple, microsoft, survivor, retired);
+        DbContext.AddRange(
+            Trade(survivor, apple, new DateOnly(2024, 1, 1), new DateOnly(2024, 1, 10)),
+            Trade(retired, apple, new DateOnly(2024, 1, 1), new DateOnly(2024, 1, 11)),
+            Trade(retired, microsoft, new DateOnly(2024, 2, 1), new DateOnly(2024, 2, 10)),
+            Disclosure(survivor, "old-report", new DateOnly(2024, 5, 1)),
+            Disclosure(retired, "new-report", new DateOnly(2024, 6, 1)),
+            new CongressMemberRedirect { Id = chainedRetiredId, MergedIntoId = retired.Id }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await (Task)
+            ProcessTransactionsMethod.Invoke(
+                BuildSut(),
+                [
+                    new List<DisclosureTransaction>
+                    {
+                        Txn(
+                            "James E Banks",
+                            "AAPL",
+                            transactionDate: new DateOnly(2024, 1, 1),
+                            filingDate: new DateOnly(2024, 1, 12)
+                        ),
+                    },
+                    CancellationToken.None,
+                ]
+            );
+
+        await using var verify = Fixture.CreateDbContext();
+        var member = await verify.Set<CongressMember>().AsNoTracking().SingleAsync();
+        member.Id.Should().Be(survivor.Id);
+        member.Name.Should().Be("James Banks");
+        member.BioguideId.Should().Be("B001299");
+        member.Position.Should().Be(CongressPosition.Senator);
+        member.StateDistrict.Should().Be("IN03");
+
+        var trades = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
+        trades.Should().HaveCount(2, "the filing-identity collision is one disclosed trade");
+        trades.Should().OnlyContain(trade => trade.CongressMemberId == survivor.Id);
+
+        var disclosure = await verify
+            .Set<CongressionalAnnualDisclosure>()
+            .AsNoTracking()
+            .SingleAsync();
+        disclosure.CongressMemberId.Should().Be(survivor.Id);
+        disclosure.ReportId.Should().Be("new-report", "the latest filed annual report wins");
+
+        var redirects = await verify
+            .Set<CongressMemberRedirect>()
+            .AsNoTracking()
+            .ToDictionaryAsync(redirect => redirect.Id);
+        redirects[retired.Id].MergedIntoId.Should().Be(survivor.Id);
+        redirects[chainedRetiredId].MergedIntoId.Should().Be(survivor.Id);
     }
 
     // A member can file several same-day purchases of the same stock that differ only in the

--- a/tests/Equibles.IntegrationTests/Web/ProfilesControllerMemberNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesControllerMemberNotFoundTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Equibles.Congress.Data.Models;
 using Equibles.IntegrationTests.Helpers;
 using Xunit;
 
@@ -27,5 +28,34 @@ public class ProfilesControllerMemberNotFoundTests
         var response = await _fixture.Client.GetAsync($"/congress/{Guid.NewGuid()}");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetMember_RetiredId_PermanentlyRedirectsToSurvivor()
+    {
+        var retiredId = Guid.NewGuid();
+        var survivorId = Guid.NewGuid();
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CongressMember
+                {
+                    Id = survivorId,
+                    Name = "Canonical Member",
+                    Position = CongressPosition.Representative,
+                }
+            );
+            db.Add(new CongressMemberRedirect { Id = retiredId, MergedIntoId = survivorId });
+            await Task.CompletedTask;
+        });
+        using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+        {
+            BaseAddress = _fixture.Client.BaseAddress,
+        };
+
+        var response = await client.GetAsync($"/congress/{retiredId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.MovedPermanently);
+        response.Headers.Location.Should().Be($"/congress/{survivorId}");
     }
 }

--- a/tests/Equibles.UnitTests/Congress/CongressMemberIdentityCatalogTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressMemberIdentityCatalogTests.cs
@@ -1,0 +1,47 @@
+using Equibles.Congress.Data.Models;
+using Xunit;
+
+namespace Equibles.UnitTests.Congress;
+
+public class CongressMemberIdentityCatalogTests
+{
+    [Theory]
+    [InlineData("James Banks", "B001299", "James Banks")]
+    [InlineData("James E Banks", "B001299", "James Banks")]
+    [InlineData("James E. Banks", "B001299", "James Banks")]
+    [InlineData("Jim Banks", "B001299", "James Banks")]
+    [InlineData("Adam B Schiff", "S001150", "Adam Schiff")]
+    [InlineData("Adam B. Schiff", "S001150", "Adam Schiff")]
+    [InlineData("C. Scott Franklin", "F000472", "Scott Franklin")]
+    public void Resolve_ReviewedExactAlias_ReturnsStableIdentity(
+        string alias,
+        string bioguideId,
+        string canonicalName
+    )
+    {
+        var result = CongressMemberIdentityCatalog.Resolve(alias);
+
+        result.Should().NotBeNull();
+        result.BioguideId.Should().Be(bioguideId);
+        result.CanonicalName.Should().Be(canonicalName);
+    }
+
+    [Theory]
+    [InlineData("J. Banks")]
+    [InlineData("Robert Goodman")]
+    [InlineData("Scott F Franklin")]
+    public void Resolve_UnreviewedSimilarName_RefusesToInferIdentity(string name)
+    {
+        CongressMemberIdentityCatalog.Resolve(name).Should().BeNull();
+    }
+
+    [Fact]
+    public void All_AliasesAndBioguideIds_AreUnambiguous()
+    {
+        var identities = CongressMemberIdentityCatalog.All;
+
+        identities.Select(identity => identity.BioguideId).Should().OnlyHaveUniqueItems();
+        var aliases = identities.SelectMany(identity => identity.Aliases).ToList();
+        aliases.Distinct(StringComparer.OrdinalIgnoreCase).Should().HaveSameCount(aliases);
+    }
+}

--- a/tests/Equibles.UnitTests/Congress/CongressServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressServiceCollectionExtensionsTests.cs
@@ -28,6 +28,16 @@ public class CongressServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddCongressWorker_AutoWiresMemberIdentityServiceContract()
+    {
+        var services = new ServiceCollection();
+
+        services.AddCongressWorker();
+
+        services.Should().Contain(d => d.ServiceType == typeof(ICongressMemberIdentityService));
+    }
+
+    [Fact]
     public void AddCongressWorker_RegistersCongressionalTradeScraperWorkerAsIHostedService()
     {
         // Sibling to AddCongressWorker_AutoWiresCongressionalTradeSyncService.

--- a/tests/Equibles.UnitTests/Congress/CongressSyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressSyncServiceTests.cs
@@ -48,7 +48,8 @@ public class CongressSyncServiceTests
             logger,
             errorReporter,
             filingLedger,
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
     }
 

--- a/tests/Equibles.UnitTests/Congress/CongressionalAnnualDisclosureSyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalAnnualDisclosureSyncServiceTests.cs
@@ -100,6 +100,20 @@ public class CongressionalAnnualDisclosureSyncServiceTests
         latest.Should().ContainSingle().Which.ReportId.Should().Be("1002");
     }
 
+    [Fact]
+    public void SelectLatestReports_ReviewedAliases_KeepsOneLatestReportPerBioguideMemberYear()
+    {
+        var original = Report("C. Scott Franklin", 2024, new DateOnly(2025, 5, 15), false, "1001");
+        var amendment = Report("Scott Franklin", 2024, new DateOnly(2025, 11, 4), true, "1002");
+
+        var latest = CongressionalAnnualDisclosureSyncService.SelectLatestReports([
+            original,
+            amendment,
+        ]);
+
+        latest.Should().ContainSingle().Which.ReportId.Should().Be("1002");
+    }
+
     [Theory]
     [InlineData("1001", "2025-05-15", false, true)] // same source report → rebuilt in place
     [InlineData("1002", "2025-11-04", false, true)] // later filing replaces

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests.cs
@@ -153,7 +153,8 @@ public class CongressionalTradeSyncServiceBuildTradesCleanAssetNameTests
             Substitute.For<ILogger<CongressionalTradeSyncService>>(),
             errorReporter,
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
     }
 }

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesFutureDateTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesFutureDateTests.cs
@@ -25,7 +25,8 @@ public class CongressionalTradeSyncServiceBuildTradesFutureDateTests
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
 
     private static List<CongressionalTrade> InvokeBuildTrades(

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesMemberNotFoundTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesMemberNotFoundTests.cs
@@ -30,7 +30,8 @@ public class CongressionalTradeSyncServiceBuildTradesMemberNotFoundTests
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
 
         var stock = new CommonStock

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesMissingMemberTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesMissingMemberTests.cs
@@ -25,7 +25,8 @@ public class CongressionalTradeSyncServiceBuildTradesMissingMemberTests
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
 
     private static List<CongressionalTrade> InvokeBuildTrades(

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesSameDayTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesSameDayTests.cs
@@ -34,7 +34,8 @@ public class CongressionalTradeSyncServiceBuildTradesSameDayTests
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
         var stock = new CommonStock
         {

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceBuildTradesTests.cs
@@ -33,7 +33,8 @@ public class CongressionalTradeSyncServiceBuildTradesTests
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Substitute.For<CongressionalFilingLedger>((IServiceScopeFactory)null),
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
 
         var member = new CongressMember { Id = Guid.NewGuid(), Name = "Jane Smith" };

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceTests.cs
@@ -50,7 +50,8 @@ public class CongressionalTradeSyncServiceTests
             logger,
             errorReporter,
             filingLedger,
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
 
         await sut.SyncAll(CancellationToken.None);
@@ -112,7 +113,8 @@ public class CongressionalTradeSyncServiceTests
             logger,
             errorReporter,
             filingLedger,
-            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null)
+            Substitute.For<CongressionalTradeImportLedger>((IServiceScopeFactory)null),
+            Substitute.For<ICongressMemberIdentityService>()
         );
 
         await sut.SyncAll(CancellationToken.None);


### PR DESCRIPTION
## Problem\nCongressional disclosure sources can spell one person several ways, creating duplicate member rows and splitting trade and annual-disclosure history.\n\n## Fix\n- resolve reviewed filing aliases through official BioGuide IDs\n- reconcile existing duplicate rows transactionally on both sync lanes\n- preserve distinct trades, the latest annual report, district data, and retired-ID redirects\n- prefer canonical members in search and profile routing\n- add the nullable unique BioGuide identity migration and regression coverage\n\n## Verification\n-   Equibles.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Data/bin/Release/net10.0/Equibles.Data.dll
  Equibles.Search.Abstractions -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Search.Abstractions/bin/Release/net10.0/Equibles.Search.Abstractions.dll
  Equibles.Core -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Core/bin/Release/net10.0/Equibles.Core.dll
  Equibles.Integrations.Common -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Integrations.Common/bin/Release/net10.0/Equibles.Integrations.Common.dll
  Equibles.CommonStocks.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.CommonStocks.Data/bin/Release/net10.0/Equibles.CommonStocks.Data.dll
  Equibles.Errors.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Errors.Data/bin/Release/net10.0/Equibles.Errors.Data.dll
  Equibles.Media.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Media.Data/bin/Release/net10.0/Equibles.Media.Data.dll
  Equibles.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Mcp/bin/Release/net10.0/Equibles.Mcp.dll
  Equibles.Congress.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Congress.Data/bin/Release/net10.0/Equibles.Congress.Data.dll
  Equibles.Holdings.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Holdings.Data/bin/Release/net10.0/Equibles.Holdings.Data.dll
  Equibles.CorporateActions.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.CorporateActions.Data/bin/Release/net10.0/Equibles.CorporateActions.Data.dll
  Equibles.Errors.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Errors.Repositories/bin/Release/net10.0/Equibles.Errors.Repositories.dll
  Equibles.Sec.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.Data/bin/Release/net10.0/Equibles.Sec.Data.dll
  Equibles.Cboe.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Cboe.Data/bin/Release/net10.0/Equibles.Cboe.Data.dll
  Equibles.InsiderTrading.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.InsiderTrading.Data/bin/Release/net10.0/Equibles.InsiderTrading.Data.dll
  Equibles.Messaging -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Messaging/bin/Release/net10.0/Equibles.Messaging.dll
  Equibles.Media.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Media.Repositories/bin/Release/net10.0/Equibles.Media.Repositories.dll
  Equibles.CommonStocks.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.CommonStocks.Repositories/bin/Release/net10.0/Equibles.CommonStocks.Repositories.dll
  Equibles.Yahoo.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Yahoo.Data/bin/Release/net10.0/Equibles.Yahoo.Data.dll
  Equibles.Congress.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Congress.Repositories/bin/Release/net10.0/Equibles.Congress.Repositories.dll
  Equibles.Media.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Media.BusinessLogic/bin/Release/net10.0/Equibles.Media.BusinessLogic.dll
  Equibles.Fred.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Fred.Data/bin/Release/net10.0/Equibles.Fred.Data.dll
  Equibles.FdaCatalysts.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.FdaCatalysts.Data/bin/Release/net10.0/Equibles.FdaCatalysts.Data.dll
  Equibles.Finra.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Finra.Data/bin/Release/net10.0/Equibles.Finra.Data.dll
  Equibles.Plugins -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Plugins/bin/Release/net10.0/Equibles.Plugins.dll
  Equibles.CorporateActions.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.CorporateActions.Repositories/bin/Release/net10.0/Equibles.CorporateActions.Repositories.dll
  Equibles.Holdings.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Holdings.Repositories/bin/Release/net10.0/Equibles.Holdings.Repositories.dll
  Equibles.Yahoo.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Yahoo.Repositories/bin/Release/net10.0/Equibles.Yahoo.Repositories.dll
  Equibles.GovernmentContracts.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.GovernmentContracts.Data/bin/Release/net10.0/Equibles.GovernmentContracts.Data.dll
  Equibles.Cboe.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Cboe.Repositories/bin/Release/net10.0/Equibles.Cboe.Repositories.dll
  Equibles.Finra.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Finra.Repositories/bin/Release/net10.0/Equibles.Finra.Repositories.dll
  Equibles.InsiderTrading.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.InsiderTrading.Repositories/bin/Release/net10.0/Equibles.InsiderTrading.Repositories.dll
  Equibles.Cftc.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Cftc.Data/bin/Release/net10.0/Equibles.Cftc.Data.dll
  Equibles.Integrations.Finra -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Integrations.Finra/bin/Release/net10.0/Equibles.Integrations.Finra.dll
  Equibles.Integrations.Fred -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Integrations.Fred/bin/Release/net10.0/Equibles.Integrations.Fred.dll
  Equibles.Integrations.Yahoo -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Integrations.Yahoo/bin/Release/net10.0/Equibles.Integrations.Yahoo.dll
  Equibles.Integrations.GovernmentContracts -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Integrations.GovernmentContracts/bin/Release/net10.0/Equibles.Integrations.GovernmentContracts.dll
  Equibles.Fred.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Fred.Repositories/bin/Release/net10.0/Equibles.Fred.Repositories.dll
  Equibles.Integrations.Cftc -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Integrations.Cftc/bin/Release/net10.0/Equibles.Integrations.Cftc.dll
  Equibles.GovernmentContracts.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.GovernmentContracts.Repositories/bin/Release/net10.0/Equibles.GovernmentContracts.Repositories.dll
  Equibles.Integrations.Cboe -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Integrations.Cboe/bin/Release/net10.0/Equibles.Integrations.Cboe.dll
  Equibles.CorporateActions.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.CorporateActions.BusinessLogic/bin/Release/net10.0/Equibles.CorporateActions.BusinessLogic.dll
  Equibles.Holdings.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Holdings.BusinessLogic/bin/Release/net10.0/Equibles.Holdings.BusinessLogic.dll
  Equibles.Integrations.Wikidata -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Integrations.Wikidata/bin/Release/net10.0/Equibles.Integrations.Wikidata.dll
  Equibles.CommonStocks.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.CommonStocks.BusinessLogic/bin/Release/net10.0/Equibles.CommonStocks.BusinessLogic.dll
  Equibles.Media.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Media.HostedService/bin/Release/net10.0/Equibles.Media.HostedService.dll
  Equibles.Sec.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.Repositories/bin/Release/net10.0/Equibles.Sec.Repositories.dll
  Equibles.Sec.FinancialFacts.Data -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.FinancialFacts.Data/bin/Release/net10.0/Equibles.Sec.FinancialFacts.Data.dll
  Equibles.Integrations.Sec -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Integrations.Sec/bin/Release/net10.0/Equibles.Integrations.Sec.dll
  Equibles.FdaCatalysts.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.FdaCatalysts.BusinessLogic/bin/Release/net10.0/Equibles.FdaCatalysts.BusinessLogic.dll
  Equibles.FdaCatalysts.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.FdaCatalysts.Repositories/bin/Release/net10.0/Equibles.FdaCatalysts.Repositories.dll
  Equibles.SmokeTests -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.SmokeTests/bin/Release/net10.0/Equibles.SmokeTests.dll
  Equibles.Errors.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Errors.BusinessLogic/bin/Release/net10.0/Equibles.Errors.BusinessLogic.dll
  Equibles.Cftc.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Cftc.Repositories/bin/Release/net10.0/Equibles.Cftc.Repositories.dll
  Equibles.Sec.FinancialFacts.Repositories -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.FinancialFacts.Repositories/bin/Release/net10.0/Equibles.Sec.FinancialFacts.Repositories.dll
  Equibles.Sec.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.BusinessLogic/bin/Release/net10.0/Equibles.Sec.BusinessLogic.dll
  Equibles.Finra.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Finra.BusinessLogic/bin/Release/net10.0/Equibles.Finra.BusinessLogic.dll
  Equibles.Yahoo.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Yahoo.Mcp/bin/Release/net10.0/Equibles.Yahoo.Mcp.dll
  Equibles.Worker -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Worker/bin/Release/net10.0/Equibles.Worker.dll
  Equibles.Search -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Search/bin/Release/net10.0/Equibles.Search.dll
  Equibles.GovernmentContracts.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.GovernmentContracts.Mcp/bin/Release/net10.0/Equibles.GovernmentContracts.Mcp.dll
  Equibles.InsiderTrading.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.InsiderTrading.Mcp/bin/Release/net10.0/Equibles.InsiderTrading.Mcp.dll
  Equibles.Sec.FinancialFacts.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.FinancialFacts.BusinessLogic/bin/Release/net10.0/Equibles.Sec.FinancialFacts.BusinessLogic.dll
  Equibles.Finra.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Finra.Mcp/bin/Release/net10.0/Equibles.Finra.Mcp.dll
  Equibles.FdaCatalysts.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.FdaCatalysts.Mcp/bin/Release/net10.0/Equibles.FdaCatalysts.Mcp.dll
  Equibles.InsiderTrading.BusinessLogic -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.InsiderTrading.BusinessLogic/bin/Release/net10.0/Equibles.InsiderTrading.BusinessLogic.dll
  Equibles.Cboe.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Cboe.Mcp/bin/Release/net10.0/Equibles.Cboe.Mcp.dll
  Equibles.Cftc.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Cftc.Mcp/bin/Release/net10.0/Equibles.Cftc.Mcp.dll
  Equibles.Sec.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.Mcp/bin/Release/net10.0/Equibles.Sec.Mcp.dll
  Equibles.CommonStocks.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.CommonStocks.HostedService/bin/Release/net10.0/Equibles.CommonStocks.HostedService.dll
  Equibles.Cftc.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Cftc.HostedService/bin/Release/net10.0/Equibles.Cftc.HostedService.dll
  Equibles.GovernmentContracts.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.GovernmentContracts.HostedService/bin/Release/net10.0/Equibles.GovernmentContracts.HostedService.dll
  Equibles.Cboe.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Cboe.HostedService/bin/Release/net10.0/Equibles.Cboe.HostedService.dll
  Equibles.Sec.FinancialFacts.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.FinancialFacts.Mcp/bin/Release/net10.0/Equibles.Sec.FinancialFacts.Mcp.dll
  Equibles.Sec.FinancialFacts.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.FinancialFacts.HostedService/bin/Release/net10.0/Equibles.Sec.FinancialFacts.HostedService.dll
  Equibles.FdaCatalysts.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.FdaCatalysts.HostedService/bin/Release/net10.0/Equibles.FdaCatalysts.HostedService.dll
  Equibles.Fred.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Fred.HostedService/bin/Release/net10.0/Equibles.Fred.HostedService.dll
  Equibles.Fred.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Fred.Mcp/bin/Release/net10.0/Equibles.Fred.Mcp.dll
  Equibles.Holdings.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Holdings.HostedService/bin/Release/net10.0/Equibles.Holdings.HostedService.dll
  Equibles.Sec.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Sec.HostedService/bin/Release/net10.0/Equibles.Sec.HostedService.dll
  Equibles.Holdings.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Holdings.Mcp/bin/Release/net10.0/Equibles.Holdings.Mcp.dll
  Equibles.Migrations -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Migrations/bin/Release/net10.0/Equibles.Migrations.dll
  Equibles.Congress.Mcp -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Congress.Mcp/bin/Release/net10.0/Equibles.Congress.Mcp.dll
  Equibles.Congress.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Congress.HostedService/bin/Release/net10.0/Equibles.Congress.HostedService.dll
  Equibles.Yahoo.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Yahoo.HostedService/bin/Release/net10.0/Equibles.Yahoo.HostedService.dll
  Equibles.Finra.HostedService -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Finra.HostedService/bin/Release/net10.0/Equibles.Finra.HostedService.dll
  Equibles.Web -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Web/bin/Release/net10.0/Equibles.Web.dll
  Equibles.Worker.Host -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Worker.Host/bin/Release/net10.0/Equibles.Worker.Host.dll
  Equibles.Benchmarks -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.Benchmarks/bin/Release/net10.0/Equibles.Benchmarks.dll
  Equibles.Mcp.Server -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/src/Equibles.Mcp.Server/bin/Release/net10.0/Equibles.Mcp.Server.dll
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(29,69): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(29,71): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(113,45): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(56,42): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(115,45): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(464,42): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Web/AuthControllerTests.cs(33,24): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Equibles.UnitTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs(80,65): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Equibles.UnitTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Mcp/McpToolExecutorTests.cs(110,47): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Equibles.UnitTests.csproj]
  Equibles.UnitTests -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/bin/Release/net10.0/Equibles.UnitTests.dll
  Equibles.IntegrationTests -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/bin/Release/net10.0/Equibles.IntegrationTests.dll
  Equibles.FunctionalTests -> /Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.FunctionalTests/bin/Release/net10.0/Equibles.FunctionalTests.dll

Build succeeded.

/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(29,69): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(29,71): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(113,45): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(56,42): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(115,45): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs(464,42): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Web/AuthControllerTests.cs(33,24): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Equibles.UnitTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs(80,65): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Equibles.UnitTests.csproj]
/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Mcp/McpToolExecutorTests.cs(110,47): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/Users/daniel/Projects/OSS/Equibles-worktrees/fix-congress-member-identity/tests/Equibles.UnitTests/Equibles.UnitTests.csproj]
    9 Warning(s)
    0 Error(s)

Time Elapsed 00:00:13.78\n- 4,586 unit tests passed\n- 2,731 integration tests passed\n- CSharpier checked 3,430 files\n- independent review: no actionable findings\n\nCloses #4305