### PR TITLE
fix(sec): guard partial FTD identity replays

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -50,6 +50,7 @@ public class FtdImportService
 
     public async Task Import(CancellationToken cancellationToken)
     {
+        var asOf = DateOnly.FromDateTime(DateTime.UtcNow);
         var startDate = await SyncStartDate.Resolve<FailToDeliverRepository>(
             _scopeFactory,
             _workerOptions,
@@ -60,7 +61,7 @@ public class FtdImportService
         var minimumStartDate = SyncDateResolver.Resolve(default, _workerOptions);
         startDate = ApplyLiveRecheckWindow(startDate, minimumStartDate);
 
-        var fileNames = GetFileNames(startDate);
+        var fileNames = GetFileNames(startDate, asOf);
 
         if (fileNames.Count == 0)
         {
@@ -79,9 +80,13 @@ public class FtdImportService
             StringComparer.OrdinalIgnoreCase
         );
         var secondaryMapBuilt = false;
+        var replayMonth = asOf.AddMonths(-LiveRecheckMonths)
+            .ToString("yyyyMM", CultureInfo.InvariantCulture);
+        var replayFiles = fileNames.Where(fileName => FtdMonthOf(fileName) == replayMonth).ToList();
         var liveIdentityEvidence = new Dictionary<string, LiveIdentityEvidence>(
             StringComparer.OrdinalIgnoreCase
         );
+        var downloadedIdentityFiles = new HashSet<string>(StringComparer.Ordinal);
         var cusipsSeeded = 0;
 
         foreach (var fileName in fileNames)
@@ -94,23 +99,31 @@ public class FtdImportService
                 if (records.Count == 0)
                     continue;
 
-                if (!secondaryMapBuilt)
+                if (FtdMonthOf(fileName) == replayMonth)
                 {
-                    secondaryMap = await BuildSecondaryTickerMap(tickerMap, cancellationToken);
-                    secondaryMapBuilt = true;
-                }
+                    if (!secondaryMapBuilt)
+                    {
+                        secondaryMap = await BuildSecondaryTickerMap(tickerMap, cancellationToken);
+                        secondaryMapBuilt = true;
+                    }
 
-                AccumulateLiveIdentityEvidence(
-                    fileName,
-                    records,
-                    tickerMap,
-                    secondaryMap,
-                    liveIdentityEvidence
-                );
+                    AccumulateLiveIdentityEvidence(
+                        fileName,
+                        records,
+                        tickerMap,
+                        secondaryMap,
+                        liveIdentityEvidence
+                    );
+                    downloadedIdentityFiles.Add(fileName);
+                }
 
                 var imported = await ImportRecords(records, tickerMap, cancellationToken);
 
                 _logger.LogInformation("FTD {File}: imported {Count} records", fileName, imported);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (HttpRequestException ex)
                 when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -150,6 +163,9 @@ public class FtdImportService
             }
         }
 
+        if (replayFiles.Count == 0 || !replayFiles.All(downloadedIdentityFiles.Contains))
+            liveIdentityEvidence.Clear();
+
         if (liveIdentityEvidence.Count > 0)
         {
             try
@@ -158,6 +174,10 @@ public class FtdImportService
                     .Values.SelectMany(evidence => evidence.Records)
                     .ToList();
                 cusipsSeeded = await SeedCusips(identityRecords, tickerMap, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -1085,6 +1105,8 @@ public class FtdImportService
         FtdRecord Record
     );
 
+    private static string FtdMonthOf(string fileName) => fileName[8..14];
+
     private static void AccumulateLiveIdentityEvidence(
         string fileName,
         List<FtdRecord> records,
@@ -1148,46 +1170,53 @@ public class FtdImportService
                 candidateRecords
             );
 
-            if (!evidenceByTicker.TryGetValue(pair.Key, out var current))
-            {
-                evidenceByTicker[pair.Key] = candidate;
-                continue;
-            }
-            if (candidate.LatestPrimaryDate > current.LatestPrimaryDate)
-            {
-                evidenceByTicker[pair.Key] = candidate;
-                continue;
-            }
-            if (candidate.LatestPrimaryDate < current.LatestPrimaryDate)
-                continue;
-
-            var latestCusips = current
-                .PrimaryRecords.Concat(candidate.PrimaryRecords)
-                .Select(record => record.Cusip.Trim().ToUpperInvariant())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Take(2)
-                .ToList();
-            if (latestCusips.Count > 1)
-            {
-                var ambiguousPrimaryRecords = current
-                    .PrimaryRecords.Concat(candidate.PrimaryRecords)
-                    .ToList();
-                evidenceByTicker[pair.Key] = new LiveIdentityEvidence(
-                    string.CompareOrdinal(candidate.SourceFile, current.SourceFile) > 0
-                        ? candidate.SourceFile
-                        : current.SourceFile,
-                    latestDate,
-                    ambiguousPrimaryRecords,
-                    ambiguousPrimaryRecords
-                );
-                continue;
-            }
-
-            if (string.CompareOrdinal(candidate.SourceFile, current.SourceFile) > 0)
-            {
-                evidenceByTicker[pair.Key] = candidate;
-            }
+            MergeLiveIdentityEvidence(pair.Key, candidate, evidenceByTicker);
         }
+    }
+
+    private static void MergeLiveIdentityEvidence(
+        string ticker,
+        LiveIdentityEvidence candidate,
+        Dictionary<string, LiveIdentityEvidence> evidenceByTicker
+    )
+    {
+        if (!evidenceByTicker.TryGetValue(ticker, out var current))
+        {
+            evidenceByTicker[ticker] = candidate;
+            return;
+        }
+        if (candidate.LatestPrimaryDate > current.LatestPrimaryDate)
+        {
+            evidenceByTicker[ticker] = candidate;
+            return;
+        }
+        if (candidate.LatestPrimaryDate < current.LatestPrimaryDate)
+            return;
+
+        var latestCusips = current
+            .PrimaryRecords.Concat(candidate.PrimaryRecords)
+            .Select(record => record.Cusip.Trim().ToUpperInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(2)
+            .ToList();
+        if (latestCusips.Count > 1)
+        {
+            var ambiguousPrimaryRecords = current
+                .PrimaryRecords.Concat(candidate.PrimaryRecords)
+                .ToList();
+            evidenceByTicker[ticker] = new LiveIdentityEvidence(
+                string.CompareOrdinal(candidate.SourceFile, current.SourceFile) > 0
+                    ? candidate.SourceFile
+                    : current.SourceFile,
+                candidate.LatestPrimaryDate,
+                ambiguousPrimaryRecords,
+                ambiguousPrimaryRecords
+            );
+            return;
+        }
+
+        if (string.CompareOrdinal(candidate.SourceFile, current.SourceFile) > 0)
+            evidenceByTicker[ticker] = candidate;
     }
 
     /// <summary>
@@ -1736,17 +1765,19 @@ public class FtdImportService
     /// Generates FTD file names from a start date to now.
     /// Format: cnsfails{YYYYMM}{a|b}.zip (a = first half, b = second half)
     /// </summary>
-    internal static List<string> GetFileNames(DateOnly startDate)
+    internal static List<string> GetFileNames(DateOnly startDate) =>
+        GetFileNames(startDate, DateOnly.FromDateTime(DateTime.UtcNow));
+
+    private static List<string> GetFileNames(DateOnly startDate, DateOnly asOf)
     {
         var fileNames = new List<string>();
-        var now = DateOnly.FromDateTime(DateTime.UtcNow);
 
         if (startDate < OldestAvailableDate)
             startDate = OldestAvailableDate;
 
         var current = new DateOnly(startDate.Year, startDate.Month, 1);
 
-        while (current <= now)
+        while (current <= asOf)
         {
             var yearMonth = current.ToString("yyyyMM", CultureInfo.InvariantCulture);
 

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceFullPipelineTests.cs
@@ -99,10 +99,12 @@ public class FtdImportServiceFullPipelineTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Import_ReplayedTransitionMonth_ReconcilesLatestCusipOnlyOnce()
+    public async Task Import_ReplayedTransitionMonth_DoesNotRevertWhenNewerFileTemporarilyFails()
     {
         var currentMonth = new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
         var transitionMonth = currentMonth.AddMonths(-1);
+        var olderMonth = transitionMonth.AddMonths(-1);
+        var olderDate = olderMonth.AddDays(5);
         var retiringDate = transitionMonth.AddDays(5);
         var replacementDate = transitionMonth.AddDays(20);
         var stock = new CommonStock
@@ -126,16 +128,33 @@ public class FtdImportServiceFullPipelineTests : IAsyncLifetime
             "SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE\n"
             + $"{replacementDate:yyyyMMdd}|60871R209|TAP|200|MOLSON COORS|51.00\n";
         var yearMonth = transitionMonth.ToString("yyyyMM");
+        var olderYearMonth = olderMonth.ToString("yyyyMM");
+        var olderCsv =
+            "SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE\n"
+            + $"{olderDate:yyyyMMdd}|60871R100|TAP|50|MOLSON COORS|49.00\n";
         var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        var replacementFileAvailable = true;
         secEdgarClient
             .DownloadStream(Arg.Any<string>())
             .Returns(call =>
             {
                 var url = call.Arg<string>();
+                if (url.Contains($"cnsfails{olderYearMonth}", StringComparison.Ordinal))
+                    return Task.FromResult<Stream>(BuildFtdZipStream(olderCsv));
                 if (url.EndsWith($"cnsfails{yearMonth}a.zip", StringComparison.Ordinal))
                     return Task.FromResult<Stream>(BuildFtdZipStream(retiringCsv));
                 if (url.EndsWith($"cnsfails{yearMonth}b.zip", StringComparison.Ordinal))
-                    return Task.FromResult<Stream>(BuildFtdZipStream(replacementCsv));
+                {
+                    return replacementFileAvailable
+                        ? Task.FromResult<Stream>(BuildFtdZipStream(replacementCsv))
+                        : Task.FromException<Stream>(
+                            new HttpRequestException(
+                                "Temporary failure",
+                                null,
+                                HttpStatusCode.ServiceUnavailable
+                            )
+                        );
+                }
                 return Task.FromException<Stream>(
                     new HttpRequestException("Not Found", null, HttpStatusCode.NotFound)
                 );
@@ -152,12 +171,14 @@ public class FtdImportServiceFullPipelineTests : IAsyncLifetime
             Options.Create(
                 new WorkerOptions
                 {
-                    MinSyncDate = transitionMonth.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+                    MinSyncDate = olderMonth.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
                 }
             )
         );
 
         await sut.Import(CancellationToken.None);
+        await sut.Import(CancellationToken.None);
+        replacementFileAvailable = false;
         await sut.Import(CancellationToken.None);
 
         await bus.Received(1)

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceImportCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceImportCatchTests.cs
@@ -164,4 +164,37 @@ public class FtdImportServiceImportCatchTests
             );
         dbContext.Set<FailToDeliver>().ToList().Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task Import_DownloadIsCancelled_PropagatesWithoutReportingAnError()
+    {
+        var (scopeFactory, dbContext) = BuildScope();
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient
+            .DownloadStream(Arg.Any<string>())
+            .Returns<Task<Stream>>(_ => throw new OperationCanceledException("cancelled"));
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+        var sut = new FtdImportService(
+            scopeFactory,
+            secEdgarClient,
+            Substitute.For<ILogger<FtdImportService>>(),
+            errorReporter,
+            Options.Create(
+                new WorkerOptions
+                {
+                    MinSyncDate = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1),
+                    TickersToSync = [],
+                }
+            )
+        );
+
+        var act = () => sut.Import(CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        errorReporter.ReceivedCalls().Should().BeEmpty();
+        dbContext.Set<FailToDeliver>().ToList().Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Summary
- reconcile live CUSIP identity only from the complete prior calendar month
- bound replay evidence to one month and capture the UTC cycle date once
- propagate cancellation without reporting it as an import failure
- prevent incomplete or older fallback archives from reverting accepted identity

## Verification
- Release solution build: 0 errors
- 4,611 unit tests passed
- 2,777 integration tests passed
- 6 focused FTD integration tests passed
- CSharpier check and git diff check passed
- independent audit: no blocking or high-confidence findings

Follow-up hardening for EquiblesCommercial#7455.