### PR TITLE
fix(holdings): exclude inactive stocks from live activity

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -77,7 +77,7 @@ public class CommonStockManager
             || listing.CommonStockId != stock.Id
             || listing.Cusip != null
             || settlementDate > listing.DelistedOn
-            || listing.HistoricalCusipBackfillSweepStartedAt != sweepStartedAt
+            || !SamePostgresTimestamp(listing.HistoricalCusipBackfillSweepStartedAt, sweepStartedAt)
             || listing.HistoricalCusipBackfillCandidateOn != settlementDate
             || listing.HistoricalCusipBackfillAmbiguous
             || listing.HistoricalCusipBackfillCandidates.Count != 1
@@ -191,6 +191,9 @@ public class CommonStockManager
 
         return DelistedListingCusipSeedResult.Seeded;
     }
+
+    private static bool SamePostgresTimestamp(DateTime? persisted, DateTime expected) =>
+        persisted.HasValue && persisted.Value.Ticks / 10 == expected.Ticks / 10;
 
     /// <summary>
     /// Records CUSIPs a stock USED to trade under, without touching its current one.

--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -8,6 +8,14 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.CommonStocks.BusinessLogic;
 
+public enum DelistedListingCusipSeedResult
+{
+    Skipped,
+    Seeded,
+    Ambiguous,
+    ClaimedByAnotherStock,
+}
+
 [Service]
 public class CommonStockManager
 {
@@ -18,6 +26,170 @@ public class CommonStockManager
     {
         _commonStockRepository = commonStockRepository;
         _bus = bus;
+    }
+
+    /// <summary>
+    /// Finalizes an authoritative historical CUSIP for one retained listed identity.
+    /// The stock row is locked before the listing row so company-sync reactivation and
+    /// historical-identity finalization cannot interleave. The listing cutoff and request
+    /// checkpoint are revalidated under those locks before any identity is written.
+    /// </summary>
+    public async Task<DelistedListingCusipSeedResult> SeedDelistedListingCusip(
+        Guid listingId,
+        string cusip,
+        DateOnly settlementDate,
+        DateTime sweepStartedAt,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var normalizedCusip = cusip?.Trim().ToUpperInvariant();
+        if (string.IsNullOrWhiteSpace(normalizedCusip))
+        {
+            return DelistedListingCusipSeedResult.Skipped;
+        }
+
+        await using var transaction = await _commonStockRepository.BeginCusipIdentityWrite(
+            cancellationToken
+        );
+        var stockId = await _commonStockRepository
+            .GetDelistedListings()
+            .AsNoTracking()
+            .Where(listing => listing.Id == listingId)
+            .Select(listing => (Guid?)listing.CommonStockId)
+            .SingleOrDefaultAsync(cancellationToken);
+        if (stockId == null)
+        {
+            return DelistedListingCusipSeedResult.Skipped;
+        }
+
+        var stock = await _commonStockRepository.GetForUpdate(stockId.Value, cancellationToken);
+        if (stock == null)
+        {
+            return DelistedListingCusipSeedResult.Skipped;
+        }
+
+        var listing = await _commonStockRepository.GetDelistedListingForUpdate(
+            listingId,
+            cancellationToken
+        );
+        if (
+            listing == null
+            || listing.CommonStockId != stock.Id
+            || listing.Cusip != null
+            || settlementDate > listing.DelistedOn
+            || listing.HistoricalCusipBackfillSweepStartedAt != sweepStartedAt
+            || listing.HistoricalCusipBackfillCandidateOn != settlementDate
+            || listing.HistoricalCusipBackfillAmbiguous
+            || listing.HistoricalCusipBackfillCandidates.Count != 1
+            || !string.Equals(
+                listing.HistoricalCusipBackfillCandidates[0],
+                normalizedCusip,
+                StringComparison.OrdinalIgnoreCase
+            )
+            || (
+                listing.HistoricalCusipBackfillRequestedAt != null
+                && listing.HistoricalCusipBackfillRequestedAt > sweepStartedAt
+            )
+        )
+        {
+            return DelistedListingCusipSeedResult.Skipped;
+        }
+
+        var primaryClaims = await _commonStockRepository
+            .GetAllIncludingInactive()
+            .Where(candidate =>
+                candidate.Cusip != null && candidate.Cusip.ToUpper() == normalizedCusip
+            )
+            .Select(candidate => candidate.Id)
+            .ToListAsync(cancellationToken);
+        var aliasClaims = await _commonStockRepository
+            .GetCusipAliases()
+            .Where(alias => alias.Cusip.ToUpper() == normalizedCusip)
+            .Select(alias => alias.CommonStockId)
+            .ToListAsync(cancellationToken);
+        var listedClaims = await _commonStockRepository
+            .GetListedCusips()
+            .Where(candidate => candidate.Cusip.ToUpper() == normalizedCusip)
+            .Select(candidate => new { candidate.CommonStockId, candidate.ListedTicker })
+            .ToListAsync(cancellationToken);
+        if (
+            primaryClaims.Any(ownerId => ownerId != stock.Id)
+            || aliasClaims.Any(ownerId => ownerId != stock.Id)
+            || listedClaims.Any(candidate => candidate.CommonStockId != stock.Id)
+        )
+        {
+            return DelistedListingCusipSeedResult.ClaimedByAnotherStock;
+        }
+
+        var isPrimary = string.Equals(
+            listing.ListedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
+        );
+        var exactListedClaim = listedClaims.FirstOrDefault(candidate =>
+            candidate.CommonStockId == stock.Id
+            && string.Equals(
+                candidate.ListedTicker,
+                listing.ListedTicker,
+                StringComparison.OrdinalIgnoreCase
+            )
+        );
+        if (
+            aliasClaims.Count > 0
+            || (isPrimary && listedClaims.Count > 0)
+            || (!isPrimary && primaryClaims.Count > 0)
+            || (!isPrimary && listedClaims.Count > 0 && exactListedClaim == null)
+            || (
+                isPrimary
+                && stock.Cusip != null
+                && !string.Equals(stock.Cusip, normalizedCusip, StringComparison.OrdinalIgnoreCase)
+            )
+        )
+        {
+            listing.HistoricalCusipBackfillAmbiguous = true;
+            await _commonStockRepository.SaveChanges();
+            if (transaction != null)
+            {
+                await transaction.CommitAsync(cancellationToken);
+            }
+            return DelistedListingCusipSeedResult.Ambiguous;
+        }
+
+        var identityAdded = false;
+        if (isPrimary && stock.Cusip == null)
+        {
+            stock.Cusip = normalizedCusip;
+            identityAdded = true;
+        }
+        else if (!isPrimary && exactListedClaim == null)
+        {
+            _commonStockRepository.AddListedCusip(
+                new CommonStockListedCusip
+                {
+                    CommonStockId = stock.Id,
+                    ListedTicker = listing.ListedTicker,
+                    Cusip = normalizedCusip,
+                }
+            );
+            identityAdded = true;
+        }
+
+        listing.Cusip = normalizedCusip;
+        await _commonStockRepository.SaveChanges();
+        if (transaction != null)
+        {
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        if (identityAdded)
+        {
+            await _bus.Publish(
+                new StockCusipChanged(stock.Id, stock.Ticker, null, stock.Cusip),
+                cancellationToken
+            );
+        }
+
+        return DelistedListingCusipSeedResult.Seeded;
     }
 
     /// <summary>
@@ -62,6 +234,7 @@ public class CommonStockManager
             return 0;
         }
 
+        await using var transaction = await _commonStockRepository.BeginCusipIdentityWrite();
         var alreadyRecorded = await _commonStockRepository
             .GetCusipAliases()
             .Where(a => candidates.Contains(a.Cusip.ToUpper()))
@@ -101,6 +274,10 @@ public class CommonStockManager
         }
 
         await _commonStockRepository.SaveChanges();
+        if (transaction != null)
+        {
+            await transaction.CommitAsync();
+        }
 
         // Root bus, after the write commits — same reasoning as SetCusip: this flow only
         // saves the financial context, so a bus outbox on another context would capture
@@ -182,6 +359,7 @@ public class CommonStockManager
             return 0;
         }
 
+        await using var transaction = await _commonStockRepository.BeginCusipIdentityWrite();
         var candidateCusips = cleaned.Select(c => c.Cusip).ToList();
         var taken = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         taken.UnionWith(
@@ -226,6 +404,10 @@ public class CommonStockManager
         }
 
         await _commonStockRepository.SaveChanges();
+        if (transaction != null)
+        {
+            await transaction.CommitAsync();
+        }
 
         // Root bus, after the write commits — same reasoning as SetCusip: this flow only
         // saves the financial context, so a bus outbox on another context would capture
@@ -274,6 +456,26 @@ public class CommonStockManager
         }
 
         var previousCusip = commonStock.Cusip;
+        var normalizedCusip = cusip?.Trim().ToUpperInvariant();
+        await using var transaction = await _commonStockRepository.BeginCusipIdentityWrite();
+
+        var claimedByAnotherPrimary = await _commonStockRepository
+            .GetAllIncludingInactive()
+            .AnyAsync(stock =>
+                stock.Id != commonStock.Id
+                && stock.Cusip != null
+                && stock.Cusip.ToUpper() == normalizedCusip
+            );
+        var claimedAsAlias = await _commonStockRepository
+            .GetCusipAliases()
+            .AnyAsync(alias => alias.Cusip.ToUpper() == normalizedCusip);
+        var claimedAsListing = await _commonStockRepository
+            .GetListedCusips()
+            .AnyAsync(listing => listing.Cusip.ToUpper() == normalizedCusip);
+        if (claimedByAnotherPrimary || claimedAsAlias || claimedAsListing)
+        {
+            return;
+        }
 
         // The alias table enforces one CUSIP → one stock, ever (global unique
         // index): a retired CUSIP already recorded — even for another stock —
@@ -296,6 +498,10 @@ public class CommonStockManager
         commonStock.Cusip = cusip;
 
         await _commonStockRepository.SaveChanges();
+        if (transaction != null)
+        {
+            await transaction.CommitAsync();
+        }
 
         // Publish via the root bus (bypasses any bus outbox) after the write commits.
         await _bus.Publish(

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -1,11 +1,16 @@
+using System.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Equibles.CommonStocks.Repositories;
 
 public class CommonStockRepository : BaseRepository<CommonStock>
 {
+    private const string CusipIdentityWriteLockSql =
+        "SELECT pg_advisory_xact_lock(1163282519, 7456)";
+
     public CommonStockRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
 
@@ -17,6 +22,34 @@ public class CommonStockRepository : BaseRepository<CommonStock>
         GetAllIncludingInactive().Where(stock => stock.Active);
 
     public IQueryable<CommonStock> GetAllIncludingInactive() => base.GetAll();
+
+    /// <summary>
+    /// Serializes the rare cross-table CUSIP identity writes. PostgreSQL cannot express one
+    /// unique constraint across CommonStock, CommonStockCusipAlias and CommonStockListedCusip,
+    /// so every writer takes this transaction-scoped database lock before checking ownership.
+    /// Returns the transaction when this call created it; callers commit only that transaction.
+    /// </summary>
+    public async Task<IDbContextTransaction> BeginCusipIdentityWrite(
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (!DbContext.Database.IsRelational())
+        {
+            return null;
+        }
+
+        IDbContextTransaction ownedTransaction = null;
+        if (DbContext.Database.CurrentTransaction == null)
+        {
+            ownedTransaction = await DbContext.Database.BeginTransactionAsync(
+                IsolationLevel.ReadCommitted,
+                cancellationToken
+            );
+        }
+
+        await DbContext.Database.ExecuteSqlRawAsync(CusipIdentityWriteLockSql, cancellationToken);
+        return ownedTransaction;
+    }
 
     public override async Task<CommonStock> Get(params object[] key)
     {

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -693,6 +693,7 @@ public class HoldingsAggregateRefreshService
             .Where(h =>
                 (h.ReportDate == reportDate || h.ReportDate == previousReportDate)
                 && h.FilingType == FilingType.Form13F
+                && h.CommonStock.Active
             )
             .GroupBy(h => h.CommonStockId)
             .Select(g => new
@@ -723,12 +724,13 @@ public class HoldingsAggregateRefreshService
                 dbContext.Set<CommonStock>(),
                 holding => holding.CommonStockId,
                 stock => stock.Id,
-                (holding, stock) => new { Holding = holding, stock.Ticker }
+                (holding, stock) => new { Holding = holding, Stock = stock }
             )
+            .Where(row => row.Stock.Active)
             .GroupBy(row => new
             {
                 row.Holding.CommonStockId,
-                PriceSeriesTicker = row.Holding.ListedTicker ?? row.Ticker,
+                PriceSeriesTicker = row.Holding.ListedTicker ?? row.Stock.Ticker,
             })
             .Select(group => new
             {
@@ -881,6 +883,7 @@ public class HoldingsAggregateRefreshService
             .Where(h =>
                 (h.ReportDate == reportDate || h.ReportDate == previousReportDate)
                 && h.FilingType == FilingType.Form13F
+                && h.CommonStock.Active
             )
             .GroupBy(h => new { h.CommonStockId, h.InstitutionalHolderId })
             .Select(g => new

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1245,9 +1245,13 @@ public class InstitutionalHoldingsTools
             }
         );
 
+        var activeIds = await GetActiveStockIds(cached.Select(row => row.CommonStockId));
         // Split restatement mutates the returned rows. Keep the cached source pristine so a
         // second request cannot compound the adjustment applied by the first request.
-        return cached.Select(CloneActivity).ToList();
+        return cached
+            .Where(row => activeIds.Contains(row.CommonStockId))
+            .Select(CloneActivity)
+            .ToList();
     }
 
     // Churn twin of LoadMarketActivity — same lanes, same empty-snapshot fallback.
@@ -1289,7 +1293,25 @@ public class InstitutionalHoldingsTools
             }
         );
 
-        return cached.Select(CloneChurn).ToList();
+        var activeIds = await GetActiveStockIds(cached.Select(row => row.CommonStockId));
+        return cached
+            .Where(row => activeIds.Contains(row.CommonStockId))
+            .Select(CloneChurn)
+            .ToList();
+    }
+
+    private async Task<HashSet<Guid>> GetActiveStockIds(IEnumerable<Guid> stockIds)
+    {
+        var ids = stockIds.Distinct().ToList();
+        if (ids.Count == 0)
+        {
+            return [];
+        }
+
+        return await _commonStockRepository
+            .GetByIds(ids)
+            .Select(stock => stock.Id)
+            .ToHashSetAsync();
     }
 
     // Only resolved 13F quarter dates reach this key builder, so the process-wide lock set grows

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -558,6 +558,7 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         ExtendCommandTimeoutForMarketWideAggregates();
         return GetAll()
             .Where(Is13F)
+            .Where(holding => holding.CommonStock.Active)
             .Where(h => h.ReportDate == current || h.ReportDate == previous);
     }
 
@@ -726,7 +727,14 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     // HoldingsAggregateRefreshService. The conviction heat map reads this instead
     // of deriving GetQuarterlyActivity + GetQuarterlyNewSoldOutPositions live.
     public IQueryable<StockQuarterlyActivity> GetStockActivitySnapshots(DateOnly reportDate) =>
-        DbContext.Set<StockQuarterlyActivity>().Where(s => s.ReportDate == reportDate);
+        DbContext
+            .Set<StockQuarterlyActivity>()
+            .Where(snapshot =>
+                snapshot.ReportDate == reportDate
+                && DbContext
+                    .Set<CommonStock>()
+                    .Any(stock => stock.Id == snapshot.CommonStockId && stock.Active)
+            );
 
     public IQueryable<StockQuarterlyActivity> GetStockActivitySnapshotsByStock(CommonStock stock) =>
         DbContext.Set<StockQuarterlyActivity>().Where(s => s.CommonStockId == stock.Id);
@@ -1039,7 +1047,15 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     // when no rows match.
     public IQueryable<StockQuarterlyActivityCombined> GetStockActivitySnapshotsCombined(
         DateOnly reportDate
-    ) => DbContext.Set<StockQuarterlyActivityCombined>().Where(s => s.ReportDate == reportDate);
+    ) =>
+        DbContext
+            .Set<StockQuarterlyActivityCombined>()
+            .Where(snapshot =>
+                snapshot.ReportDate == reportDate
+                && DbContext
+                    .Set<CommonStock>()
+                    .Any(stock => stock.Id == snapshot.CommonStockId && stock.Active)
+            );
 
     public IQueryable<StockQuarterlyListingActivity> GetStockListingActivitySnapshots(
         DateOnly reportDate,
@@ -1742,6 +1758,7 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     {
         return GetAll()
             .Where(Is13F)
+            .Where(holding => holding.CommonStock.Active)
             .Where(h =>
                 h.ReportDate == current
                 || (

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -708,159 +708,30 @@ public class FtdImportService
         }
 
         using var scope = _scopeFactory.CreateScope();
-        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var stockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
-        var listings = await stockRepo
-            .GetDelistedListings()
-            .Include(listing => listing.CommonStock)
-            .Where(listing =>
-                latestByListing.Keys.Contains(listing.Id)
-                && listing.Cusip == null
-                && (
-                    listing.HistoricalCusipBackfillRequestedAt == null
-                    || listing.HistoricalCusipBackfillRequestedAt <= sweepStartedAt
-                )
-            )
-            .ToListAsync(cancellationToken);
-
-        var candidates = latestByListing
-            .Values.Select(value => value.Cusip)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        var claims = new Dictionary<string, HashSet<Guid>>(StringComparer.OrdinalIgnoreCase);
-        void AddClaim(string cusip, Guid ownerId)
-        {
-            if (!claims.TryGetValue(cusip, out var owners))
-            {
-                owners = [];
-                claims[cusip] = owners;
-            }
-            owners.Add(ownerId);
-        }
-
-        var primaryClaims = await stockRepo
-            .GetAllIncludingInactive()
-            .Where(stock => stock.Cusip != null && candidates.Contains(stock.Cusip))
-            .Select(stock => new { stock.Id, stock.Cusip })
-            .ToListAsync(cancellationToken);
-        foreach (var claim in primaryClaims)
-        {
-            AddClaim(claim.Cusip, claim.Id);
-        }
-
-        var aliasClaims = await stockRepo
-            .GetCusipAliases()
-            .Where(alias => candidates.Contains(alias.Cusip))
-            .Select(alias => new { alias.CommonStockId, alias.Cusip })
-            .ToListAsync(cancellationToken);
-        foreach (var claim in aliasClaims)
-        {
-            AddClaim(claim.Cusip, claim.CommonStockId);
-        }
-
-        var listedClaims = await stockRepo
-            .GetListedCusips()
-            .Where(listing => candidates.Contains(listing.Cusip))
-            .Select(listing => new
-            {
-                listing.CommonStockId,
-                listing.ListedTicker,
-                listing.Cusip,
-            })
-            .ToListAsync(cancellationToken);
-        foreach (var claim in listedClaims)
-        {
-            AddClaim(claim.Cusip, claim.CommonStockId);
-        }
-
         var seeded = 0;
-        foreach (var listing in listings)
+        foreach (var candidate in latestByListing.OrderBy(candidate => candidate.Key))
         {
-            var stock = listing.CommonStock;
-            var resolved = latestByListing[listing.Id];
-            var isPrimary = string.Equals(
-                listing.ListedTicker,
-                stock.Ticker,
-                StringComparison.OrdinalIgnoreCase
+            var result = await stockManager.SeedDelistedListingCusip(
+                candidate.Key,
+                candidate.Value.Cusip,
+                candidate.Value.SettlementDate,
+                sweepStartedAt,
+                cancellationToken
             );
-            var aliasAlreadyClaimsCusip = aliasClaims.Any(claim =>
-                string.Equals(claim.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase)
-            );
-            var listedClaimsForCusip = listedClaims
-                .Where(claim =>
-                    string.Equals(claim.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase)
-                )
-                .ToList();
-            var exactListedClaim = listedClaims.FirstOrDefault(claim =>
-                claim.CommonStockId == stock.Id
-                && string.Equals(
-                    claim.ListedTicker,
-                    listing.ListedTicker,
-                    StringComparison.OrdinalIgnoreCase
-                )
-                && string.Equals(claim.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase)
-            );
-            if (
-                claims.TryGetValue(resolved.Cusip, out var owners)
-                && owners.Any(ownerId => ownerId != stock.Id)
-            )
+            if (result == DelistedListingCusipSeedResult.ClaimedByAnotherStock)
             {
                 _logger.LogWarning(
-                    "Inactive FTD identity {Ticker} resolved to CUSIP {Cusip}, but that CUSIP is already claimed by another stock — skipping",
-                    listing.ListedTicker,
-                    resolved.Cusip
+                    "Inactive FTD listing {ListingId} resolved to CUSIP {Cusip}, but that CUSIP is already claimed by another stock — skipping",
+                    candidate.Key,
+                    candidate.Value.Cusip
                 );
-                continue;
             }
-            if (
-                aliasAlreadyClaimsCusip
-                || (isPrimary && listedClaimsForCusip.Count > 0)
-                || (!isPrimary && listedClaimsForCusip.Count > 0 && exactListedClaim == null)
-            )
+            if (result == DelistedListingCusipSeedResult.Seeded)
             {
-                listing.HistoricalCusipBackfillAmbiguous = true;
-                continue;
+                seeded++;
             }
-
-            if (isPrimary)
-            {
-                if (
-                    stock.Cusip != null
-                    && !string.Equals(
-                        stock.Cusip,
-                        resolved.Cusip,
-                        StringComparison.OrdinalIgnoreCase
-                    )
-                )
-                {
-                    listing.HistoricalCusipBackfillAmbiguous = true;
-                    continue;
-                }
-                if (stock.Cusip == null)
-                {
-                    await stockManager.SetCusip(stock, resolved.Cusip);
-                }
-            }
-            else if (exactListedClaim == null)
-            {
-                var recorded = await stockManager.RecordListedTickerCusips(
-                    stock,
-                    [(listing.ListedTicker, resolved.Cusip)],
-                    [listing.ListedTicker]
-                );
-                if (recorded == 0)
-                {
-                    listing.HistoricalCusipBackfillAmbiguous = true;
-                    continue;
-                }
-            }
-
-            listing.Cusip = resolved.Cusip;
-            AddClaim(resolved.Cusip, stock.Id);
-            seeded++;
         }
-
-        await stockRepo.SaveChanges();
 
         return seeded;
     }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceCombinedLaneTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceCombinedLaneTests.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models.Taxonomies;
 using Equibles.CorporateActions.Data.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -171,6 +172,59 @@ public class HoldingsAggregateRefreshServiceCombinedLaneTests : IAsyncLifetime
         row.PreviousShares.Should().Be(1_500);
         listing.CurrentShares.Should().Be(2_200);
         listing.PreviousShares.Should().Be(1_500);
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_WindowOpen_ExcludesInactiveStocksAtReadAndGeneration()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var active = await SeedStock(seed, "LIVE", industry);
+        var inactive = await SeedStock(seed, "GONE", industry);
+        var holder = await SeedHolder(seed, "H020");
+        seed.AddRange(
+            MakeHolding(active, holder, OpenPrev, 100_000, "live-prev"),
+            MakeHolding(active, holder, OpenCur, 120_000, "live-cur"),
+            MakeHolding(inactive, holder, OpenPrev, 900_000, "gone-prev"),
+            MakeHolding(inactive, holder, OpenCur, 950_000, "gone-cur")
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(OpenCur, CancellationToken.None);
+
+        await using (var deactivate = FreshContext())
+        {
+            var persisted = await deactivate
+                .Set<CommonStock>()
+                .SingleAsync(row => row.Id == inactive.Id);
+            persisted.Active = false;
+            persisted.DelistedOn = OpenCur;
+            await deactivate.SaveChangesAsync();
+        }
+
+        await using (var staleRead = FreshContext())
+        {
+            (await staleRead.Set<StockQuarterlyActivityCombined>().CountAsync())
+                .Should()
+                .Be(2, "the materialized generation predates the directory change");
+            var repository = new InstitutionalHoldingRepository(staleRead);
+            var visible = await repository.GetMarketActivitySnapshots(OpenCur, true);
+            visible.Should().ContainSingle(row => row.CommonStockId == active.Id);
+            visible.Should().NotContain(row => row.CommonStockId == inactive.Id);
+        }
+
+        await BuildService().RebuildQuarterAsync(OpenCur, CancellationToken.None);
+
+        await using var rebuilt = FreshContext();
+        var rows = await rebuilt.Set<StockQuarterlyActivityCombined>().ToListAsync();
+        rows.Should().ContainSingle(row => row.CommonStockId == active.Id);
+        rows.Should().NotContain(row => row.CommonStockId == inactive.Id);
+        var listings = await rebuilt
+            .Set<StockQuarterlyListingActivity>()
+            .Where(row => row.IsCombined)
+            .ToListAsync();
+        listings.Should().ContainSingle(row => row.CommonStockId == active.Id);
+        listings.Should().NotContain(row => row.CommonStockId == inactive.Id);
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceStockActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceStockActivityTests.cs
@@ -2,6 +2,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Models.Taxonomies;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -163,6 +164,67 @@ public class HoldingsAggregateRefreshServiceStockActivityTests : IAsyncLifetime
                 && row.PreviousShares == 10
             );
         rows.Should().OnlyContain(row => !row.IsCombined);
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_ExcludesInactiveStocksFromLiveActivitySnapshots()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var active = await SeedStock(seed, "LIVE", industry);
+        var inactive = await SeedStock(seed, "GONE", industry);
+        inactive.Active = false;
+        inactive.DelistedOn = QCur.AddDays(-1);
+        var holder = await SeedHolder(seed, "H001");
+        seed.AddRange(
+            MakeHolding(active, holder, QCur, 100_000, "live-cur"),
+            MakeHolding(inactive, holder, QCur, 900_000, "gone-cur")
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(QCur, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var activity = await read.Set<StockQuarterlyActivity>()
+            .Where(row => row.ReportDate == QCur)
+            .ToListAsync();
+        activity.Should().ContainSingle(row => row.CommonStockId == active.Id);
+        activity.Should().NotContain(row => row.CommonStockId == inactive.Id);
+
+        var listingActivity = await read.Set<StockQuarterlyListingActivity>()
+            .Where(row => row.ReportDate == QCur && !row.IsCombined)
+            .ToListAsync();
+        listingActivity.Should().ContainSingle(row => row.CommonStockId == active.Id);
+        listingActivity.Should().NotContain(row => row.CommonStockId == inactive.Id);
+    }
+
+    [Fact]
+    public async Task MarketActivityRead_ExcludesStockDeactivatedAfterSnapshotGeneration()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var stock = await SeedStock(seed, "GONE", industry);
+        var holder = await SeedHolder(seed, "H001");
+        seed.Add(MakeHolding(stock, holder, QCur, 100_000, "gone-cur"));
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(QCur, CancellationToken.None);
+
+        await using (var deactivate = FreshContext())
+        {
+            var persisted = await deactivate
+                .Set<CommonStock>()
+                .SingleAsync(row => row.Id == stock.Id);
+            persisted.Active = false;
+            persisted.DelistedOn = QCur.AddDays(1);
+            await deactivate.SaveChangesAsync();
+        }
+
+        await using var read = FreshContext();
+        var repository = new InstitutionalHoldingRepository(read);
+        (await repository.GetMarketActivitySnapshots(QCur, false))
+            .Should()
+            .BeEmpty("inactive stocks must disappear before an aggregate rebuild catches up");
     }
 
     private static async Task<Guid> SeedTaxonomy(Equibles.Data.EquiblesFinancialDbContext ctx)

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsMarketActivityCacheTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsMarketActivityCacheTests.cs
@@ -96,6 +96,75 @@ public class InstitutionalHoldingsToolsMarketActivityCacheTests : ParadeDbMcpTes
     }
 
     [Fact]
+    public async Task GetMarketWide13FActivity_CachedQuarterRefiltersDeactivatedStock()
+    {
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var stock = new CommonStock
+        {
+            Ticker = "GONE",
+            Name = "Formerly Listed Inc.",
+            Cik = "C-DELISTED",
+        };
+        var holder = new InstitutionalHolder { Cik = "H-DELISTED", Name = "Test Filer" };
+        DbContext.AddRange(stock, holder);
+        var computedAt = DateTime.UtcNow;
+        DbContext.AddRange(
+            MakeHolding(stock, holder, prior, shares: 100, value: 100_000),
+            MakeHolding(stock, holder, current, shares: 200, value: 200_000),
+            new StockQuarterlyActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = current,
+                PreviousReportDate = prior,
+                CurrentShares = 200,
+                PreviousShares = 100,
+                CurrentValue = 200_000,
+                PreviousValue = 100_000,
+                CurrentFilerCount = 1,
+                PreviousFilerCount = 1,
+                ComputedAt = computedAt,
+            },
+            new StockQuarterlyListingActivity
+            {
+                CommonStockId = stock.Id,
+                ReportDate = current,
+                PriceSeriesTicker = stock.Ticker,
+                CurrentShares = 200,
+                PreviousShares = 100,
+                ComputedAt = computedAt,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using var read = Fixture.CreateDbContext();
+        var sut = BuildTool(read, cache);
+        var active = await sut.GetMarketWide13FActivity(
+            bucket: "top-buys",
+            reportDate: "2024-12-31"
+        );
+        active.Should().Contain("GONE");
+
+        await using (var update = Fixture.CreateDbContext())
+        {
+            var deactivated = await update
+                .Set<CommonStock>()
+                .SingleAsync(row => row.Id == stock.Id);
+            deactivated.Active = false;
+            await update.SaveChangesAsync();
+        }
+
+        var inactive = await sut.GetMarketWide13FActivity(
+            bucket: "top-buys",
+            reportDate: "2024-12-31"
+        );
+        inactive.Should().NotContain("GONE");
+        inactive.Should().NotContain("Unknown");
+    }
+
+    [Fact]
     public async Task GetMarketWide13FActivity_DirtyQuarterReadsSnapshotWithoutCachingIt()
     {
         var prior = new DateOnly(2024, 9, 30);

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
@@ -180,6 +180,8 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             DelistedOn = stock.DelistedOn.Value,
             HistoricalCusipBackfillRequestedAt = stock.HistoricalCusipBackfillRequestedAt,
         };
+        var sweepStartedAt = stock.HistoricalCusipBackfillRequestedAt!.Value.AddMinutes(1);
+        StageHistoricalCusip(listing, "123456789", listing.DelistedOn, sweepStartedAt);
         await using (var seed = _fixture.CreateDbContext())
         {
             seed.Set<CommonStock>().Add(stock);
@@ -223,14 +225,7 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             BindingFlags.NonPublic | BindingFlags.Instance
         )!;
         var seeded = await (Task<int>)
-            seedInactive.Invoke(
-                sut,
-                [
-                    matches,
-                    stock.HistoricalCusipBackfillRequestedAt!.Value.AddMinutes(1),
-                    CancellationToken.None,
-                ]
-            )!;
+            seedInactive.Invoke(sut, [matches, sweepStartedAt, CancellationToken.None])!;
 
         seeded.Should().Be(1);
         using var verify = FreshContext();
@@ -268,6 +263,8 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             DelistedOn = stock.DelistedOn.Value,
             HistoricalCusipBackfillRequestedAt = requestedAt,
         };
+        var sweepStartedAt = requestedAt.AddMinutes(-1);
+        StageHistoricalCusip(listing, "123456789", listing.DelistedOn, sweepStartedAt);
         await using (var seed = _fixture.CreateDbContext())
         {
             seed.Set<CommonStock>().Add(stock);
@@ -287,11 +284,66 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
         )!;
 
         var seeded = await (Task<int>)
-            method.Invoke(sut, [matches, requestedAt.AddMinutes(-1), CancellationToken.None])!;
+            method.Invoke(sut, [matches, sweepStartedAt, CancellationToken.None])!;
 
         seeded.Should().Be(0);
         using var verify = FreshContext();
         (await verify.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id))
+            .Cusip.Should()
+            .BeNull();
+        await bus.DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedInactiveCusips_MatchAfterCurrentDelistingCutoff_IsRejected()
+    {
+        var requestedAt = DateTime.UtcNow;
+        var stock = new CommonStock
+        {
+            Ticker = "GONE",
+            Name = "Formerly Listed Corp",
+            Cik = "0000000042",
+            Active = false,
+            DelistedOn = new DateOnly(2020, 6, 30),
+            HistoricalCusipBackfillRequestedAt = requestedAt,
+        };
+        var listing = new CommonStockDelistedListing
+        {
+            CommonStockId = stock.Id,
+            ListedTicker = stock.Ticker,
+            DelistedOn = stock.DelistedOn.Value,
+            HistoricalCusipBackfillRequestedAt = requestedAt,
+        };
+        var sweepStartedAt = requestedAt.AddMinutes(1);
+        StageHistoricalCusip(listing, "123456789", listing.DelistedOn.AddDays(1), sweepStartedAt);
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockDelistedListing>().Add(listing);
+            await seed.SaveChangesAsync();
+        }
+
+        var bus = Substitute.For<IBus>();
+        var sut = CreateSut(bus);
+        var matches = new Dictionary<Guid, (string Cusip, DateOnly SettlementDate)>
+        {
+            [listing.Id] = ("123456789", listing.DelistedOn.AddDays(1)),
+        };
+        var method = typeof(FtdImportService).GetMethod(
+            "SeedInactiveCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+
+        var seeded = await (Task<int>)
+            method.Invoke(sut, [matches, sweepStartedAt, CancellationToken.None])!;
+
+        seeded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id))
+            .Cusip.Should()
+            .BeNull();
+        (await verify.Set<CommonStockDelistedListing>().SingleAsync(row => row.Id == listing.Id))
             .Cusip.Should()
             .BeNull();
         await bus.DidNotReceive()
@@ -316,6 +368,8 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             DelistedOn = new DateOnly(2020, 6, 30),
             HistoricalCusipBackfillRequestedAt = requestedAt,
         };
+        var sweepStartedAt = requestedAt.AddMinutes(1);
+        StageHistoricalCusip(listing, "222222222", listing.DelistedOn, sweepStartedAt);
         await using (var seed = _fixture.CreateDbContext())
         {
             seed.Set<CommonStock>().Add(stock);
@@ -335,7 +389,7 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
         };
 
         var seeded = await (Task<int>)
-            method.Invoke(sut, [matches, requestedAt.AddMinutes(1), CancellationToken.None])!;
+            method.Invoke(sut, [matches, sweepStartedAt, CancellationToken.None])!;
 
         seeded.Should().Be(1);
         using var verify = FreshContext();
@@ -367,6 +421,8 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             DelistedOn = stock.DelistedOn.Value,
             HistoricalCusipBackfillRequestedAt = requestedAt,
         };
+        var sweepStartedAt = requestedAt.AddMinutes(1);
+        StageHistoricalCusip(listing, "222222222", listing.DelistedOn, sweepStartedAt);
         await using (var seed = _fixture.CreateDbContext())
         {
             seed.Set<CommonStock>().Add(stock);
@@ -394,7 +450,7 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
         };
 
         var seeded = await (Task<int>)
-            method.Invoke(sut, [matches, requestedAt.AddMinutes(1), CancellationToken.None])!;
+            method.Invoke(sut, [matches, sweepStartedAt, CancellationToken.None])!;
 
         seeded.Should().Be(0);
         using var verify = FreshContext();
@@ -404,6 +460,124 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
         (await verify.Set<CommonStockDelistedListing>().SingleAsync(row => row.Id == listing.Id))
             .HistoricalCusipBackfillAmbiguous.Should()
             .BeTrue();
+    }
+
+    [Fact]
+    public async Task SeedInactiveCusips_SiblingCandidateEqualsParentPrimaryCusip_RefusesMerge()
+    {
+        var requestedAt = DateTime.UtcNow;
+        var stock = new CommonStock
+        {
+            Ticker = "MAIN",
+            Name = "Formerly Listed Filer",
+            Cik = "0000000042",
+            Cusip = "222222222",
+        };
+        var listing = new CommonStockDelistedListing
+        {
+            CommonStockId = stock.Id,
+            ListedTicker = "OLD",
+            DelistedOn = new DateOnly(2020, 6, 30),
+            HistoricalCusipBackfillRequestedAt = requestedAt,
+        };
+        var sweepStartedAt = requestedAt.AddMinutes(1);
+        StageHistoricalCusip(listing, stock.Cusip, listing.DelistedOn, sweepStartedAt);
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockDelistedListing>().Add(listing);
+            await seed.SaveChangesAsync();
+        }
+
+        var sut = CreateSut(Substitute.For<IBus>());
+        var method = typeof(FtdImportService).GetMethod(
+            "SeedInactiveCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var matches = new Dictionary<Guid, (string Cusip, DateOnly SettlementDate)>
+        {
+            [listing.Id] = (stock.Cusip, listing.DelistedOn),
+        };
+
+        var seeded = await (Task<int>)
+            method.Invoke(sut, [matches, sweepStartedAt, CancellationToken.None])!;
+
+        seeded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStockListedCusip>().AnyAsync()).Should().BeFalse();
+        var persisted = await verify
+            .Set<CommonStockDelistedListing>()
+            .SingleAsync(row => row.Id == listing.Id);
+        persisted.Cusip.Should().BeNull();
+        persisted.HistoricalCusipBackfillAmbiguous.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SeedDelistedListingCusip_ConcurrentPrimaryClaim_KeepsFirstOwner()
+    {
+        const string contestedCusip = "555555555";
+        var sweepStartedAt = DateTime.UtcNow.AddMinutes(-1);
+        var settlementDate = new DateOnly(2020, 6, 30);
+        var owner = new CommonStock
+        {
+            Ticker = "OWNER",
+            Name = "Identity Owner",
+            Cik = "8000000001",
+        };
+        var historical = new CommonStock
+        {
+            Ticker = "OLD",
+            Name = "Historical Candidate",
+            Cik = "8000000002",
+            Active = false,
+            DelistedOn = settlementDate,
+        };
+        var listing = new CommonStockDelistedListing
+        {
+            CommonStockId = historical.Id,
+            ListedTicker = historical.Ticker,
+            DelistedOn = settlementDate,
+        };
+        StageHistoricalCusip(listing, contestedCusip, settlementDate, sweepStartedAt);
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.AddRange(owner, historical, listing);
+            await seed.SaveChangesAsync();
+        }
+
+        await using var claimingContext = _fixture.CreateDbContext();
+        var claimingRepository = new CommonStockRepository(claimingContext);
+        await using var claimTransaction = await claimingRepository.BeginCusipIdentityWrite();
+        var claimingStock = await claimingContext
+            .Set<CommonStock>()
+            .SingleAsync(stock => stock.Id == owner.Id);
+        claimingStock.Cusip = contestedCusip;
+        await claimingContext.SaveChangesAsync();
+
+        await using var finalizingContext = _fixture.CreateDbContext();
+        var finalizer = new CommonStockManager(
+            new CommonStockRepository(finalizingContext),
+            Substitute.For<IBus>()
+        );
+        var finalization = finalizer.SeedDelistedListingCusip(
+            listing.Id,
+            contestedCusip,
+            settlementDate,
+            sweepStartedAt
+        );
+        var early = await Task.WhenAny(finalization, Task.Delay(TimeSpan.FromMilliseconds(250)));
+        early.Should().NotBe(finalization, "the shared identity lock must serialize writers");
+
+        await claimTransaction.CommitAsync();
+        (await finalization).Should().Be(DelistedListingCusipSeedResult.ClaimedByAnotherStock);
+
+        await using var verify = _fixture.CreateDbContext();
+        (await verify.Set<CommonStock>().SingleAsync(stock => stock.Id == owner.Id))
+            .Cusip.Should()
+            .Be(contestedCusip);
+        (await verify.Set<CommonStockDelistedListing>().SingleAsync(row => row.Id == listing.Id))
+            .Cusip.Should()
+            .BeNull();
     }
 
     [Fact]
@@ -682,5 +856,17 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             ),
             Options.Create(new WorkerOptions())
         );
+    }
+
+    private static void StageHistoricalCusip(
+        CommonStockDelistedListing listing,
+        string cusip,
+        DateOnly settlementDate,
+        DateTime sweepStartedAt
+    )
+    {
+        listing.HistoricalCusipBackfillCandidates = [cusip];
+        listing.HistoricalCusipBackfillCandidateOn = settlementDate;
+        listing.HistoricalCusipBackfillSweepStartedAt = sweepStartedAt;
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
@@ -180,7 +180,8 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             DelistedOn = stock.DelistedOn.Value,
             HistoricalCusipBackfillRequestedAt = stock.HistoricalCusipBackfillRequestedAt,
         };
-        var sweepStartedAt = stock.HistoricalCusipBackfillRequestedAt!.Value.AddMinutes(1);
+        var sweepBase = stock.HistoricalCusipBackfillRequestedAt!.Value.AddMinutes(1);
+        var sweepStartedAt = new DateTime(sweepBase.Ticks / 10 * 10 + 7, DateTimeKind.Utc);
         StageHistoricalCusip(listing, "123456789", listing.DelistedOn, sweepStartedAt);
         await using (var seed = _fixture.CreateDbContext())
         {


### PR DESCRIPTION
## Summary
- exclude inactive stocks from plain and combined holdings activity generation and stale snapshot reads
- atomically finalize retained listing CUSIPs from staged FTD evidence with shared cross-table identity serialization
- re-filter MCP market-activity cache entries against the current active stock universe

## Verification
- `dotnet build Equibles.sln -c Release`
- focused integration tests: 46/46
- focused manager unit tests: 5/5
- full unit suite: 4,605/4,605
- full integration suite: 2,766/2,766
- independent final review: clean