### PR TITLE
fix(sec): cap chunking retries per document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - SEC document chunking now reads an indexed pending-state queue instead of scanning every stored document and probing the chunk corpus on each drained poll. Closes #3823.
 - Fails-to-deliver replays reconcile CUSIP identity only from a complete prior calendar month and no longer rewrite settled rows on every daily cycle. PRs #4461 and #4462.
 - Split adjustment of financial facts now applies only to share-denominated units, so ratio units such as USD/bbl or USD/MMBTU stay as filed. PR #4463.
+- Document chunking counts failed attempts per document and parks a document after five failures instead of letting it burn a batch slot every cycle; a content replacement or chunk reset returns it to the queue with a fresh budget. Closes #4464.
+- 13F imports no longer delete and reinsert a holding's manager-attribution legs when the re-parsed legs match the stored ones, which was burning the leg table's synthetic key space on every unchanged re-import. PR #4466.
 
 ## [1.6.1] — 2026-08-22
 

--- a/src/Equibles.Migrations/Migrations/20260825134832_AddDocumentChunkAttempts.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260825134832_AddDocumentChunkAttempts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825134832_AddDocumentChunkAttempts")]
+    partial class AddDocumentChunkAttempts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260825134832_AddDocumentChunkAttempts.cs
+++ b/src/Equibles.Migrations/Migrations/20260825134832_AddDocumentChunkAttempts.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentChunkAttempts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ChunkAttempts",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ChunkAttempts",
+                table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -66,6 +66,19 @@ public class Document
     public DateTime? ChunkedAt { get; set; }
 
     /// <summary>
+    /// How many chunking attempts for this document have failed. The pending queue stops
+    /// selecting it at <see cref="MaxChunkAttempts"/> so a deterministically failing document
+    /// cannot occupy a FIFO batch slot every cycle. A parked document (null
+    /// <see cref="ChunkedAt"/> at the ceiling) stays queryable rather than being marked
+    /// complete; content replacement and explicit chunk resets clear the counter together
+    /// with <see cref="ChunkedAt"/> so the returning document gets a fresh budget.
+    /// </summary>
+    public int ChunkAttempts { get; set; }
+
+    /// <summary>Retry ceiling for <see cref="ChunkAttempts"/>.</summary>
+    public const int MaxChunkAttempts = 5;
+
+    /// <summary>
     /// Version of the HTML-normalization and Markdown-conversion pipeline that produced
     /// <see cref="Content"/>. Existing rows default to 0; the backfill re-fetches their EDGAR
     /// submission and replaces the stored text when this is below

--- a/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentManager.cs
@@ -53,7 +53,11 @@ public class DocumentManager
 
         var pendingDocumentIds = await _documentRepository
             .GetAll()
-            .Where(d => d.ChunkedAt == null && d.Content != null)
+            .Where(d =>
+                d.ChunkedAt == null
+                && d.Content != null
+                && d.ChunkAttempts < Document.MaxChunkAttempts
+            )
             .OrderBy(d => d.CreationTime)
             .ThenBy(d => d.Id)
             .Select(d => d.Id)
@@ -93,6 +97,13 @@ public class DocumentManager
             {
                 await transaction.RollbackAsync(cancellationToken);
                 _logger.LogError(ex, "Error chunking document {DocumentId}", documentId);
+
+                // A shutdown mid-chunk is not a document fault, so only a genuine failure
+                // consumes retry budget.
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await RecordChunkAttempt(documentId, cancellationToken);
+                }
             }
             finally
             {
@@ -113,6 +124,40 @@ public class DocumentManager
 
     private Task<int> BackfillChunkedAtBatch(CancellationToken cancellationToken) =>
         _documentRepository.BackfillLegacyChunked(_loadSize, DateTime.UtcNow, cancellationToken);
+
+    // The failed transaction rolled back every tracked change, so the retry bookkeeping is
+    // persisted separately, exactly like the normalization lane's attempt counter. A document
+    // that reaches the ceiling stays pending-but-parked: visible to queries, no longer selected.
+    private async Task RecordChunkAttempt(Guid documentId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var attempts = await _documentRepository.PersistChunkAttempt(
+                documentId,
+                cancellationToken
+            );
+            if (attempts >= Document.MaxChunkAttempts)
+            {
+                _logger.LogWarning(
+                    "Document {DocumentId} failed chunking {Attempts} times and leaves the "
+                        + "pending queue; a content replacement or chunk reset returns it "
+                        + "with a fresh budget",
+                    documentId,
+                    attempts
+                );
+            }
+        }
+        catch (Exception ex)
+        {
+            // Bookkeeping must never mask the original failure; the document simply stays
+            // pending and the next cycle retries both the chunking and this counter.
+            _logger.LogError(
+                ex,
+                "Failed to record the chunk attempt for document {DocumentId}",
+                documentId
+            );
+        }
+    }
 
     public async Task<bool> GenerateEmbeddingBatch(
         BackfillCursor cursor,

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -213,12 +213,18 @@ public class DocumentPersistenceService : IDocumentPersistenceService
 
     private async Task ClearChunkedAt(Document document, CancellationToken cancellationToken)
     {
+        // A returning document gets a fresh retry budget: the failures that parked it were
+        // about the content being replaced or the chunks being reset, not the new state.
         document.ChunkedAt = null;
+        document.ChunkAttempts = 0;
         await _documentRepository
             .GetAll()
             .Where(d => d.Id == document.Id)
             .ExecuteUpdateAsync(
-                setters => setters.SetProperty(d => d.ChunkedAt, (DateTime?)null),
+                setters =>
+                    setters
+                        .SetProperty(d => d.ChunkedAt, (DateTime?)null)
+                        .SetProperty(d => d.ChunkAttempts, 0),
                 cancellationToken
             );
     }

--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -306,6 +306,28 @@ public class DocumentRepository : BaseRepository<Document>
             );
     }
 
+    /// <summary>
+    /// Persists chunk-retry bookkeeping after a failed attempt whose transaction rolled back,
+    /// and returns the new attempt count. The increment runs store-side so concurrent workers
+    /// cannot lose an attempt to a stale in-memory value.
+    /// </summary>
+    public async Task<int> PersistChunkAttempt(
+        Guid documentId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await GetAll()
+            .Where(d => d.Id == documentId)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(x => x.ChunkAttempts, x => x.ChunkAttempts + 1),
+                cancellationToken
+            );
+        return await GetAll()
+            .Where(d => d.Id == documentId)
+            .Select(d => d.ChunkAttempts)
+            .SingleOrDefaultAsync(cancellationToken);
+    }
+
     public virtual async Task<Document> GetWithContent(
         Guid id,
         CancellationToken cancellationToken = default

--- a/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentManagerTests.cs
@@ -645,6 +645,134 @@ public class DocumentManagerTests : ParadeDbMcpTestBase
             );
     }
 
+    [Fact]
+    public async Task ChunkDocumentBatch_FailingDocument_CountsTheAttemptAndStaysPending()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+        };
+        var file = MakeFile();
+        var document = MakeDocument(
+            stock,
+            file,
+            contentId: file.Id,
+            createdAt: DateTime.UtcNow.AddMinutes(-5)
+        );
+
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<File>().Add(file);
+        DbContext.Set<Document>().Add(document);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        _processor
+            .ProcessDocument(Arg.Any<Document>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("content store down")));
+
+        var sut = NewChunkingManager();
+        var act = () => sut.ChunkDocumentBatch(CancellationToken.None);
+
+        // Every document in the batch failed, so the systemic-outage backoff guard surfaces —
+        // but the attempt must already be persisted despite the chunking transaction's rollback.
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Backing off*");
+
+        var stored = await DbContext
+            .Set<Document>()
+            .AsNoTracking()
+            .SingleAsync(d => d.Id == document.Id);
+        stored.ChunkedAt.Should().BeNull("a failed document stays pending");
+        stored.ChunkAttempts.Should().Be(1, "the rolled-back attempt is still counted");
+    }
+
+    [Fact]
+    public async Task ChunkDocumentBatch_DocumentAtTheAttemptCeiling_IsParkedNotSelected()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+        };
+        var file = MakeFile();
+        var document = MakeDocument(
+            stock,
+            file,
+            contentId: file.Id,
+            createdAt: DateTime.UtcNow.AddMinutes(-5)
+        );
+        document.ChunkAttempts = Document.MaxChunkAttempts;
+
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<File>().Add(file);
+        DbContext.Set<Document>().Add(document);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var sut = NewChunkingManager();
+        var workDone = await sut.ChunkDocumentBatch(CancellationToken.None);
+
+        workDone.Should().BeFalse("a parked document must not occupy a batch slot");
+        _processor.ReceivedCalls().Should().BeEmpty();
+
+        // Parked means still visibly pending — never silently marked complete.
+        var stored = await DbContext
+            .Set<Document>()
+            .AsNoTracking()
+            .SingleAsync(d => d.Id == document.Id);
+        stored.ChunkedAt.Should().BeNull();
+        stored.ChunkAttempts.Should().Be(Document.MaxChunkAttempts);
+    }
+
+    [Fact]
+    public async Task ResetChunks_ParkedDocument_ReturnsItWithAFreshRetryBudget()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+        };
+        var file = MakeFile();
+        var document = MakeDocument(
+            stock,
+            file,
+            contentId: file.Id,
+            createdAt: DateTime.UtcNow.AddMinutes(-10)
+        );
+        document.ChunkedAt = DateTime.UtcNow.AddMinutes(-9);
+        document.ChunkAttempts = Document.MaxChunkAttempts;
+
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<File>().Add(file);
+        DbContext.Set<Document>().Add(document);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var tracked = await DbContext.Set<Document>().SingleAsync(d => d.Id == document.Id);
+        await NewResetService(DbContext).ResetChunks(tracked, CancellationToken.None);
+        DbContext.ChangeTracker.Clear();
+
+        var stored = await DbContext
+            .Set<Document>()
+            .AsNoTracking()
+            .SingleAsync(d => d.Id == document.Id);
+        stored.ChunkedAt.Should().BeNull("the reset returns the document to the pending queue");
+        stored.ChunkAttempts.Should().Be(0, "a returning document gets a fresh retry budget");
+    }
+
+    private DocumentManager NewChunkingManager() =>
+        new(
+            new DocumentRepository(DbContext),
+            new ChunkRepository(DbContext),
+            new BackfillStateRepository(DbContext),
+            _processor,
+            Options.Create(new EmbeddingConfig { Enabled = false }),
+            NullLogger<DocumentManager>()
+        );
+
     private DocumentManager NewEmbeddingManager() =>
         new(
             new DocumentRepository(DbContext),


### PR DESCRIPTION
Closes #4464.

- `Document.ChunkAttempts` + `MaxChunkAttempts = 5`, mirroring the normalization lane's ceiling.
- The pending-chunk selection skips documents at the ceiling; the attempt is persisted store-side after the failed transaction's rollback, and a shutdown mid-chunk does not consume budget.
- `ClearChunkedAt` (content replacement / chunk reset) zeroes the counter so a returning document gets a fresh budget.
- A parked document (`ChunkedAt IS NULL`, attempts at ceiling) stays queryable — never silently completed.
- Additive migration `AddDocumentChunkAttempts` (int default 0); downstream deployments mirror it.
- 3 new integration tests: failed attempt counted + stays pending, parked document not selected, reset restores budget.
- CHANGELOG: entries for this fix and the missing #4466 line.

https://claude.ai/code/session_011hGGmHpifqrFpgLgUhuEET