### PR TITLE
fix(financials): derive discrete statement quarters

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ This self-hosted build exposes 61 tools over MCP. The hosted server at `https://
 
 **Fundamentals (XBRL)**
 
-- GetFinancialStatement — income/balance/cash-flow statement anchored to one period end, with each line's exact span
+- GetFinancialStatement — income/balance/cash-flow statement anchored to one period end; quarterly USD flows are reported discrete quarters or exact derived remainders, never YTD totals
 - GetFinancialFact — one concept over time with exact spans and stale-alias coverage warnings
 - CompareFinancialFact — a concept across companies
 - GetRevenueBreakdown — revenue by segment/geography/product plus reported segment operating income and derived margin

--- a/docs/guide/how-to-ask-about-financial-statements.md
+++ b/docs/guide/how-to-ask-about-financial-statements.md
@@ -15,7 +15,7 @@ Name a company, a statement, and a period:
 - "What did Microsoft's balance sheet look like last fiscal year?"
 - "Pull NVDA's cash-flow statement for its latest annual period."
 
-The assistant calls the `GetFinancialStatement` tool and replies with the standard line items — revenue, net income, total assets, operating cash flow, and the rest — for the fiscal year and period you asked for, using the latest restated values. Every line is anchored to one statement period end and includes its actual period start, so a discrete quarter and a fiscal-year-to-date flow remain visibly different.
+The assistant calls the `GetFinancialStatement` tool and replies with the standard line items — revenue, net income, total assets, operating cash flow, and the rest — for the fiscal year and period you asked for, using the latest restated values. Every line is anchored to one statement period end. Quarterly flow rows always span one quarter: when a filer reports only cumulative USD facts, the tool derives the quarter by exact subtraction from the compatible preceding cumulative fact and marks its basis; an unprovable YTD-only line is omitted.
 
 ## Follow one metric over time
 

--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -91,7 +91,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 `FinancialStatementTools`:
 
-- `GetFinancialStatement` — full income statement / balance sheet / cash flow for a ticker + fiscal period, anchored to one actual period end with each line's exact start/end span.
+- `GetFinancialStatement` — full income statement / balance sheet / cash flow for a ticker + fiscal period, anchored to one actual period end. Quarterly USD flows are discrete quarters; a missing quarter is derived only by exact subtraction of compatible cumulative facts and marked in the `Basis` column.
 
 `RevenueBreakdownTools`:
 

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -55,9 +55,8 @@ public static class StatementLineFacts
     {
         var candidates = facts.ToList();
 
-        // A source-stamped duration remains the fallback when no ordinary span
-        // exists, but multi-year/inception durations cannot represent any one
-        // fiscal period — even when the source stamped them Q1..Q4.
+        // A source stamp never turns a cumulative or inception duration into
+        // one quarter or one fiscal year.
         candidates = candidates
             .Where(f =>
             {
@@ -80,8 +79,9 @@ public static class StatementLineFacts
                     : spanDays <= MaxDiscreteQuarterDays;
             })
             .ToList();
-        if (preferred.Count > 0)
-            candidates = preferred;
+        if (preferred.Count == 0)
+            return null;
+        candidates = preferred;
 
         return candidates
             .OrderByDescending(f => f.PeriodEnd)
@@ -109,8 +109,8 @@ public static class StatementLineFacts
     }
 
     /// <summary>
-    /// The fact to render for a line: its first variant with a fact for the
-    /// period, or null when the company reported none of them.
+    /// The fact to render for a line: the first reported variant, otherwise the
+    /// first derived variant, or null when the company reported none of them.
     /// </summary>
     public static FinancialFact PickFact(
         StatementLine line,
@@ -118,14 +118,19 @@ public static class StatementLineFacts
         IReadOnlyDictionary<Guid, FinancialFact> factByConceptId
     )
     {
+        FinancialFact derivedFallback = null;
         foreach (var reference in line.Concepts)
         {
             if (
                 conceptIdByKey.TryGetValue((reference.Taxonomy, reference.Tag), out var conceptId)
                 && factByConceptId.TryGetValue(conceptId, out var fact)
             )
-                return fact;
+            {
+                if (!StatementQuarterDerivation.IsDerived(fact))
+                    return fact;
+                derivedFallback ??= fact;
+            }
         }
-        return null;
+        return derivedFallback;
     }
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementQuarterDerivation.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementQuarterDerivation.cs
@@ -1,0 +1,188 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.Data.Statements;
+
+/// <summary>
+/// Derives missing discrete USD quarters from consecutive cumulative facts.
+/// The source facts remain unchanged; derived rows exist only in the read path.
+/// </summary>
+public static class StatementQuarterDerivation
+{
+    private const int MinQuarterDays = 80;
+    private const int MaxQuarterDays = 100;
+    private static readonly HashSet<string> NonNegativeAliases =
+    [
+        "depreciation-and-amortization",
+        "share-based-compensation",
+        "capital-expenditures",
+        "acquisitions",
+        "share-repurchases",
+        "dividends-paid",
+        "debt-issued",
+        "debt-repaid",
+        "stock-issued",
+    ];
+
+    public static IReadOnlyList<FinancialFact> AppendDerived(
+        IReadOnlyCollection<FinancialFact> facts,
+        IReadOnlySet<Guid> rejectNegativeConceptIds = null
+    )
+    {
+        var result = facts.ToList();
+        var spans = SelectSpans(facts);
+
+        foreach (
+            var concept in spans.GroupBy(s =>
+                (s.Fact.CommonStockId, s.Fact.FinancialConceptId, s.Fact.Unit, s.Fact.DimensionsKey)
+            )
+        )
+        {
+            var conceptSpans = concept.ToList();
+            foreach (var current in conceptSpans)
+            {
+                var prior = FindPrior(current, conceptSpans);
+                if (prior == null || HasReportedQuarter(current, conceptSpans))
+                    continue;
+
+                var derived = Derive(prior, current);
+                if (
+                    derived.Value < 0m
+                    && rejectNegativeConceptIds?.Contains(derived.FinancialConceptId) == true
+                )
+                    continue;
+
+                result.Add(derived);
+            }
+        }
+
+        return result;
+    }
+
+    public static bool IsDerived(FinancialFact fact) =>
+        fact.Form == null && string.IsNullOrEmpty(fact.AccessionNumber);
+
+    public static HashSet<Guid> GetNonNegativeConceptIds(
+        IEnumerable<StatementLine> lines,
+        IReadOnlyDictionary<(FactTaxonomy Taxonomy, string Tag), Guid> conceptIdByKey
+    ) =>
+        lines
+            .Where(line => NonNegativeAliases.Contains(line.Alias))
+            .SelectMany(line => line.Concepts)
+            .Select(reference =>
+                conceptIdByKey.GetValueOrDefault((reference.Taxonomy, reference.Tag))
+            )
+            .Where(id => id != Guid.Empty)
+            .ToHashSet();
+
+    private static List<SpanFact> SelectSpans(IReadOnlyCollection<FinancialFact> facts) =>
+        facts
+            .Where(f =>
+                f.PeriodType == FactPeriodType.Duration
+                && f.Unit == "USD"
+                && f.PeriodEnd >= f.PeriodStart
+                && Span(f) <= StatementLineFacts.MaxSupportedDurationDays
+            )
+            .GroupBy(f =>
+                (
+                    f.CommonStockId,
+                    f.PeriodStart,
+                    f.PeriodEnd,
+                    f.FinancialConceptId,
+                    f.Unit,
+                    f.DimensionsKey
+                )
+            )
+            .Select(g => new SpanFact(
+                g.OrderBy(f => FinancialFactSourcePriority.Rank(f.Form))
+                    .ThenByDescending(f => f.FiledDate)
+                    .ThenByDescending(f => f.AccessionNumber)
+                    .First(),
+                g.OrderBy(f => f.FiscalYear)
+                    .ThenBy(f => FinancialFactSourcePriority.Rank(f.Form))
+                    .ThenByDescending(f => f.FiledDate)
+                    .First()
+            ))
+            .ToList();
+
+    private static SpanFact FindPrior(SpanFact current, IReadOnlyCollection<SpanFact> spans)
+    {
+        var priorPeriod = current.Identity.FiscalPeriod switch
+        {
+            SecFiscalPeriod.Q2 => SecFiscalPeriod.Q1,
+            SecFiscalPeriod.Q3 => SecFiscalPeriod.Q2,
+            _ => (SecFiscalPeriod?)null,
+        };
+        if (priorPeriod == null || !HasExpectedCurrentSpan(current))
+            return null;
+
+        return spans
+            .Where(s =>
+                s.Identity.FiscalYear == current.Identity.FiscalYear
+                && s.Identity.FiscalPeriod == priorPeriod
+                && s.Fact.PeriodStart == current.Fact.PeriodStart
+                && HasExpectedPriorSpan(s, priorPeriod.Value)
+                && IsQuarterRemainder(s.Fact.PeriodEnd, current.Fact.PeriodEnd)
+            )
+            .OrderByDescending(s => s.Fact.FiledDate)
+            .ThenByDescending(s => s.Fact.AccessionNumber)
+            .FirstOrDefault();
+    }
+
+    private static bool HasExpectedCurrentSpan(SpanFact current) =>
+        current.Identity.FiscalPeriod switch
+        {
+            SecFiscalPeriod.Q2 => IsCumulativeSpan(current.Fact, 2),
+            SecFiscalPeriod.Q3 => IsCumulativeSpan(current.Fact, 3),
+            _ => false,
+        };
+
+    private static bool HasExpectedPriorSpan(SpanFact prior, SecFiscalPeriod period) =>
+        period switch
+        {
+            SecFiscalPeriod.Q1 => IsQuarterSpan(prior.Fact),
+            SecFiscalPeriod.Q2 => IsCumulativeSpan(prior.Fact, 2),
+            SecFiscalPeriod.Q3 => IsCumulativeSpan(prior.Fact, 3),
+            _ => false,
+        };
+
+    private static bool HasReportedQuarter(SpanFact current, IReadOnlyCollection<SpanFact> spans) =>
+        spans.Any(s =>
+            s.Fact.PeriodEnd == current.Fact.PeriodEnd
+            && s.Identity.FiscalPeriod == current.Identity.FiscalPeriod
+            && IsQuarterSpan(s.Fact)
+        );
+
+    private static FinancialFact Derive(SpanFact prior, SpanFact current) =>
+        new()
+        {
+            CommonStockId = current.Fact.CommonStockId,
+            FinancialConceptId = current.Fact.FinancialConceptId,
+            Unit = current.Fact.Unit,
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = prior.Fact.PeriodEnd.AddDays(1),
+            PeriodEnd = current.Fact.PeriodEnd,
+            Value = current.Fact.Value - prior.Fact.Value,
+            FiscalYear = current.Identity.FiscalYear,
+            FiscalPeriod = current.Identity.FiscalPeriod,
+            FiledDate =
+                current.Fact.FiledDate > prior.Fact.FiledDate
+                    ? current.Fact.FiledDate
+                    : prior.Fact.FiledDate,
+            DimensionsKey = current.Fact.DimensionsKey,
+        };
+
+    private static bool IsQuarterSpan(FinancialFact fact) =>
+        Span(fact) is >= MinQuarterDays and <= MaxQuarterDays;
+
+    private static bool IsCumulativeSpan(FinancialFact fact, int quarters) =>
+        Span(fact) >= MinQuarterDays * quarters && Span(fact) <= MaxQuarterDays * quarters;
+
+    private static bool IsQuarterRemainder(DateOnly priorEnd, DateOnly currentEnd) =>
+        currentEnd.DayNumber - priorEnd.DayNumber is >= MinQuarterDays and <= MaxQuarterDays;
+
+    private static int Span(FinancialFact fact) =>
+        fact.PeriodEnd.DayNumber - fact.PeriodStart.DayNumber;
+
+    private sealed record SpanFact(FinancialFact Fact, FinancialFact Identity);
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -52,8 +52,9 @@ public class FinancialStatementTools
             + "given fiscal year and period, sourced from SEC Company Facts (structured XBRL). "
             + "Returns the standard line items (e.g. revenue, net income, total assets, "
             + "operating cash flow) with the latest-restated value for one exact statement "
-            + "period end. Each row carries its actual period start/end so discrete-quarter "
-            + "and fiscal-year-to-date flow facts remain distinguishable. "
+            + "period end. Quarterly flow rows are always discrete quarters: when the filer "
+            + "reports only cumulative year-to-date USD values, the quarter is derived by "
+            + "exact subtraction from the preceding cumulative period and marked Derived. "
             + "Company-specific dimensional facts (e.g. product-segment revenue) are not "
             + "included — use GetRevenueBreakdown for segment/geographic revenue, and "
             + "GetFinancialFact or CompareFinancialFact for one line item across periods "
@@ -135,7 +136,6 @@ public class FinancialStatementTools
                     .GetConsolidatedByStock(stock)
                     .Where(f =>
                         f.FiscalYear == selectedYear
-                        && f.FiscalPeriod == selectedPeriod
                         && conceptIds.Contains(f.FinancialConceptId)
                         && (
                             f.PeriodType != FactPeriodType.Duration
@@ -147,6 +147,19 @@ public class FinancialStatementTools
                         )
                     )
                     .ToListAsync();
+
+                if (statementType != FinancialStatementType.BalanceSheet)
+                {
+                    var rejectNegativeConceptIds =
+                        StatementQuarterDerivation.GetNonNegativeConceptIds(
+                            statementLines,
+                            conceptIdByKey
+                        );
+                    facts = StatementQuarterDerivation
+                        .AppendDerived(facts, rejectNegativeConceptIds)
+                        .ToList();
+                }
+                facts = facts.Where(f => f.FiscalPeriod == selectedPeriod).ToList();
 
                 if (facts.Count == 0)
                     return $"No {statementType.NameForHumans().ToLowerInvariant()} line items "
@@ -211,8 +224,8 @@ public class FinancialStatementTools
             $"{statementType.NameForHumans()} for {stock.Ticker} "
                 + $"({FactMarkdown.Cell(stock.Name)}) — "
                 + $"FY{selectedYear} {selectedPeriod.NameForHumans()}:",
-            "| Line Item | Value | Unit | Period Start | Period End | Form | Filed |",
-            "|-----------|------:|------|--------------|------------|------|-------|"
+            "| Line Item | Value | Unit | Basis | Period Start | Period End | Form | Filed |",
+            "|-----------|------:|------|-------|--------------|------------|------|-------|"
         );
 
         var rendered = 0;
@@ -238,6 +251,7 @@ public class FinancialStatementTools
                 $"| {FactMarkdown.Cell(line.Label)} | "
                     + $"{FactMarkdown.Value(value, fact.Unit)} | "
                     + $"{FactMarkdown.Cell(fact.Unit)} | "
+                    + $"{(StatementQuarterDerivation.IsDerived(fact) ? "Derived quarter" : "Reported")} | "
                     + $"{fact.PeriodStart:yyyy-MM-dd} | "
                     + $"{fact.PeriodEnd:yyyy-MM-dd} | "
                     + $"{FactMarkdown.Cell(fact.Form?.DisplayName)} | "
@@ -268,9 +282,9 @@ public class FinancialStatementTools
             && statementType != FinancialStatementType.BalanceSheet
         )
             result.AppendLine(
-                "\n_Quarterly flow rows preserve the exact SEC-reported span. A period can "
-                    + "contain discrete-quarter and fiscal-year-to-date facts; use Period Start "
-                    + "and Period End to distinguish them._"
+                "\n_All flow rows span one discrete quarter. A Derived quarter is exact "
+                    + "subtraction of consecutive cumulative USD facts with the same concept, "
+                    + "unit and fiscal-year start; an unprovable YTD-only line is omitted._"
             );
 
         // Each line independently takes its latest restatement, so one

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -717,7 +717,6 @@ public class StockTabService
             .GetConsolidatedByStock(stock)
             .Where(f =>
                 f.FiscalYear == fiscalYear
-                && f.FiscalPeriod == fiscalPeriod
                 && conceptIds.Contains(f.FinancialConceptId)
                 && (
                     f.PeriodType != FactPeriodType.Duration
@@ -727,6 +726,23 @@ public class StockTabService
                 )
             )
             .ToListAsync();
+
+        if (statementType != FinancialStatementType.BalanceSheet)
+        {
+            var rejectNegativeConceptIds = StatementQuarterDerivation.GetNonNegativeConceptIds(
+                statementLines,
+                conceptIdByKey
+            );
+            facts = StatementQuarterDerivation
+                .AppendDerived(facts, rejectNegativeConceptIds)
+                .ToList();
+        }
+        facts = facts.Where(f => f.FiscalPeriod == fiscalPeriod).ToList();
+        if (facts.Count > 0)
+        {
+            var statementPeriodEnd = facts.Max(f => f.PeriodEnd);
+            facts = facts.Where(f => f.PeriodEnd == statementPeriodEnd).ToList();
+        }
 
         // The currently-reported fact per concept: span-aware so a quarter never
         // shows the 10-Q's year-to-date figure, latest-ending so a comparative
@@ -778,6 +794,7 @@ public class StockTabService
                     row.PeriodEnd = fact.PeriodEnd;
                     row.Form = fact.Form?.DisplayName;
                     row.FiledDate = fact.FiledDate;
+                    row.Derived = StatementQuarterDerivation.IsDerived(fact);
                 }
                 return row;
             })

--- a/src/Equibles.Web/ViewModels/Stocks/FinancialsLineViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/FinancialsLineViewModel.cs
@@ -13,6 +13,8 @@ public class FinancialsLineViewModel
 
     public decimal Value { get; set; }
 
+    public bool Derived { get; set; }
+
     public string Unit { get; set; }
 
     public DateOnly PeriodEnd { get; set; }

--- a/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
@@ -66,7 +66,7 @@
                                     : isMoney
                                         ? "$" + line.Value.ToString("N0")
                                         : line.Value.ToString("N0");
-                                <td class="text-right font-mono">@formatted</td>
+                                <td class="text-right font-mono">@formatted@if (line.Derived) {<sup title="Derived by subtracting consecutive cumulative year-to-date facts">d</sup>}</td>
                                 <td class="hidden md:table-cell text-base-content/60">@line.Unit</td>
                                 <td class="hidden md:table-cell text-base-content/60">@line.PeriodEnd.ToString("yyyy-MM-dd")</td>
                                 <td class="hidden lg:table-cell text-base-content/60">@line.Form</td>
@@ -82,6 +82,10 @@
                     }
                 </tbody>
             </table-card>
+
+    @if (Model.Lines.Any(line => line.Derived)) {
+        <p class="mt-2 text-sm text-base-content/60"><sup>d</sup> Derived quarter: exact subtraction of consecutive cumulative USD facts with the same concept, unit and fiscal-year start.</p>
+    }
 
     <script>
     // Financials tab filters: changing the statement type or fiscal period

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
@@ -353,7 +353,8 @@ public class FinancialStatementToolsTests : ParadeDbMcpTestBase
             DateOnly start,
             DateOnly end,
             decimal value,
-            string accession
+            string accession,
+            SecFiscalPeriod fiscalPeriod = SecFiscalPeriod.Q2
         ) =>
             new()
             {
@@ -365,7 +366,7 @@ public class FinancialStatementToolsTests : ParadeDbMcpTestBase
                 PeriodEnd = end,
                 Value = value,
                 FiscalYear = 2025,
-                FiscalPeriod = SecFiscalPeriod.Q2,
+                FiscalPeriod = fiscalPeriod,
                 Form = DocumentType.TenQ,
                 FiledDate = new DateOnly(2025, 8, 1),
                 AccessionNumber = accession,
@@ -380,6 +381,14 @@ public class FinancialStatementToolsTests : ParadeDbMcpTestBase
                     new DateOnly(2025, 6, 30),
                     25_000_000m,
                     "revenue"
+                ),
+                Fact(
+                    netIncome,
+                    new DateOnly(2025, 1, 1),
+                    new DateOnly(2025, 3, 31),
+                    3_000_000m,
+                    "net-income-q1",
+                    SecFiscalPeriod.Q1
                 ),
                 Fact(
                     netIncome,
@@ -401,10 +410,16 @@ public class FinancialStatementToolsTests : ParadeDbMcpTestBase
         var result = await Sut()
             .GetFinancialStatement("AAPL", statement: "income", year: 2025, period: "Q2");
 
-        result.Should().Contain("| Revenue | $25,000,000 | USD | 2025-04-01 | 2025-06-30 |");
-        result.Should().Contain("| Net Income | $4,000,000 | USD | 2025-01-01 | 2025-06-30 |");
+        result
+            .Should()
+            .Contain("| Revenue | $25,000,000 | USD | Reported | 2025-04-01 | 2025-06-30 |");
+        result
+            .Should()
+            .Contain(
+                "| Net Income | $1,000,000 | USD | Derived quarter | 2025-04-01 | 2025-06-30 |"
+            );
         result.Should().NotContain("$99,000,000");
-        result.Should().Contain("discrete-quarter and fiscal-year-to-date facts");
+        result.Should().Contain("All flow rows span one discrete quarter");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsPickFactTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsPickFactTests.cs
@@ -69,6 +69,40 @@ public class StatementLineFactsPickFactTests
     }
 
     [Fact]
+    public void PickFact_LaterReportedVariant_WinsOverPreferredDerivedVariant()
+    {
+        var line = RdLine();
+        var genericId = Guid.NewGuid();
+        var softwareId = Guid.NewGuid();
+        var conceptIdByKey = new Dictionary<(FactTaxonomy, string), Guid>
+        {
+            [(FactTaxonomy.UsGaap, "ResearchAndDevelopmentExpense")] = genericId,
+            [
+                (
+                    FactTaxonomy.UsGaap,
+                    "ResearchAndDevelopmentExpenseSoftwareExcludingAcquiredInProcessCost"
+                )
+            ] = softwareId,
+        };
+        var derived = new FinancialFact { Value = 100m };
+        var reported = new FinancialFact
+        {
+            Value = 200m,
+            Form = Equibles.Sec.Data.Models.DocumentType.TenQ,
+            AccessionNumber = "reported",
+        };
+        var facts = new Dictionary<Guid, FinancialFact>
+        {
+            [genericId] = derived,
+            [softwareId] = reported,
+        };
+
+        var picked = StatementLineFacts.PickFact(line, conceptIdByKey, facts);
+
+        picked.Should().BeSameAs(reported);
+    }
+
+    [Fact]
     public void PickFact_NothingReported_ReturnsNull()
     {
         var line = RdLine();
@@ -201,5 +235,23 @@ public class StatementLineFactsPickFactTests
             .PickCurrentlyReported([inceptionToDate], SecFiscalPeriod.Q2)
             .Should()
             .BeNull("a fiscal stamp cannot turn an inception duration into a quarter");
+    }
+
+    [Fact]
+    public void PickCurrentlyReported_QuarterWithOnlyYearToDateFact_ReturnsNull()
+    {
+        var yearToDate = new FinancialFact
+        {
+            Value = 40m,
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = new DateOnly(2026, 1, 1),
+            PeriodEnd = new DateOnly(2026, 6, 30),
+            FiscalPeriod = SecFiscalPeriod.Q2,
+        };
+
+        StatementLineFacts
+            .PickCurrentlyReported([yearToDate], SecFiscalPeriod.Q2)
+            .Should()
+            .BeNull("a cumulative fact must never appear as one discrete quarter");
     }
 }

--- a/tests/Equibles.UnitTests/Sec/StatementQuarterDerivationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementQuarterDerivationTests.cs
@@ -1,0 +1,178 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class StatementQuarterDerivationTests
+{
+    private readonly Guid _stockId = Guid.NewGuid();
+    private readonly Guid _conceptId = Guid.NewGuid();
+
+    [Theory]
+    [InlineData(80_200_000, 156_600_000, 76_400_000)]
+    [InlineData(23_000_000, 7_000_000, -16_000_000)]
+    public void AppendDerived_Q2CumulativeChain_ProvidesDiscreteQuarter(
+        decimal firstQuarter,
+        decimal firstHalf,
+        decimal expected
+    )
+    {
+        var facts = new[]
+        {
+            Fact("2026-01-01", "2026-03-31", firstQuarter, SecFiscalPeriod.Q1, "q1"),
+            Fact("2026-01-01", "2026-06-30", firstHalf, SecFiscalPeriod.Q2, "q2"),
+        };
+
+        var derived = StatementQuarterDerivation
+            .AppendDerived(facts)
+            .Single(StatementQuarterDerivation.IsDerived);
+
+        derived.Value.Should().Be(expected);
+        derived.PeriodStart.Should().Be(new DateOnly(2026, 4, 1));
+        derived.PeriodEnd.Should().Be(new DateOnly(2026, 6, 30));
+        derived.FiscalYear.Should().Be(2026);
+        derived.FiscalPeriod.Should().Be(SecFiscalPeriod.Q2);
+    }
+
+    [Fact]
+    public void AppendDerived_Q3CumulativeChain_ProvidesDiscreteQuarter()
+    {
+        var facts = new[]
+        {
+            Fact("2026-01-01", "2026-06-30", 156m, SecFiscalPeriod.Q2, "h1"),
+            Fact("2026-01-01", "2026-09-30", 241m, SecFiscalPeriod.Q3, "nine-months"),
+        };
+
+        var derived = StatementQuarterDerivation
+            .AppendDerived(facts)
+            .Single(StatementQuarterDerivation.IsDerived);
+
+        derived.Value.Should().Be(85m);
+        derived.PeriodStart.Should().Be(new DateOnly(2026, 7, 1));
+        derived.PeriodEnd.Should().Be(new DateOnly(2026, 9, 30));
+        derived.FiscalPeriod.Should().Be(SecFiscalPeriod.Q3);
+    }
+
+    [Fact]
+    public void AppendDerived_ReportedDiscreteQuarterExists_DoesNotAddAnother()
+    {
+        var facts = new[]
+        {
+            Fact("2026-01-01", "2026-03-31", 80m, SecFiscalPeriod.Q1, "q1"),
+            Fact("2026-01-01", "2026-06-30", 156m, SecFiscalPeriod.Q2, "h1"),
+            Fact("2026-04-01", "2026-06-30", 75m, SecFiscalPeriod.Q2, "reported-q2"),
+        };
+
+        var result = StatementQuarterDerivation.AppendDerived(facts);
+
+        result.Should().HaveCount(facts.Length);
+        result.Count(StatementQuarterDerivation.IsDerived).Should().Be(0);
+    }
+
+    [Fact]
+    public void AppendDerived_DifferentFiscalYearStart_RefusesSubtraction()
+    {
+        var facts = new[]
+        {
+            Fact("2026-01-02", "2026-03-31", 80m, SecFiscalPeriod.Q1, "q1"),
+            Fact("2026-01-01", "2026-06-30", 156m, SecFiscalPeriod.Q2, "h1"),
+        };
+
+        StatementQuarterDerivation
+            .AppendDerived(facts)
+            .Count(StatementQuarterDerivation.IsDerived)
+            .Should()
+            .Be(0);
+    }
+
+    [Fact]
+    public void AppendDerived_DifferentStockOrDimensions_RefusesSubtraction()
+    {
+        var firstQuarter = Fact("2026-01-01", "2026-03-31", 80m, SecFiscalPeriod.Q1, "q1");
+        var firstHalf = Fact("2026-01-01", "2026-06-30", 156m, SecFiscalPeriod.Q2, "h1");
+
+        firstQuarter.CommonStockId = Guid.NewGuid();
+        firstHalf.DimensionsKey = "segment-a";
+
+        StatementQuarterDerivation
+            .AppendDerived([firstQuarter, firstHalf])
+            .Count(StatementQuarterDerivation.IsDerived)
+            .Should()
+            .Be(0);
+    }
+
+    [Fact]
+    public void AppendDerived_IncompatibleQuarterEndpoint_RefusesSubtraction()
+    {
+        var facts = new[]
+        {
+            Fact("2026-01-01", "2026-03-31", 80m, SecFiscalPeriod.Q1, "q1"),
+            Fact("2026-01-01", "2026-08-31", 156m, SecFiscalPeriod.Q2, "h1"),
+        };
+
+        StatementQuarterDerivation
+            .AppendDerived(facts)
+            .Count(StatementQuarterDerivation.IsDerived)
+            .Should()
+            .Be(0);
+    }
+
+    [Fact]
+    public void AppendDerived_PerShareCumulativeFacts_RefusesSubtraction()
+    {
+        var facts = new[]
+        {
+            Fact("2026-01-01", "2026-03-31", 1m, SecFiscalPeriod.Q1, "q1", "USD/shares"),
+            Fact("2026-01-01", "2026-06-30", 2m, SecFiscalPeriod.Q2, "h1", "USD/shares"),
+        };
+
+        StatementQuarterDerivation
+            .AppendDerived(facts)
+            .Count(StatementQuarterDerivation.IsDerived)
+            .Should()
+            .Be(0);
+    }
+
+    [Fact]
+    public void AppendDerived_NonNegativeConceptWouldProduceNegative_RefusesSubtraction()
+    {
+        var facts = new[]
+        {
+            Fact("2026-01-01", "2026-03-31", 23m, SecFiscalPeriod.Q1, "q1"),
+            Fact("2026-01-01", "2026-06-30", 7m, SecFiscalPeriod.Q2, "h1"),
+        };
+
+        StatementQuarterDerivation
+            .AppendDerived(facts, new HashSet<Guid> { _conceptId })
+            .Count(StatementQuarterDerivation.IsDerived)
+            .Should()
+            .Be(0);
+    }
+
+    private FinancialFact Fact(
+        string start,
+        string end,
+        decimal value,
+        SecFiscalPeriod period,
+        string accession,
+        string unit = "USD"
+    ) =>
+        new()
+        {
+            CommonStockId = _stockId,
+            FinancialConceptId = _conceptId,
+            Unit = unit,
+            PeriodType = FactPeriodType.Duration,
+            PeriodStart = DateOnly.Parse(start),
+            PeriodEnd = DateOnly.Parse(end),
+            Value = value,
+            FiscalYear = 2026,
+            FiscalPeriod = period,
+            FiledDate =
+                period == SecFiscalPeriod.Q1
+                    ? new DateOnly(2026, 4, 22)
+                    : new DateOnly(2026, 7, 29),
+            AccessionNumber = accession,
+        };
+}


### PR DESCRIPTION
## Summary

- derive Q2 and Q3 flow values from exact consecutive cumulative USD facts
- omit unprovable YTD-only rows from quarterly statements
- mark derived values in MCP and web output
- preserve reported facts across statement alias families

## Code changes

- add shared read-time quarter derivation with nonnegative guards
- use homogeneous quarter selection in MCP and web statements
- add unit and integration coverage for VRT/GEV-shaped facts and refusal cases
- document the quarterly statement contract