### PR TITLE
fix(sec): replay recent FTD identity evidence

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -25,6 +25,7 @@ public class FtdImportService
 {
     private const string BaseUrl = "https://www.sec.gov/files/data/fails-deliver-data";
     private const int InsertBatchSize = 1000;
+    private const int LiveRecheckMonths = 1;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ISecEdgarClient _secEdgarClient;
@@ -56,6 +57,9 @@ public class FtdImportService
             cancellationToken
         );
 
+        var minimumStartDate = SyncDateResolver.Resolve(default, _workerOptions);
+        startDate = ApplyLiveRecheckWindow(startDate, minimumStartDate);
+
         var fileNames = GetFileNames(startDate);
 
         if (fileNames.Count == 0)
@@ -71,6 +75,13 @@ public class FtdImportService
         );
 
         var tickerMap = await BuildTickerMap(cancellationToken);
+        var secondaryMap = new Dictionary<string, (Guid StockId, string Ticker)>(
+            StringComparer.OrdinalIgnoreCase
+        );
+        var secondaryMapBuilt = false;
+        var liveIdentityEvidence = new Dictionary<string, LiveIdentityEvidence>(
+            StringComparer.OrdinalIgnoreCase
+        );
         var cusipsSeeded = 0;
 
         foreach (var fileName in fileNames)
@@ -83,7 +94,19 @@ public class FtdImportService
                 if (records.Count == 0)
                     continue;
 
-                cusipsSeeded += await SeedCusips(records, tickerMap, cancellationToken);
+                if (!secondaryMapBuilt)
+                {
+                    secondaryMap = await BuildSecondaryTickerMap(tickerMap, cancellationToken);
+                    secondaryMapBuilt = true;
+                }
+
+                AccumulateLiveIdentityEvidence(
+                    fileName,
+                    records,
+                    tickerMap,
+                    secondaryMap,
+                    liveIdentityEvidence
+                );
 
                 var imported = await ImportRecords(records, tickerMap, cancellationToken);
 
@@ -123,6 +146,27 @@ public class FtdImportService
                     "FtdImport.ProcessFile",
                     ex,
                     $"file: {fileName}"
+                );
+            }
+        }
+
+        if (liveIdentityEvidence.Count > 0)
+        {
+            try
+            {
+                var identityRecords = liveIdentityEvidence
+                    .Values.SelectMany(evidence => evidence.Records)
+                    .ToList();
+                cusipsSeeded = await SeedCusips(identityRecords, tickerMap, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reconciling CUSIPs from live FTD evidence");
+                await _errorReporter.Report(
+                    ErrorSource.FtdScraper,
+                    "FtdImport.SeedCusips",
+                    ex,
+                    $"files: {fileNames.Count}"
                 );
             }
         }
@@ -1028,6 +1072,124 @@ public class FtdImportService
     // FTD worker's run long.
     private const int AliasSweepFilesPerCycle = 12;
 
+    private sealed record LiveIdentityEvidence(
+        string SourceFile,
+        DateOnly LatestPrimaryDate,
+        List<FtdRecord> PrimaryRecords,
+        List<FtdRecord> Records
+    );
+
+    private sealed record SecondaryIdentityObservation(
+        Guid StockId,
+        string Ticker,
+        FtdRecord Record
+    );
+
+    private static void AccumulateLiveIdentityEvidence(
+        string fileName,
+        List<FtdRecord> records,
+        Dictionary<string, Guid> primaryMap,
+        Dictionary<string, (Guid StockId, string Ticker)> secondaryMap,
+        Dictionary<string, LiveIdentityEvidence> evidenceByTicker
+    )
+    {
+        var strippedPrimaryAliases = BuildStrippedTickerAliases(primaryMap);
+        var primaryObservations = new Dictionary<string, List<FtdRecord>>(
+            StringComparer.OrdinalIgnoreCase
+        );
+        foreach (var record in records)
+        {
+            if (
+                string.IsNullOrEmpty(record.Cusip)
+                || string.IsNullOrEmpty(record.Symbol)
+                || !TryResolveSymbol(
+                    record.Symbol,
+                    primaryMap,
+                    strippedPrimaryAliases,
+                    out var ticker
+                )
+            )
+            {
+                continue;
+            }
+
+            if (!primaryObservations.TryGetValue(ticker, out var rows))
+            {
+                rows = [];
+                primaryObservations[ticker] = rows;
+            }
+            rows.Add(record);
+        }
+
+        var secondaryObservations = BuildLatestSecondaryObservations(
+            records,
+            primaryMap,
+            secondaryMap
+        );
+
+        foreach (var pair in primaryObservations)
+        {
+            var latestDate = pair.Value.Max(record => record.SettlementDate);
+            var latestPrimaryRecords = pair
+                .Value.Where(record => record.SettlementDate == latestDate)
+                .ToList();
+            var stockId = primaryMap[pair.Key];
+            var candidateRecords = latestPrimaryRecords
+                .Concat(
+                    secondaryObservations.TryGetValue(stockId, out var secondaryRows)
+                        ? secondaryRows.Select(observation => observation.Record)
+                        : []
+                )
+                .ToList();
+            var candidate = new LiveIdentityEvidence(
+                fileName,
+                latestDate,
+                latestPrimaryRecords,
+                candidateRecords
+            );
+
+            if (!evidenceByTicker.TryGetValue(pair.Key, out var current))
+            {
+                evidenceByTicker[pair.Key] = candidate;
+                continue;
+            }
+            if (candidate.LatestPrimaryDate > current.LatestPrimaryDate)
+            {
+                evidenceByTicker[pair.Key] = candidate;
+                continue;
+            }
+            if (candidate.LatestPrimaryDate < current.LatestPrimaryDate)
+                continue;
+
+            var latestCusips = current
+                .PrimaryRecords.Concat(candidate.PrimaryRecords)
+                .Select(record => record.Cusip.Trim().ToUpperInvariant())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(2)
+                .ToList();
+            if (latestCusips.Count > 1)
+            {
+                var ambiguousPrimaryRecords = current
+                    .PrimaryRecords.Concat(candidate.PrimaryRecords)
+                    .ToList();
+                evidenceByTicker[pair.Key] = new LiveIdentityEvidence(
+                    string.CompareOrdinal(candidate.SourceFile, current.SourceFile) > 0
+                        ? candidate.SourceFile
+                        : current.SourceFile,
+                    latestDate,
+                    ambiguousPrimaryRecords,
+                    ambiguousPrimaryRecords
+                );
+                continue;
+            }
+
+            if (string.CompareOrdinal(candidate.SourceFile, current.SourceFile) > 0)
+            {
+                evidenceByTicker[pair.Key] = candidate;
+            }
+        }
+    }
+
     /// <summary>
     /// Seeds and updates CUSIP values on CommonStock records by matching FTD
     /// ticker→CUSIP pairs. Beyond filling stocks that have no CUSIP yet, this is
@@ -1205,6 +1367,49 @@ public class FtdImportService
         Dictionary<string, (Guid StockId, string Ticker)> secondaryMap
     )
     {
+        var observations = BuildLatestSecondaryObservations(records, primaryMap, secondaryMap);
+        var unambiguous = observations
+            .SelectMany(pair =>
+                pair.Value.GroupBy(
+                        observation => observation.Ticker,
+                        StringComparer.OrdinalIgnoreCase
+                    )
+                    .Select(group =>
+                    {
+                        var latestCusips = group
+                            .Select(observation =>
+                                observation.Record.Cusip.Trim().ToUpperInvariant()
+                            )
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
+                            .Take(2)
+                            .ToList();
+                        return (
+                            StockId: pair.Key,
+                            Ticker: group.Key,
+                            Cusip: latestCusips.Count == 1 ? latestCusips[0] : null
+                        );
+                    })
+            )
+            .Where(pair => pair.Cusip != null)
+            .ToList();
+
+        return unambiguous
+            .GroupBy(pair => pair.StockId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(pair => (pair.Ticker, pair.Cusip)).ToList()
+            );
+    }
+
+    private static Dictionary<
+        Guid,
+        List<SecondaryIdentityObservation>
+    > BuildLatestSecondaryObservations(
+        IEnumerable<FtdRecord> records,
+        Dictionary<string, Guid> primaryMap,
+        Dictionary<string, (Guid StockId, string Ticker)> secondaryMap
+    )
+    {
         var strippedAliases = BuildStrippedSecondaryAliases(secondaryMap, primaryMap);
         var observations = new Dictionary<(Guid StockId, string Ticker), List<FtdRecord>>();
         foreach (var record in records)
@@ -1234,27 +1439,20 @@ public class FtdImportService
             rows.Add(record);
         }
 
-        var unambiguous = observations
-            .Select(pair =>
+        return observations
+            .SelectMany(pair =>
             {
                 var latestDate = pair.Value.Max(record => record.SettlementDate);
-                var latestCusips = pair
+                return pair
                     .Value.Where(record => record.SettlementDate == latestDate)
-                    .Select(record => record.Cusip.Trim().ToUpperInvariant())
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .Take(2)
-                    .ToList();
-                return (pair.Key, Cusip: latestCusips.Count == 1 ? latestCusips[0] : null);
+                    .Select(record => new SecondaryIdentityObservation(
+                        pair.Key.StockId,
+                        pair.Key.Ticker,
+                        record
+                    ));
             })
-            .Where(pair => pair.Cusip != null)
-            .ToList();
-
-        return unambiguous
-            .GroupBy(pair => pair.Key.StockId)
-            .ToDictionary(
-                group => group.Key,
-                group => group.Select(pair => (pair.Key.Ticker, pair.Cusip)).ToList()
-            );
+            .GroupBy(observation => observation.StockId)
+            .ToDictionary(group => group.Key, group => group.ToList());
     }
 
     private static string ResolveDisplacedListedTicker(
@@ -1510,6 +1708,29 @@ public class FtdImportService
     // Oldest FTD file available on SEC EDGAR is cnsfails201706b.zip (second half of June 2017).
     // Some individual files within the range may 404 (handled gracefully above).
     private static readonly DateOnly OldestAvailableDate = new(2017, 6, 1);
+
+    /// <summary>
+    /// Replays the prior calendar month so late identity corrections can be applied from
+    /// recent FTD evidence without turning the live import into an unbounded backfill.
+    /// </summary>
+    internal static DateOnly ApplyLiveRecheckWindow(
+        DateOnly syncStartDate,
+        DateOnly minimumStartDate
+    )
+    {
+        var syncMonth = new DateOnly(syncStartDate.Year, syncStartDate.Month, 1);
+        var configuredMinimumMonth = new DateOnly(minimumStartDate.Year, minimumStartDate.Month, 1);
+        var minimumMonth =
+            configuredMinimumMonth < OldestAvailableDate
+                ? OldestAvailableDate
+                : configuredMinimumMonth;
+
+        if (syncMonth <= minimumMonth)
+            return minimumMonth;
+
+        var recheckStart = syncMonth.AddMonths(-LiveRecheckMonths);
+        return recheckStart < minimumMonth ? minimumMonth : recheckStart;
+    }
 
     /// <summary>
     /// Generates FTD file names from a start date to now.

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceFullPipelineTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Net;
 using System.Text;
 using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Data.Models;
@@ -8,6 +9,7 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging.Contracts.CommonStocks;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
@@ -70,7 +72,9 @@ public class FtdImportServiceFullPipelineTests : IAsyncLifetime
     /// TickerMapService is registered with this same factory so its inner CreateScope()
     /// also lands on a fresh context.
     /// </summary>
-    private IServiceScopeFactory CreateScopeFactory()
+    private IServiceScopeFactory CreateScopeFactory() => CreateScopeFactory(Substitute.For<IBus>());
+
+    private IServiceScopeFactory CreateScopeFactory(IBus bus)
     {
         var scopeFactory = Substitute.For<IServiceScopeFactory>();
         scopeFactory
@@ -83,12 +87,7 @@ public class FtdImportServiceFullPipelineTests : IAsyncLifetime
                 sp.GetService(typeof(CommonStockRepository))
                     .Returns(new CommonStockRepository(ctx));
                 sp.GetService(typeof(CommonStockManager))
-                    .Returns(
-                        new CommonStockManager(
-                            new CommonStockRepository(ctx),
-                            Substitute.For<IBus>()
-                        )
-                    );
+                    .Returns(new CommonStockManager(new CommonStockRepository(ctx), bus));
                 sp.GetService(typeof(FailToDeliverRepository))
                     .Returns(new FailToDeliverRepository(ctx));
                 sp.GetService(typeof(TickerMapService)).Returns(new TickerMapService(scopeFactory));
@@ -97,6 +96,84 @@ public class FtdImportServiceFullPipelineTests : IAsyncLifetime
                 return scope;
             });
         return scopeFactory;
+    }
+
+    [Fact]
+    public async Task Import_ReplayedTransitionMonth_ReconcilesLatestCusipOnlyOnce()
+    {
+        var currentMonth = new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+        var transitionMonth = currentMonth.AddMonths(-1);
+        var retiringDate = transitionMonth.AddDays(5);
+        var replacementDate = transitionMonth.AddDays(20);
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "TAP",
+            Name = "Molson Coors Beverage Co",
+            Cik = "24545",
+            Cusip = "60871R100",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var retiringCsv =
+            "SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE\n"
+            + $"{retiringDate:yyyyMMdd}|60871R100|TAP|100|MOLSON COORS|50.00\n";
+        var replacementCsv =
+            "SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE\n"
+            + $"{replacementDate:yyyyMMdd}|60871R209|TAP|200|MOLSON COORS|51.00\n";
+        var yearMonth = transitionMonth.ToString("yyyyMM");
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient
+            .DownloadStream(Arg.Any<string>())
+            .Returns(call =>
+            {
+                var url = call.Arg<string>();
+                if (url.EndsWith($"cnsfails{yearMonth}a.zip", StringComparison.Ordinal))
+                    return Task.FromResult<Stream>(BuildFtdZipStream(retiringCsv));
+                if (url.EndsWith($"cnsfails{yearMonth}b.zip", StringComparison.Ordinal))
+                    return Task.FromResult<Stream>(BuildFtdZipStream(replacementCsv));
+                return Task.FromException<Stream>(
+                    new HttpRequestException("Not Found", null, HttpStatusCode.NotFound)
+                );
+            });
+        var bus = Substitute.For<IBus>();
+        var sut = new FtdImportService(
+            CreateScopeFactory(bus),
+            secEdgarClient,
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(
+                new WorkerOptions
+                {
+                    MinSyncDate = transitionMonth.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+                }
+            )
+        );
+
+        await sut.Import(CancellationToken.None);
+        await sut.Import(CancellationToken.None);
+
+        await bus.Received(1)
+            .Publish(
+                Arg.Is<StockCusipChanged>(change =>
+                    change.CommonStockId == stock.Id
+                    && change.PreviousCusip == "60871R100"
+                    && change.Cusip == "60871R209"
+                ),
+                Arg.Any<CancellationToken>()
+            );
+        await bus.Received(1).Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+
+        await using var verify = _fixture.CreateDbContext();
+        (await verify.Set<CommonStock>().SingleAsync()).Cusip.Should().Be("60871R209");
+        (await verify.Set<CommonStockCusipAlias>().SingleAsync()).Cusip.Should().Be("60871R100");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs
@@ -4,6 +4,45 @@ namespace Equibles.UnitTests.Sec;
 
 public class FtdImportServiceTests
 {
+    // ── ApplyLiveRecheckWindow ──
+
+    [Fact]
+    public void ApplyLiveRecheckWindow_IncrementalSync_ReplaysPriorCalendarMonth()
+    {
+        var startDate = FtdImportService.ApplyLiveRecheckWindow(
+            new DateOnly(2026, 8, 1),
+            new DateOnly(2020, 1, 1)
+        );
+
+        startDate.Should().Be(new DateOnly(2026, 7, 1));
+        FtdImportService
+            .GetFileNames(startDate)
+            .Should()
+            .StartWith("cnsfails202607a.zip", "cnsfails202607b.zip");
+    }
+
+    [Fact]
+    public void ApplyLiveRecheckWindow_InitialSync_DoesNotCrossConfiguredFloor()
+    {
+        var startDate = FtdImportService.ApplyLiveRecheckWindow(
+            new DateOnly(2020, 1, 1),
+            new DateOnly(2020, 1, 15)
+        );
+
+        startDate.Should().Be(new DateOnly(2020, 1, 1));
+    }
+
+    [Fact]
+    public void ApplyLiveRecheckWindow_PreArchiveFloor_ClampsToOldestAvailableMonth()
+    {
+        var startDate = FtdImportService.ApplyLiveRecheckWindow(
+            new DateOnly(2017, 6, 1),
+            new DateOnly(2010, 1, 1)
+        );
+
+        startDate.Should().Be(new DateOnly(2017, 6, 1));
+    }
+
     // ── GetFileNames ──
 
     [Fact]


### PR DESCRIPTION
## Summary
- replay the prior FTD calendar month within configured/archive floors
- reconcile each ticker once from the newest unambiguous evidence across the live window
- retain per-file FTD upserts while preventing repeat CUSIP-change events and holdings rescans

## Verification
- `dotnet csharpier check` on changed files
- `dotnet build Equibles.sln -c Release`
- 4,611 unit tests passed
- 2,776 integration tests passed
- independent review: no blocking findings

Follow-up for daniel3303/EquiblesCommercial#7455.