### PR TITLE
fix: correct bank interest aliases, congress inline metadata, and insider ownership buckets

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -501,9 +501,10 @@ public class CongressionalTradeSyncService
                 continue;
 
             var cleanedName = DisclosureParsingHelper.CleanAssetName(details.AssetName);
-            var cleanedSubholding = details.Subholding == null
-                ? ""
-                : CleanStoredText(DisclosureParsingHelper.Truncate(details.Subholding, 256));
+            var cleanedSubholding =
+                details.Subholding == null
+                    ? ""
+                    : CleanStoredText(DisclosureParsingHelper.Truncate(details.Subholding, 256));
             legacyCandidates.Add(
                 new LegacyInlineMetadataCandidate(
                     legacy,

--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -47,7 +47,11 @@ public class CongressionalTradeSyncService
     // Congressional trade disclosures are available from 2012 (STOCK Act).
     private static readonly DateOnly EarliestAvailableDate = new(2012, 4, 1);
     private const int LegacyTradeParserVersion = 4;
-    private const int CurrentTradeParserVersion = 5;
+
+    // v6: reopens filings whose rows carried a filing-status-only inline metadata suffix
+    // ("... F S: New" with no subholding field) — earlier parses stored it inside AssetName,
+    // and the replay's repair deletes those polluted twins once the cleaned rows arrive.
+    private const int CurrentTradeParserVersion = 6;
     private const int ReprocessPerCycleLimit = 1_000;
 
     public async Task SyncAll(CancellationToken ct)
@@ -489,13 +493,17 @@ public class CongressionalTradeSyncService
         foreach (var legacy in legacyRows)
         {
             var details = HouseDisclosureClient.ExtractInlineAssetDetails(legacy.AssetName);
-            if (details.Subholding == null)
+            // A row can carry a filing-status-only suffix and no subholding field; the
+            // extractor still separates the metadata (Subholding stays null). Only rows the
+            // extractor left untouched hold no separable metadata and are skipped — a
+            // legitimate name such as "Series D:" never enters the repair.
+            if (details.Subholding == null && details.AssetName == legacy.AssetName)
                 continue;
 
             var cleanedName = DisclosureParsingHelper.CleanAssetName(details.AssetName);
-            var cleanedSubholding = CleanStoredText(
-                DisclosureParsingHelper.Truncate(details.Subholding, 256)
-            );
+            var cleanedSubholding = details.Subholding == null
+                ? ""
+                : CleanStoredText(DisclosureParsingHelper.Truncate(details.Subholding, 256));
             legacyCandidates.Add(
                 new LegacyInlineMetadataCandidate(
                     legacy,

--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -542,10 +542,10 @@ public partial class HouseDisclosureClient
         // subholding before removing that metadata suffix from the asset name.
         var inlineDetails = ExtractInlineAssetDetails(assetText);
         if (inlineDetails.Subholding != null)
-        {
             subholding = inlineDetails.Subholding;
-            assetText = inlineDetails.AssetName;
-        }
+        // Always adopt the returned name: a filing-status-only suffix is cut even when no
+        // subholding field is present (the extractor returns the text unchanged otherwise).
+        assetText = inlineDetails.AssetName;
 
         // The PDF's row checkboxes extract as "gfedc"/"gfedcb" glued onto the asset name — strip
         // them before the name is stored or mined for a ticker (see CleanAssetName).
@@ -667,11 +667,24 @@ public partial class HouseDisclosureClient
     internal static HouseInlineAssetDetails ExtractInlineAssetDetails(string assetText)
     {
         var subholdingMatch = InlineSubholdingRegex().Match(assetText);
+        var filingStatusMatch = InlineFilingStatusRegex().Match(assetText);
         if (!subholdingMatch.Success)
-            return new HouseInlineAssetDetails(assetText, null);
+        {
+            // No subholding field, but the compact filing-status label is still row metadata
+            // the word clustering glues onto the asset name ("Apple Inc. (AAPL) [ST] F S: New").
+            // Cut there; a bare "D:"/"Description:" stays untouched because names such as
+            // "Series D:" are legitimate. A line that IS entirely metadata keeps its text —
+            // it is not an asset row and must not become an empty name.
+            if (!filingStatusMatch.Success)
+                return new HouseInlineAssetDetails(assetText, null);
+
+            var nameBeforeStatus = assetText[..filingStatusMatch.Index].Trim();
+            return nameBeforeStatus.Length == 0
+                ? new HouseInlineAssetDetails(assetText, null)
+                : new HouseInlineAssetDetails(nameBeforeStatus, null);
+        }
 
         var metadataStart = subholdingMatch.Index;
-        var filingStatusMatch = InlineFilingStatusRegex().Match(assetText);
         if (filingStatusMatch.Success && filingStatusMatch.Index < metadataStart)
             metadataStart = filingStatusMatch.Index;
 

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -265,7 +265,7 @@ public class InsiderTradingTools
         ReadOnly = true
     )]
     [Description(
-        "Get a summary of insider ownership for a stock, ranked by shares held. Shares Owned is each insider's actual-share (non-derivative) position — options and other derivative holdings are excluded. Each row is as-of the last line of that insider's most recent SEC Form 3/4/5 filing (former insiders may linger with stale dates or zero shares), and share counts are restated onto today's split basis, so they can differ from the raw figures in older filings. Returns at most maxResults insiders (default 30). Use this to understand the insider ownership structure of a company; use GetInsiderTransactions for the underlying trades."
+        "Get a summary of insider ownership for a stock, ranked by total shares held. Shares come from each insider's most recent SEC Form 3/4/5 filing: the filing's closing balance per security and ownership bucket (actual shares only — options and other derivative holdings are excluded), summed into Direct and Indirect columns and restated onto today's split basis, so they can differ from the raw figures in older filings. Indirect can understate an insider holding through several vehicles, because a filing reports one balance per vehicle and only the last is kept. Former insiders may linger with stale dates or zero shares. Returns at most maxResults insiders (default 30). Use this to understand the insider ownership structure of a company; use GetInsiderTransactions for the underlying trades."
     )]
     public Task<string> GetInsiderOwnership(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -296,51 +296,62 @@ public class InsiderTradingTools
                     .GetByStock(stock)
                     .Where(t => t.SecurityKind == InsiderSecurityKind.NonDerivative);
 
-                // One row per insider — the LAST row of their newest filing, which carries
-                // the end-of-day balance (earlier rows of a multi-row Form 4 are intermediate
-                // balances). Materialize them ALL before ranking: each row sits on its own
-                // split basis, and cutting on the raw counts would under-rank insiders whose
-                // last filing predates a large split (pre-split counts are smaller until
-                // restated).
+                // Every row of each insider's NEWEST filing — not just its last line. A
+                // filing reports one closing balance PER OWNERSHIP BUCKET (security title ×
+                // direct or indirect), so the last line alone is only the final bucket's
+                // balance and understates every insider who also holds under another class
+                // or vehicle — the old single-row read published whichever bucket happened
+                // to sit on the filing's last line. Materialize them ALL before ranking:
+                // each row sits on its own split basis, and cutting on the raw counts would
+                // under-rank insiders whose last filing predates a large split. The Id
+                // clause keeps rows without an accession number reachable (they degrade to
+                // the old single-row read); the accession clause is correlated per insider,
+                // so a joint filing cannot leak another owner's rows in.
                 var currentByStock = byStock.OrderCurrentPositionFirst();
                 var latestTransactions = await _transactionRepository
                     .GetByStockWithOwner(stock)
                     .Where(t => t.SecurityKind == InsiderSecurityKind.NonDerivative)
                     .Where(t =>
                         t.Id
-                        == currentByStock
-                            .Where(t2 => t2.InsiderOwnerId == t.InsiderOwnerId)
-                            .Select(t2 => t2.Id)
-                            .First()
+                            == currentByStock
+                                .Where(t2 => t2.InsiderOwnerId == t.InsiderOwnerId)
+                                .Select(t2 => t2.Id)
+                                .First()
+                        || (
+                            t.AccessionNumber != null
+                            && t.AccessionNumber
+                                == currentByStock
+                                    .Where(t2 => t2.InsiderOwnerId == t.InsiderOwnerId)
+                                    .Select(t2 => t2.AccessionNumber)
+                                    .First()
+                        )
                     )
                     .ToListAsync();
 
-                // Restate every position onto today's basis, then rank and cut on the
-                // adjusted holding so the ordering — and the top-N cut itself — compares
+                // Restate every balance onto today's basis, then rank and cut on the
+                // adjusted total so the ordering — and the top-N cut itself — compares
                 // like with like.
                 var splits = await _stockSplitRepository
                     .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
                     .ToListAsync();
+                var positions = latestTransactions
+                    .GroupBy(t => t.InsiderOwnerId)
+                    .Select(group => BuildOwnershipPosition([.. group], splits))
+                    .ToList();
                 offset = McpLimit.ClampOffset(offset);
                 // Adjusted holdings tie constantly (zero-share former insiders), so the
                 // ordering ends on stable keys — an offset over a partial order would
                 // silently repeat or skip insiders between pages.
-                var ranked = latestTransactions
-                    .OrderByDescending(t =>
-                        SplitAdjustment.AdjustShareCount(
-                            t.SharesOwnedAfter,
-                            t.TransactionDate,
-                            splits
-                        )
-                    )
-                    .ThenBy(t => t.InsiderOwner.Name)
-                    .ThenBy(t => t.Id)
+                var ranked = positions
+                    .OrderByDescending(p => p.DirectShares + p.IndirectShares)
+                    .ThenBy(p => p.Anchor.InsiderOwner.Name)
+                    .ThenBy(p => p.Anchor.InsiderOwnerId)
                     .Skip(offset)
                     .Take(maxResults)
                     .ToList();
 
                 if (ranked.Count == 0 && offset > 0)
-                    return $"No results at offset {offset} - only {latestTransactions.Count} insiders on file; lower offset.";
+                    return $"No results at offset {offset} - only {positions.Count} insiders on file; lower offset.";
                 if (ranked.Count == 0)
                     return $"No insider ownership data found for {stock.Ticker}.";
 
@@ -348,31 +359,29 @@ public class InsiderTradingTools
                 sb.AppendLine($"Insider ownership summary for {stock.Name} ({stock.Ticker}):");
                 sb.AppendLine($"Showing {ranked.Count} insiders with most recent data");
                 sb.AppendLine(
-                    "_Each row is as-of that insider's most recent filing; Shares Owned is the actual-share (non-derivative) end-of-filing balance restated onto today's split basis. Former insiders may linger with stale dates or zero shares._"
+                    "_Each row is as-of that insider's most recent filing: the filing's closing balance per security and ownership bucket (actual shares only), summed into Direct and Indirect and restated onto today's split basis. A filing reports one balance per indirect vehicle and keeps no vehicle identity, so Indirect can understate an insider holding through several vehicles. Former insiders may linger with stale dates or zero shares._"
                 );
                 sb.AppendLine();
-                sb.AppendLine("| Insider | Role | Shares Owned | Last Transaction | Last Date |");
-                sb.AppendLine("|---------|------|-------------|-----------------|-----------|");
+                sb.AppendLine(
+                    "| Insider | Role | Direct Shares | Indirect Shares | Total | Last Transaction | Last Date |"
+                );
+                sb.AppendLine(
+                    "|---------|------|--------------|-----------------|-------|-----------------|-----------|"
+                );
                 sb.AppendRows(
                     ranked,
-                    t =>
+                    p =>
                     {
-                        var role = GetRole(t.InsiderOwner);
-                        var lastType = t.TransactionCode.NameForHumans();
-                        var sharesOwned = McpFormat.WholeNumber(
-                            SplitAdjustment.AdjustShareCount(
-                                t.SharesOwnedAfter,
-                                t.TransactionDate,
-                                splits
-                            )
-                        );
-                        return $"| {t.InsiderOwner.Name} | {role} | {sharesOwned} | {lastType} | {t.TransactionDate:yyyy-MM-dd} |";
+                        var role = GetRole(p.Anchor.InsiderOwner);
+                        var lastType = p.Anchor.TransactionCode.NameForHumans();
+                        var total = McpFormat.WholeNumber(p.DirectShares + p.IndirectShares);
+                        return $"| {p.Anchor.InsiderOwner.Name} | {role} | {McpFormat.WholeNumber(p.DirectShares)} | {McpFormat.WholeNumber(p.IndirectShares)} | {total} | {lastType} | {p.Anchor.TransactionDate:yyyy-MM-dd} |";
                     }
                 );
 
                 var truncation = McpOutput.PagedTruncationNote(
                     ranked.Count,
-                    latestTransactions.Count,
+                    positions.Count,
                     offset
                 );
                 if (truncation.Length > 0)
@@ -386,6 +395,50 @@ public class InsiderTradingTools
             "GetInsiderOwnership",
             $"ticker: {ticker}, offset: {offset}"
         );
+    }
+
+    private sealed record InsiderOwnershipPosition(
+        InsiderTransaction Anchor,
+        long DirectShares,
+        long IndirectShares
+    );
+
+    // One insider's current position from their newest filing's rows. A multi-row filing lists
+    // intermediate balances per bucket, so only each (security title, direct/indirect) bucket's
+    // LAST row — filing order, mirroring OrderCurrentPositionFirst — is that bucket's closing
+    // balance; those are restated onto today's split basis and summed per nature. The anchor is
+    // the filing's overall last row (the row the tool previously showed alone).
+    private static InsiderOwnershipPosition BuildOwnershipPosition(
+        List<InsiderTransaction> rows,
+        List<StockSplit> splits
+    )
+    {
+        var ordered = rows.OrderByDescending(t => t.TransactionDate)
+            .ThenByDescending(t => t.FilingDate)
+            .ThenByDescending(t => t.AccessionNumber, StringComparer.Ordinal)
+            .ThenByDescending(t => t.TransactionOrder)
+            .ThenByDescending(t => t.Id)
+            .ToList();
+
+        long direct = 0;
+        long indirect = 0;
+        foreach (
+            var bucket in ordered.GroupBy(t => (Title: t.SecurityTitle ?? "", t.OwnershipNature))
+        )
+        {
+            var closing = bucket.First();
+            var adjusted = SplitAdjustment.AdjustShareCount(
+                closing.SharesOwnedAfter,
+                closing.TransactionDate,
+                splits
+            );
+            if (bucket.Key.OwnershipNature == OwnershipNature.Direct)
+                direct += adjusted;
+            else
+                indirect += adjusted;
+        }
+
+        return new InsiderOwnershipPosition(ordered[0], direct, indirect);
     }
 
     [McpServerTool(

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -106,8 +106,22 @@ public static class FinancialConceptAliases
         // line, never a fallback for operating-expenses.
         ["total-costs-and-expenses"] = [G("CostsAndExpenses")],
         ["operating-income"] = [G("OperatingIncomeLoss")],
-        ["interest-expense"] = [G("InterestExpense"), G("InterestExpenseNonoperating")],
-        ["interest-income"] = [G("InvestmentIncomeInterest")],
+        // InterestExpense was deprecated from the 2024 taxonomy; banks continue the
+        // series under the operating variant (nonfinancial filers moved to the
+        // nonoperating one), so without the fallback a bank's interest-expense
+        // series ends mid-2024 (JPM stops at 2024-03-31 without it).
+        ["interest-expense"] = [
+            G("InterestExpense"),
+            G("InterestExpenseNonoperating"),
+            G("InterestExpenseOperating"),
+        ],
+        // Banks report the income statement's gross interest-income line under the
+        // operating tag while ALSO tagging the narrow investment-interest sub-item
+        // (JPM FY2024: $193.9B vs $23.1B). Preferring the narrow tag printed it as
+        // the bank's "Interest Income" beside a five-times-larger Net Interest
+        // Income — arithmetically impossible on one statement. Nonfinancial filers
+        // never tag the operating variant, so their series are unaffected.
+        ["interest-income"] = [G("InterestIncomeOperating"), G("InvestmentIncomeInterest")],
         ["other-nonoperating-income"] =
         [
             G("NonoperatingIncomeExpense"),

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -110,7 +110,8 @@ public static class FinancialConceptAliases
         // series under the operating variant (nonfinancial filers moved to the
         // nonoperating one), so without the fallback a bank's interest-expense
         // series ends mid-2024 (JPM stops at 2024-03-31 without it).
-        ["interest-expense"] = [
+        ["interest-expense"] =
+        [
             G("InterestExpense"),
             G("InterestExpenseNonoperating"),
             G("InterestExpenseOperating"),

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeSyncServiceProcessTests.cs
@@ -779,6 +779,56 @@ public class CongressionalTradeSyncServiceProcessTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task ProcessTransactions_FilingStatusOnlyPollutedLegacyName_ReplayDeletesTheTwin()
+    {
+        // The Chip Roy shape: the compact filing-status label rode the asset line with NO
+        // subholding field, so the legacy row stored "... F S: New" inside AssetName. The old
+        // repair only recognized rows with a separable subholding and skipped these, leaving a
+        // polluted twin beside the clean replayed row forever.
+        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
+        var member = new CongressMember { Name = "Jane Doe", Position = CongressPosition.Senator };
+        DbContext.AddRange(stock, member);
+        DbContext.Add(
+            new CongressionalTrade
+            {
+                CongressMember = member,
+                CongressMemberId = member.Id,
+                CommonStock = stock,
+                CommonStockId = stock.Id,
+                TransactionDate = new DateOnly(2024, 6, 1),
+                FilingDate = new DateOnly(2024, 6, 14),
+                TransactionType = CongressTransactionType.Purchase,
+                OwnerType = "self",
+                AssetName = "Apple Inc. (AAPL) F S: New",
+                AssetType = "ST",
+                Subholding = "",
+                AmountFrom = 1_001,
+                AmountTo = 15_000,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await (Task)
+            ProcessTransactionsMethod.Invoke(
+                BuildSut(),
+                [
+                    new List<DisclosureTransaction>
+                    {
+                        Txn("Jane Doe", "AAPL", assetName: "Apple Inc. (AAPL)"),
+                    },
+                    CancellationToken.None,
+                ]
+            );
+
+        await using var verify = Fixture.CreateDbContext();
+        var stored = await verify.Set<CongressionalTrade>().AsNoTracking().ToListAsync();
+        var trade = stored.Should().ContainSingle().Subject;
+        trade.AssetName.Should().Be("Apple Inc. (AAPL)");
+        trade.SourceId.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task ProcessTransactions_TwoPollutedLegacyAccounts_ReplaySeparatesBothAccounts()
     {
         const string firstSubholding = "Brokerage Account A";

--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeReplayGateTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeReplayGateTests.cs
@@ -8,7 +8,7 @@ public class CongressionalTradeReplayGateTests
     [InlineData(true, false, 4)]
     [InlineData(true, true, 4)]
     [InlineData(false, true, 4)]
-    [InlineData(false, false, 5)]
+    [InlineData(false, false, 6)]
     public void SelectTradeParserVersion_EvidenceAndTickerScope_ActivatesExpectedVersion(
         bool evidenceBackfillPending,
         bool tickerScopeRestricted,

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
@@ -177,6 +177,36 @@ public class HouseDisclosureClientTests
     }
 
     [Fact]
+    public void ParseTransactionLines_InlineFilingStatusWithoutSubholding_StripsTheMetadataSuffix()
+    {
+        // The compact filing-status label can ride the asset line with NO subholding field.
+        // Before the cut, the suffix was stored inside AssetName ("... F S: New"), creating a
+        // polluted twin of the clean row a later replay produced (Chip Roy, 2026-08).
+        var result = Parse(
+            "Apple Inc. (AAPL) [ST] F S: New P 03/03/2025 03/05/2025 $1,001 - $15,000"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.Ticker.Should().Be("AAPL");
+        tx.AssetType.Should().Be("ST");
+        tx.Subholding.Should().BeNull();
+        tx.AssetName.Should().Be("Apple Inc. (AAPL)");
+    }
+
+    [Fact]
+    public void ParseTransactionLines_ExpandedFilingStatusWithoutSubholding_StripsTheMetadataSuffix()
+    {
+        var result = Parse(
+            "Tesla Inc. (TSLA) [ST] Filing Status: Amended P 03/03/2025 03/05/2025 $1,001 - $15,000"
+        );
+
+        var tx = result.Should().ContainSingle().Subject;
+        tx.Ticker.Should().Be("TSLA");
+        tx.Subholding.Should().BeNull();
+        tx.AssetName.Should().Be("Tesla Inc. (TSLA)");
+    }
+
+    [Fact]
     public void ParseTransactionLines_SeriesDAssetNameWithoutSubholding_PreservesAssetName()
     {
         var result = Parse(

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipBucketsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipBucketsTests.cs
@@ -1,0 +1,236 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Mcp.Tools;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Media.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Mcp;
+
+/// <summary>
+/// Pins the ownership-summary balance rule: a Form 3/4/5 reports one closing balance PER
+/// OWNERSHIP BUCKET (security title × direct/indirect), so an insider's position is the sum of
+/// the newest filing's per-bucket closing balances split into Direct and Indirect columns —
+/// never just the filing's last line. The last line is only whichever bucket happened to be
+/// printed last: LLY's CEO filed 571,715 direct shares followed by a 7,307-share 401(k) line,
+/// and the single-last-row read published 7,307 as his entire position.
+/// </summary>
+public class InsiderTradingToolsOwnershipBucketsTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+                new InsiderTradingModuleConfiguration(),
+                new ErrorsModuleConfiguration(),
+                new MediaModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static InsiderTradingTools Sut(EquiblesFinancialDbContext db) =>
+        new(
+            new InsiderTransactionRepository(db),
+            new InsiderOwnerRepository(db),
+            new Form144FilingRepository(db),
+            new CommonStockRepository(db),
+            new StockSplitRepository(db),
+            new ErrorManager(new ErrorRepository(db)),
+            Substitute.For<ILogger<InsiderTradingTools>>()
+        );
+
+    private static InsiderTransaction Row(
+        CommonStock stock,
+        InsiderOwner owner,
+        string accession,
+        int order,
+        long ownedAfter,
+        OwnershipNature nature,
+        string title = "Common Stock",
+        DateOnly? transactionDate = null,
+        DateOnly? filingDate = null
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            CommonStock = stock,
+            InsiderOwnerId = owner.Id,
+            InsiderOwner = owner,
+            TransactionDate = transactionDate ?? new DateOnly(2026, 2, 10),
+            FilingDate = filingDate ?? new DateOnly(2026, 2, 12),
+            TransactionCode = TransactionCode.Sale,
+            Shares = 1_000,
+            PricePerShare = 100m,
+            AcquiredDisposed = AcquiredDisposed.Disposed,
+            SharesOwnedAfter = ownedAfter,
+            OwnershipNature = nature,
+            SecurityKind = InsiderSecurityKind.NonDerivative,
+            SecurityTitle = title,
+            AccessionNumber = accession,
+            TransactionOrder = order,
+        };
+
+    private static (CommonStock Stock, InsiderOwner Owner) Fixture(EquiblesFinancialDbContext db)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "LLY",
+            Name = "Eli Lilly and Company",
+            Cik = "0000059478",
+        };
+        var owner = new InsiderOwner
+        {
+            OwnerCik = "0001233333",
+            Name = "David Ricks",
+            IsOfficer = true,
+            OfficerTitle = "CEO",
+        };
+        db.AddRange(stock, owner);
+        return (stock, owner);
+    }
+
+    // The LLY shape: the direct balance is filed BEFORE a small indirect 401(k) line, so the
+    // filing's last row is the 7,307-share bucket — the old read published that as the CEO's
+    // whole position.
+    [Fact]
+    public async Task GetInsiderOwnership_DirectAndIndirectBuckets_SumsPerBucketClosingBalances()
+    {
+        await using var db = NewDb();
+        var (stock, owner) = Fixture(db);
+        db.AddRange(
+            Row(stock, owner, "acc-1", order: 0, ownedAfter: 571_715, OwnershipNature.Direct),
+            Row(stock, owner, "acc-1", order: 1, ownedAfter: 7_307, OwnershipNature.Indirect)
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("LLY");
+
+        output.Should().Contain("| 571,715 | 7,307 | 579,022 |");
+    }
+
+    // A multi-row filing lists intermediate balances inside one bucket; only the bucket's last
+    // row is its closing balance, so intermediate rows must not be summed in.
+    [Fact]
+    public async Task GetInsiderOwnership_IntermediateBalancesInOneBucket_TakesOnlyTheClosingRow()
+    {
+        await using var db = NewDb();
+        var (stock, owner) = Fixture(db);
+        db.AddRange(
+            Row(stock, owner, "acc-1", order: 0, ownedAfter: 600_000, OwnershipNature.Direct),
+            Row(stock, owner, "acc-1", order: 1, ownedAfter: 571_715, OwnershipNature.Direct),
+            Row(stock, owner, "acc-1", order: 2, ownedAfter: 7_307, OwnershipNature.Indirect)
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("LLY");
+
+        output.Should().Contain("| 571,715 | 7,307 | 579,022 |");
+        output.Should().NotContain("600,000");
+    }
+
+    // Two different securities held directly are two buckets — both closing balances count.
+    [Fact]
+    public async Task GetInsiderOwnership_TwoSecurityTitles_SumsBothBuckets()
+    {
+        await using var db = NewDb();
+        var (stock, owner) = Fixture(db);
+        db.AddRange(
+            Row(stock, owner, "acc-1", order: 0, ownedAfter: 100_000, OwnershipNature.Direct),
+            Row(
+                stock,
+                owner,
+                "acc-1",
+                order: 1,
+                ownedAfter: 50_000,
+                OwnershipNature.Direct,
+                title: "Class B Common Stock"
+            )
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("LLY");
+
+        output.Should().Contain("| 150,000 |");
+    }
+
+    // Only the NEWEST filing's buckets count — an older filing's balances are superseded even
+    // when they are larger.
+    [Fact]
+    public async Task GetInsiderOwnership_OlderFiling_IsIgnored()
+    {
+        await using var db = NewDb();
+        var (stock, owner) = Fixture(db);
+        db.AddRange(
+            Row(
+                stock,
+                owner,
+                "acc-0",
+                order: 0,
+                ownedAfter: 900_000,
+                OwnershipNature.Direct,
+                transactionDate: new DateOnly(2025, 11, 1),
+                filingDate: new DateOnly(2025, 11, 3)
+            ),
+            Row(stock, owner, "acc-1", order: 0, ownedAfter: 571_715, OwnershipNature.Direct)
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("LLY");
+
+        output.Should().Contain("| 571,715 |");
+        output.Should().NotContain("900,000");
+    }
+
+    // Ranking uses the combined Direct + Indirect total, so a mostly-indirect holder outranks a
+    // smaller all-direct one.
+    [Fact]
+    public async Task GetInsiderOwnership_RanksByCombinedTotal()
+    {
+        await using var db = NewDb();
+        var (stock, owner) = Fixture(db);
+        var trustee = new InsiderOwner
+        {
+            OwnerCik = "0001244444",
+            Name = "Trust Holder",
+            IsDirector = true,
+        };
+        db.Add(trustee);
+        db.AddRange(
+            Row(stock, owner, "acc-1", order: 0, ownedAfter: 100_000, OwnershipNature.Direct),
+            Row(stock, trustee, "acc-2", order: 0, ownedAfter: 1_000, OwnershipNature.Direct),
+            Row(stock, trustee, "acc-2", order: 1, ownedAfter: 500_000, OwnershipNature.Indirect)
+        );
+        await db.SaveChangesAsync();
+
+        var output = await Sut(db).GetInsiderOwnership("LLY");
+
+        output
+            .IndexOf("Trust Holder", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("David Ricks", StringComparison.Ordinal));
+        output.Should().Contain("| 1,000 | 500,000 | 501,000 |");
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipBucketsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsOwnershipBucketsTests.cs
@@ -1,6 +1,8 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
@@ -9,8 +11,6 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Mcp.Tools;
 using Equibles.InsiderTrading.Repositories;
-using Equibles.CommonStocks.Repositories;
-using Equibles.CorporateActions.Repositories;
 using Equibles.Media.Data;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
Three defects confirmed by the 2026-08-25 full MCP tool audit (109 tools, adversarially verified against SEC filings and prod data):

1. **fix(sec)** — `interest-income` resolved only to `InvestmentIncomeInterest`, printing JPM's narrow $23.1B investment-interest sub-item as its income-statement "Interest Income" beside a five-times-larger Net Interest Income. Banks tag the real line as `InterestIncomeOperating` (JPM: full 2010–2025 coverage, FY2024 $193.9B — reconciles: 193.9 gross − 101.3 expense = 92.6 net). `interest-expense` gains the post-2024-deprecation `InterestExpenseOperating` fallback. Nonfinancial filers tag neither operating variant; their series are unchanged.

2. **fix(congress)** — the compact `F S:` filing-status label riding an asset line **without** a subholding field was never stripped, storing "… F S: New" inside `AssetName` and creating permanent polluted twins beside the clean replayed rows (Chip Roy, prod, 2026-08-22/23). The extractor now cuts at the filing-status label alone (bare `D:` untouched — "Series D:" is a legitimate name), the twin repair accepts null-subholding candidates, and `TradeParserVersion` 6 reopens processed filings so replay heals stored history. Unit + PostgreSQL integration coverage added.

3. **fix(insider-trading)** — `GetInsiderOwnership` read only the LAST line of each insider's newest Form 3/4/5, but a filing reports one closing balance per ownership bucket (security title × direct/indirect); LLY's CEO showed 7,307 shares (his 401(k) line) instead of 571,715 direct + 7,307 indirect. Now sums per-bucket closing balances into Direct/Indirect columns ranked by the combined total, with the multi-vehicle indirect understatement disclosed in the tool text.

Tests: new unit tests (House line shapes, ownership buckets) + a new integration test for the filing-status-only repair; full suite run with `Category!=Functional&Category!=Live`.

https://claude.ai/code/session_01D2hdbsYSPoYGMj2ZE9QmRp