### PR TITLE
fix(finra): refuse secondary ticker misattribution

### DIFF
--- a/src/Equibles.Finra.BusinessLogic/FinraTickerScope.cs
+++ b/src/Equibles.Finra.BusinessLogic/FinraTickerScope.cs
@@ -1,0 +1,26 @@
+using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.Finra.BusinessLogic;
+
+/// <summary>
+/// FINRA rows currently carry issuer identity, not exact listed-symbol identity. A secondary
+/// listing must therefore be refused instead of being relabelled with the issuer's primary data.
+/// </summary>
+public static class FinraTickerScope
+{
+    public static string SecondaryListingUnavailable(
+        CommonStock stock,
+        string requestedTicker,
+        string dataset
+    )
+    {
+        if (!SecondaryTickerPolicy.IsSecondarySymbol(stock, requestedTicker))
+            return null;
+
+        var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, requestedTicker);
+        return $"No exact {dataset} series is available for {listedTicker}. It is a separate "
+            + $"listing on the same SEC filer as {stock.Ticker} ({stock.Name}); {stock.Ticker}'s "
+            + "FINRA rows are not substituted.";
+    }
+}

--- a/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Repositories;
 using Equibles.Mcp;
@@ -64,6 +65,13 @@ public class OffExchangeVolumeTools
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
+                var listingError = FinraTickerScope.SecondaryListingUnavailable(
+                    stock,
+                    ticker,
+                    "off-exchange-volume"
+                );
+                if (listingError != null)
+                    return listingError;
 
                 var (startWeek, endWeek, rangeError) = ParseStrictDateRange(
                     startDate,

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -88,6 +88,13 @@ public class ShortDataTools
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
+                var listingError = FinraTickerScope.SecondaryListingUnavailable(
+                    stock,
+                    ticker,
+                    "short-volume"
+                );
+                if (listingError != null)
+                    return listingError;
 
                 var (start, end, rangeError) = ParseStrictDateRange(
                     startDate,
@@ -179,6 +186,13 @@ public class ShortDataTools
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
+                var listingError = FinraTickerScope.SecondaryListingUnavailable(
+                    stock,
+                    ticker,
+                    "short-interest"
+                );
+                if (listingError != null)
+                    return listingError;
 
                 var (start, end, rangeError) = ParseStrictDateRange(
                     startDate,
@@ -688,6 +702,22 @@ public class ShortDataTools
         return _runner.Execute(
             async () =>
             {
+                CommonStock requestedStock = null;
+                if (!string.IsNullOrWhiteSpace(ticker))
+                {
+                    var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                    if (stockError != null)
+                        return stockError;
+                    var listingError = FinraTickerScope.SecondaryListingUnavailable(
+                        stock,
+                        ticker,
+                        "short-squeeze score"
+                    );
+                    if (listingError != null)
+                        return listingError;
+                    requestedStock = stock;
+                }
+
                 // The score is peer-relative, so it is always computed for the whole
                 // universe at once — a per-call Compute() made every request pay that
                 // multi-second build. Cached under the manager-owned shared key so a
@@ -709,8 +739,8 @@ public class ShortDataTools
 
                 var settlementDate = scores[0].SettlementDate;
 
-                if (!string.IsNullOrWhiteSpace(ticker))
-                    return await RenderSingleSqueezeScore(ticker, scores, settlementDate);
+                if (requestedStock != null)
+                    return RenderSingleSqueezeScore(requestedStock, scores, settlementDate);
 
                 // Liquidity gates are a view over the scored universe, applied after the
                 // peer-relative percentiles so a stock's score never depends on the
@@ -784,16 +814,12 @@ public class ShortDataTools
     // One stock's score card: composite, rank in the score-descending universe, and the
     // factor breakdown (raw reading + universe percentile per factor). The board answers
     // "what looks squeeze-prone"; this answers "does MY stock look squeeze-prone".
-    private async Task<string> RenderSingleSqueezeScore(
-        string ticker,
+    private static string RenderSingleSqueezeScore(
+        CommonStock stock,
         IReadOnlyList<ShortSqueezeScore> scores,
         DateOnly settlementDate
     )
     {
-        var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
-        if (stockError != null)
-            return stockError;
-
         var index = -1;
         for (var i = 0; i < scores.Count; i++)
         {

--- a/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsStrictDatesAndTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsStrictDatesAndTruncationTests.cs
@@ -69,6 +69,19 @@ public class OffExchangeVolumeToolsStrictDatesAndTruncationTests : ParadeDbMcpTe
     }
 
     [Fact]
+    public async Task GetOffExchangeVolume_SecondaryListing_DoesNotReturnPrimarySeries()
+    {
+        var stock = AddGme();
+        stock.SecondaryTickers = ["GME-A"];
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetOffExchangeVolume("GME-A");
+
+        result.Should().Contain("No exact off-exchange-volume series is available for GME-A");
+        result.Should().Contain("GME's FINRA rows are not substituted");
+    }
+
+    [Fact]
     public async Task GetOffExchangeVolume_InvertedRange_ReturnsExplicitError()
     {
         var stock = AddGme();

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -104,13 +104,17 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
     [Fact]
     public async Task GetShortSqueezeScores_SecondaryTicker_IsRefusedBeforeEmptyUniverse()
     {
-        DbContext.Set<CommonStock>().Add(new CommonStock
-        {
-            Ticker = "AAXJ",
-            Name = "iShares Trust",
-            Cik = "0000000199",
-            SecondaryTickers = ["SOXX"],
-        });
+        DbContext
+            .Set<CommonStock>()
+            .Add(
+                new CommonStock
+                {
+                    Ticker = "AAXJ",
+                    Name = "iShares Trust",
+                    Cik = "0000000199",
+                    SecondaryTickers = ["SOXX"],
+                }
+            );
         await DbContext.SaveChangesAsync();
 
         var result = await Sut().GetShortSqueezeScores(ticker: "SOXX");

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -101,6 +101,25 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
         result.Should().Contain("No short-squeeze scores available");
     }
 
+    [Fact]
+    public async Task GetShortSqueezeScores_SecondaryTicker_IsRefusedBeforeEmptyUniverse()
+    {
+        DbContext.Set<CommonStock>().Add(new CommonStock
+        {
+            Ticker = "AAXJ",
+            Name = "iShares Trust",
+            Cik = "0000000199",
+            SecondaryTickers = ["SOXX"],
+        });
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortSqueezeScores(ticker: "SOXX");
+
+        result.Should().Contain("No exact short-squeeze score series is available for SOXX");
+        result.Should().Contain("AAXJ's FINRA rows are not substituted");
+        result.Should().NotContain("No short-squeeze scores available");
+    }
+
     // The raw board is dominated by untradeable micro-caps; the liquidity gates must
     // drop them from the view (nulls fail an active gate) while leaving the scored
     // universe — and therefore every score — untouched.

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -83,6 +83,20 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task GetShortVolume_SecondaryListing_DoesNotReturnPrimarySeries()
+    {
+        var stock = GmeStock();
+        stock.SecondaryTickers = ["GME-A"];
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortVolume("GME-A");
+
+        result.Should().Contain("No exact short-volume series is available for GME-A");
+        result.Should().Contain("GME's FINRA rows are not substituted");
+    }
+
+    [Fact]
     public async Task GetShortVolume_StockWithData_RendersAscendingTable()
     {
         var stock = GmeStock();
@@ -201,6 +215,20 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
         var result = await Sut().GetShortInterest("ZZZZ");
 
         result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+
+    [Fact]
+    public async Task GetShortInterest_SecondaryListing_DoesNotReturnPrimarySeries()
+    {
+        var stock = GmeStock();
+        stock.SecondaryTickers = ["GME-A"];
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterest("GME-A");
+
+        result.Should().Contain("No exact short-interest series is available for GME-A");
+        result.Should().Contain("GME's FINRA rows are not substituted");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Finra/FinraTickerScopeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraTickerScopeTests.cs
@@ -17,7 +17,8 @@ public class FinraTickerScopeTests
     [Fact]
     public void SecondaryListingUnavailable_PrimaryTicker_IsSupported()
     {
-        FinraTickerScope.SecondaryListingUnavailable(Stock, "AAXJ", "short-volume")
+        FinraTickerScope
+            .SecondaryListingUnavailable(Stock, "AAXJ", "short-volume")
             .Should()
             .BeNull();
     }
@@ -25,11 +26,7 @@ public class FinraTickerScopeTests
     [Fact]
     public void SecondaryListingUnavailable_SecondaryTicker_RefusesPrimaryRows()
     {
-        var result = FinraTickerScope.SecondaryListingUnavailable(
-            Stock,
-            "SOXX",
-            "short-volume"
-        );
+        var result = FinraTickerScope.SecondaryListingUnavailable(Stock, "SOXX", "short-volume");
 
         result.Should().Contain("No exact short-volume series is available for SOXX");
         result.Should().Contain("AAXJ's FINRA rows are not substituted");
@@ -38,7 +35,8 @@ public class FinraTickerScopeTests
     [Fact]
     public void SecondaryListingUnavailable_CompanyName_IsNotTreatedAsAListing()
     {
-        FinraTickerScope.SecondaryListingUnavailable(Stock, "iShares Trust", "short-volume")
+        FinraTickerScope
+            .SecondaryListingUnavailable(Stock, "iShares Trust", "short-volume")
             .Should()
             .BeNull();
     }

--- a/tests/Equibles.UnitTests/Finra/FinraTickerScopeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraTickerScopeTests.cs
@@ -1,0 +1,45 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Finra.BusinessLogic;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Finra;
+
+public class FinraTickerScopeTests
+{
+    private static readonly CommonStock Stock = new()
+    {
+        Ticker = "AAXJ",
+        Name = "iShares Trust",
+        SecondaryTickers = ["SOXX"],
+    };
+
+    [Fact]
+    public void SecondaryListingUnavailable_PrimaryTicker_IsSupported()
+    {
+        FinraTickerScope.SecondaryListingUnavailable(Stock, "AAXJ", "short-volume")
+            .Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void SecondaryListingUnavailable_SecondaryTicker_RefusesPrimaryRows()
+    {
+        var result = FinraTickerScope.SecondaryListingUnavailable(
+            Stock,
+            "SOXX",
+            "short-volume"
+        );
+
+        result.Should().Contain("No exact short-volume series is available for SOXX");
+        result.Should().Contain("AAXJ's FINRA rows are not substituted");
+    }
+
+    [Fact]
+    public void SecondaryListingUnavailable_CompanyName_IsNotTreatedAsAListing()
+    {
+        FinraTickerScope.SecondaryListingUnavailable(Stock, "iShares Trust", "short-volume")
+            .Should()
+            .BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- refuse issuer-level FINRA rows for secondary listed symbols
- guard short volume, short interest, off-exchange volume, and ticker-scoped squeeze scores
- add unit and integration regression coverage

## Verification
- Finra MCP project builds with 0 warnings/errors
- FinraTickerScopeTests: 3 passed
- affected MCP integration tests: 42 passed

Commercial feedback follow-up: SOXX/SMH must never receive AAXJ/AFK FINRA rows.