### PR TITLE
feat(financial-facts): support IFRS screener fundamentals

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/CuratedSeriesRegistry.cs
+++ b/src/Equibles.Fred.HostedService/Services/CuratedSeriesRegistry.cs
@@ -8,7 +8,8 @@ namespace Equibles.Fred.HostedService.Services;
 // Curated rather than swept: FRED publishes around 800,000 series and almost all of them are a
 // county-level or vintage-specific slice nobody asks for. The list below is the set a reader
 // (or a model answering about the US economy) actually names, chosen against FRED's own
-// popularity score with a floor of 50, and it deliberately fills out the families already here
+// popularity score with a floor of 50, plus official series consumed by a product calculation,
+// and it deliberately fills out the families already here
 // rather than opening new ones. Two series that cleared the floor are excluded on purpose:
 // USSLIND stopped updating in April 2020, and FPCPITOTLZGUSA is an annual World Bank restatement
 // of CPI that lags the series we already carry. A frozen series is worse than a missing one; it
@@ -67,6 +68,9 @@ public static class CuratedSeriesRegistry
         // Exchange Rates
         new("DTWEXBGS", FredSeriesCategory.ExchangeRates),
         new("DEXUSEU", FredSeriesCategory.ExchangeRates),
+        // New Taiwan dollars per US dollar, used to translate Taiwan issuers' native
+        // financial statements without licensing a commercial fundamentals feed.
+        new("DEXTAUS", FredSeriesCategory.ExchangeRates),
         // Market
         new("SP500", FredSeriesCategory.Market),
         new("VIXCLS", FredSeriesCategory.Market),

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -32,6 +32,8 @@ public static class FinancialConceptAliases
 
     private static ConceptRef G(string tag) => new(FactTaxonomy.UsGaap, tag);
 
+    private static ConceptRef I(string tag) => new(FactTaxonomy.IfrsFull, tag);
+
     private static readonly Dictionary<string, IReadOnlyList<ConceptRef>> Map = new()
     {
         // ── Income statement ────────────────────────────────────────────────
@@ -61,6 +63,8 @@ public static class FinancialConceptAliases
             // REITs filed it instead of SalesRevenueNet, so without it their
             // revenue series starts at the ASC 606 transition.
             G("RealEstateRevenueNet"),
+            I("Revenue"),
+            I("RevenueFromContractsWithCustomers"),
         ],
         // Financial-sector top lines: banks, broker-dealers and insurers never
         // file the operating-company revenue tags above.
@@ -85,8 +89,9 @@ public static class FinancialConceptAliases
             G("CostOfRevenue"),
             G("CostOfGoodsAndServicesSold"),
             G("CostOfGoodsSold"),
+            I("CostOfSales"),
         ],
-        ["gross-profit"] = [G("GrossProfit")],
+        ["gross-profit"] = [G("GrossProfit"), I("GrossProfit")],
         ["research-and-development"] =
         [
             G("ResearchAndDevelopmentExpense"),
@@ -94,10 +99,15 @@ public static class FinancialConceptAliases
             // software-development-cost variant instead of the generic tag.
             G("ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost"),
             G("ResearchAndDevelopmentExpenseExcludingAcquiredInProcessCost"),
+            I("ResearchAndDevelopmentExpense"),
         ],
-        ["selling-general-and-administrative"] = [G("SellingGeneralAndAdministrativeExpense")],
-        ["selling-and-marketing"] = [G("SellingAndMarketingExpense")],
-        ["general-and-administrative"] = [G("GeneralAndAdministrativeExpense")],
+        ["selling-general-and-administrative"] =
+        [
+            G("SellingGeneralAndAdministrativeExpense"),
+        ],
+        ["selling-and-marketing"] = [G("SellingAndMarketingExpense"), I("DistributionCosts")],
+        ["general-and-administrative"] =
+        [G("GeneralAndAdministrativeExpense"), I("AdministrativeExpense")],
         ["amortization-of-intangibles"] = [G("AmortizationOfIntangibleAssets")],
         ["restructuring"] = [G("RestructuringCharges")],
         ["operating-expenses"] = [G("OperatingExpenses")],
@@ -105,7 +115,7 @@ public static class FinancialConceptAliases
         // figure instead; it INCLUDES cost of revenue, so it is a separate
         // line, never a fallback for operating-expenses.
         ["total-costs-and-expenses"] = [G("CostsAndExpenses")],
-        ["operating-income"] = [G("OperatingIncomeLoss")],
+        ["operating-income"] = [G("OperatingIncomeLoss"), I("ProfitLossFromOperatingActivities")],
         // InterestExpense was deprecated from the 2024 taxonomy; banks continue the
         // series under the operating variant (nonfinancial filers moved to the
         // nonoperating one), so without the fallback a bank's interest-expense
@@ -115,6 +125,7 @@ public static class FinancialConceptAliases
             G("InterestExpense"),
             G("InterestExpenseNonoperating"),
             G("InterestExpenseOperating"),
+            I("FinanceCosts"),
         ],
         // Banks report the income statement's gross interest-income line under the
         // operating tag while ALSO tagging the narrow investment-interest sub-item
@@ -137,13 +148,14 @@ public static class FinancialConceptAliases
                 "IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLossFromEquityMethodInvestments"
             ),
         ],
-        ["income-tax"] = [G("IncomeTaxExpenseBenefit")],
+        ["income-tax"] =
+        [G("IncomeTaxExpenseBenefit"), I("IncomeTaxExpenseContinuingOperations")],
         // ProfitLoss (net income including noncontrolling interests) last: it
         // only fills filers that never report the parent-attributable figure.
-        ["net-income"] = [G("NetIncomeLoss"), G("ProfitLoss")],
+        ["net-income"] = [G("NetIncomeLoss"), G("ProfitLoss"), I("ProfitLoss")],
         ["comprehensive-income"] = [G("ComprehensiveIncomeNetOfTax")],
-        ["eps-basic"] = [G("EarningsPerShareBasic")],
-        ["eps-diluted"] = [G("EarningsPerShareDiluted")],
+        ["eps-basic"] = [G("EarningsPerShareBasic"), I("BasicEarningsLossPerShare")],
+        ["eps-diluted"] = [G("EarningsPerShareDiluted"), I("DilutedEarningsLossPerShare")],
         ["weighted-average-shares-basic"] =
         [
             G("WeightedAverageNumberOfSharesOutstandingBasic"),
@@ -167,21 +179,30 @@ public static class FinancialConceptAliases
             // Post-ASU 2016-18 filers may only report the restricted-cash-
             // inclusive total; it fills periods the pure tag lacks.
             G("CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents"),
+            I("CashAndCashEquivalents"),
         ],
         ["short-term-investments"] = [G("ShortTermInvestments"), G("MarketableSecuritiesCurrent")],
-        ["accounts-receivable"] = [G("AccountsReceivableNetCurrent"), G("ReceivablesNetCurrent")],
-        ["inventory"] = [G("InventoryNet")],
-        ["current-assets"] = [G("AssetsCurrent")],
-        ["property-plant-and-equipment"] = [G("PropertyPlantAndEquipmentNet")],
-        ["operating-lease-assets"] = [G("OperatingLeaseRightOfUseAsset")],
-        ["goodwill"] = [G("Goodwill")],
+        ["accounts-receivable"] =
+        [
+            G("AccountsReceivableNetCurrent"),
+            G("ReceivablesNetCurrent"),
+            I("CurrentTradeReceivables"),
+            I("TradeAndOtherCurrentReceivables"),
+        ],
+        ["inventory"] = [G("InventoryNet"), I("Inventories")],
+        ["current-assets"] = [G("AssetsCurrent"), I("CurrentAssets")],
+        ["property-plant-and-equipment"] =
+        [G("PropertyPlantAndEquipmentNet"), I("PropertyPlantAndEquipment")],
+        ["operating-lease-assets"] = [G("OperatingLeaseRightOfUseAsset"), I("RightofuseAssets")],
+        ["goodwill"] = [G("Goodwill"), I("Goodwill")],
         ["intangible-assets"] =
         [
             G("FiniteLivedIntangibleAssetsNet"),
             G("IntangibleAssetsNetExcludingGoodwill"),
+            I("IntangibleAssetsOtherThanGoodwill"),
         ],
         ["long-term-investments"] = [G("LongTermInvestments"), G("MarketableSecuritiesNoncurrent")],
-        ["total-assets"] = [G("Assets")],
+        ["total-assets"] = [G("Assets"), I("Assets")],
         ["accounts-payable"] = [G("AccountsPayableCurrent"), G("AccountsPayableTradeCurrent")],
         ["accrued-liabilities"] = [G("AccruedLiabilitiesCurrent")],
         ["deferred-revenue"] =
@@ -194,11 +215,20 @@ public static class FinancialConceptAliases
             G("DebtCurrent"),
             G("LongTermDebtCurrent"),
             G("ShortTermBorrowings"),
+            I("CurrentBorrowings"),
+            I("CurrentPortionOfLongtermBorrowings"),
+            I("ShorttermBorrowings"),
         ],
-        ["current-liabilities"] = [G("LiabilitiesCurrent")],
+        ["current-liabilities"] = [G("LiabilitiesCurrent"), I("CurrentLiabilities")],
         // LongTermDebt (the total including the current portion) last: it only
         // fills filers that never split out the noncurrent portion.
-        ["long-term-debt"] = [G("LongTermDebtNoncurrent"), G("LongTermDebt")],
+        ["long-term-debt"] =
+        [
+            G("LongTermDebtNoncurrent"),
+            G("LongTermDebt"),
+            I("LongtermBorrowings"),
+            I("NoncurrentPortionOfNoncurrentLoansReceived"),
+        ],
         ["operating-lease-liabilities"] =
         [
             G("OperatingLeaseLiabilityNoncurrent"),
@@ -209,20 +239,22 @@ public static class FinancialConceptAliases
             G("ContractWithCustomerLiabilityNoncurrent"),
             G("DeferredRevenueNoncurrent"),
         ],
-        ["total-liabilities"] = [G("Liabilities")],
+        ["total-liabilities"] = [G("Liabilities"), I("Liabilities")],
         ["common-stock-value"] =
         [
             G("CommonStockValue"),
             G("CommonStocksIncludingAdditionalPaidInCapital"),
         ],
         ["additional-paid-in-capital"] = [G("AdditionalPaidInCapital")],
-        ["retained-earnings"] = [G("RetainedEarningsAccumulatedDeficit")],
+        ["retained-earnings"] = [G("RetainedEarningsAccumulatedDeficit"), I("RetainedEarnings")],
         ["accumulated-oci"] = [G("AccumulatedOtherComprehensiveIncomeLossNetOfTax")],
         ["treasury-stock"] = [G("TreasuryStockValue"), G("TreasuryStockCommonValue")],
         ["stockholders-equity"] =
         [
             G("StockholdersEquity"),
             G("StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest"),
+            I("EquityAttributableToOwnersOfParent"),
+            I("Equity"),
         ],
         ["total-liabilities-and-equity"] = [G("LiabilitiesAndStockholdersEquity")],
         // The issuer's common shares outstanding at a point in time. The dei cover-page
@@ -245,8 +277,14 @@ public static class FinancialConceptAliases
             // Capital-heavy filers (REITs) tag the cash-flow add-back with the
             // plain income-statement element instead of the DD&A variants.
             G("DepreciationAndAmortization"),
+            I("DepreciationAndAmortisationExpense"),
+            I("DepreciationExpense"),
         ],
-        ["share-based-compensation"] = [G("ShareBasedCompensation")],
+        ["share-based-compensation"] =
+        [
+            G("ShareBasedCompensation"),
+            I("ExpenseFromSharebasedPaymentTransactionsInWhichGoodsOrServicesReceivedDidNotQualifyForRecognitionAsAssets"),
+        ],
         ["deferred-income-taxes"] =
         [
             G("DeferredIncomeTaxExpenseBenefit"),
@@ -256,27 +294,49 @@ public static class FinancialConceptAliases
         [
             G("NetCashProvidedByUsedInOperatingActivities"),
             G("NetCashProvidedByUsedInOperatingActivitiesContinuingOperations"),
+            I("CashFlowsFromUsedInOperatingActivities"),
         ],
         ["capital-expenditures"] =
         [
             G("PaymentsToAcquirePropertyPlantAndEquipment"),
             G("PaymentsToAcquireProductiveAssets"),
+            I("PurchaseOfPropertyPlantAndEquipmentClassifiedAsInvestingActivities"),
         ],
         ["acquisitions"] = [G("PaymentsToAcquireBusinessesNetOfCashAcquired")],
         ["investing-cash-flow"] =
         [
             G("NetCashProvidedByUsedInInvestingActivities"),
             G("NetCashProvidedByUsedInInvestingActivitiesContinuingOperations"),
+            I("CashFlowsFromUsedInInvestingActivities"),
         ],
-        ["share-repurchases"] = [G("PaymentsForRepurchaseOfCommonStock")],
-        ["dividends-paid"] = [G("PaymentsOfDividends"), G("PaymentsOfDividendsCommonStock")],
-        ["debt-issued"] = [G("ProceedsFromIssuanceOfLongTermDebt")],
-        ["debt-repaid"] = [G("RepaymentsOfLongTermDebt"), G("RepaymentsOfDebt")],
-        ["stock-issued"] = [G("ProceedsFromIssuanceOfCommonStock")],
+        ["share-repurchases"] =
+        [G("PaymentsForRepurchaseOfCommonStock"), I("PaymentsToAcquireOrRedeemEntitysShares")],
+        ["dividends-paid"] =
+        [
+            G("PaymentsOfDividends"),
+            G("PaymentsOfDividendsCommonStock"),
+            I("DividendsPaid"),
+            I("DividendsPaidClassifiedAsFinancingActivities"),
+        ],
+        ["debt-issued"] =
+        [
+            G("ProceedsFromIssuanceOfLongTermDebt"),
+            I("ProceedsFromCurrentBorrowings"),
+            I("ProceedsFromNoncurrentBorrowings"),
+        ],
+        ["debt-repaid"] =
+        [
+            G("RepaymentsOfLongTermDebt"),
+            G("RepaymentsOfDebt"),
+            I("RepaymentsOfNoncurrentBorrowings"),
+            I("RepaymentsOfBondsNotesAndDebentures"),
+        ],
+        ["stock-issued"] = [G("ProceedsFromIssuanceOfCommonStock"), I("ProceedsFromIssuingShares")],
         ["financing-cash-flow"] =
         [
             G("NetCashProvidedByUsedInFinancingActivities"),
             G("NetCashProvidedByUsedInFinancingActivitiesContinuingOperations"),
+            I("CashFlowsFromUsedInFinancingActivities"),
         ],
         ["fx-effect-on-cash"] =
         [
@@ -284,6 +344,7 @@ public static class FinancialConceptAliases
                 "EffectOfExchangeRateOnCashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents"
             ),
             G("EffectOfExchangeRateOnCashAndCashEquivalents"),
+            I("EffectOfExchangeRateChangesOnCashAndCashEquivalents"),
         ],
         ["net-change-in-cash"] =
         [
@@ -297,6 +358,7 @@ public static class FinancialConceptAliases
             G(
                 "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalentsPeriodIncreaseDecreaseExcludingExchangeRateEffect"
             ),
+            I("IncreaseDecreaseInCashAndCashEquivalents"),
         ],
     };
 

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -101,13 +101,13 @@ public static class FinancialConceptAliases
             G("ResearchAndDevelopmentExpenseExcludingAcquiredInProcessCost"),
             I("ResearchAndDevelopmentExpense"),
         ],
-        ["selling-general-and-administrative"] =
-        [
-            G("SellingGeneralAndAdministrativeExpense"),
-        ],
+        ["selling-general-and-administrative"] = [G("SellingGeneralAndAdministrativeExpense")],
         ["selling-and-marketing"] = [G("SellingAndMarketingExpense"), I("DistributionCosts")],
         ["general-and-administrative"] =
-        [G("GeneralAndAdministrativeExpense"), I("AdministrativeExpense")],
+        [
+            G("GeneralAndAdministrativeExpense"),
+            I("AdministrativeExpense"),
+        ],
         ["amortization-of-intangibles"] = [G("AmortizationOfIntangibleAssets")],
         ["restructuring"] = [G("RestructuringCharges")],
         ["operating-expenses"] = [G("OperatingExpenses")],
@@ -148,8 +148,7 @@ public static class FinancialConceptAliases
                 "IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLossFromEquityMethodInvestments"
             ),
         ],
-        ["income-tax"] =
-        [G("IncomeTaxExpenseBenefit"), I("IncomeTaxExpenseContinuingOperations")],
+        ["income-tax"] = [G("IncomeTaxExpenseBenefit"), I("IncomeTaxExpenseContinuingOperations")],
         // ProfitLoss (net income including noncontrolling interests) last: it
         // only fills filers that never report the parent-attributable figure.
         ["net-income"] = [G("NetIncomeLoss"), G("ProfitLoss"), I("ProfitLoss")],
@@ -192,7 +191,10 @@ public static class FinancialConceptAliases
         ["inventory"] = [G("InventoryNet"), I("Inventories")],
         ["current-assets"] = [G("AssetsCurrent"), I("CurrentAssets")],
         ["property-plant-and-equipment"] =
-        [G("PropertyPlantAndEquipmentNet"), I("PropertyPlantAndEquipment")],
+        [
+            G("PropertyPlantAndEquipmentNet"),
+            I("PropertyPlantAndEquipment"),
+        ],
         ["operating-lease-assets"] = [G("OperatingLeaseRightOfUseAsset"), I("RightofuseAssets")],
         ["goodwill"] = [G("Goodwill"), I("Goodwill")],
         ["intangible-assets"] =
@@ -283,7 +285,9 @@ public static class FinancialConceptAliases
         ["share-based-compensation"] =
         [
             G("ShareBasedCompensation"),
-            I("ExpenseFromSharebasedPaymentTransactionsInWhichGoodsOrServicesReceivedDidNotQualifyForRecognitionAsAssets"),
+            I(
+                "ExpenseFromSharebasedPaymentTransactionsInWhichGoodsOrServicesReceivedDidNotQualifyForRecognitionAsAssets"
+            ),
         ],
         ["deferred-income-taxes"] =
         [
@@ -310,7 +314,10 @@ public static class FinancialConceptAliases
             I("CashFlowsFromUsedInInvestingActivities"),
         ],
         ["share-repurchases"] =
-        [G("PaymentsForRepurchaseOfCommonStock"), I("PaymentsToAcquireOrRedeemEntitysShares")],
+        [
+            G("PaymentsForRepurchaseOfCommonStock"),
+            I("PaymentsToAcquireOrRedeemEntitysShares"),
+        ],
         ["dividends-paid"] =
         [
             G("PaymentsOfDividends"),

--- a/tests/Equibles.UnitTests/Fred/CuratedSeriesRegistryTests.cs
+++ b/tests/Equibles.UnitTests/Fred/CuratedSeriesRegistryTests.cs
@@ -51,6 +51,7 @@ public class CuratedSeriesRegistryTests
     [InlineData("M2SL")]
     [InlineData("ICSA")]
     [InlineData("HOUST")]
+    [InlineData("DEXTAUS")]
     public void Series_ContainsExpectedKeySeriesId(string expectedSeriesId)
     {
         CuratedSeriesRegistry.Series.Should().Contain(s => s.SeriesId == expectedSeriesId);
@@ -75,6 +76,7 @@ public class CuratedSeriesRegistryTests
     [InlineData("M2SL", FredSeriesCategory.MoneySupply)]
     [InlineData("UMCSENT", FredSeriesCategory.Sentiment)]
     [InlineData("DTWEXBGS", FredSeriesCategory.ExchangeRates)]
+    [InlineData("DEXTAUS", FredSeriesCategory.ExchangeRates)]
     public void WellKnownSeries_HasExpectedCategory(
         string seriesId,
         FredSeriesCategory expectedCategory

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesIfrsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesIfrsTests.cs
@@ -20,7 +20,10 @@ public class FinancialConceptAliasesIfrsTests
             { "total-liabilities", "Liabilities" },
             { "stockholders-equity", "EquityAttributableToOwnersOfParent" },
             { "operating-cash-flow", "CashFlowsFromUsedInOperatingActivities" },
-            { "capital-expenditures", "PurchaseOfPropertyPlantAndEquipmentClassifiedAsInvestingActivities" },
+            {
+                "capital-expenditures",
+                "PurchaseOfPropertyPlantAndEquipmentClassifiedAsInvestingActivities"
+            },
             { "dividends-paid", "DividendsPaid" },
         };
 

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesIfrsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesIfrsTests.cs
@@ -1,0 +1,35 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialConceptAliasesIfrsTests
+{
+    public static TheoryData<string, string> CoreAliases =>
+        new()
+        {
+            { "revenue", "Revenue" },
+            { "gross-profit", "GrossProfit" },
+            { "operating-income", "ProfitLossFromOperatingActivities" },
+            { "net-income", "ProfitLoss" },
+            { "eps-diluted", "DilutedEarningsLossPerShare" },
+            { "cash", "CashAndCashEquivalents" },
+            { "current-assets", "CurrentAssets" },
+            { "total-assets", "Assets" },
+            { "current-liabilities", "CurrentLiabilities" },
+            { "total-liabilities", "Liabilities" },
+            { "stockholders-equity", "EquityAttributableToOwnersOfParent" },
+            { "operating-cash-flow", "CashFlowsFromUsedInOperatingActivities" },
+            { "capital-expenditures", "PurchaseOfPropertyPlantAndEquipmentClassifiedAsInvestingActivities" },
+            { "dividends-paid", "DividendsPaid" },
+        };
+
+    [Theory]
+    [MemberData(nameof(CoreAliases))]
+    public void TryResolve_CoreAlias_IncludesIfrsConcept(string alias, string tag)
+    {
+        FinancialConceptAliases.TryResolve(alias, out var refs).Should().BeTrue();
+
+        refs.Should().Contain(r => r.Taxonomy == FactTaxonomy.IfrsFull && r.Tag == tag);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveOperatingProfitSynonymTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveOperatingProfitSynonymTests.cs
@@ -21,9 +21,10 @@ public class FinancialConceptAliasesTryResolveOperatingProfitSynonymTests
         var success = FinancialConceptAliases.TryResolve("Operating Profit", out var concepts);
 
         success.Should().BeTrue();
-        concepts.Should().Contain(concept =>
-            concept.Taxonomy == FactTaxonomy.UsGaap
-            && concept.Tag == "OperatingIncomeLoss"
-        );
+        concepts
+            .Should()
+            .Contain(concept =>
+                concept.Taxonomy == FactTaxonomy.UsGaap && concept.Tag == "OperatingIncomeLoss"
+            );
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveOperatingProfitSynonymTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveOperatingProfitSynonymTests.cs
@@ -21,8 +21,9 @@ public class FinancialConceptAliasesTryResolveOperatingProfitSynonymTests
         var success = FinancialConceptAliases.TryResolve("Operating Profit", out var concepts);
 
         success.Should().BeTrue();
-        concepts.Should().HaveCount(1);
-        concepts[0].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
-        concepts[0].Tag.Should().Be("OperatingIncomeLoss");
+        concepts.Should().Contain(concept =>
+            concept.Taxonomy == FactTaxonomy.UsGaap
+            && concept.Tag == "OperatingIncomeLoss"
+        );
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSlashSeparatorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSlashSeparatorTests.cs
@@ -18,9 +18,10 @@ public class FinancialConceptAliasesTryResolveSlashSeparatorTests
         var success = FinancialConceptAliases.TryResolve("operating/income", out var concepts);
 
         success.Should().BeTrue();
-        concepts.Should().Contain(concept =>
-            concept.Taxonomy == FactTaxonomy.UsGaap
-            && concept.Tag == "OperatingIncomeLoss"
-        );
+        concepts
+            .Should()
+            .Contain(concept =>
+                concept.Taxonomy == FactTaxonomy.UsGaap && concept.Tag == "OperatingIncomeLoss"
+            );
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSlashSeparatorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSlashSeparatorTests.cs
@@ -18,8 +18,9 @@ public class FinancialConceptAliasesTryResolveSlashSeparatorTests
         var success = FinancialConceptAliases.TryResolve("operating/income", out var concepts);
 
         success.Should().BeTrue();
-        concepts.Should().HaveCount(1);
-        concepts[0].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
-        concepts[0].Tag.Should().Be("OperatingIncomeLoss");
+        concepts.Should().Contain(concept =>
+            concept.Taxonomy == FactTaxonomy.UsGaap
+            && concept.Tag == "OperatingIncomeLoss"
+        );
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveUnderscoreSeparatorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveUnderscoreSeparatorTests.cs
@@ -19,8 +19,9 @@ public class FinancialConceptAliasesTryResolveUnderscoreSeparatorTests
         var success = FinancialConceptAliases.TryResolve("operating_income", out var concepts);
 
         success.Should().BeTrue();
-        concepts.Should().HaveCount(1);
-        concepts[0].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
-        concepts[0].Tag.Should().Be("OperatingIncomeLoss");
+        concepts.Should().Contain(concept =>
+            concept.Taxonomy == FactTaxonomy.UsGaap
+            && concept.Tag == "OperatingIncomeLoss"
+        );
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveUnderscoreSeparatorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveUnderscoreSeparatorTests.cs
@@ -19,9 +19,10 @@ public class FinancialConceptAliasesTryResolveUnderscoreSeparatorTests
         var success = FinancialConceptAliases.TryResolve("operating_income", out var concepts);
 
         success.Should().BeTrue();
-        concepts.Should().Contain(concept =>
-            concept.Taxonomy == FactTaxonomy.UsGaap
-            && concept.Tag == "OperatingIncomeLoss"
-        );
+        concepts
+            .Should()
+            .Contain(concept =>
+                concept.Taxonomy == FactTaxonomy.UsGaap && concept.Tag == "OperatingIncomeLoss"
+            );
     }
 }

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsPickFactTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsPickFactTests.cs
@@ -87,7 +87,7 @@ public class StatementLineFactsPickFactTests
     {
         var (taxonomies, tags) = StatementLineFacts.CollectConceptPairs([RdLine()]);
 
-        taxonomies.Should().Equal(FactTaxonomy.UsGaap);
+        taxonomies.Should().Contain([FactTaxonomy.UsGaap, FactTaxonomy.IfrsFull]);
         tags.Should()
             .Contain([
                 "ResearchAndDevelopmentExpense",


### PR DESCRIPTION
## Summary
- add IFRS concept aliases for core financial statement metrics
- add the official FRED Taiwan dollar exchange-rate series
- cover IFRS aliases and registry contracts with tests

## Verification
- dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release (4,680 passed)