### PR TITLE
fix(financial-facts): corroborate FullYear-bucket transition stubs

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/AnnualTransitionStubs.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/AnnualTransitionStubs.cs
@@ -1,0 +1,88 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.Data.Statements;
+
+/// <summary>
+/// Corroboration for sub-annual durations stamped <see cref="SecFiscalPeriod.FullYear"/>.
+/// The annual bucket is the enum's zero value, so it collects unclassified periods on
+/// top of the discrete-Q4-under-fp=FY case — a FullYear bucket with no ordinary
+/// annual-span fact holds either a genuine fiscal-calendar transition stub (a short
+/// "year" filed when the issuer moved its year end) or a misclassified sub-annual span
+/// (a six/nine-month year-to-date, a lone discrete quarter). The two are told apart by
+/// the surrounding fiscal years: a real transition stub is seamed into the company's
+/// annual timeline on BOTH sides — the previous annual window ends where the stub
+/// starts and the next annual window starts where the stub ends. A year-to-date span
+/// only abuts on the start side (its own fiscal year began there) and a discrete
+/// fourth quarter only on the end side (the next year begins there), so requiring both
+/// seams refuses each while keeping the stub. A stub whose next annual window has not
+/// been filed yet fails closed: absent beats publishing a span that may be a fraction
+/// of a year as the year.
+/// </summary>
+public static class AnnualTransitionStubs
+{
+    // Aligned with the annual gates used by every per-period picker (350-380 days,
+    // sized for 52/53-week calendars). A span at or above the floor is an ordinary
+    // annual fact and never needs corroboration; one above the ceiling is multi-year
+    // or inception-to-date and is never publishable as a year — without the floor cut
+    // a two-year cumulative would corroborate, because the years on either side of it
+    // abut it exactly the way a transition stub's neighbours do.
+    public const int MinAnnualSpanDays = 350;
+    public const int MaxAnnualSpanDays = 380;
+
+    // Calendar drift headroom for the seam test: a 52/53-week filer's year end moves
+    // by up to a week against the calendar, so "ends where the stub starts" is exact
+    // to within that drift (the same allowance the year-turn stamping rules use).
+    public const int AbutmentToleranceDays = 7;
+
+    /// <summary>
+    /// True when <paramref name="stub"/> is a sub-annual duration seamed into the
+    /// company's annual timeline on both sides by annual-span durations found in
+    /// <paramref name="context"/>. A null or empty context corroborates nothing.
+    /// </summary>
+    public static bool IsCorroborated(FinancialFact stub, IEnumerable<FinancialFact> context)
+    {
+        if (context == null)
+            return false;
+        return IsCorroborated(
+            stub.PeriodStart,
+            stub.PeriodEnd,
+            context
+                .Where(f => f.PeriodType == FactPeriodType.Duration)
+                .Select(f => (f.PeriodStart, f.PeriodEnd))
+        );
+    }
+
+    /// <summary>
+    /// The date-level rule, for callers whose facts are projected records rather than
+    /// entities. <paramref name="durations"/> may contain any spans; only annual-span
+    /// windows (350-380 days) corroborate.
+    /// </summary>
+    public static bool IsCorroborated(
+        DateOnly stubStart,
+        DateOnly stubEnd,
+        IEnumerable<(DateOnly Start, DateOnly End)> durations
+    )
+    {
+        var stubSpan = stubEnd.DayNumber - stubStart.DayNumber;
+        if (stubSpan < 0 || stubSpan >= MinAnnualSpanDays)
+            return false;
+
+        var previousYearAbuts = false;
+        var nextYearAbuts = false;
+        foreach (var (start, end) in durations)
+        {
+            var span = end.DayNumber - start.DayNumber;
+            if (span is < MinAnnualSpanDays or > MaxAnnualSpanDays)
+                continue;
+            if (Math.Abs(end.DayNumber - (stubStart.DayNumber - 1)) <= AbutmentToleranceDays)
+                previousYearAbuts = true;
+            if (Math.Abs(start.DayNumber - (stubEnd.DayNumber + 1)) <= AbutmentToleranceDays)
+                nextYearAbuts = true;
+            if (previousYearAbuts && nextYearAbuts)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -187,7 +187,12 @@ public class FinancialFactsTools
                 var perPeriod = DedupeByReportingSpan(
                         filtered
                             .GroupBy(f => (f.FiscalYear, f.FiscalPeriod))
-                            .Select(g => PickBestFact(g, conceptPriority, asOriginallyReported))
+                            // The full unfiltered history is the corroboration
+                            // context: a transition stub's neighbouring annual
+                            // windows can sit outside the caller's date window.
+                            .Select(g =>
+                                PickBestFact(g, conceptPriority, asOriginallyReported, facts)
+                            )
                             .Where(f => f != null)
                     )
                     .OrderByDescending(f => f.PeriodEnd)
@@ -634,7 +639,8 @@ public class FinancialFactsTools
     private static FinancialFact PickBestFact(
         IEnumerable<FinancialFact> facts,
         IReadOnlyDictionary<Guid, int> conceptPriority,
-        bool asOriginallyReported = false
+        bool asOriginallyReported = false,
+        IReadOnlyCollection<FinancialFact> corroborationContext = null
     )
     {
         var candidates = facts.ToList();
@@ -643,8 +649,8 @@ public class FinancialFactsTools
         // quarter reads as the discrete three months and never the year-to-date total a
         // 10-Q tags under the same fiscal Q2/Q3 (the financials tab handles this in
         // FinancialStatementsHelper.PickCurrentlyReportedFact). Instants (balance sheet,
-        // zero span) always qualify. A source-stamped short transition year remains a
-        // fallback; a duration above the annual ceiling is removed before fallback.
+        // zero span) always qualify. A corroborated fiscal-calendar transition stub
+        // remains a fallback; a duration above the annual ceiling is removed before it.
         var fiscalPeriod = candidates[0].FiscalPeriod;
         candidates = candidates
             .Where(f =>
@@ -669,9 +675,29 @@ public class FinancialFactsTools
             })
             .ToList();
         if (preferredSpan.Count > 0)
+        {
             candidates = preferredSpan;
-        else if (fiscalPeriod != SecFiscalPeriod.FullYear)
+        }
+        else if (fiscalPeriod == SecFiscalPeriod.FullYear)
+        {
+            // A FullYear bucket with no annual-span fact holds either a genuine
+            // fiscal-calendar transition stub or a misclassified sub-annual span (a
+            // year-to-date, a lone discrete quarter — FullYear is the enum's zero
+            // value, so unclassified periods land here too). Only a stub the
+            // surrounding annual windows corroborate on both sides may publish as
+            // the year; a caller with no corroboration context (the cross-company
+            // comparison, which loads a single fiscal slice — where a short stub
+            // would not be comparable anyway) fails closed instead.
+            candidates = candidates
+                .Where(f => AnnualTransitionStubs.IsCorroborated(f, corroborationContext))
+                .ToList();
+            if (candidates.Count == 0)
+                return null;
+        }
+        else
+        {
             return null;
+        }
 
         // Latest period end first: a filing re-reports comparative prior periods (the
         // prior-year quarter, prior fiscal years, the prior year-end balance instant)

--- a/tests/Equibles.UnitTests/Sec/AnnualTransitionStubsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/AnnualTransitionStubsTests.cs
@@ -1,0 +1,152 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+// The FullYear bucket is the enum's zero value, so it collects unclassified periods on
+// top of the discrete-Q4-under-fp=FY case. When no ordinary annual-span fact exists in
+// the bucket, a sub-annual duration may publish as the year ONLY when the surrounding
+// fiscal years seam it in on both sides — the previous annual window ends where it
+// starts AND the next annual window starts where it ends. One-sided seams are exactly
+// the two wrong shapes: a year-to-date span abuts only on its start (its fiscal year
+// began there) and a lone discrete fourth quarter only on its end (the next year
+// begins there).
+public class AnnualTransitionStubsTests
+{
+    // A genuine transition stub: the issuer moved its year end from December to June,
+    // filing a six-month "year" (Jan-Jun 2024) between the old December-ending year
+    // and the new June-ending one.
+    [Fact]
+    public void IsCorroborated_TransitionStubSeamedOnBothSides_Corroborates()
+    {
+        var corroborated = AnnualTransitionStubs.IsCorroborated(
+            stubStart: new DateOnly(2024, 1, 1),
+            stubEnd: new DateOnly(2024, 6, 30),
+            durations:
+            [
+                (new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31)),
+                (new DateOnly(2024, 7, 1), new DateOnly(2025, 6, 30)),
+            ]
+        );
+
+        corroborated.Should().BeTrue("both neighbouring annual windows seam the stub in");
+    }
+
+    // A six-month year-to-date span starts where its own fiscal year does (the prior
+    // annual window abuts its start), but the NEXT annual window starts half a year
+    // after it ends — the missing end-side seam is what refuses it.
+    [Fact]
+    public void IsCorroborated_YearToDateSpan_IsRefused()
+    {
+        var corroborated = AnnualTransitionStubs.IsCorroborated(
+            stubStart: new DateOnly(2025, 1, 1),
+            stubEnd: new DateOnly(2025, 6, 30),
+            durations:
+            [
+                (new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31)),
+                (new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31)),
+                (new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31)),
+            ]
+        );
+
+        corroborated.Should().BeFalse("no annual window starts where the YTD span ends");
+    }
+
+    // A lone discrete fourth quarter under fp=FY ends where the year does (the next
+    // annual window abuts its end), but no annual window ends where the quarter
+    // starts — the missing start-side seam refuses it.
+    [Fact]
+    public void IsCorroborated_DiscreteFourthQuarter_IsRefused()
+    {
+        var corroborated = AnnualTransitionStubs.IsCorroborated(
+            stubStart: new DateOnly(2025, 10, 1),
+            stubEnd: new DateOnly(2025, 12, 31),
+            durations:
+            [
+                (new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31)),
+                (new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31)),
+            ]
+        );
+
+        corroborated.Should().BeFalse("no annual window ends where the quarter starts");
+    }
+
+    // A two-year cumulative duration is seamed on both sides by the years before and
+    // after it — the span floor is what refuses it, not the seam test.
+    [Fact]
+    public void IsCorroborated_MultiYearCumulative_IsRefused()
+    {
+        var corroborated = AnnualTransitionStubs.IsCorroborated(
+            stubStart: new DateOnly(2023, 1, 1),
+            stubEnd: new DateOnly(2024, 12, 31),
+            durations:
+            [
+                (new DateOnly(2022, 1, 1), new DateOnly(2022, 12, 31)),
+                (new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31)),
+            ]
+        );
+
+        corroborated.Should().BeFalse("a span at or above the annual floor is never a stub");
+    }
+
+    // 52/53-week filers drift up to a week against the calendar; the seam tolerates
+    // exactly that drift and no more.
+    [Theory]
+    [InlineData(7, true)]
+    [InlineData(8, false)]
+    public void IsCorroborated_SeamToleratesCalendarDriftOnly(int driftDays, bool expected)
+    {
+        var corroborated = AnnualTransitionStubs.IsCorroborated(
+            stubStart: new DateOnly(2024, 1, 1),
+            stubEnd: new DateOnly(2024, 6, 30),
+            durations:
+            [
+                (new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31).AddDays(-driftDays)),
+                (new DateOnly(2024, 7, 1).AddDays(driftDays), new DateOnly(2025, 6, 30)),
+            ]
+        );
+
+        corroborated.Should().Be(expected);
+    }
+
+    // Only ANNUAL-span windows corroborate: quarters abutting the stub on both sides
+    // do not seam it into an annual timeline.
+    [Fact]
+    public void IsCorroborated_QuarterWindowsNeverCorroborate()
+    {
+        var corroborated = AnnualTransitionStubs.IsCorroborated(
+            stubStart: new DateOnly(2024, 1, 1),
+            stubEnd: new DateOnly(2024, 6, 30),
+            durations:
+            [
+                (new DateOnly(2023, 10, 1), new DateOnly(2023, 12, 31)),
+                (new DateOnly(2024, 7, 1), new DateOnly(2024, 9, 30)),
+            ]
+        );
+
+        corroborated.Should().BeFalse("only annual-span windows corroborate a stub");
+    }
+
+    // The entity overload: a null context corroborates nothing (fail closed), and
+    // instants in the context never act as annual windows.
+    [Fact]
+    public void IsCorroborated_NullContextOrInstantsOnly_FailsClosed()
+    {
+        var stub = new FinancialFact
+        {
+            PeriodStart = new DateOnly(2024, 1, 1),
+            PeriodEnd = new DateOnly(2024, 6, 30),
+            PeriodType = FactPeriodType.Duration,
+        };
+        var instant = new FinancialFact
+        {
+            PeriodStart = new DateOnly(2023, 12, 31),
+            PeriodEnd = new DateOnly(2023, 12, 31),
+            PeriodType = FactPeriodType.Instant,
+        };
+
+        AnnualTransitionStubs.IsCorroborated(stub, null).Should().BeFalse();
+        AnnualTransitionStubs.IsCorroborated(stub, [instant]).Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/AnnualTransitionStubsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/AnnualTransitionStubsTests.cs
@@ -149,4 +149,19 @@ public class AnnualTransitionStubsTests
         AnnualTransitionStubs.IsCorroborated(stub, null).Should().BeFalse();
         AnnualTransitionStubs.IsCorroborated(stub, [instant]).Should().BeFalse();
     }
+
+    // FinancialFactsTools mixes two constant sets in one code path: the Mcp-internal
+    // FiscalPeriodSpanDays gates the preferred annual filter while AnnualTransitionStubs
+    // carries its own bounds for the fallback. If they drift, a span one side calls
+    // annual stops seaming the other side's stubs.
+    [Fact]
+    public void AnnualBounds_MatchTheMcpSpanConstants()
+    {
+        AnnualTransitionStubs
+            .MinAnnualSpanDays.Should()
+            .Be(Equibles.Sec.FinancialFacts.Mcp.Helpers.FiscalPeriodSpanDays.MinAnnualSpanDays);
+        AnnualTransitionStubs
+            .MaxAnnualSpanDays.Should()
+            .Be(Equibles.Sec.FinancialFacts.Mcp.Helpers.FiscalPeriodSpanDays.MaxAnnualSpanDays);
+    }
 }

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactAccessionTiebreakTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactAccessionTiebreakTests.cs
@@ -64,7 +64,7 @@ public class FinancialFactsToolsPickBestFactAccessionTiebreakTests
         );
 
         var result = (FinancialFact)
-            method!.Invoke(null, [new[] { earlierAcc, laterAcc }, conceptPriority, false]);
+            method!.Invoke(null, [new[] { earlierAcc, laterAcc }, conceptPriority, false, null]);
 
         result.Value.Should().Be(200m);
         result.AccessionNumber.Should().Be("0000320193-24-000999");

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactAsOriginallyReportedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactAsOriginallyReportedTests.cs
@@ -63,7 +63,7 @@ public class FinancialFactsToolsPickBestFactAsOriginallyReportedTests
         );
 
         var result = (FinancialFact)
-            method!.Invoke(null, [new[] { restated, original }, conceptPriority, true]);
+            method!.Invoke(null, [new[] { restated, original }, conceptPriority, true, null]);
 
         result.Value.Should().Be(1_000m);
         result.FiledDate.Should().Be(new DateOnly(2024, 5, 1));

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactConceptPriorityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactConceptPriorityTests.cs
@@ -70,7 +70,7 @@ public class FinancialFactsToolsPickBestFactConceptPriorityTests
         );
 
         var result = (FinancialFact)
-            method!.Invoke(null, [new[] { synonym, primary }, conceptPriority, false]);
+            method!.Invoke(null, [new[] { synonym, primary }, conceptPriority, false, null]);
 
         result.Value.Should().Be(100m);
         result.FinancialConceptId.Should().Be(primaryConceptId);

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
@@ -44,7 +44,7 @@ public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
         );
 
         var result = (FinancialFact)
-            method!.Invoke(null, [new[] { yearToDate, discreteQuarter }, conceptPriority, false]);
+            method!.Invoke(null, [new[] { yearToDate, discreteQuarter }, conceptPriority, false, null]);
 
         result.Value.Should().Be(96_428m, "the discrete quarter wins over the year-to-date span");
     }
@@ -77,8 +77,8 @@ public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
         );
 
         var picked = (FinancialFact)
-            method!.Invoke(null, [new[] { inceptionToDate, validAnnual }, conceptPriority, false]);
-        var rejected = method.Invoke(null, [new[] { inceptionToDate }, conceptPriority, false]);
+            method!.Invoke(null, [new[] { inceptionToDate, validAnnual }, conceptPriority, false, null]);
+        var rejected = method.Invoke(null, [new[] { inceptionToDate }, conceptPriority, false, null]);
 
         picked.Should().BeSameAs(validAnnual);
         rejected.Should().BeNull("a multi-year duration is not a fiscal-year fact");
@@ -112,8 +112,8 @@ public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
         );
 
         var picked = (FinancialFact)
-            method!.Invoke(null, [new[] { inceptionToDate, validQuarter }, conceptPriority, false]);
-        var rejected = method.Invoke(null, [new[] { inceptionToDate }, conceptPriority, false]);
+            method!.Invoke(null, [new[] { inceptionToDate, validQuarter }, conceptPriority, false, null]);
+        var rejected = method.Invoke(null, [new[] { inceptionToDate }, conceptPriority, false, null]);
 
         picked.Should().BeSameAs(validQuarter);
         rejected.Should().BeNull("a fiscal stamp cannot turn an inception duration into a quarter");
@@ -138,7 +138,7 @@ public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
-        var rejected = method!.Invoke(null, [new[] { yearToDate }, conceptPriority, false]);
+        var rejected = method!.Invoke(null, [new[] { yearToDate }, conceptPriority, false, null]);
 
         rejected.Should().BeNull("a six-month YTD span is not a discrete fiscal quarter");
     }

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactDiscreteQuarterTests.cs
@@ -44,7 +44,10 @@ public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
         );
 
         var result = (FinancialFact)
-            method!.Invoke(null, [new[] { yearToDate, discreteQuarter }, conceptPriority, false, null]);
+            method!.Invoke(
+                null,
+                [new[] { yearToDate, discreteQuarter }, conceptPriority, false, null]
+            );
 
         result.Value.Should().Be(96_428m, "the discrete quarter wins over the year-to-date span");
     }
@@ -77,8 +80,14 @@ public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
         );
 
         var picked = (FinancialFact)
-            method!.Invoke(null, [new[] { inceptionToDate, validAnnual }, conceptPriority, false, null]);
-        var rejected = method.Invoke(null, [new[] { inceptionToDate }, conceptPriority, false, null]);
+            method!.Invoke(
+                null,
+                [new[] { inceptionToDate, validAnnual }, conceptPriority, false, null]
+            );
+        var rejected = method.Invoke(
+            null,
+            [new[] { inceptionToDate }, conceptPriority, false, null]
+        );
 
         picked.Should().BeSameAs(validAnnual);
         rejected.Should().BeNull("a multi-year duration is not a fiscal-year fact");
@@ -112,8 +121,14 @@ public class FinancialFactsToolsPickBestFactDiscreteQuarterTests
         );
 
         var picked = (FinancialFact)
-            method!.Invoke(null, [new[] { inceptionToDate, validQuarter }, conceptPriority, false, null]);
-        var rejected = method.Invoke(null, [new[] { inceptionToDate }, conceptPriority, false, null]);
+            method!.Invoke(
+                null,
+                [new[] { inceptionToDate, validQuarter }, conceptPriority, false, null]
+            );
+        var rejected = method.Invoke(
+            null,
+            [new[] { inceptionToDate }, conceptPriority, false, null]
+        );
 
         picked.Should().BeSameAs(validQuarter);
         rejected.Should().BeNull("a fiscal stamp cannot turn an inception duration into a quarter");

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactFullYearFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactFullYearFallbackTests.cs
@@ -1,0 +1,132 @@
+using System.Reflection;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+// A FullYear bucket with no annual-span fact used to fall back to ANY duration up to
+// the annual ceiling, publishing six/nine-month year-to-date spans (and lone discrete
+// quarters the resolver could not classify) as the annual value. The fallback now
+// admits only a fiscal-calendar transition stub the surrounding annual windows
+// corroborate on both sides, and fails closed for callers with no corroboration
+// context (the cross-company comparison, which loads a single fiscal slice).
+public class FinancialFactsToolsPickBestFactFullYearFallbackTests
+{
+    [Fact]
+    public void PickBestFact_FullYearBucketWithOnlyYtd_ReturnsNullDespiteContext()
+    {
+        var conceptId = Guid.NewGuid();
+        var yearToDate = MakeFact(
+            conceptId,
+            value: 60m,
+            periodStart: new DateOnly(2026, 1, 1),
+            periodEnd: new DateOnly(2026, 6, 30)
+        );
+        // The company's ordinary calendar years: the prior one abuts the YTD's start,
+        // but nothing starts where the YTD ends — no end-side seam.
+        var context = new[]
+        {
+            MakeFact(
+                conceptId,
+                value: 100m,
+                periodStart: new DateOnly(2025, 1, 1),
+                periodEnd: new DateOnly(2025, 12, 31)
+            ),
+            yearToDate,
+        };
+        var conceptPriority = new Dictionary<Guid, int> { [conceptId] = 0 };
+
+        var rejected = InvokePickBestFact([yearToDate], conceptPriority, context);
+
+        rejected.Should().BeNull("a year-to-date span must never publish as the annual value");
+    }
+
+    [Fact]
+    public void PickBestFact_CorroboratedTransitionStub_IsKept()
+    {
+        var conceptId = Guid.NewGuid();
+        var stub = MakeFact(
+            conceptId,
+            value: 45m,
+            periodStart: new DateOnly(2024, 1, 1),
+            periodEnd: new DateOnly(2024, 6, 30)
+        );
+        var context = new[]
+        {
+            MakeFact(
+                conceptId,
+                value: 100m,
+                periodStart: new DateOnly(2023, 1, 1),
+                periodEnd: new DateOnly(2023, 12, 31)
+            ),
+            stub,
+            MakeFact(
+                conceptId,
+                value: 110m,
+                periodStart: new DateOnly(2024, 7, 1),
+                periodEnd: new DateOnly(2025, 6, 30)
+            ),
+        };
+        var conceptPriority = new Dictionary<Guid, int> { [conceptId] = 0 };
+
+        var picked = InvokePickBestFact([stub], conceptPriority, context);
+
+        picked.Should().BeSameAs(stub, "both neighbouring annual windows corroborate the stub");
+    }
+
+    [Fact]
+    public void PickBestFact_NoCorroborationContext_FailsClosed()
+    {
+        var conceptId = Guid.NewGuid();
+        var stub = MakeFact(
+            conceptId,
+            value: 45m,
+            periodStart: new DateOnly(2024, 1, 1),
+            periodEnd: new DateOnly(2024, 6, 30)
+        );
+        var conceptPriority = new Dictionary<Guid, int> { [conceptId] = 0 };
+
+        var rejected = InvokePickBestFact([stub], conceptPriority, context: null);
+
+        rejected
+            .Should()
+            .BeNull("without context a sub-annual FullYear duration cannot be proven a stub");
+    }
+
+    private static FinancialFact InvokePickBestFact(
+        FinancialFact[] group,
+        Dictionary<Guid, int> conceptPriority,
+        FinancialFact[] context
+    )
+    {
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "PickBestFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        return (FinancialFact)method!.Invoke(null, [group, conceptPriority, false, context]);
+    }
+
+    private static FinancialFact MakeFact(
+        Guid conceptId,
+        decimal value,
+        DateOnly periodStart,
+        DateOnly periodEnd
+    ) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            FinancialConceptId = conceptId,
+            Value = value,
+            Unit = "USD",
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            FiscalYear = periodEnd.Year,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            PeriodType = FactPeriodType.Duration,
+            Form = DocumentType.TenK,
+            FiledDate = periodEnd.AddMonths(2),
+            AccessionNumber = "0000000000-26-000001",
+        };
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactLatestReportedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactLatestReportedTests.cs
@@ -61,7 +61,7 @@ public class FinancialFactsToolsPickBestFactLatestReportedTests
         );
 
         var result = (FinancialFact)
-            method!.Invoke(null, [new[] { original, restated }, conceptPriority, false]);
+            method!.Invoke(null, [new[] { original, restated }, conceptPriority, false, null]);
 
         result.Value.Should().Be(1_200m);
         result.FiledDate.Should().Be(new DateOnly(2024, 9, 15));


### PR DESCRIPTION
## Summary

- A FullYear bucket with no annual-span fact fell back to any duration up to the annual ceiling (380 days), so a six/nine-month year-to-date span — or a lone discrete quarter the period resolver could not classify — could publish as the annual value.
- The fallback now keeps only a fiscal-calendar transition stub the surrounding annual windows corroborate on BOTH sides: the previous annual window ends where the stub starts and the next annual window starts where the stub ends (±7 days for 52/53-week calendar drift). A YTD span abuts only on its start side, a lone discrete Q4 only on its end side, so each is refused while a genuine short transition year is kept.
- `GetFinancialFact` passes its full unfiltered fact history as the corroboration context (a stub's neighbours can sit outside the caller's date window); the cross-company comparison loads a single fiscal slice, so it fails closed — a short stub would not be comparable across companies anyway.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Data/Statements/AnnualTransitionStubs.cs` — new corroboration helper (entity + date-level overloads), public so web-tier consumers of this package share one implementation.
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — `PickBestFact` gains an optional corroboration context; the FullYear fallback filters through it and fails closed without one.
- `tests/Equibles.UnitTests/Sec/AnnualTransitionStubsTests.cs` — seam rule pinned: stub kept, YTD refused, discrete Q4 refused, multi-year refused, ±7-day boundary, quarter windows never corroborate, null context fails closed.
- `tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactFullYearFallbackTests.cs` — the tool-level fallback behaviour; existing reflection call sites updated for the new parameter.