### PR TITLE
fix(mcp): repair the two integration tests broken on main

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -373,7 +373,9 @@ public class FinancialFactsTools
         string fiscalPeriod = "FY"
     ) =>
         CompareFinancialFact(
-            tickers?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+            // Keep empty entries: "AAPL,,MSFT" signals a malformed list and must be
+            // named invalid, not silently collapsed to the valid neighbours.
+            tickers?.Split(',', StringSplitOptions.TrimEntries),
             concept,
             fiscalYear,
             fiscalPeriod
@@ -543,7 +545,7 @@ public class FinancialFactsTools
 
     internal static (List<string> Tickers, string Error) ParseComparisonTickers(string tickers) =>
         ParseComparisonTickers(
-            tickers?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            tickers?.Split(',', StringSplitOptions.TrimEntries)
         );
 
     private static CommonStock ResolveComparisonStock(

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
@@ -75,7 +75,8 @@ public class InstitutionalHoldingsToolsGetInstitutionConsensusHoldingsTests : Pa
             "Consensus A LP, Consensus B LP, Consensus C LP"
         );
 
-        output.Should().Contain("Consensus holdings — **3 funds**");
+        // #4472 renamed the header's noun from "funds" to "institutions".
+        output.Should().Contain("Consensus holdings — **3 institutions**");
         output.Should().Contain("AAPL");
         output.Should().Contain("MSFT");
         output.Should().Contain("NVDA");


### PR DESCRIPTION
## Summary

- Repairs the two `build-and-test` failures currently on `main` (they predate every open PR; the check never ran on them because it was gated behind a red lint):
  - #4472 renamed the consensus-holdings header noun from **funds** to **institutions** but the integration test kept the old wording.
  - `CompareFinancialFact`'s comma split used `RemoveEmptyEntries`, silently collapsing a malformed list like `AAPL,,MSFT` past validation and into a null-repository fault — the contract test expects it to be named invalid.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — keep empty segments in both comparison-ticker splits so an empty segment reaches `TickerNormalizer` and returns the "Invalid ticker" refusal.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs` — expectation updated to the renamed `**3 institutions**` header.

https://claude.ai/code/session_01EmFktLhVMYhA1DjHcGLb14