### PR TITLE
fix: restore green ci after the mcp tool contract refactor

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -373,10 +373,11 @@ public class FinancialFactsTools
         string fiscalPeriod = "FY"
     ) =>
         CompareFinancialFact(
-            tickers?.Split(
-                ',',
-                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
-            ),
+            // Empty segments are kept, never dropped: a batch like "AAPL,,MSFT" is
+            // malformed and must reach ParseComparisonTickers to be reported as an
+            // invalid ticker. Removing them here silently narrows the caller's
+            // request and answers for fewer companies than were asked for.
+            tickers?.Split(',', StringSplitOptions.TrimEntries),
             concept,
             fiscalYear,
             fiscalPeriod
@@ -546,10 +547,11 @@ public class FinancialFactsTools
 
     internal static (List<string> Tickers, string Error) ParseComparisonTickers(string tickers) =>
         ParseComparisonTickers(
-            tickers?.Split(
-                ',',
-                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
-            )
+            // Empty segments are kept, never dropped: a batch like "AAPL,,MSFT" is
+            // malformed and must reach ParseComparisonTickers to be reported as an
+            // invalid ticker. Removing them here silently narrows the caller's
+            // request and answers for fewer companies than were asked for.
+            tickers?.Split(',', StringSplitOptions.TrimEntries)
         );
 
     private static CommonStock ResolveComparisonStock(

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -373,7 +373,10 @@ public class FinancialFactsTools
         string fiscalPeriod = "FY"
     ) =>
         CompareFinancialFact(
-            tickers?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+            tickers?.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            ),
             concept,
             fiscalYear,
             fiscalPeriod
@@ -543,7 +546,10 @@ public class FinancialFactsTools
 
     internal static (List<string> Tickers, string Error) ParseComparisonTickers(string tickers) =>
         ParseComparisonTickers(
-            tickers?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            tickers?.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            )
         );
 
     private static CommonStock ResolveComparisonStock(

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -148,7 +148,11 @@ public class StockPriceTools
         );
     }
 
-    [McpServerTool(Name = "GetLatestClosingPrices", Title = "Latest Closing Prices", ReadOnly = true)]
+    [McpServerTool(
+        Name = "GetLatestClosingPrices",
+        Title = "Latest Closing Prices",
+        ReadOnly = true
+    )]
     [Description(
         "Get each ticker's newest traded, settled daily close in USD, with one-session change, volume, and trailing 52-week closing range. Rows can have different dates while a session settles; use the Date column. Change is omitted when the immediately prior trading session is absent. Split-limited or partial 52-week ranges are marked in the response. This is settled history, not an intraday quote."
     )]
@@ -409,9 +413,7 @@ public class StockPriceTools
     }
 
     public Task<string> GetLatestClosingPrices(string tickers) =>
-        GetLatestClosingPrices(
-            tickers?.Split(',', StringSplitOptions.TrimEntries)
-        );
+        GetLatestClosingPrices(tickers?.Split(',', StringSplitOptions.TrimEntries));
 
     [McpServerTool(
         Name = "GetStochasticOscillator",

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
@@ -75,7 +75,7 @@ public class InstitutionalHoldingsToolsGetInstitutionConsensusHoldingsTests : Pa
             "Consensus A LP, Consensus B LP, Consensus C LP"
         );
 
-        output.Should().Contain("Consensus holdings — **3 funds**");
+        output.Should().Contain("Consensus holdings — **3 institutions**");
         output.Should().Contain("AAPL");
         output.Should().Contain("MSFT");
         output.Should().Contain("NVDA");

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
@@ -118,7 +118,10 @@ public class InstitutionalHoldingsToolsGetInstitutionConsensusHoldingsTests : Pa
         await using var verify = Fixture.CreateDbContext();
         var sut = NewSut(verify);
 
-        var output = await sut.GetInstitutionConsensusHoldings("Filter A LP, Filter B LP", minFunds: 2);
+        var output = await sut.GetInstitutionConsensusHoldings(
+            "Filter A LP, Filter B LP",
+            minFunds: 2
+        );
 
         output.Should().Contain("AAPL");
         output.Should().NotContain("NVDA");

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsThresholdAboveAllTests.cs
@@ -64,7 +64,10 @@ public class InstitutionalHoldingsToolsGetInstitutionConsensusHoldingsThresholdA
             Substitute.For<ILogger<InstitutionalHoldingsTools>>()
         );
 
-        var output = await sut.GetInstitutionConsensusHoldings("Threshold A, Threshold B", minFunds: 3);
+        var output = await sut.GetInstitutionConsensusHoldings(
+            "Threshold A, Threshold B",
+            minFunds: 3
+        );
 
         output.Should().Contain("No stocks meet the minInstitutions threshold");
         output.Should().NotContain("| # | Ticker |");

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
@@ -132,7 +132,11 @@ public class InstitutionalHoldingsToolsCompareInstitutionPortfoliosTests : Parad
         await using var verify = Fixture.CreateDbContext();
         var sut = NewSut(verify);
 
-        var output = await sut.CompareInstitutionPortfolios("Dated A LP", "Dated B LP", reportDate: "2024-09-30");
+        var output = await sut.CompareInstitutionPortfolios(
+            "Dated A LP",
+            "Dated B LP",
+            reportDate: "2024-09-30"
+        );
 
         output.Should().Contain("as of 2024-09-30");
     }

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
@@ -298,8 +298,7 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
 
         // A near-miss type ('10K', 'Transcript') must not silently search unfiltered —
         // the caller would present mixed-type results as filtered ones.
-        var result = await Sut()
-            .SearchDocuments("cloud revenue", "AAPL", documentTypes: ["10K"]);
+        var result = await Sut().SearchDocuments("cloud revenue", "AAPL", documentTypes: ["10K"]);
 
         result.Should().StartWith("Unknown documentTypes '10K'.");
         result.Should().Contain("'TenK' (10-K)");

--- a/tests/Equibles.IntegrationTests/Mcp/Server/McpServerMismatchedArgumentTypeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Server/McpServerMismatchedArgumentTypeTests.cs
@@ -77,7 +77,10 @@ public class McpServerMismatchedArgumentTypeTests : IAsyncLifetime
                 "the client should be told its arguments were the problem, not given an opaque server error"
             );
         text.Should()
-            .Contain("GetLatestClosingPrices", "the error should name the tool that rejected the call");
+            .Contain(
+                "GetLatestClosingPrices",
+                "the error should name the tool that rejected the call"
+            );
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/Server/McpServerMissingRequiredArgumentTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Server/McpServerMissingRequiredArgumentTests.cs
@@ -75,6 +75,9 @@ public class McpServerMissingRequiredArgumentTests : IAsyncLifetime
                 "the client should be told its arguments were the problem, not given an opaque server error"
             );
         text.Should()
-            .Contain("GetLatestClosingPrices", "the error should name the tool that rejected the call");
+            .Contain(
+                "GetLatestClosingPrices",
+                "the error should name the tool that rejected the call"
+            );
     }
 }

--- a/tests/Equibles.UnitTests/Mcp/McpToolAnnotationsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpToolAnnotationsTests.cs
@@ -104,23 +104,33 @@ public class McpToolAnnotationsTests
             .Select(t => $"{t.Name}: {t.Description?.Length ?? 0} characters")
             .ToList();
 
-        invalid.Should().BeEmpty("tool descriptions should be concise enough for reliable selection");
+        invalid
+            .Should()
+            .BeEmpty("tool descriptions should be concise enough for reliable selection");
     }
 
     [Fact]
     public void ToolParameterDescriptions_StayFocusedForInvocation()
     {
         var invalid = EnumerateTools()
-            .SelectMany(t => t.Method.GetParameters()
-                .Where(parameter => parameter.ParameterType != typeof(CancellationToken))
-                .Select(parameter => new
-                {
-                    Tool = t.Attribute.Name ?? t.Method.Name,
-                    Parameter = parameter.Name,
-                    Description = parameter.GetCustomAttribute<DescriptionAttribute>()?.Description,
-                }))
-            .Where(item => string.IsNullOrWhiteSpace(item.Description) || item.Description.Length > 500)
-            .Select(item => $"{item.Tool}.{item.Parameter}: {item.Description?.Length ?? 0} characters")
+            .SelectMany(t =>
+                t.Method.GetParameters()
+                    .Where(parameter => parameter.ParameterType != typeof(CancellationToken))
+                    .Select(parameter => new
+                    {
+                        Tool = t.Attribute.Name ?? t.Method.Name,
+                        Parameter = parameter.Name,
+                        Description = parameter
+                            .GetCustomAttribute<DescriptionAttribute>()
+                            ?.Description,
+                    })
+            )
+            .Where(item =>
+                string.IsNullOrWhiteSpace(item.Description) || item.Description.Length > 500
+            )
+            .Select(item =>
+                $"{item.Tool}.{item.Parameter}: {item.Description?.Length ?? 0} characters"
+            )
             .ToList();
 
         invalid.Should().BeEmpty("every model-facing parameter needs concise invocation guidance");
@@ -152,8 +162,9 @@ public class McpToolAnnotationsTests
         };
 
         names.Should().NotContain(retired);
-        names.Should().Contain(
-            [
+        names
+            .Should()
+            .Contain([
                 "GetFundProfile",
                 "SearchDocuments",
                 "SearchDocument",
@@ -169,8 +180,7 @@ public class McpToolAnnotationsTests
                 "GetInstitutionConsensusHoldings",
                 "GetInstitutionalOwnershipHistory",
                 "GetTopInstitutionalBuyersSellers",
-            ]
-        );
+            ]);
     }
 
     [Fact]


### PR DESCRIPTION
Restores CI to green on `main`. Three defects, all originating in **ec7756e1, `refactor(mcp): consolidate and clarify tool contracts` (#4472)**.

## Why it went unnoticed for three commits

CI's `build-and-test` job declares `needs: lint`, and `lint` runs `dotnet csharpier check .`. The formatting miss below failed `lint`, so `build-and-test` **never started** on #4472, #4473 or #4474: no Release build, no test run. The green ticks on those commits come from `Functional Tests` and `CodeQL`, separate workflows with no `needs: lint`, which is why the breakage looked partially green while it compounded.

Once `lint` is fixed, `build-and-test` runs for the first time since #4472 and surfaces two genuine test failures that had been hidden behind it. All three are fixed here so one merge returns `main` to green.

## 1. `style:` formatting (`ce60f614`)

`dotnet csharpier format .` at the version pinned in `.config/dotnet-tools.json` (csharpier **1.3.0**). #4472 introduced 9 files it rejects; the formatter touched only those 9 of the 3447 it checks.

Pure line reflow, with **no token changed**, verified mechanically: stripping all whitespace from each file gives a byte-identical hash before and after.

## 2. `test:` stale consensus assertion (`cd12b28f`)

#4472 deliberately reworded the consensus header from `N funds` to `N institutions`:

```diff
-$"Consensus holdings — **{holders.Count} funds** as of {FormatDate(selected)}"
+$"Consensus holdings — **{holders.Count} institutions** as of {FormatDate(selected)}"
```

That matches the tool's own name, its `institutionNames` parameter, the `Institutions:` list heading and the `# Institutions` table column, but the one test asserting the old wording wasn't updated, so `GetInstitutionConsensusHoldings_ThreeFunds_RanksConsensusFirst` has failed ever since. The assertion follows the rename; no production code changed.

## 3. `fix:` empty tickers silently dropped from a comparison batch (`785b5239`)

The real bug. #4472 moved `CompareFinancialFact` to a `string[]` contract and gave the string overloads a split with `RemoveEmptyEntries`:

```diff
-var segments = tickers.Split(',').Select(ticker => ticker.Trim()).ToList();   // before #4472
+tickers?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
```

An empty segment is now discarded **before** `ParseComparisonTickers` can see it, so a malformed batch like `"AAPL,,MSFT"` is silently narrowed to two tickers and answered as though the caller had asked for exactly those, rather than reported as an invalid ticker. Silently answering for fewer companies than were requested is precisely the kind of quiet narrowing this repo's data-accuracy rule exists to prevent.

Restored to `TrimEntries` only at both string overloads, matching the pre-#4472 behaviour and the sibling `StockPriceTools`, with a comment recording why. The array-based validator was always correct and is untouched.

This re-greens `CompareFinancialFact_InvalidBatchFailsBeforeRepositoryAccess("AAPL,,MSFT")`, a test that **predates** #4472 and pins exactly this guard, including that it must reject before any repository access (it passes null repositories to prove it).

## Verification

| Check | Result |
|---|---|
| `dotnet csharpier check .` | clean, 3447 files, 0 errors (was 9) |
| `dotnet build Equibles.sln -c Release` | 0 errors, 9 pre-existing warnings |
| `Equibles.UnitTests` | 4680 passed, 0 failed |
| `Equibles.IntegrationTests` | 2776 passed, 0 failed (was 2 failed) |

Run locally against the exact CI invocation, `--filter "Category!=Functional&Category!=Live"`.

Scope note: `InstitutionalHoldingsTools` also splits with `RemoveEmptyEntries`, but that predates #4472 and applies to free-text institution names rather than tickers, so it is deliberately left alone.

https://claude.ai/code/session_013Sg2yqnreqWADkoPk4XSoj