### PR TITLE
fix(holdings): index stuck value repairs

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -165,6 +165,21 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
             .HasDatabaseName("IX_InstitutionalHolding_ValuePending_Pairs")
             .HasFilter("\"ValuePending\"");
 
+        // Worklist for the bounded stuck-zero repair. The table holds tens of millions of
+        // historical rows, while only the abandoned zero backlog matches this predicate.
+        // Leading with Id satisfies ORDER BY Id + LIMIT without scanning and heap-filtering the
+        // primary key. Entries disappear as the repair publishes FiledValue, so the index
+        // converges toward an empty steady state instead of indexing the holdings corpus.
+        builder
+            .Entity<InstitutionalHolding>()
+            .HasIndex(h => h.Id)
+            .HasDatabaseName("IX_InstitutionalHolding_StuckZeroRepair")
+            .HasFilter(
+                "\"Value\" = 0 AND NOT \"ValuePending\" AND NOT \"ValueUnavailable\" "
+                    + "AND \"FiledValue\" IS NOT NULL AND \"FiledValue\" > 0"
+            )
+            .IsCreatedConcurrently();
+
         builder.Entity<UnmappedCusip>();
         builder.Entity<FilingOtherManager>();
         builder.Entity<ProcessedDataSet>();

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
@@ -90,9 +90,9 @@ namespace Equibles.Holdings.HostedService.Services;
 /// Filed population) or re-exhausts into a retry stamp this phase excludes. Phase 3 terminates
 /// because the recalculator guards the same number this phase tests — the effective per-share
 /// price (factor × close) — so a reset row can never re-derive back above the cap and be reset
-/// again. The candidate predicates are not index-served (none are selective enough to earn one),
-/// so a drained backlog still costs bounded sequential scans per daily cycle — accepted for a 24h
-/// cadence. Affected filing rollups and AUM quarters are re-derived through
+/// again. The stuck-zero phase is served by a partial Id worklist index whose entries disappear
+/// as rows heal. The other candidate predicates are not index-served. Affected filing rollups and
+/// AUM quarters are re-derived through
 /// <see cref="HoldingsRollupRefresher"/> in the same pass — a healed position with a stale rollup
 /// would just move the lie one aggregate up.
 /// </para>
@@ -397,13 +397,10 @@ public class HoldingValueFallbackRepairService
     /// <summary>
     /// Publishes the filed value on rows the old ladder abandoned at <c>Value = 0</c>.
     /// </summary>
-    private async Task<int> HealStuckZeros(CancellationToken cancellationToken)
-    {
-        using var scope = _scopeFactory.CreateScope();
-        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
-        ExtendCommandTimeout(dbContext);
-
-        var rows = await dbContext
+    internal static IQueryable<InstitutionalHolding> BuildStuckZeroCandidateQuery(
+        EquiblesFinancialDbContext dbContext
+    ) =>
+        dbContext
             .Set<InstitutionalHolding>()
             .Include(h => h.ManagerEntries)
             .Where(h =>
@@ -414,8 +411,15 @@ public class HoldingValueFallbackRepairService
                 && h.FiledValue > 0
             )
             .OrderBy(h => h.Id)
-            .Take(MaxRowsPerCycle)
-            .ToListAsync(cancellationToken);
+            .Take(MaxRowsPerCycle);
+
+    private async Task<int> HealStuckZeros(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        ExtendCommandTimeout(dbContext);
+
+        var rows = await BuildStuckZeroCandidateQuery(dbContext).ToListAsync(cancellationToken);
 
         if (rows.Count == 0)
         {

--- a/src/Equibles.Migrations/Migrations/20260830153706_AddHoldingStuckZeroRepairIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260830153706_AddHoldingStuckZeroRepairIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260830153706_AddHoldingStuckZeroRepairIndex")]
+    partial class AddHoldingStuckZeroRepairIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260830153706_AddHoldingStuckZeroRepairIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260830153706_AddHoldingStuckZeroRepairIndex.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <summary>
+    /// Adds the small partial worklist used by the abandoned holding-value repair. The holdings
+    /// table is 72 GB in production, so both retry cleanup and creation run concurrently. The
+    /// cleanup makes an interrupted concurrent build retry-safe without taking a table write lock.
+    /// </summary>
+    public partial class AddHoldingStuckZeroRepairIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InstitutionalHolding_StuckZeroRepair\";",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_InstitutionalHolding_StuckZeroRepair\" "
+                    + "ON \"InstitutionalHolding\" (\"Id\") "
+                    + "WHERE \"Value\" = 0 AND NOT \"ValuePending\" AND NOT \"ValueUnavailable\" "
+                    + "AND \"FiledValue\" IS NOT NULL AND \"FiledValue\" > 0;",
+                suppressTransaction: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InstitutionalHolding_StuckZeroRepair\";",
+                suppressTransaction: true
+            );
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsModuleStuckZeroRepairIndexTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsModuleStuckZeroRepairIndexTests.cs
@@ -1,0 +1,82 @@
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsModuleStuckZeroRepairIndexTests
+{
+    private const string IndexName = "IX_InstitutionalHolding_StuckZeroRepair";
+    private const string IndexConcurrentAnnotation = "Npgsql:CreatedConcurrently";
+
+    [Fact]
+    public void StuckZeroRepairIndex_IsASmallConcurrentWorklist()
+    {
+        using var db = NewDb();
+
+        var entity = db.Model.FindEntityType(typeof(InstitutionalHolding));
+        entity.Should().NotBeNull();
+
+        var index = entity.GetIndexes().Single(i => i.GetDatabaseName() == IndexName);
+
+        index.Properties.Select(p => p.Name).Should().Equal(nameof(InstitutionalHolding.Id));
+        index
+            .GetFilter()
+            .Should()
+            .Be(
+                "\"Value\" = 0 AND NOT \"ValuePending\" AND NOT \"ValueUnavailable\" "
+                    + "AND \"FiledValue\" IS NOT NULL AND \"FiledValue\" > 0"
+            );
+        index
+            .FindAnnotation(IndexConcurrentAnnotation)
+            ?.Value.Should()
+            .Be(true, "the 72 GB holdings table must stay writable while the index builds");
+    }
+
+    [Fact]
+    public void StuckZeroCandidateQuery_MatchesThePartialIndexPredicateAndOrdering()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only")
+            .EnableServiceProviderCaching(false)
+            .Options;
+        using var db = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new HoldingsModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+
+        var sql = HoldingValueFallbackRepairService
+            .BuildStuckZeroCandidateQuery(db)
+            .ToQueryString();
+
+        sql.Should().Contain("WHERE i.\"Value\" = 0");
+        sql.Should().Contain("NOT (i.\"ValuePending\")");
+        sql.Should().Contain("NOT (i.\"ValueUnavailable\")");
+        sql.Should().Contain("i.\"FiledValue\" IS NOT NULL");
+        sql.Should().Contain("i.\"FiledValue\" > 0");
+        sql.Should().Contain("ORDER BY i.\"Id\"");
+        sql.Should().Contain("LIMIT");
+    }
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new HoldingsModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+    }
+}

--- a/tests/Equibles.UnitTests/Migrations/HoldingStuckZeroRepairIndexMigrationTests.cs
+++ b/tests/Equibles.UnitTests/Migrations/HoldingStuckZeroRepairIndexMigrationTests.cs
@@ -1,0 +1,40 @@
+namespace Equibles.UnitTests.Migrations;
+
+public class HoldingStuckZeroRepairIndexMigrationTests
+{
+    private const string MigrationPath =
+        "src/Equibles.Migrations/Migrations/20260830153706_AddHoldingStuckZeroRepairIndex.cs";
+
+    [Fact]
+    public void Migration_IsConcurrentAndRetrySafe()
+    {
+        var migration = File.ReadAllText(FindRepositoryPath(MigrationPath));
+        var up = migration[..migration.IndexOf("protected override void Down", StringComparison.Ordinal)];
+        var down = migration[migration.IndexOf("protected override void Down", StringComparison.Ordinal)..];
+
+        up.Should().Contain("DROP INDEX CONCURRENTLY IF EXISTS");
+        up.Should().Contain("CREATE INDEX CONCURRENTLY IF NOT EXISTS");
+        up.Should().ContainEquivalentOf("suppressTransaction: true", Exactly.Twice());
+        down.Should().Contain("DROP INDEX CONCURRENTLY IF EXISTS");
+        down.Should().Contain("suppressTransaction: true");
+    }
+
+    private static string FindRepositoryPath(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            var candidate = Path.Combine(directory.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate {relativePath} above {AppContext.BaseDirectory}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a small partial Id worklist index for abandoned zero-value holding repairs
- build and drop it concurrently with retry-safe migration behavior
- pin the LINQ predicate, index metadata, and migration SQL with focused tests

## Test plan
- dotnet build tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release
- dotnet tests/Equibles.UnitTests/bin/Release/net10.0/Equibles.UnitTests.dll -class "*HoldingsModuleStuckZeroRepairIndexTests*" -class "*HoldingStuckZeroRepairIndexMigrationTests*"
- dotnet ef migrations has-pending-model-changes --project src/Equibles.Migrations --configuration Release --no-build
- inspect generated migration SQL