### PR TITLE
fix(financial-facts): recover multi-currency reported statements

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260829051046_TrackReportedStatementParseAttemptVersion.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260829051046_TrackReportedStatementParseAttemptVersion.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260829051046_TrackReportedStatementParseAttemptVersion")]
+    partial class TrackReportedStatementParseAttemptVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260829051046_TrackReportedStatementParseAttemptVersion.cs
+++ b/src/Equibles.Migrations/Migrations/20260829051046_TrackReportedStatementParseAttemptVersion.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrackReportedStatementParseAttemptVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ReportedStatementsParseAttemptVersion",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ReportedStatementsParseAttemptVersion",
+                table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -291,6 +291,12 @@ public class Document
     /// </summary>
     public int ReportedStatementsParseAttempts { get; set; }
 
+    /// <summary>
+    /// Parser version whose failures <see cref="ReportedStatementsParseAttempts"/> counts.
+    /// A version upgrade receives a fresh bounded retry budget.
+    /// </summary>
+    public int ReportedStatementsParseAttemptVersion { get; set; }
+
     /// <summary>Retry ceiling for <see cref="ReportedStatementsParseAttempts"/>.</summary>
     public const int MaxReportedStatementsParseAttempts = 5;
 
@@ -300,7 +306,7 @@ public class Document
     /// backoffice "pending" metric can reference it without depending on the hosted-service
     /// assembly. Bump after a parser change to re-derive the corpus.
     /// </summary>
-    public const int ReportedStatementsParserVersion = 1;
+    public const int ReportedStatementsParserVersion = 3;
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/ReportedStatements/RFileStatementParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/ReportedStatements/RFileStatementParser.cs
@@ -26,23 +26,43 @@ public static class RFileStatementParser
         RegexOptions.Compiled
     );
 
+    private static readonly Regex PresentationContextPattern = new(
+        @"defref_[A-Za-z0-9_-]+=[A-Za-z0-9_-]+",
+        RegexOptions.Compiled
+    );
+
     private static readonly Regex DurationMonthsPattern = new(
         @"(\d+)\s+Month",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
+
+    private static readonly Regex DurationWeeksPattern = new(
+        @"(\d+)\s+Week",
         RegexOptions.Compiled | RegexOptions.IgnoreCase
     );
 
     // One "<subject> in <magnitude>" segment of the scale note; segments are
     // comma-separated, so the subject is everything since the last comma.
     private static readonly Regex ScaleSegmentPattern = new(
-        @"([^,]*?)\s*\bin\s+(Thousands|Millions|Billions)\b",
+        @"(?:^|,)\s*(?<before>.*?)(?:\bin\s+)?(?<scale>Units|Unscaled|Thousands|Millions|Billions)\b(?<after>[^,]*)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase
     );
 
     // The note's leading ISO currency code, rendered as "<code> (<symbol>)" —
     // "USD ($)", "EUR (€)", "CAD ($)".
     private static readonly Regex CurrencyCodePattern = new(
-        @"^([A-Za-z]{3})\s*\(",
+        @"(?<![A-Za-z])([A-Za-z]{3})\s*\(",
         RegexOptions.Compiled
+    );
+
+    private static readonly Regex ColumnCurrencyCodePattern = new(
+        @"(?<![A-Za-z])([A-Za-z]{3})\s*\(",
+        RegexOptions.Compiled
+    );
+
+    private static readonly Regex DatePattern = new(
+        @"(?<![A-Za-z])(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)(?:\.|[a-z]+)?\s+\d{1,2},\s+\d{4}(?!\d)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
     );
 
     public static RFileStatement Parse(string html)
@@ -61,7 +81,7 @@ public static class RFileStatementParser
         }
 
         var (scaleNote, currency, scale) = ParseTitle(table);
-        var columns = ParseColumns(table, out var durationByColumn);
+        var columns = ParseColumns(table, scaleNote, out var durationByColumn);
         var rows = ParseRows(table);
         if (rows.Count == 0)
         {
@@ -82,7 +102,8 @@ public static class RFileStatementParser
 
     private static (string ScaleNote, string Currency, long Scale) ParseTitle(IElement table)
     {
-        var title = Clean(table.QuerySelector("th.tl")?.TextContent);
+        var titleCell = table.QuerySelector("th.tl");
+        var title = Clean(titleCell?.TextContent);
         if (string.IsNullOrEmpty(title))
         {
             return (null, null, 1);
@@ -91,10 +112,29 @@ public static class RFileStatementParser
         // The scale / currency note is the tail after the last " - ", e.g.
         // "... OPERATIONS (Unaudited) - USD ($)  shares in Thousands, $ in Millions".
         var dash = title.LastIndexOf(" - ", StringComparison.Ordinal);
-        var note = dash >= 0 ? title[(dash + 3)..].Trim() : null;
-        var haystack = note ?? title;
+        var breakTail = TextAfterLastBreak(titleCell);
+        var note =
+            dash >= 0 ? title[(dash + 3)..].Trim()
+            : !string.IsNullOrWhiteSpace(breakTail) ? breakTail
+            : title;
+        var haystack = note;
 
         return (note, ParseCurrency(haystack), ParseMoneyScale(haystack));
+    }
+
+    private static string TextAfterLastBreak(IElement element)
+    {
+        var lineBreak = element?.QuerySelectorAll("br").LastOrDefault();
+        if (lineBreak == null)
+        {
+            return null;
+        }
+        var builder = new StringBuilder();
+        for (var node = lineBreak.NextSibling; node != null; node = node.NextSibling)
+        {
+            builder.Append(' ').Append(node.TextContent);
+        }
+        return Clean(builder.ToString());
     }
 
     private static string ParseCurrency(string haystack)
@@ -103,6 +143,13 @@ public static class RFileStatementParser
         return match.Success ? match.Groups[1].Value.ToUpperInvariant() : null;
     }
 
+    private static IReadOnlyList<string> ParseCurrencies(string haystack) =>
+        CurrencyCodePattern
+            .Matches(haystack ?? string.Empty)
+            .Select(match => match.Groups[1].Value.ToUpperInvariant())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
     // The note scales each unit family in its own segment — "$ in Thousands",
     // "shares in Millions", "$ / shares in Thousands" — and only the money segment may
     // set the statement scale: "USD ($) shares in Thousands" presents dollars UNSCALED,
@@ -110,20 +157,7 @@ public static class RFileStatementParser
     // downstream. A subject-less "(In Thousands)" (old-style title) applies to money.
     private static long ParseMoneyScale(string haystack)
     {
-        foreach (Match match in ScaleSegmentPattern.Matches(haystack))
-        {
-            if (match.Groups[1].Value.Contains("share", StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-            return match.Groups[2].Value.ToLowerInvariant() switch
-            {
-                "billions" => 1_000_000_000L,
-                "millions" => 1_000_000L,
-                _ => 1_000L,
-            };
-        }
-        return 1L;
+        return MoneyScaleSegments(haystack).FirstOrDefault()?.Scale ?? 1L;
     }
 
     // Columns come from the header rows: the row of period-end dates is the column set; an earlier
@@ -131,6 +165,7 @@ public static class RFileStatementParser
     // column. A balance sheet has only the date row (no durations) — its columns are instants.
     private static List<ReportedStatementColumn> ParseColumns(
         IElement table,
+        string scaleNote,
         out List<string> durationByColumn
     )
     {
@@ -168,12 +203,27 @@ public static class RFileStatementParser
 
         var columns = new List<ReportedStatementColumn>();
         var dateCells = dateRow.QuerySelectorAll("th.th").ToList();
+        var titleCurrencies = ParseCurrencies(scaleNote);
+        var unambiguousStatementCurrency = titleCurrencies.Count == 1 ? titleCurrencies[0] : null;
         for (var i = 0; i < dateCells.Count; i++)
         {
+            var header = Clean(dateCells[i].TextContent);
+            var (label, periodEnd) = ParseDateLabel(header);
+            var explicitCurrency = ParseColumnCurrency(header);
+            var scaleCurrency = explicitCurrency ?? unambiguousStatementCurrency;
+            var ambiguousCurrency = explicitCurrency == null && titleCurrencies.Count > 1;
             columns.Add(
                 new ReportedStatementColumn
                 {
-                    Label = Clean(dateCells[i].TextContent),
+                    Label = label,
+                    PeriodEnd = periodEnd,
+                    Currency = explicitCurrency ?? unambiguousStatementCurrency,
+                    Scale = ambiguousCurrency
+                        ? null
+                        : ParseColumnMoneyScale(header, scaleCurrency, scaleNote),
+                    PerShareScale = ambiguousCurrency
+                        ? null
+                        : ParseColumnPerShareScale(header, scaleCurrency, scaleNote),
                     Duration = i < durationByColumn.Count ? durationByColumn[i] : null,
                     IsInstant = !hasDurations,
                 }
@@ -182,13 +232,155 @@ public static class RFileStatementParser
         return columns;
     }
 
+    private static long? ParseColumnMoneyScale(string header, string currency, string scaleNote)
+    {
+        var headerSegments = MoneyScaleSegments(header);
+        if (headerSegments.Count > 0)
+        {
+            return ResolveColumnMoneyScale(headerSegments, currency);
+        }
+
+        var titleSegments = MoneyScaleSegments(scaleNote);
+        return titleSegments.Count == 0 ? 1L : ResolveColumnMoneyScale(titleSegments, currency);
+    }
+
+    private static long? ResolveColumnMoneyScale(
+        IReadOnlyList<MoneyScaleSegment> segments,
+        string currency
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(currency))
+        {
+            var currencyScales = segments
+                .Where(segment => segment.Currencies.Contains(currency, StringComparer.Ordinal))
+                .Select(segment => segment.Scale)
+                .Distinct()
+                .ToList();
+            if (currencyScales.Count == 1)
+            {
+                return currencyScales[0];
+            }
+            if (currencyScales.Count > 1)
+            {
+                return null;
+            }
+        }
+
+        var globalScales = segments
+            .Where(segment => segment.Currencies.Count == 0)
+            .Select(segment => segment.Scale)
+            .Distinct()
+            .ToList();
+        if (globalScales.Count == 1)
+        {
+            return globalScales[0];
+        }
+        if (globalScales.Count > 1)
+        {
+            return null;
+        }
+
+        if (
+            !string.IsNullOrWhiteSpace(currency)
+            && segments.Any(segment => segment.Currencies.Count > 0)
+        )
+        {
+            return null;
+        }
+
+        var allScales = segments.Select(segment => segment.Scale).Distinct().ToList();
+        return allScales.Count == 1 ? allScales[0] : null;
+    }
+
+    private static long? ParseColumnPerShareScale(string header, string currency, string scaleNote)
+    {
+        var headerSegments = PerShareScaleSegments(header);
+        if (headerSegments.Count > 0)
+        {
+            return ResolveColumnMoneyScale(headerSegments, currency);
+        }
+
+        var titleSegments = PerShareScaleSegments(scaleNote);
+        return titleSegments.Count == 0 ? 1L : ResolveColumnMoneyScale(titleSegments, currency);
+    }
+
+    private static List<MoneyScaleSegment> MoneyScaleSegments(string haystack)
+    {
+        var result = new List<MoneyScaleSegment>();
+        foreach (Match match in ScaleSegmentPattern.Matches(haystack ?? string.Empty))
+        {
+            var subject = $"{match.Groups["before"].Value} {match.Groups["after"].Value}";
+            if (subject.Contains("share", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            var scale = match.Groups["scale"].Value.ToLowerInvariant() switch
+            {
+                "billions" => 1_000_000_000L,
+                "millions" => 1_000_000L,
+                "thousands" => 1_000L,
+                _ => 1L,
+            };
+            var currencies = CurrencyCodePattern
+                .Matches(subject)
+                .Select(match => match.Groups[1].Value.ToUpperInvariant())
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            result.Add(new MoneyScaleSegment(scale, currencies));
+        }
+        return result;
+    }
+
+    private static List<MoneyScaleSegment> PerShareScaleSegments(string haystack)
+    {
+        var result = new List<MoneyScaleSegment>();
+        foreach (Match match in ScaleSegmentPattern.Matches(haystack ?? string.Empty))
+        {
+            var subject = $"{match.Groups["before"].Value} {match.Groups["after"].Value}";
+            if (
+                !subject.Contains("per share", StringComparison.OrdinalIgnoreCase)
+                && !Regex.IsMatch(subject, @"/\s*shares?\b", RegexOptions.IgnoreCase)
+            )
+            {
+                continue;
+            }
+            var scale = match.Groups["scale"].Value.ToLowerInvariant() switch
+            {
+                "billions" => 1_000_000_000L,
+                "millions" => 1_000_000L,
+                "thousands" => 1_000L,
+                _ => 1L,
+            };
+            var currencies = CurrencyCodePattern
+                .Matches(subject)
+                .Select(match => match.Groups[1].Value.ToUpperInvariant())
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            result.Add(new MoneyScaleSegment(scale, currencies));
+        }
+        return result;
+    }
+
     private static List<ReportedStatementRow> ParseRows(IElement table)
     {
         var rows = new List<ReportedStatementRow>();
         var inSection = false;
+        string presentationContext = null;
 
         foreach (var tr in table.QuerySelectorAll("tr"))
         {
+            if (tr.ClassList.Contains("rh"))
+            {
+                var contextCell = tr.QuerySelector("td.pl");
+                var onclick = contextCell?.QuerySelector("a")?.GetAttribute("onclick");
+                var match = PresentationContextPattern.Match(onclick ?? string.Empty);
+                presentationContext = match.Success
+                    ? match.Value
+                    : $"r-file-heading:{Clean(contextCell?.TextContent)}";
+                inSection = false;
+                continue;
+            }
+
             var isTotal = tr.ClassList.Contains("reu") || tr.ClassList.Contains("rou");
             var isData = isTotal || tr.ClassList.Contains("re") || tr.ClassList.Contains("ro");
             if (!isData)
@@ -240,6 +432,7 @@ public static class RFileStatementParser
                     Depth = depth,
                     IsAbstract = isAbstract,
                     IsTotal = isTotal,
+                    PresentationContext = presentationContext,
                     Values = values,
                 }
             );
@@ -256,7 +449,7 @@ public static class RFileStatementParser
     )
     {
         var dated = columns
-            .Select(c => (Column: c, End: ParseDate(c.Label)))
+            .Select(c => (Column: c, End: c.PeriodEnd ?? ParseDate(c.Label)))
             .Where(x => x.End != null)
             .ToList();
         if (dated.Count == 0)
@@ -267,14 +460,20 @@ public static class RFileStatementParser
         var maxEnd = dated.Max(x => x.End.Value);
         var primary = dated
             .Where(x => x.End.Value == maxEnd)
-            .OrderBy(x => DurationMonths(x.Column.Duration))
+            .OrderBy(x => DurationDays(x.Column.Duration))
             .First();
 
         var end = primary.End.Value;
-        var months = DurationMonths(primary.Column.Duration);
+        var durationDays = DurationDays(primary.Column.Duration);
         result.PrimaryPeriodEnd = end;
-        result.PrimaryIsInstant = primary.Column.IsInstant || months == 0;
-        result.PrimaryPeriodStart = result.PrimaryIsInstant ? end : end.AddMonths(-months);
+        result.PrimaryIsInstant = primary.Column.IsInstant || durationDays == 0;
+        result.PrimaryPeriodStart = result.PrimaryIsInstant
+            ? end
+            : DurationStart(end, primary.Column.Duration);
+        result.Currency ??= primary.Column.Currency;
+        // Statement.Scale remains compatibility/display metadata. Current consumers bind to
+        // Column.Scale; zero records that the primary column's scale was ambiguous.
+        result.Scale = primary.Column.Scale ?? 0L;
     }
 
     private static (string Taxonomy, string Concept) ParseConcept(string onclick)
@@ -319,10 +518,24 @@ public static class RFileStatementParser
 
     private static DateOnly? ParseDate(string text)
     {
+        var (_, date) = ParseDateLabel(text);
+        return date;
+    }
+
+    private static (string Label, DateOnly? Date) ParseDateLabel(string text)
+    {
         var cleaned = Clean(text);
+        var match = DatePattern.Match(cleaned ?? string.Empty);
+        var candidate = match.Success ? match.Value : cleaned;
+        var parseCandidate = Regex.Replace(
+            candidate ?? string.Empty,
+            @"\bSept(?=\.?\s)",
+            "Sep",
+            RegexOptions.IgnoreCase
+        );
         if (
             DateOnly.TryParseExact(
-                cleaned,
+                parseCandidate,
                 DateFormats,
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.None,
@@ -330,9 +543,15 @@ public static class RFileStatementParser
             )
         )
         {
-            return date;
+            return (candidate, date);
         }
-        return null;
+        return (cleaned, null);
+    }
+
+    private static string ParseColumnCurrency(string text)
+    {
+        var match = ColumnCurrencyCodePattern.Match(text ?? string.Empty);
+        return match.Success ? match.Groups[1].Value.ToUpperInvariant() : null;
     }
 
     private static bool IsDate(string text) => ParseDate(text) != null;
@@ -349,6 +568,39 @@ public static class RFileStatementParser
             return months;
         }
         return duration.Contains("Year", StringComparison.OrdinalIgnoreCase) ? 12 : 0;
+    }
+
+    private static int DurationWeeks(string duration)
+    {
+        if (string.IsNullOrEmpty(duration))
+        {
+            return 0;
+        }
+        var match = DurationWeeksPattern.Match(duration);
+        if (!match.Success || !int.TryParse(match.Groups[1].Value, out var weeks))
+        {
+            return 0;
+        }
+        return weeks is 13 or 14 or 26 or 27 or 39 or 40 or 41 or 52 or 53 ? weeks : 0;
+    }
+
+    private static int DurationDays(string duration)
+    {
+        var weeks = DurationWeeks(duration);
+        if (weeks > 0)
+        {
+            return weeks * 7;
+        }
+        var months = DurationMonths(duration);
+        return months * 31;
+    }
+
+    private static DateOnly DurationStart(DateOnly end, string duration)
+    {
+        var weeks = DurationWeeks(duration);
+        return weeks > 0
+            ? end.AddDays(1 - weeks * 7)
+            : end.AddDays(1).AddMonths(-DurationMonths(duration));
     }
 
     private static int ParseSpan(string colspan) =>
@@ -382,4 +634,6 @@ public static class RFileStatementParser
         }
         return builder.ToString().Trim();
     }
+
+    private sealed record MoneyScaleSegment(long Scale, IReadOnlyList<string> Currencies);
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/FiscalPeriods/ReportedFiscalPeriodResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/FiscalPeriods/ReportedFiscalPeriodResolver.cs
@@ -1,0 +1,122 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+
+namespace Equibles.Sec.FinancialFacts.Data.FiscalPeriods;
+
+/// <summary>
+/// Resolves an as-reported period against a company's authoritative fiscal-year-end anchor.
+/// </summary>
+public static class ReportedFiscalPeriodResolver
+{
+    private const int FyeMatchWindowDays = 14;
+    private const int EarlyJanuaryFiscalYearEndDay = 7;
+    private const int AnnualMinDays = 350;
+    private const int AnnualMaxDays = 380;
+    private const int QuarterMinDays = 80;
+    private const int QuarterMaxDays = 100;
+    private const int HalfYearMinDays = 170;
+    private const int HalfYearMaxDays = 190;
+    private const int NineMonthMinDays = 260;
+
+    // A 41-week cumulative third quarter spans 286 days. Keep the same bounded
+    // tolerance used by the reported-statement lane for non-calendar filers.
+    private const int NineMonthMaxDays = 292;
+
+    public static (int Year, SecFiscalPeriod Period)? Resolve(
+        DateOnly periodStart,
+        DateOnly periodEnd,
+        int? fyeMonth,
+        int? fyeDay,
+        bool classifyInterimInstants = false
+    )
+    {
+        if (fyeMonth is null || fyeDay is null)
+            return null;
+        if (fyeMonth < 1 || fyeMonth > 12 || fyeDay < 1 || fyeDay > 31)
+            return null;
+
+        if (fyeMonth == 1 && fyeDay <= EarlyJanuaryFiscalYearEndDay)
+        {
+            fyeMonth = 12;
+            fyeDay = 31;
+        }
+
+        var candidates = new[]
+        {
+            CreateSafe(periodEnd.Year - 1, fyeMonth.Value, fyeDay.Value),
+            CreateSafe(periodEnd.Year, fyeMonth.Value, fyeDay.Value),
+            CreateSafe(periodEnd.Year + 1, fyeMonth.Value, fyeDay.Value),
+        };
+
+        var durationDays = periodEnd.DayNumber - periodStart.DayNumber;
+        var isInstant = durationDays == 0;
+        var isAnnual = IsWithinDays(durationDays, AnnualMinDays, AnnualMaxDays);
+        var closest = ClosestTo(candidates, periodEnd);
+
+        if (isAnnual || isInstant)
+        {
+            if (Math.Abs(closest.DayNumber - periodEnd.DayNumber) <= FyeMatchWindowDays)
+                return (closest.Year, SecFiscalPeriod.FullYear);
+            if (!isInstant || !classifyInterimInstants)
+                return null;
+        }
+
+        var isQuarter = IsWithinDays(durationDays, QuarterMinDays, QuarterMaxDays);
+        var isHalfYear = IsWithinDays(durationDays, HalfYearMinDays, HalfYearMaxDays);
+        var isNineMonths = IsWithinDays(durationDays, NineMonthMinDays, NineMonthMaxDays);
+        var interimInstant = isInstant && classifyInterimInstants;
+        if (!interimInstant && !isQuarter && !isHalfYear && !isNineMonths)
+            return null;
+
+        // A 52/53-week close may spill a few days past the nominal FYE. Keep it in Q4 of
+        // that fiscal year instead of treating it as Q1 of the following year.
+        DateOnly endingFye;
+        if (
+            periodEnd.DayNumber > closest.DayNumber
+            && periodEnd.DayNumber - closest.DayNumber <= FyeMatchWindowDays
+        )
+        {
+            endingFye = closest;
+        }
+        else
+        {
+            var matches = candidates
+                .Where(candidate => candidate.DayNumber >= periodEnd.DayNumber)
+                .ToList();
+            if (matches.Count == 0)
+                return null;
+            endingFye = matches.MinBy(candidate => candidate.DayNumber);
+        }
+
+        if (endingFye.DayNumber - periodEnd.DayNumber > AnnualMaxDays || endingFye.Year < 2)
+            return null;
+
+        var fiscalYearStart = endingFye.AddYears(-1).AddDays(1);
+        var monthsElapsed =
+            (periodEnd.Year - fiscalYearStart.Year) * 12
+            + (periodEnd.Month - fiscalYearStart.Month);
+        var period = monthsElapsed switch
+        {
+            <= 4 => SecFiscalPeriod.Q1,
+            <= 7 => SecFiscalPeriod.Q2,
+            <= 10 => SecFiscalPeriod.Q3,
+            _ => SecFiscalPeriod.Q4,
+        };
+
+        return (endingFye.Year, period);
+    }
+
+    private static DateOnly CreateSafe(int year, int month, int day)
+    {
+        if (year < 1)
+            return DateOnly.MinValue;
+        if (year > 9999)
+            return DateOnly.MaxValue;
+        return new DateOnly(year, month, Math.Min(day, DateTime.DaysInMonth(year, month)));
+    }
+
+    private static DateOnly ClosestTo(DateOnly[] candidates, DateOnly target) =>
+        candidates.MinBy(candidate => Math.Abs(candidate.DayNumber - target.DayNumber));
+
+    private static bool IsWithinDays(int durationDays, int min, int max) =>
+        durationDays >= min && durationDays <= max;
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -102,11 +102,17 @@ public static class FinancialConceptAliases
             I("ResearchAndDevelopmentExpense"),
         ],
         ["selling-general-and-administrative"] = [G("SellingGeneralAndAdministrativeExpense")],
-        ["selling-and-marketing"] = [G("SellingAndMarketingExpense"), I("DistributionCosts")],
+        ["selling-and-marketing"] =
+        [
+            G("SellingAndMarketingExpense"),
+            I("DistributionCosts"),
+            I("SalesAndMarketingExpense"),
+        ],
         ["general-and-administrative"] =
         [
             G("GeneralAndAdministrativeExpense"),
             I("AdministrativeExpense"),
+            I("GeneralAndAdministrativeExpense"),
         ],
         ["amortization-of-intangibles"] = [G("AmortizationOfIntangibleAssets")],
         ["restructuring"] = [G("RestructuringCharges")],
@@ -147,11 +153,18 @@ public static class FinancialConceptAliases
             G(
                 "IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLossFromEquityMethodInvestments"
             ),
+            I("ProfitLossBeforeTax"),
         ],
         ["income-tax"] = [G("IncomeTaxExpenseBenefit"), I("IncomeTaxExpenseContinuingOperations")],
         // ProfitLoss (net income including noncontrolling interests) last: it
         // only fills filers that never report the parent-attributable figure.
-        ["net-income"] = [G("NetIncomeLoss"), G("ProfitLoss"), I("ProfitLoss")],
+        ["net-income"] =
+        [
+            G("NetIncomeLoss"),
+            I("ProfitLossAttributableToOwnersOfParent"),
+            G("ProfitLoss"),
+            I("ProfitLoss"),
+        ],
         ["comprehensive-income"] = [G("ComprehensiveIncomeNetOfTax")],
         ["eps-basic"] = [G("EarningsPerShareBasic"), I("BasicEarningsLossPerShare")],
         ["eps-diluted"] = [G("EarningsPerShareDiluted"), I("DilutedEarningsLossPerShare")],
@@ -181,6 +194,18 @@ public static class FinancialConceptAliases
             I("CashAndCashEquivalents"),
         ],
         ["short-term-investments"] = [G("ShortTermInvestments"), G("MarketableSecuritiesCurrent")],
+        // IFRS filers may report the current investment balance as three additive
+        // measurement-category siblings. Keep them separate here; consumers must sum an exact
+        // same-statement column and must never treat these aliases as alternatives.
+        ["current-financial-assets-fvtpl"] =
+        [
+            I("CurrentFinancialAssetsAtFairValueThroughProfitOrLoss"),
+        ],
+        ["current-financial-assets-fvoci"] =
+        [
+            I("CurrentFinancialAssetsAtFairValueThroughOtherComprehensiveIncome"),
+        ],
+        ["current-financial-assets-amortised-cost"] = [I("CurrentFinancialAssetsAtAmortisedCost")],
         ["accounts-receivable"] =
         [
             G("AccountsReceivableNetCurrent"),
@@ -281,6 +306,9 @@ public static class FinancialConceptAliases
             G("DepreciationAndAmortization"),
             I("DepreciationAndAmortisationExpense"),
             I("DepreciationExpense"),
+            I("AdjustmentsForDepreciationExpense"),
+            I("AdjustmentsForAmortisationExpense"),
+            I("AdjustmentsForAmortizationExpense"),
         ],
         ["share-based-compensation"] =
         [
@@ -288,6 +316,7 @@ public static class FinancialConceptAliases
             I(
                 "ExpenseFromSharebasedPaymentTransactionsInWhichGoodsOrServicesReceivedDidNotQualifyForRecognitionAsAssets"
             ),
+            I("AdjustmentsForSharebasedPayments"),
         ],
         ["deferred-income-taxes"] =
         [
@@ -322,8 +351,8 @@ public static class FinancialConceptAliases
         [
             G("PaymentsOfDividends"),
             G("PaymentsOfDividendsCommonStock"),
-            I("DividendsPaid"),
             I("DividendsPaidClassifiedAsFinancingActivities"),
+            I("DividendsPaid"),
         ],
         ["debt-issued"] =
         [

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/ReportedStatementColumn.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/ReportedStatementColumn.cs
@@ -10,6 +10,27 @@ public class ReportedStatementColumn
     /// <summary>The column's period-end label as filed, e.g. <c>"Mar. 28, 2026"</c>.</summary>
     public string Label { get; set; }
 
+    /// <summary>The parsed period end carried by <see cref="Label"/>.</summary>
+    public DateOnly? PeriodEnd { get; set; }
+
+    /// <summary>
+    /// The column's proven ISO monetary unit: explicit header currency first, otherwise the title's
+    /// single unambiguous currency. Null is ambiguous and consumers must fail closed.
+    /// </summary>
+    public string Currency { get; set; }
+
+    /// <summary>
+    /// The exact whole-money multiplier for this column. Null means the title/header carried
+    /// conflicting currency-specific scales and consumers must not publish monetary values.
+    /// </summary>
+    public long? Scale { get; set; }
+
+    /// <summary>
+    /// The exact per-share multiplier for this column. Null means currency-specific per-share
+    /// clauses conflict or do not prove a scale for this column.
+    /// </summary>
+    public long? PerShareScale { get; set; }
+
     /// <summary>The duration group as filed, e.g. <c>"3 Months Ended"</c>; null for a point-in-time (balance sheet) column.</summary>
     public string Duration { get; set; }
 

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/ReportedStatementRow.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/ReportedStatementRow.cs
@@ -27,6 +27,12 @@ public class ReportedStatementRow
     /// <summary>A subtotal / total line (rendered emphasized), e.g. <c>"Total current assets"</c>.</summary>
     public bool IsTotal { get; set; }
 
+    /// <summary>
+    /// The authoritative SEC R-file presentation-member handle inherited from the nearest
+    /// <c>tr.rh</c> row; null means the row is on the statement's unqualified primary basis.
+    /// </summary>
+    public string PresentationContext { get; set; }
+
     /// <summary>The value per period column, aligned to <see cref="ReportedStatementColumn"/>; null = blank cell.</summary>
     public List<decimal?> Values { get; set; } = [];
 }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsParseWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsParseWorker.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Sec.Data.Models;
@@ -27,6 +28,36 @@ public class ReportedStatementsParseWorker : BaseScraperWorker
     // Let live capture land bundles first after a deploy; this sweep has no external budget.
     protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(12);
 
+    internal static Expression<Func<Document, bool>> NeedsCurrentParser =>
+        document =>
+            document.ReportedStatementsParseVersion < Document.ReportedStatementsParserVersion
+            && (
+                document.ReportedStatementsParseAttemptVersion
+                    < Document.ReportedStatementsParserVersion
+                || document.ReportedStatementsParseAttempts
+                    < Document.MaxReportedStatementsParseAttempts
+            );
+
+    internal static void BeginCurrentParserAttempt(Document document)
+    {
+        if (
+            document.ReportedStatementsParseAttemptVersion
+            == Document.ReportedStatementsParserVersion
+        )
+        {
+            return;
+        }
+        document.ReportedStatementsParseAttemptVersion = Document.ReportedStatementsParserVersion;
+        document.ReportedStatementsParseAttempts = 0;
+    }
+
+    internal static void CompleteCurrentParserAttempt(Document document)
+    {
+        document.ReportedStatementsParseVersion = Document.ReportedStatementsParserVersion;
+        document.ReportedStatementsParseAttemptVersion = Document.ReportedStatementsParserVersion;
+        document.ReportedStatementsParseAttempts = 0;
+    }
+
     public ReportedStatementsParseWorker(
         ILogger<ReportedStatementsParseWorker> logger,
         IServiceScopeFactory scopeFactory,
@@ -53,11 +84,7 @@ public class ReportedStatementsParseWorker : BaseScraperWorker
             // Captured bundles whose parse is below the current parser version, newest first.
             var batch = await documentRepository
                 .GetByReportedStatementsStatus(XbrlCaptureStatus.Captured)
-                .Where(d =>
-                    d.ReportedStatementsParseVersion < Document.ReportedStatementsParserVersion
-                    && d.ReportedStatementsParseAttempts
-                        < Document.MaxReportedStatementsParseAttempts
-                )
+                .Where(NeedsCurrentParser)
                 .OrderByDescending(d => d.ReportingDate)
                 .Take(batchSize)
                 .ToListAsync(stoppingToken);
@@ -73,9 +100,9 @@ public class ReportedStatementsParseWorker : BaseScraperWorker
                 stoppingToken.ThrowIfCancellationRequested();
                 try
                 {
+                    BeginCurrentParserAttempt(document);
                     statements += await parseService.Parse(document, stoppingToken);
-                    document.ReportedStatementsParseVersion =
-                        Document.ReportedStatementsParserVersion;
+                    CompleteCurrentParserAttempt(document);
                 }
                 // Shutdown mid-batch is not a document failure: let it surface so the
                 // base loop winds down quietly instead of burning one of the document's

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
@@ -1,4 +1,5 @@
 using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.FiscalPeriods;
 
 namespace Equibles.Sec.FinancialFacts.HostedService.Services;
 
@@ -12,28 +13,6 @@ namespace Equibles.Sec.FinancialFacts.HostedService.Services;
 /// </summary>
 internal static class FiscalPeriodResolver
 {
-    // 52/53-week filers (Apple, Microsoft, etc.) slide PeriodEnd a few days
-    // around the nominal fiscal year end. ±14 days is comfortably wider than
-    // any real-world drift while still rejecting unrelated dates.
-    private const int FyeMatchWindowDays = 14;
-
-    // A fiscal-year end in the first days of January marks a 52/53-week filer
-    // whose year-end oscillates around Dec 31 and occasionally lands just into
-    // the new year (e.g. Johnson & Johnson: SEC's submissions fiscalYearEnd is
-    // "0103", yet every recent fiscal year is December-anchored — FY2025 ended
-    // 2025-12-28). It is *not* a genuine late-January retail year-end (Walmart,
-    // Target: day ~31). The day cutoff separates the two.
-    private const int EarlyJanuaryFiscalYearEndDay = 7;
-
-    private const int AnnualMinDays = 350;
-    private const int AnnualMaxDays = 380;
-    private const int QuarterMinDays = 80;
-    private const int QuarterMaxDays = 100;
-    private const int HalfYearMinDays = 170;
-    private const int HalfYearMaxDays = 190;
-    private const int NineMonthMinDays = 260;
-    private const int NineMonthMaxDays = 280;
-
     /// <summary>
     /// Resolves <paramref name="periodStart"/> / <paramref name="periodEnd"/>
     /// against the company's fiscal-year-end month and day. Returns
@@ -56,100 +35,12 @@ internal static class FiscalPeriodResolver
         int? fyeMonth,
         int? fyeDay,
         bool classifyInterimInstants = false
-    )
-    {
-        if (fyeMonth is null || fyeDay is null)
-            return null;
-        if (fyeMonth < 1 || fyeMonth > 12 || fyeDay < 1 || fyeDay > 31)
-            return null;
-
-        // Treat an early-January (year-turn) fiscal-year end as December-anchored
-        // so the period lands in the year the company actually reports. Without
-        // this, every period for such a filer is labelled one fiscal year too
-        // high (e.g. J&J's quarter ending 2026-03-29 would resolve to FY2027
-        // instead of FY2026). Issue #4423.
-        if (fyeMonth == 1 && fyeDay <= EarlyJanuaryFiscalYearEndDay)
-        {
-            fyeMonth = 12;
-            fyeDay = 31;
-        }
-
-        var candidates = new[]
-        {
-            CreateSafe(periodEnd.Year - 1, fyeMonth.Value, fyeDay.Value),
-            CreateSafe(periodEnd.Year, fyeMonth.Value, fyeDay.Value),
-            CreateSafe(periodEnd.Year + 1, fyeMonth.Value, fyeDay.Value),
-        };
-
-        var durationDays = periodEnd.DayNumber - periodStart.DayNumber;
-        var isInstant = durationDays == 0;
-        var isAnnual = IsWithinDays(durationDays, AnnualMinDays, AnnualMaxDays);
-
-        if (isAnnual || isInstant)
-        {
-            var closest = ClosestTo(candidates, periodEnd);
-            if (Math.Abs(closest.DayNumber - periodEnd.DayNumber) <= FyeMatchWindowDays)
-                return (closest.Year, SecFiscalPeriod.FullYear);
-            // An opted-in interim instant falls through to the quarter classification
-            // below; everything else keeps the null fallback (see the summary).
-            if (!isInstant || !classifyInterimInstants)
-                return null;
-        }
-
-        var isQuarter = IsWithinDays(durationDays, QuarterMinDays, QuarterMaxDays);
-        var isHalfYear = IsWithinDays(durationDays, HalfYearMinDays, HalfYearMaxDays);
-        var isNineMonths = IsWithinDays(durationDays, NineMonthMinDays, NineMonthMaxDays);
-
-        var interimInstant = isInstant && classifyInterimInstants;
-        if (!interimInstant && !isQuarter && !isHalfYear && !isNineMonths)
-            return null;
-
-        // The fiscal year containing periodEnd is the one whose FYE is on or
-        // after periodEnd within roughly twelve months — ranks the matched
-        // year correctly even when the quarter closes a few days late.
-        var matches = candidates.Where(c => c.DayNumber >= periodEnd.DayNumber).ToList();
-        if (matches.Count == 0)
-            return null;
-        var endingFye = matches.MinBy(c => c.DayNumber);
-        if (endingFye.DayNumber - periodEnd.DayNumber > AnnualMaxDays)
-            return null;
-
-        if (endingFye.Year < 2)
-            return null;
-        var priorFye = endingFye.AddYears(-1);
-        var fiscalYearStart = priorFye.AddDays(1);
-        var monthsElapsed =
-            (periodEnd.Year - fiscalYearStart.Year) * 12
-            + (periodEnd.Month - fiscalYearStart.Month);
-
-        var period = monthsElapsed switch
-        {
-            <= 4 => SecFiscalPeriod.Q1,
-            <= 7 => SecFiscalPeriod.Q2,
-            <= 10 => SecFiscalPeriod.Q3,
-            _ => SecFiscalPeriod.Q4,
-        };
-
-        return (endingFye.Year, period);
-    }
-
-    // Companies with a Feb 29 FYE land on Feb 28 in non-leap years; clamp the
-    // requested day to the month's actual length so DateOnly construction
-    // never throws.
-    private static DateOnly CreateSafe(int year, int month, int day)
-    {
-        if (year < 1)
-            return DateOnly.MinValue;
-        if (year > 9999)
-            return DateOnly.MaxValue;
-        var maxDay = DateTime.DaysInMonth(year, month);
-        return new DateOnly(year, month, Math.Min(day, maxDay));
-    }
-
-    private static DateOnly ClosestTo(DateOnly[] candidates, DateOnly target) =>
-        candidates.MinBy(c => Math.Abs(c.DayNumber - target.DayNumber));
-
-    // Inclusive day-count band for a recognised period shape (annual, quarter, …).
-    private static bool IsWithinDays(int durationDays, int min, int max) =>
-        durationDays >= min && durationDays <= max;
+    ) =>
+        ReportedFiscalPeriodResolver.Resolve(
+            periodStart,
+            periodEnd,
+            fyeMonth,
+            fyeDay,
+            classifyInterimInstants
+        );
 }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsCaptureService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsCaptureService.cs
@@ -147,6 +147,8 @@ public class ReportedStatementsCaptureService
         document.ReportedStatementsUncompressedSize = uncompressedSize;
         // A fresh bundle invalidates any earlier parse — let the parse sweep re-derive it.
         document.ReportedStatementsParseVersion = 0;
+        document.ReportedStatementsParseAttempts = 0;
+        document.ReportedStatementsParseAttemptVersion = Document.ReportedStatementsParserVersion;
         return XbrlCaptureStatus.Captured;
     }
 }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsParseService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsParseService.cs
@@ -43,13 +43,17 @@ public class ReportedStatementsParseService
     {
         if (document.ReportedStatementsContent == null)
         {
-            return 0;
+            throw new InvalidOperationException(
+                $"Captured reported-statements content is missing for document {document.Id}."
+            );
         }
 
         var bytes = await _fileManager.GetContent(document.ReportedStatementsContent);
         if (bytes is not { Length: > 0 })
         {
-            return 0;
+            throw new InvalidOperationException(
+                $"Captured reported-statements content is empty for document {document.Id}."
+            );
         }
 
         var files = ReportedStatementsBundle.Unpack(bytes);

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesIfrsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesIfrsTests.cs
@@ -11,6 +11,8 @@ public class FinancialConceptAliasesIfrsTests
             { "revenue", "Revenue" },
             { "gross-profit", "GrossProfit" },
             { "operating-income", "ProfitLossFromOperatingActivities" },
+            { "pretax-income", "ProfitLossBeforeTax" },
+            { "net-income", "ProfitLossAttributableToOwnersOfParent" },
             { "net-income", "ProfitLoss" },
             { "eps-diluted", "DilutedEarningsLossPerShare" },
             { "cash", "CashAndCashEquivalents" },
@@ -25,6 +27,15 @@ public class FinancialConceptAliasesIfrsTests
                 "PurchaseOfPropertyPlantAndEquipmentClassifiedAsInvestingActivities"
             },
             { "dividends-paid", "DividendsPaid" },
+            {
+                "current-financial-assets-fvtpl",
+                "CurrentFinancialAssetsAtFairValueThroughProfitOrLoss"
+            },
+            {
+                "current-financial-assets-fvoci",
+                "CurrentFinancialAssetsAtFairValueThroughOtherComprehensiveIncome"
+            },
+            { "current-financial-assets-amortised-cost", "CurrentFinancialAssetsAtAmortisedCost" },
         };
 
     [Theory]
@@ -34,5 +45,31 @@ public class FinancialConceptAliasesIfrsTests
         FinancialConceptAliases.TryResolve(alias, out var refs).Should().BeTrue();
 
         refs.Should().Contain(r => r.Taxonomy == FactTaxonomy.IfrsFull && r.Tag == tag);
+    }
+
+    [Fact]
+    public void NetIncome_OrdersParentAttributableConceptsBeforeGenericProfitLossFallbacks()
+    {
+        FinancialConceptAliases.TryResolve("net-income", out var refs).Should().BeTrue();
+
+        refs.Select(reference => (reference.Taxonomy, reference.Tag))
+            .Should()
+            .Equal(
+                (FactTaxonomy.UsGaap, "NetIncomeLoss"),
+                (FactTaxonomy.IfrsFull, "ProfitLossAttributableToOwnersOfParent"),
+                (FactTaxonomy.UsGaap, "ProfitLoss"),
+                (FactTaxonomy.IfrsFull, "ProfitLoss")
+            );
+    }
+
+    [Fact]
+    public void DividendsPaid_OrdersCashFlowConceptBeforeGenericEquityMovement()
+    {
+        FinancialConceptAliases.TryResolve("dividends-paid", out var refs).Should().BeTrue();
+
+        var ifrs = refs.Where(reference => reference.Taxonomy == FactTaxonomy.IfrsFull).ToList();
+        ifrs.Select(reference => reference.Tag)
+            .Should()
+            .Equal("DividendsPaidClassifiedAsFinancingActivities", "DividendsPaid");
     }
 }

--- a/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverQ4QuarterIsolatedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverQ4QuarterIsolatedTests.cs
@@ -54,4 +54,17 @@ public class FiscalPeriodResolverQ4QuarterIsolatedTests
 
         result.Should().Be((2024, SecFiscalPeriod.Q4));
     }
+
+    [Fact]
+    public void Resolve_WeekBasedQuarterSpillingPastNominalFye_RemainsQ4()
+    {
+        var result = FiscalPeriodResolver.Resolve(
+            periodStart: new DateOnly(2026, 7, 4),
+            periodEnd: new DateOnly(2026, 10, 2),
+            fyeMonth: 9,
+            fyeDay: 30
+        );
+
+        result.Should().Be((2026, SecFiscalPeriod.Q4));
+    }
 }

--- a/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverTests.cs
@@ -157,6 +157,33 @@ public class FiscalPeriodResolverTests
     }
 
     [Fact]
+    public void Resolve_Q3_NonCalendarFiler_AcceptsFortyOneWeekCumulativePeriod()
+    {
+        var result = FiscalPeriodResolver.Resolve(
+            periodStart: new DateOnly(2025, 1, 5),
+            periodEnd: new DateOnly(2025, 10, 18),
+            fyeMonth: 1,
+            fyeDay: 3
+        );
+
+        result.Should().Be((2025, SecFiscalPeriod.Q3));
+    }
+
+    [Fact]
+    public void SharedResolver_Q3_NonCalendarFiler_AcceptsFortyOneWeekCumulativePeriod()
+    {
+        var result =
+            Equibles.Sec.FinancialFacts.Data.FiscalPeriods.ReportedFiscalPeriodResolver.Resolve(
+                periodStart: new DateOnly(2025, 1, 5),
+                periodEnd: new DateOnly(2025, 10, 18),
+                fyeMonth: 1,
+                fyeDay: 3
+            );
+
+        result.Should().Be((2025, SecFiscalPeriod.Q3));
+    }
+
+    [Fact]
     public void Resolve_Q1_MarchFye()
     {
         // Q1 for a March FYE filer: Apr 1 to Jun 30

--- a/tests/Equibles.UnitTests/Sec/RFileStatementParserScaleNoteTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RFileStatementParserScaleNoteTests.cs
@@ -32,6 +32,12 @@ public class RFileStatementParserScaleNoteTests
     [InlineData("STATEMENT - USD ($) shares in Thousands", 1L, "USD")]
     [InlineData("STATEMENT - USD ($) shares in Millions", 1L, "USD")]
     [InlineData("STATEMENT - USD ($) $ / shares in Thousands", 1L, "USD")]
+    [InlineData("STATEMENT - USD ($) amounts in Thousands of shares", 1L, "USD")]
+    [InlineData(
+        "STATEMENT - USD ($) amounts in Thousands of shares, $ in Millions",
+        1_000_000L,
+        "USD"
+    )]
     [InlineData("STATEMENT - $ / shares shares in Thousands", 1L, null)]
     [InlineData("STATEMENT - shares shares in Millions", 1L, null)]
     // No scale segments at all.
@@ -59,5 +65,17 @@ public class RFileStatementParserScaleNoteTests
         statement.IsEmpty.Should().BeFalse();
         statement.Scale.Should().Be(expectedScale);
         statement.Currency.Should().Be(expectedCurrency);
+    }
+
+    [Fact]
+    public void Parse_NoDashBreakSeparatedTitle_PreservesTheScaleBearingText()
+    {
+        var statement = RFileStatementParser.Parse(
+            RFile("CONSOLIDATED STATEMENTS OF INCOME<br>USD ($) $ in Millions, shares in Thousands")
+        );
+
+        statement.Currency.Should().Be("USD");
+        statement.Scale.Should().Be(1_000_000L);
+        statement.Payload.ScaleNote.Should().Contain("shares in Thousands");
     }
 }

--- a/tests/Equibles.UnitTests/Sec/RFileStatementParserTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RFileStatementParserTests.cs
@@ -23,12 +23,17 @@ public class RFileStatementParserTests
         statement.Currency.Should().Be("USD");
         statement.Scale.Should().Be(1_000_000);
         statement.PrimaryIsInstant.Should().BeFalse();
+        statement.PrimaryPeriodStart.Should().Be(new DateOnly(2025, 12, 29));
         statement.PrimaryPeriodEnd.Should().Be(new DateOnly(2026, 3, 28));
 
         var payload = statement.Payload;
         // 3 Months Ended (current + prior) + 6 Months Ended (current + prior).
         payload.Columns.Should().HaveCount(4);
         payload.Columns[0].Label.Should().Be("Mar. 28, 2026");
+        payload.Columns[0].PeriodEnd.Should().Be(new DateOnly(2026, 3, 28));
+        payload.Columns[0].Currency.Should().Be("USD");
+        payload.Columns[0].Scale.Should().Be(1_000_000L);
+        payload.Columns[0].PerShareScale.Should().Be(1L);
         payload.Columns[0].Duration.Should().Be("3 Months Ended");
         payload.Columns[0].IsInstant.Should().BeFalse();
 
@@ -49,6 +54,172 @@ public class RFileStatementParserTests
     }
 
     [Fact]
+    public void Parse_MultiCurrencyColumnHeaders_RetainDateAndExactCurrency()
+    {
+        const string html = """
+            <html><body><table class="report">
+            <tr>
+              <th class="tl" rowspan="2">CONSOLIDATED STATEMENTS - $ in Millions</th>
+              <th class="th" colspan="3">12 Months Ended</th>
+            </tr>
+            <tr>
+              <th class="th"><div>Dec. 31, 2025</div><div>TWD ($)</div><div>$ / shares</div></th>
+              <th class="th"><div>Dec. 31, 2025</div><div>USD ($)</div><div>$ / shares</div></th>
+              <th class="th"><div>Dec. 31, 2024</div><div>TWD ($)</div><div>$ / shares</div></th>
+            </tr>
+            <tr class="re"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_RevenueFromContractsWithCustomers', window );">Revenue</a></td><td class="num">3,809,054.3</td><td class="num">121,423.5</td><td class="num">2,894,307.7</td></tr>
+            </table></body></html>
+            """;
+
+        var statement = RFileStatementParser.Parse(html);
+
+        statement.IsEmpty.Should().BeFalse();
+        statement.Currency.Should().Be("TWD");
+        statement.PrimaryPeriodStart.Should().Be(new DateOnly(2025, 1, 1));
+        statement.PrimaryPeriodEnd.Should().Be(new DateOnly(2025, 12, 31));
+        statement
+            .Payload.Columns.Select(column => column.Label)
+            .Should()
+            .Equal("Dec. 31, 2025", "Dec. 31, 2025", "Dec. 31, 2024");
+        statement
+            .Payload.Columns.Select(column => column.Currency)
+            .Should()
+            .Equal("TWD", "USD", "TWD");
+        statement
+            .Payload.Columns.Select(column => column.PeriodEnd)
+            .Should()
+            .Equal(
+                new DateOnly(2025, 12, 31),
+                new DateOnly(2025, 12, 31),
+                new DateOnly(2024, 12, 31)
+            );
+        statement
+            .Payload.Columns.Select(column => column.Scale)
+            .Should()
+            .Equal(1_000_000L, 1_000_000L, 1_000_000L);
+    }
+
+    [Fact]
+    public void Parse_MultiCurrencyTitle_RetainsExactScaleForEachColumn()
+    {
+        const string html = """
+            <html><body><table class="report">
+            <tr>
+              <th class="tl" rowspan="2">CONSOLIDATED STATEMENTS - TWD ($) in Millions, USD ($) in Thousands</th>
+              <th class="th" colspan="2">12 Months Ended</th>
+            </tr>
+            <tr>
+              <th class="th">Dec. 31, 2025 TWD ($)</th>
+              <th class="th">Dec. 31, 2025 USD ($)</th>
+            </tr>
+            <tr class="re"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_Revenue', window );">Revenue</a></td><td class="num">100</td><td class="num">4</td></tr>
+            </table></body></html>
+            """;
+
+        var columns = RFileStatementParser.Parse(html).Payload.Columns;
+
+        columns.Select(column => column.Currency).Should().Equal("TWD", "USD");
+        columns.Select(column => column.Scale).Should().Equal(1_000_000L, 1_000L);
+    }
+
+    [Fact]
+    public void Parse_MultiCurrencyTitleWithDateOnlyColumn_FailsClosed()
+    {
+        const string html = """
+            <html><body><table class="report">
+            <tr>
+              <th class="tl" rowspan="2">CONSOLIDATED STATEMENTS - TWD ($) in Millions, USD ($) in Thousands</th>
+              <th class="th">12 Months Ended</th>
+            </tr>
+            <tr><th class="th">Dec. 31, 2025</th></tr>
+            <tr class="re"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_Revenue', window );">Revenue</a></td><td class="num">100</td></tr>
+            </table></body></html>
+            """;
+
+        var column = RFileStatementParser.Parse(html).Payload.Columns.Single();
+
+        column.Currency.Should().BeNull();
+        column.Scale.Should().BeNull();
+        column.PerShareScale.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_ConflictingSameCurrencyScales_LeavesColumnScaleAmbiguous()
+    {
+        const string html = """
+            <html><body><table class="report">
+            <tr>
+              <th class="tl" rowspan="2">CONSOLIDATED STATEMENTS - TWD ($) in Millions, TWD ($) in Thousands</th>
+              <th class="th">12 Months Ended</th>
+            </tr>
+            <tr><th class="th">Dec. 31, 2025 TWD ($)</th></tr>
+            <tr class="re"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_Revenue', window );">Revenue</a></td><td class="num">100</td></tr>
+            </table></body></html>
+            """;
+
+        RFileStatementParser.Parse(html).Payload.Columns.Single().Scale.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_ExplicitScalesForOtherCurrencies_DoNotAuthorizeColumnScale()
+    {
+        const string html = """
+            <html><body><table class="report">
+            <tr>
+              <th class="tl" rowspan="2">CONSOLIDATED STATEMENTS - TWD ($) in Millions, USD ($) in Millions</th>
+              <th class="th">12 Months Ended</th>
+            </tr>
+            <tr><th class="th">Dec. 31, 2025 EUR (€)</th></tr>
+            <tr class="re"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_Revenue', window );">Revenue</a></td><td class="num">100</td></tr>
+            </table></body></html>
+            """;
+
+        RFileStatementParser.Parse(html).Payload.Columns.Single().Scale.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_MultiCurrencyPerShareClauses_RetainExactColumnScales()
+    {
+        const string html = """
+            <html><body><table class="report">
+            <tr>
+              <th class="tl" rowspan="2">INCOME - TWD ($) TWD / shares in Units, USD ($) USD / shares in Thousands, $ in Millions</th>
+              <th class="th" colspan="2">12 Months Ended</th>
+            </tr>
+            <tr><th class="th">Dec. 31, 2025 TWD ($)</th><th class="th">Dec. 31, 2025 USD ($)</th></tr>
+            <tr class="re"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_DilutedEarningsLossPerShare', window );">EPS</a></td><td class="num">65.47</td><td class="num">0.002</td></tr>
+            </table></body></html>
+            """;
+
+        var columns = RFileStatementParser.Parse(html).Payload.Columns;
+
+        columns.Select(column => column.PerShareScale).Should().Equal(1L, 1_000L);
+    }
+
+    [Fact]
+    public void Parse_WeekBasedForeignStatement_RetainsDurationAndFiscalAnchor()
+    {
+        const string html = """
+            <html><body><table class="report">
+            <tr>
+              <th class="tl" rowspan="2">CONSOLIDATED STATEMENTS - TWD ($) in Millions</th>
+              <th class="th">52 Weeks Ended</th>
+            </tr>
+            <tr><th class="th">Sept. 30, 2025 TWD ($)</th></tr>
+            <tr class="re"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_Revenue', window );">Revenue</a></td><td class="num">100</td></tr>
+            </table></body></html>
+            """;
+
+        var statement = RFileStatementParser.Parse(html);
+
+        statement.PrimaryIsInstant.Should().BeFalse();
+        statement.PrimaryPeriodStart.Should().Be(new DateOnly(2024, 10, 2));
+        statement.PrimaryPeriodEnd.Should().Be(new DateOnly(2025, 9, 30));
+        statement.Payload.Columns.Single().Label.Should().Be("Sept. 30, 2025");
+        statement.Payload.Columns.Single().PeriodEnd.Should().Be(new DateOnly(2025, 9, 30));
+    }
+
+    [Fact]
     public void Parse_BalanceSheet_IsInstantAndMarksTotals()
     {
         var statement = RFileStatementParser.Parse(Load("aapl-10q-balance-R4.htm"));
@@ -66,6 +237,31 @@ public class RFileStatementParserTests
         var totalAssets = payload.Rows.First(r => r.Concept == "Assets" && r.Taxonomy == "us-gaap");
         totalAssets.IsTotal.Should().BeTrue();
         totalAssets.Values[0].Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Parse_PresentationMemberHeader_IsInheritedByOnlyItsFollowingRows()
+    {
+        const string html = """
+            <html><body><table class="report">
+            <tr>
+              <th class="tl" rowspan="2">INCOME - TWD ($) $ / shares in Units</th>
+              <th class="th">12 Months Ended</th>
+            </tr>
+            <tr><th class="th">Dec. 31, 2025 TWD ($)</th></tr>
+            <tr class="ro"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_DilutedEarningsLossPerShare', window );">Diluted EPS</a></td><td class="num">65.47</td></tr>
+            <tr class="rh"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_ClassesOfShareCapitalAxis=tsm_AmericanDepositarySharesMember', window );">American depositary shares</a></td><td class="text">&#160;</td></tr>
+            <tr class="ro"><td class="pl"><a onclick="top.Show.showAR( this, 'defref_ifrs-full_DilutedEarningsLossPerShare', window );">Diluted EPS</a></td><td class="num">327.34</td></tr>
+            </table></body></html>
+            """;
+
+        var rows = RFileStatementParser.Parse(html).Payload.Rows;
+
+        rows.Should().HaveCount(2);
+        rows[0].PresentationContext.Should().BeNull();
+        rows[1]
+            .PresentationContext.Should()
+            .Be("defref_ifrs-full_ClassesOfShareCapitalAxis=tsm_AmericanDepositarySharesMember");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Sec/ReportedStatementsParseWorkerVersionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ReportedStatementsParseWorkerVersionTests.cs
@@ -1,0 +1,73 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.HostedService;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class ReportedStatementsParseWorkerVersionTests
+{
+    [Fact]
+    public void NeedsCurrentParser_OldAttemptBudgetReopensAfterVersionUpgrade()
+    {
+        var document = new Document
+        {
+            ReportedStatementsParseVersion = Document.ReportedStatementsParserVersion - 1,
+            ReportedStatementsParseAttemptVersion = Document.ReportedStatementsParserVersion - 1,
+            ReportedStatementsParseAttempts = Document.MaxReportedStatementsParseAttempts,
+        };
+
+        ReportedStatementsParseWorker.NeedsCurrentParser.Compile()(document).Should().BeTrue();
+        ReportedStatementsParseWorker.BeginCurrentParserAttempt(document);
+
+        document
+            .ReportedStatementsParseAttemptVersion.Should()
+            .Be(Document.ReportedStatementsParserVersion);
+        document.ReportedStatementsParseAttempts.Should().Be(0);
+    }
+
+    [Fact]
+    public void NeedsCurrentParser_CurrentAttemptBudgetRemainsCapped()
+    {
+        var document = new Document
+        {
+            ReportedStatementsParseVersion = Document.ReportedStatementsParserVersion - 1,
+            ReportedStatementsParseAttemptVersion = Document.ReportedStatementsParserVersion,
+            ReportedStatementsParseAttempts = Document.MaxReportedStatementsParseAttempts,
+        };
+
+        ReportedStatementsParseWorker.NeedsCurrentParser.Compile()(document).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SuccessfulReplayStateResetsAttemptsAndClosesTheWorkset()
+    {
+        var document = new Document
+        {
+            ReportedStatementsParseVersion = Document.ReportedStatementsParserVersion - 1,
+            ReportedStatementsParseAttemptVersion = Document.ReportedStatementsParserVersion,
+            ReportedStatementsParseAttempts = 3,
+        };
+
+        ReportedStatementsParseWorker.CompleteCurrentParserAttempt(document);
+
+        ReportedStatementsParseWorker.NeedsCurrentParser.Compile()(document).Should().BeFalse();
+        document.ReportedStatementsParseAttempts.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MissingCapturedContentCannotStampTheCurrentParserVersion()
+    {
+        var oldVersion = Document.ReportedStatementsParserVersion - 1;
+        var document = new Document
+        {
+            ReportedStatementsParseVersion = oldVersion,
+            ReportedStatementsParseAttemptVersion = Document.ReportedStatementsParserVersion,
+        };
+        var service = new ReportedStatementsParseService(null!, null!);
+
+        Func<Task> act = () => service.Parse(document, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        document.ReportedStatementsParseVersion.Should().Be(oldVersion);
+    }
+}


### PR DESCRIPTION
## Problem

Foreign-issuer R-file statement headers combine dates, currencies, and per-column scales. The old parser required a date-only header, so current 20-F annual columns were discarded and downstream fundamentals stayed stale.

## Changes

- parse exact date, currency, scale, share scale, and presentation context per column
- preserve canonical fiscal-period and source-precedence semantics
- add parser-version-scoped durable replay attempts
- fail closed on ambiguous currency, scale, context, or missing captured content
- expand IFRS aliases and regression coverage for real multi-currency forms

## Verification

- full OSS suite: 4,735 passed
- commercial consumers: full Release build and all commercial suites green
- independent release review: clean