### PR TITLE
fix(common-stocks): retain exact delisted listing claims

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -140,7 +140,8 @@ public class CommonStockManager
     /// </summary>
     public async Task<int> RecordListedTickerCusips(
         CommonStock commonStock,
-        IReadOnlyCollection<(string ListedTicker, string Cusip)> candidates
+        IReadOnlyCollection<(string ListedTicker, string Cusip)> candidates,
+        IReadOnlyCollection<string> authoritativeHistoricalTickers = null
     )
     {
         ArgumentNullException.ThrowIfNull(commonStock);
@@ -150,6 +151,7 @@ public class CommonStockManager
             commonStock.SecondaryTickers ?? [],
             StringComparer.OrdinalIgnoreCase
         );
+        secondaryTickers.UnionWith(authoritativeHistoricalTickers ?? []);
         var cleaned = candidates
             .Where(c =>
                 !string.IsNullOrWhiteSpace(c.ListedTicker) && !string.IsNullOrWhiteSpace(c.Cusip)

--- a/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
+++ b/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
@@ -12,6 +12,7 @@ public class CommonStocksModuleConfiguration : Equibles.Data.IFinancialModule
         commonStock.Property(stock => stock.Active).HasDefaultValue(true);
         commonStock.HasIndex(stock => stock.Ticker).IsUnique().HasFilter("\"Active\"");
         builder.Entity<CommonStockCusipAlias>();
+        builder.Entity<CommonStockDelistedListing>();
         builder.Entity<CommonStockListedCusip>();
         builder.Entity<CommonStockTickerAlias>();
         builder.Entity<CommonStockTickerEvidence>();

--- a/src/Equibles.CommonStocks.Data/Models/CommonStockDelistedListing.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStockDelistedListing.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// One authoritative inactive common-stock listing belonging to an SEC filer. A filer may have
+/// several exact listed securities, so each symbol keeps its own final trading date and historical
+/// backfill state rather than inheriting an arbitrary filer-level cutoff.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(ListedTicker), IsUnique = true)]
+[Index(nameof(ListedTicker), nameof(DelistedOn))]
+public class CommonStockDelistedListing
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+
+    public virtual CommonStock CommonStock { get; set; }
+
+    [Required]
+    [MaxLength(32)]
+    public string ListedTicker { get; set; }
+
+    public DateOnly DelistedOn { get; set; }
+
+    public DateTime? HistoricalPriceBackfillAttemptedAt { get; set; }
+
+    [MaxLength(9)]
+    public string Cusip { get; set; }
+
+    public DateTime? HistoricalCusipBackfillRequestedAt { get; set; }
+
+    public List<string> HistoricalCusipBackfillCandidates { get; set; } = [];
+
+    public DateOnly? HistoricalCusipBackfillCandidateOn { get; set; }
+
+    public bool HistoricalCusipBackfillAmbiguous { get; set; }
+
+    public DateTime? HistoricalCusipBackfillSweepStartedAt { get; set; }
+}

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -227,6 +227,63 @@ public class CommonStockRepository : BaseRepository<CommonStock>
         return listedCusip;
     }
 
+    public IQueryable<CommonStockDelistedListing> GetDelistedListings()
+    {
+        return DbContext.Set<CommonStockDelistedListing>().AsQueryable();
+    }
+
+    public CommonStockDelistedListing AddDelistedListing(CommonStockDelistedListing delistedListing)
+    {
+        DbContext.Set<CommonStockDelistedListing>().Add(delistedListing);
+        return delistedListing;
+    }
+
+    public void DeleteDelistedListing(CommonStockDelistedListing delistedListing)
+    {
+        DbContext.Set<CommonStockDelistedListing>().Remove(delistedListing);
+    }
+
+    public async Task<CommonStockDelistedListing> GetDelistedListingForUpdate(
+        Guid delistedListingId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var listings = DbContext.Set<CommonStockDelistedListing>();
+        if (!DbContext.Database.IsRelational())
+        {
+            return await listings.FirstOrDefaultAsync(
+                listing => listing.Id == delistedListingId,
+                cancellationToken
+            );
+        }
+
+        if (DbContext.Database.CurrentTransaction == null)
+            throw new InvalidOperationException(
+                "GetDelistedListingForUpdate requires an active transaction."
+            );
+
+        var trackedEntry = DbContext
+            .ChangeTracker.Entries<CommonStockDelistedListing>()
+            .FirstOrDefault(entry => entry.Entity.Id == delistedListingId);
+        if (trackedEntry != null && trackedEntry.State != EntityState.Unchanged)
+        {
+            throw new InvalidOperationException(
+                $"GetDelistedListingForUpdate cannot refresh listing {delistedListingId} while "
+                    + $"its tracked state is {trackedEntry.State}."
+            );
+        }
+
+        var listing = await listings
+            .FromSqlInterpolated(
+                $"""SELECT * FROM "CommonStockDelistedListing" WHERE "Id" = {delistedListingId} FOR UPDATE"""
+            )
+            .FirstOrDefaultAsync(cancellationToken);
+        if (listing != null && trackedEntry != null)
+            await DbContext.Entry(listing).ReloadAsync(cancellationToken);
+
+        return listing;
+    }
+
     /// <summary>
     /// Retired primary tickers recorded when the SEC sync renamed a stock's symbol.
     /// Same aggregate reasoning as the CUSIP aliases: no independent lifecycle, so

--- a/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/CorporateActionPriceReconciliationManager.cs
@@ -186,6 +186,28 @@ public class CorporateActionPriceReconciliationManager
         );
     }
 
+    public Task<int> StampAppliedHistorical(
+        PendingPriceReconciliationSeries selectedSeries,
+        IReadOnlyCollection<CapturedDividend> priceSeriesDividends,
+        DateOnly settledBefore,
+        DateTime appliedTime,
+        Guid historicalListingId,
+        DateOnly expectedDelistedOn,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return StampAppliedCore(
+            selectedSeries,
+            priceSeriesDividends,
+            true,
+            settledBefore,
+            appliedTime,
+            cancellationToken,
+            expectedDelistedOn: expectedDelistedOn,
+            expectedHistoricalListingId: historicalListingId
+        );
+    }
+
     /// <summary>
     /// Stamps actions only when the locked issuer still has the listing state that bounded the
     /// provider response. This prevents a delisting or reactivation race from certifying stale
@@ -258,7 +280,8 @@ public class CorporateActionPriceReconciliationManager
         DateTime appliedTime,
         CancellationToken cancellationToken,
         bool? expectedActive = null,
-        DateOnly? expectedDelistedOn = null
+        DateOnly? expectedDelistedOn = null,
+        Guid? expectedHistoricalListingId = null
     )
     {
         await using var transaction = await _stockRepository.CreateTransaction(
@@ -269,12 +292,31 @@ public class CorporateActionPriceReconciliationManager
             selectedSeries.CommonStockId,
             cancellationToken
         );
-        if (
-            stock == null
-            || (
-                expectedActive != null
-                && (stock.Active != expectedActive.Value || stock.DelistedOn != expectedDelistedOn)
+        if (stock == null)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return 0;
+        }
+        if (expectedHistoricalListingId != null)
+        {
+            var listing = await _stockRepository.GetDelistedListingForUpdate(
+                expectedHistoricalListingId.Value,
+                cancellationToken
+            );
+            if (
+                listing == null
+                || listing.CommonStockId != stock.Id
+                || listing.ListedTicker != selectedSeries.ListedTicker
+                || listing.DelistedOn != expectedDelistedOn
             )
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return 0;
+            }
+        }
+        else if (
+            expectedActive != null
+            && (stock.Active != expectedActive.Value || stock.DelistedOn != expectedDelistedOn)
         )
         {
             await transaction.RollbackAsync(cancellationToken);

--- a/src/Equibles.Migrations/Migrations/20260824012336_AddDelistedCommonStockListings.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260824012336_AddDelistedCommonStockListings.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824012336_AddDelistedCommonStockListings")]
+    partial class AddDelistedCommonStockListings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260824012336_AddDelistedCommonStockListings.cs
+++ b/src/Equibles.Migrations/Migrations/20260824012336_AddDelistedCommonStockListings.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDelistedCommonStockListings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CommonStockDelistedListing",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ListedTicker = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    DelistedOn = table.Column<DateOnly>(type: "date", nullable: false),
+                    HistoricalPriceBackfillAttemptedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Cusip = table.Column<string>(type: "character varying(9)", maxLength: 9, nullable: true),
+                    HistoricalCusipBackfillRequestedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    HistoricalCusipBackfillCandidates = table.Column<List<string>>(type: "text[]", nullable: true),
+                    HistoricalCusipBackfillCandidateOn = table.Column<DateOnly>(type: "date", nullable: true),
+                    HistoricalCusipBackfillAmbiguous = table.Column<bool>(type: "boolean", nullable: false),
+                    HistoricalCusipBackfillSweepStartedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CommonStockDelistedListing", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CommonStockDelistedListing_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStockDelistedListing_CommonStockId_ListedTicker",
+                table: "CommonStockDelistedListing",
+                columns: new[] { "CommonStockId", "ListedTicker" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommonStockDelistedListing_ListedTicker_DelistedOn",
+                table: "CommonStockDelistedListing",
+                columns: new[] { "ListedTicker", "DelistedOn" });
+
+            migrationBuilder.Sql(
+                """
+                INSERT INTO "CommonStockDelistedListing" (
+                    "Id",
+                    "CommonStockId",
+                    "ListedTicker",
+                    "DelistedOn",
+                    "HistoricalPriceBackfillAttemptedAt",
+                    "Cusip",
+                    "HistoricalCusipBackfillRequestedAt",
+                    "HistoricalCusipBackfillCandidates",
+                    "HistoricalCusipBackfillCandidateOn",
+                    "HistoricalCusipBackfillAmbiguous",
+                    "HistoricalCusipBackfillSweepStartedAt")
+                SELECT
+                    gen_random_uuid(),
+                    "Id",
+                    "Ticker",
+                    "DelistedOn",
+                    "HistoricalPriceBackfillAttemptedAt",
+                    "Cusip",
+                    "HistoricalCusipBackfillRequestedAt",
+                    "HistoricalCusipBackfillCandidates",
+                    "HistoricalCusipBackfillCandidateOn",
+                    "HistoricalCusipBackfillAmbiguous",
+                    "HistoricalCusipBackfillSweepStartedAt"
+                FROM "CommonStock"
+                WHERE NOT "Active" AND "DelistedOn" IS NOT NULL;
+                """
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1
+                        FROM "CommonStockDelistedListing" listing
+                        JOIN "CommonStock" stock ON stock."Id" = listing."CommonStockId"
+                        WHERE stock."Active"
+                           OR listing."ListedTicker" <> stock."Ticker"
+                           OR listing."DelistedOn" IS DISTINCT FROM stock."DelistedOn"
+                           OR listing."Cusip" IS DISTINCT FROM stock."Cusip")
+                    THEN
+                        RAISE EXCEPTION 'cannot remove per-listing delisting history: exact listing identity would be lost';
+                    END IF;
+                END $$;
+
+                UPDATE "CommonStock" stock
+                SET
+                    "HistoricalPriceBackfillAttemptedAt" = listing."HistoricalPriceBackfillAttemptedAt",
+                    "HistoricalCusipBackfillRequestedAt" = listing."HistoricalCusipBackfillRequestedAt",
+                    "HistoricalCusipBackfillCandidates" = listing."HistoricalCusipBackfillCandidates",
+                    "HistoricalCusipBackfillCandidateOn" = listing."HistoricalCusipBackfillCandidateOn",
+                    "HistoricalCusipBackfillAmbiguous" = listing."HistoricalCusipBackfillAmbiguous",
+                    "HistoricalCusipBackfillSweepStartedAt" = listing."HistoricalCusipBackfillSweepStartedAt"
+                FROM "CommonStockDelistedListing" listing
+                WHERE listing."CommonStockId" = stock."Id"
+                  AND listing."ListedTicker" = stock."Ticker";
+                """
+            );
+
+            migrationBuilder.DropTable(
+                name: "CommonStockDelistedListing");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -276,7 +276,7 @@ public class FtdImportService
                             record.SettlementDate,
                             tickerMap,
                             strippedAliases,
-                            out var stockId
+                            out var listingId
                         )
                     )
                     {
@@ -284,7 +284,7 @@ public class FtdImportService
                     }
 
                     candidates.Add(
-                        new HistoricalCusipCandidate(stockId, record.Cusip, record.SettlementDate)
+                        new HistoricalCusipCandidate(listingId, record.Cusip, record.SettlementDate)
                     );
                 }
                 lastCompletedFile = fileName;
@@ -497,6 +497,21 @@ public class FtdImportService
             .Where(cs => cs.SecondaryTickers.Count > 0)
             .Select(cs => new { cs.Id, cs.SecondaryTickers })
             .ToListAsync(cancellationToken);
+        var stockIds = stocks.Select(stock => stock.Id).ToList();
+        var delistedRows = await stockRepo
+            .GetDelistedListings()
+            .Where(listing => stockIds.Contains(listing.CommonStockId))
+            .Select(listing => new { listing.CommonStockId, listing.ListedTicker })
+            .ToListAsync(cancellationToken);
+        var delistedByStock = delistedRows
+            .GroupBy(listing => listing.CommonStockId)
+            .ToDictionary(
+                group => group.Key,
+                group =>
+                    group
+                        .Select(listing => listing.ListedTicker)
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase)
+            );
 
         var map = new Dictionary<string, (Guid StockId, string Ticker)>(
             StringComparer.OrdinalIgnoreCase
@@ -506,6 +521,11 @@ public class FtdImportService
         {
             foreach (var ticker in stock.SecondaryTickers.Where(t => !string.IsNullOrWhiteSpace(t)))
             {
+                if (
+                    delistedByStock.TryGetValue(stock.Id, out var delisted)
+                    && delisted.Contains(ticker)
+                )
+                    continue;
                 if (primaryMap.ContainsKey(ticker))
                     continue;
                 if (!map.TryAdd(ticker, (stock.Id, ticker)) && map[ticker].StockId != stock.Id)
@@ -597,39 +617,39 @@ public class FtdImportService
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var query = stockRepo
-            .GetAllIncludingInactive()
-            .Where(stock =>
-                !stock.Active
-                && stock.Cusip == null
-                && stock.DelistedOn != null
+            .GetDelistedListings()
+            .Where(listing =>
+                listing.Cusip == null
                 && (
-                    stock.HistoricalCusipBackfillRequestedAt == null
-                    || stock.HistoricalCusipBackfillRequestedAt <= sweepStartedAt
+                    listing.HistoricalCusipBackfillRequestedAt == null
+                    || listing.HistoricalCusipBackfillRequestedAt <= sweepStartedAt
                 )
             );
         if (_workerOptions.TickersToSync?.Count > 0)
         {
-            query = query.Where(stock => _workerOptions.TickersToSync.Contains(stock.Ticker));
+            query = query.Where(listing =>
+                _workerOptions.TickersToSync.Contains(listing.ListedTicker)
+            );
         }
 
-        var stocks = await query.ToListAsync(cancellationToken);
+        var listings = await query.ToListAsync(cancellationToken);
         foreach (
-            var stock in stocks.Where(stock =>
-                stock.HistoricalCusipBackfillSweepStartedAt != sweepStartedAt
+            var listing in listings.Where(listing =>
+                listing.HistoricalCusipBackfillSweepStartedAt != sweepStartedAt
             )
         )
         {
-            stock.HistoricalCusipBackfillCandidates = [];
-            stock.HistoricalCusipBackfillCandidateOn = null;
-            stock.HistoricalCusipBackfillAmbiguous = false;
-            stock.HistoricalCusipBackfillSweepStartedAt = sweepStartedAt;
+            listing.HistoricalCusipBackfillCandidates = [];
+            listing.HistoricalCusipBackfillCandidateOn = null;
+            listing.HistoricalCusipBackfillAmbiguous = false;
+            listing.HistoricalCusipBackfillSweepStartedAt = sweepStartedAt;
         }
         await stockRepo.SaveChanges();
 
-        var identities = stocks.Select(stock => new HistoricalTickerIdentity(
-            stock.Id,
-            stock.Ticker,
-            stock.DelistedOn!.Value
+        var identities = listings.Select(listing => new HistoricalTickerIdentity(
+            listing.Id,
+            listing.ListedTicker,
+            listing.DelistedOn
         ));
 
         return identities
@@ -647,10 +667,10 @@ public class FtdImportService
         DateOnly settlementDate,
         Dictionary<string, List<HistoricalTickerIdentity>> tickerMap,
         Dictionary<string, string> strippedAliases,
-        out Guid stockId
+        out Guid listingId
     )
     {
-        stockId = default;
+        listingId = default;
         var ticker = tickerMap.ContainsKey(symbol)
             ? symbol
             : strippedAliases.GetValueOrDefault(symbol);
@@ -672,17 +692,17 @@ public class FtdImportService
             return false;
         }
 
-        stockId = eligible[0].StockId;
+        listingId = eligible[0].ListingId;
         return true;
     }
 
     private async Task<int> SeedInactiveCusips(
-        Dictionary<Guid, (string Cusip, DateOnly SettlementDate)> latestByStock,
+        Dictionary<Guid, (string Cusip, DateOnly SettlementDate)> latestByListing,
         DateTime sweepStartedAt,
         CancellationToken cancellationToken
     )
     {
-        if (latestByStock.Count == 0)
+        if (latestByListing.Count == 0)
         {
             return 0;
         }
@@ -690,19 +710,20 @@ public class FtdImportService
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var stockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
-        var stocks = await stockRepo
-            .GetByIdsIncludingInactive(latestByStock.Keys)
-            .Where(stock =>
-                !stock.Active
-                && stock.Cusip == null
+        var listings = await stockRepo
+            .GetDelistedListings()
+            .Include(listing => listing.CommonStock)
+            .Where(listing =>
+                latestByListing.Keys.Contains(listing.Id)
+                && listing.Cusip == null
                 && (
-                    stock.HistoricalCusipBackfillRequestedAt == null
-                    || stock.HistoricalCusipBackfillRequestedAt <= sweepStartedAt
+                    listing.HistoricalCusipBackfillRequestedAt == null
+                    || listing.HistoricalCusipBackfillRequestedAt <= sweepStartedAt
                 )
             )
             .ToListAsync(cancellationToken);
 
-        var candidates = latestByStock
+        var candidates = latestByListing
             .Values.Select(value => value.Cusip)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -737,37 +758,109 @@ public class FtdImportService
             AddClaim(claim.Cusip, claim.CommonStockId);
         }
 
-        var listedClaimValues = await stockRepo
+        var listedClaims = await stockRepo
             .GetListedCusips()
             .Where(listing => candidates.Contains(listing.Cusip))
-            .Select(listing => listing.Cusip)
+            .Select(listing => new
+            {
+                listing.CommonStockId,
+                listing.ListedTicker,
+                listing.Cusip,
+            })
             .ToListAsync(cancellationToken);
-        var listedClaims = new HashSet<string>(listedClaimValues, StringComparer.OrdinalIgnoreCase);
+        foreach (var claim in listedClaims)
+        {
+            AddClaim(claim.Cusip, claim.CommonStockId);
+        }
 
         var seeded = 0;
-        foreach (var stock in stocks)
+        foreach (var listing in listings)
         {
-            var resolved = latestByStock[stock.Id];
-            if (
-                listedClaims.Contains(resolved.Cusip)
-                || (
-                    claims.TryGetValue(resolved.Cusip, out var owners)
-                    && owners.Any(ownerId => ownerId != stock.Id)
+            var stock = listing.CommonStock;
+            var resolved = latestByListing[listing.Id];
+            var isPrimary = string.Equals(
+                listing.ListedTicker,
+                stock.Ticker,
+                StringComparison.OrdinalIgnoreCase
+            );
+            var aliasAlreadyClaimsCusip = aliasClaims.Any(claim =>
+                string.Equals(claim.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase)
+            );
+            var listedClaimsForCusip = listedClaims
+                .Where(claim =>
+                    string.Equals(claim.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase)
                 )
+                .ToList();
+            var exactListedClaim = listedClaims.FirstOrDefault(claim =>
+                claim.CommonStockId == stock.Id
+                && string.Equals(
+                    claim.ListedTicker,
+                    listing.ListedTicker,
+                    StringComparison.OrdinalIgnoreCase
+                )
+                && string.Equals(claim.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase)
+            );
+            if (
+                claims.TryGetValue(resolved.Cusip, out var owners)
+                && owners.Any(ownerId => ownerId != stock.Id)
             )
             {
                 _logger.LogWarning(
                     "Inactive FTD identity {Ticker} resolved to CUSIP {Cusip}, but that CUSIP is already claimed by another stock — skipping",
-                    stock.Ticker,
+                    listing.ListedTicker,
                     resolved.Cusip
                 );
                 continue;
             }
+            if (
+                aliasAlreadyClaimsCusip
+                || (isPrimary && listedClaimsForCusip.Count > 0)
+                || (!isPrimary && listedClaimsForCusip.Count > 0 && exactListedClaim == null)
+            )
+            {
+                listing.HistoricalCusipBackfillAmbiguous = true;
+                continue;
+            }
 
-            await stockManager.SetCusip(stock, resolved.Cusip);
+            if (isPrimary)
+            {
+                if (
+                    stock.Cusip != null
+                    && !string.Equals(
+                        stock.Cusip,
+                        resolved.Cusip,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                {
+                    listing.HistoricalCusipBackfillAmbiguous = true;
+                    continue;
+                }
+                if (stock.Cusip == null)
+                {
+                    await stockManager.SetCusip(stock, resolved.Cusip);
+                }
+            }
+            else if (exactListedClaim == null)
+            {
+                var recorded = await stockManager.RecordListedTickerCusips(
+                    stock,
+                    [(listing.ListedTicker, resolved.Cusip)],
+                    [listing.ListedTicker]
+                );
+                if (recorded == 0)
+                {
+                    listing.HistoricalCusipBackfillAmbiguous = true;
+                    continue;
+                }
+            }
+
+            listing.Cusip = resolved.Cusip;
             AddClaim(resolved.Cusip, stock.Id);
             seeded++;
         }
+
+        await stockRepo.SaveChanges();
 
         return seeded;
     }
@@ -786,80 +879,83 @@ public class FtdImportService
 
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
-        var stocks = await stockRepo
-            .GetByIdsIncludingInactive(batch.Select(candidate => candidate.StockId).Distinct())
-            .Where(stock =>
-                !stock.Active
-                && stock.Cusip == null
-                && stock.HistoricalCusipBackfillSweepStartedAt == sweepStartedAt
+        var listings = await stockRepo
+            .GetDelistedListings()
+            .Where(listing =>
+                batch.Select(candidate => candidate.ListingId).Distinct().Contains(listing.Id)
+                && listing.Cusip == null
+                && listing.HistoricalCusipBackfillSweepStartedAt == sweepStartedAt
             )
             .ToListAsync(cancellationToken);
-        foreach (var stock in stocks)
+        foreach (var listing in listings)
         {
             ApplyHistoricalCusipEvidence(
-                stock,
-                batch.Where(candidate => candidate.StockId == stock.Id)
+                listing,
+                batch.Where(candidate => candidate.ListingId == listing.Id)
             );
         }
         await stockRepo.SaveChanges();
 
         var staged = await stockRepo
-            .GetAllIncludingInactive()
-            .Where(stock =>
-                !stock.Active
-                && stock.Cusip == null
-                && stock.HistoricalCusipBackfillSweepStartedAt == sweepStartedAt
+            .GetDelistedListings()
+            .Where(listing =>
+                listing.Cusip == null
+                && listing.HistoricalCusipBackfillSweepStartedAt == sweepStartedAt
             )
             .ToListAsync(cancellationToken);
         RejectContestedHistoricalCusips(staged);
         await stockRepo.SaveChanges();
     }
 
-    internal static void RejectContestedHistoricalCusips(IEnumerable<CommonStock> stocks)
+    internal static void RejectContestedHistoricalCusips(
+        IEnumerable<CommonStockDelistedListing> listings
+    )
     {
-        var contestedStockIds = stocks
-            .SelectMany(stock =>
-                stock
+        var contestedListingIds = listings
+            .SelectMany(listing =>
+                listing
                     .HistoricalCusipBackfillCandidates.Distinct(StringComparer.OrdinalIgnoreCase)
-                    .Select(cusip => new { stock.Id, Cusip = cusip })
+                    .Select(cusip => new { listing.Id, Cusip = cusip })
             )
             .GroupBy(claim => claim.Cusip, StringComparer.OrdinalIgnoreCase)
             .Where(group => group.Select(claim => claim.Id).Distinct().Count() > 1)
             .SelectMany(group => group.Select(claim => claim.Id))
             .ToHashSet();
-        foreach (var contested in stocks.Where(stock => contestedStockIds.Contains(stock.Id)))
+        foreach (
+            var contested in listings.Where(listing => contestedListingIds.Contains(listing.Id))
+        )
         {
             contested.HistoricalCusipBackfillAmbiguous = true;
         }
     }
 
     internal static void ApplyHistoricalCusipEvidence(
-        CommonStock stock,
+        CommonStockDelistedListing listing,
         IEnumerable<HistoricalCusipCandidate> candidates
     )
     {
         foreach (var candidate in candidates)
         {
             if (
-                stock.HistoricalCusipBackfillCandidateOn == null
-                || candidate.SettlementDate > stock.HistoricalCusipBackfillCandidateOn
+                listing.HistoricalCusipBackfillCandidateOn == null
+                || candidate.SettlementDate > listing.HistoricalCusipBackfillCandidateOn
             )
             {
-                stock.HistoricalCusipBackfillCandidates = [candidate.Cusip];
-                stock.HistoricalCusipBackfillCandidateOn = candidate.SettlementDate;
-                stock.HistoricalCusipBackfillAmbiguous = false;
+                listing.HistoricalCusipBackfillCandidates = [candidate.Cusip];
+                listing.HistoricalCusipBackfillCandidateOn = candidate.SettlementDate;
+                listing.HistoricalCusipBackfillAmbiguous = false;
                 continue;
             }
             if (
-                candidate.SettlementDate == stock.HistoricalCusipBackfillCandidateOn
-                && !stock.HistoricalCusipBackfillCandidates.Contains(
+                candidate.SettlementDate == listing.HistoricalCusipBackfillCandidateOn
+                && !listing.HistoricalCusipBackfillCandidates.Contains(
                     candidate.Cusip,
                     StringComparer.OrdinalIgnoreCase
                 )
             )
             {
-                stock.HistoricalCusipBackfillCandidates.Add(candidate.Cusip);
-                stock.HistoricalCusipBackfillAmbiguous = true;
+                listing.HistoricalCusipBackfillCandidates.Add(candidate.Cusip);
+                listing.HistoricalCusipBackfillAmbiguous = true;
             }
         }
     }
@@ -872,25 +968,24 @@ public class FtdImportService
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var staged = await stockRepo
-            .GetAllIncludingInactive()
-            .Where(stock =>
-                !stock.Active
-                && stock.Cusip == null
-                && stock.HistoricalCusipBackfillSweepStartedAt == sweepStartedAt
-                && stock.HistoricalCusipBackfillCandidateOn != null
+            .GetDelistedListings()
+            .Where(listing =>
+                listing.Cusip == null
+                && listing.HistoricalCusipBackfillSweepStartedAt == sweepStartedAt
+                && listing.HistoricalCusipBackfillCandidateOn != null
             )
             .ToListAsync(cancellationToken);
         var candidates = staged
-            .Where(stock =>
-                !stock.HistoricalCusipBackfillAmbiguous
-                && stock.HistoricalCusipBackfillCandidates.Count == 1
+            .Where(listing =>
+                !listing.HistoricalCusipBackfillAmbiguous
+                && listing.HistoricalCusipBackfillCandidates.Count == 1
             )
             .ToDictionary(
-                stock => stock.Id,
-                stock =>
+                listing => listing.Id,
+                listing =>
                     (
-                        stock.HistoricalCusipBackfillCandidates[0],
-                        stock.HistoricalCusipBackfillCandidateOn!.Value
+                        listing.HistoricalCusipBackfillCandidates[0],
+                        listing.HistoricalCusipBackfillCandidateOn!.Value
                     )
             );
 
@@ -917,12 +1012,12 @@ public class FtdImportService
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var state = await stateRepo.GetByName(InactiveCusipSweepCursorName);
 
-        var pending = stockRepo
-            .GetAllIncludingInactive()
-            .Where(stock => !stock.Active && stock.Cusip == null && stock.DelistedOn != null);
+        var pending = stockRepo.GetDelistedListings().Where(listing => listing.Cusip == null);
         if (_workerOptions.TickersToSync?.Count > 0)
         {
-            pending = pending.Where(stock => _workerOptions.TickersToSync.Contains(stock.Ticker));
+            pending = pending.Where(listing =>
+                _workerOptions.TickersToSync.Contains(listing.ListedTicker)
+            );
         }
 
         if (state == null)
@@ -961,9 +1056,9 @@ public class FtdImportService
         {
             var startedAt = state.LastFullRescanAt ?? DateTime.MinValue;
             var requestedAfterStart = await pending.AnyAsync(
-                stock =>
-                    stock.HistoricalCusipBackfillRequestedAt != null
-                    && stock.HistoricalCusipBackfillRequestedAt > startedAt,
+                listing =>
+                    listing.HistoricalCusipBackfillRequestedAt != null
+                    && listing.HistoricalCusipBackfillRequestedAt > startedAt,
                 cancellationToken
             );
             if (!requestedAfterStart)
@@ -1228,13 +1323,13 @@ public class FtdImportService
     }
 
     internal sealed record HistoricalTickerIdentity(
-        Guid StockId,
+        Guid ListingId,
         string Ticker,
         DateOnly DelistedOn
     );
 
     internal sealed record HistoricalCusipCandidate(
-        Guid StockId,
+        Guid ListingId,
         string Cusip,
         DateOnly SettlementDate
     );

--- a/src/Equibles.Worker/TickerMapService.cs
+++ b/src/Equibles.Worker/TickerMapService.cs
@@ -33,6 +33,12 @@ public class TickerMapService
 
         var query =
             tickersToSync?.Count > 0 ? stockRepo.GetByTickers(tickersToSync) : stockRepo.GetAll();
+        var delistedListings = stockRepo.GetDelistedListings();
+        query = query.Where(stock =>
+            !delistedListings.Any(listing =>
+                listing.CommonStockId == stock.Id && listing.ListedTicker == stock.Ticker
+            )
+        );
 
         return await query.ToDictionaryAsync(
             s => s.Ticker,

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -33,13 +33,18 @@ internal readonly record struct PriceSeriesTarget(
     bool RequiresFullHistory = false,
     DateTime? YahooEnrichmentAttemptedAt = null,
     bool IsHistorical = false,
-    DateOnly? HistoryEndDate = null
+    DateOnly? HistoryEndDate = null,
+    Guid? HistoricalListingId = null
 )
 {
     public PriceSeriesKey Key => new(CommonStockId, Ticker);
 }
 
-internal readonly record struct LockedPriceSeries(CommonStock Stock, bool IsPrimary);
+internal readonly record struct LockedPriceSeries(
+    CommonStock Stock,
+    bool IsPrimary,
+    CommonStockDelistedListing HistoricalListing = null
+);
 
 internal readonly record struct AppliedSplitBoundary(
     Guid SplitId,
@@ -173,6 +178,21 @@ public class YahooPriceImportService
 
         using var scope = _scopeFactory.CreateScope();
         var stockRepository = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var delistedRows = await stockRepository
+            .GetDelistedListings()
+            .Where(listing => stockIds.Contains(listing.CommonStockId))
+            .Select(listing => new { listing.CommonStockId, listing.ListedTicker })
+            .ToListAsync(cancellationToken);
+        var delistedByStock = delistedRows
+            .GroupBy(listing => listing.CommonStockId)
+            .ToDictionary(
+                group => group.Key,
+                group =>
+                    group
+                        .Select(listing => TickerNormalizer.NormalizeListed(listing.ListedTicker))
+                        .Where(ticker => ticker != null)
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase)
+            );
         var stocks = await stockRepository
             .GetByIds(stockIds)
             .Select(stock => new
@@ -204,24 +224,32 @@ public class YahooPriceImportService
                 .Select(TickerNormalizer.NormalizeListed)
                 .Where(ticker => ticker != null)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var delistedTickers = delistedByStock.GetValueOrDefault(stock.Id) ?? [];
 
-            targets.Add(
-                new PriceSeriesTarget(
-                    primaryTicker,
-                    stock.Id,
-                    IsPrimary: true,
-                    RequiresFullHistory: referenceTickers.Contains(primaryTicker)
-                        && !backfilledTickers.Contains(primaryTicker),
-                    YahooEnrichmentAttemptedAt: stock.YahooEnrichmentAttemptedAt
-                )
-            );
+            if (!delistedTickers.Contains(primaryTicker))
+            {
+                targets.Add(
+                    new PriceSeriesTarget(
+                        primaryTicker,
+                        stock.Id,
+                        IsPrimary: true,
+                        RequiresFullHistory: referenceTickers.Contains(primaryTicker)
+                            && !backfilledTickers.Contains(primaryTicker),
+                        YahooEnrichmentAttemptedAt: stock.YahooEnrichmentAttemptedAt
+                    )
+                );
+            }
 
             foreach (
                 var secondaryTicker in (stock.SecondaryTickers ?? [])
                     .Concat(stock.ReferenceTickers ?? [])
                     .Where(ticker => !string.IsNullOrWhiteSpace(ticker))
                     .Select(TickerNormalizer.NormalizeListed)
-                    .Where(ticker => ticker != null && ticker != primaryTicker)
+                    .Where(ticker =>
+                        ticker != null
+                        && ticker != primaryTicker
+                        && !delistedTickers.Contains(ticker)
+                    )
                     .Distinct(StringComparer.OrdinalIgnoreCase)
             )
             {
@@ -252,29 +280,28 @@ public class YahooPriceImportService
         var historyFloor = PriceHistoryFloor();
 
         return await stockRepository
-            .GetAllIncludingInactive()
-            .Where(stock =>
-                !stock.Active
-                && stock.DelistedOn != null
-                && stock.DelistedOn >= historyFloor
-                && !stock.PriceHistoryBackfilledTickers.Contains(stock.Ticker)
+            .GetDelistedListings()
+            .Where(listing =>
+                listing.DelistedOn >= historyFloor
+                && !listing.CommonStock.PriceHistoryBackfilledTickers.Contains(listing.ListedTicker)
                 && (
-                    stock.HistoricalPriceBackfillAttemptedAt == null
-                    || stock.HistoricalPriceBackfillAttemptedAt <= retryBefore
+                    listing.HistoricalPriceBackfillAttemptedAt == null
+                    || listing.HistoricalPriceBackfillAttemptedAt <= retryBefore
                 )
             )
-            .OrderBy(stock => stock.HistoricalPriceBackfillAttemptedAt ?? DateTime.MinValue)
-            .ThenBy(stock => stock.DelistedOn)
-            .ThenBy(stock => stock.Ticker)
+            .OrderBy(listing => listing.HistoricalPriceBackfillAttemptedAt ?? DateTime.MinValue)
+            .ThenBy(listing => listing.DelistedOn)
+            .ThenBy(listing => listing.ListedTicker)
             .Take(Math.Max(1, _scraperOptions.HistoricalBackfillBatchSize))
-            .Select(stock => new PriceSeriesTarget(
-                stock.Ticker,
-                stock.Id,
-                IsPrimary: true,
+            .Select(listing => new PriceSeriesTarget(
+                listing.ListedTicker,
+                listing.CommonStockId,
+                IsPrimary: listing.ListedTicker == listing.CommonStock.Ticker,
                 RequiresFullHistory: true,
                 YahooEnrichmentAttemptedAt: null,
                 IsHistorical: true,
-                HistoryEndDate: stock.DelistedOn
+                HistoryEndDate: listing.DelistedOn,
+                HistoricalListingId: listing.Id
             ))
             .ToListAsync(cancellationToken);
     }
@@ -288,19 +315,33 @@ public class YahooPriceImportService
         var stock = await stockRepository.GetForUpdate(target.CommonStockId, cancellationToken);
         if (stock == null)
             return null;
-        if (
-            target.IsHistorical
-            && (
-                stock.Active
-                || stock.DelistedOn == null
-                || stock.DelistedOn != target.HistoryEndDate
+        CommonStockDelistedListing historicalListing = null;
+        if (target.IsHistorical)
+        {
+            if (target.HistoricalListingId == null)
+                return null;
+            historicalListing = await stockRepository.GetDelistedListingForUpdate(
+                target.HistoricalListingId.Value,
+                cancellationToken
+            );
+            if (
+                historicalListing == null
+                || historicalListing.CommonStockId != target.CommonStockId
+                || historicalListing.DelistedOn != target.HistoryEndDate
+                || !string.Equals(
+                    historicalListing.ListedTicker,
+                    target.Ticker,
+                    StringComparison.OrdinalIgnoreCase
+                )
             )
-        )
-            return null;
+                return null;
+        }
         if (!target.IsHistorical && !stock.Active)
             return null;
 
-        var resolvedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, target.Ticker);
+        var resolvedTicker =
+            historicalListing?.ListedTicker
+            ?? SecondaryTickerPolicy.ResolveListedTicker(stock, target.Ticker);
         if (
             resolvedTicker == null
             || !string.Equals(resolvedTicker, target.Ticker, StringComparison.OrdinalIgnoreCase)
@@ -309,7 +350,8 @@ public class YahooPriceImportService
 
         return new LockedPriceSeries(
             stock,
-            string.Equals(resolvedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase)
+            string.Equals(resolvedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase),
+            historicalListing
         );
     }
 
@@ -553,17 +595,13 @@ public class YahooPriceImportService
             cancellationToken
         );
         var lockedSeries = await LockPriceSeries(stockRepo, target, cancellationToken);
-        if (
-            lockedSeries is not { IsPrimary: true }
-            || lockedSeries.Value.Stock.Active
-            || lockedSeries.Value.Stock.DelistedOn != target.HistoryEndDate
-        )
+        if (lockedSeries?.HistoricalListing == null)
         {
             await transaction.RollbackAsync(cancellationToken);
             return;
         }
 
-        lockedSeries.Value.Stock.HistoricalPriceBackfillAttemptedAt = DateTime.UtcNow;
+        lockedSeries.Value.HistoricalListing.HistoricalPriceBackfillAttemptedAt = DateTime.UtcNow;
         await stockRepo.SaveChanges();
         await transaction.CommitAsync(cancellationToken);
     }
@@ -737,10 +775,18 @@ public class YahooPriceImportService
             if (stock == null)
                 return;
 
-            var resolvedTicker = SecondaryTickerPolicy.ResolveListedTicker(
-                stock,
-                selectedSeries.ListedTicker
-            );
+            var delistedListing = await stockRepository
+                .GetDelistedListings()
+                .FirstOrDefaultAsync(
+                    listing =>
+                        listing.CommonStockId == stock.Id
+                        && listing.ListedTicker == selectedSeries.ListedTicker,
+                    cancellationToken
+                );
+
+            var resolvedTicker =
+                delistedListing?.ListedTicker
+                ?? SecondaryTickerPolicy.ResolveListedTicker(stock, selectedSeries.ListedTicker);
             if (
                 resolvedTicker == null
                 || !string.Equals(
@@ -748,7 +794,7 @@ public class YahooPriceImportService
                     selectedSeries.ListedTicker,
                     StringComparison.OrdinalIgnoreCase
                 )
-                || (!stock.Active && stock.DelistedOn == null)
+                || (!stock.Active && delistedListing == null)
             )
                 return;
 
@@ -760,8 +806,9 @@ public class YahooPriceImportService
                     stock.Ticker,
                     StringComparison.OrdinalIgnoreCase
                 ),
-                IsHistorical: !stock.Active,
-                HistoryEndDate: stock.Active ? null : stock.DelistedOn
+                IsHistorical: delistedListing != null,
+                HistoryEndDate: delistedListing?.DelistedOn,
+                HistoricalListingId: delistedListing?.Id
             );
         }
 
@@ -861,15 +908,25 @@ public class YahooPriceImportService
         using var scope = _scopeFactory.CreateScope();
         var manager =
             scope.ServiceProvider.GetRequiredService<CorporateActionPriceReconciliationManager>();
-        var stamped = await manager.StampApplied(
-            certifiableSeries,
-            capturedDividends,
-            settledBefore,
-            DateTime.UtcNow,
-            expectedActive: !target.IsHistorical,
-            expectedDelistedOn: target.HistoryEndDate,
-            cancellationToken: cancellationToken
-        );
+        var stamped = target.IsHistorical
+            ? await manager.StampAppliedHistorical(
+                certifiableSeries,
+                capturedDividends,
+                settledBefore,
+                DateTime.UtcNow,
+                target.HistoricalListingId!.Value,
+                target.HistoryEndDate!.Value,
+                cancellationToken
+            )
+            : await manager.StampApplied(
+                certifiableSeries,
+                capturedDividends,
+                settledBefore,
+                DateTime.UtcNow,
+                expectedActive: true,
+                expectedDelistedOn: null,
+                cancellationToken: cancellationToken
+            );
         _logger.LogInformation(
             "Reconciled {Ticker}: replaced stored price history and stamped {Count} corporate action(s) applied",
             target.Ticker,

--- a/tests/Equibles.IntegrationTests/Integrations/TickerMapServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Integrations/TickerMapServiceTests.cs
@@ -104,6 +104,26 @@ public class TickerMapServiceTests : IDisposable
         result.Should().ContainKey("GOOG").WhoseValue.Should().Be(goog.Id);
     }
 
+    [Fact]
+    public async Task Build_PrimaryWithAuthoritativeDelistedClaim_ExcludesHistoricalSymbol()
+    {
+        var stock = CreateStock("OLD", "Still Listed Under Another Symbol");
+        await SeedStocks(stock);
+        _stockRepo.AddDelistedListing(
+            new CommonStockDelistedListing
+            {
+                CommonStockId = stock.Id,
+                ListedTicker = stock.Ticker,
+                DelistedOn = new DateOnly(2023, 1, 10),
+            }
+        );
+        await _stockRepo.SaveChanges();
+
+        var result = await _service.Build(null, CancellationToken.None);
+
+        result.Should().NotContainKey("OLD");
+    }
+
     // ── Build filters by tickers ──────────────────────────────────────
     // These tests use _clientEvalService because GetByTickers uses
     // SecondaryTickers.Any() which the in-memory provider cannot translate.

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceInactiveSweepRetryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceInactiveSweepRetryTests.cs
@@ -29,15 +29,22 @@ public class FtdImportServiceInactiveSweepRetryTests
             new CommonStocksModuleConfiguration(),
             new SecTestModuleConfiguration()
         );
-        db.Set<CommonStock>()
+        var stock = new CommonStock
+        {
+            Ticker = "GONE",
+            Name = "Formerly Listed Corp",
+            Cik = "42",
+            Active = false,
+            DelistedOn = new DateOnly(2020, 6, 30),
+        };
+        db.Set<CommonStock>().Add(stock);
+        db.Set<CommonStockDelistedListing>()
             .Add(
-                new CommonStock
+                new CommonStockDelistedListing
                 {
-                    Ticker = "GONE",
-                    Name = "Formerly Listed Corp",
-                    Cik = "42",
-                    Active = false,
-                    DelistedOn = new DateOnly(2020, 6, 30),
+                    CommonStockId = stock.Id,
+                    ListedTicker = stock.Ticker,
+                    DelistedOn = stock.DelistedOn.Value,
                     HistoricalCusipBackfillRequestedAt = DateTime.UtcNow.AddMinutes(-1),
                 }
             );

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
@@ -173,9 +173,17 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             DelistedOn = new DateOnly(2020, 6, 30),
             HistoricalCusipBackfillRequestedAt = DateTime.UtcNow,
         };
+        var listing = new CommonStockDelistedListing
+        {
+            CommonStockId = stock.Id,
+            ListedTicker = stock.Ticker,
+            DelistedOn = stock.DelistedOn.Value,
+            HistoricalCusipBackfillRequestedAt = stock.HistoricalCusipBackfillRequestedAt,
+        };
         await using (var seed = _fixture.CreateDbContext())
         {
             seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockDelistedListing>().Add(listing);
             await seed.SaveChangesAsync();
         }
 
@@ -207,7 +215,7 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
         );
         var matches = new Dictionary<Guid, (string Cusip, DateOnly SettlementDate)>
         {
-            [stock.Id] = ("123456789", new DateOnly(2020, 6, 30)),
+            [listing.Id] = ("123456789", new DateOnly(2020, 6, 30)),
         };
 
         var seedInactive = typeof(FtdImportService).GetMethod(
@@ -228,6 +236,9 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
         using var verify = FreshContext();
         var persisted = await verify.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id);
         persisted.Cusip.Should().Be("123456789");
+        (await verify.Set<CommonStockDelistedListing>().SingleAsync(row => row.Id == listing.Id))
+            .Cusip.Should()
+            .Be("123456789");
         await bus.Received(1)
             .Publish(
                 Arg.Is<StockCusipChanged>(change =>
@@ -250,9 +261,17 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             DelistedOn = new DateOnly(2020, 6, 30),
             HistoricalCusipBackfillRequestedAt = requestedAt,
         };
+        var listing = new CommonStockDelistedListing
+        {
+            CommonStockId = stock.Id,
+            ListedTicker = stock.Ticker,
+            DelistedOn = stock.DelistedOn.Value,
+            HistoricalCusipBackfillRequestedAt = requestedAt,
+        };
         await using (var seed = _fixture.CreateDbContext())
         {
             seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockDelistedListing>().Add(listing);
             await seed.SaveChangesAsync();
         }
 
@@ -260,7 +279,7 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
         var sut = CreateSut(bus);
         var matches = new Dictionary<Guid, (string Cusip, DateOnly SettlementDate)>
         {
-            [stock.Id] = ("123456789", new DateOnly(2020, 6, 30)),
+            [listing.Id] = ("123456789", new DateOnly(2020, 6, 30)),
         };
         var method = typeof(FtdImportService).GetMethod(
             "SeedInactiveCusips",
@@ -277,6 +296,114 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             .BeNull();
         await bus.DidNotReceive()
             .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedInactiveCusips_DelistedSibling_RecordsExactListedCusip()
+    {
+        var requestedAt = DateTime.UtcNow;
+        var stock = new CommonStock
+        {
+            Ticker = "LIVE",
+            Name = "Still Listed Filer",
+            Cik = "0000000042",
+            Cusip = "111111111",
+        };
+        var listing = new CommonStockDelistedListing
+        {
+            CommonStockId = stock.Id,
+            ListedTicker = "OLD",
+            DelistedOn = new DateOnly(2020, 6, 30),
+            HistoricalCusipBackfillRequestedAt = requestedAt,
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockDelistedListing>().Add(listing);
+            await seed.SaveChangesAsync();
+        }
+
+        var bus = Substitute.For<IBus>();
+        var sut = CreateSut(bus);
+        var method = typeof(FtdImportService).GetMethod(
+            "SeedInactiveCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var matches = new Dictionary<Guid, (string Cusip, DateOnly SettlementDate)>
+        {
+            [listing.Id] = ("222222222", listing.DelistedOn),
+        };
+
+        var seeded = await (Task<int>)
+            method.Invoke(sut, [matches, requestedAt.AddMinutes(1), CancellationToken.None])!;
+
+        seeded.Should().Be(1);
+        using var verify = FreshContext();
+        var exact = await verify.Set<CommonStockListedCusip>().SingleAsync();
+        exact.CommonStockId.Should().Be(stock.Id);
+        exact.ListedTicker.Should().Be("OLD");
+        exact.Cusip.Should().Be("222222222");
+        (await verify.Set<CommonStockDelistedListing>().SingleAsync(row => row.Id == listing.Id))
+            .Cusip.Should()
+            .Be("222222222");
+    }
+
+    [Fact]
+    public async Task SeedInactiveCusips_PrimaryCandidateClaimedBySameFilerSibling_RefusesMerge()
+    {
+        var requestedAt = DateTime.UtcNow;
+        var stock = new CommonStock
+        {
+            Ticker = "MAIN",
+            Name = "Formerly Listed Filer",
+            Cik = "0000000042",
+            Active = false,
+            DelistedOn = new DateOnly(2020, 6, 30),
+        };
+        var listing = new CommonStockDelistedListing
+        {
+            CommonStockId = stock.Id,
+            ListedTicker = stock.Ticker,
+            DelistedOn = stock.DelistedOn.Value,
+            HistoricalCusipBackfillRequestedAt = requestedAt,
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockDelistedListing>().Add(listing);
+            seed.Set<CommonStockListedCusip>()
+                .Add(
+                    new CommonStockListedCusip
+                    {
+                        CommonStockId = stock.Id,
+                        ListedTicker = "SIBLING",
+                        Cusip = "222222222",
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var sut = CreateSut(Substitute.For<IBus>());
+        var method = typeof(FtdImportService).GetMethod(
+            "SeedInactiveCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var matches = new Dictionary<Guid, (string Cusip, DateOnly SettlementDate)>
+        {
+            [listing.Id] = ("222222222", listing.DelistedOn),
+        };
+
+        var seeded = await (Task<int>)
+            method.Invoke(sut, [matches, requestedAt.AddMinutes(1), CancellationToken.None])!;
+
+        seeded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id))
+            .Cusip.Should()
+            .BeNull();
+        (await verify.Set<CommonStockDelistedListing>().SingleAsync(row => row.Id == listing.Id))
+            .HistoricalCusipBackfillAmbiguous.Should()
+            .BeTrue();
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -121,7 +121,23 @@ public class YahooPriceImportServiceTests : IDisposable
     {
         _stockRepo.AddRange(stocks);
         await _stockRepo.SaveChanges();
+        foreach (var stock in stocks.Where(stock => !stock.Active && stock.DelistedOn != null))
+        {
+            _stockRepo.AddDelistedListing(
+                new CommonStockDelistedListing
+                {
+                    CommonStockId = stock.Id,
+                    ListedTicker = stock.Ticker,
+                    DelistedOn = stock.DelistedOn.Value,
+                    HistoricalPriceBackfillAttemptedAt = stock.HistoricalPriceBackfillAttemptedAt,
+                }
+            );
+        }
+        await _stockRepo.SaveChanges();
     }
+
+    private CommonStockDelistedListing GetDelistedListing(CommonStock stock) =>
+        _stockRepo.GetDelistedListings().Single(listing => listing.CommonStockId == stock.Id);
 
     [Fact]
     public async Task Import_InactiveListing_BackfillsOnlyThroughAuthoritativeDelistingDate()
@@ -158,11 +174,60 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _yahooClient.Received(1).GetChart("GONE", floor, delistedOn);
         var retained = _stockRepo.GetAllIncludingInactive().Single(row => row.Id == stock.Id);
-        retained.HistoricalPriceBackfillAttemptedAt.Should().NotBeNull();
+        GetDelistedListing(retained).HistoricalPriceBackfillAttemptedAt.Should().NotBeNull();
         retained.PriceHistoryBackfilledTickers.Should().Equal("GONE");
         _priceRepo
             .GetAllSeries()
             .Where(price => price.CommonStockId == stock.Id)
+            .Select(price => price.Date)
+            .Should()
+            .Equal(prices.Select(price => price.Date));
+    }
+
+    [Fact]
+    public async Task Import_DelistedSiblingOfActiveFiler_BackfillsItsExactSeriesAndCutoff()
+    {
+        var floor = new DateOnly(2023, 1, 1);
+        var delistedOn = new DateOnly(2023, 1, 10);
+        _workerOptions.MinSyncDate = floor.ToDateTime(TimeOnly.MinValue);
+        var stock = CreateStock("LIVE", "Still Listed Filer");
+        await SeedStocks(stock);
+        _stockRepo.AddDelistedListing(
+            new CommonStockDelistedListing
+            {
+                CommonStockId = stock.Id,
+                ListedTicker = "OLD",
+                DelistedOn = delistedOn,
+            }
+        );
+        await _stockRepo.SaveChanges();
+        var prices = Enumerable
+            .Range(0, delistedOn.DayNumber - floor.DayNumber + 1)
+            .Select(floor.AddDays)
+            .Where(UsMarketCalendar.IsTradingDay)
+            .Select(date => new HistoricalPrice
+            {
+                Date = date,
+                Open = 10m,
+                High = 11m,
+                Low = 9m,
+                Close = 10m,
+                AdjustedClose = 10m,
+                Volume = 1_000,
+            })
+            .ToList();
+        _yahooClient
+            .GetChart("OLD", floor, delistedOn)
+            .Returns(new YahooChartData { FirstTradeDate = floor, Prices = prices });
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        await _yahooClient.Received(1).GetChart("OLD", floor, delistedOn);
+        await _yahooClient.Received(1).GetChart("OLD", Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
+        stock.PriceHistoryBackfilledTickers.Should().Contain("OLD");
+        _priceRepo
+            .GetAllSeries()
+            .Where(price => price.CommonStockId == stock.Id && price.ListedTicker == "OLD")
             .Select(price => price.Date)
             .Should()
             .Equal(prices.Select(price => price.Date));
@@ -383,7 +448,7 @@ public class YahooPriceImportServiceTests : IDisposable
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
         var retained = _stockRepo.GetAllIncludingInactive().Single(row => row.Id == stock.Id);
-        retained.HistoricalPriceBackfillAttemptedAt.Should().NotBeNull();
+        GetDelistedListing(retained).HistoricalPriceBackfillAttemptedAt.Should().NotBeNull();
         retained.PriceHistoryBackfilledTickers.Should().BeEmpty();
     }
 
@@ -418,6 +483,7 @@ public class YahooPriceImportServiceTests : IDisposable
             {
                 stock.Active = true;
                 stock.DelistedOn = null;
+                _dbContext.Set<CommonStockDelistedListing>().Remove(GetDelistedListing(stock));
                 _dbContext.SaveChanges();
                 return new YahooChartData { FirstTradeDate = floor, Prices = prices };
             });

--- a/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/CorporateActionPriceReconciliationManagerStampingTests.cs
@@ -485,4 +485,36 @@ public class CorporateActionPriceReconciliationManagerStampingTests
         stamped.Should().Be(0);
         split.PriceAdjustmentAppliedTime.Should().BeNull();
     }
+
+    [Fact]
+    public async Task StampAppliedHistorical_ActiveFilerSibling_ValidatesExactListing()
+    {
+        await using var db = NewDb();
+        var stockId = Guid.NewGuid();
+        var delistedOn = new DateOnly(2026, 7, 31);
+        var stock = Stock(stockId, "LIVE");
+        var listing = new CommonStockDelistedListing
+        {
+            CommonStockId = stockId,
+            ListedTicker = "OLD",
+            DelistedOn = delistedOn,
+        };
+        var split = PendingSplit(stockId, new DateOnly(2026, 7, 15), "OLD");
+        db.AddRange(stock, listing, split);
+        await db.SaveChangesAsync();
+
+        var manager = NewManager(db);
+        var selected = (await manager.SelectPendingSeries(50, SettledBefore)).Series.Single();
+        var stamped = await manager.StampAppliedHistorical(
+            selected,
+            [],
+            delistedOn.AddDays(1),
+            DateTime.UtcNow,
+            listing.Id,
+            delistedOn
+        );
+
+        stamped.Should().Be(1);
+        split.PriceAdjustmentAppliedTime.Should().NotBeNull();
+    }
 }

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceHistoricalIdentityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceHistoricalIdentityTests.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Sec.HostedService.Services;
 using Xunit;
 
@@ -26,11 +27,11 @@ public class FtdImportServiceHistoricalIdentityTests
             new DateOnly(2020, 6, 30),
             map,
             [],
-            out var stockId
+            out var listingId
         );
 
         resolved.Should().BeTrue();
-        stockId.Should().Be(oldId);
+        listingId.Should().Be(oldId);
     }
 
     [Fact]
@@ -79,66 +80,60 @@ public class FtdImportServiceHistoricalIdentityTests
     [Fact]
     public void SelectCusips_DifferentValuesOnLatestDate_DropsStock()
     {
-        var stockId = Guid.NewGuid();
-        var stock = new Equibles.CommonStocks.Data.Models.CommonStock { Id = stockId };
+        var listingId = Guid.NewGuid();
+        var listing = new CommonStockDelistedListing { Id = listingId };
         FtdImportService.ApplyHistoricalCusipEvidence(
-            stock,
-            [new(stockId, "111111111", new DateOnly(2020, 6, 30))]
+            listing,
+            [new(listingId, "111111111", new DateOnly(2020, 6, 30))]
         );
         FtdImportService.ApplyHistoricalCusipEvidence(
-            stock,
-            [new(stockId, "222222222", new DateOnly(2020, 6, 30))]
+            listing,
+            [new(listingId, "222222222", new DateOnly(2020, 6, 30))]
         );
         FtdImportService.ApplyHistoricalCusipEvidence(
-            stock,
-            [new(stockId, "000000000", new DateOnly(2020, 6, 29))]
+            listing,
+            [new(listingId, "000000000", new DateOnly(2020, 6, 29))]
         );
 
-        stock.HistoricalCusipBackfillCandidates.Should().Equal("111111111", "222222222");
-        stock.HistoricalCusipBackfillAmbiguous.Should().BeTrue();
-        stock.HistoricalCusipBackfillCandidateOn.Should().Be(new DateOnly(2020, 6, 30));
+        listing.HistoricalCusipBackfillCandidates.Should().Equal("111111111", "222222222");
+        listing.HistoricalCusipBackfillAmbiguous.Should().BeTrue();
+        listing.HistoricalCusipBackfillCandidateOn.Should().Be(new DateOnly(2020, 6, 30));
     }
 
     [Fact]
     public void SelectCusips_SameValueClaimsMultipleStocks_DropsEveryOwner()
     {
-        var stocks = new[]
+        var listings = new[]
         {
-            new Equibles.CommonStocks.Data.Models.CommonStock
-            {
-                HistoricalCusipBackfillCandidates = ["111111111"],
-            },
-            new Equibles.CommonStocks.Data.Models.CommonStock
-            {
-                HistoricalCusipBackfillCandidates = ["111111111"],
-            },
+            new CommonStockDelistedListing { HistoricalCusipBackfillCandidates = ["111111111"] },
+            new CommonStockDelistedListing { HistoricalCusipBackfillCandidates = ["111111111"] },
         };
 
-        FtdImportService.RejectContestedHistoricalCusips(stocks);
+        FtdImportService.RejectContestedHistoricalCusips(listings);
 
-        stocks
+        listings
             .Should()
-            .OnlyContain(stock =>
-                stock.HistoricalCusipBackfillCandidates.Count == 1
-                && stock.HistoricalCusipBackfillCandidates[0] == "111111111"
+            .OnlyContain(listing =>
+                listing.HistoricalCusipBackfillCandidates.Count == 1
+                && listing.HistoricalCusipBackfillCandidates[0] == "111111111"
             );
-        stocks.Should().OnlyContain(stock => stock.HistoricalCusipBackfillAmbiguous);
+        listings.Should().OnlyContain(listing => listing.HistoricalCusipBackfillAmbiguous);
     }
 
     [Fact]
     public void SelectCusips_ContestedClaimFromEarlierBatch_RemainsVisibleToLaterOwner()
     {
-        var first = new Equibles.CommonStocks.Data.Models.CommonStock
+        var first = new CommonStockDelistedListing
         {
             HistoricalCusipBackfillCandidates = ["111111111"],
         };
-        var second = new Equibles.CommonStocks.Data.Models.CommonStock
+        var second = new CommonStockDelistedListing
         {
             HistoricalCusipBackfillCandidates = ["111111111"],
         };
         FtdImportService.RejectContestedHistoricalCusips([first, second]);
 
-        var later = new Equibles.CommonStocks.Data.Models.CommonStock
+        var later = new CommonStockDelistedListing
         {
             HistoricalCusipBackfillCandidates = ["111111111"],
         };
@@ -146,6 +141,6 @@ public class FtdImportServiceHistoricalIdentityTests
 
         new[] { first, second, later }
             .Should()
-            .OnlyContain(stock => stock.HistoricalCusipBackfillAmbiguous);
+            .OnlyContain(listing => listing.HistoricalCusipBackfillAmbiguous);
     }
 }


### PR DESCRIPTION
## Summary
- model every authoritative delisted common-stock symbol as an exact per-filer listing with its own cutoff and backfill state
- backfill Yahoo prices and SEC FTD CUSIPs per exact historical listing, including siblings of active filers
- exclude historical symbols from live ticker maps and serialize cutoff validation with row locks
- add generated migration with safe legacy backfill and rollback refusal for unrepresentable listing identity

## Verification
- `dotnet build Equibles.sln -c Release --no-restore`
- 4,605 unit tests passed
- 2,759 integration tests passed
- CSharpier formatted 3,439 files
- independent review clean