### PR TITLE
fix(prices): retain delisted stock histories

### DIFF
--- a/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
+++ b/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
@@ -8,7 +8,12 @@ public class CommonStocksModuleConfiguration : Equibles.Data.IFinancialModule
 {
     public void ConfigureEntities(ModelBuilder builder)
     {
-        builder.Entity<CommonStock>();
+        var commonStock = builder.Entity<CommonStock>();
+        commonStock.Property(stock => stock.Active).HasDefaultValue(true);
+        commonStock
+            .HasIndex(stock => stock.Ticker)
+            .IsUnique()
+            .HasFilter("\"Active\"");
         builder.Entity<CommonStockCusipAlias>();
         builder.Entity<CommonStockListedCusip>();
         builder.Entity<CommonStockTickerAlias>();

--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -1,19 +1,39 @@
 using System.ComponentModel.DataAnnotations;
 using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Data.Contracts;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.CommonStocks.Data.Models;
 
-[Index(nameof(Ticker), IsUnique = true)]
 [Index(nameof(Cik), IsUnique = true)]
 [Index(nameof(Cusip))]
 [Index(nameof(IndustryId))]
-public class CommonStock
+public class CommonStock : IActivable
 {
     public Guid Id { get; set; } = Guid.NewGuid();
 
     [MaxLength(16)]
     public string Ticker { get; set; }
+
+    /// <summary>
+    /// Whether this issuer currently has an active listed common-stock symbol. Inactive rows are
+    /// retained because their exact price series and historical holdings remain valid inputs to
+    /// point-in-time analysis; ordinary stock discovery excludes them through the repository.
+    /// </summary>
+    public bool Active { get; set; } = true;
+
+    /// <summary>
+    /// The authoritative final trading date published by the listing reference directory. Null
+    /// for active rows and legacy rows whose status has not yet been reconciled.
+    /// </summary>
+    public DateOnly? DelistedOn { get; set; }
+
+    /// <summary>
+    /// Last bounded Yahoo history attempt for an inactive listing. Successful backfills also add
+    /// the ticker to <see cref="PriceHistoryBackfilledTickers"/>; failed responses cool down
+    /// before retrying instead of occupying every price cycle.
+    /// </summary>
+    public DateTime? HistoricalPriceBackfillAttemptedAt { get; set; }
 
     [MaxLength(256)]
     public string Name { get; set; }

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -9,6 +9,26 @@ public class CommonStockRepository : BaseRepository<CommonStock>
     public CommonStockRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
 
+    /// <summary>
+    /// The live stock directory. Historical identities stay stored but do not leak into search,
+    /// screeners, workers, or current ticker resolution.
+    /// </summary>
+    public override IQueryable<CommonStock> GetAll() =>
+        GetAllIncludingInactive().Where(stock => stock.Active);
+
+    public IQueryable<CommonStock> GetAllIncludingInactive() => base.GetAll();
+
+    public override async Task<CommonStock> Get(params object[] key)
+    {
+        var stock = await base.Get(key);
+        return stock?.Active == true ? stock : null;
+    }
+
+    public Task<CommonStock> GetIncludingInactive(params object[] key) => base.Get(key);
+
+    public IQueryable<CommonStock> GetByIdsIncludingInactive(IEnumerable<Guid> ids) =>
+        GetAllIncludingInactive().Where(stock => ids.Contains(stock.Id));
+
     public IQueryable<CommonStock> Search(string search)
     {
         var query = GetAll();
@@ -130,7 +150,7 @@ public class CommonStockRepository : BaseRepository<CommonStock>
     {
         if (!DbContext.Database.IsRelational())
         {
-            return await GetAll()
+            return await GetAllIncludingInactive()
                 .FirstOrDefaultAsync(stock => stock.Id == commonStockId, cancellationToken);
         }
 

--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -59,7 +59,10 @@ public static class CommonStockRepositoryExtensions
         CancellationToken cancellationToken = default
     )
     {
-        return repository.GetByIds(ids).Select(s => s.Id).ToHashSetAsync(cancellationToken);
+        return repository
+            .GetByIdsIncludingInactive(ids)
+            .Select(s => s.Id)
+            .ToHashSetAsync(cancellationToken);
     }
 
     // Returns the subset of items whose CommonStockId still exists, preserving order.

--- a/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
+++ b/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
@@ -74,7 +74,7 @@ public class BacktestPriceLoader
             .Distinct()
             .ToArray();
         var primaryTickers = await _stockRepository
-            .GetByIds(stockIds)
+            .GetByIdsIncludingInactive(stockIds)
             .Select(stock => new { stock.Id, stock.Ticker })
             .ToDictionaryAsync(stock => stock.Id, stock => stock.Ticker, cancellationToken);
 

--- a/src/Equibles.Migrations/Migrations/20260823220856_RetainDelistedCommonStocks.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260823220856_RetainDelistedCommonStocks.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823220856_RetainDelistedCommonStocks")]
+    partial class RetainDelistedCommonStocks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260823220856_RetainDelistedCommonStocks.cs
+++ b/src/Equibles.Migrations/Migrations/20260823220856_RetainDelistedCommonStocks.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class RetainDelistedCommonStocks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CommonStock_Ticker",
+                table: "CommonStock");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Active",
+                table: "CommonStock",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "DelistedOn",
+                table: "CommonStock",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "HistoricalPriceBackfillAttemptedAt",
+                table: "CommonStock",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStock_Ticker",
+                table: "CommonStock",
+                column: "Ticker",
+                unique: true,
+                filter: "\"Active\"");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CommonStock_Ticker",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "Active",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "DelistedOn",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "HistoricalPriceBackfillAttemptedAt",
+                table: "CommonStock");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStock_Ticker",
+                table: "CommonStock",
+                column: "Ticker",
+                unique: true);
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -179,7 +179,7 @@ public class CompanySyncService : ICompanySyncService
         // as SecondaryCiks on prior syncs. We can't filter by SEC CIKs alone because
         // the subsidiary's CIK won't match any incoming primary CIK — it lives only
         // inside another stock's SecondaryCiks list.
-        var allExistingStocks = await commonStockRepository.GetAll().ToListAsync();
+        var allExistingStocks = await commonStockRepository.GetAllIncludingInactive().ToListAsync();
         var existingStocks = allExistingStocks
             .Where(stock => secCiks.Contains(CikNormalizer.Canonicalize(stock.Cik)))
             .ToList();
@@ -197,12 +197,14 @@ public class CompanySyncService : ICompanySyncService
         var primaryTickerToStock = new Dictionary<string, CommonStock>(
             StringComparer.OrdinalIgnoreCase
         );
-        foreach (var stock in allExistingStocks)
+        foreach (var stock in allExistingStocks.Where(stock => stock.Active))
         {
             primaryTickerToStock[stock.Ticker] = stock;
         }
 
-        var secondaryCikToParent = BuildSecondaryCikToParent(allExistingStocks);
+        var secondaryCikToParent = BuildSecondaryCikToParent(
+            allExistingStocks.Where(stock => stock.Active).ToList()
+        );
 
         var existingPrimaryTickers = (
             await commonStockRepository.GetAllTickers().ToListAsync()
@@ -246,7 +248,9 @@ public class CompanySyncService : ICompanySyncService
             string.IsNullOrEmpty(existingStock.Website)
             && ShouldAttemptWebsiteFetch(secCompany.Cik);
         var needsUpdate =
-            existingStock.Ticker != primaryTicker
+            !existingStock.Active
+            || existingStock.DelistedOn != null
+            || existingStock.Ticker != primaryTicker
             || existingStock.Name != normalizedName
             || !(existingStock.SecondaryTickers ?? []).SequenceEqual(combinedSecondaryTickers)
             || missingWebsite;
@@ -259,6 +263,8 @@ public class CompanySyncService : ICompanySyncService
 
         // Save old values for rollback
         var oldTicker = existingStock.Ticker;
+        var oldActive = existingStock.Active;
+        var oldDelistedOn = existingStock.DelistedOn;
         var oldName = existingStock.Name;
         var oldSecondaryTickers = existingStock.SecondaryTickers.ToList();
         var oldWebsite = existingStock.Website;
@@ -269,11 +275,15 @@ public class CompanySyncService : ICompanySyncService
                 existingStock.Website = await FetchWebsite(secCompany.Cik);
 
             existingStock.Ticker = primaryTicker;
+            existingStock.Active = true;
+            existingStock.DelistedOn = null;
             existingStock.Name = normalizedName;
             existingStock.SecondaryTickers = combinedSecondaryTickers;
 
             if (
                 existingStock.Ticker == oldTicker
+                && existingStock.Active == oldActive
+                && existingStock.DelistedOn == oldDelistedOn
                 && existingStock.Name == oldName
                 && oldSecondaryTickers.SequenceEqual(existingStock.SecondaryTickers)
                 && existingStock.Website == oldWebsite
@@ -308,6 +318,8 @@ public class CompanySyncService : ICompanySyncService
         {
             // Revert entity to old values and detach changes to prevent dirty state
             existingStock.Ticker = oldTicker;
+            existingStock.Active = oldActive;
+            existingStock.DelistedOn = oldDelistedOn;
             existingStock.Name = oldName;
             existingStock.SecondaryTickers = oldSecondaryTickers;
             existingStock.Website = oldWebsite;
@@ -388,10 +400,10 @@ public class CompanySyncService : ICompanySyncService
 
             try
             {
-                await DeleteAndUntrack(tickerHolder, state);
+                await RetireAndUntrack(tickerHolder, state);
 
                 _logger.LogInformation(
-                    "Removed obsolete company {Name} (CIK: {Cik}) holding ticker {Ticker}",
+                    "Retired obsolete company {Name} (CIK: {Cik}) holding ticker {Ticker} without deleting its history",
                     tickerHolder.Name,
                     tickerHolder.Cik,
                     primaryTicker
@@ -404,7 +416,7 @@ public class CompanySyncService : ICompanySyncService
                     "Error removing obsolete company for ticker {Ticker}",
                     primaryTicker
                 );
-                await ReportError("CompanySync.RemoveObsolete", ex, $"ticker: {primaryTicker}");
+                await ReportError("CompanySync.RetireObsolete", ex, $"ticker: {primaryTicker}");
                 return false;
             }
         }
@@ -471,7 +483,7 @@ public class CompanySyncService : ICompanySyncService
 
         try
         {
-            await DeleteAndUntrack(obsoleteStock, state);
+            await RetireAndUntrack(obsoleteStock, state);
 
             var website = await FetchWebsite(secCompany.Cik);
             var newStock = await CreateCommonStock(
@@ -901,7 +913,7 @@ public class CompanySyncService : ICompanySyncService
         state.PrimaryTickerToStock[primaryTicker] = newStock;
     }
 
-    private static async Task DeleteAndUntrack(CommonStock stock, StockSyncState state)
+    private static async Task RetireAndUntrack(CommonStock stock, StockSyncState state)
     {
         if (state.DbContext.Database.IsRelational())
         {
@@ -926,10 +938,11 @@ public class CompanySyncService : ICompanySyncService
                     );
                 }
 
-                // Deleting the parent cascades through both the legacy and isolated exact-price
-                // foreign keys. The row lock and revalidation keep that deletion from racing a
-                // listing importer that is about to persist fresh exact-series rows.
-                state.CommonStockRepository.Delete(lockedStock);
+                // A recycled ticker ends the live designation, not the old issuer's identity.
+                // Retain the row and every exact price/holding FK; the authoritative inactive
+                // directory fills DelistedOn before any historical backfill is attempted.
+                lockedStock.Active = false;
+                InvalidateHistoricalPriceCompletion(lockedStock);
                 await state.CommonStockRepository.SaveChanges();
             }
 
@@ -937,7 +950,8 @@ public class CompanySyncService : ICompanySyncService
         }
         else
         {
-            state.CommonStockRepository.Delete(stock);
+            stock.Active = false;
+            InvalidateHistoricalPriceCompletion(stock);
             await state.CommonStockRepository.SaveChanges();
         }
 
@@ -951,6 +965,16 @@ public class CompanySyncService : ICompanySyncService
             && mapped.Id == stock.Id
         )
             state.PrimaryTickerToStock.Remove(stock.Ticker);
+    }
+
+    private static void InvalidateHistoricalPriceCompletion(CommonStock stock)
+    {
+        stock.PriceHistoryBackfilledTickers = stock
+            .PriceHistoryBackfilledTickers.Where(ticker =>
+                !string.Equals(ticker, stock.Ticker, StringComparison.OrdinalIgnoreCase)
+            )
+            .ToList();
+        stock.HistoricalPriceBackfillAttemptedAt = null;
     }
 
     private Task ReportError(string operation, Exception ex, string context) =>

--- a/src/Equibles.Yahoo.HostedService/Configuration/YahooPriceScraperOptions.cs
+++ b/src/Equibles.Yahoo.HostedService/Configuration/YahooPriceScraperOptions.cs
@@ -36,4 +36,10 @@ public class YahooPriceScraperOptions : ScraperOptions
     /// limit. Set to zero to disable it.
     /// </summary>
     public int OhlcRepairBatchSize { get; set; } = 100;
+
+    /// <summary>Maximum inactive listings attempted per price cycle.</summary>
+    public int HistoricalBackfillBatchSize { get; set; } = 25;
+
+    /// <summary>Days before retrying an incomplete inactive-listing response.</summary>
+    public int HistoricalBackfillRetryDays { get; set; } = 30;
 }

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -31,7 +31,9 @@ internal readonly record struct PriceSeriesTarget(
     Guid CommonStockId,
     bool IsPrimary,
     bool RequiresFullHistory = false,
-    DateTime? YahooEnrichmentAttemptedAt = null
+    DateTime? YahooEnrichmentAttemptedAt = null,
+    bool IsHistorical = false,
+    DateOnly? HistoryEndDate = null
 )
 {
     public PriceSeriesKey Key => new(CommonStockId, Ticker);
@@ -116,6 +118,7 @@ public class YahooPriceImportService
             tickerMap.Values.Distinct().ToList(),
             cancellationToken
         );
+        priceTargets.AddRange(await BuildHistoricalPriceTargets(cancellationToken));
         _logger.LogInformation(
             "Starting Yahoo price sync for {SeriesCount} listed symbols across {StockCount} stocks (enrichment: {Enrichment})",
             priceTargets.Count,
@@ -153,7 +156,9 @@ public class YahooPriceImportService
 
         if (includeEnrichment)
         {
-            var primaryOrder = crawlOrder.Where(target => target.IsPrimary).ToList();
+            var primaryOrder = crawlOrder
+                .Where(target => target.IsPrimary && !target.IsHistorical)
+                .ToList();
             await ImportEnrichment(primaryOrder, cancellationToken);
         }
     }
@@ -235,6 +240,45 @@ public class YahooPriceImportService
         return targets;
     }
 
+    private async Task<List<PriceSeriesTarget>> BuildHistoricalPriceTargets(
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepository = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var retryBefore = DateTime.UtcNow.AddDays(
+            -Math.Max(1, _scraperOptions.HistoricalBackfillRetryDays)
+        );
+        var historyFloor = PriceHistoryFloor();
+
+        return await stockRepository
+            .GetAllIncludingInactive()
+            .Where(stock =>
+                !stock.Active
+                && stock.DelistedOn != null
+                && stock.DelistedOn >= historyFloor
+                && !stock.PriceHistoryBackfilledTickers.Contains(stock.Ticker)
+                && (
+                    stock.HistoricalPriceBackfillAttemptedAt == null
+                    || stock.HistoricalPriceBackfillAttemptedAt <= retryBefore
+                )
+            )
+            .OrderBy(stock => stock.HistoricalPriceBackfillAttemptedAt ?? DateTime.MinValue)
+            .ThenBy(stock => stock.DelistedOn)
+            .ThenBy(stock => stock.Ticker)
+            .Take(Math.Max(1, _scraperOptions.HistoricalBackfillBatchSize))
+            .Select(stock => new PriceSeriesTarget(
+                stock.Ticker,
+                stock.Id,
+                IsPrimary: true,
+                RequiresFullHistory: true,
+                YahooEnrichmentAttemptedAt: null,
+                IsHistorical: true,
+                HistoryEndDate: stock.DelistedOn
+            ))
+            .ToListAsync(cancellationToken);
+    }
+
     private static async Task<LockedPriceSeries?> LockPriceSeries(
         CommonStockRepository stockRepository,
         PriceSeriesTarget target,
@@ -242,6 +286,18 @@ public class YahooPriceImportService
     )
     {
         var stock = await stockRepository.GetForUpdate(target.CommonStockId, cancellationToken);
+        if (stock == null)
+            return null;
+        if (
+            target.IsHistorical
+            && (
+                stock.Active
+                || stock.DelistedOn == null
+                || stock.DelistedOn != target.HistoryEndDate
+            )
+        )
+            return null;
+
         var resolvedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, target.Ticker);
         if (
             resolvedTicker == null
@@ -290,6 +346,8 @@ public class YahooPriceImportService
             catch (HttpRequestException ex)
             {
                 _logger.LogWarning(ex, "Failed to fetch prices for {Ticker}, skipping", ticker);
+                if (target.IsHistorical)
+                    await StampHistoricalBackfillAttempt(target, cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -300,6 +358,8 @@ public class YahooPriceImportService
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error importing prices for {Ticker}", ticker);
+                if (target.IsHistorical)
+                    await StampHistoricalBackfillAttempt(target, cancellationToken);
                 await _errorReporter.Report(
                     ErrorSource.YahooPriceScraper,
                     $"ImportTicker({ticker})",
@@ -476,6 +536,33 @@ public class YahooPriceImportService
             )
         )
             return;
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    private async Task StampHistoricalBackfillAttempt(
+        PriceSeriesTarget target,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        await using var transaction = await stockRepo.CreateTransaction(
+            IsolationLevel.ReadCommitted,
+            cancellationToken
+        );
+        var lockedSeries = await LockPriceSeries(stockRepo, target, cancellationToken);
+        if (
+            lockedSeries is not { IsPrimary: true }
+            || lockedSeries.Value.Stock.Active
+            || lockedSeries.Value.Stock.DelistedOn != target.HistoryEndDate
+        )
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return;
+        }
+
+        lockedSeries.Value.Stock.HistoricalPriceBackfillAttemptedAt = DateTime.UtcNow;
+        await stockRepo.SaveChanges();
         await transaction.CommitAsync(cancellationToken);
     }
 
@@ -1173,19 +1260,23 @@ public class YahooPriceImportService
         CancellationToken cancellationToken
     )
     {
-        var startDate = await ResolveStartDate(target, today, cancellationToken);
-        if (!HasSettledTradingDay(startDate, today))
+        var chartEnd = target.HistoryEndDate is { } delisted && delisted < today ? delisted : today;
+        var settledAsOf = target.IsHistorical ? chartEnd.AddDays(1) : today;
+        var startDate = await ResolveStartDate(target, settledAsOf, cancellationToken);
+        if (!HasSettledTradingDay(startDate, settledAsOf))
             return NoFetchNeeded;
 
         // One chart fetch yields the price bars plus any split and dividend
         // events for the window — capture both off the same response, no extra
         // HTTP.
-        var chartData = await _yahooClient.GetChart(target.Ticker, startDate, today);
+        var chartData = await _yahooClient.GetChart(target.Ticker, startDate, chartEnd);
+        if (target.IsHistorical)
+            await StampHistoricalBackfillAttempt(target, cancellationToken);
 
         if (target.RequiresFullHistory)
         {
             await CaptureSplits(target, chartData.Splits, cancellationToken);
-            if (!IsCompleteReferenceHistory(chartData, PriceHistoryFloor(), today))
+            if (!IsCompleteReferenceHistory(chartData, PriceHistoryFloor(), settledAsOf))
             {
                 _logger.LogWarning(
                     "Yahoo returned incomplete full history for reference listing {Ticker}; keeping its grouped bootstrap rows pending",
@@ -1205,7 +1296,7 @@ public class YahooPriceImportService
                             split.Denominator
                         ))
                         .ToList(),
-                    today
+                    settledAsOf
                 )
             )
                 return new TickerImportResult(Fetched: true, Inserted: 0);
@@ -1213,7 +1304,7 @@ public class YahooPriceImportService
             var replaced = await ReplaceStoredPrices(
                 target,
                 PriceHistoryFloor(),
-                today,
+                settledAsOf,
                 chartData.Prices,
                 cancellationToken
             );

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryTests.cs
@@ -61,6 +61,27 @@ public class CommonStockRepositoryTests : IDisposable
         await _dbContext.SaveChangesAsync();
     }
 
+    [Fact]
+    public async Task GetAll_ExcludesInactiveRows_WhileHistoricalQueryRetainsThem()
+    {
+        var active = MakeStock(ticker: "LIVE", cik: "111");
+        var delisted = MakeStock(ticker: "GONE", cik: "222");
+        delisted.Active = false;
+        delisted.DelistedOn = new DateOnly(2024, 6, 14);
+        await SeedStocks(active, delisted);
+
+        var liveDirectory = await _repository.GetAll().Select(stock => stock.Ticker).ToListAsync();
+        var retained = await _repository
+            .GetAllIncludingInactive()
+            .Select(stock => stock.Ticker)
+            .ToListAsync();
+
+        liveDirectory.Should().Equal("LIVE");
+        retained.Should().BeEquivalentTo("LIVE", "GONE");
+        (await _repository.Get(delisted.Id)).Should().BeNull();
+        (await _repository.GetIncludingInactive(delisted.Id)).Should().BeSameAs(delisted);
+    }
+
     // ── GetByCik ────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Holdings/BacktestPriceLoaderInactiveStockTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/BacktestPriceLoaderInactiveStockTests.cs
@@ -1,0 +1,96 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Repositories.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class BacktestPriceLoaderInactiveStockTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+
+    public BacktestPriceLoaderInactiveStockTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CorporateActionsModuleConfiguration(),
+            new CommonStocksModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task RunBacktest_PricesRetainedInactiveHolding()
+    {
+        var from = new DateOnly(2023, 1, 3);
+        var to = new DateOnly(2023, 2, 3);
+        var delisted = new CommonStock
+        {
+            Ticker = "GONE",
+            Name = "Formerly Listed",
+            Cik = "111",
+            Active = false,
+            DelistedOn = to,
+        };
+        var benchmark = new CommonStock { Ticker = "SPY", Name = "Benchmark", Cik = "222" };
+        _dbContext.AddRange(delisted, benchmark);
+        AddPrice(delisted, from, 10m);
+        AddPrice(delisted, to, 12m);
+        AddPrice(benchmark, from, 100m);
+        AddPrice(benchmark, to, 100m);
+        await _dbContext.SaveChangesAsync();
+
+        var loader = new BacktestPriceLoader(
+            new DailyStockPriceRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            new StockSplitRepository(_dbContext)
+        );
+        var snapshots = new[]
+        {
+            new BacktestQuarterSnapshot
+            {
+                ReportDate = from.AddDays(-46),
+                Positions =
+                [
+                    new BacktestPosition
+                    {
+                        CommonStockId = delisted.Id,
+                        Shares = 1_000,
+                        Value = 10_000,
+                    },
+                ],
+            },
+        };
+
+        var result = await loader.RunBacktest(snapshots, benchmark, "SPY", from, to);
+
+        result.Reason.Should().BeNull();
+        result.Points.Should().NotBeEmpty();
+        result.Points[^1].PortfolioValue.Should().Be(120m);
+    }
+
+    private void AddPrice(CommonStock stock, DateOnly date, decimal close) =>
+        _dbContext.Add(
+            new DailyStockPrice
+            {
+                CommonStockId = stock.Id,
+                ListedTicker = stock.Ticker,
+                Date = date,
+                Open = close,
+                High = close,
+                Low = close,
+                Close = close,
+                AdjustedClose = close,
+                Volume = 1_000,
+            }
+        );
+}

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCaseMismatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCaseMismatchTests.cs
@@ -93,11 +93,13 @@ public class CompanySyncServiceReplaceObsoleteCaseMismatchTests : ParadeDbMcpTes
 
         await using var verify = Fixture.CreateDbContext();
         var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
-        stocks
+        stocks.Should().HaveCount(2, "the retired case variant remains queryable historically");
+        var current = stocks
             .Should()
-            .ContainSingle("the obsolete holder must be replaced, not kept alongside a duplicate");
-        stocks[0].Cik.Should().Be("0000000111");
-        stocks[0].Ticker.Should().Be("REUSED", "listed tickers are persisted canonically");
-        stocks[0].Name.Should().Be("Acquirer Inc.");
+            .ContainSingle(stock => stock.Cik == "0000000111" && stock.Active)
+            .Subject;
+        current.Ticker.Should().Be("REUSED", "listed tickers are persisted canonically");
+        current.Name.Should().Be("Acquirer Inc.");
+        stocks.Should().ContainSingle(stock => stock.Cik != "0000000111" && !stock.Active);
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
@@ -37,7 +37,7 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
         : base(fixture) { }
 
     [Fact]
-    public async Task SyncCompaniesFromSecApi_NewCikReusesTickerOfDroppedCik_ReplacesObsoleteRow()
+    public async Task SyncCompaniesFromSecApi_NewCikReusesTickerOfDroppedCik_RetainsHistoricalRow()
     {
         // Seed an "obsolete" stock whose CIK no longer appears in SEC's feed.
         var obsolete = new CommonStock
@@ -45,6 +45,8 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
             Cik = "0000000999",
             Ticker = "REUSED",
             Name = "Defunct Old Inc.",
+            PriceHistoryBackfilledTickers = ["REUSED"],
+            HistoricalPriceBackfillAttemptedAt = DateTime.UtcNow,
         };
         var exactPriceId = Guid.NewGuid();
         DbContext.AddRange(
@@ -110,13 +112,17 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
 
         await using var verify = Fixture.CreateDbContext();
         var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
-        stocks.Should().ContainSingle("the obsolete CIK is gone and the new one took its ticker");
-        stocks[0].Cik.Should().Be("0000000111");
-        stocks[0].Ticker.Should().Be("REUSED");
-        stocks[0].Name.Should().Be("Acquirer Inc.");
+        stocks.Should().HaveCount(2, "ticker reuse must not erase historical identities");
+        stocks.Should().ContainSingle(stock => stock.Cik == "0000000111" && stock.Active);
+        var retired = stocks.Should()
+            .ContainSingle(stock => stock.Cik == "0000000999" && !stock.Active)
+            .Subject;
+        retired.PriceHistoryBackfilledTickers.Should().BeEmpty();
+        retired.HistoricalPriceBackfillAttemptedAt.Should().BeNull();
+        stocks.Should().OnlyContain(stock => stock.Ticker == "REUSED");
         (await verify.Set<DailyStockPrice>().AsNoTracking().ToListAsync())
             .Should()
-            .BeEmpty("the authorized parent cascade removes the obsolete listing's exact rows");
+            .ContainSingle("retiring a listing must preserve its exact historical prices");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
@@ -107,10 +107,12 @@ public class CompanySyncServiceUpdateExistingCollisionTests : ParadeDbMcpTestBas
 
         await using var verify = Fixture.CreateDbContext();
         var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
-        stocks.Should().ContainSingle("the obsolete holder must be deleted");
-        stocks[0].Id.Should().Be(updating.Id);
-        stocks[0].Ticker.Should().Be("NEW");
-        stocks[0].Name.Should().Be("Berkshire Hathaway Inc.");
+        stocks.Should().HaveCount(2, "the obsolete holder remains as historical identity");
+        var updated = stocks.Should().ContainSingle(stock => stock.Id == updating.Id).Subject;
+        updated.Active.Should().BeTrue();
+        updated.Ticker.Should().Be("NEW");
+        updated.Name.Should().Be("Berkshire Hathaway Inc.");
+        stocks.Should().ContainSingle(stock => stock.Id == obsoleteHolder.Id && !stock.Active);
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -123,6 +123,165 @@ public class YahooPriceImportServiceTests : IDisposable
         await _stockRepo.SaveChanges();
     }
 
+    [Fact]
+    public async Task Import_InactiveListing_BackfillsOnlyThroughAuthoritativeDelistingDate()
+    {
+        var floor = new DateOnly(2023, 1, 1);
+        var delistedOn = new DateOnly(2023, 1, 10);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        var stock = CreateStock("GONE", "Formerly Listed");
+        stock.Active = false;
+        stock.DelistedOn = delistedOn;
+        await SeedStocks(stock);
+
+        var prices = Enumerable
+            .Range(0, delistedOn.DayNumber - floor.DayNumber + 1)
+            .Select(floor.AddDays)
+            .Where(UsMarketCalendar.IsTradingDay)
+            .Select(date => new HistoricalPrice
+            {
+                Date = date,
+                Open = 10m,
+                High = 11m,
+                Low = 9m,
+                Close = 10m,
+                AdjustedClose = 10m,
+                Volume = 1_000,
+            })
+            .ToList();
+        _yahooClient
+            .GetChart("GONE", floor, delistedOn)
+            .Returns(new YahooChartData { FirstTradeDate = floor, Prices = prices });
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        await _yahooClient.Received(1).GetChart("GONE", floor, delistedOn);
+        var retained = _stockRepo
+            .GetAllIncludingInactive()
+            .Single(row => row.Id == stock.Id);
+        retained.HistoricalPriceBackfillAttemptedAt.Should().NotBeNull();
+        retained.PriceHistoryBackfilledTickers.Should().Equal("GONE");
+        _priceRepo
+            .GetAllSeries()
+            .Where(price => price.CommonStockId == stock.Id)
+            .Select(price => price.Date)
+            .Should()
+            .Equal(prices.Select(price => price.Date));
+    }
+
+    [Fact]
+    public async Task Import_PreHistoryDelistings_DoNotStarveEligibleHistoricalBackfill()
+    {
+        var floor = new DateOnly(2023, 1, 1);
+        var delistedOn = new DateOnly(2023, 1, 10);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        var ineligible = Enumerable
+            .Range(0, 25)
+            .Select(index => CreateStock($"OLD{index:D2}", $"Old Listing {index:D2}"))
+            .ToArray();
+        foreach (var stock in ineligible)
+        {
+            stock.Active = false;
+            stock.DelistedOn = floor.AddDays(-1);
+        }
+
+        var eligible = CreateStock("GONE", "Formerly Listed");
+        eligible.Active = false;
+        eligible.DelistedOn = delistedOn;
+        await SeedStocks([.. ineligible, eligible]);
+
+        var prices = Enumerable
+            .Range(0, delistedOn.DayNumber - floor.DayNumber + 1)
+            .Select(floor.AddDays)
+            .Where(UsMarketCalendar.IsTradingDay)
+            .Select(date => new HistoricalPrice
+            {
+                Date = date,
+                Open = 10m,
+                High = 11m,
+                Low = 9m,
+                Close = 10m,
+                AdjustedClose = 10m,
+                Volume = 1_000,
+            })
+            .ToList();
+        _yahooClient
+            .GetChart("GONE", floor, delistedOn)
+            .Returns(new YahooChartData { FirstTradeDate = floor, Prices = prices });
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        await _yahooClient.Received(1).GetChart("GONE", floor, delistedOn);
+        await _yahooClient
+            .DidNotReceive()
+            .GetChart(Arg.Is<string>(ticker => ticker.StartsWith("OLD")), Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
+        eligible.PriceHistoryBackfilledTickers.Should().Equal("GONE");
+    }
+
+    [Fact]
+    public async Task Import_InactiveListingHttpFailure_CheckpointsAttemptWithoutCompleting()
+    {
+        var stock = CreateStock("GONE", "Formerly Listed");
+        stock.Active = false;
+        stock.DelistedOn = new DateOnly(2023, 1, 10);
+        await SeedStocks(stock);
+        _yahooClient
+            .GetChart("GONE", Arg.Any<DateOnly>(), stock.DelistedOn.Value)
+            .ThrowsAsync(new HttpRequestException("temporary"));
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        var retained = _stockRepo
+            .GetAllIncludingInactive()
+            .Single(row => row.Id == stock.Id);
+        retained.HistoricalPriceBackfillAttemptedAt.Should().NotBeNull();
+        retained.PriceHistoryBackfilledTickers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Import_InactiveListingReactivatedDuringFetch_RefusesStaleReplacement()
+    {
+        var floor = new DateOnly(2023, 1, 1);
+        var delistedOn = new DateOnly(2023, 1, 10);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        var stock = CreateStock("GONE", "Formerly Listed");
+        stock.Active = false;
+        stock.DelistedOn = delistedOn;
+        await SeedStocks(stock);
+        var prices = Enumerable
+            .Range(0, delistedOn.DayNumber - floor.DayNumber + 1)
+            .Select(floor.AddDays)
+            .Where(UsMarketCalendar.IsTradingDay)
+            .Select(date => new HistoricalPrice
+            {
+                Date = date,
+                Open = 10m,
+                High = 11m,
+                Low = 9m,
+                Close = 10m,
+                AdjustedClose = 10m,
+                Volume = 1_000,
+            })
+            .ToList();
+        _yahooClient
+            .GetChart("GONE", floor, delistedOn)
+            .Returns(_ =>
+            {
+                stock.Active = true;
+                stock.DelistedOn = null;
+                _dbContext.SaveChanges();
+                return new YahooChartData { FirstTradeDate = floor, Prices = prices };
+            });
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo
+            .GetAllSeries()
+            .Should()
+            .BeEmpty("the fetched cutoff no longer describes the listing at commit time");
+        stock.PriceHistoryBackfilledTickers.Should().BeEmpty();
+    }
+
     private async Task SeedPrices(params DailyStockPrice[] prices)
     {
         _priceRepo.AddRange(prices);

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
@@ -100,7 +100,7 @@ public class CompanySyncServiceUpdateExistingBranchATests
     }
 
     [Fact]
-    public async Task UpdateExistingStock_TickerHeldByOutOfFeedStock_DeletesObsoleteHolderThenUpdates()
+    public async Task UpdateExistingStock_TickerHeldByOutOfFeedStock_RetiresHolderThenUpdates()
     {
         using var db = NewDb();
         var existing = new CommonStock
@@ -132,9 +132,8 @@ public class CompanySyncServiceUpdateExistingBranchATests
 
         await Invoke(BuildSut(), secCompany, "NEWT", state);
 
-        (await db.Set<CommonStock>().AnyAsync(s => s.Cik == "0000000999"))
-            .Should()
-            .BeFalse("the obsolete holder must have been deleted");
+        var retired = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000999");
+        retired.Active.Should().BeFalse("the historical identity must remain without a live claim");
         var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000002");
         updated.Ticker.Should().Be("NEWT");
         updated.Name.Should().Be("Updated Name");


### PR DESCRIPTION
## Summary

- retain inactive common-stock identities and their exact price/holding relationships
- keep ordinary directory and worker reads active-only while allowing explicit historical reads
- backfill inactive Yahoo histories only through authoritative delisting cutoffs with retry and concurrency guards
- preserve recycled ticker histories through an active-only unique constraint

## Verification

- `dotnet build Equibles.sln -c Release --no-restore`
- 4,595 OSS unit tests passed
- 113 focused integration tests passed