### PR TITLE
fix: recover recurring production errors

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -984,11 +984,19 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             .OrderBy(row => row.ReportDate)
             .ToListAsync(cancellationToken);
         var exact = await Get13FHistoryByStock(stock)
-            .GroupBy(holding => new { holding.ReportDate, holding.ListedTicker })
+            // A primary-listing holding can be stored either with a null ListedTicker (legacy
+            // meaning "the stock's primary ticker") or with that ticker stated explicitly. Coalesce
+            // before grouping so the two identities sum into one series instead of colliding when
+            // the result is materialised as a ticker dictionary.
+            .GroupBy(holding => new
+            {
+                holding.ReportDate,
+                PriceSeriesTicker = holding.ListedTicker ?? stock.Ticker,
+            })
             .Select(group => new
             {
                 group.Key.ReportDate,
-                PriceSeriesTicker = group.Key.ListedTicker ?? stock.Ticker,
+                group.Key.PriceSeriesTicker,
                 Shares = group.Sum(holding => holding.Shares),
             })
             .ToListAsync(cancellationToken);

--- a/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsParseWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/ReportedStatementsParseWorker.cs
@@ -111,6 +111,20 @@ public class ReportedStatementsParseWorker : BaseScraperWorker
                 {
                     throw;
                 }
+                // The database row can outlive a lost filesystem blob after a storage restore or
+                // manual volume repair. Retire that stale row and let the capture sweep fetch a
+                // fresh bundle instead of spending the parse retry budget on the same missing path.
+                catch (Exception ex)
+                    when (ex is FileNotFoundException or DirectoryNotFoundException)
+                {
+                    parseService.RequeueMissingBundle(document);
+                    Logger.LogWarning(
+                        ex,
+                        "As-reported statements bundle is missing for document {DocumentId} ({Accession}); requeued for capture.",
+                        document.Id,
+                        document.AccessionNumber
+                    );
+                }
                 // Per-document fault isolation: count the attempt and keep the cycle going.
                 catch (Exception ex)
                 {

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsParseService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/ReportedStatementsParseService.cs
@@ -90,6 +90,23 @@ public class ReportedStatementsParseService
         return entities.Count;
     }
 
+    /// <summary>
+    /// Retires a captured-bundle row whose filesystem payload has disappeared and reopens the
+    /// document for the network capture sweep. Existing parsed statements stay available until a
+    /// replacement bundle is captured and parsed successfully.
+    /// </summary>
+    public void RequeueMissingBundle(Document document)
+    {
+        _fileManager.DeleteFile(document.ReportedStatementsContent);
+        document.ReportedStatementsContent = null;
+        document.ReportedStatementsContentId = null;
+        document.ReportedStatementsUncompressedSize = null;
+        document.ReportedStatementsStatus = XbrlCaptureStatus.NotChecked;
+        document.ReportedStatementsCaptureAttempts = 0;
+        document.ReportedStatementsParseAttempts = 0;
+        document.ReportedStatementsParseAttemptVersion = Document.ReportedStatementsParserVersion;
+    }
+
     private static ReportedFinancialStatement Build(
         Document document,
         FilingSummaryReport report,

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepository13FAvailableReportDatesTests.cs
@@ -358,6 +358,39 @@ public class InstitutionalHoldingRepository13FAvailableReportDatesTests : IDispo
     }
 
     [Fact]
+    public async Task GetStockActivitySnapshotsByStockSnapshotBacked_MergesImplicitAndExplicitPrimaryListing()
+    {
+        var stock = Stock("LBRDK");
+        var first = Holder("0000000020");
+        var second = Holder("0000000021");
+        var quarter = new DateOnly(2026, 3, 31);
+        var implicitPrimary = Holding(
+            stock.Id,
+            first.Id,
+            quarter,
+            FilingType.Form13F,
+            "13F-IMPLICIT-PRIMARY"
+        );
+        var explicitPrimary = Holding(
+            stock.Id,
+            second.Id,
+            quarter,
+            FilingType.Form13F,
+            "13F-EXPLICIT-PRIMARY"
+        );
+        explicitPrimary.ListedTicker = stock.Ticker;
+        _dbContext.AddRange(stock, first, second, implicitPrimary, explicitPrimary);
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var rows = await _repository.GetStockActivitySnapshotsByStockSnapshotBacked(stock);
+
+        var activity = rows.Should().ContainSingle().Which;
+        var listing = activity.ListingShares.Should().ContainSingle().Which;
+        listing.PriceSeriesTicker.Should().Be(stock.Ticker);
+        listing.CurrentShares.Should().Be(200);
+    }
+
+    [Fact]
     public async Task GetStockActivitySnapshotsByStockSnapshotBacked_BoundsStaleRowsAndAppendsRefreshLag()
     {
         var stock = Stock("TREND-LAG");

--- a/tests/Equibles.UnitTests/Sec/ReportedStatementsParseWorkerVersionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ReportedStatementsParseWorkerVersionTests.cs
@@ -1,6 +1,10 @@
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.HostedService;
 using Equibles.Sec.FinancialFacts.HostedService.Services;
+using NSubstitute;
+using MediaFile = Equibles.Media.Data.Models.File;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -69,5 +73,37 @@ public class ReportedStatementsParseWorkerVersionTests
 
         await act.Should().ThrowAsync<InvalidOperationException>();
         document.ReportedStatementsParseVersion.Should().Be(oldVersion);
+    }
+
+    [Fact]
+    public void RequeueMissingBundle_RetiresStaleFileAndReopensCapture()
+    {
+        var file = new MediaFile
+        {
+            StorageProvider = StorageProvider.FileSystem,
+            RelativePath = "blob/sha256/aa/bb/missing",
+            ContentHash = "sha256:missing",
+        };
+        var document = new Document
+        {
+            ReportedStatementsContent = file,
+            ReportedStatementsContentId = file.Id,
+            ReportedStatementsUncompressedSize = 123,
+            ReportedStatementsStatus = XbrlCaptureStatus.Captured,
+            ReportedStatementsCaptureAttempts = Document.MaxReportedStatementsCaptureAttempts,
+            ReportedStatementsParseAttempts = Document.MaxReportedStatementsParseAttempts,
+        };
+        var fileManager = Substitute.For<IFileManager>();
+        var service = new ReportedStatementsParseService(null!, fileManager);
+
+        service.RequeueMissingBundle(document);
+
+        fileManager.Received(1).DeleteFile(file);
+        document.ReportedStatementsContent.Should().BeNull();
+        document.ReportedStatementsContentId.Should().BeNull();
+        document.ReportedStatementsUncompressedSize.Should().BeNull();
+        document.ReportedStatementsStatus.Should().Be(XbrlCaptureStatus.NotChecked);
+        document.ReportedStatementsCaptureAttempts.Should().Be(0);
+        document.ReportedStatementsParseAttempts.Should().Be(0);
     }
 }


### PR DESCRIPTION
## Summary
- requeue missing filesystem-backed SEC statement bundles for recapture without producing repeated error rows
- coalesce implicit and explicit primary listing identities before aggregating 13F activity

## Verification
- dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --filter FullyQualifiedName~ReportedStatementsParseWorkerVersionTests
- dotnet test tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj --filter FullyQualifiedName~GetStockActivitySnapshotsByStockSnapshotBacked_MergesImplicitAndExplicitPrimaryListing
- dotnet tool run csharpier check <five changed files>
- independent Codex review approved