### PR TITLE
fix(common-stocks): reconcile current CUSIP designations

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -437,6 +437,13 @@ public class CommonStockManager
     /// deletes and re-inserts a quarter.
     /// </para>
     /// <para>
+    /// A same-stock alias may be promoted back to current when a newer authoritative
+    /// observation reverses a stale designation. An exact listed-ticker claim may be
+    /// promoted only with <paramref name="displacedListedTicker"/>: the authoritative
+    /// ticker that now owns the displaced CUSIP. This swaps the two designations instead
+    /// of collapsing the sibling security into the primary alias set.
+    /// </para>
+    /// <para>
     /// This is a financial-domain event, so it publishes via the root
     /// <see cref="IBus"/> rather than the scoped <c>IPublishEndpoint</c>. A host
     /// that enables a bus outbox on a different context (e.g. the commercial
@@ -449,56 +456,88 @@ public class CommonStockManager
     /// data sets and heals the gap.
     /// </para>
     /// </summary>
-    public async Task SetCusip(CommonStock commonStock, string cusip)
+    public async Task<bool> SetCusip(
+        CommonStock commonStock,
+        string cusip,
+        string displacedListedTicker = null
+    )
     {
         ArgumentNullException.ThrowIfNull(commonStock);
 
-        if (string.Equals(commonStock.Cusip, cusip, StringComparison.OrdinalIgnoreCase))
+        var observedCusip = commonStock.Cusip;
+        var observedTicker = commonStock.Ticker;
+        if (string.Equals(observedCusip, cusip, StringComparison.OrdinalIgnoreCase))
         {
-            return;
+            return false;
         }
 
-        var previousCusip = commonStock.Cusip;
         var normalizedCusip = cusip?.Trim().ToUpperInvariant();
         await using var transaction = await _commonStockRepository.BeginCusipIdentityWrite();
-
-        var claimedByAnotherPrimary = await _commonStockRepository
-            .GetAllIncludingInactive()
-            .AnyAsync(stock =>
-                stock.Id != commonStock.Id
-                && stock.Cusip != null
-                && stock.Cusip.ToUpper() == normalizedCusip
+        commonStock =
+            await _commonStockRepository.GetForUpdate(commonStock.Id)
+            ?? throw new InvalidOperationException(
+                $"CommonStock {commonStock.Id} no longer exists."
             );
-        var claimedAsAlias = await _commonStockRepository
-            .GetCusipAliases()
-            .AnyAsync(alias => alias.Cusip.ToUpper() == normalizedCusip);
-        var claimedAsListing = await _commonStockRepository
-            .GetListedCusips()
-            .AnyAsync(listing => listing.Cusip.ToUpper() == normalizedCusip);
-        if (claimedByAnotherPrimary || claimedAsAlias || claimedAsListing)
-        {
-            return;
-        }
-
-        // The alias table enforces one CUSIP → one stock, ever (global unique
-        // index): a retired CUSIP already recorded — even for another stock —
-        // is left with its first owner rather than reassigned. The existence
-        // check is case-insensitive so a case-variant CUSIP can't slip past
-        // the index as a duplicate row.
-        var normalizedPrevious = previousCusip?.ToUpperInvariant();
         if (
-            previousCusip != null
-            && !await _commonStockRepository
-                .GetCusipAliases()
-                .AnyAsync(a => a.Cusip.ToUpper() == normalizedPrevious)
+            !string.Equals(commonStock.Cusip, observedCusip, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(
+                commonStock.Ticker,
+                observedTicker,
+                StringComparison.OrdinalIgnoreCase
+            )
         )
-        {
-            _commonStockRepository.AddCusipAlias(
-                new CommonStockCusipAlias { CommonStockId = commonStock.Id, Cusip = previousCusip }
+            return false;
+        if (string.Equals(commonStock.Cusip, normalizedCusip, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var previousCusip = commonStock.Cusip;
+        var claims = await GetCusipClaims(normalizedCusip);
+        if (claims.PrimaryOwnerIds.Any(ownerId => ownerId != commonStock.Id))
+            return false;
+
+        var promotesOwnAlias =
+            claims.Aliases.Count > 0
+            && claims.Aliases.All(alias => alias.CommonStockId == commonStock.Id);
+        var promotesExactListing =
+            claims.Listings.Count > 0
+            && claims.Listings.All(listing =>
+                listing.CommonStockId == commonStock.Id
+                && string.Equals(
+                    listing.ListedTicker,
+                    commonStock.Ticker,
+                    StringComparison.OrdinalIgnoreCase
+                )
             );
+        if (
+            (claims.Aliases.Count > 0 && !promotesOwnAlias)
+            || (claims.Listings.Count > 0 && !promotesExactListing)
+        )
+            return false;
+
+        if (promotesExactListing)
+        {
+            if (
+                !await TryStageExactListingPromotion(
+                    commonStock,
+                    previousCusip,
+                    displacedListedTicker,
+                    claims.Aliases,
+                    claims.Listings
+                )
+            )
+                return false;
+        }
+        else
+        {
+            if (promotesOwnAlias)
+            {
+                foreach (var alias in claims.Aliases)
+                    _commonStockRepository.DeleteCusipAlias(alias);
+            }
+            await StageRetiredCusip(commonStock, previousCusip);
         }
 
-        commonStock.Cusip = cusip;
+        commonStock.Cusip = normalizedCusip;
 
         await _commonStockRepository.SaveChanges();
         if (transaction != null)
@@ -508,8 +547,145 @@ public class CommonStockManager
 
         // Publish via the root bus (bypasses any bus outbox) after the write commits.
         await _bus.Publish(
-            new StockCusipChanged(commonStock.Id, commonStock.Ticker, previousCusip, cusip)
+            new StockCusipChanged(
+                commonStock.Id,
+                commonStock.Ticker,
+                previousCusip,
+                normalizedCusip
+            )
         );
+        return true;
+    }
+
+    private async Task<(
+        List<Guid> PrimaryOwnerIds,
+        List<CommonStockCusipAlias> Aliases,
+        List<CommonStockListedCusip> Listings
+    )> GetCusipClaims(string normalizedCusip)
+    {
+        var primaryOwnerIds = await _commonStockRepository
+            .GetAllIncludingInactive()
+            .Where(stock => stock.Cusip != null && stock.Cusip.ToUpper() == normalizedCusip)
+            .Select(stock => stock.Id)
+            .ToListAsync();
+        var aliases = await _commonStockRepository
+            .GetCusipAliases()
+            .Where(candidate => candidate.Cusip.ToUpper() == normalizedCusip)
+            .ToListAsync();
+        var listings = await _commonStockRepository
+            .GetListedCusips()
+            .Where(candidate => candidate.Cusip.ToUpper() == normalizedCusip)
+            .ToListAsync();
+        return (primaryOwnerIds, aliases, listings);
+    }
+
+    private async Task<bool> TryStageExactListingPromotion(
+        CommonStock commonStock,
+        string previousCusip,
+        string displacedListedTicker,
+        IReadOnlyCollection<CommonStockCusipAlias> promotedAliases,
+        IReadOnlyCollection<CommonStockListedCusip> promotedListings
+    )
+    {
+        var displacedTicker = displacedListedTicker?.Trim().ToUpperInvariant();
+        if (
+            previousCusip == null
+            || displacedTicker == null
+            || !commonStock.SecondaryTickers.Contains(
+                displacedTicker,
+                StringComparer.OrdinalIgnoreCase
+            )
+        )
+            return false;
+
+        var claims = await GetDisplacedCusipClaims(commonStock, previousCusip);
+        if (!CanAssignDisplacedListing(commonStock, displacedTicker, claims))
+            return false;
+
+        foreach (var alias in promotedAliases)
+            _commonStockRepository.DeleteCusipAlias(alias);
+        foreach (var listing in promotedListings)
+            _commonStockRepository.DeleteListedCusip(listing);
+        foreach (var alias in claims.Aliases)
+            _commonStockRepository.DeleteCusipAlias(alias);
+        if (claims.Listings.Count == 0)
+        {
+            _commonStockRepository.AddListedCusip(
+                new CommonStockListedCusip
+                {
+                    CommonStockId = commonStock.Id,
+                    ListedTicker = displacedTicker,
+                    Cusip = previousCusip.ToUpperInvariant(),
+                }
+            );
+        }
+        return true;
+    }
+
+    private async Task<(
+        bool PrimaryClaimedElsewhere,
+        List<CommonStockCusipAlias> Aliases,
+        List<CommonStockListedCusip> Listings
+    )> GetDisplacedCusipClaims(CommonStock commonStock, string previousCusip)
+    {
+        var normalized = previousCusip.ToUpperInvariant();
+        var primaryClaimedElsewhere = await _commonStockRepository
+            .GetAllIncludingInactive()
+            .AnyAsync(stock =>
+                stock.Id != commonStock.Id
+                && stock.Cusip != null
+                && stock.Cusip.ToUpper() == normalized
+            );
+        var aliases = await _commonStockRepository
+            .GetCusipAliases()
+            .Where(alias => alias.Cusip.ToUpper() == normalized)
+            .ToListAsync();
+        var listings = await _commonStockRepository
+            .GetListedCusips()
+            .Where(listing => listing.Cusip.ToUpper() == normalized)
+            .ToListAsync();
+        return (primaryClaimedElsewhere, aliases, listings);
+    }
+
+    private static bool CanAssignDisplacedListing(
+        CommonStock commonStock,
+        string displacedTicker,
+        (
+            bool PrimaryClaimedElsewhere,
+            List<CommonStockCusipAlias> Aliases,
+            List<CommonStockListedCusip> Listings
+        ) claims
+    ) =>
+        !claims.PrimaryClaimedElsewhere
+        && claims.Aliases.All(alias => alias.CommonStockId == commonStock.Id)
+        && claims.Listings.All(listing =>
+            listing.CommonStockId == commonStock.Id
+            && string.Equals(
+                listing.ListedTicker,
+                displacedTicker,
+                StringComparison.OrdinalIgnoreCase
+            )
+        );
+
+    private async Task StageRetiredCusip(CommonStock commonStock, string previousCusip)
+    {
+        if (previousCusip == null)
+            return;
+
+        var normalized = previousCusip.ToUpperInvariant();
+        var alreadyClaimed =
+            await _commonStockRepository
+                .GetCusipAliases()
+                .AnyAsync(alias => alias.Cusip.ToUpper() == normalized)
+            || await _commonStockRepository
+                .GetListedCusips()
+                .AnyAsync(listing => listing.Cusip.ToUpper() == normalized);
+        if (!alreadyClaimed)
+        {
+            _commonStockRepository.AddCusipAlias(
+                new CommonStockCusipAlias { CommonStockId = commonStock.Id, Cusip = normalized }
+            );
+        }
     }
 
     /// <summary>

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -244,6 +244,11 @@ public class CommonStockRepository : BaseRepository<CommonStock>
         return alias;
     }
 
+    public void DeleteCusipAlias(CommonStockCusipAlias alias)
+    {
+        DbContext.Set<CommonStockCusipAlias>().Remove(alias);
+    }
+
     /// <summary>
     /// CUSIPs of a filer's OTHER listed securities (sibling share classes, units),
     /// keyed to the exact secondary ticker they identify. Same aggregate reasoning
@@ -258,6 +263,11 @@ public class CommonStockRepository : BaseRepository<CommonStock>
     {
         DbContext.Set<CommonStockListedCusip>().Add(listedCusip);
         return listedCusip;
+    }
+
+    public void DeleteListedCusip(CommonStockListedCusip listedCusip)
+    {
+        DbContext.Set<CommonStockListedCusip>().Remove(listedCusip);
     }
 
     public IQueryable<CommonStockDelistedListing> GetDelistedListings()

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -1047,7 +1047,7 @@ public class FtdImportService
         // Latest settlement date wins: during a CUSIP transition a single FTD
         // file can carry both the retiring and the replacement CUSIP for one
         // symbol, and the most recent trading day reflects the current security.
-        var tickerToCusip = new Dictionary<string, (string Cusip, DateOnly SettlementDate)>(
+        var primaryObservations = new Dictionary<string, List<FtdRecord>>(
             StringComparer.OrdinalIgnoreCase
         );
         foreach (var record in records)
@@ -1056,17 +1056,42 @@ public class FtdImportService
                 continue;
             if (!TryResolveSymbol(record.Symbol, tickerMap, strippedAliases, out var ticker))
                 continue;
-            if (
-                !tickerToCusip.TryGetValue(ticker, out var current)
-                || record.SettlementDate > current.SettlementDate
-            )
+            if (!primaryObservations.TryGetValue(ticker, out var rows))
             {
-                tickerToCusip[ticker] = (record.Cusip, record.SettlementDate);
+                rows = [];
+                primaryObservations[ticker] = rows;
             }
+            rows.Add(record);
         }
+
+        var tickerToCusip = primaryObservations
+            .Select(pair =>
+            {
+                var latestDate = pair.Value.Max(record => record.SettlementDate);
+                var latestCusips = pair
+                    .Value.Where(record => record.SettlementDate == latestDate)
+                    .Select(record => record.Cusip.Trim().ToUpperInvariant())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Take(2)
+                    .ToList();
+                return (
+                    Ticker: pair.Key,
+                    Cusip: latestCusips.Count == 1 ? latestCusips[0] : null,
+                    SettlementDate: latestDate
+                );
+            })
+            .Where(candidate => candidate.Cusip != null)
+            .ToDictionary(
+                candidate => candidate.Ticker,
+                candidate => (candidate.Cusip, candidate.SettlementDate),
+                StringComparer.OrdinalIgnoreCase
+            );
 
         if (tickerToCusip.Count == 0)
             return 0;
+
+        var secondaryMap = await BuildSecondaryTickerMap(tickerMap, cancellationToken);
+        var secondaryCusips = BuildLatestSecondaryCusips(records, tickerMap, secondaryMap);
 
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
@@ -1112,12 +1137,16 @@ public class FtdImportService
         {
             AddOwner(owner.Cusip, owner.CommonStockId);
         }
-        var listedClaimValues = await stockRepo
+        var listedClaimRows = await stockRepo
             .GetListedCusips()
             .Where(listing => resolvedCusips.Contains(listing.Cusip))
-            .Select(listing => listing.Cusip)
+            .Select(listing => new
+            {
+                listing.CommonStockId,
+                listing.ListedTicker,
+                listing.Cusip,
+            })
             .ToListAsync(cancellationToken);
-        var listedClaims = new HashSet<string>(listedClaimValues, StringComparer.OrdinalIgnoreCase);
 
         var seeded = 0;
         foreach (var stock in stocks)
@@ -1126,8 +1155,22 @@ public class FtdImportService
                 continue;
             if (string.Equals(stock.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase))
                 continue;
+            var listedClaim = listedClaimRows.FirstOrDefault(listing =>
+                string.Equals(listing.Cusip, resolved.Cusip, StringComparison.OrdinalIgnoreCase)
+            );
+            var promotesExactListing =
+                listedClaim?.CommonStockId == stock.Id
+                && string.Equals(
+                    listedClaim.ListedTicker,
+                    stock.Ticker,
+                    StringComparison.OrdinalIgnoreCase
+                );
+            var displacedTicker = promotesExactListing
+                ? ResolveDisplacedListedTicker(stock, secondaryCusips)
+                : null;
             if (
-                listedClaims.Contains(resolved.Cusip)
+                (listedClaim != null && !promotesExactListing)
+                || (promotesExactListing && displacedTicker == null)
                 || (
                     cusipOwners.TryGetValue(resolved.Cusip, out var ownerIds)
                     && ownerIds.Any(ownerId => ownerId != stock.Id)
@@ -1146,12 +1189,91 @@ public class FtdImportService
             // published (outbox) — lets Holdings backfill any 13F data
             // sets processed before this stock had a CUSIP (or while it
             // still carried the retired one, kept as an alias).
-            await stockManager.SetCusip(stock, resolved.Cusip);
-            AddOwner(resolved.Cusip, stock.Id);
-            seeded++;
+            if (await stockManager.SetCusip(stock, resolved.Cusip, displacedTicker))
+            {
+                AddOwner(resolved.Cusip, stock.Id);
+                seeded++;
+            }
         }
 
         return seeded;
+    }
+
+    private static Dictionary<Guid, List<(string Ticker, string Cusip)>> BuildLatestSecondaryCusips(
+        IEnumerable<FtdRecord> records,
+        Dictionary<string, Guid> primaryMap,
+        Dictionary<string, (Guid StockId, string Ticker)> secondaryMap
+    )
+    {
+        var strippedAliases = BuildStrippedSecondaryAliases(secondaryMap, primaryMap);
+        var observations = new Dictionary<(Guid StockId, string Ticker), List<FtdRecord>>();
+        foreach (var record in records)
+        {
+            if (
+                string.IsNullOrEmpty(record.Cusip)
+                || string.IsNullOrEmpty(record.Symbol)
+                || primaryMap.ContainsKey(record.Symbol)
+            )
+                continue;
+
+            if (
+                !secondaryMap.TryGetValue(record.Symbol, out var listing)
+                && !(
+                    strippedAliases.TryGetValue(record.Symbol, out var spelled)
+                    && secondaryMap.TryGetValue(spelled, out listing)
+                )
+            )
+                continue;
+
+            var key = (listing.StockId, listing.Ticker);
+            if (!observations.TryGetValue(key, out var rows))
+            {
+                rows = [];
+                observations[key] = rows;
+            }
+            rows.Add(record);
+        }
+
+        var unambiguous = observations
+            .Select(pair =>
+            {
+                var latestDate = pair.Value.Max(record => record.SettlementDate);
+                var latestCusips = pair
+                    .Value.Where(record => record.SettlementDate == latestDate)
+                    .Select(record => record.Cusip.Trim().ToUpperInvariant())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Take(2)
+                    .ToList();
+                return (pair.Key, Cusip: latestCusips.Count == 1 ? latestCusips[0] : null);
+            })
+            .Where(pair => pair.Cusip != null)
+            .ToList();
+
+        return unambiguous
+            .GroupBy(pair => pair.Key.StockId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(pair => (pair.Key.Ticker, pair.Cusip)).ToList()
+            );
+    }
+
+    private static string ResolveDisplacedListedTicker(
+        CommonStock stock,
+        IReadOnlyDictionary<Guid, List<(string Ticker, string Cusip)>> secondaryCusips
+    )
+    {
+        if (stock.Cusip == null || !secondaryCusips.TryGetValue(stock.Id, out var candidates))
+            return null;
+
+        var matches = candidates
+            .Where(candidate =>
+                string.Equals(candidate.Cusip, stock.Cusip, StringComparison.OrdinalIgnoreCase)
+            )
+            .Select(candidate => candidate.Ticker)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(2)
+            .ToList();
+        return matches.Count == 1 ? matches[0] : null;
     }
 
     /// <summary>

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsUpdatesChangedCusipTests.cs
@@ -161,6 +161,269 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SeedCusips_CurrentCusipIsOwnAlias_PromotesAliasAndRetiresPreviousCusip()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "TAP",
+            Name = "Molson Coors Beverage Co",
+            Cik = "24545",
+            Cusip = "60871R100",
+            SecondaryTickers = ["TAP-A"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockCusipAlias>()
+                .Add(new CommonStockCusipAlias { CommonStockId = stock.Id, Cusip = "60871R209" });
+            await seed.SaveChangesAsync();
+        }
+
+        var bus = Substitute.For<IBus>();
+        var seeded = await InvokeSeedCusips(
+            CreateSut(bus),
+            BuildRecords(("TAP", "60871R209", new DateOnly(2026, 7, 29))),
+            new Dictionary<string, Guid> { ["TAP"] = stock.Id }
+        );
+
+        seeded.Should().Be(1);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync()).Cusip.Should().Be("60871R209");
+        (await verify.Set<CommonStockCusipAlias>().SingleAsync()).Cusip.Should().Be("60871R100");
+        await bus.Received(1)
+            .Publish(
+                Arg.Is<StockCusipChanged>(change =>
+                    change.PreviousCusip == "60871R100" && change.Cusip == "60871R209"
+                ),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SeedCusips_ConflictingLatestPrimaryCusips_AbstainsRegardlessOfOrder(
+        bool reverse
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "TAP",
+            Name = "Molson Coors Beverage Co",
+            Cik = "24545",
+            Cusip = "60871R100",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var first = ("TAP", "60871R209", new DateOnly(2026, 7, 31));
+        var second = ("TAP", "60871R217", new DateOnly(2026, 7, 31));
+        var records = reverse ? BuildRecords(second, first) : BuildRecords(first, second);
+        var bus = Substitute.For<IBus>();
+
+        var seeded = await InvokeSeedCusips(
+            CreateSut(bus),
+            records,
+            new Dictionary<string, Guid> { ["TAP"] = stock.Id }
+        );
+
+        seeded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync()).Cusip.Should().Be("60871R100");
+        (await verify.Set<CommonStockCusipAlias>().AnyAsync()).Should().BeFalse();
+        await bus.DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedCusips_ExactPrimaryListingClaim_ReassignsDisplacedCusipToProvenSibling()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "BF-B",
+            Name = "Brown Forman Corp",
+            Cik = "14693",
+            Cusip = "115637100",
+            SecondaryTickers = ["BF-A"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockListedCusip>()
+                .Add(
+                    new CommonStockListedCusip
+                    {
+                        CommonStockId = stock.Id,
+                        ListedTicker = "BF-B",
+                        Cusip = "115637209",
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var bus = Substitute.For<IBus>();
+        var seeded = await InvokeSeedCusips(
+            CreateSut(bus),
+            BuildRecords(
+                ("BFB", "115637209", new DateOnly(2026, 7, 29)),
+                ("BFA", "115637100", new DateOnly(2026, 7, 31))
+            ),
+            new Dictionary<string, Guid> { ["BF-B"] = stock.Id }
+        );
+
+        seeded.Should().Be(1);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync()).Cusip.Should().Be("115637209");
+        var listing = await verify.Set<CommonStockListedCusip>().SingleAsync();
+        listing.ListedTicker.Should().Be("BF-A");
+        listing.Cusip.Should().Be("115637100");
+        (await verify.Set<CommonStockCusipAlias>().AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SeedCusips_ExactPrimaryListingWithoutDisplacedEvidence_LeavesDesignationsAlone()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "BF-B",
+            Name = "Brown Forman Corp",
+            Cik = "14693",
+            Cusip = "115637100",
+            SecondaryTickers = ["BF-A"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockListedCusip>()
+                .Add(
+                    new CommonStockListedCusip
+                    {
+                        CommonStockId = stock.Id,
+                        ListedTicker = "BF-B",
+                        Cusip = "115637209",
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var seeded = await InvokeSeedCusips(
+            CreateSut(Substitute.For<IBus>()),
+            BuildRecords(("BFB", "115637209", new DateOnly(2026, 7, 29))),
+            new Dictionary<string, Guid> { ["BF-B"] = stock.Id }
+        );
+
+        seeded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync()).Cusip.Should().Be("115637100");
+        var listing = await verify.Set<CommonStockListedCusip>().SingleAsync();
+        listing.ListedTicker.Should().Be("BF-B");
+        listing.Cusip.Should().Be("115637209");
+    }
+
+    [Fact]
+    public async Task SeedCusips_ConflictingLatestSecondaryCusips_LeavesDesignationsAlone()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "BF-B",
+            Name = "Brown Forman Corp",
+            Cik = "14693",
+            Cusip = "115637100",
+            SecondaryTickers = ["BF-A"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            seed.Set<CommonStockListedCusip>()
+                .Add(
+                    new CommonStockListedCusip
+                    {
+                        CommonStockId = stock.Id,
+                        ListedTicker = "BF-B",
+                        Cusip = "115637209",
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var seeded = await InvokeSeedCusips(
+            CreateSut(Substitute.For<IBus>()),
+            BuildRecords(
+                ("BFB", "115637209", new DateOnly(2026, 7, 29)),
+                ("BFA", "115637100", new DateOnly(2026, 7, 31)),
+                ("BFA", "115637118", new DateOnly(2026, 7, 31))
+            ),
+            new Dictionary<string, Guid> { ["BF-B"] = stock.Id }
+        );
+
+        seeded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync()).Cusip.Should().Be("115637100");
+        var listing = await verify.Set<CommonStockListedCusip>().SingleAsync();
+        listing.ListedTicker.Should().Be("BF-B");
+        listing.Cusip.Should().Be("115637209");
+    }
+
+    [Fact]
+    public async Task SeedCusips_ManagerRejectsCaseVariantForeignClaim_DoesNotCountSeed()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "BF-B",
+            Name = "Brown Forman Corp",
+            Cik = "14693",
+            Cusip = "11563R100",
+            SecondaryTickers = ["BF-A"],
+        };
+        var foreign = new CommonStock
+        {
+            Ticker = "OTHER",
+            Name = "Other Corp",
+            Cik = "99999",
+            Cusip = "999999999",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.AddRange(stock, foreign);
+            seed.Set<CommonStockListedCusip>()
+                .AddRange(
+                    new CommonStockListedCusip
+                    {
+                        CommonStockId = stock.Id,
+                        ListedTicker = "BF-B",
+                        Cusip = "11563R209",
+                    },
+                    new CommonStockListedCusip
+                    {
+                        CommonStockId = foreign.Id,
+                        ListedTicker = "OTHER-A",
+                        Cusip = "11563r209",
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var seeded = await InvokeSeedCusips(
+            CreateSut(Substitute.For<IBus>()),
+            BuildRecords(
+                ("BFB", "11563R209", new DateOnly(2026, 7, 29)),
+                ("BFA", "11563R100", new DateOnly(2026, 7, 31))
+            ),
+            new Dictionary<string, Guid> { ["BF-B"] = stock.Id }
+        );
+
+        seeded.Should().Be(0);
+        using var verify = FreshContext();
+        (await verify.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id))
+            .Cusip.Should()
+            .Be("11563R100");
+        (await verify.Set<CommonStockListedCusip>().CountAsync()).Should().Be(2);
+    }
+
+    [Fact]
     public async Task SeedInactiveCusips_AuthoritativeHistoricalMatch_SeedsRetainedIdentity()
     {
         var stock = new CommonStock
@@ -582,6 +845,99 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SetCusip_ConcurrentDesignationChange_AbstainsFromStaleTransition()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "TAP",
+            Name = "Molson Coors Beverage Co",
+            Cik = "24545",
+            Cusip = "60871R100",
+            SecondaryTickers = ["TAP-A"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Add(stock);
+            seed.Set<CommonStockCusipAlias>()
+                .Add(new CommonStockCusipAlias { CommonStockId = stock.Id, Cusip = "60871R209" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var staleContext = _fixture.CreateDbContext();
+        var staleStock = await staleContext
+            .Set<CommonStock>()
+            .SingleAsync(row => row.Id == stock.Id);
+        var bus = Substitute.For<IBus>();
+        var staleManager = new CommonStockManager(new CommonStockRepository(staleContext), bus);
+
+        await using var writerContext = _fixture.CreateDbContext();
+        var writerRepository = new CommonStockRepository(writerContext);
+        await using var writerTransaction = await writerRepository.BeginCusipIdentityWrite();
+        var lockedStock = await writerRepository.GetForUpdate(stock.Id);
+        lockedStock.Cusip = "60871R217";
+        await writerRepository.SaveChanges();
+
+        var staleTransition = staleManager.SetCusip(staleStock, "60871R209");
+        var early = await Task.WhenAny(staleTransition, Task.Delay(TimeSpan.FromMilliseconds(250)));
+        early.Should().NotBe(staleTransition, "the shared identity lock must serialize writers");
+
+        await writerTransaction.CommitAsync();
+        await staleTransition;
+
+        await using var verify = _fixture.CreateDbContext();
+        (await verify.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id))
+            .Cusip.Should()
+            .Be("60871R217");
+        (await verify.Set<CommonStockCusipAlias>().SingleAsync()).Cusip.Should().Be("60871R209");
+        await bus.DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetCusip_CaseVariantForeignAliasClaim_Abstains()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "TAP",
+            Name = "Molson Coors Beverage Co",
+            Cik = "24545",
+            Cusip = "60871R100",
+        };
+        var foreign = new CommonStock
+        {
+            Ticker = "OTHER",
+            Name = "Other Corp",
+            Cik = "99999",
+            Cusip = "999999999",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.AddRange(stock, foreign);
+            seed.Set<CommonStockCusipAlias>()
+                .AddRange(
+                    new CommonStockCusipAlias { CommonStockId = stock.Id, Cusip = "60871r209" },
+                    new CommonStockCusipAlias { CommonStockId = foreign.Id, Cusip = "60871R209" }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        await using var context = _fixture.CreateDbContext();
+        var tracked = await context.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id);
+        var bus = Substitute.For<IBus>();
+        var manager = new CommonStockManager(new CommonStockRepository(context), bus);
+
+        await manager.SetCusip(tracked, "60871R209");
+
+        await using var verify = _fixture.CreateDbContext();
+        (await verify.Set<CommonStock>().SingleAsync(row => row.Id == stock.Id))
+            .Cusip.Should()
+            .Be("60871R100");
+        (await verify.Set<CommonStockCusipAlias>().CountAsync()).Should().Be(2);
+        await bus.DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task SeedCusips_ResolvedCusipBelongsToAnotherStock_SkipsWithoutUpdating()
     {
         // Ticker-recycling shape: a delisted issuer's stale stock still holds
@@ -857,6 +1213,38 @@ public class FtdImportServiceSeedCusipsUpdatesChangedCusipTests : IAsyncLifetime
             ),
             Options.Create(new WorkerOptions())
         );
+    }
+
+    private static IList BuildRecords(
+        params (string Symbol, string Cusip, DateOnly SettlementDate)[] rows
+    )
+    {
+        var recordType = typeof(FtdImportService).Assembly.GetType(
+            "Equibles.Sec.HostedService.Models.FtdRecord"
+        )!;
+        var records = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(recordType))!;
+        foreach (var row in rows)
+        {
+            var record = Activator.CreateInstance(recordType)!;
+            recordType.GetProperty("Symbol")!.SetValue(record, row.Symbol);
+            recordType.GetProperty("Cusip")!.SetValue(record, row.Cusip);
+            recordType.GetProperty("SettlementDate")!.SetValue(record, row.SettlementDate);
+            records.Add(record);
+        }
+        return records;
+    }
+
+    private static async Task<int> InvokeSeedCusips(
+        FtdImportService sut,
+        IList records,
+        Dictionary<string, Guid> tickerMap
+    )
+    {
+        var method = typeof(FtdImportService).GetMethod(
+            "SeedCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        return await (Task<int>)method.Invoke(sut, [records, tickerMap, CancellationToken.None])!;
     }
 
     private static void StageHistoricalCusip(

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipTests.cs
@@ -39,6 +39,8 @@ public class CommonStockManagerSetCusipTests
             Name = "Apple",
             Cusip = "037833100",
         };
+        db.Set<CommonStock>().Add(stock);
+        await db.SaveChangesAsync();
 
         await sut.SetCusip(stock, "594918104");
 


### PR DESCRIPTION
## Summary
- let authoritative current FTD evidence reactivate a CUSIP already retained as the same stock's alias
- swap primary and sibling-listing designations only when the same FTD file uniquely proves both sides
- abstain on ambiguous, foreign-owned, or stale concurrent identity evidence

## Verification
- `dotnet build Equibles.sln -c Release --no-restore`
- 4,608 unit tests passed
- 2,775 integration tests passed
- independent review completed with no findings

Related to daniel3303/EquiblesCommercial#7455.