### PR TITLE
fix(yahoo): validate full history against captured splits

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
@@ -58,7 +58,7 @@ public class StockSplitCaptureManager
 
         foreach (var split in splits)
         {
-            if (split.Denominator <= 0)
+            if (split.Numerator <= 0 || split.Denominator <= 0)
                 continue;
 
             var match = existing.FirstOrDefault(s => s.EffectiveDate == split.EffectiveDate);

--- a/src/Equibles.CorporateActions.Data/SplitAdjustment.cs
+++ b/src/Equibles.CorporateActions.Data/SplitAdjustment.cs
@@ -15,14 +15,14 @@ public static class SplitAdjustment
     /// <see cref="StockSplit.Numerator"/>/<see cref="StockSplit.Denominator"/>
     /// ratio. The comparison is strict (<c>&gt;</c>) because a report dated on the
     /// effective date already reflects the post-split count. Splits with a
-    /// non-positive denominator are skipped to guard against divide-by-zero.
+    /// non-positive ratio arm are skipped because they cannot describe a split.
     /// </summary>
     public static decimal ShareCountFactor(DateOnly asOf, IEnumerable<StockSplit> splits)
     {
         var factor = 1m;
         foreach (var split in splits)
         {
-            if (split.EffectiveDate > asOf && split.Denominator > 0)
+            if (split.EffectiveDate > asOf && split.Numerator > 0 && split.Denominator > 0)
             {
                 factor *= split.Numerator / split.Denominator;
             }

--- a/src/Equibles.CorporateActions.Data/SplitBasisResolver.cs
+++ b/src/Equibles.CorporateActions.Data/SplitBasisResolver.cs
@@ -105,12 +105,11 @@ public static class SplitBasisResolver
                 return false;
             }
 
-            // Mirrors SplitAdjustment: a non-positive denominator is a malformed ratio, skipped
-            // rather than allowed to divide by zero. It cannot make the basis ambiguous because
-            // it moves no figure.
-            if (split.Denominator <= 0)
+            // A malformed stored action makes the basis unprovable. Returning a factor of zero or
+            // silently ignoring the row would corrupt or overstate every downstream restatement.
+            if (split.Numerator <= 0 || split.Denominator <= 0)
             {
-                continue;
+                return false;
             }
 
             resolved *= split.Numerator / split.Denominator;

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -843,11 +843,13 @@ public class YahooPriceImportService
                 split.Numerator,
                 split.Denominator
             ))
-            .Concat(chartData.Splits.Select(split => new SplitBasisDefinition(
-                split.Date,
-                split.Numerator,
-                split.Denominator
-            )));
+            .Concat(
+                chartData.Splits.Select(split => new SplitBasisDefinition(
+                    split.Date,
+                    split.Numerator,
+                    split.Denominator
+                ))
+            );
 
         var replaced = await ReplaceStoredPrices(
             target,
@@ -1016,8 +1018,7 @@ public class YahooPriceImportService
     {
         var invalid = splits
             .Where(split =>
-                split.EffectiveDate <= today
-                && (split.Numerator <= 0m || split.Denominator <= 0m)
+                split.EffectiveDate <= today && (split.Numerator <= 0m || split.Denominator <= 0m)
             )
             .Select(split => (SplitBasisDefinition?)split)
             .FirstOrDefault();

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -1241,7 +1241,7 @@ public class YahooPriceImportService
         try
         {
             var lockedSeries = await LockPriceSeries(stockRepo, target, cancellationToken);
-            if (lockedSeries == null)
+            if (lockedSeries is not LockedPriceSeries currentSeries)
             {
                 await transaction.RollbackAsync(cancellationToken);
                 _logger.LogWarning(
@@ -1256,7 +1256,7 @@ public class YahooPriceImportService
                 .GetEffectiveByStock(target.CommonStockId, settledBefore)
                 .Where(split =>
                     split.PriceSeriesTicker == target.Ticker
-                    || (lockedSeries.Value.IsPrimary && split.PriceSeriesTicker == null)
+                    || (currentSeries.IsPrimary && split.PriceSeriesTicker == null)
                 )
                 .Select(split => new SplitBasisDefinition(
                     split.EffectiveDate,
@@ -1305,7 +1305,7 @@ public class YahooPriceImportService
                 floor,
                 replaceThrough,
                 freshRows,
-                lockedSeries.Value,
+                currentSeries,
                 cancellationToken
             );
             await transaction.CommitAsync(cancellationToken);

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -837,30 +837,17 @@ public class YahooPriceImportService
             return;
         }
 
-        var splitBoundaries = selectedSeries
+        var responseBoundaries = selectedSeries
             .Splits.Select(split => new SplitBasisDefinition(
                 split.EffectiveDate,
                 split.Numerator,
                 split.Denominator
             ))
-            .Concat(
-                chartData.Splits.Select(split => new SplitBasisDefinition(
-                    split.Date,
-                    split.Numerator,
-                    split.Denominator
-                ))
-            )
-            .Distinct()
-            .ToList();
-        if (
-            !TryPutHistoryOnSingleSplitBasis(
-                target.Ticker,
-                chartData.Prices,
-                splitBoundaries,
-                settledBefore
-            )
-        )
-            return;
+            .Concat(chartData.Splits.Select(split => new SplitBasisDefinition(
+                split.Date,
+                split.Numerator,
+                split.Denominator
+            )));
 
         var replaced = await ReplaceStoredPrices(
             target,
@@ -868,6 +855,7 @@ public class YahooPriceImportService
             historyEndDate,
             settledBefore,
             chartData.Prices,
+            responseBoundaries,
             cancellationToken
         );
         if (!replaced)
@@ -1026,6 +1014,26 @@ public class YahooPriceImportService
         DateOnly today
     )
     {
+        var invalid = splits
+            .Where(split =>
+                split.EffectiveDate <= today
+                && (split.Numerator <= 0m || split.Denominator <= 0m)
+            )
+            .Select(split => (SplitBasisDefinition?)split)
+            .FirstOrDefault();
+        if (invalid.HasValue)
+        {
+            var boundary = invalid.Value;
+            _logger.LogWarning(
+                "Refusing full history for {Ticker}: captured split {EffectiveDate} has invalid ratio {Numerator}:{Denominator}",
+                ticker,
+                boundary.EffectiveDate,
+                boundary.Numerator,
+                boundary.Denominator
+            );
+            return false;
+        }
+
         var restated = RestateHistoryAcrossKnownSplits(prices, splits, today);
         if (restated > 0)
         {
@@ -1184,38 +1192,167 @@ public class YahooPriceImportService
         DateOnly replaceThrough,
         DateOnly settledBefore,
         List<HistoricalPrice> prices,
+        IEnumerable<SplitBasisDefinition> responseBoundaries,
         CancellationToken cancellationToken
     )
     {
-        var freshRows = MapFreshRows(target.CommonStockId, prices, target.Ticker, settledBefore);
-        if (freshRows.Count == 0)
-        {
-            _logger.LogWarning(
-                "No storable prices for {Ticker} after the numeric range guard; keeping existing rows",
-                target.Ticker
-            );
-            return false;
-        }
-
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var splitRepo = scope.ServiceProvider.GetRequiredService<StockSplitRepository>();
         var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
-        var replaced = await ReplacePriceRows(
+        return await ReplaceValidatedPriceRows(
             repo,
             stockRepo,
+            splitRepo,
             target,
             floor,
             replaceThrough,
-            freshRows,
+            settledBefore,
+            prices,
+            responseBoundaries,
             cancellationToken
         );
-        if (!replaced)
-            _logger.LogWarning(
-                "Skipping reconcile for {Ticker}: it no longer belongs to CommonStock {Id}",
+    }
+
+    // Full-history basis validation and replacement share the same parent-row lock and transaction.
+    // Split capture takes that lock too, so no effective boundary or primary designation can change
+    // between the applicable-split read and the final row swap.
+    private async Task<bool> ReplaceValidatedPriceRows(
+        DailyStockPriceRepository repo,
+        CommonStockRepository stockRepo,
+        StockSplitRepository splitRepo,
+        PriceSeriesTarget target,
+        DateOnly floor,
+        DateOnly replaceThrough,
+        DateOnly settledBefore,
+        List<HistoricalPrice> prices,
+        IEnumerable<SplitBasisDefinition> responseBoundaries,
+        CancellationToken cancellationToken
+    )
+    {
+        if (prices.Count == 0)
+            return false;
+
+        await using var transaction = await repo.CreateTransaction(
+            IsolationLevel.ReadCommitted,
+            cancellationToken
+        );
+        try
+        {
+            var lockedSeries = await LockPriceSeries(stockRepo, target, cancellationToken);
+            if (lockedSeries == null)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                _logger.LogWarning(
+                    "Skipping full-history replacement for {Ticker}: it no longer belongs to CommonStock {Id}",
+                    target.Ticker,
+                    target.CommonStockId
+                );
+                return false;
+            }
+
+            var capturedBoundaries = await splitRepo
+                .GetEffectiveByStock(target.CommonStockId, settledBefore)
+                .Where(split =>
+                    split.PriceSeriesTicker == target.Ticker
+                    || (lockedSeries.Value.IsPrimary && split.PriceSeriesTicker == null)
+                )
+                .Select(split => new SplitBasisDefinition(
+                    split.EffectiveDate,
+                    split.Numerator,
+                    split.Denominator
+                ))
+                .ToListAsync(cancellationToken);
+            if (
+                !TryResolveSplitBoundaries(
+                    target.Ticker,
+                    capturedBoundaries,
+                    responseBoundaries,
+                    out var boundaries
+                )
+            )
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+            if (!TryPutHistoryOnSingleSplitBasis(target.Ticker, prices, boundaries, settledBefore))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            var freshRows = MapFreshRows(
+                target.CommonStockId,
+                prices,
                 target.Ticker,
-                target.CommonStockId
+                settledBefore
             );
-        return replaced;
+            if (freshRows.Count == 0)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                _logger.LogWarning(
+                    "No storable prices for {Ticker} after the numeric range guard; keeping existing rows",
+                    target.Ticker
+                );
+                return false;
+            }
+
+            await ReplaceLockedPriceRows(
+                repo,
+                stockRepo,
+                target,
+                floor,
+                replaceThrough,
+                freshRows,
+                lockedSeries.Value,
+                cancellationToken
+            );
+            await transaction.CommitAsync(cancellationToken);
+            return true;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+
+    // The locked database row is the current authoritative definition, while selection and chart
+    // definitions can predate a concurrent correction. Two ratios for one effective date make the
+    // fetched basis ambiguous, so fail closed instead of restating with whichever ratio happens to
+    // be enumerated first.
+    private bool TryResolveSplitBoundaries(
+        string ticker,
+        IReadOnlyCollection<SplitBasisDefinition> capturedBoundaries,
+        IEnumerable<SplitBasisDefinition> responseBoundaries,
+        out IReadOnlyList<SplitBasisDefinition> resolved
+    )
+    {
+        var candidates = capturedBoundaries.Concat(responseBoundaries).ToList();
+        var conflict = candidates
+            .GroupBy(boundary => boundary.EffectiveDate)
+            .Select(group => new
+            {
+                EffectiveDate = group.Key,
+                Ratios = group
+                    .Select(boundary => (boundary.Numerator, boundary.Denominator))
+                    .Distinct()
+                    .ToList(),
+            })
+            .FirstOrDefault(group => group.Ratios.Count > 1);
+        if (conflict != null)
+        {
+            _logger.LogWarning(
+                "Refusing full history for {Ticker}: split {EffectiveDate} has conflicting ratio definitions",
+                ticker,
+                conflict.EffectiveDate
+            );
+            resolved = [];
+            return false;
+        }
+
+        resolved = candidates.Distinct().OrderBy(boundary => boundary.EffectiveDate).ToList();
+        return true;
     }
 
     private async Task PurgePricesAfterHistoricalCutoff(
@@ -1284,40 +1421,16 @@ public class YahooPriceImportService
                 await transaction.RollbackAsync(cancellationToken);
                 return false;
             }
-            var existing = await repo.GetAllSeries()
-                .Where(p =>
-                    p.CommonStockId == target.CommonStockId
-                    && p.ListedTicker == target.Ticker
-                    && (
-                        target.IsHistorical
-                            ? p.Date >= floor || p.Date > target.HistoryEndDate!.Value
-                            : p.Date >= floor && p.Date <= replaceThrough
-                    )
-                )
-                .ToListAsync(cancellationToken);
-            if (existing.Count > 0)
-            {
-                repo.Delete(existing);
-                await repo.SaveChanges();
-            }
-
-            foreach (var batch in freshRows.Chunk(InsertBatchSize))
-            {
-                repo.AddRange(batch);
-                await repo.SaveChanges();
-            }
-
-            if (target.RequiresFullHistory)
-            {
-                lockedSeries.Value.Stock.PriceHistoryBackfilledTickers = lockedSeries
-                    .Value.Stock.PriceHistoryBackfilledTickers.Append(target.Ticker)
-                    .Select(TickerNormalizer.NormalizeListed)
-                    .Where(ticker => ticker != null)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .OrderBy(ticker => ticker, StringComparer.Ordinal)
-                    .ToList();
-                await stockRepo.SaveChanges();
-            }
+            await ReplaceLockedPriceRows(
+                repo,
+                stockRepo,
+                target,
+                floor,
+                replaceThrough,
+                freshRows,
+                lockedSeries.Value,
+                cancellationToken
+            );
 
             await transaction.CommitAsync(cancellationToken);
             return true;
@@ -1326,6 +1439,53 @@ public class YahooPriceImportService
         {
             await transaction.RollbackAsync(cancellationToken);
             throw;
+        }
+    }
+
+    private static async Task ReplaceLockedPriceRows(
+        DailyStockPriceRepository repo,
+        CommonStockRepository stockRepo,
+        PriceSeriesTarget target,
+        DateOnly floor,
+        DateOnly replaceThrough,
+        List<DailyStockPrice> freshRows,
+        LockedPriceSeries lockedSeries,
+        CancellationToken cancellationToken
+    )
+    {
+        var existing = await repo.GetAllSeries()
+            .Where(p =>
+                p.CommonStockId == target.CommonStockId
+                && p.ListedTicker == target.Ticker
+                && (
+                    target.IsHistorical
+                        ? p.Date >= floor || p.Date > target.HistoryEndDate!.Value
+                        : p.Date >= floor && p.Date <= replaceThrough
+                )
+            )
+            .ToListAsync(cancellationToken);
+        if (existing.Count > 0)
+        {
+            repo.Delete(existing);
+            await repo.SaveChanges();
+        }
+
+        foreach (var batch in freshRows.Chunk(InsertBatchSize))
+        {
+            repo.AddRange(batch);
+            await repo.SaveChanges();
+        }
+
+        if (target.RequiresFullHistory)
+        {
+            lockedSeries.Stock.PriceHistoryBackfilledTickers = lockedSeries
+                .Stock.PriceHistoryBackfilledTickers.Append(target.Ticker)
+                .Select(TickerNormalizer.NormalizeListed)
+                .Where(ticker => ticker != null)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(ticker => ticker, StringComparer.Ordinal)
+                .ToList();
+            await stockRepo.SaveChanges();
         }
     }
 
@@ -1437,28 +1597,17 @@ public class YahooPriceImportService
                 return new TickerImportResult(Fetched: true, Inserted: 0);
             }
 
-            if (
-                !TryPutHistoryOnSingleSplitBasis(
-                    target.Ticker,
-                    chartData.Prices,
-                    chartData
-                        .Splits.Select(split => new SplitBasisDefinition(
-                            split.Date,
-                            split.Numerator,
-                            split.Denominator
-                        ))
-                        .ToList(),
-                    settledAsOf
-                )
-            )
-                return new TickerImportResult(Fetched: true, Inserted: 0);
-
             var replaced = await ReplaceStoredPrices(
                 target,
                 PriceHistoryFloor(),
                 chartEnd,
                 settledAsOf,
                 chartData.Prices,
+                chartData.Splits.Select(split => new SplitBasisDefinition(
+                    split.Date,
+                    split.Numerator,
+                    split.Denominator
+                )),
                 cancellationToken
             );
             if (replaced)
@@ -1481,24 +1630,34 @@ public class YahooPriceImportService
         // harmless. Issuer-level action capture below independently locks and requires whichever
         // listing is primary at write time.
         var floor = PriceHistoryFloor();
-        if (chartData.Splits.Count > 0 && startDate == floor)
+        if (startDate == floor)
         {
             await CaptureSplits(target, chartData.Splits, cancellationToken);
-            if (
-                !TryPutHistoryOnSingleSplitBasis(
-                    target.Ticker,
-                    chartData.Prices,
-                    chartData
-                        .Splits.Select(split => new SplitBasisDefinition(
-                            split.Date,
-                            split.Numerator,
-                            split.Denominator
-                        ))
-                        .ToList(),
-                    today
-                )
-            )
-                return new TickerImportResult(Fetched: true, Inserted: 0);
+            var replaced = await ReplaceStoredPrices(
+                target,
+                floor,
+                chartEnd,
+                today,
+                chartData.Prices,
+                chartData.Splits.Select(split => new SplitBasisDefinition(
+                    split.Date,
+                    split.Numerator,
+                    split.Denominator
+                )),
+                cancellationToken
+            );
+            if (replaced)
+            {
+                _logger.LogInformation(
+                    "Reconciled {Ticker}: replaced its full listed price history",
+                    target.Ticker
+                );
+                await CaptureDividends(target, chartData.Dividends, cancellationToken);
+            }
+            return new TickerImportResult(
+                Fetched: true,
+                Inserted: replaced ? chartData.Prices.Count : 0
+            );
         }
 
         if (chartData.Splits.Count > 0 && startDate > floor)
@@ -1515,31 +1674,19 @@ public class YahooPriceImportService
                 return new TickerImportResult(Fetched: true, Inserted: 0);
             }
 
-            var splitBoundaries = chartData
-                .Splits.Concat(fullChart.Splits)
-                .Select(split => new SplitBasisDefinition(
-                    split.Date,
-                    split.Numerator,
-                    split.Denominator
-                ))
-                .Distinct()
-                .ToList();
-            if (
-                !TryPutHistoryOnSingleSplitBasis(
-                    target.Ticker,
-                    fullChart.Prices,
-                    splitBoundaries,
-                    today
-                )
-            )
-                return new TickerImportResult(Fetched: true, Inserted: 0);
-
             var replaced = await ReplaceStoredPrices(
                 target,
                 floor,
                 today,
                 today,
                 fullChart.Prices,
+                chartData
+                    .Splits.Concat(fullChart.Splits)
+                    .Select(split => new SplitBasisDefinition(
+                        split.Date,
+                        split.Numerator,
+                        split.Denominator
+                    )),
                 cancellationToken
             );
             if (replaced)
@@ -1553,7 +1700,17 @@ public class YahooPriceImportService
             return new TickerImportResult(Fetched: true, Inserted: 0);
         }
 
-        var inserted = await PersistPrices(target, chartData.Prices, today, cancellationToken);
+        var inserted = await PersistPrices(
+            target,
+            chartData.Prices,
+            today,
+            chartData.Splits.Select(split => new SplitBasisDefinition(
+                split.Date,
+                split.Numerator,
+                split.Denominator
+            )),
+            cancellationToken
+        );
 
         // The capture paths lock and revalidate the current primary. A stale crawl target can
         // therefore keep its exact prices but cannot write issuer-level actions.
@@ -1612,6 +1769,7 @@ public class YahooPriceImportService
         PriceSeriesTarget target,
         List<HistoricalPrice> prices,
         DateOnly today,
+        IEnumerable<SplitBasisDefinition> responseBoundaries,
         CancellationToken cancellationToken
     )
     {
@@ -1627,16 +1785,13 @@ public class YahooPriceImportService
         // or the complete backfill, never the first 500-row batch of a multi-batch insert.
         if (!await HasStoredSeries(target, cancellationToken))
         {
-            using var scope = _scopeFactory.CreateScope();
-            var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
-            var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
-            var stored = await ReplacePriceRows(
-                repo,
-                stockRepo,
+            var stored = await ReplaceStoredPrices(
                 target,
                 PriceHistoryFloor(),
                 today,
-                freshRows,
+                today,
+                prices,
+                responseBoundaries,
                 cancellationToken
             );
             return stored ? freshRows.Count : 0;

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -1601,6 +1601,223 @@ public class YahooPriceImportServiceTests : IDisposable
             .And.AllSatisfy(split => split.PriceAdjustmentAppliedTime.Should().BeNull());
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Import_FullResponseOmitsOlderCapturedSplit_StillValidatesItsBoundary(
+        bool legacyNullAttribution
+    )
+    {
+        var stock = CreateStock("DBSP", "Captured Split Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var latestSettled = UsMarketCalendar.PreviousTradingDay(today);
+        var priorSettled = UsMarketCalendar.PreviousTradingDay(latestSettled);
+        var olderEffectiveDate = UsMarketCalendar.PreviousTradingDay(priorSettled);
+        var olderBeforeDate = UsMarketCalendar.PreviousTradingDay(olderEffectiveDate);
+        await SeedPrices(
+            CreatePrice(stock, olderBeforeDate, 3.00m),
+            CreatePrice(stock, olderEffectiveDate, 57.10m),
+            CreatePrice(stock, priorSettled, 56.00m)
+        );
+        _splitRepo.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = legacyNullAttribution ? null : stock.Ticker,
+                EffectiveDate = olderEffectiveDate,
+                Numerator = 1m,
+                Denominator = 16m,
+                Source = StockSplitSource.Yahoo,
+                PriceAdjustmentAppliedTime = olderEffectiveDate
+                    .AddDays(1)
+                    .ToDateTime(TimeOnly.MinValue),
+            }
+        );
+        await _splitRepo.SaveChanges();
+
+        var incremental = new YahooChartData
+        {
+            Prices = CreateHistoricalPrices((latestSettled, 60m)),
+            Splits =
+            [
+                new StockSplitEvent
+                {
+                    Date = latestSettled,
+                    Numerator = 2m,
+                    Denominator = 1m,
+                },
+            ],
+        };
+        var fullHistory = CreateChartData(
+            (olderBeforeDate, 3.20m),
+            (olderEffectiveDate, 58.00m),
+            (priorSettled, 57.00m),
+            (latestSettled, 60.00m)
+        );
+        var floor = new DateOnly(2020, 1, 1);
+        _yahooClient
+            .GetChart("DBSP", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(call => call.ArgAt<DateOnly>(1) == floor ? fullHistory : incremental);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        // The full response omitted the older 1:16 event, but the applicable database row is
+        // still authoritative. Primary-series legacy null attribution follows the same rule.
+        _priceRepo
+            .GetAll()
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(51.20m, 58.00m, 57.00m, 60.00m);
+    }
+
+    [Fact]
+    public async Task Import_FullResponseWithInvalidCapturedBoundary_RefusesReplacement()
+    {
+        var stock = CreateStock("BADR", "Malformed Split Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var latestSettled = UsMarketCalendar.PreviousTradingDay(today);
+        var priorSettled = UsMarketCalendar.PreviousTradingDay(latestSettled);
+        var malformedEffectiveDate = UsMarketCalendar.PreviousTradingDay(priorSettled);
+        var beforeMalformedDate = UsMarketCalendar.PreviousTradingDay(malformedEffectiveDate);
+        await SeedPrices(
+            CreatePrice(stock, beforeMalformedDate, 10.00m),
+            CreatePrice(stock, malformedEffectiveDate, 10.50m),
+            CreatePrice(stock, priorSettled, 11.00m)
+        );
+        _splitRepo.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = stock.Ticker,
+                EffectiveDate = malformedEffectiveDate,
+                Numerator = 0m,
+                Denominator = 1m,
+                Source = StockSplitSource.Yahoo,
+                PriceAdjustmentAppliedTime = malformedEffectiveDate
+                    .AddDays(1)
+                    .ToDateTime(TimeOnly.MinValue),
+            }
+        );
+        await _splitRepo.SaveChanges();
+
+        var incremental = new YahooChartData
+        {
+            Prices = CreateHistoricalPrices((latestSettled, 12m)),
+            Splits =
+            [
+                new StockSplitEvent
+                {
+                    Date = latestSettled,
+                    Numerator = 2m,
+                    Denominator = 1m,
+                },
+            ],
+        };
+        var fullHistory = CreateChartData(
+            (beforeMalformedDate, 10.00m),
+            (malformedEffectiveDate, 10.50m),
+            (priorSettled, 11.00m),
+            (latestSettled, 12.00m)
+        );
+        var floor = new DateOnly(2020, 1, 1);
+        _yahooClient
+            .GetChart("BADR", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(call => call.ArgAt<DateOnly>(1) == floor ? fullHistory : incremental);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        // A legacy malformed row cannot certify how the two segments relate. Keep the previous
+        // store intact until a valid authoritative capture replaces the bad boundary.
+        _priceRepo
+            .GetAll()
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(10.00m, 10.50m, 11.00m);
+    }
+
+    [Fact]
+    public async Task Import_PrimaryBecomesSecondaryBeforeReplacement_ExcludesLegacyPrimarySplit()
+    {
+        var stock = CreateStock("OLD", "Designation Change Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var latestSettled = UsMarketCalendar.PreviousTradingDay(today);
+        var priorSettled = UsMarketCalendar.PreviousTradingDay(latestSettled);
+        var malformedEffectiveDate = UsMarketCalendar.PreviousTradingDay(priorSettled);
+        var beforeMalformedDate = UsMarketCalendar.PreviousTradingDay(malformedEffectiveDate);
+        await SeedPrices(
+            CreatePrice(stock, beforeMalformedDate, 10.00m),
+            CreatePrice(stock, malformedEffectiveDate, 10.50m),
+            CreatePrice(stock, priorSettled, 11.00m)
+        );
+        _splitRepo.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = null,
+                EffectiveDate = malformedEffectiveDate,
+                Numerator = 0m,
+                Denominator = 1m,
+                Source = StockSplitSource.Yahoo,
+                PriceAdjustmentAppliedTime = malformedEffectiveDate
+                    .AddDays(1)
+                    .ToDateTime(TimeOnly.MinValue),
+            }
+        );
+        await _splitRepo.SaveChanges();
+
+        var incremental = new YahooChartData
+        {
+            Prices = CreateHistoricalPrices((latestSettled, 12m)),
+            Splits =
+            [
+                new StockSplitEvent
+                {
+                    Date = latestSettled,
+                    Numerator = 2m,
+                    Denominator = 1m,
+                },
+            ],
+        };
+        var fullHistory = CreateChartData(
+            (beforeMalformedDate, 10.00m),
+            (malformedEffectiveDate, 10.50m),
+            (priorSettled, 11.00m),
+            (latestSettled, 12.00m)
+        );
+        var floor = new DateOnly(2020, 1, 1);
+        var designationChanged = false;
+        _yahooClient
+            .GetChart("OLD", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(call =>
+            {
+                if (!designationChanged)
+                {
+                    stock.Ticker = "NEW";
+                    stock.SecondaryTickers = ["OLD"];
+                    _dbContext.SaveChanges();
+                    designationChanged = true;
+                }
+                return call.ArgAt<DateOnly>(1) == floor ? fullHistory : incremental;
+            });
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        // OLD was primary when the crawl target was built but secondary at the locked write. The
+        // legacy null split belongs only to the current primary, so it cannot block or restate OLD.
+        _priceRepo
+            .GetAllSeries()
+            .Where(price => price.ListedTicker == "OLD")
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(10.00m, 10.50m, 11.00m, 12.00m);
+    }
+
     [Fact]
     public async Task Import_PendingReconcileResponseHasNewMixedSplit_RestatesAndStampsTheSelected()
     {
@@ -1667,6 +1884,102 @@ public class YahooPriceImportServiceTests : IDisposable
         splits[0].PriceAdjustmentAppliedTime.Should().NotBeNull();
         splits[1].EffectiveDate.Should().Be(newEffectiveDate);
         splits[1].PriceAdjustmentAppliedTime.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Import_PendingSplitRatioChangesDuringFetch_RefusesStaleRestatement()
+    {
+        var stock = CreateStock("RREV", "Revised Split Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var effectiveDate = today.AddDays(-10);
+        var beforeDate = effectiveDate.AddDays(-1);
+        var afterDate = effectiveDate.AddDays(1);
+        var latestDate = today.AddDays(-1);
+        await SeedPrices(
+            CreatePrice(stock, beforeDate, 90m),
+            CreatePrice(stock, afterDate, 45m),
+            CreatePrice(stock, latestDate, 44m)
+        );
+        var split = new StockSplit
+        {
+            CommonStockId = stock.Id,
+            PriceSeriesTicker = stock.Ticker,
+            EffectiveDate = effectiveDate,
+            Numerator = 2m,
+            Denominator = 1m,
+            Source = StockSplitSource.Yahoo,
+        };
+        _splitRepo.Add(split);
+        await _splitRepo.SaveChanges();
+
+        var response = CreateChartData(
+            (beforeDate, 100m),
+            (afterDate, 50m),
+            (latestDate, 49m)
+        );
+        _yahooClient
+            .GetChart("RREV", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(_ =>
+            {
+                // Selection snapshotted 2:1. The authoritative row changes before replacement
+                // locks and reloads it, so the stale ratio must not restate or certify the serve.
+                split.Numerator = 3m;
+                _dbContext.SaveChanges();
+                return response;
+            });
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo
+            .GetAllSeries()
+            .Where(price => price.ListedTicker == "RREV")
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(90m, 45m, 44m);
+        split.Numerator.Should().Be(3m);
+        split.PriceAdjustmentAppliedTime.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Import_EmptySeriesWithOmittedInvalidCapturedSplit_PublishesNothing()
+    {
+        var stock = CreateStock("EBAD", "Empty Invalid Split Company");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var effectiveDate = today.AddDays(-4);
+        _splitRepo.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = stock.Ticker,
+                EffectiveDate = effectiveDate,
+                Numerator = 0m,
+                Denominator = 1m,
+                Source = StockSplitSource.Yahoo,
+            }
+        );
+        await _splitRepo.SaveChanges();
+
+        // Yahoo omits the known boundary. Both the pending reconciliation and the ordinary
+        // first-history path must still reload the stored split and refuse publication.
+        _yahooClient
+            .GetChart("EBAD", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(
+                CreateChartData(
+                    (effectiveDate.AddDays(-1), 10m),
+                    (effectiveDate.AddDays(1), 10.5m),
+                    (today.AddDays(-1), 11m)
+                )
+            );
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo
+            .GetAllSeries()
+            .Should()
+            .NotContain(price => price.CommonStockId == stock.Id);
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -1913,11 +1913,7 @@ public class YahooPriceImportServiceTests : IDisposable
         _splitRepo.Add(split);
         await _splitRepo.SaveChanges();
 
-        var response = CreateChartData(
-            (beforeDate, 100m),
-            (afterDate, 50m),
-            (latestDate, 49m)
-        );
+        var response = CreateChartData((beforeDate, 100m), (afterDate, 50m), (latestDate, 49m));
         _yahooClient
             .GetChart("RREV", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
             .Returns(_ =>
@@ -1976,10 +1972,7 @@ public class YahooPriceImportServiceTests : IDisposable
 
         await _service.Import(includeEnrichment: false, CancellationToken.None);
 
-        _priceRepo
-            .GetAllSeries()
-            .Should()
-            .NotContain(price => price.CommonStockId == stock.Id);
+        _priceRepo.GetAllSeries().Should().NotContain(price => price.CommonStockId == stock.Id);
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/CorporateActions/SplitAdjustmentTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/SplitAdjustmentTests.cs
@@ -114,6 +114,22 @@ public class SplitAdjustmentTests
     }
 
     [Fact]
+    public void ShareCountFactor_ZeroNumerator_IsSkippedWithoutZeroingShares()
+    {
+        StockSplit[] splits =
+        [
+            new()
+            {
+                EffectiveDate = new DateOnly(2024, 1, 1),
+                Numerator = 0m,
+                Denominator = 1m,
+            },
+        ];
+
+        SplitAdjustment.ShareCountFactor(new DateOnly(2023, 1, 1), splits).Should().Be(1m);
+    }
+
+    [Fact]
     public void AdjustShareCount_NoSplits_ReturnsCountUnchanged()
     {
         SplitAdjustment.AdjustShareCount(1_000, new DateOnly(2020, 1, 1), []).Should().Be(1_000);

--- a/tests/Equibles.UnitTests/CorporateActions/SplitBasisResolverAppliedMarkerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/SplitBasisResolverAppliedMarkerTests.cs
@@ -44,4 +44,41 @@ public class SplitBasisResolverAppliedMarkerTests
         resolved.Should().Be(expectedResolved);
         factor.Should().Be(expectedFactor);
     }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(-1, 1)]
+    [InlineData(1, 0)]
+    [InlineData(1, -1)]
+    public void TryResolveFactor_NonPositiveRatioArm_Defers(decimal numerator, decimal denominator)
+    {
+        var split = new StockSplit
+        {
+            PriceSeriesTicker = "AAPL",
+            EffectiveDate = new DateOnly(2026, 8, 12),
+            Numerator = numerator,
+            Denominator = denominator,
+            PriceAdjustmentAppliedTime = new DateTime(
+                2026,
+                8,
+                13,
+                12,
+                0,
+                0,
+                DateTimeKind.Utc
+            ),
+        };
+
+        var resolved = SplitBasisResolver.TryResolveFactor(
+            new DateOnly(2026, 8, 1),
+            [split],
+            listedTicker: null,
+            primaryTicker: "AAPL",
+            secondaryTickers: [],
+            out var factor
+        );
+
+        resolved.Should().BeFalse();
+        factor.Should().Be(1m);
+    }
 }

--- a/tests/Equibles.UnitTests/CorporateActions/SplitBasisResolverAppliedMarkerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/SplitBasisResolverAppliedMarkerTests.cs
@@ -58,15 +58,7 @@ public class SplitBasisResolverAppliedMarkerTests
             EffectiveDate = new DateOnly(2026, 8, 12),
             Numerator = numerator,
             Denominator = denominator,
-            PriceAdjustmentAppliedTime = new DateTime(
-                2026,
-                8,
-                13,
-                12,
-                0,
-                0,
-                DateTimeKind.Utc
-            ),
+            PriceAdjustmentAppliedTime = new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Utc),
         };
 
         var resolved = SplitBasisResolver.TryResolveFactor(

--- a/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
@@ -154,14 +154,13 @@ public class StockSplitCaptureManagerTests
     [InlineData(-2, 1)]
     [InlineData(2, 0)]
     [InlineData(2, -1)]
-    public async Task Capture_NonPositiveRatioArm_DoesNotPersist(decimal numerator, decimal denominator)
+    public async Task Capture_NonPositiveRatioArm_DoesNotPersist(
+        decimal numerator,
+        decimal denominator
+    )
     {
         await using var context = NewDb();
-        var stock = new CommonStock
-        {
-            Id = Guid.NewGuid(),
-            Ticker = "SAFE",
-        };
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "SAFE" };
         context.Add(stock);
         await context.SaveChangesAsync();
         var split = Split(numerator);

--- a/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
@@ -148,4 +148,28 @@ public class StockSplitCaptureManagerTests
         attributed.Numerator.Should().Be(20m);
         attributed.PriceAdjustmentAppliedTime.Should().BeNull();
     }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(-2, 1)]
+    [InlineData(2, 0)]
+    [InlineData(2, -1)]
+    public async Task Capture_NonPositiveRatioArm_DoesNotPersist(decimal numerator, decimal denominator)
+    {
+        await using var context = NewDb();
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "SAFE",
+        };
+        context.Add(stock);
+        await context.SaveChangesAsync();
+        var split = Split(numerator);
+        split.Denominator = denominator;
+
+        var changes = await NewManager(context).Capture(stock.Id, stock.Ticker, [split]);
+
+        changes.Should().Be(0);
+        (await context.Set<StockSplit>().ToListAsync()).Should().BeEmpty();
+    }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueBasisBoundaryAndCompoundTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueBasisBoundaryAndCompoundTests.cs
@@ -91,11 +91,10 @@ public class HoldingValueBasisBoundaryAndCompoundTests
     }
 
     [Fact]
-    public void TryResolveShareCountFactor_MalformedRatio_SkipsItRatherThanDividingByZero()
+    public void TryResolveShareCountFactor_MalformedRatio_DefersInsteadOfCorruptingTheFactor()
     {
-        // A zero denominator is a broken capture, not an ambiguous basis: it moves no count, so it
-        // must neither divide by zero nor park the row as unresolvable. The good split beside it
-        // still has to apply.
+        // A malformed stored action leaves the basis unprovable. It must not divide by zero,
+        // return a zero factor, or silently apply only the well-formed split beside it.
         var splits = new List<StockSplit>
         {
             Applied(new DateOnly(2025, 1, 2), 3m, 0m),
@@ -112,8 +111,8 @@ public class HoldingValueBasisBoundaryAndCompoundTests
                 out var factor
             )
             .Should()
-            .BeTrue();
+            .BeFalse();
 
-        factor.Should().Be(2m);
+        factor.Should().Be(1m);
     }
 }


### PR DESCRIPTION
## Summary
- validate every full-history replacement against current stored and response split boundaries under one parent-row lock
- restate provider history only from authoritative positive split ratios and reject conflicts or malformed actions
- use the current locked listing designation for legacy split applicability, including first-history responses

## Verification
- dotnet build tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release
- dotnet vstest tests/Equibles.UnitTests/bin/Release/net10.0/Equibles.UnitTests.dll (4710 passed)
- dotnet vstest tests/Equibles.IntegrationTests/bin/Release/net10.0/Equibles.IntegrationTests.dll --TestCaseFilter:"FullyQualifiedName~YahooPriceImportServiceTests" (66 passed)
- commercial Release solution build and all 14 required commercial unit projects passed against this submodule commit
- independent audit: no blocking or high-confidence findings