### PR TITLE
fix(holdings): rebuild inactive stock identities

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -68,6 +68,13 @@ public class CommonStockManager
             .Select(a => a.Cusip)
             .ToListAsync();
         var taken = new HashSet<string>(alreadyRecorded, StringComparer.OrdinalIgnoreCase);
+        taken.UnionWith(
+            await _commonStockRepository
+                .GetAllIncludingInactive()
+                .Where(stock => stock.Cusip != null && candidates.Contains(stock.Cusip.ToUpper()))
+                .Select(stock => stock.Cusip)
+                .ToListAsync()
+        );
         // A CUSIP recorded as a sibling LISTING is a different security's current identity —
         // aliasing it would outrank the listing at resolution time and merge the two classes'
         // positions into one row. One CUSIP identifies one security, in both directions.
@@ -191,7 +198,7 @@ public class CommonStockManager
         );
         taken.UnionWith(
             await _commonStockRepository
-                .GetAll()
+                .GetAllIncludingInactive()
                 .Where(cs => cs.Cusip != null && candidateCusips.Contains(cs.Cusip.ToUpper()))
                 .Select(cs => cs.Cusip)
                 .ToListAsync()

--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -35,6 +35,26 @@ public class CommonStock : IActivable
     /// </summary>
     public DateTime? HistoricalPriceBackfillAttemptedAt { get; set; }
 
+    /// <summary>
+    /// When an authoritative inactive-listing directory requested an SEC FTD archive scan to
+    /// recover this security's historical CUSIP. The sweep snapshots this timestamp so an
+    /// identity discovered during a running scan receives a complete pass on the next cycle.
+    /// </summary>
+    public DateTime? HistoricalCusipBackfillRequestedAt { get; set; }
+
+    /// <summary>
+    /// CUSIPs observed on the newest eligible FTD settlement date during the current historical
+    /// identity sweep. Claims remain staged until the entire archive has been read so a conflict
+    /// discovered in a later batch cannot be forgotten.
+    /// </summary>
+    public List<string> HistoricalCusipBackfillCandidates { get; set; } = [];
+
+    public DateOnly? HistoricalCusipBackfillCandidateOn { get; set; }
+
+    public bool HistoricalCusipBackfillAmbiguous { get; set; }
+
+    public DateTime? HistoricalCusipBackfillSweepStartedAt { get; set; }
+
     [MaxLength(256)]
     public string Name { get; set; }
 

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -453,10 +453,19 @@ public class HoldingsImportService
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var uniqueCusipsList = uniqueCusips.ToList();
 
-        var query =
-            _workerOptions.TickersToSync?.Count > 0
-                ? stockRepo.GetByTickers(_workerOptions.TickersToSync)
-                : stockRepo.GetAll();
+        // Historical filings must resolve identities that are no longer in the live directory.
+        // The default repository surface is active-only by design, so this importer opts into
+        // retained inactive rows explicitly.
+        var query = stockRepo.GetAllIncludingInactive();
+        if (_workerOptions.TickersToSync?.Count > 0)
+        {
+            query = query.Where(stock =>
+                _workerOptions.TickersToSync.Contains(stock.Ticker)
+                || stock.SecondaryTickers.Any(ticker =>
+                    _workerOptions.TickersToSync.Contains(ticker)
+                )
+            );
+        }
 
         var stocksWithCusip = await query
             .Where(cs => cs.Cusip != null && uniqueCusipsList.Contains(cs.Cusip))
@@ -557,7 +566,7 @@ public class HoldingsImportService
         var mappedStockIds = cusipMapping.Values.Select(t => t.CommonStockId).Distinct().ToList();
         context.IssuerSizes = await LoadIssuerSizes(stockRepo, mappedStockIds, cancellationToken);
         var tickerIdentities = await stockRepo
-            .GetByIds(mappedStockIds)
+            .GetByIdsIncludingInactive(mappedStockIds)
             .Select(cs => new
             {
                 cs.Id,
@@ -597,7 +606,7 @@ public class HoldingsImportService
     )
     {
         var sizes = await stockRepo
-            .GetAll()
+            .GetAllIncludingInactive()
             .Where(cs => stockIds.Contains(cs.Id))
             .Select(cs => new
             {

--- a/src/Equibles.Migrations/Migrations/20260824003016_RequestHistoricalCusipBackfills.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260824003016_RequestHistoricalCusipBackfills.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824003016_RequestHistoricalCusipBackfills")]
+    partial class RequestHistoricalCusipBackfills
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260824003016_RequestHistoricalCusipBackfills.cs
+++ b/src/Equibles.Migrations/Migrations/20260824003016_RequestHistoricalCusipBackfills.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class RequestHistoricalCusipBackfills : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "HistoricalCusipBackfillAmbiguous",
+                table: "CommonStock",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "HistoricalCusipBackfillCandidateOn",
+                table: "CommonStock",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<List<string>>(
+                name: "HistoricalCusipBackfillCandidates",
+                table: "CommonStock",
+                type: "text[]",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "HistoricalCusipBackfillRequestedAt",
+                table: "CommonStock",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "HistoricalCusipBackfillSweepStartedAt",
+                table: "CommonStock",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HistoricalCusipBackfillAmbiguous",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "HistoricalCusipBackfillCandidateOn",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "HistoricalCusipBackfillCandidates",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "HistoricalCusipBackfillRequestedAt",
+                table: "CommonStock");
+
+            migrationBuilder.DropColumn(
+                name: "HistoricalCusipBackfillSweepStartedAt",
+                table: "CommonStock");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
@@ -67,6 +67,10 @@ public class FtdScraperWorker : BaseScraperWorker
         // that happen while it is running.
         await ftdService.BackfillRetiredCusips(stoppingToken);
 
+        // Newly materialized inactive identities have no CUSIP yet. Resolve them from the
+        // authoritative SEC symbol+CUSIP archive before Holdings retries historical filings.
+        await ftdService.BackfillInactiveCusips(stoppingToken);
+
         // And the sibling-listing sweep: secondary tickers' CUSIPs (share classes, units)
         // recorded against the exact listed symbol so 13F lines filed under them resolve.
         await ftdService.BackfillListedTickerCusips(stoppingToken);

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -204,7 +204,7 @@ public class FtdImportService
                     cusips.Add(record.Cusip);
                 }
             }
-            catch (HttpRequestException ex)
+            catch (Exception ex) when (ex is HttpRequestException or InvalidDataException)
             {
                 // A missing archive file costs coverage for that fortnight only; the
                 // frontier still advances so the sweep cannot wedge on one bad file.
@@ -226,6 +226,104 @@ public class FtdImportService
                 recorded,
                 fileNames.Count
             );
+        }
+    }
+
+    /// <summary>
+    /// Recovers the primary CUSIP for retained inactive identities from the SEC CNS fails
+    /// archive. Files are scanned newest-first and a row is admitted only when its settlement
+    /// date is on or before that identity's inclusive delisting cutoff. For recycled symbols,
+    /// the earliest cutoff covering the row wins; equal cutoffs are ambiguous and refused.
+    /// </summary>
+    public async Task BackfillInactiveCusips(CancellationToken cancellationToken)
+    {
+        var sweep = await NextInactiveCusipSweepFiles(cancellationToken);
+        if (sweep.StartedAt == null)
+        {
+            return;
+        }
+        if (sweep.FileNames.Count == 0)
+        {
+            await FinalizeInactiveCusips(sweep.StartedAt.Value, cancellationToken);
+            return;
+        }
+
+        var tickerMap = await BuildInactiveTickerMap(sweep.StartedAt.Value, cancellationToken);
+        if (tickerMap.Count == 0)
+        {
+            await AdvanceSweepFrontier(InactiveCusipSweepCursorName, sweep.FileNames[^1]);
+            return;
+        }
+
+        var strippedAliases = BuildStrippedTickerAliases(tickerMap.Keys);
+        var candidates = new List<HistoricalCusipCandidate>();
+        string lastCompletedFile = null;
+
+        foreach (var fileName in sweep.FileNames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var records = await DownloadAndParse(fileName, cancellationToken);
+                foreach (var record in records)
+                {
+                    if (
+                        string.IsNullOrEmpty(record.Cusip)
+                        || string.IsNullOrEmpty(record.Symbol)
+                        || !TryResolveHistoricalIdentity(
+                            record.Symbol,
+                            record.SettlementDate,
+                            tickerMap,
+                            strippedAliases,
+                            out var stockId
+                        )
+                    )
+                    {
+                        continue;
+                    }
+
+                    candidates.Add(
+                        new HistoricalCusipCandidate(stockId, record.Cusip, record.SettlementDate)
+                    );
+                }
+                lastCompletedFile = fileName;
+            }
+            catch (HttpRequestException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.NotFound
+                    && !IsRecentFtdFile(fileName)
+                )
+            {
+                // SEC permanently omits a few old fortnight files. A confirmed old 404 has no
+                // rows to recover, so it is a completed gap rather than a transient response.
+                _logger.LogWarning(
+                    "Inactive-CUSIP sweep: archive file {File} is unavailable (404), advancing",
+                    fileName
+                );
+                lastCompletedFile = fileName;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or InvalidDataException)
+            {
+                // Stop at the gap and retry it next cycle. Evidence from completed newer files
+                // stays staged, but nothing is seeded until the full archive pass completes.
+                _logger.LogWarning(
+                    ex,
+                    "Inactive-CUSIP sweep: failed to read {File}; leaving it retryable",
+                    fileName
+                );
+                break;
+            }
+        }
+
+        await StageInactiveCusipEvidence(candidates, sweep.StartedAt.Value, cancellationToken);
+        if (lastCompletedFile != null)
+        {
+            await AdvanceSweepFrontier(InactiveCusipSweepCursorName, lastCompletedFile);
+        }
+
+        if (IsOldestArchiveFile(lastCompletedFile))
+        {
+            await FinalizeInactiveCusips(sweep.StartedAt.Value, cancellationToken);
         }
     }
 
@@ -314,7 +412,7 @@ public class FtdImportService
                     cusips.Add(record.Cusip);
                 }
             }
-            catch (HttpRequestException ex)
+            catch (Exception ex) when (ex is HttpRequestException or InvalidDataException)
             {
                 // A missing archive file costs coverage for that fortnight only; the
                 // frontier still advances so the sweep cannot wedge on one bad file.
@@ -491,6 +589,405 @@ public class FtdImportService
         return recorded;
     }
 
+    private async Task<Dictionary<string, List<HistoricalTickerIdentity>>> BuildInactiveTickerMap(
+        DateTime sweepStartedAt,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var query = stockRepo
+            .GetAllIncludingInactive()
+            .Where(stock =>
+                !stock.Active
+                && stock.Cusip == null
+                && stock.DelistedOn != null
+                && (
+                    stock.HistoricalCusipBackfillRequestedAt == null
+                    || stock.HistoricalCusipBackfillRequestedAt <= sweepStartedAt
+                )
+            );
+        if (_workerOptions.TickersToSync?.Count > 0)
+        {
+            query = query.Where(stock => _workerOptions.TickersToSync.Contains(stock.Ticker));
+        }
+
+        var stocks = await query.ToListAsync(cancellationToken);
+        foreach (
+            var stock in stocks.Where(stock =>
+                stock.HistoricalCusipBackfillSweepStartedAt != sweepStartedAt
+            )
+        )
+        {
+            stock.HistoricalCusipBackfillCandidates = [];
+            stock.HistoricalCusipBackfillCandidateOn = null;
+            stock.HistoricalCusipBackfillAmbiguous = false;
+            stock.HistoricalCusipBackfillSweepStartedAt = sweepStartedAt;
+        }
+        await stockRepo.SaveChanges();
+
+        var identities = stocks.Select(stock => new HistoricalTickerIdentity(
+            stock.Id,
+            stock.Ticker,
+            stock.DelistedOn!.Value
+        ));
+
+        return identities
+            .Where(identity => !string.IsNullOrWhiteSpace(identity.Ticker))
+            .GroupBy(identity => identity.Ticker, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderBy(identity => identity.DelistedOn).ToList(),
+                StringComparer.OrdinalIgnoreCase
+            );
+    }
+
+    internal static bool TryResolveHistoricalIdentity(
+        string symbol,
+        DateOnly settlementDate,
+        Dictionary<string, List<HistoricalTickerIdentity>> tickerMap,
+        Dictionary<string, string> strippedAliases,
+        out Guid stockId
+    )
+    {
+        stockId = default;
+        var ticker = tickerMap.ContainsKey(symbol)
+            ? symbol
+            : strippedAliases.GetValueOrDefault(symbol);
+        if (ticker == null || !tickerMap.TryGetValue(ticker, out var identities))
+        {
+            return false;
+        }
+
+        var eligible = identities
+            .Where(identity => settlementDate <= identity.DelistedOn)
+            .OrderBy(identity => identity.DelistedOn)
+            .Take(2)
+            .ToList();
+        if (
+            eligible.Count == 0
+            || (eligible.Count > 1 && eligible[0].DelistedOn == eligible[1].DelistedOn)
+        )
+        {
+            return false;
+        }
+
+        stockId = eligible[0].StockId;
+        return true;
+    }
+
+    private async Task<int> SeedInactiveCusips(
+        Dictionary<Guid, (string Cusip, DateOnly SettlementDate)> latestByStock,
+        DateTime sweepStartedAt,
+        CancellationToken cancellationToken
+    )
+    {
+        if (latestByStock.Count == 0)
+        {
+            return 0;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var stockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
+        var stocks = await stockRepo
+            .GetByIdsIncludingInactive(latestByStock.Keys)
+            .Where(stock =>
+                !stock.Active
+                && stock.Cusip == null
+                && (
+                    stock.HistoricalCusipBackfillRequestedAt == null
+                    || stock.HistoricalCusipBackfillRequestedAt <= sweepStartedAt
+                )
+            )
+            .ToListAsync(cancellationToken);
+
+        var candidates = latestByStock
+            .Values.Select(value => value.Cusip)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var claims = new Dictionary<string, HashSet<Guid>>(StringComparer.OrdinalIgnoreCase);
+        void AddClaim(string cusip, Guid ownerId)
+        {
+            if (!claims.TryGetValue(cusip, out var owners))
+            {
+                owners = [];
+                claims[cusip] = owners;
+            }
+            owners.Add(ownerId);
+        }
+
+        var primaryClaims = await stockRepo
+            .GetAllIncludingInactive()
+            .Where(stock => stock.Cusip != null && candidates.Contains(stock.Cusip))
+            .Select(stock => new { stock.Id, stock.Cusip })
+            .ToListAsync(cancellationToken);
+        foreach (var claim in primaryClaims)
+        {
+            AddClaim(claim.Cusip, claim.Id);
+        }
+
+        var aliasClaims = await stockRepo
+            .GetCusipAliases()
+            .Where(alias => candidates.Contains(alias.Cusip))
+            .Select(alias => new { alias.CommonStockId, alias.Cusip })
+            .ToListAsync(cancellationToken);
+        foreach (var claim in aliasClaims)
+        {
+            AddClaim(claim.Cusip, claim.CommonStockId);
+        }
+
+        var listedClaimValues = await stockRepo
+            .GetListedCusips()
+            .Where(listing => candidates.Contains(listing.Cusip))
+            .Select(listing => listing.Cusip)
+            .ToListAsync(cancellationToken);
+        var listedClaims = new HashSet<string>(listedClaimValues, StringComparer.OrdinalIgnoreCase);
+
+        var seeded = 0;
+        foreach (var stock in stocks)
+        {
+            var resolved = latestByStock[stock.Id];
+            if (
+                listedClaims.Contains(resolved.Cusip)
+                || (
+                    claims.TryGetValue(resolved.Cusip, out var owners)
+                    && owners.Any(ownerId => ownerId != stock.Id)
+                )
+            )
+            {
+                _logger.LogWarning(
+                    "Inactive FTD identity {Ticker} resolved to CUSIP {Cusip}, but that CUSIP is already claimed by another stock — skipping",
+                    stock.Ticker,
+                    resolved.Cusip
+                );
+                continue;
+            }
+
+            await stockManager.SetCusip(stock, resolved.Cusip);
+            AddClaim(resolved.Cusip, stock.Id);
+            seeded++;
+        }
+
+        return seeded;
+    }
+
+    private async Task StageInactiveCusipEvidence(
+        IEnumerable<HistoricalCusipCandidate> candidates,
+        DateTime sweepStartedAt,
+        CancellationToken cancellationToken
+    )
+    {
+        var batch = candidates.ToList();
+        if (batch.Count == 0)
+        {
+            return;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var stocks = await stockRepo
+            .GetByIdsIncludingInactive(batch.Select(candidate => candidate.StockId).Distinct())
+            .Where(stock =>
+                !stock.Active
+                && stock.Cusip == null
+                && stock.HistoricalCusipBackfillSweepStartedAt == sweepStartedAt
+            )
+            .ToListAsync(cancellationToken);
+        foreach (var stock in stocks)
+        {
+            ApplyHistoricalCusipEvidence(
+                stock,
+                batch.Where(candidate => candidate.StockId == stock.Id)
+            );
+        }
+        await stockRepo.SaveChanges();
+
+        var staged = await stockRepo
+            .GetAllIncludingInactive()
+            .Where(stock =>
+                !stock.Active
+                && stock.Cusip == null
+                && stock.HistoricalCusipBackfillSweepStartedAt == sweepStartedAt
+            )
+            .ToListAsync(cancellationToken);
+        RejectContestedHistoricalCusips(staged);
+        await stockRepo.SaveChanges();
+    }
+
+    internal static void RejectContestedHistoricalCusips(IEnumerable<CommonStock> stocks)
+    {
+        var contestedStockIds = stocks
+            .SelectMany(stock =>
+                stock
+                    .HistoricalCusipBackfillCandidates.Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Select(cusip => new { stock.Id, Cusip = cusip })
+            )
+            .GroupBy(claim => claim.Cusip, StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Select(claim => claim.Id).Distinct().Count() > 1)
+            .SelectMany(group => group.Select(claim => claim.Id))
+            .ToHashSet();
+        foreach (var contested in stocks.Where(stock => contestedStockIds.Contains(stock.Id)))
+        {
+            contested.HistoricalCusipBackfillAmbiguous = true;
+        }
+    }
+
+    internal static void ApplyHistoricalCusipEvidence(
+        CommonStock stock,
+        IEnumerable<HistoricalCusipCandidate> candidates
+    )
+    {
+        foreach (var candidate in candidates)
+        {
+            if (
+                stock.HistoricalCusipBackfillCandidateOn == null
+                || candidate.SettlementDate > stock.HistoricalCusipBackfillCandidateOn
+            )
+            {
+                stock.HistoricalCusipBackfillCandidates = [candidate.Cusip];
+                stock.HistoricalCusipBackfillCandidateOn = candidate.SettlementDate;
+                stock.HistoricalCusipBackfillAmbiguous = false;
+                continue;
+            }
+            if (
+                candidate.SettlementDate == stock.HistoricalCusipBackfillCandidateOn
+                && !stock.HistoricalCusipBackfillCandidates.Contains(
+                    candidate.Cusip,
+                    StringComparer.OrdinalIgnoreCase
+                )
+            )
+            {
+                stock.HistoricalCusipBackfillCandidates.Add(candidate.Cusip);
+                stock.HistoricalCusipBackfillAmbiguous = true;
+            }
+        }
+    }
+
+    private async Task FinalizeInactiveCusips(
+        DateTime sweepStartedAt,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var staged = await stockRepo
+            .GetAllIncludingInactive()
+            .Where(stock =>
+                !stock.Active
+                && stock.Cusip == null
+                && stock.HistoricalCusipBackfillSweepStartedAt == sweepStartedAt
+                && stock.HistoricalCusipBackfillCandidateOn != null
+            )
+            .ToListAsync(cancellationToken);
+        var candidates = staged
+            .Where(stock =>
+                !stock.HistoricalCusipBackfillAmbiguous
+                && stock.HistoricalCusipBackfillCandidates.Count == 1
+            )
+            .ToDictionary(
+                stock => stock.Id,
+                stock =>
+                    (
+                        stock.HistoricalCusipBackfillCandidates[0],
+                        stock.HistoricalCusipBackfillCandidateOn!.Value
+                    )
+            );
+
+        var seeded = await SeedInactiveCusips(candidates, sweepStartedAt, cancellationToken);
+        if (seeded > 0)
+        {
+            _logger.LogInformation(
+                "Inactive-CUSIP sweep: seeded {Count} identity CUSIP(s) after the complete archive pass",
+                seeded
+            );
+        }
+    }
+
+    private static bool IsOldestArchiveFile(string fileName) =>
+        fileName != null
+        && string.Equals(fileName, GetFileNames(OldestAvailableDate)[0], StringComparison.Ordinal);
+
+    private async Task<(List<string> FileNames, DateTime? StartedAt)> NextInactiveCusipSweepFiles(
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stateRepo = scope.ServiceProvider.GetRequiredService<BackfillStateRepository>();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var state = await stateRepo.GetByName(InactiveCusipSweepCursorName);
+
+        var pending = stockRepo
+            .GetAllIncludingInactive()
+            .Where(stock => !stock.Active && stock.Cusip == null && stock.DelistedOn != null);
+        if (_workerOptions.TickersToSync?.Count > 0)
+        {
+            pending = pending.Where(stock => _workerOptions.TickersToSync.Contains(stock.Ticker));
+        }
+
+        if (state == null)
+        {
+            if (!await pending.AnyAsync(cancellationToken))
+            {
+                return ([], null);
+            }
+
+            state = new BackfillState
+            {
+                Name = InactiveCusipSweepCursorName,
+                LastFullRescanAt = DateTime.UtcNow,
+            };
+            stateRepo.Add(state);
+            await stateRepo.SaveChanges();
+        }
+
+        var all = GetStableHistoricalFileNames(
+            OldestAvailableDate,
+            DateOnly.FromDateTime(state.LastFullRescanAt ?? DateTime.UtcNow)
+        );
+        all.Reverse();
+        var startIndex = 0;
+        if (state.Floor != null)
+        {
+            var index = all.IndexOf(FileNameOf(state.Floor.Value));
+            if (index < 0)
+            {
+                return ([], state.LastFullRescanAt);
+            }
+            startIndex = index + 1;
+        }
+
+        if (startIndex >= all.Count)
+        {
+            var startedAt = state.LastFullRescanAt ?? DateTime.MinValue;
+            var requestedAfterStart = await pending.AnyAsync(
+                stock =>
+                    stock.HistoricalCusipBackfillRequestedAt != null
+                    && stock.HistoricalCusipBackfillRequestedAt > startedAt,
+                cancellationToken
+            );
+            if (!requestedAfterStart)
+            {
+                return ([], state.LastFullRescanAt);
+            }
+
+            state.Floor = null;
+            state.LastFullRescanAt = DateTime.UtcNow;
+            await stateRepo.SaveChanges();
+            all = GetStableHistoricalFileNames(
+                OldestAvailableDate,
+                DateOnly.FromDateTime(state.LastFullRescanAt.Value)
+            );
+            all.Reverse();
+            startIndex = 0;
+        }
+
+        return (
+            all.Skip(startIndex).Take(AliasSweepFilesPerCycle).ToList(),
+            state.LastFullRescanAt
+        );
+    }
+
     // The sweeps run oldest-first from the start of the archive and stop once their
     // frontier passes the newest file — the live import owns everything from there.
     private async Task<List<string>> NextSweepFiles(string cursorName)
@@ -553,6 +1050,8 @@ public class FtdImportService
     }
 
     private const string AliasSweepCursorName = "Ftd.RetiredCusipSweep";
+
+    private const string InactiveCusipSweepCursorName = "Ftd.InactiveCusipSweep";
 
     // Separate cursor: the alias sweep's frontier has already consumed the archive on
     // long-running deployments, and listed-CUSIP rows were never collected on that pass.
@@ -618,16 +1117,41 @@ public class FtdImportService
         // Cusip index is non-unique) and misroute that CUSIP's 13F lines, so
         // such rows are skipped — CompanySync owns ticker reassignment.
         var resolvedCusips = tickerToCusip.Values.Select(v => v.Cusip).Distinct().ToList();
-        var cusipOwners = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
+        var cusipOwners = new Dictionary<string, HashSet<Guid>>(StringComparer.OrdinalIgnoreCase);
+        void AddOwner(string cusip, Guid ownerId)
+        {
+            if (!cusipOwners.TryGetValue(cusip, out var ownerIds))
+            {
+                ownerIds = [];
+                cusipOwners[cusip] = ownerIds;
+            }
+            ownerIds.Add(ownerId);
+        }
+
         var owners = await stockRepo
-            .GetAll()
+            .GetAllIncludingInactive()
             .Where(s => s.Cusip != null && resolvedCusips.Contains(s.Cusip))
             .Select(s => new { s.Id, s.Cusip })
             .ToListAsync(cancellationToken);
         foreach (var owner in owners)
         {
-            cusipOwners[owner.Cusip] = owner.Id;
+            AddOwner(owner.Cusip, owner.Id);
         }
+        var aliasOwners = await stockRepo
+            .GetCusipAliases()
+            .Where(alias => resolvedCusips.Contains(alias.Cusip))
+            .Select(alias => new { alias.CommonStockId, alias.Cusip })
+            .ToListAsync(cancellationToken);
+        foreach (var owner in aliasOwners)
+        {
+            AddOwner(owner.Cusip, owner.CommonStockId);
+        }
+        var listedClaimValues = await stockRepo
+            .GetListedCusips()
+            .Where(listing => resolvedCusips.Contains(listing.Cusip))
+            .Select(listing => listing.Cusip)
+            .ToListAsync(cancellationToken);
+        var listedClaims = new HashSet<string>(listedClaimValues, StringComparer.OrdinalIgnoreCase);
 
         var seeded = 0;
         foreach (var stock in stocks)
@@ -636,7 +1160,13 @@ public class FtdImportService
                 continue;
             if (string.Equals(stock.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase))
                 continue;
-            if (cusipOwners.TryGetValue(resolved.Cusip, out var ownerId) && ownerId != stock.Id)
+            if (
+                listedClaims.Contains(resolved.Cusip)
+                || (
+                    cusipOwners.TryGetValue(resolved.Cusip, out var ownerIds)
+                    && ownerIds.Any(ownerId => ownerId != stock.Id)
+                )
+            )
             {
                 _logger.LogWarning(
                     "FTD maps {Ticker} to CUSIP {Cusip}, but that CUSIP already identifies another tracked stock — skipping (possible ticker reuse)",
@@ -651,6 +1181,7 @@ public class FtdImportService
             // sets processed before this stock had a CUSIP (or while it
             // still carried the retired one, kept as an alias).
             await stockManager.SetCusip(stock, resolved.Cusip);
+            AddOwner(resolved.Cusip, stock.Id);
             seeded++;
         }
 
@@ -666,12 +1197,17 @@ public class FtdImportService
     /// </summary>
     private static Dictionary<string, string> BuildStrippedTickerAliases(
         Dictionary<string, Guid> tickerMap
+    ) => BuildStrippedTickerAliases(tickerMap.Keys);
+
+    private static Dictionary<string, string> BuildStrippedTickerAliases(
+        IEnumerable<string> tickers
     )
     {
         var aliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var ambiguous = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var tickerSet = new HashSet<string>(tickers, StringComparer.OrdinalIgnoreCase);
 
-        foreach (var ticker in tickerMap.Keys)
+        foreach (var ticker in tickerSet)
         {
             var stripped = string.Concat(ticker.Where(char.IsLetterOrDigit));
             if (
@@ -679,7 +1215,7 @@ public class FtdImportService
                 || string.Equals(stripped, ticker, StringComparison.OrdinalIgnoreCase)
             )
                 continue;
-            if (tickerMap.ContainsKey(stripped))
+            if (tickerSet.Contains(stripped))
                 continue;
             if (!aliases.TryAdd(stripped, ticker))
                 ambiguous.Add(stripped);
@@ -690,6 +1226,18 @@ public class FtdImportService
 
         return aliases;
     }
+
+    internal sealed record HistoricalTickerIdentity(
+        Guid StockId,
+        string Ticker,
+        DateOnly DelistedOn
+    );
+
+    internal sealed record HistoricalCusipCandidate(
+        Guid StockId,
+        string Cusip,
+        DateOnly SettlementDate
+    );
 
     private static bool TryResolveSymbol(
         string symbol,
@@ -806,7 +1354,7 @@ public class FtdImportService
                 null,
                 $"file: {fileName}"
             );
-            return [];
+            throw new InvalidDataException($"FTD archive {fileName} contains no entries.");
         }
 
         await using var entryStream = entry.Open();
@@ -822,6 +1370,11 @@ public class FtdImportService
             var record = ParseLine(line);
             if (record != null)
                 records.Add(record);
+        }
+
+        if (records.Count == 0)
+        {
+            throw new InvalidDataException($"FTD archive {fileName} contains no valid rows.");
         }
 
         return records;
@@ -898,6 +1451,24 @@ public class FtdImportService
         }
 
         return fileNames;
+    }
+
+    /// <summary>
+    /// Returns only archive months that were already outside the SEC's 45-day publication
+    /// window when a historical sweep started. Freezing this ceiling prevents a moving,
+    /// unpublished current-month file from pinning a newest-first sweep forever.
+    /// </summary>
+    internal static List<string> GetStableHistoricalFileNames(DateOnly startDate, DateOnly asOf)
+    {
+        var firstUnstableMonth = new DateOnly(asOf.Year, asOf.Month, 1).AddMonths(-2);
+        var lastStableMonth = firstUnstableMonth.AddMonths(-1);
+        return GetFileNames(startDate)
+            .Where(fileName =>
+            {
+                var frontier = FrontierOf(fileName);
+                return new DateOnly(frontier.Year, frontier.Month, 1) <= lastStableMonth;
+            })
+            .ToList();
     }
 
     /// <summary>

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerRecordListedTickerCusipsTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerRecordListedTickerCusipsTests.cs
@@ -37,7 +37,8 @@ public class CommonStockManagerRecordListedTickerCusipsTests
         string ticker,
         string cik,
         string cusip = null,
-        List<string> secondaryTickers = null
+        List<string> secondaryTickers = null,
+        bool active = true
     )
     {
         var stock = new CommonStock
@@ -47,6 +48,7 @@ public class CommonStockManagerRecordListedTickerCusipsTests
             Cik = cik,
             Cusip = cusip,
             SecondaryTickers = secondaryTickers ?? [],
+            Active = active,
         };
         _repository.Add(stock);
         await _repository.SaveChanges();
@@ -121,11 +123,11 @@ public class CommonStockManagerRecordListedTickerCusipsTests
     }
 
     [Fact]
-    public async Task RecordListedTickerCusips_CusipAlreadyOwned_FirstOwnerKeepsIt()
+    public async Task RecordListedTickerCusips_CusipOwnedByInactivePrimary_FirstOwnerKeepsIt()
     {
         // One CUSIP identifies one security, ever. Whether the prior owner holds it as a
         // primary, an alias, or another listing, a later claim is dropped silently.
-        var owner = await SeedStock("AAA", "0000000001", cusip: "111111111");
+        var owner = await SeedStock("AAA", "0000000001", cusip: "111111111", active: false);
         var claimant = await SeedStock(
             "BBB",
             "0000000002",
@@ -137,6 +139,20 @@ public class CommonStockManagerRecordListedTickerCusipsTests
 
         recorded.Should().Be(0);
         (await _repository.GetListedCusips().AnyAsync()).Should().BeFalse();
+        await _bus.DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordRetiredCusipAliases_CusipOwnedByInactivePrimary_RecordsNothing()
+    {
+        await SeedStock("OLD", "0000000001", cusip: "111111111", active: false);
+        var claimant = await SeedStock("LIVE", "0000000002", cusip: "222222222");
+
+        var recorded = await _sut.RecordRetiredCusipAliases(claimant, ["111111111"]);
+
+        recorded.Should().Be(0);
+        (await _repository.GetCusipAliases().AnyAsync()).Should().BeFalse();
         await _bus.DidNotReceive()
             .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
@@ -28,6 +28,7 @@ public class SecTestModuleConfiguration : Equibles.Data.IModuleConfiguration
         });
 
         builder.Entity<FailToDeliver>();
+        builder.Entity<BackfillState>();
         builder.Entity<FundSeries>();
         builder.Entity<FormDFiling>();
         builder.Entity<FormDRelatedPerson>();

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCusipAliasTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCusipAliasTests.cs
@@ -190,6 +190,56 @@ public class HoldingsImportServiceCusipAliasTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ImportDataSet_FilingReferencesInactiveStock_ResolvesRetainedIdentity()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "GONE",
+            Name = "Formerly Listed Corp",
+            Cik = "0000000042",
+            Cusip = "123456789",
+            Active = false,
+            DelistedOn = new DateOnly(2021, 6, 30),
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2020, 12, 31);
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-INACTIVE\t2021-02-12\t2020-12-31\t0001142031\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-INACTIVE\tN\tHistorical Manager\tBoston\tMA\t028-04556\t105909\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+            + "ACC-INACTIVE\t123456789\t2500\tSH\t\tSOLE\t2500\t0\t0\tCOM\t\n";
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+        var prices = new Dictionary<(Guid, string, DateOnly), decimal>
+        {
+            [(stock.Id, null, reportDate)] = 20m,
+        };
+
+        var result = await CreateImporter(PriceProviderReturning(prices))
+            .ImportDataSet(archive, new DateOnly(2020, 10, 1), CancellationToken.None);
+
+        result.IsComplete.Should().BeTrue();
+        using var verify = FreshContext();
+        var holding = await verify.Set<InstitutionalHolding>().SingleAsync();
+        holding.CommonStockId.Should().Be(stock.Id);
+        holding.Shares.Should().Be(2500);
+    }
+
+    [Fact]
     public async Task ImportDataSet_AliasCollidesWithAnotherStocksCurrentCusip_CurrentCusipWins()
     {
         // Precedence pin: if a CUSIP is simultaneously stock A's CURRENT value

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceInactiveSweepRetryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceInactiveSweepRetryTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging.Contracts.CommonStocks;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class FtdImportServiceInactiveSweepRetryTests
+{
+    [Fact]
+    public async Task BackfillInactiveCusips_TransientFirstFileFailure_DoesNotAdvanceFrontier()
+    {
+        await using var db = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        db.Set<CommonStock>()
+            .Add(
+                new CommonStock
+                {
+                    Ticker = "GONE",
+                    Name = "Formerly Listed Corp",
+                    Cik = "42",
+                    Active = false,
+                    DelistedOn = new DateOnly(2020, 6, 30),
+                    HistoricalCusipBackfillRequestedAt = DateTime.UtcNow.AddMinutes(-1),
+                }
+            );
+        await db.SaveChangesAsync();
+
+        var bus = Substitute.For<IBus>();
+        var stockRepo = new CommonStockRepository(db);
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(CommonStockRepository), stockRepo),
+            (typeof(CommonStockManager), new CommonStockManager(stockRepo, bus)),
+            (typeof(BackfillStateRepository), new BackfillStateRepository(db))
+        );
+        var secClient = Substitute.For<ISecEdgarClient>();
+        secClient
+            .DownloadStream(Arg.Any<string>())
+            .Returns<Task<Stream>>(_ =>
+                throw new HttpRequestException(
+                    "temporary outage",
+                    null,
+                    HttpStatusCode.ServiceUnavailable
+                )
+            );
+        var sut = new FtdImportService(
+            scopeFactory,
+            secClient,
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions())
+        );
+
+        await sut.BackfillInactiveCusips(CancellationToken.None);
+
+        var state = await db.Set<BackfillState>()
+            .SingleAsync(row => row.Name == "Ftd.InactiveCusipSweep");
+        state.Floor.Should().BeNull();
+        await secClient.Received(1).DownloadStream(Arg.Any<string>());
+        await bus.DidNotReceiveWithAnyArgs()
+            .Publish(default(StockCusipChanged), default(CancellationToken));
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
@@ -161,6 +161,125 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SeedInactiveCusips_AuthoritativeHistoricalMatch_SeedsRetainedIdentity()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "GONE",
+            Name = "Formerly Listed Corp",
+            Cik = "0000000042",
+            Active = false,
+            DelistedOn = new DateOnly(2020, 6, 30),
+            HistoricalCusipBackfillRequestedAt = DateTime.UtcNow,
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var bus = Substitute.For<IBus>();
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(CommonStockManager))
+                    .Returns(new CommonStockManager(new CommonStockRepository(ctx), bus));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        var sut = new FtdImportService(
+            scopeFactory,
+            Substitute.For<ISecEdgarClient>(),
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions())
+        );
+        var matches = new Dictionary<Guid, (string Cusip, DateOnly SettlementDate)>
+        {
+            [stock.Id] = ("123456789", new DateOnly(2020, 6, 30)),
+        };
+
+        var seedInactive = typeof(FtdImportService).GetMethod(
+            "SeedInactiveCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var seeded = await (Task<int>)
+            seedInactive.Invoke(
+                sut,
+                [
+                    matches,
+                    stock.HistoricalCusipBackfillRequestedAt!.Value.AddMinutes(1),
+                    CancellationToken.None,
+                ]
+            )!;
+
+        seeded.Should().Be(1);
+        using var verify = FreshContext();
+        var persisted = await verify.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id);
+        persisted.Cusip.Should().Be("123456789");
+        await bus.Received(1)
+            .Publish(
+                Arg.Is<StockCusipChanged>(change =>
+                    change.CommonStockId == stock.Id && change.Cusip == "123456789"
+                ),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task SeedInactiveCusips_RequestChangedAfterSweepStarted_LeavesIdentityForNextPass()
+    {
+        var requestedAt = DateTime.UtcNow;
+        var stock = new CommonStock
+        {
+            Ticker = "GONE",
+            Name = "Formerly Listed Corp",
+            Cik = "0000000042",
+            Active = false,
+            DelistedOn = new DateOnly(2020, 6, 30),
+            HistoricalCusipBackfillRequestedAt = requestedAt,
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var bus = Substitute.For<IBus>();
+        var sut = CreateSut(bus);
+        var matches = new Dictionary<Guid, (string Cusip, DateOnly SettlementDate)>
+        {
+            [stock.Id] = ("123456789", new DateOnly(2020, 6, 30)),
+        };
+        var method = typeof(FtdImportService).GetMethod(
+            "SeedInactiveCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+
+        var seeded = await (Task<int>)
+            method.Invoke(sut, [matches, requestedAt.AddMinutes(-1), CancellationToken.None])!;
+
+        seeded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id))
+            .Cusip.Should()
+            .BeNull();
+        await bus.DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task SeedCusips_ResolvedCusipBelongsToAnotherStock_SkipsWithoutUpdating()
     {
         // Ticker-recycling shape: a delisted issuer's stale stock still holds
@@ -182,6 +301,7 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             Name = "New Owner Corp",
             Cik = "0000000002",
             Cusip = "222222222",
+            Active = false,
         };
         await using (var seed = _fixture.CreateDbContext())
         {
@@ -250,6 +370,87 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
         using var verify = FreshContext();
         var persistedStale = await verify.Set<CommonStock>().FirstAsync(s => s.Id == staleStock.Id);
         persistedStale.Cusip.Should().Be("111111111");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SeedCusips_ResolvedCusipIsHistoricalOrListingClaim_SkipsWithoutUpdating(
+        bool listingClaim
+    )
+    {
+        var target = new CommonStock
+        {
+            Ticker = "TICK",
+            Name = "Target Corp",
+            Cik = "0000000001",
+            Cusip = "111111111",
+        };
+        var owner = new CommonStock
+        {
+            Ticker = "OWNER",
+            Name = "Identity Owner Corp",
+            Cik = "0000000002",
+            Cusip = "333333333",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().AddRange(target, owner);
+            if (listingClaim)
+            {
+                seed.Set<CommonStockListedCusip>()
+                    .Add(
+                        new CommonStockListedCusip
+                        {
+                            CommonStockId = owner.Id,
+                            ListedTicker = "OWNER-A",
+                            Cusip = "222222222",
+                        }
+                    );
+            }
+            else
+            {
+                seed.Set<CommonStockCusipAlias>()
+                    .Add(
+                        new CommonStockCusipAlias { CommonStockId = owner.Id, Cusip = "222222222" }
+                    );
+            }
+            await seed.SaveChangesAsync();
+        }
+
+        var bus = Substitute.For<IBus>();
+        var sut = CreateSut(bus);
+        var recordType = typeof(FtdImportService).Assembly.GetType(
+            "Equibles.Sec.HostedService.Models.FtdRecord"
+        )!;
+        var record = Activator.CreateInstance(recordType)!;
+        recordType.GetProperty("Cusip")!.SetValue(record, "222222222");
+        recordType.GetProperty("Symbol")!.SetValue(record, "TICK");
+        recordType.GetProperty("SettlementDate")!.SetValue(record, new DateOnly(2026, 6, 12));
+        var records = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(recordType))!;
+        records.Add(record);
+        var method = typeof(FtdImportService).GetMethod(
+            "SeedCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+
+        var seeded = await (Task<int>)
+            method.Invoke(
+                sut,
+                [
+                    records,
+                    new Dictionary<string, Guid> { ["TICK"] = target.Id },
+                    CancellationToken.None,
+                ]
+            )!;
+
+        seeded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync(stock => stock.Id == target.Id))
+            .Cusip.Should()
+            .Be("111111111");
+        await bus.DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -325,5 +526,34 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
 
         using var verify = FreshContext();
         (await verify.Set<CommonStockCusipAlias>().AnyAsync()).Should().BeFalse();
+    }
+
+    private FtdImportService CreateSut(IBus bus)
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var repository = new CommonStockRepository(ctx);
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(CommonStockRepository)).Returns(repository);
+                sp.GetService(typeof(CommonStockManager))
+                    .Returns(new CommonStockManager(repository, bus));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return new FtdImportService(
+            scopeFactory,
+            Substitute.For<ISecEdgarClient>(),
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions())
+        );
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceHistoricalIdentityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceHistoricalIdentityTests.cs
@@ -1,0 +1,151 @@
+using Equibles.Sec.HostedService.Services;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FtdImportServiceHistoricalIdentityTests
+{
+    [Fact]
+    public void Resolve_RecycledTicker_UsesEarliestCutoffCoveringSettlementDate()
+    {
+        var oldId = Guid.NewGuid();
+        var laterId = Guid.NewGuid();
+        var map = new Dictionary<string, List<FtdImportService.HistoricalTickerIdentity>>(
+            StringComparer.OrdinalIgnoreCase
+        )
+        {
+            ["USED"] =
+            [
+                new(oldId, "USED", new DateOnly(2020, 6, 30)),
+                new(laterId, "USED", new DateOnly(2024, 6, 30)),
+            ],
+        };
+
+        var resolved = FtdImportService.TryResolveHistoricalIdentity(
+            "USED",
+            new DateOnly(2020, 6, 30),
+            map,
+            [],
+            out var stockId
+        );
+
+        resolved.Should().BeTrue();
+        stockId.Should().Be(oldId);
+    }
+
+    [Fact]
+    public void Resolve_EqualCoveringCutoffs_RefusesAmbiguousIdentity()
+    {
+        var cutoff = new DateOnly(2020, 6, 30);
+        var map = new Dictionary<string, List<FtdImportService.HistoricalTickerIdentity>>(
+            StringComparer.OrdinalIgnoreCase
+        )
+        {
+            ["USED"] = [new(Guid.NewGuid(), "USED", cutoff), new(Guid.NewGuid(), "USED", cutoff)],
+        };
+
+        var resolved = FtdImportService.TryResolveHistoricalIdentity(
+            "USED",
+            cutoff,
+            map,
+            [],
+            out _
+        );
+
+        resolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resolve_AfterInclusiveCutoff_RefusesIdentity()
+    {
+        var map = new Dictionary<string, List<FtdImportService.HistoricalTickerIdentity>>(
+            StringComparer.OrdinalIgnoreCase
+        )
+        {
+            ["GONE"] = [new(Guid.NewGuid(), "GONE", new DateOnly(2020, 6, 30))],
+        };
+
+        var resolved = FtdImportService.TryResolveHistoricalIdentity(
+            "GONE",
+            new DateOnly(2020, 7, 1),
+            map,
+            [],
+            out _
+        );
+
+        resolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SelectCusips_DifferentValuesOnLatestDate_DropsStock()
+    {
+        var stockId = Guid.NewGuid();
+        var stock = new Equibles.CommonStocks.Data.Models.CommonStock { Id = stockId };
+        FtdImportService.ApplyHistoricalCusipEvidence(
+            stock,
+            [new(stockId, "111111111", new DateOnly(2020, 6, 30))]
+        );
+        FtdImportService.ApplyHistoricalCusipEvidence(
+            stock,
+            [new(stockId, "222222222", new DateOnly(2020, 6, 30))]
+        );
+        FtdImportService.ApplyHistoricalCusipEvidence(
+            stock,
+            [new(stockId, "000000000", new DateOnly(2020, 6, 29))]
+        );
+
+        stock.HistoricalCusipBackfillCandidates.Should().Equal("111111111", "222222222");
+        stock.HistoricalCusipBackfillAmbiguous.Should().BeTrue();
+        stock.HistoricalCusipBackfillCandidateOn.Should().Be(new DateOnly(2020, 6, 30));
+    }
+
+    [Fact]
+    public void SelectCusips_SameValueClaimsMultipleStocks_DropsEveryOwner()
+    {
+        var stocks = new[]
+        {
+            new Equibles.CommonStocks.Data.Models.CommonStock
+            {
+                HistoricalCusipBackfillCandidates = ["111111111"],
+            },
+            new Equibles.CommonStocks.Data.Models.CommonStock
+            {
+                HistoricalCusipBackfillCandidates = ["111111111"],
+            },
+        };
+
+        FtdImportService.RejectContestedHistoricalCusips(stocks);
+
+        stocks
+            .Should()
+            .OnlyContain(stock =>
+                stock.HistoricalCusipBackfillCandidates.Count == 1
+                && stock.HistoricalCusipBackfillCandidates[0] == "111111111"
+            );
+        stocks.Should().OnlyContain(stock => stock.HistoricalCusipBackfillAmbiguous);
+    }
+
+    [Fact]
+    public void SelectCusips_ContestedClaimFromEarlierBatch_RemainsVisibleToLaterOwner()
+    {
+        var first = new Equibles.CommonStocks.Data.Models.CommonStock
+        {
+            HistoricalCusipBackfillCandidates = ["111111111"],
+        };
+        var second = new Equibles.CommonStocks.Data.Models.CommonStock
+        {
+            HistoricalCusipBackfillCandidates = ["111111111"],
+        };
+        FtdImportService.RejectContestedHistoricalCusips([first, second]);
+
+        var later = new Equibles.CommonStocks.Data.Models.CommonStock
+        {
+            HistoricalCusipBackfillCandidates = ["111111111"],
+        };
+        FtdImportService.RejectContestedHistoricalCusips([first, second, later]);
+
+        new[] { first, second, later }
+            .Should()
+            .OnlyContain(stock => stock.HistoricalCusipBackfillAmbiguous);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs
@@ -86,6 +86,19 @@ public class FtdImportServiceTests
     }
 
     [Fact]
+    public void GetStableHistoricalFileNames_ExcludesPublicationWindowAndMovingCurrentHead()
+    {
+        var fileNames = FtdImportService.GetStableHistoricalFileNames(
+            new DateOnly(2025, 1, 1),
+            new DateOnly(2026, 8, 24)
+        );
+
+        fileNames.TakeLast(2).Should().Equal("cnsfails202605a.zip", "cnsfails202605b.zip");
+        fileNames.Should().NotContain(file => file.Contains("202606"));
+        fileNames.Should().NotContain(file => file.Contains("202608"));
+    }
+
+    [Fact]
     public void GetFileNames_StartBeforeOldestAvailableDate_OmitsJune2017AFile()
     {
         // June 2017 is the oldest month SEC publishes FTD data for, and uniquely has


### PR DESCRIPTION
## Summary
- retain inactive CommonStock identities in historical holdings resolution
- recover missing inactive CUSIPs through a publication-safe, retryable SEC FTD archive sweep
- preserve cross-batch ambiguity and protect inactive CUSIP ownership across primary, alias, and listing paths

## Verification
- dotnet build Equibles.sln -c Release --no-restore
- 4,604 unit tests passed
- 2,755 integration tests passed
- dotnet csharpier check .
- independent final review: no actionable findings