### PR TITLE
fix(prices): enforce delisted history cutoffs

### DIFF
--- a/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
+++ b/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
@@ -10,10 +10,7 @@ public class CommonStocksModuleConfiguration : Equibles.Data.IFinancialModule
     {
         var commonStock = builder.Entity<CommonStock>();
         commonStock.Property(stock => stock.Active).HasDefaultValue(true);
-        commonStock
-            .HasIndex(stock => stock.Ticker)
-            .IsUnique()
-            .HasFilter("\"Active\"");
+        commonStock.HasIndex(stock => stock.Ticker).IsUnique().HasFilter("\"Active\"");
         builder.Entity<CommonStockCusipAlias>();
         builder.Entity<CommonStockListedCusip>();
         builder.Entity<CommonStockTickerAlias>();

--- a/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
@@ -187,6 +187,33 @@ public class CorporateActionPriceReconciliationManager
     }
 
     /// <summary>
+    /// Stamps actions only when the locked issuer still has the listing state that bounded the
+    /// provider response. This prevents a delisting or reactivation race from certifying stale
+    /// price history.
+    /// </summary>
+    public Task<int> StampApplied(
+        PendingPriceReconciliationSeries selectedSeries,
+        IReadOnlyCollection<CapturedDividend> priceSeriesDividends,
+        DateOnly settledBefore,
+        DateTime appliedTime,
+        bool expectedActive,
+        DateOnly? expectedDelistedOn,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return StampAppliedCore(
+            selectedSeries,
+            priceSeriesDividends,
+            true,
+            settledBefore,
+            appliedTime,
+            cancellationToken,
+            expectedActive,
+            expectedDelistedOn
+        );
+    }
+
+    /// <summary>
     /// Clears reconciliation markers whose stored price boundary proves that the replacement did
     /// not put the series on one split basis. The next selection pass retries those exact series.
     /// </summary>
@@ -229,7 +256,9 @@ public class CorporateActionPriceReconciliationManager
         bool requirePriceSeriesDividendMatch,
         DateOnly settledBefore,
         DateTime appliedTime,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        bool? expectedActive = null,
+        DateOnly? expectedDelistedOn = null
     )
     {
         await using var transaction = await _stockRepository.CreateTransaction(
@@ -240,7 +269,16 @@ public class CorporateActionPriceReconciliationManager
             selectedSeries.CommonStockId,
             cancellationToken
         );
-        if (stock == null)
+        if (
+            stock == null
+            || (
+                expectedActive != null
+                && (
+                    stock.Active != expectedActive.Value
+                    || stock.DelistedOn != expectedDelistedOn
+                )
+            )
+        )
         {
             await transaction.RollbackAsync(cancellationToken);
             return 0;

--- a/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
@@ -273,10 +273,7 @@ public class CorporateActionPriceReconciliationManager
             stock == null
             || (
                 expectedActive != null
-                && (
-                    stock.Active != expectedActive.Value
-                    || stock.DelistedOn != expectedDelistedOn
-                )
+                && (stock.Active != expectedActive.Value || stock.DelistedOn != expectedDelistedOn)
             )
         )
         {

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -726,8 +726,8 @@ public class YahooPriceImportService
         PriceSeriesTarget target;
         using (var identityScope = _scopeFactory.CreateScope())
         {
-            var stockRepository = identityScope.ServiceProvider
-                .GetRequiredService<CommonStockRepository>();
+            var stockRepository =
+                identityScope.ServiceProvider.GetRequiredService<CommonStockRepository>();
             var stock = await stockRepository
                 .GetAllIncludingInactive()
                 .FirstOrDefaultAsync(

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -297,6 +297,8 @@ public class YahooPriceImportService
             )
         )
             return null;
+        if (!target.IsHistorical && !stock.Active)
+            return null;
 
         var resolvedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, target.Ticker);
         if (
@@ -721,12 +723,58 @@ public class YahooPriceImportService
         CancellationToken cancellationToken
     )
     {
-        var target = new PriceSeriesTarget(
-            selectedSeries.ListedTicker,
-            selectedSeries.CommonStockId,
-            IsPrimary: false
-        );
-        var chartData = await _yahooClient.GetChart(target.Ticker, floor, today);
+        PriceSeriesTarget target;
+        using (var identityScope = _scopeFactory.CreateScope())
+        {
+            var stockRepository = identityScope.ServiceProvider
+                .GetRequiredService<CommonStockRepository>();
+            var stock = await stockRepository
+                .GetAllIncludingInactive()
+                .FirstOrDefaultAsync(
+                    candidate => candidate.Id == selectedSeries.CommonStockId,
+                    cancellationToken
+                );
+            if (stock == null)
+                return;
+
+            var resolvedTicker = SecondaryTickerPolicy.ResolveListedTicker(
+                stock,
+                selectedSeries.ListedTicker
+            );
+            if (
+                resolvedTicker == null
+                || !string.Equals(
+                    resolvedTicker,
+                    selectedSeries.ListedTicker,
+                    StringComparison.OrdinalIgnoreCase
+                )
+                || (!stock.Active && stock.DelistedOn == null)
+            )
+                return;
+
+            target = new PriceSeriesTarget(
+                selectedSeries.ListedTicker,
+                selectedSeries.CommonStockId,
+                IsPrimary: string.Equals(
+                    resolvedTicker,
+                    stock.Ticker,
+                    StringComparison.OrdinalIgnoreCase
+                ),
+                IsHistorical: !stock.Active,
+                HistoryEndDate: stock.Active ? null : stock.DelistedOn
+            );
+        }
+
+        var historyEndDate = target.HistoryEndDate ?? today;
+        if (target.IsHistorical)
+        {
+            await PurgePricesAfterHistoricalCutoff(target, cancellationToken);
+            if (historyEndDate < floor)
+                return;
+        }
+
+        var settledBefore = target.IsHistorical ? historyEndDate.AddDays(1) : today;
+        var chartData = await _yahooClient.GetChart(target.Ticker, floor, historyEndDate);
         await CaptureSplits(target, chartData.Splits, cancellationToken);
 
         // A delisted/unresolved ticker returns no prices. Do NOT wipe the existing series in that
@@ -760,7 +808,7 @@ public class YahooPriceImportService
                 target.Ticker,
                 chartData.Prices,
                 splitBoundaries,
-                today
+                settledBefore
             )
         )
             return;
@@ -768,7 +816,8 @@ public class YahooPriceImportService
         var replaced = await ReplaceStoredPrices(
             target,
             floor,
-            today,
+            historyEndDate,
+            settledBefore,
             chartData.Prices,
             cancellationToken
         );
@@ -806,7 +855,7 @@ public class YahooPriceImportService
         // quote-summary or EDGAR enrichment succeeding. Gate on the certifiable set: a provider
         // that has not served the split's first post-effective bar is serving pre-split
         // key statistics too.
-        if (certifiableSeries.Splits.Count > 0)
+        if (!target.IsHistorical && certifiableSeries.Splits.Count > 0)
             await SyncKeyStatistics(target, cancellationToken);
 
         using var scope = _scopeFactory.CreateScope();
@@ -815,9 +864,11 @@ public class YahooPriceImportService
         var stamped = await manager.StampApplied(
             certifiableSeries,
             capturedDividends,
-            today,
+            settledBefore,
             DateTime.UtcNow,
-            cancellationToken
+            expectedActive: !target.IsHistorical,
+            expectedDelistedOn: target.HistoryEndDate,
+            cancellationToken: cancellationToken
         );
         _logger.LogInformation(
             "Reconciled {Ticker}: replaced stored price history and stamped {Count} corporate action(s) applied",
@@ -1063,19 +1114,21 @@ public class YahooPriceImportService
         return Math.Abs(observedRatio - splitRatio) / splitRatio <= SplitRatioMatchTolerance;
     }
 
-    // Transactionally swaps a stock's stored rows in [floor, today] for the fresh provider-served
-    // series. Returns false without touching the stored rows when there is nothing usable to store
+    // Transactionally swaps a stock's stored rows in the authoritative replacement window for the
+    // fresh provider-served series. Returns false without touching the stored rows when there is
+    // nothing usable to store
     // (all rows overflowed the numeric ceiling, or the parent CommonStock was removed) so a stock
     // is never left with an empty series.
     private async Task<bool> ReplaceStoredPrices(
         PriceSeriesTarget target,
         DateOnly floor,
-        DateOnly today,
+        DateOnly replaceThrough,
+        DateOnly settledBefore,
         List<HistoricalPrice> prices,
         CancellationToken cancellationToken
     )
     {
-        var freshRows = MapFreshRows(target.CommonStockId, prices, target.Ticker, today);
+        var freshRows = MapFreshRows(target.CommonStockId, prices, target.Ticker, settledBefore);
         if (freshRows.Count == 0)
         {
             _logger.LogWarning(
@@ -1093,7 +1146,7 @@ public class YahooPriceImportService
             stockRepo,
             target,
             floor,
-            today,
+            replaceThrough,
             freshRows,
             cancellationToken
         );
@@ -1106,7 +1159,42 @@ public class YahooPriceImportService
         return replaced;
     }
 
-    // The transactional core of the replacement: delete the stock's rows in [floor, today], then
+    private async Task PurgePricesAfterHistoricalCutoff(
+        PriceSeriesTarget target,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+        await using var transaction = await repo.CreateTransaction(
+            IsolationLevel.ReadCommitted,
+            cancellationToken
+        );
+        if (await LockPriceSeries(stockRepo, target, cancellationToken) == null)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return;
+        }
+
+        var recycledRows = await repo.GetAllSeries()
+            .Where(price =>
+                price.CommonStockId == target.CommonStockId
+                && price.ListedTicker == target.Ticker
+                && price.Date > target.HistoryEndDate!.Value
+            )
+            .ToListAsync(cancellationToken);
+        if (recycledRows.Count > 0)
+        {
+            repo.Delete(recycledRows);
+            await repo.SaveChanges();
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    // The transactional core of the replacement: delete the stock's rows in the authoritative
+    // window, then
     // bulk-insert the fresh rows in batches, all in one transaction so the stock is never left with
     // a partial series on failure. Takes the repo so it is unit-testable without a live worker.
     private static async Task<bool> ReplacePriceRows(
@@ -1114,7 +1202,7 @@ public class YahooPriceImportService
         CommonStockRepository stockRepo,
         PriceSeriesTarget target,
         DateOnly floor,
-        DateOnly today,
+        DateOnly replaceThrough,
         List<DailyStockPrice> freshRows,
         CancellationToken cancellationToken
     )
@@ -1141,8 +1229,11 @@ public class YahooPriceImportService
                 .Where(p =>
                     p.CommonStockId == target.CommonStockId
                     && p.ListedTicker == target.Ticker
-                    && p.Date >= floor
-                    && p.Date <= today
+                    && (
+                        target.IsHistorical
+                            ? p.Date >= floor || p.Date > target.HistoryEndDate!.Value
+                            : p.Date >= floor && p.Date <= replaceThrough
+                    )
                 )
                 .ToListAsync(cancellationToken);
             if (existing.Count > 0)
@@ -1262,6 +1353,8 @@ public class YahooPriceImportService
     {
         var chartEnd = target.HistoryEndDate is { } delisted && delisted < today ? delisted : today;
         var settledAsOf = target.IsHistorical ? chartEnd.AddDays(1) : today;
+        if (target.IsHistorical)
+            await PurgePricesAfterHistoricalCutoff(target, cancellationToken);
         var startDate = await ResolveStartDate(target, settledAsOf, cancellationToken);
         if (!HasSettledTradingDay(startDate, settledAsOf))
             return NoFetchNeeded;
@@ -1304,6 +1397,7 @@ public class YahooPriceImportService
             var replaced = await ReplaceStoredPrices(
                 target,
                 PriceHistoryFloor(),
+                chartEnd,
                 settledAsOf,
                 chartData.Prices,
                 cancellationToken
@@ -1384,6 +1478,7 @@ public class YahooPriceImportService
             var replaced = await ReplaceStoredPrices(
                 target,
                 floor,
+                today,
                 today,
                 fullChart.Prices,
                 cancellationToken

--- a/tests/Equibles.IntegrationTests/Holdings/BacktestPriceLoaderInactiveStockTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/BacktestPriceLoaderInactiveStockTests.cs
@@ -41,7 +41,12 @@ public class BacktestPriceLoaderInactiveStockTests : IDisposable
             Active = false,
             DelistedOn = to,
         };
-        var benchmark = new CommonStock { Ticker = "SPY", Name = "Benchmark", Cik = "222" };
+        var benchmark = new CommonStock
+        {
+            Ticker = "SPY",
+            Name = "Benchmark",
+            Cik = "222",
+        };
         _dbContext.AddRange(delisted, benchmark);
         AddPrice(delisted, from, 10m);
         AddPrice(delisted, to, 12m);

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
@@ -82,7 +82,7 @@ public class CompanySyncServiceDispatchTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task SyncCompaniesFromSecApi_TickerHeldByCompanyNotInFeed_ReplacesObsoleteStock()
+    public async Task SyncCompaniesFromSecApi_TickerReuse_RetainsInactivePriorIdentity()
     {
         DbContext.Add(
             new CommonStock
@@ -102,12 +102,18 @@ public class CompanySyncServiceDispatchTests : ParadeDbMcpTestBase
 
         await BuildSut(client).SyncCompaniesFromSecApi();
 
-        // Old holder (CIK not in feed) deleted; the incoming CIK now owns REPL.
+        // The incoming CIK owns the live ticker while the prior identity remains for history.
         await using var verify = Fixture.CreateDbContext();
         var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
-        stocks.Should().ContainSingle();
-        stocks[0].Cik.Should().Be("0000000021");
-        stocks[0].Ticker.Should().Be("REPL");
+        stocks.Should().HaveCount(2);
+        stocks
+            .Should()
+            .ContainSingle(stock => stock.Cik == "0000000020" && !stock.Active);
+        stocks
+            .Should()
+            .ContainSingle(stock =>
+                stock.Cik == "0000000021" && stock.Ticker == "REPL" && stock.Active
+            );
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
@@ -106,9 +106,7 @@ public class CompanySyncServiceDispatchTests : ParadeDbMcpTestBase
         await using var verify = Fixture.CreateDbContext();
         var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
         stocks.Should().HaveCount(2);
-        stocks
-            .Should()
-            .ContainSingle(stock => stock.Cik == "0000000020" && !stock.Active);
+        stocks.Should().ContainSingle(stock => stock.Cik == "0000000020" && !stock.Active);
         stocks
             .Should()
             .ContainSingle(stock =>

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
@@ -19,11 +19,10 @@ using Xunit;
 namespace Equibles.IntegrationTests.Sec;
 
 /// <summary>
-/// Completes the <c>ReplaceObsoleteStock</c> pins: the replace path is exercised
-/// (obsolete row deleted) but the replacement <c>CommonStockManager.Create</c>
+/// Completes the ticker-reuse pins: the old identity is retired but the replacement
+/// <c>CommonStockManager.Create</c>
 /// fails validation (empty Name) and the catch arm must log and report rather
-/// than rethrow — so one malformed SEC entry can't abort the sync after the
-/// obsolete delete already committed.
+/// than rethrow — so one malformed SEC entry cannot abort the sync.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class CompanySyncServiceReplaceObsoleteCatchTests : ParadeDbMcpTestBase
@@ -32,7 +31,7 @@ public class CompanySyncServiceReplaceObsoleteCatchTests : ParadeDbMcpTestBase
         : base(fixture) { }
 
     [Fact]
-    public async Task SyncCompaniesFromSecApi_ReplaceCreateFailsValidation_DeletesObsoleteThenReportsError()
+    public async Task SyncCompaniesFromSecApi_ReplacementFailsValidation_RetainsInactiveIdentity()
     {
         var obsolete = new CommonStock
         {
@@ -46,8 +45,8 @@ public class CompanySyncServiceReplaceObsoleteCatchTests : ParadeDbMcpTestBase
 
         // New CIK (not in feed-scoped existing set) wants REUSED. The obsolete
         // holder's own CIK is absent from the feed → replace path. The new
-        // company has an empty Name → Create throws after the obsolete delete
-        // has already committed, exercising the catch arm.
+        // company has an empty Name → Create throws after the obsolete identity
+        // has been retired, exercising the catch arm.
         var secEdgarClient = Substitute.For<ISecEdgarClient>();
         secEdgarClient
             .GetActiveCompanies()
@@ -89,8 +88,9 @@ public class CompanySyncServiceReplaceObsoleteCatchTests : ParadeDbMcpTestBase
 
         await using var verify = Fixture.CreateDbContext();
         var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
-        stocks
-            .Should()
-            .BeEmpty("the obsolete row was deleted and the invalid replacement was not created");
+        var retained = stocks.Should().ContainSingle().Which;
+        retained.Cik.Should().Be(obsolete.Cik);
+        retained.Ticker.Should().Be(obsolete.Ticker);
+        retained.Active.Should().BeFalse();
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
@@ -114,7 +114,8 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
         var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
         stocks.Should().HaveCount(2, "ticker reuse must not erase historical identities");
         stocks.Should().ContainSingle(stock => stock.Cik == "0000000111" && stock.Active);
-        var retired = stocks.Should()
+        var retired = stocks
+            .Should()
             .ContainSingle(stock => stock.Cik == "0000000999" && !stock.Active)
             .Subject;
         retired.PriceHistoryBackfilledTickers.Should().BeEmpty();

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -157,9 +157,7 @@ public class YahooPriceImportServiceTests : IDisposable
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
         await _yahooClient.Received(1).GetChart("GONE", floor, delistedOn);
-        var retained = _stockRepo
-            .GetAllIncludingInactive()
-            .Single(row => row.Id == stock.Id);
+        var retained = _stockRepo.GetAllIncludingInactive().Single(row => row.Id == stock.Id);
         retained.HistoricalPriceBackfillAttemptedAt.Should().NotBeNull();
         retained.PriceHistoryBackfilledTickers.Should().Equal("GONE");
         _priceRepo
@@ -261,15 +259,9 @@ public class YahooPriceImportServiceTests : IDisposable
         );
         chartData.Dividends =
         [
-            new CashDividendEvent
-            {
-                Date = delistedOn,
-                Amount = dividend.AmountPerShare,
-            },
+            new CashDividendEvent { Date = delistedOn, Amount = dividend.AmountPerShare },
         ];
-        _yahooClient
-            .GetChart("GONE", floor, delistedOn)
-            .Returns(chartData);
+        _yahooClient.GetChart("GONE", floor, delistedOn).Returns(chartData);
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
@@ -337,7 +329,11 @@ public class YahooPriceImportServiceTests : IDisposable
         await _yahooClient.Received(1).GetChart("GONE", floor, delistedOn);
         await _yahooClient
             .DidNotReceive()
-            .GetChart(Arg.Is<string>(ticker => ticker.StartsWith("OLD")), Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
+            .GetChart(
+                Arg.Is<string>(ticker => ticker.StartsWith("OLD")),
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>()
+            );
         eligible.PriceHistoryBackfilledTickers.Should().Equal("GONE");
     }
 
@@ -366,11 +362,10 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
-        await _yahooClient.DidNotReceive().GetChart("OLD", Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
-        _priceRepo
-            .GetAllSeries()
-            .Should()
-            .NotContain(price => price.CommonStockId == stock.Id);
+        await _yahooClient
+            .DidNotReceive()
+            .GetChart("OLD", Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
+        _priceRepo.GetAllSeries().Should().NotContain(price => price.CommonStockId == stock.Id);
         split.PriceAdjustmentAppliedTime.Should().BeNull();
     }
 
@@ -387,9 +382,7 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
-        var retained = _stockRepo
-            .GetAllIncludingInactive()
-            .Single(row => row.Id == stock.Id);
+        var retained = _stockRepo.GetAllIncludingInactive().Single(row => row.Id == stock.Id);
         retained.HistoricalPriceBackfillAttemptedAt.Should().NotBeNull();
         retained.PriceHistoryBackfilledTickers.Should().BeEmpty();
     }

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -133,6 +133,7 @@ public class YahooPriceImportServiceTests : IDisposable
         stock.Active = false;
         stock.DelistedOn = delistedOn;
         await SeedStocks(stock);
+        await SeedPrices(CreatePrice(stock, delistedOn.AddDays(3), 99m));
 
         var prices = Enumerable
             .Range(0, delistedOn.DayNumber - floor.DayNumber + 1)
@@ -167,6 +168,128 @@ public class YahooPriceImportServiceTests : IDisposable
             .Select(price => price.Date)
             .Should()
             .Equal(prices.Select(price => price.Date));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Import_InactiveListing_PurgesPostCutoffRowsWithoutUsableReplacement(
+        bool emptyResponse
+    )
+    {
+        var floor = new DateOnly(2023, 1, 1);
+        var delistedOn = new DateOnly(2023, 1, 10);
+        var retainedDate = delistedOn.AddDays(-1);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        var stock = CreateStock("GONE", "Formerly Listed");
+        stock.Active = false;
+        stock.DelistedOn = delistedOn;
+        await SeedStocks(stock);
+        await SeedPrices(
+            CreatePrice(stock, retainedDate, 10m),
+            CreatePrice(stock, delistedOn.AddDays(3), 99m)
+        );
+        var response = new YahooChartData
+        {
+            FirstTradeDate = floor,
+            Prices = emptyResponse
+                ? []
+                :
+                [
+                    new HistoricalPrice
+                    {
+                        Date = delistedOn,
+                        Open = 10m,
+                        High = 11m,
+                        Low = 9m,
+                        Close = 10m,
+                        AdjustedClose = 10m,
+                        Volume = 1_000,
+                    },
+                ],
+        };
+        _yahooClient.GetChart("GONE", floor, delistedOn).Returns(response);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo
+            .GetAllSeries()
+            .Where(price => price.CommonStockId == stock.Id)
+            .Select(price => price.Date)
+            .Should()
+            .Equal(retainedDate);
+        stock.PriceHistoryBackfilledTickers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Import_InactivePendingCorporateAction_FetchesOnlyThroughDelistingDate()
+    {
+        var floor = new DateOnly(2023, 1, 1);
+        var delistedOn = new DateOnly(2023, 1, 10);
+        var splitDate = new DateOnly(2023, 1, 6);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        var stock = CreateStock("GONE", "Formerly Listed");
+        stock.Active = false;
+        stock.DelistedOn = delistedOn;
+        stock.PriceHistoryBackfilledTickers = ["GONE"];
+        await SeedStocks(stock);
+        await SeedPrices(CreatePrice(stock, delistedOn.AddDays(3), 99m));
+        _splitRepo.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = stock.Ticker,
+                EffectiveDate = splitDate,
+                Numerator = 2m,
+                Denominator = 1m,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        var dividend = new CashDividend
+        {
+            CommonStockId = stock.Id,
+            ExDate = delistedOn,
+            AmountPerShare = 0.25m,
+            Source = CashDividendSource.Yahoo,
+        };
+        _dividendRepo.Add(dividend);
+        await _splitRepo.SaveChanges();
+        var chartData = CreateChartData(
+            (splitDate.AddDays(-1), 10m),
+            (splitDate.AddDays(1), 10m),
+            (delistedOn, 10m)
+        );
+        chartData.Dividends =
+        [
+            new CashDividendEvent
+            {
+                Date = delistedOn,
+                Amount = dividend.AmountPerShare,
+            },
+        ];
+        _yahooClient
+            .GetChart("GONE", floor, delistedOn)
+            .Returns(chartData);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        await _yahooClient.Received(1).GetChart("GONE", floor, delistedOn);
+        await _yahooClient
+            .DidNotReceive()
+            .GetChart(
+                "GONE",
+                Arg.Any<DateOnly>(),
+                Arg.Is<DateOnly>(endDate => endDate > delistedOn)
+            );
+        _priceRepo
+            .GetAllSeries()
+            .Where(price => price.CommonStockId == stock.Id)
+            .OrderBy(price => price.Date)
+            .Select(price => price.Date)
+            .Should()
+            .Equal(splitDate.AddDays(-1), splitDate.AddDays(1), delistedOn);
+        dividend.PriceAdjustmentAppliedAmountPerShare.Should().Be(dividend.AmountPerShare);
+        dividend.PriceAdjustmentAppliedTime.Should().NotBeNull();
     }
 
     [Fact]
@@ -216,6 +339,39 @@ public class YahooPriceImportServiceTests : IDisposable
             .DidNotReceive()
             .GetChart(Arg.Is<string>(ticker => ticker.StartsWith("OLD")), Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
         eligible.PriceHistoryBackfilledTickers.Should().Equal("GONE");
+    }
+
+    [Fact]
+    public async Task Import_PreHistoryDelisting_PurgesRecycledRowsWithoutCertifyingAction()
+    {
+        var floor = new DateOnly(2023, 1, 1);
+        var delistedOn = floor.AddDays(-10);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        var stock = CreateStock("OLD", "Former Listing");
+        stock.Active = false;
+        stock.DelistedOn = delistedOn;
+        await SeedStocks(stock);
+        await SeedPrices(CreatePrice(stock, floor, 99m));
+        var split = new StockSplit
+        {
+            CommonStockId = stock.Id,
+            PriceSeriesTicker = stock.Ticker,
+            EffectiveDate = delistedOn.AddDays(-1),
+            Numerator = 2m,
+            Denominator = 1m,
+            Source = StockSplitSource.Yahoo,
+        };
+        _splitRepo.Add(split);
+        await _splitRepo.SaveChanges();
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        await _yahooClient.DidNotReceive().GetChart("OLD", Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
+        _priceRepo
+            .GetAllSeries()
+            .Should()
+            .NotContain(price => price.CommonStockId == stock.Id);
+        split.PriceAdjustmentAppliedTime.Should().BeNull();
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
@@ -427,4 +427,62 @@ public class CorporateActionPriceReconciliationManagerStampingTests
             .Which.ListedTicker.Should()
             .Be("MSFT");
     }
+
+    [Fact]
+    public async Task StampApplied_ListingCutoffChangedDuringFetch_LeavesActionsPending()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var expectedDelistedOn = new DateOnly(2026, 7, 31);
+        var stock = Stock(stockId);
+        stock.Active = false;
+        stock.DelistedOn = expectedDelistedOn.AddDays(1);
+        var split = PendingSplit(stockId, new DateOnly(2026, 7, 15));
+        db.Add(stock);
+        db.Add(split);
+        await db.SaveChangesAsync();
+
+        var manager = NewManager(db);
+        var selected = (await manager.SelectPendingSeries(50, SettledBefore)).Series.Single();
+        var stamped = await manager.StampApplied(
+            selected,
+            [],
+            expectedDelistedOn.AddDays(1),
+            DateTime.UtcNow,
+            expectedActive: false,
+            expectedDelistedOn: expectedDelistedOn
+        );
+
+        stamped.Should().Be(0);
+        split.PriceAdjustmentAppliedTime.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StampApplied_ListingReactivatedDuringFetch_LeavesActionsPending()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var expectedDelistedOn = new DateOnly(2026, 7, 31);
+        var stock = Stock(stockId);
+        stock.Active = true;
+        stock.DelistedOn = expectedDelistedOn;
+        var split = PendingSplit(stockId, new DateOnly(2026, 7, 15));
+        db.Add(stock);
+        db.Add(split);
+        await db.SaveChangesAsync();
+
+        var manager = NewManager(db);
+        var selected = (await manager.SelectPendingSeries(50, SettledBefore)).Series.Single();
+        var stamped = await manager.StampApplied(
+            selected,
+            [],
+            expectedDelistedOn.AddDays(1),
+            DateTime.UtcNow,
+            expectedActive: false,
+            expectedDelistedOn: expectedDelistedOn
+        );
+
+        stamped.Should().Be(0);
+        split.PriceAdjustmentAppliedTime.Should().BeNull();
+    }
 }


### PR DESCRIPTION
## Summary
- cap inactive Yahoo replacement and corporate-action reconciliation at the authoritative delisting date
- purge recycled-ticker rows after that cutoff even when replacement history is unavailable
- revalidate listing state before corporate actions are marked reconciled
- update ticker-reuse integration expectations to retain inactive identities

## Verification
- dotnet build tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release --no-restore
- dotnet build tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj -c Release --no-restore
- 4,597 OSS unit tests passed
- 2,748 OSS integration tests passed
- independent review: clean