### PR TITLE
fix(migrations): guard delisted listing downgrade

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260824012336_AddDelistedCommonStockListings.cs
+++ b/src/Equibles.Migrations/Migrations/20260824012336_AddDelistedCommonStockListings.cs
@@ -97,8 +97,14 @@ namespace Equibles.Migrations.Migrations
                            OR listing."ListedTicker" <> stock."Ticker"
                            OR listing."DelistedOn" IS DISTINCT FROM stock."DelistedOn"
                            OR listing."Cusip" IS DISTINCT FROM stock."Cusip")
+                       OR EXISTS (
+                        SELECT 1
+                        FROM "CommonStock"
+                        WHERE "Ticker" IS NOT NULL
+                        GROUP BY "Ticker"
+                        HAVING COUNT(*) > 1)
                     THEN
-                        RAISE EXCEPTION 'cannot remove per-listing delisting history: exact listing identity would be lost';
+                        RAISE EXCEPTION 'cannot remove per-listing delisting history: exact listing identity or ticker-reuse protection would be lost';
                     END IF;
                 END $$;
 


### PR DESCRIPTION
## Summary
- refuse the per-listing downgrade before exact state is dropped when non-null ticker reuse prevents the following global-uniqueness downgrade
- preserve PostgreSQL NULLS DISTINCT behavior for nullable ticker rows

## Verification
- Release build: Equibles.Migrations
- git diff --check
- independent review: clean

Follow-up to #4449.