### PR TITLE
fix(yahoo): prioritize current prices over backfills

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -139,9 +139,9 @@ public class YahooPriceImportService
             cancellationToken
         );
 
-        // Crawl the recently-active stocks first, stalest-first within them, and the long-dormant
-        // tail afterwards (see OrderByCrawlPriority for why the plain stalest-first order starved
-        // the daily lane).
+        // Crawl current listings before historical recovery targets. Within each partition,
+        // recently-active stocks lead stalest-first and the long-dormant tail follows (see
+        // OrderByCrawlPriority for why the plain stalest-first order starved the daily lane).
         var crawlOrder = await OrderByCrawlPriority(priceTargets, cancellationToken);
 
         // Prices for the WHOLE universe first, enrichment only afterwards. The two used to be
@@ -611,9 +611,9 @@ public class YahooPriceImportService
     // holiday, so a healthy stock can never fall out of the set just because the market was shut.
     private const int ActivelyTradedWindowDays = 10;
 
-    // Orders the crawl: actively-traded stocks first (stalest of them leading), long-dormant and
-    // never-synced stocks after them, stalest-first within each group. One grouped MAX(Date) query
-    // over the price table per cycle.
+    // Orders the crawl: current listings before historical recovery targets; inside each
+    // partition, actively-traded stocks lead stalest-first and long-dormant or never-synced stocks
+    // follow stalest-first. One grouped MAX(Date) query over the price table per cycle.
     //
     // Plain stalest-first is the obvious order and it was actively harmful. Sorting the whole
     // universe by last stored date puts the stocks that will never return data — delisted tickers,
@@ -669,8 +669,10 @@ public class YahooPriceImportService
                     ? lastDate
                     : DateOnly.MinValue,
             })
+            // Current listings lead every historical recovery target. Within each partition,
             // false (0) sorts before true (1), so the actively-traded group leads.
-            .OrderBy(x => x.LastDate < activeSince)
+            .OrderBy(x => x.Target.IsHistorical)
+            .ThenBy(x => x.LastDate < activeSince)
             .ThenBy(x => x.LastDate)
             .ThenBy(x => x.Target.Ticker, StringComparer.Ordinal)
             .ThenBy(x => x.Target.CommonStockId)

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceCrawlOrderTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceCrawlOrderTests.cs
@@ -153,4 +153,39 @@ public class YahooPriceImportServiceCrawlOrderTests
 
         ordered.Select(target => target.Ticker).Should().Equal("GOOGL", "GOOG");
     }
+
+    [Fact]
+    public void CurrentListings_LeadHistoricalRegardlessOfFreshness()
+    {
+        var liveRecent = new PriceSeriesTarget("LIVE", Guid.NewGuid(), IsPrimary: true);
+        var liveNeverSynced = new PriceSeriesTarget("NEW", Guid.NewGuid(), IsPrimary: true);
+        var historicalRecent = new PriceSeriesTarget(
+            "OLD-LIVE",
+            Guid.NewGuid(),
+            IsPrimary: true,
+            IsHistorical: true
+        );
+        var historicalNeverSynced = new PriceSeriesTarget(
+            "OLD-NEW",
+            Guid.NewGuid(),
+            IsPrimary: true,
+            IsHistorical: true
+        );
+        var lastDates = new Dictionary<PriceSeriesKey, DateOnly>
+        {
+            [liveRecent.Key] = Today.AddDays(-1),
+            [historicalRecent.Key] = Today.AddDays(-1),
+        };
+
+        var ordered = YahooPriceImportService.BuildCrawlOrder(
+            [historicalRecent, liveNeverSynced, historicalNeverSynced, liveRecent],
+            lastDates,
+            Today
+        );
+
+        ordered
+            .Select(target => target.Ticker)
+            .Should()
+            .Equal("LIVE", "NEW", "OLD-LIVE", "OLD-NEW");
+    }
 }


### PR DESCRIPTION
## Summary

Keep current Yahoo price coverage ahead of bounded historical listing recovery, even when the historical batch is enlarged.

## Code changes

- partition current listings before historical targets in the crawl order
- preserve the existing active/dormant ordering within each partition
- add a regression test covering mixed freshness and never-synced targets