### PR TITLE
feat(sec): materialize latest fund filing reference

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260828024704_AddFundSeriesLatestNportFiling.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260828024704_AddFundSeriesLatestNportFiling.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828024704_AddFundSeriesLatestNportFiling")]
+    partial class AddFundSeriesLatestNportFiling
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260828024704_AddFundSeriesLatestNportFiling.cs
+++ b/src/Equibles.Migrations/Migrations/20260828024704_AddFundSeriesLatestNportFiling.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFundSeriesLatestNportFiling : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "LatestNportFilingId",
+                table: "FundSeries",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "FundSeries" AS series
+                SET "LatestNportFilingId" = (
+                    SELECT filing."Id"
+                    FROM "NportFiling" AS filing
+                    WHERE filing."ReportPeriodDate" = series."LatestReportPeriodDate"
+                      AND filing."FilingDate" = series."LatestFilingDate"
+                      AND (
+                          (series."SeriesId" <> '' AND filing."SeriesId" = series."SeriesId")
+                          OR (
+                              series."SeriesId" = ''
+                              AND series."CommonStockId" IS NOT NULL
+                              AND filing."CommonStockId" = series."CommonStockId"
+                              AND (filing."SeriesId" IS NULL OR filing."SeriesId" = '')
+                          )
+                          OR (
+                              series."SeriesId" = ''
+                              AND series."CommonStockId" IS NULL
+                              AND filing."CommonStockId" IS NULL
+                              AND filing."RegistrantCik" = series."RegistrantCik"
+                              AND (filing."SeriesId" IS NULL OR filing."SeriesId" = '')
+                          )
+                      )
+                    ORDER BY filing."AccessionNumber" DESC
+                    LIMIT 1
+                );
+                """
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FundSeries_LatestNportFilingId",
+                table: "FundSeries",
+                column: "LatestNportFilingId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_FundSeries_LatestNportFilingId",
+                table: "FundSeries");
+
+            migrationBuilder.DropColumn(
+                name: "LatestNportFilingId",
+                table: "FundSeries");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/FundSeries.cs
+++ b/src/Equibles.Sec.Data/Models/FundSeries.cs
@@ -29,6 +29,7 @@ namespace Equibles.Sec.Data.Models;
 /// </summary>
 [Index(nameof(IdentityKey), IsUnique = true)]
 [Index(nameof(Slug), IsUnique = true)]
+[Index(nameof(LatestNportFilingId), IsUnique = true)]
 [Index(nameof(CommonStockId))]
 [Index(nameof(RegistrantCik), nameof(SeriesId))]
 public class FundSeries
@@ -82,6 +83,12 @@ public class FundSeries
     public DateOnly LatestReportPeriodDate { get; set; }
 
     public DateOnly LatestFilingDate { get; set; }
+
+    /// <summary>
+    /// The exact NPORT-P filing selected by the directory materializer. Readers join through this
+    /// reference instead of repeating the latest-report identity and amendment rules.
+    /// </summary>
+    public Guid LatestNportFilingId { get; set; }
 
     /// <summary>Net assets in USD, from the latest report header.</summary>
     public decimal NetAssets { get; set; }

--- a/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
@@ -100,16 +100,21 @@ public class FundSeriesRefreshService
 
         if (rows.Count > 0)
         {
-            // A series can move between the issuer-feed and sweep populations while retaining its
-            // canonical route slug. Remove the superseded identity first so the unique Slug index
-            // cannot block the replacement; the transaction preserves the old directory if the
-            // subsequent rebuild fails.
+            // Reprocessing can change a filing's resolved identity while retaining its filing ID,
+            // and a series can move populations while retaining its route slug. Remove either
+            // superseded owner before upsert so both unique indexes permit the replacement; the
+            // transaction preserves the old directory if the subsequent rebuild fails.
             var currentIdentityKeys = rows.Select(s => s.IdentityKey).ToList();
             var currentSlugs = rows.Select(s => s.Slug).ToList();
+            var currentFilingIds = rows.Select(s => s.LatestNportFilingId).ToList();
             await dbContext
                 .Set<FundSeries>()
                 .Where(s =>
-                    currentSlugs.Contains(s.Slug) && !currentIdentityKeys.Contains(s.IdentityKey)
+                    !currentIdentityKeys.Contains(s.IdentityKey)
+                    && (
+                        currentSlugs.Contains(s.Slug)
+                        || currentFilingIds.Contains(s.LatestNportFilingId)
+                    )
                 )
                 .ExecuteDeleteAsync(cancellationToken);
 

--- a/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
@@ -67,6 +67,7 @@ public class FundSeriesRefreshService
             .GetLatestPerSeries(DateOnly.MinValue)
             .Select(f => new FundSeriesAggregate
             {
+                LatestNportFilingId = f.Id,
                 CommonStockId = f.CommonStockId,
                 RegistrantCik = f.RegistrantCik,
                 SeriesId = f.SeriesId,
@@ -127,6 +128,7 @@ public class FundSeriesRefreshService
                             SeriesName = incoming.SeriesName,
                             RegistrantName = incoming.RegistrantName,
                             Ticker = incoming.Ticker,
+                            LatestNportFilingId = incoming.LatestNportFilingId,
                             LatestReportPeriodDate = incoming.LatestReportPeriodDate,
                             LatestFilingDate = incoming.LatestFilingDate,
                             NetAssets = incoming.NetAssets,
@@ -273,6 +275,7 @@ public class FundSeriesRefreshService
             SeriesName = a.SeriesName,
             RegistrantName = a.RegistrantName,
             Ticker = ticker,
+            LatestNportFilingId = a.LatestNportFilingId,
             LatestReportPeriodDate = a.LatestReportPeriodDate,
             LatestFilingDate = a.LatestFilingDate,
             NetAssets = a.NetAssets,
@@ -334,6 +337,7 @@ public class FundSeriesRefreshService
 
     private class FundSeriesAggregate
     {
+        public Guid LatestNportFilingId { get; set; }
         public Guid? CommonStockId { get; set; }
         public string RegistrantCik { get; set; }
         public string SeriesId { get; set; }

--- a/tests/Equibles.IntegrationTests/Mcp/FundDirectoryToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FundDirectoryToolsTests.cs
@@ -264,6 +264,7 @@ public class FundDirectoryToolsTests : IDisposable
     {
         var series = new FundSeries
         {
+            LatestNportFilingId = Guid.NewGuid(),
             IdentityKey = $"rc:0000999999:{seriesId}",
             Slug = $"{name.ToLower().Replace(' ', '-').Replace("--", "-")}-{seriesId.ToLower()}",
             RegistrantCik = "0000999999",

--- a/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolTests.cs
@@ -150,6 +150,7 @@ public class NCenFundOperationsToolTests : IDisposable
         _dbContext.Add(
             new FundSeries
             {
+                LatestNportFilingId = Guid.NewGuid(),
                 IdentityKey = "rc:1100663:S000004310",
                 Slug = "ishares-core-sp-500-etf-s000004310",
                 RegistrantCik = "1100663",
@@ -177,6 +178,7 @@ public class NCenFundOperationsToolTests : IDisposable
         _dbContext.Add(
             new FundSeries
             {
+                LatestNportFilingId = Guid.NewGuid(),
                 IdentityKey = "rc:0000102909:S000002839",
                 Slug = "vanguard-500-index-fund-s000002839",
                 RegistrantCik = "0000102909",
@@ -202,6 +204,7 @@ public class NCenFundOperationsToolTests : IDisposable
         _dbContext.Add(
             new FundSeries
             {
+                LatestNportFilingId = Guid.NewGuid(),
                 IdentityKey = "rc:1100663:S000004310",
                 Slug = "unsafe-fund-s000004310",
                 RegistrantCik = "1100663",

--- a/tests/Equibles.IntegrationTests/Migrations/FundSeriesLatestNportFilingMigrationTests.cs
+++ b/tests/Equibles.IntegrationTests/Migrations/FundSeriesLatestNportFilingMigrationTests.cs
@@ -1,0 +1,160 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equibles.IntegrationTests.Migrations;
+
+[Collection(ParadeDbCollection.Name)]
+public class FundSeriesLatestNportFilingMigrationTests : ParadeDbMcpTestBase
+{
+    private const string PreviousMigration = "20260825134832_AddDocumentChunkAttempts";
+    private const string ReferenceMigration = "20260828024704_AddFundSeriesLatestNportFiling";
+
+    public FundSeriesLatestNportFilingMigrationTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Up_BackfillsEveryIdentityPopulationAndHighestAccession()
+    {
+        var migrator = DbContext.Database.GetService<IMigrator>();
+
+        try
+        {
+            var trackedSeriesStock = Stock("SERIES");
+            var trackedIdlessStock = Stock("IDLESS");
+            var reportDate = new DateOnly(2026, 6, 30);
+            var filingDate = new DateOnly(2026, 8, 1);
+            var crossPopulationLower = Filing(
+                "0001",
+                "S-CROSS",
+                trackedSeriesStock.Id,
+                null,
+                reportDate,
+                filingDate
+            );
+            var crossPopulationHigher = Filing(
+                "0002",
+                "S-CROSS",
+                null,
+                "000100",
+                reportDate,
+                filingDate
+            );
+            var trackedIdlessLower = Filing(
+                "1001",
+                null,
+                trackedIdlessStock.Id,
+                null,
+                reportDate,
+                filingDate
+            );
+            var trackedIdlessHigher = Filing(
+                "1002",
+                "",
+                trackedIdlessStock.Id,
+                null,
+                reportDate,
+                filingDate
+            );
+            var trustIdlessLower = Filing(
+                "2001",
+                null,
+                null,
+                "000200",
+                reportDate,
+                filingDate
+            );
+            var trustIdlessHigher = Filing(
+                "2002",
+                "",
+                null,
+                "000200",
+                reportDate,
+                filingDate
+            );
+
+            DbContext.AddRange(
+                trackedSeriesStock,
+                trackedIdlessStock,
+                crossPopulationLower,
+                crossPopulationHigher,
+                trackedIdlessLower,
+                trackedIdlessHigher,
+                trustIdlessLower,
+                trustIdlessHigher,
+                Series("cross", "S-CROSS", null, "000100", reportDate, filingDate),
+                Series("tracked-idless", "", trackedIdlessStock.Id, null, reportDate, filingDate),
+                Series("trust-idless", "", null, "000200", reportDate, filingDate)
+            );
+            await DbContext.SaveChangesAsync();
+            DbContext.ChangeTracker.Clear();
+
+            await migrator.MigrateAsync(PreviousMigration);
+            await migrator.MigrateAsync(ReferenceMigration);
+            DbContext.ChangeTracker.Clear();
+
+            var references = await DbContext
+                .Set<FundSeries>()
+                .ToDictionaryAsync(series => series.IdentityKey, series => series.LatestNportFilingId);
+            references["cross"].Should().Be(crossPopulationHigher.Id);
+            references["tracked-idless"].Should().Be(trackedIdlessHigher.Id);
+            references["trust-idless"].Should().Be(trustIdlessHigher.Id);
+            references.Values.Should().OnlyHaveUniqueItems();
+        }
+        finally
+        {
+            await migrator.MigrateAsync();
+        }
+    }
+
+    private static CommonStock Stock(string ticker) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = ticker,
+            Cik = Guid.NewGuid().ToString("N")[..10],
+        };
+
+    private static NportFiling Filing(
+        string accession,
+        string seriesId,
+        Guid? commonStockId,
+        string registrantCik,
+        DateOnly reportDate,
+        DateOnly filingDate
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            AccessionNumber = accession,
+            SeriesId = seriesId,
+            CommonStockId = commonStockId,
+            RegistrantCik = registrantCik,
+            ReportPeriodDate = reportDate,
+            FilingDate = filingDate,
+        };
+
+    private static FundSeries Series(
+        string identityKey,
+        string seriesId,
+        Guid? commonStockId,
+        string registrantCik,
+        DateOnly reportDate,
+        DateOnly filingDate
+    ) =>
+        new()
+        {
+            IdentityKey = identityKey,
+            Slug = identityKey,
+            LatestNportFilingId = Guid.NewGuid(),
+            SeriesId = seriesId,
+            CommonStockId = commonStockId,
+            RegistrantCik = registrantCik,
+            LatestReportPeriodDate = reportDate,
+            LatestFilingDate = filingDate,
+        };
+}

--- a/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
@@ -124,6 +124,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         tracked.TotalAssets.Should().Be(1_100m);
         tracked.PositionCount.Should().Be(2);
         tracked.ReportedHoldingCount.Should().Be(2);
+        tracked.LatestNportFilingId.Should().Be(trackedFiling.Id);
         tracked.LatestReportPeriodDate.Should().Be(new DateOnly(2025, 3, 31));
 
         var trust = await read.Set<FundSeries>().SingleAsync(s => s.RegistrantCik == "0001100663");
@@ -134,6 +135,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         trust.NetAssets.Should().Be(2_000m);
         trust.PositionCount.Should().Be(1, "only the tracked-CUSIP holding is stored for a trust");
         trust.ReportedHoldingCount.Should().Be(347, "the full filing count survives filtering");
+        trust.LatestNportFilingId.Should().Be(trustFiling.Id);
     }
 
     [Fact]
@@ -175,6 +177,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         var row = await read.Set<FundSeries>().SingleAsync(s => s.CommonStockId == cef.Id);
         row.NetAssets.Should().Be(900m, "the newest report wins");
         row.PositionCount.Should().Be(2);
+        row.LatestNportFilingId.Should().Be(newer.Id);
         row.LatestReportPeriodDate.Should().Be(new DateOnly(2025, 3, 31));
     }
 
@@ -272,6 +275,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
             .Add(
                 new FundSeries
                 {
+                    LatestNportFilingId = tracked.Id,
                     IdentityKey = $"cs:{trust.Id}:S000002277",
                     Slug = "ishares-russell-2000-etf-s000002277",
                     CommonStockId = trust.Id,
@@ -312,6 +316,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         seed.Add(swept);
         var previous = new FundSeries
         {
+            LatestNportFilingId = Guid.NewGuid(),
             IdentityKey = $"cs:{trust.Id}:S000002277",
             Slug = "ishares-russell-2000-etf-s000002277",
             CommonStockId = trust.Id,
@@ -406,6 +411,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         seed.AddRange(
             new FundSeries
             {
+                LatestNportFilingId = Guid.NewGuid(),
                 IdentityKey = "rc:9999999999:S000099999",
                 Slug = "ghost-fund-s000099999",
                 RegistrantCik = "9999999999",
@@ -420,6 +426,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
             },
             new FundSeries
             {
+                LatestNportFilingId = Guid.NewGuid(),
                 IdentityKey = $"cs:{cef.Id}",
                 Slug = "stale-slug",
                 CommonStockId = cef.Id,
@@ -454,6 +461,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         db.AddRange(
             new FundSeries
             {
+                LatestNportFilingId = Guid.NewGuid(),
                 IdentityKey = "rc:1100663:S000004310",
                 Slug = "ishares-core-sp-500-etf-s000004310",
                 RegistrantCik = "1100663",
@@ -464,6 +472,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
             },
             new FundSeries
             {
+                LatestNportFilingId = Guid.NewGuid(),
                 IdentityKey = "rc:0000102909:S000002839",
                 Slug = "vanguard-500-index-fund-s000002839",
                 RegistrantCik = "0000102909",

--- a/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
@@ -298,6 +298,49 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RebuildAll_ReprocessedFilingChangesIdentity_ReplacesPriorFilingOwner()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "IVV", "0001100663");
+        var filing = MakeFiling(
+            stock.Id,
+            null,
+            "0001100663-25-000001",
+            "S000002277",
+            "iShares Core S&P 500 ETF",
+            "iShares Trust",
+            new DateOnly(2025, 1, 31),
+            netAssets: 2_100m,
+            totalAssets: 2_150m
+        );
+        seed.Add(filing);
+        seed.Set<FundSeries>()
+            .Add(
+                new FundSeries
+                {
+                    LatestNportFilingId = filing.Id,
+                    IdentityKey = $"cs:{stock.Id}",
+                    Slug = "ishares-trust-ivv",
+                    CommonStockId = stock.Id,
+                    SeriesId = "",
+                    SeriesName = "iShares Trust",
+                    LatestReportPeriodDate = filing.ReportPeriodDate,
+                    LatestFilingDate = filing.FilingDate,
+                }
+            );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildAllAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var row = await read.Set<FundSeries>().SingleAsync();
+        row.LatestNportFilingId.Should().Be(filing.Id);
+        row.IdentityKey.Should().Be($"cs:{stock.Id}:S000002277");
+        row.Slug.Should().Be("ishares-core-s-p-500-etf-s000002277");
+        row.SeriesId.Should().Be("S000002277");
+    }
+
+    [Fact]
     public async Task RebuildAll_ReplacementUpsertFails_RollsBackConflictingSlugDeletion()
     {
         await using var seed = FreshContext();


### PR DESCRIPTION
## Summary

Materialize the exact latest N-PORT filing selected for each fund series so read paths can join by one stable reference instead of repeating identity, date, and amendment-selection logic.

## Code changes

- Add the unique `FundSeries.LatestNportFilingId` provenance reference and paired schema migration.
- Backfill existing directory rows across series-bearing, tracked id-less, and trust id-less identities with accession tie-breaking.
- Make `FundSeriesRefreshService` persist the selected filing and safely replace stale owners when reprocessing changes identity.
- Add populated migration-transition and refresh regression coverage for all identity populations and same-filing identity changes.

## Verification

- `Equibles.UnitTests`: 4,692 passed.
- `Equibles.IntegrationTests`: 2,778 passed.