### PR TITLE
feat(mcp): add filing feed and dividend history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - `CommonStockRepository.Search` accepts an `includeInactive` flag so operator surfaces can audit retained delisted identities; reader-facing surfaces keep the active-only default.
+- `ListFilings` provides company-scoped or market-wide filing discovery with date, document-type, exact 8-K item-number, and paging filters.
+- `GetDividendHistory` returns stored cash-dividend history newest first with date and paging controls.
+
+### Changed
+
+- `ListFilings` replaces the retired `ListCompanyDocuments` public MCP tool; clients with cached tool catalogs must refresh their MCP connection.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See [`docs/`](docs/README.md) for the user guide and technical documentation.
 
 ## What's Included
 
-Everything marked **Self-hosted** is scraped, stored, and served by this repo — **61 MCP tools**, no account, no key. [Equibles Cloud](https://equibles.com) runs this exact core over the same protocol with the same tool names, and adds more tools on top.
+Everything marked **Self-hosted** is scraped, stored, and served by this repo — **62 MCP tools**, no account, no key. [Equibles Cloud](https://equibles.com) runs this exact core over the same protocol with the same tool names, and adds more tools on top.
 
 | Domain | Data Source | Self-hosted | [Equibles Cloud](https://equibles.com) | Description |
 |--------|------------|:---:|:---:|-------------|
@@ -299,7 +299,7 @@ Any MCP-compatible client can connect to `http://localhost:8081/mcp` (HTTP trans
 
 ## Tools
 
-This self-hosted build exposes 61 tools over MCP. The hosted server at `https://mcp.equibles.com/mcp` runs this same core and [adds more on top](#whats-included). Full catalog and client setup: [daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server).
+This self-hosted build exposes 62 tools over MCP. The hosted server at `https://mcp.equibles.com/mcp` runs this same core and [adds more on top](#whats-included). Full catalog and client setup: [daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server).
 
 **13F institutional holdings**
 
@@ -328,7 +328,7 @@ This self-hosted build exposes 61 tools over MCP. The hosted server at `https://
 
 - SearchDocuments — hybrid keyword+semantic search across all filings, optionally scoped by ticker
 - SearchDocument — search within a single filing
-- ListCompanyDocuments — browse a company's filings
+- ListFilings — browse filings market-wide or for one company, with date/type/8-K item filters
 - ReadDocumentLines — read a line range from a filing
 
 **Funds, ETFs & advisers**
@@ -391,6 +391,7 @@ This self-hosted build exposes 61 tools over MCP. The hosted server at `https://
 
 - GetStockPrices — daily OHLCV plus the stored auxiliary adjusted close when it differs
 - GetLatestClosingPrices — latest close/change/volume
+- GetDividendHistory — stored declared cash dividends for a company's primary ticker
 - GetStochasticOscillator — stochastic oscillator (%K/%D)
 - GetAverageTrueRange — average true range (ATR)
 - GetOnBalanceVolume — on-balance volume (OBV)

--- a/docs/guide/how-to-ask-about-sec-filings.md
+++ b/docs/guide/how-to-ask-about-sec-filings.md
@@ -22,10 +22,11 @@ The assistant searches that company's filings with the `SearchDocuments` tool an
 
 To work inside a single filing rather than across many:
 
-- "List Apple's recent SEC filings." — the assistant calls `ListCompanyDocuments` and returns each filing's type, filing date, and reporting period.
+- "List Apple's recent SEC filings." — the assistant calls `ListFilings` and returns each filing's type, filing date, and reporting period.
+- "List recent 8-Ks across the market that report Item 2.02 results." — the assistant calls `ListFilings` without a ticker and filters by document type and exact SEC item number.
 - "Search that 10-K for what they say about supply-chain risk." — the assistant uses `SearchDocument` in semantic mode for relevant passages or exact mode for a literal word or phrase, then `ReadDocumentLines` to read a passage in full.
 
-You can narrow any of these by document type (10-K, 10-Q, or 8-K) or by filing-date range — for example, "only 10-Qs filed in 2024."
+You can narrow any of these by document type (10-K, 10-Q, or 8-K), filing-date range, or exact 8-K item number — for example, "only Item 5.02 8-Ks filed this week."
 
 ## What you should see
 

--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -54,7 +54,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 - `SearchDocuments` — hybrid BM25 and semantic search across indexed SEC documents, optionally scoped by `ticker`; without embeddings it retains ranked BM25 results.
 - `SearchDocument` — semantic or exact literal search inside a specific document.
-- `ListCompanyDocuments` — list documents available for a company.
+- `ListFilings` — list stored filings newest first, market-wide or for one company, with date, document-type, and exact 8-K item-number filters.
 
 `FailToDeliverTools`:
 
@@ -125,6 +125,7 @@ never substitutes `BRK-B`; dot share-class spelling such as `BRK.A` resolves to 
 
 - `GetStockPrices` — daily OHLCV + `AdjustedClose` for a ticker over a date range.
 - `GetLatestClosingPrices` — latest close for one or more tickers.
+- `GetDividendHistory` — declared cash-dividend history by ex-date for a company's current primary ticker.
 - `GetStochasticOscillator` — Stochastic Oscillator (%K and %D) for a ticker over a date range.
 - `GetAverageTrueRange` — Wilder's Average True Range (ATR) volatility measure for a ticker over a date range.
 - `GetOnBalanceVolume` — On-Balance Volume (OBV) cumulative-flow indicator for a ticker over a date range.

--- a/src/Equibles.CorporateActions.Repositories/CashDividendRepository.cs
+++ b/src/Equibles.CorporateActions.Repositories/CashDividendRepository.cs
@@ -15,6 +15,21 @@ public class CashDividendRepository : BaseRepository<CashDividend>
         return GetAll().Where(d => d.CommonStockId == commonStockId);
     }
 
+    public IQueryable<CashDividend> GetHistory(
+        Guid commonStockId,
+        DateOnly? startDate = null,
+        DateOnly? endDate = null
+    )
+    {
+        var query = GetByStock(commonStockId);
+        if (startDate.HasValue)
+            query = query.Where(d => d.ExDate >= startDate.Value);
+        if (endDate.HasValue)
+            query = query.Where(d => d.ExDate <= endDate.Value);
+
+        return query.OrderByDescending(d => d.ExDate).ThenByDescending(d => d.Id);
+    }
+
     public IQueryable<CashDividend> GetPendingPriceAdjustment()
     {
         return GetAll()

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -86,7 +86,7 @@ public partial class Program
         );
         // EmbeddingClient resolves IHttpClientFactory unconditionally in its constructor,
         // even when embeddings are disabled -- without this, any Sec search tool
-        // (ListCompanyDocuments, SearchDocuments, SearchDocument) fails to activate.
+        // (ListFilings, SearchDocuments, SearchDocument) fails to activate.
         builder.Services.AddHttpClient();
         builder.Services.Configure<Equibles.Media.BusinessLogic.Configuration.FileStorageOptions>(
             builder.Configuration.GetSection("FileStorage")

--- a/src/Equibles.Sec.BusinessLogic/Search/ISecDocumentService.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/ISecDocumentService.cs
@@ -6,12 +6,13 @@ namespace Equibles.Sec.BusinessLogic.Search;
 public interface ISecDocumentService
 {
     Task<List<SecDocumentInfo>> GetRecentDocuments(
-        string ticker,
+        string ticker = null,
         DateTime? startDate = null,
         DateTime? endDate = null,
         int maxItems = 10,
         int page = 1,
-        DocumentType documentType = null
+        DocumentType documentType = null,
+        string itemNumber = null
     );
 
     /// <summary>
@@ -20,9 +21,10 @@ public interface ISecDocumentService
     /// so callers can report totals and page counts alongside a page of results.
     /// </summary>
     Task<int> CountDocuments(
-        string ticker,
+        string ticker = null,
         DateTime? startDate = null,
         DateTime? endDate = null,
-        DocumentType documentType = null
+        DocumentType documentType = null,
+        string itemNumber = null
     );
 }

--- a/src/Equibles.Sec.BusinessLogic/Search/Models/SecDocumentInfo.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/Models/SecDocumentInfo.cs
@@ -42,4 +42,9 @@ public class SecDocumentInfo
     /// Total number of lines in the document content.
     /// </summary>
     public int LineCount { get; set; }
+
+    /// <summary>
+    /// Comma-separated SEC item numbers reported by the filing, such as 2.02 and 9.01.
+    /// </summary>
+    public string Items { get; set; }
 }

--- a/src/Equibles.Sec.BusinessLogic/Search/SecDocumentService.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/SecDocumentService.cs
@@ -24,23 +24,39 @@ public class SecDocumentService : ISecDocumentService
     }
 
     public async Task<List<SecDocumentInfo>> GetRecentDocuments(
-        string ticker,
+        string ticker = null,
         DateTime? startDate = null,
         DateTime? endDate = null,
         int maxItems = 10,
         int page = 1,
-        DocumentType documentType = null
+        DocumentType documentType = null,
+        string itemNumber = null
     )
     {
-        if (ticker == null)
-        {
-            throw new ApplicationException("Ticker cannot be null");
-        }
         try
         {
-            var documents = await BuildDocumentsQuery(ticker, startDate, endDate, documentType)
+            if (page < 1)
+                throw new ArgumentOutOfRangeException(nameof(page), "Page must be at least 1.");
+            if (maxItems < 1)
+                throw new ArgumentOutOfRangeException(
+                    nameof(maxItems),
+                    "Maximum items must be at least 1."
+                );
+
+            var offset = ((long)page - 1) * maxItems;
+            if (offset > int.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(page), "Page offset is too large.");
+
+            var documents = await BuildDocumentsQuery(
+                    ticker,
+                    startDate,
+                    endDate,
+                    documentType,
+                    itemNumber
+                )
                 .OrderByDescending(d => d.ReportingDate)
-                .Skip((page - 1) * maxItems)
+                .ThenByDescending(d => d.Id)
+                .Skip((int)offset)
                 .Take(maxItems)
                 .Select(d => new SecDocumentInfo
                 {
@@ -51,11 +67,12 @@ public class SecDocumentService : ISecDocumentService
                     ReportingDate = d.ReportingDate,
                     ReportingForDate = d.ReportingForDate,
                     LineCount = d.LineCount,
+                    Items = d.Items,
                 })
                 .ToListAsync();
 
             _logger.LogInformation(
-                "Found {Count} recent documents for ticker {Ticker}",
+                "Found {Count} recent documents for ticker filter {Ticker}",
                 documents.Count,
                 ticker
             );
@@ -63,34 +80,38 @@ public class SecDocumentService : ISecDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving recent documents for ticker {Ticker}", ticker);
+            _logger.LogError(
+                ex,
+                "Error retrieving recent documents for ticker filter {Ticker}",
+                ticker
+            );
             throw;
         }
     }
 
     public async Task<int> CountDocuments(
-        string ticker,
+        string ticker = null,
         DateTime? startDate = null,
         DateTime? endDate = null,
-        DocumentType documentType = null
+        DocumentType documentType = null,
+        string itemNumber = null
     )
     {
-        if (ticker == null)
-        {
-            throw new ApplicationException("Ticker cannot be null");
-        }
-
-        return await BuildDocumentsQuery(ticker, startDate, endDate, documentType).CountAsync();
+        return await BuildDocumentsQuery(ticker, startDate, endDate, documentType, itemNumber)
+            .CountAsync();
     }
 
     private IQueryable<Document> BuildDocumentsQuery(
         string ticker,
         DateTime? startDate,
         DateTime? endDate,
-        DocumentType documentType
+        DocumentType documentType,
+        string itemNumber
     )
     {
-        var query = _documentRepository.GetByTicker(ticker);
+        var query = string.IsNullOrWhiteSpace(ticker)
+            ? _documentRepository.GetAll()
+            : _documentRepository.GetByTicker(ticker);
 
         if (startDate.HasValue)
         {
@@ -106,17 +127,32 @@ public class SecDocumentService : ISecDocumentService
 
         if (documentType != null)
         {
-            return query.Where(d => d.DocumentType == documentType);
+            query = query.Where(d => d.DocumentType == documentType);
+        }
+        else
+        {
+            // No explicit type filter: honor DocumentType.HiddenFromFilingLists — types registered
+            // as hidden (e.g. investor-relations news) are news-like content, not filings, and must
+            // not crowd real filings out of the recent-documents list. They stay reachable through
+            // search and through an explicit documentType request.
+            var hiddenTypes = DocumentType.GetAll().Where(t => t.HiddenFromFilingLists).ToList();
+            if (hiddenTypes.Count > 0)
+            {
+                query = query.Where(d => !hiddenTypes.Contains(d.DocumentType));
+            }
         }
 
-        // No explicit type filter: honor DocumentType.HiddenFromFilingLists — types registered
-        // as hidden (e.g. investor-relations news) are news-like content, not filings, and must
-        // not crowd real filings out of the recent-documents list. They stay reachable through
-        // search and through an explicit documentType request (the branch above).
-        var hiddenTypes = DocumentType.GetAll().Where(t => t.HiddenFromFilingLists).ToList();
-        if (hiddenTypes.Count > 0)
+        if (itemNumber != null)
         {
-            query = query.Where(d => !hiddenTypes.Contains(d.DocumentType));
+            var first = itemNumber + ",";
+            var middle = "," + itemNumber + ",";
+            var last = "," + itemNumber;
+            query = query.Where(d =>
+                d.Items == itemNumber
+                || d.Items.StartsWith(first)
+                || d.Items.Contains(middle)
+                || d.Items.EndsWith(last)
+            );
         }
 
         return query;

--- a/src/Equibles.Sec.BusinessLogic/Search/SecFilingItemNumber.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/SecFilingItemNumber.cs
@@ -1,0 +1,31 @@
+namespace Equibles.Sec.BusinessLogic.Search;
+
+/// <summary>
+/// Validates SEC current-report item numbers used by filing-list filters.
+/// </summary>
+public static class SecFilingItemNumber
+{
+    public static string Normalize(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var item = value.Trim();
+        return
+            item.Length == 4
+            && item[0] is >= '1' and <= '9'
+            && item[1] == '.'
+            && char.IsAsciiDigit(item[2])
+            && char.IsAsciiDigit(item[3])
+            ? item
+            : null;
+    }
+
+    public static IReadOnlyList<string> ParseStored(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? []
+            : value.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            );
+}

--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -67,7 +67,7 @@ public class DocumentTextTools
         "Read numbered lines from one SEC filing or earnings-call transcript. Use line numbers returned by SearchDocument or request a known range. Returns at most 2,000 lines and identifies the next startLine when truncated."
     )]
     public Task<string> ReadDocumentLines(
-        [Description("Document ID obtained from ListCompanyDocuments")] Guid documentId,
+        [Description("Document ID obtained from ListFilings")] Guid documentId,
         [Description("First line to read (1-based, inclusive)")] int startLine,
         [Description(
             "Last line to read (1-based, inclusive). At most 2,000 lines are returned per call; a longer range is truncated with a note on how to continue."

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -72,7 +73,7 @@ public class RagSearchTools
 
     [McpServerTool(Name = "SearchDocuments", Title = "Search SEC Filings", ReadOnly = true)]
     [Description(
-        "Search SEC filings and earnings-call transcripts with hybrid keyword and semantic retrieval. Omit ticker to search every company, or provide one ticker to search only that company. Returns excerpts with document IDs for SearchDocument or ReadDocumentLines. Use excludeTickers and maxResultsPerCompany only for market-wide discovery; use ListCompanyDocuments to browse one company's available filings."
+        "Search SEC filings and earnings-call transcripts with hybrid keyword and semantic retrieval. Omit ticker to search every company, or provide one ticker to search only that company. Returns excerpts with document IDs for SearchDocument or ReadDocumentLines. Use excludeTickers and maxResultsPerCompany only for market-wide discovery; use ListFilings to browse filings newest first without a text query."
     )]
     public Task<string> SearchDocuments(
         [Description(
@@ -164,16 +165,14 @@ public class RagSearchTools
 
     [McpServerTool(Name = "SearchDocument", Title = "Search Within One Filing", ReadOnly = true)]
     [Description(
-        "Search one SEC filing or earnings-call transcript by document ID. semantic mode uses hybrid relevance and returns excerpts in document order with approximate line numbers. exact mode performs a literal case-insensitive substring match and returns precise matching lines. Get document IDs from SearchDocuments or ListCompanyDocuments; use ReadDocumentLines for surrounding text."
+        "Search one SEC filing or earnings-call transcript by document ID. semantic mode uses hybrid relevance and returns excerpts in document order with approximate line numbers. exact mode performs a literal case-insensitive substring match and returns precise matching lines. Get document IDs from SearchDocuments or ListFilings; use ReadDocumentLines for surrounding text."
     )]
     public Task<string> SearchDocument(
         [Description(
             "Search query — plain keywords or a short natural-language phrase. When too few excerpts match every word, the search automatically broadens to match any of the words. In searchMode 'exact', matched as a literal case-insensitive substring."
         )]
             string query,
-        [Description(
-            "Document ID obtained from ListCompanyDocuments or a SearchDocuments result header"
-        )]
+        [Description("Document ID obtained from ListFilings or a SearchDocuments result header")]
             Guid documentId,
         [Description("Maximum number of results to return (default: 5)")] int maxResults = 5,
         [Description(MaxExcerptCharsDescription)] int maxExcerptChars = 0,
@@ -217,7 +216,7 @@ public class RagSearchTools
                     // about the topic" — tell the caller the ID itself is wrong.
                     var document = await _documentRepository.Get(documentId);
                     if (document == null)
-                        return $"Document {documentId} not found — obtain a valid document ID from ListCompanyDocuments.";
+                        return $"Document {documentId} not found — obtain a valid document ID from ListFilings.";
 
                     return $"No matching excerpts found in this document ({document.DocumentType} filed {McpFormat.Invariant(document.ReportingDate, "yyyy-MM-dd")}). Try searchMode 'exact' for literal-term matches.";
                 }
@@ -236,21 +235,20 @@ public class RagSearchTools
         );
     }
 
-    [McpServerTool(
-        Name = "ListCompanyDocuments",
-        Title = "Browse Company Filings",
-        ReadOnly = true
-    )]
+    [McpServerTool(Name = "ListFilings", Title = "List Filings", ReadOnly = true)]
     [Description(
-        "List a company's stored SEC filings and earnings-call transcripts newest first. Returns document IDs, types, filing and reporting dates, line counts, and page totals. Supports date and document-type filters. Hidden document types remain excluded unless explicitly requested. Pass a returned ID to SearchDocument or ReadDocumentLines."
+        "List stored SEC filings and earnings-call transcripts newest first. Omit ticker for a market-wide feed or provide one ticker for a company-specific list. Returns company identity, document IDs, types, filing and reporting dates, SEC item numbers, line counts, and page totals. Supports date, document-type, and exact SEC item-number filters. Hidden document types remain excluded unless explicitly requested. Pass a returned ID to SearchDocument or ReadDocumentLines."
     )]
-    public Task<string> ListCompanyDocuments(
-        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+    public Task<string> ListFilings(
+        [Description("Optional company ticker symbol (e.g., AAPL, MSFT). Omit for all companies.")]
+            string ticker = null,
         [Description("Page number for pagination (default: 1)")] int page = 1,
         [Description("Maximum number of documents per page (default: 10)")] int maxItems = 10,
         [Description("Optional start date filter in YYYY-MM-DD format")] DateTime? startDate = null,
         [Description("Optional end date filter in YYYY-MM-DD format")] DateTime? endDate = null,
-        [Description(DocumentTypeDescription)] string documentType = null
+        [Description(DocumentTypeDescription)] string documentType = null,
+        [Description("Optional exact SEC current-report item number, e.g. 2.02, 5.02, or 1.01.")]
+            string itemNumber = null
     )
     {
         return _runner.Execute(
@@ -271,33 +269,46 @@ public class RagSearchTools
                         return UnknownDocumentType("documentType", documentType);
                 }
 
-                var normalizedTicker = McpToolExecutor.NormalizeTicker(ticker);
-                if (normalizedTicker == null)
-                    return McpToolExecutor.StockNotFound(ticker);
+                var normalizedItemNumber = SecFilingItemNumber.Normalize(itemNumber);
+                if (!string.IsNullOrWhiteSpace(itemNumber) && normalizedItemNumber == null)
+                    return $"Invalid itemNumber '{itemNumber}'. Use an SEC item number such as 2.02, 5.02, or 1.01.";
 
-                var stock = await _commonStockRepository.GetByTicker(normalizedTicker);
-                if (stock == null)
-                    return McpToolExecutor.StockNotFound(ticker);
+                CommonStock stock = null;
+                if (!string.IsNullOrWhiteSpace(ticker))
+                {
+                    var normalizedTicker = McpToolExecutor.NormalizeTicker(ticker);
+                    if (normalizedTicker == null)
+                        return McpToolExecutor.StockNotFound(ticker);
+
+                    stock = await _commonStockRepository.GetByTicker(normalizedTicker);
+                    if (stock == null)
+                        return McpToolExecutor.StockNotFound(ticker);
+                }
 
                 maxItems = McpLimit.Clamp(maxItems);
+                var offset = ((long)page - 1) * maxItems;
+                if (offset > McpLimit.MaxOffset)
+                    return $"Page {page} starts beyond the maximum supported offset of {McpFormat.WholeNumber(McpLimit.MaxOffset)} — lower page or narrow the filing filters.";
 
                 int totalCount;
                 List<SecDocumentInfo> documents;
                 try
                 {
                     totalCount = await _secDocumentService.CountDocuments(
-                        stock.Ticker,
+                        stock?.Ticker,
                         startDate,
                         endDate,
-                        parsedType
+                        parsedType,
+                        normalizedItemNumber
                     );
                     documents = await _secDocumentService.GetRecentDocuments(
-                        stock.Ticker,
+                        stock?.Ticker,
                         startDate,
                         endDate,
                         maxItems,
                         page,
-                        parsedType
+                        parsedType,
+                        normalizedItemNumber
                     );
                 }
                 catch (ApplicationException ex)
@@ -309,12 +320,19 @@ public class RagSearchTools
                 {
                     // Distinguish "the filters excluded everything" from "nothing is
                     // ingested for this company" — the ticker itself is already known good.
-                    var hasFilters = startDate.HasValue || endDate.HasValue || parsedType != null;
+                    var hasFilters =
+                        startDate.HasValue
+                        || endDate.HasValue
+                        || parsedType != null
+                        || normalizedItemNumber != null;
                     if (!hasFilters)
-                        return $"No documents found for ticker {stock.Ticker}";
+                        return stock == null
+                            ? "No filings are stored."
+                            : $"No documents found for ticker {stock.Ticker}";
 
-                    var unfiltered = await _secDocumentService.CountDocuments(stock.Ticker);
-                    return $"No documents match the given filters for {stock.Ticker} — {McpFormat.WholeNumber(unfiltered)} document(s) exist without them. Relax documentType/startDate/endDate.";
+                    var scope = stock == null ? "the market-wide corpus" : stock.Ticker;
+                    var unfiltered = await _secDocumentService.CountDocuments(stock?.Ticker);
+                    return $"No documents match the given filters for {scope} — {McpFormat.WholeNumber(unfiltered)} document(s) exist without them. Relax documentType/itemNumber/startDate/endDate.";
                 }
 
                 var totalPages = (totalCount + maxItems - 1) / maxItems;
@@ -322,21 +340,26 @@ public class RagSearchTools
                     return $"Page {page} is out of range — {McpFormat.WholeNumber(totalCount)} matching document(s) fill only {McpFormat.WholeNumber(totalPages)} page(s) of {maxItems}.";
 
                 var result = MarkdownTable.Start(
-                    $"Financial documents for {stock.Name} ({stock.Ticker}) — page {page} of {McpFormat.WholeNumber(totalPages)} ({McpFormat.WholeNumber(totalCount)} documents):",
-                    "ID | Type | Filed | Reporting For | Lines",
-                    "---|------|-------|---------------|------"
+                    stock == null
+                        ? $"Market-wide filings — page {page} of {McpFormat.WholeNumber(totalPages)} ({McpFormat.WholeNumber(totalCount)} documents):"
+                        : $"Financial documents for {MarkdownTable.EscapeCell(stock.Name)} ({MarkdownTable.EscapeCell(stock.Ticker)}) — page {page} of {McpFormat.WholeNumber(totalPages)} ({McpFormat.WholeNumber(totalCount)} documents):",
+                    "Ticker | Company | ID | Type | Filed | Reporting For | Items | Lines",
+                    "-------|---------|----|------|-------|---------------|-------|------"
                 );
 
                 result.AppendRows(
                     documents,
                     doc =>
-                        $"{doc.Id} | {doc.DocumentType} | {doc.ReportingDate:yyyy-MM-dd} | {doc.ReportingForDate:yyyy-MM-dd} | {McpFormat.WholeNumber(doc.LineCount)}"
+                    {
+                        var items = string.Join(",", SecFilingItemNumber.ParseStored(doc.Items));
+                        return $"{MarkdownTable.EscapeCell(doc.Ticker)} | {MarkdownTable.EscapeCell(doc.CompanyName)} | {doc.Id} | {doc.DocumentType} | {McpFormat.Invariant(doc.ReportingDate, "yyyy-MM-dd")} | {McpFormat.Invariant(doc.ReportingForDate, "yyyy-MM-dd")} | {MarkdownTable.EscapeCell(items, "—")} | {McpFormat.WholeNumber(doc.LineCount)}";
+                    }
                 );
 
                 return result.ToString();
             },
-            "ListCompanyDocuments",
-            $"ticker: {ticker}"
+            "ListFilings",
+            $"ticker: {ticker}, itemNumber: {itemNumber}"
         );
     }
 

--- a/src/Equibles.Yahoo.Mcp/Tools/DividendTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/DividendTools.cs
@@ -1,0 +1,116 @@
+using System.ComponentModel;
+using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.Errors.Data.Models;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Yahoo.Mcp.Tools;
+
+[McpServerToolType]
+public class DividendTools
+{
+    private readonly CashDividendRepository _cashDividendRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly McpToolRunner _runner;
+
+    public DividendTools(
+        CashDividendRepository cashDividendRepository,
+        CommonStockRepository commonStockRepository,
+        ErrorManager errorManager,
+        ILogger<DividendTools> logger
+    )
+    {
+        _cashDividendRepository = cashDividendRepository;
+        _commonStockRepository = commonStockRepository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "GetDividendHistory", Title = "Dividend History", ReadOnly = true)]
+    [Description(
+        "Get a company's stored declared cash dividends newest first. Each row gives the ex-dividend date, cash amount per share in USD, and source. Date filters apply to the ex-dividend date. Future ex-dates can appear after a dividend is declared. Dividend records are issuer-level and available only through the company's current primary ticker; a secondary share class is never assumed to have the same dividend."
+    )]
+    public Task<string> GetDividendHistory(
+        [Description("Current primary stock ticker (e.g., AAPL, MSFT).")] string ticker,
+        [Description("Optional earliest ex-dividend date in YYYY-MM-DD format.")]
+            DateTime? startDate = null,
+        [Description("Optional latest ex-dividend date in YYYY-MM-DD format.")]
+            DateTime? endDate = null,
+        [Description("Maximum number of records to return (default: 20, max: 500).")]
+            int maxResults = 20,
+        [Description("Number of newest matching records to skip for pagination (default: 0).")]
+            int offset = 0
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                if (startDate.HasValue && endDate.HasValue && startDate.Value > endDate.Value)
+                {
+                    return $"startDate {McpFormat.Invariant(startDate.Value, "yyyy-MM-dd")} is after endDate {McpFormat.Invariant(endDate.Value, "yyyy-MM-dd")} — swap the values.";
+                }
+
+                var normalizedTicker = TickerNormalizer.NormalizeDashListed(ticker);
+                if (normalizedTicker == null)
+                    return McpToolExecutor.StockNotFound(ticker);
+
+                var stock = await _commonStockRepository.GetByTicker(normalizedTicker);
+                if (stock == null)
+                    return McpToolExecutor.StockNotFound(ticker);
+                if (!string.Equals(stock.Ticker, normalizedTicker, StringComparison.Ordinal))
+                {
+                    return $"Dividend history is available only for the current primary ticker {stock.Ticker}; {normalizedTicker} is a separate listing and is not assumed to share its dividends.";
+                }
+
+                var start = startDate.HasValue
+                    ? DateOnly.FromDateTime(startDate.Value)
+                    : (DateOnly?)null;
+                var end = endDate.HasValue ? DateOnly.FromDateTime(endDate.Value) : (DateOnly?)null;
+                maxResults = McpLimit.Clamp(maxResults);
+                offset = McpLimit.ClampOffset(offset);
+
+                var query = _cashDividendRepository.GetHistory(stock.Id, start, end);
+                var total = await query.CountAsync();
+                var dividends = await query.Skip(offset).Take(maxResults).ToListAsync();
+
+                if (dividends.Count == 0)
+                {
+                    if (total > 0)
+                        return McpOutput.PagedTruncationNote(0, total, offset);
+
+                    return start.HasValue || end.HasValue
+                        ? $"No stored cash-dividend records match the ex-date range for {stock.Ticker}."
+                        : $"No cash-dividend records are stored for {stock.Ticker}.";
+                }
+
+                var result = MarkdownTable.Start(
+                    $"Declared cash dividends for {MarkdownTable.EscapeCell(stock.Name)} ({MarkdownTable.EscapeCell(stock.Ticker)}), newest first:",
+                    "Ex-Date | Amount Per Share | Source",
+                    "--------|------------------|-------"
+                );
+                result.AppendRows(
+                    dividends,
+                    dividend =>
+                        $"{McpFormat.Invariant(dividend.ExDate, "yyyy-MM-dd")} | ${McpFormat.Price(dividend.AmountPerShare)} | {dividend.Source}"
+                );
+
+                var pagingNote = McpOutput.PagedTruncationNote(dividends.Count, total, offset);
+                if (!string.IsNullOrEmpty(pagingNote))
+                {
+                    result.AppendLine();
+                    result.AppendLine(pagingNote);
+                }
+
+                return result.ToString();
+            },
+            "GetDividendHistory",
+            $"ticker: {ticker}"
+        );
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/DividendToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/DividendToolsTests.cs
@@ -1,0 +1,157 @@
+using System.Globalization;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Mcp.Tools;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class DividendToolsTests : ParadeDbMcpTestBase
+{
+    public DividendToolsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private DividendTools Sut() =>
+        new(
+            new CashDividendRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<DividendTools>()
+        );
+
+    private async Task<CommonStock> SeedStock(
+        string ticker = "AAPL",
+        string name = "Apple Inc.",
+        params string[] secondaryTickers
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = name,
+            Cik = Random.Shared.NextInt64(1_000_000_000L, 9_999_999_999L).ToString(),
+            SecondaryTickers = secondaryTickers.ToList(),
+        };
+        DbContext.Add(stock);
+        await DbContext.SaveChangesAsync();
+        return stock;
+    }
+
+    private async Task SeedDividend(
+        CommonStock stock,
+        DateOnly exDate,
+        decimal amount,
+        CashDividendSource source = CashDividendSource.Yahoo
+    )
+    {
+        DbContext.Add(
+            new CashDividend
+            {
+                CommonStockId = stock.Id,
+                CommonStock = stock,
+                ExDate = exDate,
+                AmountPerShare = amount,
+                Source = source,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetDividendHistory_ReturnsNewestFirstWithSource()
+    {
+        var stock = await SeedStock();
+        await SeedDividend(stock, new DateOnly(2025, 2, 10), 0.25m);
+        await SeedDividend(stock, new DateOnly(2025, 5, 12), 0.26m, CashDividendSource.External);
+
+        var result = await Sut().GetDividendHistory("AAPL");
+
+        result.Should().Contain("Declared cash dividends for Apple Inc. (AAPL), newest first:");
+        result.IndexOf("2025-05-12").Should().BeLessThan(result.IndexOf("2025-02-10"));
+        result.Should().Contain("$0.26 | External");
+    }
+
+    [Fact]
+    public async Task GetDividendHistory_FiltersByExDateAndPagesWithOffset()
+    {
+        var stock = await SeedStock();
+        await SeedDividend(stock, new DateOnly(2025, 2, 10), 0.25m);
+        await SeedDividend(stock, new DateOnly(2025, 5, 12), 0.26m);
+        await SeedDividend(stock, new DateOnly(2025, 8, 11), 0.27m);
+
+        var filtered = await Sut()
+            .GetDividendHistory(
+                "AAPL",
+                startDate: new DateTime(2025, 5, 1),
+                endDate: new DateTime(2025, 8, 1)
+            );
+        var secondPage = await Sut().GetDividendHistory("AAPL", maxResults: 1, offset: 1);
+
+        filtered.Should().Contain("2025-05-12");
+        filtered.Should().NotContain("2025-02-10");
+        filtered.Should().NotContain("2025-08-11");
+        secondPage.Should().Contain("2025-05-12");
+        secondPage.Should().Contain("pass offset=2 to continue");
+    }
+
+    [Fact]
+    public async Task GetDividendHistory_SecondaryTicker_IsRejected()
+    {
+        await SeedStock("BRK-B", "Berkshire Hathaway Inc.", "BRK-A");
+
+        var result = await Sut().GetDividendHistory("BRK.A");
+
+        result.Should().Contain("available only for the current primary ticker BRK-B");
+        result.Should().Contain("BRK-A is a separate listing");
+    }
+
+    [Fact]
+    public async Task GetDividendHistory_InvertedDateRange_ReturnsCorrectiveError()
+    {
+        var result = await Sut()
+            .GetDividendHistory(
+                "AAPL",
+                startDate: new DateTime(2025, 8, 1),
+                endDate: new DateTime(2025, 5, 1)
+            );
+
+        result.Should().Contain("startDate 2025-08-01 is after endDate 2025-05-01");
+    }
+
+    [Fact]
+    public async Task GetDividendHistory_UnderNonGregorianCulture_RendersIsoDate()
+    {
+        var stock = await SeedStock();
+        await SeedDividend(stock, new DateOnly(2025, 5, 12), 0.26m);
+
+        var previous = CultureInfo.CurrentCulture;
+        string result;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+            result = await Sut().GetDividendHistory("AAPL");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+
+        result.Should().Contain("2025-05-12 | $0.26");
+    }
+
+    [Fact]
+    public async Task GetDividendHistory_EscapesCompanyNameInHeading()
+    {
+        var stock = await SeedStock(name: "Pipe | Corp\\Line\nTwo");
+        await SeedDividend(stock, new DateOnly(2025, 5, 12), 0.26m);
+
+        var result = await Sut().GetDividendHistory("AAPL");
+
+        result.Should().Contain(@"Pipe \| Corp\\Line Two (AAPL)");
+        result.Should().NotContain("Corp\\Line\nTwo");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsListFilingsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsListFilingsCultureInvarianceTests.cs
@@ -15,9 +15,9 @@ using File = Equibles.Media.Data.Models.File;
 namespace Equibles.IntegrationTests.Mcp;
 
 [Collection(ParadeDbCollection.Name)]
-public class RagSearchToolsListCompanyDocumentsCultureInvarianceTests : ParadeDbMcpTestBase
+public class RagSearchToolsListFilingsCultureInvarianceTests : ParadeDbMcpTestBase
 {
-    public RagSearchToolsListCompanyDocumentsCultureInvarianceTests(ParadeDbFixture fixture)
+    public RagSearchToolsListFilingsCultureInvarianceTests(ParadeDbFixture fixture)
         : base(fixture) { }
 
     private RagSearchTools Sut()
@@ -42,15 +42,8 @@ public class RagSearchToolsListCompanyDocumentsCultureInvarianceTests : ParadeDb
         );
     }
 
-    // Contract (the repo-wide MCP rule, enforced by McpFormat and the dozens of InvariantCulture
-    // MCP call sites that comment "MCP markdown must not fork the separators by host locale"):
-    // LLM-facing markdown must render numbers identically on every host locale. The
-    // ListCompanyDocuments table builds the Lines cell with the culture-implicit :N0 specifier
-    // (RagSearchTools.cs:174), which honours the thread CurrentCulture — de-DE swaps the thousand
-    // separator (1,500 -> 1.500), forking the response by host locale. Same bug class as the
-    // already-pinned ReadDocumentLines (GH-3110) and GetLatestClosingPrices (GH-3100) repros.
     [Fact]
-    public async Task ListCompanyDocuments_UnderNonInvariantCulture_RendersLineCountCultureInvariantly()
+    public async Task ListFilings_UnderNonGregorianCulture_RendersDatesAndCountsInvariantly()
     {
         var stock = new CommonStock
         {
@@ -85,27 +78,21 @@ public class RagSearchToolsListCompanyDocumentsCultureInvarianceTests : ParadeDb
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
-        // Pin de-DE only for the rendering call; CurrentCulture flows through the tool's await
-        // chain via ExecutionContext. Base class restores invariant.
         var previous = CultureInfo.CurrentCulture;
         string result;
         try
         {
-            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
-            result = await Sut().ListCompanyDocuments("AAPL");
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+            result = await Sut().ListFilings("AAPL");
         }
         finally
         {
             CultureInfo.CurrentCulture = previous;
         }
 
-        // The Lines cell must render with the en-US thousand comma on any host locale;
-        // de-DE would produce "| 1.500".
+        result.Should().Contain("2026-03-15 | 2026-02-15");
         result
             .Should()
-            .Contain(
-                "| 1,500",
-                "the MCP document-listing table must not fork the thousand separator by host locale"
-            );
+            .Contain("| 1,500", "the MCP filing table must not fork numbers by host locale");
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
@@ -71,7 +71,8 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
         string ticker = "AAPL",
         string companyName = "Apple Inc",
         DocumentType documentType = null,
-        DateOnly? reportingDate = null
+        DateOnly? reportingDate = null,
+        string items = null
     )
     {
         documentType ??= DocumentType.TenK;
@@ -115,6 +116,7 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
             DocumentType = documentType,
             ReportingDate = docReportingDate,
             ReportingForDate = docReportingDate.AddDays(-30),
+            Items = items,
             LineCount = chunkContents.Length,
         };
         DbContext.Set<Document>().Add(document);
@@ -331,7 +333,7 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
         var result = await Sut().SearchDocuments("services segment revenue");
 
         // The ID feeds SearchDocument/ReadDocumentLines directly — without it the caller
-        // must re-derive it from ListCompanyDocuments by fuzzy type+date matching.
+        // must re-derive it from ListFilings by fuzzy type+date matching.
         result.Should().Contain($"(ID: {document.Id})");
     }
 
@@ -368,9 +370,7 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
         // topic" — the caller needs to know the ID itself is wrong.
         result
             .Should()
-            .Be(
-                $"Document {missingId} not found — obtain a valid document ID from ListCompanyDocuments."
-            );
+            .Be($"Document {missingId} not found — obtain a valid document ID from ListFilings.");
     }
 
     [Fact]
@@ -461,12 +461,12 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
             .Be("Unknown searchMode \"fuzzy\" — pass 'semantic' (default) or 'exact'.");
     }
 
-    // ── ListCompanyDocuments ────────────────────────────────────────────
+    // ── ListFilings ────────────────────────────────────────────
 
     [Fact]
-    public async Task ListCompanyDocuments_UnknownTicker_ReturnsStockNotFound()
+    public async Task ListFilings_UnknownTicker_ReturnsStockNotFound()
     {
-        var result = await Sut().ListCompanyDocuments("ZZZZ");
+        var result = await Sut().ListFilings("ZZZZ");
 
         // An unknown ticker is not the same empty state as "known company, nothing
         // ingested" — the caller must be told the ticker itself missed.
@@ -474,7 +474,7 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_KnownTickerNoDocuments_ReturnsNoDocumentsMessage()
+    public async Task ListFilings_KnownTickerNoDocuments_ReturnsNoDocumentsMessage()
     {
         DbContext
             .Set<CommonStock>()
@@ -488,13 +488,13 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
             );
         await DbContext.SaveChangesAsync();
 
-        var result = await Sut().ListCompanyDocuments("NODOC");
+        var result = await Sut().ListFilings("NODOC");
 
         result.Should().Contain("No documents found for ticker NODOC");
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_FiltersExcludeEverything_SaysDocumentsExistWithoutThem()
+    public async Task ListFilings_FiltersExcludeEverything_SaysDocumentsExistWithoutThem()
     {
         await SeedDocumentWithChunks(
             ticker: "AAPL",
@@ -504,7 +504,7 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
         );
 
         var result = await Sut()
-            .ListCompanyDocuments(
+            .ListFilings(
                 "AAPL",
                 startDate: new DateTime(1990, 1, 1),
                 endDate: new DateTime(1990, 12, 31)
@@ -516,7 +516,7 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_UnknownDocumentType_ReturnsAcceptedValues()
+    public async Task ListFilings_UnknownDocumentType_ReturnsAcceptedValues()
     {
         await SeedDocumentWithChunks(
             ticker: "AAPL",
@@ -525,14 +525,14 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
 
         // The old lenient behavior returned an UNFILTERED list for a near-miss like
         // 'AnnualReport' — indistinguishable from a correctly filtered one.
-        var result = await Sut().ListCompanyDocuments("AAPL", documentType: "AnnualReport");
+        var result = await Sut().ListFilings("AAPL", documentType: "AnnualReport");
 
         result.Should().StartWith("Unknown documentType 'AnnualReport'.");
         result.Should().Contain("'TenK' (10-K)");
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_PageZero_ReturnsExplicitError()
+    public async Task ListFilings_PageZero_ReturnsExplicitError()
     {
         await SeedDocumentWithChunks(
             ticker: "AAPL",
@@ -541,13 +541,21 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
 
         // page=0 used to flow into Skip(-maxItems) — a negative OFFSET PostgreSQL rejects,
         // surfacing as the generic internal-error sentinel.
-        var result = await Sut().ListCompanyDocuments("AAPL", page: 0);
+        var result = await Sut().ListFilings("AAPL", page: 0);
 
         result.Should().Be("Invalid page 0 — pages are numbered from 1.");
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_PagePastEnd_ReturnsOutOfRangeMessage()
+    public async Task ListFilings_PageBeyondMaximumOffset_ReturnsExplicitError()
+    {
+        var result = await Sut().ListFilings(page: int.MaxValue, maxItems: 500);
+
+        result.Should().Contain("maximum supported offset of 100,000");
+    }
+
+    [Fact]
+    public async Task ListFilings_PagePastEnd_ReturnsOutOfRangeMessage()
     {
         await SeedDocumentWithChunks(
             ticker: "AAPL",
@@ -556,14 +564,14 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
 
         // Paging past the end used to return "No documents found for ticker AAPL" even
         // though documents plainly exist — the caller would conclude the company has none.
-        var result = await Sut().ListCompanyDocuments("AAPL", page: 5);
+        var result = await Sut().ListFilings("AAPL", page: 5);
 
         result.Should().Contain("Page 5 is out of range");
         result.Should().Contain("1 matching document(s)");
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_HiddenDocumentType_ExcludedUnlessExplicitlyRequested()
+    public async Task ListFilings_HiddenDocumentType_ExcludedUnlessExplicitlyRequested()
     {
         // Registration is process-global and idempotent (TryAdd); the type is test-only
         // and no other test filters on it.
@@ -587,9 +595,8 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
             chunkContents: new[] { "News item content." }
         );
 
-        var unfiltered = await Sut().ListCompanyDocuments("AAPL");
-        var explicitlyRequested = await Sut()
-            .ListCompanyDocuments("AAPL", documentType: "TestHiddenNews");
+        var unfiltered = await Sut().ListFilings("AAPL");
+        var explicitlyRequested = await Sut().ListFilings("AAPL", documentType: "TestHiddenNews");
 
         // Hidden types are news, not filings: they must not crowd the unfiltered list,
         // but an explicit request for the type still returns them.
@@ -601,7 +608,7 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_RendersDocumentsForCompany()
+    public async Task ListFilings_RendersDocumentsForCompany()
     {
         await SeedDocumentWithChunks(
             ticker: "AAPL",
@@ -616,17 +623,94 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
             chunkContents: new[] { "Quarterly content." }
         );
 
-        var result = await Sut().ListCompanyDocuments("AAPL");
+        var result = await Sut().ListFilings("AAPL");
 
         result.Should().Contain("Financial documents for Apple Inc (AAPL)");
         result.Should().Contain("10-K");
         result.Should().Contain("10-Q");
         result.Should().Contain("page 1");
-        result.Should().Contain("ID | Type | Filed | Reporting For | Lines");
+        result
+            .Should()
+            .Contain("Ticker | Company | ID | Type | Filed | Reporting For | Items | Lines");
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_OrdersNewestFirst()
+    public async Task ListFilings_WithoutTicker_ReturnsMarketWideFilings()
+    {
+        await SeedDocumentWithChunks(
+            ticker: "AAPL",
+            companyName: "Apple Inc",
+            reportingDate: new DateOnly(2026, 3, 15),
+            chunkContents: new[] { "Apple filing." }
+        );
+        await SeedDocumentWithChunks(
+            ticker: "MSFT",
+            companyName: "Microsoft Corp",
+            reportingDate: new DateOnly(2026, 4, 30),
+            chunkContents: new[] { "Microsoft filing." }
+        );
+
+        var result = await Sut().ListFilings();
+
+        result.Should().Contain("Market-wide filings");
+        result.Should().Contain("AAPL | Apple Inc");
+        result.Should().Contain("MSFT | Microsoft Corp");
+    }
+
+    [Fact]
+    public async Task ListFilings_EscapesUntrustedMarkdownCells()
+    {
+        await SeedDocumentWithChunks(
+            ticker: "PIPE",
+            companyName: "Pipe | Corp\\Line\nTwo",
+            reportingDate: new DateOnly(2026, 4, 30),
+            items: "2.02|9.01",
+            chunkContents: new[] { "Filing." }
+        );
+
+        var result = await Sut().ListFilings("PIPE");
+
+        result.Should().Contain(@"PIPE | Pipe \| Corp\\Line Two");
+        result.Should().Contain(@"2.02\|9.01");
+        result.Should().NotContain("Corp\\Line\nTwo");
+    }
+
+    [Fact]
+    public async Task ListFilings_FiltersByExactItemNumber()
+    {
+        await SeedDocumentWithChunks(
+            ticker: "AAPL",
+            documentType: DocumentType.EightK,
+            reportingDate: new DateOnly(2026, 4, 10),
+            items: "2.02,9.01",
+            chunkContents: new[] { "Earnings release." }
+        );
+        await SeedDocumentWithChunks(
+            ticker: "MSFT",
+            companyName: "Microsoft Corp",
+            documentType: DocumentType.EightK,
+            reportingDate: new DateOnly(2026, 4, 11),
+            items: "1.02",
+            chunkContents: new[] { "Agreement." }
+        );
+
+        var result = await Sut().ListFilings(itemNumber: "2.02");
+
+        result.Should().Contain("AAPL | Apple Inc");
+        result.Should().Contain("2.02,9.01");
+        result.Should().NotContain("MSFT | Microsoft Corp");
+    }
+
+    [Fact]
+    public async Task ListFilings_InvalidItemNumber_ReturnsCorrectiveError()
+    {
+        var result = await Sut().ListFilings(itemNumber: "2.2");
+
+        result.Should().StartWith("Invalid itemNumber '2.2'.");
+    }
+
+    [Fact]
+    public async Task ListFilings_OrdersNewestFirst()
     {
         await SeedDocumentWithChunks(
             ticker: "AAPL",
@@ -640,13 +724,13 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
             chunkContents: new[] { "Newer filing." }
         );
 
-        var result = await Sut().ListCompanyDocuments("AAPL");
+        var result = await Sut().ListFilings("AAPL");
 
         result.IndexOf("2026-04-30").Should().BeLessThan(result.IndexOf("2025-06-30"));
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_FiltersByDocumentType()
+    public async Task ListFilings_FiltersByDocumentType()
     {
         await SeedDocumentWithChunks(
             ticker: "AAPL",
@@ -661,14 +745,14 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
             chunkContents: new[] { "Current report." }
         );
 
-        var result = await Sut().ListCompanyDocuments("AAPL", documentType: "EightK");
+        var result = await Sut().ListFilings("AAPL", documentType: "EightK");
 
         result.Should().Contain("8-K");
         result.Should().NotContain("10-K");
     }
 
     [Fact]
-    public async Task ListCompanyDocuments_PaginatesAcrossPages()
+    public async Task ListFilings_PaginatesAcrossPages()
     {
         // Seed 12 docs so pages 1 and 2 each have content; page 2 should return docs 11-12.
         for (var i = 0; i < 12; i++)
@@ -680,8 +764,8 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
             );
         }
 
-        var page1 = await Sut().ListCompanyDocuments("AAPL", page: 1);
-        var page2 = await Sut().ListCompanyDocuments("AAPL", page: 2);
+        var page1 = await Sut().ListFilings("AAPL", page: 1);
+        var page2 = await Sut().ListFilings("AAPL", page: 2);
 
         page1.Should().Contain("page 1");
         page2.Should().Contain("page 2");

--- a/tests/Equibles.IntegrationTests/Mcp/Server/McpServerToolInvocationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Server/McpServerToolInvocationTests.cs
@@ -131,7 +131,7 @@ public class McpServerToolInvocationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task CallTool_ListCompanyDocuments_EmbeddingsDisabled_ActivatesSecSearchGraph()
+    public async Task CallTool_ListFilings_EmbeddingsDisabled_ActivatesSecSearchGraph()
     {
         var httpClient = _serverFixture.CreateClient();
         httpClient.BaseAddress = new Uri("http://localhost/");
@@ -147,7 +147,7 @@ public class McpServerToolInvocationTests : IAsyncLifetime
 
         await using var client = await McpClient.CreateAsync(transport);
         var result = await client.CallToolAsync(
-            toolName: "ListCompanyDocuments",
+            toolName: "ListFilings",
             arguments: new Dictionary<string, object> { ["ticker"] = "ZZZZ" }
         );
 

--- a/tests/Equibles.IntegrationTests/Sec/SecDocumentServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecDocumentServiceTests.cs
@@ -46,7 +46,8 @@ public class SecDocumentServiceTests
         CommonStock stock,
         DocumentType docType,
         DateOnly reportingDate,
-        DateOnly reportingForDate
+        DateOnly reportingForDate,
+        string items = null
     )
     {
         var file = new Equibles.Media.Data.Models.File
@@ -65,6 +66,7 @@ public class SecDocumentServiceTests
             DocumentType = docType,
             ReportingDate = reportingDate,
             ReportingForDate = reportingForDate,
+            Items = items,
             LineCount = 100,
             Content = file,
             ContentId = file.Id,
@@ -75,11 +77,26 @@ public class SecDocumentServiceTests
     }
 
     [Fact]
-    public async Task GetRecentDocuments_NullTicker_ThrowsApplicationException()
+    public async Task GetRecentDocuments_NullTicker_ReturnsMarketWideDocuments()
     {
-        var act = () => _sut.GetRecentDocuments(null);
+        var apple = CreateStock("AAPL", "Apple Inc.");
+        var microsoft = CreateStock("MSFT", "Microsoft Corp.");
+        CreateDocument(
+            apple,
+            DocumentType.TenK,
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2023, 12, 31)
+        );
+        CreateDocument(
+            microsoft,
+            DocumentType.TenQ,
+            new DateOnly(2024, 4, 1),
+            new DateOnly(2024, 3, 31)
+        );
 
-        await act.Should().ThrowAsync<ApplicationException>().WithMessage("*Ticker*null*");
+        var result = await _sut.GetRecentDocuments();
+
+        result.Select(document => document.Ticker).Should().Equal("MSFT", "AAPL");
     }
 
     [Fact]
@@ -177,6 +194,31 @@ public class SecDocumentServiceTests
 
         result.Should().ContainSingle();
         result[0].DocumentType.Should().Be(DocumentType.TenQ);
+    }
+
+    [Fact]
+    public async Task GetRecentDocuments_FilterByItemNumber_UsesExactTokenMatch()
+    {
+        var stock = CreateStock("AAPL");
+        CreateDocument(
+            stock,
+            DocumentType.EightK,
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2023, 12, 31),
+            "2.02,9.01"
+        );
+        CreateDocument(
+            stock,
+            DocumentType.EightK,
+            new DateOnly(2024, 2, 1),
+            new DateOnly(2024, 1, 31),
+            "1.02"
+        );
+
+        var result = await _sut.GetRecentDocuments("AAPL", itemNumber: "2.02");
+
+        result.Should().ContainSingle();
+        result[0].Items.Should().Be("2.02,9.01");
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -300,7 +300,7 @@ public class McpModuleToolDiscoveryTests
 
         toolNames.Should().Contain("SearchDocuments");
         toolNames.Should().Contain("SearchDocument");
-        toolNames.Should().Contain("ListCompanyDocuments");
+        toolNames.Should().Contain("ListFilings");
         toolNames.Should().Contain("ReadDocumentLines");
         toolNames.Should().Contain("GetFailsToDeliver");
         toolNames.Should().Contain("GetFormDOfferings");
@@ -398,7 +398,7 @@ public class McpModuleToolDiscoveryTests
                 {
                     "SearchDocuments",
                     "SearchDocument",
-                    "ListCompanyDocuments",
+                    "ListFilings",
                     "ReadDocumentLines",
                     "GetFailsToDeliver",
                     "GetFormDOfferings",
@@ -448,6 +448,7 @@ public class McpModuleToolDiscoveryTests
                 {
                     "GetStockPrices",
                     "GetLatestClosingPrices",
+                    "GetDividendHistory",
                     "GetStochasticOscillator",
                     "GetAverageTrueRange",
                     "GetOnBalanceVolume",


### PR DESCRIPTION
## Summary
- replace the public ListCompanyDocuments MCP tool with ListFilings while preserving company-scoped filtering and paging
- add market-wide filing discovery with exact SEC item filtering
- add stored cash-dividend history and update OSS documentation

## Verification
- dotnet build Equibles.sln -c Release --no-restore
- 4,736 unit tests passed
- 50 focused integration tests passed
- CSharpier checks passed
- independent review found no remaining findings