### PR TITLE
feat(common-stocks): search can include retained delisted identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- `CommonStockRepository.Search` accepts an `includeInactive` flag so operator surfaces can audit retained delisted identities; reader-facing surfaces keep the active-only default.
+
 ### Fixed
 
 - SEC document chunking now reads an indexed pending-state queue instead of scanning every stored document and probing the chunk corpus on each drained poll. Closes #3823.

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -62,9 +62,14 @@ public class CommonStockRepository : BaseRepository<CommonStock>
     public IQueryable<CommonStock> GetByIdsIncludingInactive(IEnumerable<Guid> ids) =>
         GetAllIncludingInactive().Where(stock => ids.Contains(stock.Id));
 
-    public IQueryable<CommonStock> Search(string search)
+    /// <param name="includeInactive">
+    /// When true, retained delisted identities (<c>Active == false</c>) are searched too —
+    /// for operator surfaces that must audit what a delisting sync retired. Reader-facing
+    /// surfaces keep the default active-only universe.
+    /// </param>
+    public IQueryable<CommonStock> Search(string search, bool includeInactive = false)
     {
-        var query = GetAll();
+        var query = includeInactive ? GetAllIncludingInactive() : GetAll();
 
         if (string.IsNullOrEmpty(search))
         {

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryTests.cs
@@ -537,6 +537,25 @@ public class CommonStockRepositoryTests : IDisposable
     }
 
     [Fact]
+    public void Search_DefaultUniverse_ExcludesRetainedDelistedIdentities()
+    {
+        var live = MakeStock(ticker: "LIVE", cik: "111");
+        var delisted = MakeStock(ticker: "GONE", cik: "222");
+        delisted.Active = false;
+        _dbContext.Set<CommonStock>().AddRange(live, delisted);
+        _dbContext.SaveChanges();
+
+        var readers = _repository.Search("").Select(s => s.Ticker).ToList();
+        var operators = _repository
+            .Search("", includeInactive: true)
+            .Select(s => s.Ticker)
+            .ToList();
+
+        readers.Should().Equal("LIVE");
+        operators.Should().Equal("GONE", "LIVE");
+    }
+
+    [Fact]
     public void Search_WithNull_ReturnsAllStocks()
     {
         _dbContext


### PR DESCRIPTION
`CommonStockRepository.Search` gains an `includeInactive` flag (default false) so operator surfaces can audit retained delisted identities; reader-facing surfaces keep the active-only universe. Needed by the commercial backoffice (EquiblesCommercial#7534).

- One new test pinning the default excludes and the flag includes.
- CHANGELOG Added entry.

https://claude.ai/code/session_011hGGmHpifqrFpgLgUhuEET