### PR TITLE
feat(fred): add dynamic series search

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/CuratedSeriesRegistry.cs
+++ b/src/Equibles.Fred.HostedService/Services/CuratedSeriesRegistry.cs
@@ -68,9 +68,6 @@ public static class CuratedSeriesRegistry
         // Exchange Rates
         new("DTWEXBGS", FredSeriesCategory.ExchangeRates),
         new("DEXUSEU", FredSeriesCategory.ExchangeRates),
-        // New Taiwan dollars per US dollar, used to translate Taiwan issuers' native
-        // financial statements without licensing a commercial fundamentals feed.
-        new("DEXTAUS", FredSeriesCategory.ExchangeRates),
         // Market
         new("SP500", FredSeriesCategory.Market),
         new("VIXCLS", FredSeriesCategory.Market),

--- a/src/Equibles.Integrations.Fred/Contracts/IFredClient.cs
+++ b/src/Equibles.Integrations.Fred/Contracts/IFredClient.cs
@@ -6,6 +6,7 @@ public interface IFredClient
 {
     bool IsConfigured { get; }
     Task<FredSeriesRecord> GetSeriesMetadata(string seriesId);
+    Task<List<FredSeriesRecord>> SearchSeries(string searchText, int limit = 25);
     Task<List<FredObservationRecord>> GetObservations(string seriesId, DateOnly? startDate = null);
     Task<FredReleaseRecord> GetSeriesRelease(string seriesId);
     Task<List<FredReleaseDateRecord>> GetReleaseDates(

--- a/src/Equibles.Integrations.Fred/FredClient.cs
+++ b/src/Equibles.Integrations.Fred/FredClient.cs
@@ -59,6 +59,25 @@ public class FredClient : IFredClient
         return response?.Series?.FirstOrDefault();
     }
 
+    public async Task<List<FredSeriesRecord>> SearchSeries(string searchText, int limit = 25)
+    {
+        if (string.IsNullOrWhiteSpace(searchText))
+            return [];
+
+        var boundedLimit = Math.Clamp(limit, 1, 100);
+        _logger.LogDebug("Searching FRED series for {SearchText}", searchText);
+        var url =
+            $"{ApiBaseUrl}/fred/series/search"
+            + $"?search_text={Uri.EscapeDataString(searchText.Trim())}"
+            + $"&api_key={_options.ApiKey}"
+            + "&file_type=json"
+            + "&order_by=popularity"
+            + "&sort_order=desc"
+            + $"&limit={boundedLimit}";
+        var content = await SendWithRetry(url);
+        return JsonConvert.DeserializeObject<FredSeriesResponse>(content)?.Series ?? [];
+    }
+
     public async Task<List<FredObservationRecord>> GetObservations(
         string seriesId,
         DateOnly? startDate = null

--- a/tests/Equibles.IntegrationTests/Fred/FredClientSearchSeriesTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredClientSearchSeriesTests.cs
@@ -11,9 +11,11 @@ public class FredClientSearchSeriesTests
     [Fact]
     public async Task SearchSeries_EncodesQueryBoundsLimitAndReturnsMetadata()
     {
-        var handler = new CapturingHandler("""
+        var handler = new CapturingHandler(
+            """
             {"seriess":[{"id":"DEXTAUS","title":"Taiwan Dollars to U.S. Dollar Exchange Rate","frequency":"Daily","units":"New Taiwan Dollars to One U.S. Dollar","notes":"Noon buying rates."}]}
-            """);
+            """
+        );
         var client = new FredClient(
             new HttpClient(handler),
             Substitute.For<ILogger<FredClient>>(),
@@ -55,9 +57,12 @@ public class FredClientSearchSeriesTests
         )
         {
             RequestUri = request.RequestUri;
-            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK) {
-                Content = new StringContent(response),
-            });
+            return Task.FromResult(
+                new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent(response),
+                }
+            );
         }
     }
 }

--- a/tests/Equibles.IntegrationTests/Fred/FredClientSearchSeriesTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredClientSearchSeriesTests.cs
@@ -1,0 +1,63 @@
+using Equibles.Integrations.Fred;
+using Equibles.Integrations.Fred.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Fred;
+
+public class FredClientSearchSeriesTests
+{
+    [Fact]
+    public async Task SearchSeries_EncodesQueryBoundsLimitAndReturnsMetadata()
+    {
+        var handler = new CapturingHandler("""
+            {"seriess":[{"id":"DEXTAUS","title":"Taiwan Dollars to U.S. Dollar Exchange Rate","frequency":"Daily","units":"New Taiwan Dollars to One U.S. Dollar","notes":"Noon buying rates."}]}
+            """);
+        var client = new FredClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<FredClient>>(),
+            Options.Create(new FredOptions { ApiKey = "test-key" })
+        );
+
+        var result = await client.SearchSeries("TWD per U.S. dollar", 500);
+
+        Assert.Single(result);
+        Assert.Equal("DEXTAUS", result[0].Id);
+        Assert.Contains("search_text=TWD%20per%20U.S.%20dollar", handler.RequestUri.Query);
+        Assert.Contains("limit=100", handler.RequestUri.Query);
+        Assert.Contains("api_key=test-key", handler.RequestUri.Query);
+    }
+
+    [Fact]
+    public async Task SearchSeries_BlankQuery_DoesNotCallApi()
+    {
+        var handler = new CapturingHandler("{}");
+        var client = new FredClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<FredClient>>(),
+            Options.Create(new FredOptions { ApiKey = "test-key" })
+        );
+
+        var result = await client.SearchSeries("  ");
+
+        Assert.Empty(result);
+        Assert.Null(handler.RequestUri);
+    }
+
+    private sealed class CapturingHandler(string response) : HttpMessageHandler
+    {
+        public Uri RequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            RequestUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK) {
+                Content = new StringContent(response),
+            });
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Fred/CuratedSeriesRegistryTests.cs
+++ b/tests/Equibles.UnitTests/Fred/CuratedSeriesRegistryTests.cs
@@ -51,7 +51,6 @@ public class CuratedSeriesRegistryTests
     [InlineData("M2SL")]
     [InlineData("ICSA")]
     [InlineData("HOUST")]
-    [InlineData("DEXTAUS")]
     public void Series_ContainsExpectedKeySeriesId(string expectedSeriesId)
     {
         CuratedSeriesRegistry.Series.Should().Contain(s => s.SeriesId == expectedSeriesId);
@@ -76,7 +75,6 @@ public class CuratedSeriesRegistryTests
     [InlineData("M2SL", FredSeriesCategory.MoneySupply)]
     [InlineData("UMCSENT", FredSeriesCategory.Sentiment)]
     [InlineData("DTWEXBGS", FredSeriesCategory.ExchangeRates)]
-    [InlineData("DEXTAUS", FredSeriesCategory.ExchangeRates)]
     public void WellKnownSeries_HasExpectedCategory(
         string seriesId,
         FredSeriesCategory expectedCategory


### PR DESCRIPTION
- add provider-level FRED series search for source-driven FX discovery
- remove the curated international FX exception
- cover official response mapping and curated-registry behavior