### PR TITLE
fix(sec): restate only share-denominated facts across splits

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FinancialFactSplitAdjustment.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FinancialFactSplitAdjustment.cs
@@ -10,8 +10,28 @@ internal static class FinancialFactSplitAdjustment
         "Per-share values are split-adjusted to today's share basis using splits effective "
         + "strictly after each fact's Filed date.";
 
-    internal static bool IsPerShare(FinancialFact fact) =>
-        fact.Unit?.Contains('/', StringComparison.Ordinal) == true;
+    // Only a share-denominated ratio may be split-adjusted. Filers publish many
+    // other ratio units (USD/bbl, USD/MMBTU, USD/EUR, shares/USD, USD/Shareholder, …)
+    // whose values a stock split does not change, so the denominator measure must
+    // literally be shares; anything else stays as filed.
+    internal static bool IsPerShare(FinancialFact fact)
+    {
+        var unit = fact.Unit;
+        if (unit == null)
+        {
+            return false;
+        }
+
+        var separator = unit.IndexOf('/', StringComparison.Ordinal);
+        if (separator <= 0 || separator != unit.LastIndexOf('/'))
+        {
+            return false;
+        }
+
+        var denominator = unit[(separator + 1)..].Trim();
+        return denominator.Equals("shares", StringComparison.OrdinalIgnoreCase)
+            || denominator.Equals("share", StringComparison.OrdinalIgnoreCase);
+    }
 
     internal static decimal Restate(
         FinancialFact fact,

--- a/tests/Equibles.UnitTests/Sec/FinancialFactSplitAdjustmentIsPerShareTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactSplitAdjustmentIsPerShareTests.cs
@@ -1,0 +1,117 @@
+using Equibles.CorporateActions.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// <see cref="FinancialFactSplitAdjustment.IsPerShare"/> decides which stored
+/// facts get divided by a stock-split factor before an MCP answer renders
+/// them. The facts importer stores every unit SEC companyfacts publishes, and
+/// filers report many non-share ratios (USD/bbl, USD/MMBTU, USD/EUR,
+/// shares/USD, USD/Shareholder, …) whose values a stock split does not
+/// change. A classifier that keys on the mere presence of '/' restates a
+/// commodity realization price across a split; only a literal share
+/// denominator may qualify, and everything else must stay as filed.
+/// </summary>
+public class FinancialFactSplitAdjustmentIsPerShareTests
+{
+    private static FinancialFact Fact(string unit) =>
+        new()
+        {
+            Unit = unit,
+            Value = 100m,
+            FiledDate = new DateOnly(2020, 1, 2),
+        };
+
+    [Theory]
+    [InlineData("USD/shares")]
+    [InlineData("CAD/shares")]
+    [InlineData("EUR/shares")]
+    [InlineData("USD/Shares")]
+    [InlineData("USD/share")]
+    [InlineData("USD/Share")]
+    public void IsPerShare_ShareDenominatedRatio_IsTrue(string unit)
+    {
+        FinancialFactSplitAdjustment.IsPerShare(Fact(unit)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("USD/bbl")]
+    [InlineData("USD/MMBTU")]
+    [InlineData("USD/MWh")]
+    [InlineData("USD/oz")]
+    [InlineData("USD/EUR")]
+    [InlineData("USD/item")]
+    [InlineData("USD/loan")]
+    [InlineData("bbl/D")]
+    [InlineData("USD/Shareholder")]
+    [InlineData("USD/derivativeShare")]
+    [InlineData("USD/shares_unit")]
+    [InlineData("MXN/pershare")]
+    [InlineData("USD/oneTen-thousandthShare")]
+    public void IsPerShare_NonShareRatio_IsFalse(string unit)
+    {
+        FinancialFactSplitAdjustment.IsPerShare(Fact(unit)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPerShare_InvertedShareNumerator_IsFalse()
+    {
+        // shares/USD is share-count per dollar: a split multiplies it, so the
+        // per-share divide is wrong in both classification and direction.
+        FinancialFactSplitAdjustment.IsPerShare(Fact("shares/USD")).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("USD")]
+    [InlineData("shares")]
+    [InlineData("pure")]
+    [InlineData("/shares")]
+    [InlineData("USD/shares/shares")]
+    [InlineData(null)]
+    public void IsPerShare_NonRatioOrMalformedUnit_IsFalse(string unit)
+    {
+        FinancialFactSplitAdjustment.IsPerShare(Fact(unit)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Restate_NonShareRatioAcrossSplit_StaysAsFiled()
+    {
+        var fact = Fact("USD/bbl");
+        var splits = new List<StockSplit>
+        {
+            new()
+            {
+                EffectiveDate = new DateOnly(2022, 7, 18),
+                Numerator = 10m,
+                Denominator = 1m,
+            },
+        };
+
+        var value = FinancialFactSplitAdjustment.Restate(fact, splits, out var adjusted);
+
+        value.Should().Be(100m);
+        adjusted.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Restate_ShareDenominatedRatioAcrossSplit_IsDivided()
+    {
+        var fact = Fact("USD/shares");
+        var splits = new List<StockSplit>
+        {
+            new()
+            {
+                EffectiveDate = new DateOnly(2022, 7, 18),
+                Numerator = 10m,
+                Denominator = 1m,
+            },
+        };
+
+        var value = FinancialFactSplitAdjustment.Restate(fact, splits, out var adjusted);
+
+        value.Should().Be(10m);
+        adjusted.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Problem
`FinancialFactSplitAdjustment.IsPerShare` treated **any** ratio unit as per-share (`Unit.Contains('/')`). The facts importer stores every unit SEC companyfacts publishes, which includes non-share ratios filers use (USD/bbl, USD/MMBTU, USD/MWh, USD/oz, USD/EUR, shares/USD, USD/Shareholder, …). For a company with a post-filing stock split, `GetFinancialFact` / `CompareFinancialFact` / `GetFinancialStatement` divided such values by the split factor — e.g. a USD/bbl realization price divided by 10 after a 10:1 split — while the footer claimed only per-share values were adjusted.

## Fix
`IsPerShare` now requires a single-separator ratio whose denominator measure is literally `shares`/`share` (case-insensitive, covering the `USD/Shares`, `USD/share`, `CAD/Shares` variants that appear in real filings). Every other unit — including inverted `shares/USD` and per-shareholder ratios — stays as filed, which is the honest value when the classification is not certain.

## Tests
28 new unit tests over the real unit spellings observed in the production facts store (share-denominated variants adjust; commodity/currency/custom ratios, inverted ratios, malformed units, and bare units never adjust; `Restate` leaves a non-share ratio untouched across a split). Full `Equibles.UnitTests` (4,639) and the affected `FinancialFacts*`/`FinancialStatement*` integration classes (35, Testcontainers) pass locally.

https://claude.ai/code/session_011hGGmHpifqrFpgLgUhuEET