### PR TITLE
fix(holdings): stop rewriting unchanged 13F manager attribution

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -2015,17 +2015,83 @@ public class HoldingsImportService
 
         foreach (var dbHolding in dbHoldings)
         {
-            if (entriesByKey.TryGetValue(BuildHoldingKey(dbHolding), out var entries))
-            {
-                dbHolding.ManagerEntries.Clear();
-                dbHolding.ManagerEntries.AddRange(entries);
-            }
+            if (!entriesByKey.TryGetValue(BuildHoldingKey(dbHolding), out var entries))
+                continue;
+
+            // Replacing the collection deletes every stored row and re-inserts it, and each
+            // re-insert draws a fresh value from the owned type's synthetic key sequence. A
+            // re-import re-derives identical attribution for almost every position it revisits,
+            // so rewriting unconditionally burned roughly 45 keys per surviving row and
+            // exhausted the int sequence — halting the entire lane — five months after the table
+            // was created. Rewrite only when the attribution actually changed.
+            if (ManagerEntriesMatch(dbHolding.ManagerEntries, entries))
+                continue;
+
+            dbHolding.ManagerEntries.Clear();
+            dbHolding.ManagerEntries.AddRange(entries);
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return new HoldingsFlushResult(safeHoldings.Count, SkippedStaleParent: skipped > 0);
     }
+
+    /// <summary>
+    /// True when the stored attribution already says exactly what the re-parsed filing says.
+    /// Stored rows come back in whatever order Postgres returns them, which need not be the
+    /// order the filing was parsed in, so the two sides are compared as multisets rather than
+    /// as sequences — otherwise a re-ordered read would be mistaken for a real change.
+    /// </summary>
+    private static bool ManagerEntriesMatch(
+        List<HoldingManagerEntry> stored,
+        List<HoldingManagerEntry> incoming
+    )
+    {
+        if (stored.Count != incoming.Count)
+            return false;
+
+        var remaining = new Dictionary<ManagerEntryIdentity, int>();
+        foreach (var entry in stored)
+        {
+            var identity = ToIdentity(entry);
+            remaining[identity] = remaining.GetValueOrDefault(identity) + 1;
+        }
+
+        foreach (var entry in incoming)
+        {
+            var identity = ToIdentity(entry);
+            if (!remaining.TryGetValue(identity, out var count) || count == 0)
+                return false;
+
+            remaining[identity] = count - 1;
+        }
+
+        return true;
+    }
+
+    private static ManagerEntryIdentity ToIdentity(HoldingManagerEntry entry) =>
+        new(
+            entry.ManagerNumber,
+            entry.ManagerName,
+            entry.SharedManagerNumbers,
+            entry.Shares,
+            entry.Value,
+            entry.InvestmentDiscretion
+        );
+
+    /// <summary>
+    /// Every persisted column of a manager entry except the synthetic key. Record-struct
+    /// equality compares the names ordinally, so no culture rule can report two different
+    /// attributions as the same one and suppress a write that was needed.
+    /// </summary>
+    private readonly record struct ManagerEntryIdentity(
+        int? ManagerNumber,
+        string ManagerName,
+        string SharedManagerNumbers,
+        long Shares,
+        long Value,
+        InvestmentDiscretion InvestmentDiscretion
+    );
 
     // Recomputes the InstitutionalFiling rollup for every (holder, quarter) this
     // import touched, straight from the resulting holdings. The latest-filings feed

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceManagerEntriesMatchChangedFieldTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceManagerEntriesMatchChangedFieldTests.cs
@@ -1,0 +1,92 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceManagerEntriesMatchChangedFieldTests
+{
+    // The failure mode this guards is the opposite of the one the reorder test guards, and it
+    // is the dangerous one: reporting "unchanged" for attribution that actually moved means
+    // the flush skips the rewrite and the stored breakdown keeps a superseded figure forever,
+    // because nothing else in the lane ever revisits a manager entry. An amendment that only
+    // re-attributes shares between managers — same count of legs, same names — is exactly the
+    // case a comparison written on Count alone, or on the manager names alone, would wave
+    // through.
+    //
+    // Every persisted column except the synthetic key is asserted, so narrowing the comparison
+    // to a convenient subset fails here rather than in production a quarter later.
+    [Theory]
+    [MemberData(nameof(MutatedEntries))]
+    public void ManagerEntriesMatch_AnyPersistedFieldDiffers_ReportsChanged(
+        HoldingManagerEntry mutated
+    )
+    {
+        var stored = new List<HoldingManagerEntry> { Baseline() };
+        var incoming = new List<HoldingManagerEntry> { mutated };
+
+        Invoke(stored, incoming).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ManagerEntriesMatch_DifferentEntryCount_ReportsChanged()
+    {
+        var stored = new List<HoldingManagerEntry> { Baseline() };
+        var incoming = new List<HoldingManagerEntry> { Baseline(), Baseline() };
+
+        Invoke(stored, incoming).Should().BeFalse();
+    }
+
+    public static TheoryData<HoldingManagerEntry> MutatedEntries()
+    {
+        var data = new TheoryData<HoldingManagerEntry>();
+
+        var managerNumber = Baseline();
+        managerNumber.ManagerNumber = 7;
+        data.Add(managerNumber);
+
+        var managerName = Baseline();
+        managerName.ManagerName = "BETA ADVISORS";
+        data.Add(managerName);
+
+        var shared = Baseline();
+        shared.SharedManagerNumbers = "4,8,11";
+        data.Add(shared);
+
+        var shares = Baseline();
+        shares.Shares = 101;
+        data.Add(shares);
+
+        var value = Baseline();
+        value.Value = 2001;
+        data.Add(value);
+
+        var discretion = Baseline();
+        discretion.InvestmentDiscretion = InvestmentDiscretion.Defined;
+        data.Add(discretion);
+
+        return data;
+    }
+
+    private static HoldingManagerEntry Baseline() =>
+        new()
+        {
+            ManagerNumber = 1,
+            ManagerName = "ALPHA CAPITAL",
+            SharedManagerNumbers = "4,8",
+            Shares = 100,
+            Value = 2000,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+        };
+
+    private static bool Invoke(List<HoldingManagerEntry> stored, List<HoldingManagerEntry> incoming)
+    {
+        var method = typeof(HoldingsImportService).GetMethod(
+            "ManagerEntriesMatch",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            [typeof(List<HoldingManagerEntry>), typeof(List<HoldingManagerEntry>)]
+        );
+
+        return (bool)method.Invoke(null, [stored, incoming]);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceManagerEntriesMatchDuplicateLegsTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceManagerEntriesMatchDuplicateLegsTests.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceManagerEntriesMatchDuplicateLegsTests
+{
+    // Order-insensitivity must be multiset equality, not "every incoming leg exists somewhere
+    // in the stored set". A filer can report the same manager twice for one position — two
+    // legs that merge into one holding — so duplicates are real data, not a parser artefact.
+    //
+    // Written as a `stored.All(incoming.Contains)` style check, a filing that moved a leg from
+    // ALPHA to BETA while keeping the leg count identical would report "unchanged": every
+    // remaining ALPHA leg still has a match, and the count agrees. The rewrite would be
+    // skipped and the stored breakdown would keep attributing shares to a manager the amended
+    // filing no longer credits.
+    [Fact]
+    public void ManagerEntriesMatch_SameLegCountButOneLegReattributed_ReportsChanged()
+    {
+        var stored = new List<HoldingManagerEntry> { Entry(1, "ALPHA"), Entry(1, "ALPHA") };
+        var incoming = new List<HoldingManagerEntry> { Entry(1, "ALPHA"), Entry(2, "BETA") };
+
+        Invoke(stored, incoming).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ManagerEntriesMatch_IdenticalDuplicateLegs_ReportsUnchanged()
+    {
+        var stored = new List<HoldingManagerEntry> { Entry(1, "ALPHA"), Entry(1, "ALPHA") };
+        var incoming = new List<HoldingManagerEntry> { Entry(1, "ALPHA"), Entry(1, "ALPHA") };
+
+        Invoke(stored, incoming).Should().BeTrue();
+    }
+
+    private static HoldingManagerEntry Entry(int? managerNumber, string managerName) =>
+        new()
+        {
+            ManagerNumber = managerNumber,
+            ManagerName = managerName,
+            SharedManagerNumbers = null,
+            Shares = 100,
+            Value = 2000,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+        };
+
+    private static bool Invoke(List<HoldingManagerEntry> stored, List<HoldingManagerEntry> incoming)
+    {
+        var method = typeof(HoldingsImportService).GetMethod(
+            "ManagerEntriesMatch",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            [typeof(List<HoldingManagerEntry>), typeof(List<HoldingManagerEntry>)]
+        );
+
+        return (bool)method.Invoke(null, [stored, incoming]);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceManagerEntriesMatchReorderedTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceManagerEntriesMatchReorderedTests.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceManagerEntriesMatchReorderedTests
+{
+    // The flush path replaces a holding's manager entries by clearing the owned collection
+    // and re-adding it, which EF turns into a delete-and-reinsert of every row — and every
+    // reinsert draws a fresh value from the owned type's int key sequence. Re-imports
+    // re-derive identical attribution for nearly every position they revisit, so doing that
+    // unconditionally burned ~45 keys per surviving row and exhausted the sequence, halting
+    // the whole 13F lane.
+    //
+    // The stored side is read back without an ORDER BY, so Postgres may hand the rows back
+    // in a different order than the filing was parsed in. Comparing the two as SEQUENCES
+    // would then report "changed" for attribution that is in fact identical, the rewrite
+    // would happen anyway, and the fix would silently buy nothing while still looking
+    // correct in every other test.
+    [Fact]
+    public void ManagerEntriesMatch_SameEntriesInADifferentOrder_ReportsUnchanged()
+    {
+        var stored = new List<HoldingManagerEntry>
+        {
+            Entry(1, "ALPHA CAPITAL", null, 100, 2000),
+            Entry(4, "BETA ADVISORS", "4,8", 250, 5000),
+        };
+        var incoming = new List<HoldingManagerEntry>
+        {
+            Entry(4, "BETA ADVISORS", "4,8", 250, 5000),
+            Entry(1, "ALPHA CAPITAL", null, 100, 2000),
+        };
+
+        Invoke(stored, incoming).Should().BeTrue();
+    }
+
+    private static HoldingManagerEntry Entry(
+        int? managerNumber,
+        string managerName,
+        string sharedManagerNumbers,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            ManagerNumber = managerNumber,
+            ManagerName = managerName,
+            SharedManagerNumbers = sharedManagerNumbers,
+            Shares = shares,
+            Value = value,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+        };
+
+    private static bool Invoke(List<HoldingManagerEntry> stored, List<HoldingManagerEntry> incoming)
+    {
+        var method = typeof(HoldingsImportService).GetMethod(
+            "ManagerEntriesMatch",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            [typeof(List<HoldingManagerEntry>), typeof(List<HoldingManagerEntry>)]
+        );
+
+        return (bool)method.Invoke(null, [stored, incoming]);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceManagerEntryIdentityCoversEveryColumnTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceManagerEntryIdentityCoversEveryColumnTests.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceManagerEntryIdentityCoversEveryColumnTests
+{
+    // Two contracts depend on ManagerEntryIdentity naming EVERY persisted column of
+    // HoldingManagerEntry, and both fail silently if a new column is added without being
+    // listed there:
+    //
+    //  1. A filing that amends only the omitted column would compare equal, the flush would
+    //     skip the rewrite, and the stored leg would keep a superseded figure forever —
+    //     nothing else in the lane revisits a manager entry.
+    //  2. Re-import IS the backfill mechanism for newly added columns on this table. That
+    //     works only because a re-parsed leg differs from the stored one while the stored
+    //     value is still the default; if the new column is not compared, every leg reads as
+    //     unchanged and the column never populates for existing rows.
+    //
+    // Adding a property to HoldingManagerEntry therefore has to fail here until it is also
+    // added to the identity, rather than a quarter later in the data.
+    [Fact]
+    public void ManagerEntryIdentity_ListsEveryPersistedColumnOfHoldingManagerEntry()
+    {
+        var identityType = typeof(HoldingsImportService).GetNestedType(
+            "ManagerEntryIdentity",
+            BindingFlags.NonPublic
+        );
+
+        identityType.Should().NotBeNull();
+
+        var persistedColumns = typeof(HoldingManagerEntry)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(property => property.Name)
+            .OrderBy(name => name)
+            .ToList();
+
+        var comparedColumns = identityType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(property => property.Name)
+            .OrderBy(name => name)
+            .ToList();
+
+        comparedColumns.Should().Equal(persistedColumns);
+    }
+}


### PR DESCRIPTION
## Problem

The 13F import lane stopped writing in production with:

```
2200H: nextval: reached maximum value of sequence "HoldingManagerEntry_Id_seq" (2147483647)
```

`HoldingManagerEntry` is an EF `[Owned]` collection on `InstitutionalHolding`, keyed by the composite `(InstitutionalHoldingId, Id)` where `Id` is a synthetic `int` identity. The table holds **48M rows** but had consumed **2.1B keys** — a ~45x churn ratio — exhausting the sequence about five months after the table was created.

The cause is in `HoldingsImportService.FlushHoldings`:

```csharp
dbHolding.ManagerEntries.Clear();
dbHolding.ManagerEntries.AddRange(entries);
```

Replacing an owned collection makes EF delete every stored row and re-insert it, and each re-insert draws a fresh sequence value. A re-import re-derives byte-identical attribution for nearly every position it revisits, so this burned a key per leg on every pass — and cost a continuous delete/insert of ~14M rows a day in WAL, bloat and autovacuum pressure for no change in stored data.

## Fix

Compare the stored attribution against the re-parsed one and rewrite only when it actually differs.

Two details are load-bearing:

- **Multiset, not sequence.** The stored side is read back with no `ORDER BY`, so Postgres may return the legs in a different order than the filing was parsed in. A sequence comparison would report "changed" for identical attribution, the rewrite would happen anyway, and the fix would silently buy nothing while still looking correct.
- **Ordinal name comparison.** Record-struct equality uses `EqualityComparer<string>.Default`, so no culture rule can report two different attributions as the same one and suppress a write that was needed.

Duplicate legs are real data (a filer can credit the same manager twice for one position), which is why this is multiset equality rather than a subset check.

## Tests

Nine new tests in `tests/Equibles.UnitTests/Holdings/`:

- reordered-but-identical entries report **unchanged** (the saving this PR exists for)
- each of the six persisted columns, changed individually, reports **changed**
- differing leg counts report **changed**
- same leg count with one leg re-attributed reports **changed** (the multiset guard)

Mutation-checked: forcing the comparison to always return `true` fails 8 of them. Full suite green at 4,649 passed.

## Deployment note

Production was unblocked separately by moving the exhausted sequence into the negative half of the `int` range, which is provably free (all stored ids are >= 9,288,206). This PR removes the churn that consumed the range in the first place, dropping the burn rate roughly 45x. Widening the key to `bigint` remains worthwhile but is a table rewrite and a breaking migration, so it is tracked separately rather than bundled here.