### PR TITLE
feat(mcp): add filter and paging parity

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -16,6 +16,8 @@ public static class CommonStockRepositoryExtensions
             return (null, $"Stock '{ticker}' not found.");
 
         var stock = await repository.GetByTicker(normalized);
+        if (stock == null && normalized.Contains('.'))
+            stock = await repository.GetByTicker(normalized.Replace('.', '-'));
         return stock == null ? (null, $"Stock '{ticker}' not found.") : (stock, null);
     }
 

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Congress.Data;
@@ -60,7 +61,9 @@ public class CongressTools
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to today)")] string endDate = null,
         [Description("Maximum number of trades to return (default: 50, max: 500, newest first)")]
-            int maxResults = 50
+            int maxResults = 50,
+        [Description("Number of matching trades to skip before returning rows (default: 0)")]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -83,13 +86,17 @@ public class CongressTools
                     query = query.Where(t => t.TransactionType == typeFilter);
 
                 maxResults = McpLimit.Clamp(maxResults);
+                offset = McpLimit.ClampOffset(offset);
                 var totalCount = await query.CountAsync();
 
                 var trades = await query
                     .Include(t => t.CongressMember)
                     .OrderNewestFirst()
+                    .Skip(offset)
                     .Take(maxResults)
                     .ToListAsync();
+                if (trades.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {totalCount} trades match; lower offset.";
 
                 var table = MarkdownTable.Render(
                     trades,
@@ -108,10 +115,11 @@ public class CongressTools
                         return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {EscapeCell(t.AssetName)} | {EscapeCell(t.AssetType)} | {FormatOwner(t.OwnerType)} | {EscapeCell(t.Subholding)} |";
                     }
                 );
-                return AppendTruncationNote(table, trades.Count, totalCount);
+                var note = McpOutput.PagedTruncationNote(trades.Count, totalCount, offset);
+                return note.Length == 0 ? table : $"{table}\n{note}";
             },
             "GetCongressionalTrades",
-            $"ticker: {ticker}"
+            $"ticker: {ticker}, offset: {offset}"
         );
     }
 
@@ -136,12 +144,17 @@ public class CongressTools
         [Description(
             "Number of trades to skip before returning rows — pass the previous call's shown count to page past the maxResults cap (default: 0)"
         )]
-            int offset = 0
+            int offset = 0,
+        [Description("Optional stock ticker to combine with the member filter (e.g., AAPL)")]
+            string ticker = null
     )
     {
         return _runner.Execute(
             async () =>
             {
+                if (string.IsNullOrWhiteSpace(memberName))
+                    return "Provide a congress member name. Use SearchCongressMembers to inspect the tracked roster.";
+
                 var member = await ResolveMember(memberName.Trim());
                 if (member == null)
                     return $"Member '{memberName}' not found in the tracked congressional roster. Use SearchCongressMembers to inspect the tracked roster and find the exact filed name.";
@@ -154,11 +167,24 @@ public class CongressTools
                 if (typeError != null)
                     return typeError;
 
+                CommonStock stock = null;
+                if (!string.IsNullOrWhiteSpace(ticker))
+                {
+                    var (resolvedStock, stockError) = await _commonStockRepository.ResolveByTicker(
+                        ticker
+                    );
+                    if (stockError != null)
+                        return stockError;
+                    stock = resolvedStock;
+                }
+
                 var query = _tradeRepository
                     .GetByMember(member)
                     .Where(t => t.TransactionDate >= start && t.TransactionDate <= end);
                 if (typeFilter != null)
                     query = query.Where(t => t.TransactionType == typeFilter);
+                if (stock != null)
+                    query = query.Where(t => t.CommonStockId == stock.Id);
 
                 maxResults = McpLimit.Clamp(maxResults);
                 offset = McpLimit.ClampOffset(offset);
@@ -175,8 +201,8 @@ public class CongressTools
 
                 var table = MarkdownTable.Render(
                     trades,
-                    $"No trades found for {member.Name} ({DescribeMember(member)}) between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
-                    $"Trades by {member.Name} ({DescribeMember(member)}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
+                    $"No trades found for {member.Name} ({DescribeMember(member)}){(stock == null ? "" : $" in {stock.Ticker}")} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
+                    $"Trades by {member.Name} ({DescribeMember(member)}){(stock == null ? "" : $" in {stock.Ticker}")}, {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
                     "| Date | Filed | Ticker | Type | Amount Range | Asset | Asset Type | Owner | Account |",
                     "|------|-------|--------|------|-------------|-------|------------|-------|---------|",
                     t =>
@@ -191,7 +217,7 @@ public class CongressTools
                 return note.Length == 0 ? table : $"{table}\n{note}";
             },
             "GetMemberTrades",
-            $"memberName: {memberName}, offset: {offset}"
+            $"memberName: {memberName}, ticker: {ticker}, offset: {offset}"
         );
     }
 
@@ -290,6 +316,9 @@ public class CongressTools
         return _runner.Execute(
             async () =>
             {
+                if (string.IsNullOrWhiteSpace(query))
+                    return "Provide part or all of a congress member's name.";
+
                 var (positionFilter, positionError) = ParsePositionArgument(position);
                 if (positionError != null)
                     return positionError;
@@ -318,7 +347,7 @@ public class CongressTools
                 return AppendTruncationNote(table, members.Count, totalCount);
             },
             "SearchCongressMembers",
-            $"query: {query}"
+            $"query: {query}, position: {position}"
         );
     }
 

--- a/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
@@ -162,11 +162,10 @@ public class OffExchangeVolumeTools
     // DISPLAYS them oldest-first: "first N" would read as the oldest N, so the note names
     // the kept end explicitly. Empty when nothing was cut.
     private static string NewestKeptNote(int shown, int total, string unit) =>
-        shown >= total
-            ? string.Empty
-            : shown >= McpLimit.MaxResults
-                ? $"_Showing the newest {shown} of {total} {unit} in the range — narrow the date range to see earlier ones._"
-                : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
+        shown >= total ? string.Empty
+        : shown >= McpLimit.MaxResults
+            ? $"_Showing the newest {shown} of {total} {unit} in the range — narrow the date range to see earlier ones._"
+        : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
 
     private static string HistoricalCoverageNote(IReadOnlyCollection<OffExchangeVolume> records) =>
         records.Any(record =>

--- a/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
@@ -164,7 +164,9 @@ public class OffExchangeVolumeTools
     private static string NewestKeptNote(int shown, int total, string unit) =>
         shown >= total
             ? string.Empty
-            : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
+            : shown >= McpLimit.MaxResults
+                ? $"_Showing the newest {shown} of {total} {unit} in the range — narrow the date range to see earlier ones._"
+                : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
 
     private static string HistoricalCoverageNote(IReadOnlyCollection<OffExchangeVolume> records) =>
         records.Any(record =>

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -623,11 +623,10 @@ public class ShortDataTools
     // to start where the range starts), so the note names the kept end explicitly. Empty
     // when nothing was cut, so callers can append it unconditionally via AppendNote.
     private static string NewestKeptNote(int shown, int total, string unit) =>
-        shown >= total
-            ? string.Empty
-            : shown >= McpLimit.MaxResults
-                ? $"_Showing the newest {shown} of {total} {unit} in the range — narrow the date range to see earlier ones._"
-                : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
+        shown >= total ? string.Empty
+        : shown >= McpLimit.MaxResults
+            ? $"_Showing the newest {shown} of {total} {unit} in the range — narrow the date range to see earlier ones._"
+        : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
 
     // Appends a note line under a rendered table (blank line first so strict CommonMark
     // renderers keep the table intact); a no-op for the empty note or an empty-state message.

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -625,7 +625,9 @@ public class ShortDataTools
     private static string NewestKeptNote(int shown, int total, string unit) =>
         shown >= total
             ? string.Empty
-            : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
+            : shown >= McpLimit.MaxResults
+                ? $"_Showing the newest {shown} of {total} {unit} in the range — narrow the date range to see earlier ones._"
+                : $"_Showing the newest {shown} of {total} {unit} in the range — raise maxResults (max {McpLimit.MaxResults}) or narrow the date range to see earlier ones._";
 
     // Appends a note line under a rendered table (blank line first so strict CommonMark
     // renderers keep the table intact); a no-op for the empty note or an empty-state message.

--- a/src/Equibles.GovernmentContracts.Data/Extensions/GovernmentContractQueryExtensions.cs
+++ b/src/Equibles.GovernmentContracts.Data/Extensions/GovernmentContractQueryExtensions.cs
@@ -1,0 +1,20 @@
+using Equibles.GovernmentContracts.Data.Models;
+
+namespace Equibles.GovernmentContracts.Data.Extensions;
+
+public static class GovernmentContractQueryExtensions
+{
+    public static IOrderedQueryable<GovernmentContract> OrderForPublicSurface(
+        this IQueryable<GovernmentContract> query,
+        bool sortByDate
+    ) =>
+        sortByDate
+            ? query
+                .OrderByDescending(contract => contract.ActionDate)
+                .ThenByDescending(contract => contract.Amount)
+                .ThenBy(contract => contract.AwardUniqueKey)
+            : query
+                .OrderByDescending(contract => contract.Amount)
+                .ThenByDescending(contract => contract.ActionDate)
+                .ThenBy(contract => contract.AwardUniqueKey);
+}

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -4,8 +4,10 @@ using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
+using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.GovernmentContracts.Data.Extensions;
 using Equibles.GovernmentContracts.Data.Models;
 using Equibles.GovernmentContracts.Repositories;
 using Equibles.Mcp;
@@ -68,7 +70,9 @@ public class GovernmentContractsTools
         [Description(
             "Optional case-insensitive substring filter on the awarding agency (e.g., 'Defense')"
         )]
-            string agency = null
+            string agency = null,
+        [Description("Number of matching awards to skip before returning rows (default: 0)")]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -87,6 +91,7 @@ public class GovernmentContractsTools
                     return sortError;
 
                 maxResults = McpLimit.Clamp(maxResults);
+                offset = McpLimit.ClampOffset(offset);
 
                 var query = _contractRepository
                     .GetByCommonStock(stock)
@@ -94,19 +99,27 @@ public class GovernmentContractsTools
 
                 if (!string.IsNullOrWhiteSpace(agency))
                 {
-                    var agencyTerm = agency.Trim().ToLower();
+                    var pattern = LikePattern.Contains(agency.Trim());
                     query = query.Where(c =>
-                        c.AwardingAgency != null && c.AwardingAgency.ToLower().Contains(agencyTerm)
+                        c.AwardingAgency != null
+                        && EF.Functions.ILike(
+                            c.AwardingAgency,
+                            pattern,
+                            LikePattern.EscapeChar
+                        )
                     );
                 }
 
                 var totalCount = await query.CountAsync();
                 var totalValue = totalCount == 0 ? 0m : await query.SumAsync(c => c.Amount);
 
-                var ordered = sortByDate
-                    ? query.OrderByDescending(c => c.ActionDate).ThenByDescending(c => c.Amount)
-                    : query.OrderByDescending(c => c.Amount);
-                var awards = await ordered.Take(maxResults).ToListAsync();
+                var awards = await query
+                    .OrderForPublicSurface(sortByDate)
+                    .Skip(offset)
+                    .Take(maxResults)
+                    .ToListAsync();
+                if (awards.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {totalCount} federal contract awards match; lower offset.";
 
                 // USAspending reports outlays on only about a quarter of awards, so a permanent
                 // column would be mostly em-dashes; it renders when this answer actually carries
@@ -142,11 +155,12 @@ public class GovernmentContractsTools
                     totalCount,
                     end,
                     hasOutlays,
-                    hasRecipient: true
+                    hasRecipient: true,
+                    offset: offset
                 );
             },
             "GetGovernmentContracts",
-            $"ticker: {ticker}"
+            $"ticker: {ticker}, agency: {agency}, sortBy: {sortBy}, offset: {offset}"
         );
     }
 
@@ -241,14 +255,17 @@ public class GovernmentContractsTools
         int total,
         DateOnly rangeEnd,
         bool hasOutlays,
-        bool hasRecipient
+        bool hasRecipient,
+        int? offset = null
     )
     {
         var sb = new StringBuilder(table.TrimEnd('\n', '\r'));
         sb.AppendLine();
         sb.AppendLine();
 
-        var truncationNote = McpOutput.TruncationNote(shown, total);
+        var truncationNote = offset.HasValue
+            ? McpOutput.PagedTruncationNote(shown, total, offset.Value)
+            : McpOutput.TruncationNote(shown, total);
         if (truncationNote.Length > 0)
             sb.AppendLine(truncationNote);
 

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -102,11 +102,7 @@ public class GovernmentContractsTools
                     var pattern = LikePattern.Contains(agency.Trim());
                     query = query.Where(c =>
                         c.AwardingAgency != null
-                        && EF.Functions.ILike(
-                            c.AwardingAgency,
-                            pattern,
-                            LikePattern.EscapeChar
-                        )
+                        && EF.Functions.ILike(c.AwardingAgency, pattern, LikePattern.EscapeChar)
                     );
                 }
 

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -107,8 +107,10 @@ public class InstitutionalHoldingsTools
             "Quarter-end 13F report date in YYYY-MM-DD format, e.g. 2026-03-31 (defaults to the latest available; an off-quarter date snaps to the nearest report on or before it)"
         )]
             string reportDate = null,
-        [Description("Maximum number of holders to return (default: 20, clamped to 1-500)")]
-            int maxResults = 20
+        [Description("Maximum number of holding rows to return (default: 20, clamped to 1-500)")]
+            int maxResults = 20,
+        [Description("Number of ranked holding rows to skip before returning results (default: 0)")]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -181,14 +183,19 @@ public class InstitutionalHoldingsTools
                     .Select(h => h.InstitutionalHolderId)
                     .Distinct()
                     .Count();
+                var totalRows = holdings.Count;
                 var totalShares = holdings.Sum(h => h.Shares);
                 var totalValue = holdings.Sum(h => h.Value);
                 maxResults = McpLimit.Clamp(maxResults);
+                offset = McpLimit.ClampOffset(offset);
                 holdings = holdings
                     .OrderByDescending(h => h.Shares)
                     .ThenBy(h => h.Id)
+                    .Skip(offset)
                     .Take(maxResults)
                     .ToList();
+                if (holdings.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {totalRows} holding rows exist; lower offset.";
 
                 return RenderAdjustedTopHoldersTable(
                     stock,
@@ -198,6 +205,8 @@ public class InstitutionalHoldingsTools
                     totalShares,
                     totalValue,
                     holdings,
+                    totalRows,
+                    offset,
                     JoinNotes(
                         dateNote,
                         presentCombined ? CombinedViewNote(targetDate, anchor) : null
@@ -205,7 +214,7 @@ public class InstitutionalHoldingsTools
                 );
             },
             "GetTopHolders",
-            $"ticker: {ticker}"
+            $"ticker: {ticker}, reportDate: {reportDate}, offset: {offset}"
         );
     }
 
@@ -268,6 +277,8 @@ public class InstitutionalHoldingsTools
             adjustedTotalShares,
             totalValueAll,
             adjustedRows,
+            adjustedRows.Count,
+            0,
             combinedNote
         );
     }
@@ -280,11 +291,15 @@ public class InstitutionalHoldingsTools
         long totalSharesAll,
         long totalValueAll,
         List<TopHolderRow> holdings,
+        int totalRows,
+        int offset,
         string combinedNote
     )
     {
+        var first = holdings.Count == 0 ? 0 : offset + 1;
+        var last = offset + holdings.Count;
         var subtitle =
-            $"Showing {holdings.Count} of {totalInstitutions} institutions. Total: "
+            $"Showing rows {first}-{last} of {totalRows} across {totalInstitutions} institutions. Total: "
             + $"{McpFormat.WholeNumber(totalSharesAll)} shares, "
             + $"${FormatMillions(totalValueAll)}M value";
         if (combinedNote != null)
@@ -307,7 +322,7 @@ public class InstitutionalHoldingsTools
                     h.ListedTicker == null
                         ? PositionType(h.OptionType)
                         : $"{PositionType(h.OptionType)} ({h.ListedTicker})";
-                return $"| {rank} | {h.InstitutionName} | "
+                return $"| {offset + rank} | {h.InstitutionName} | "
                     + $"{positionType} | "
                     + $"{McpFormat.WholeNumber(h.Shares)} | "
                     + $"{FormatMillions(h.Value)} | "
@@ -324,6 +339,13 @@ public class InstitutionalHoldingsTools
                 + "underlying's notional value. A PUT IS A BEARISH POSITION, so a large put line is a "
                 + "holder betting against this stock, not accumulating it._"
         );
+
+        var pagingNote = McpOutput.PagedTruncationNote(holdings.Count, totalRows, offset);
+        if (pagingNote.Length > 0)
+        {
+            result.AppendLine();
+            result.AppendLine(pagingNote);
+        }
 
         return result.ToString();
     }

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -211,7 +211,9 @@ public class InsiderTradingTools
 
                 var sb = new StringBuilder();
                 sb.AppendLine($"Recent insider transactions for {stock.Name} ({stock.Ticker}):");
-                sb.AppendLine($"Showing transactions {offset + 1}-{offset + transactions.Count} of {total}");
+                sb.AppendLine(
+                    $"Showing transactions {offset + 1}-{offset + transactions.Count} of {total}"
+                );
                 sb.AppendLine(
                     "_Shares/Price/Value are as filed; Owned After is the post-transaction balance restated onto today's split basis. Security is the filed security title (kind when the filing names none) — balances are tracked per security and ownership form (see Security/Ownership), not as one running total per insider, so an issuer with several listed securities (e.g. ordinary shares and ADS) shows separate balances. 10b5-1 '-' means the filing predates the 2023 checkbox._"
                 );
@@ -261,11 +263,7 @@ public class InsiderTradingTools
                     }
                 );
 
-                var truncation = McpOutput.PagedTruncationNote(
-                    transactions.Count,
-                    total,
-                    offset
-                );
+                var truncation = McpOutput.PagedTruncationNote(transactions.Count, total, offset);
                 if (truncation.Length > 0)
                 {
                     sb.AppendLine();

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -149,12 +149,12 @@ public class InsiderTradingTools
                     filtered = true;
                 }
 
-                if (fromDay.HasValue && toDay.HasValue && fromDay.Value > toDay.Value)
+                if (fromDay is { } parsedFrom && toDay is { } parsedTo && parsedFrom > parsedTo)
                     return "fromDate must be on or before toDate.";
-                if (fromDay.HasValue)
-                    query = query.Where(t => t.TransactionDate >= fromDay.Value);
-                if (toDay.HasValue)
-                    query = query.Where(t => t.TransactionDate <= toDay.Value);
+                if (fromDay is { } earliestDay)
+                    query = query.Where(t => t.TransactionDate >= earliestDay);
+                if (toDay is { } latestDay)
+                    query = query.Where(t => t.TransactionDate <= latestDay);
 
                 if (!string.IsNullOrWhiteSpace(transactionType))
                 {
@@ -511,12 +511,12 @@ public class InsiderTradingTools
                     toDay = DateOnly.FromDateTime(to);
                 }
 
-                if (fromDay.HasValue && toDay.HasValue && fromDay.Value > toDay.Value)
+                if (fromDay is { } parsedFrom && toDay is { } parsedTo && parsedFrom > parsedTo)
                     return "fromDate must be on or before toDate.";
-                if (fromDay.HasValue)
-                    query = query.Where(f => f.FilingDate >= fromDay.Value);
-                if (toDay.HasValue)
-                    query = query.Where(f => f.FilingDate <= toDay.Value);
+                if (fromDay is { } earliestDay)
+                    query = query.Where(f => f.FilingDate >= earliestDay);
+                if (toDay is { } latestDay)
+                    query = query.Where(f => f.FilingDate <= latestDay);
 
                 var totalCount = await query.CountAsync();
                 if (totalCount == 0)

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -107,7 +107,9 @@ public class InsiderTradingTools
         [Description(
             "Only include transactions by insiders whose SEC-filed name contains every word of this value, case-insensitive (e.g. 'Huang') (optional)"
         )]
-            string insiderName = null
+            string insiderName = null,
+        [Description("Number of matching transactions to skip before returning rows (default: 0)")]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -118,6 +120,7 @@ public class InsiderTradingTools
                     return stockError;
 
                 maxResults = McpLimit.Clamp(maxResults);
+                offset = McpLimit.ClampOffset(offset);
 
                 var query = _transactionRepository
                     .GetByStockWithOwner(stock)
@@ -128,12 +131,13 @@ public class InsiderTradingTools
                     .Where(t => t.Shares != 0 || t.SharesOwnedAfter != 0);
 
                 var filtered = false;
+                DateOnly? fromDay = null;
+                DateOnly? toDay = null;
                 if (!string.IsNullOrWhiteSpace(fromDate))
                 {
                     if (!McpOutput.TryParseDate(fromDate, out var from))
                         return McpOutput.InvalidArgument("fromDate", fromDate, "yyyy-MM-dd");
-                    var fromDay = DateOnly.FromDateTime(from);
-                    query = query.Where(t => t.TransactionDate >= fromDay);
+                    fromDay = DateOnly.FromDateTime(from);
                     filtered = true;
                 }
 
@@ -141,10 +145,16 @@ public class InsiderTradingTools
                 {
                     if (!McpOutput.TryParseDate(toDate, out var to))
                         return McpOutput.InvalidArgument("toDate", toDate, "yyyy-MM-dd");
-                    var toDay = DateOnly.FromDateTime(to);
-                    query = query.Where(t => t.TransactionDate <= toDay);
+                    toDay = DateOnly.FromDateTime(to);
                     filtered = true;
                 }
+
+                if (fromDay.HasValue && toDay.HasValue && fromDay.Value > toDay.Value)
+                    return "fromDate must be on or before toDate.";
+                if (fromDay.HasValue)
+                    query = query.Where(t => t.TransactionDate >= fromDay.Value);
+                if (toDay.HasValue)
+                    query = query.Where(t => t.TransactionDate <= toDay.Value);
 
                 if (!string.IsNullOrWhiteSpace(transactionType))
                 {
@@ -176,8 +186,14 @@ public class InsiderTradingTools
                 }
 
                 var total = await query.CountAsync();
-                var transactions = await query.OrderNewestFirst().Take(maxResults).ToListAsync();
+                var transactions = await query
+                    .OrderNewestFirst()
+                    .Skip(offset)
+                    .Take(maxResults)
+                    .ToListAsync();
 
+                if (transactions.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {total} insider transactions match; lower offset.";
                 if (transactions.Count == 0)
                     return filtered
                         ? $"No insider transactions found for {stock.Ticker} matching the given filters."
@@ -195,7 +211,7 @@ public class InsiderTradingTools
 
                 var sb = new StringBuilder();
                 sb.AppendLine($"Recent insider transactions for {stock.Name} ({stock.Ticker}):");
-                sb.AppendLine($"Showing {transactions.Count} most recent transactions");
+                sb.AppendLine($"Showing transactions {offset + 1}-{offset + transactions.Count} of {total}");
                 sb.AppendLine(
                     "_Shares/Price/Value are as filed; Owned After is the post-transaction balance restated onto today's split basis. Security is the filed security title (kind when the filing names none) — balances are tracked per security and ownership form (see Security/Ownership), not as one running total per insider, so an issuer with several listed securities (e.g. ordinary shares and ADS) shows separate balances. 10b5-1 '-' means the filing predates the 2023 checkbox._"
                 );
@@ -245,7 +261,11 @@ public class InsiderTradingTools
                     }
                 );
 
-                var truncation = McpOutput.TruncationNote(transactions.Count, total);
+                var truncation = McpOutput.PagedTruncationNote(
+                    transactions.Count,
+                    total,
+                    offset
+                );
                 if (truncation.Length > 0)
                 {
                     sb.AppendLine();
@@ -255,7 +275,7 @@ public class InsiderTradingTools
                 return sb.ToString();
             },
             "GetInsiderTransactions",
-            $"ticker: {ticker}, fromDate: {fromDate}, toDate: {toDate}, transactionType: {transactionType}, insiderName: {insiderName}"
+            $"ticker: {ticker}, fromDate: {fromDate}, toDate: {toDate}, transactionType: {transactionType}, insiderName: {insiderName}, offset: {offset}"
         );
     }
 
@@ -462,7 +482,9 @@ public class InsiderTradingTools
         [Description(
             "Optional latest filing date to include, ISO format yyyy-MM-dd (e.g., 2025-12-31)"
         )]
-            string toDate = null
+            string toDate = null,
+        [Description("Number of matching notices to skip before returning rows (default: 0)")]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -474,30 +496,42 @@ public class InsiderTradingTools
 
                 var query = _form144Repository.GetByStock(stock);
 
+                DateOnly? fromDay = null;
+                DateOnly? toDay = null;
+
                 if (!string.IsNullOrWhiteSpace(fromDate))
                 {
                     if (!McpOutput.TryParseDate(fromDate, out var from))
                         return McpOutput.InvalidArgument("fromDate", fromDate, "yyyy-MM-dd");
-                    var fromDay = DateOnly.FromDateTime(from);
-                    query = query.Where(f => f.FilingDate >= fromDay);
+                    fromDay = DateOnly.FromDateTime(from);
                 }
 
                 if (!string.IsNullOrWhiteSpace(toDate))
                 {
                     if (!McpOutput.TryParseDate(toDate, out var to))
                         return McpOutput.InvalidArgument("toDate", toDate, "yyyy-MM-dd");
-                    var toDay = DateOnly.FromDateTime(to);
-                    query = query.Where(f => f.FilingDate <= toDay);
+                    toDay = DateOnly.FromDateTime(to);
                 }
+
+                if (fromDay.HasValue && toDay.HasValue && fromDay.Value > toDay.Value)
+                    return "fromDate must be on or before toDate.";
+                if (fromDay.HasValue)
+                    query = query.Where(f => f.FilingDate >= fromDay.Value);
+                if (toDay.HasValue)
+                    query = query.Where(f => f.FilingDate <= toDay.Value);
 
                 var totalCount = await query.CountAsync();
                 if (totalCount == 0)
                     return $"No Form 144 proposed sales found for {stock.Ticker}.";
 
+                offset = McpLimit.ClampOffset(offset);
                 var filings = await query
                     .OrderNewestFirst()
+                    .Skip(offset)
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
+                if (filings.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {totalCount} Form 144 notices match; lower offset.";
 
                 // Each Form 144 is an as-filed notice: the proposed Shares pair with the
                 // notice's own Aggregate Market Value, so both stay exactly as reported. The
@@ -513,7 +547,7 @@ public class InsiderTradingTools
                     .ToListAsync();
                 var result = MarkdownTable.Start(
                     $"Recent proposed sales (Form 144) for {stock.Name} ({stock.Ticker}):",
-                    $"Showing {filings.Count} of {totalCount} most recent notices",
+                    $"Showing notices {offset + 1}-{offset + filings.Count} of {totalCount}, newest first",
                     "| Filed | Seller | Relationship | Shares | Market Value | % Outstanding | Approx. Sale Date | Broker | Remarks |",
                     "|-------|--------|--------------|--------|--------------|---------------|-------------------|--------|---------|"
                 );
@@ -540,7 +574,7 @@ public class InsiderTradingTools
                     }
                 );
 
-                var note = McpOutput.TruncationNote(filings.Count, totalCount);
+                var note = McpOutput.PagedTruncationNote(filings.Count, totalCount, offset);
                 if (note.Length > 0)
                 {
                     result.AppendLine();
@@ -550,7 +584,7 @@ public class InsiderTradingTools
                 return result.ToString();
             },
             "GetForm144ProposedSales",
-            $"ticker: {ticker}"
+            $"ticker: {ticker}, fromDate: {fromDate}, toDate: {toDate}, offset: {offset}"
         );
     }
 

--- a/src/Equibles.Sec.Data/Extensions/FormDFilingQueryOrderExtensions.cs
+++ b/src/Equibles.Sec.Data/Extensions/FormDFilingQueryOrderExtensions.cs
@@ -1,0 +1,14 @@
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Data.Extensions;
+
+public static class FormDFilingQueryOrderExtensions
+{
+    public static IOrderedQueryable<FormDFiling> OrderNewestFirst(
+        this IQueryable<FormDFiling> query
+    ) =>
+        query
+            .OrderByDescending(filing => filing.FilingDate)
+            .ThenBy(filing => filing.AccessionNumber)
+            .ThenBy(filing => filing.Id);
+}

--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -6,6 +6,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Mcp;
 using Equibles.Mcp.Helpers;
+using Equibles.Sec.Data.Extensions;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -54,7 +55,9 @@ public class FormDTools
         [Description(
             "Optional latest filing date to include, ISO format yyyy-MM-dd (e.g., 2024-12-31)"
         )]
-            string toDate = null
+            string toDate = null,
+        [Description("Number of matching notices to skip before returning rows (default: 0)")]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -66,33 +69,45 @@ public class FormDTools
 
                 var query = _formDRepository.GetByStock(stock);
 
+                DateOnly? fromDay = null;
+                DateOnly? toDay = null;
+
                 if (!string.IsNullOrWhiteSpace(fromDate))
                 {
                     if (!McpOutput.TryParseDate(fromDate, out var from))
                         return McpOutput.InvalidArgument("fromDate", fromDate, "yyyy-MM-dd");
-                    var fromDay = DateOnly.FromDateTime(from);
-                    query = query.Where(f => f.FilingDate >= fromDay);
+                    fromDay = DateOnly.FromDateTime(from);
                 }
 
                 if (!string.IsNullOrWhiteSpace(toDate))
                 {
                     if (!McpOutput.TryParseDate(toDate, out var to))
                         return McpOutput.InvalidArgument("toDate", toDate, "yyyy-MM-dd");
-                    var toDay = DateOnly.FromDateTime(to);
-                    query = query.Where(f => f.FilingDate <= toDay);
+                    toDay = DateOnly.FromDateTime(to);
                 }
+
+                if (fromDay.HasValue && toDay.HasValue && fromDay.Value > toDay.Value)
+                    return "fromDate must be on or before toDate.";
+                if (fromDay.HasValue)
+                    query = query.Where(f => f.FilingDate >= fromDay.Value);
+                if (toDay.HasValue)
+                    query = query.Where(f => f.FilingDate <= toDay.Value);
 
                 var totalCount = await query.CountAsync();
                 if (totalCount == 0)
                     return $"No Form D exempt offerings found for {ticker}.";
 
+                offset = McpLimit.ClampOffset(offset);
                 var filings = await query
-                    .OrderByDescending(f => f.FilingDate)
+                    .OrderNewestFirst()
+                    .Skip(offset)
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
+                if (filings.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {totalCount} Form D notices match; lower offset.";
 
                 var result = MarkdownTable.Start(
-                    $"Recent exempt offerings (Form D) for {stock.Name} ({ticker}) — showing {filings.Count} most recent notices:",
+                    $"Recent exempt offerings (Form D) for {stock.Name} ({ticker}) — showing notices {offset + 1}-{offset + filings.Count} of {totalCount}, newest first:",
                     "| Filed | Amendment | First Sale | Industry | Offering Amount | Sold | Remaining | Min. Investment | Investors | Exemptions | Accession |",
                     "|-------|-----------|------------|----------|-----------------|------|-----------|-----------------|-----------|------------|-----------|"
                 );
@@ -111,12 +126,21 @@ public class FormDTools
                     );
                 }
 
-                TruncationNotes.Append(result, filings.Count, totalCount);
+                var pagingNote = McpOutput.PagedTruncationNote(
+                    filings.Count,
+                    totalCount,
+                    offset
+                );
+                if (pagingNote.Length > 0)
+                {
+                    result.AppendLine();
+                    result.AppendLine(pagingNote);
+                }
 
                 return result.ToString();
             },
             "GetFormDOfferings",
-            $"ticker: {ticker}"
+            $"ticker: {ticker}, fromDate: {fromDate}, toDate: {toDate}, offset: {offset}"
         );
     }
 

--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -86,12 +86,12 @@ public class FormDTools
                     toDay = DateOnly.FromDateTime(to);
                 }
 
-                if (fromDay.HasValue && toDay.HasValue && fromDay.Value > toDay.Value)
+                if (fromDay is { } parsedFrom && toDay is { } parsedTo && parsedFrom > parsedTo)
                     return "fromDate must be on or before toDate.";
-                if (fromDay.HasValue)
-                    query = query.Where(f => f.FilingDate >= fromDay.Value);
-                if (toDay.HasValue)
-                    query = query.Where(f => f.FilingDate <= toDay.Value);
+                if (fromDay is { } earliestDay)
+                    query = query.Where(f => f.FilingDate >= earliestDay);
+                if (toDay is { } latestDay)
+                    query = query.Where(f => f.FilingDate <= latestDay);
 
                 var totalCount = await query.CountAsync();
                 if (totalCount == 0)

--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -126,11 +126,7 @@ public class FormDTools
                     );
                 }
 
-                var pagingNote = McpOutput.PagedTruncationNote(
-                    filings.Count,
-                    totalCount,
-                    offset
-                );
+                var pagingNote = McpOutput.PagedTruncationNote(filings.Count, totalCount, offset);
                 if (pagingNote.Length > 0)
                 {
                     result.AppendLine();

--- a/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FundDirectoryTools.cs
@@ -106,7 +106,9 @@ public class FundDirectoryTools
         )]
             string fund,
         [Description("Maximum number of holdings to return, largest first (default: 20, max: 500)")]
-            int maxResults = 20
+            int maxResults = 20,
+        [Description("Number of ranked holdings to skip before returning rows (default: 0)")]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -140,10 +142,22 @@ public class FundDirectoryTools
                 if (latest == null)
                     return $"No stored Form NPORT-P report is on record for {MarkdownText(series.SeriesName ?? series.RegistrantName)}. This is a dataset coverage result, not evidence that no SEC filing exists; the report may be outside the filing scope or absent from this ingestion, fetch, or replay state.";
 
+                var totalHoldings = latest.Holdings.Count;
+                if (totalHoldings == 0)
+                    return $"{MarkdownText(series.SeriesName ?? series.RegistrantName)} has a stored Form NPORT-P report for {latest.ReportPeriodDate:yyyy-MM-dd} with {FormatCount(latest.ReportedHoldingCount)} holdings reported, but no {(latest.CommonStockId == null ? "tracked-stock " : "")}holding rows are stored for that report.";
+
+                offset = McpLimit.ClampOffset(offset);
                 var holdings = latest
                     .Holdings.OrderByDescending(h => h.ValueUsd)
+                    .ThenBy(h => h.Id)
+                    .Skip(offset)
                     .Take(McpLimit.Clamp(maxResults))
                     .ToList();
+                if (holdings.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {totalHoldings} stored holdings exist; lower offset.";
+
+                var first = offset + 1;
+                var last = offset + holdings.Count;
 
                 var header =
                     $"{MarkdownText(series.SeriesName ?? series.RegistrantName)}"
@@ -153,7 +167,7 @@ public class FundDirectoryTools
                     + $"net assets ${FormatAmount(latest.NetAssets)}, total assets ${FormatAmount(latest.TotalAssets)}, "
                     + $"{FormatCount(latest.ReportedHoldingCount)} holdings reported, {latest.Holdings.Count} stored"
                     + (latest.CommonStockId == null ? " tracked-stock holdings" : " holdings")
-                    + $", showing the largest {holdings.Count} stored rows:";
+                    + $", showing stored rows {first}-{last} by value:";
 
                 var result = MarkdownTable.Start(
                     header,
@@ -167,12 +181,21 @@ public class FundDirectoryTools
                         $"| {MarkdownText(h.Name) ?? "-"} | {MarkdownText(h.Cusip) ?? "-"} | {FundCodes.Balance(h.Balance)} | {MarkdownText(FundCodes.Unit(h.Units))} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {MarkdownText(FundCodes.AssetCategory(h.AssetCategory))} | {MarkdownText(h.InvestmentCountry) ?? "-"} |"
                 );
 
-                TruncationNotes.Append(result, holdings.Count, latest.Holdings.Count);
+                var pagingNote = McpOutput.PagedTruncationNote(
+                    holdings.Count,
+                    totalHoldings,
+                    offset
+                );
+                if (pagingNote.Length > 0)
+                {
+                    result.AppendLine();
+                    result.AppendLine(pagingNote);
+                }
 
                 return result.ToString();
             },
             "GetFundProfile",
-            $"fund: {fund}"
+            $"fund: {fund}, offset: {offset}"
         );
     }
 

--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -52,7 +52,9 @@ public class NportTools
             "Optional registrant or series name filter (case-insensitive contains, e.g. 'Vanguard') — reaches positions beyond the largest 500"
         )]
             string registrantOrSeries = null,
-        [Description("Number of matching fund positions to skip before returning rows (default: 0)")]
+        [Description(
+            "Number of matching fund positions to skip before returning rows (default: 0)"
+        )]
             int offset = 0
     )
     {
@@ -141,11 +143,7 @@ public class NportTools
                         $"| {MarkdownText(p.RegistrantName) ?? "-"} | {MarkdownText(p.SeriesName) ?? "-"} | {p.ReportPeriodDate:yyyy-MM-dd} | {FormatAmount(p.Balance)} | {MarkdownText(FundCodes.Unit(p.Units))} | ${FormatAmount(p.ValueUsd)} | {FormatPercent(p.PercentValue)} | {MarkdownText(p.PayoffProfile) ?? "-"} |"
                 );
 
-                var pagingNote = McpOutput.PagedTruncationNote(
-                    positions.Count,
-                    totalCount,
-                    offset
-                );
+                var pagingNote = McpOutput.PagedTruncationNote(positions.Count, totalCount, offset);
                 if (pagingNote.Length > 0)
                 {
                     result.AppendLine();

--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -51,7 +51,9 @@ public class NportTools
         [Description(
             "Optional registrant or series name filter (case-insensitive contains, e.g. 'Vanguard') — reaches positions beyond the largest 500"
         )]
-            string registrantOrSeries = null
+            string registrantOrSeries = null,
+        [Description("Number of matching fund positions to skip before returning rows (default: 0)")]
+            int offset = 0
     )
     {
         return _runner.Execute(
@@ -78,6 +80,7 @@ public class NportTools
                         (h, f) =>
                             new
                             {
+                                h.Id,
                                 f.RegistrantName,
                                 f.SeriesName,
                                 f.ReportPeriodDate,
@@ -110,17 +113,23 @@ public class NportTools
                         ? $"No current position in {safeTicker} matched the ingested latest Form NPORT-P reports. This is a dataset coverage result, not evidence that no fund reports one."
                         : $"No current position in {safeTicker} for a fund matching '{MarkdownText(registrantOrSeries)}' matched the ingested latest Form NPORT-P reports. This is a dataset coverage result, not evidence that no fund reports one.";
 
+                offset = McpLimit.ClampOffset(offset);
                 var positions = await currentPositions
                     .OrderByDescending(p => p.ValueUsd)
+                    .ThenBy(p => p.Id)
+                    .Skip(offset)
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
+                if (positions.Count == 0 && offset > 0)
+                    return $"No results at offset {offset} - only {totalCount} current fund positions match; lower offset.";
 
                 var filterLabel = string.IsNullOrWhiteSpace(registrantOrSeries)
                     ? ""
                     : $" matching '{MarkdownText(registrantOrSeries)}'";
                 var result = MarkdownTable.Start(
                     $"Funds holding {MarkdownText(stock.Name)} ({safeTicker}) on each series' most recent Form NPORT-P — "
-                        + $"{totalCount} current fund positions{filterLabel}, showing the largest {positions.Count}. "
+                        + $"{totalCount} current fund positions{filterLabel}, showing rows "
+                        + $"{offset + 1}-{offset + positions.Count} by value. "
                         + "Report dates differ per series (each fund's own fiscal quarter):",
                     "| Registrant | Series | Report Date | Balance | Units | Value (USD) | % Net Assets | Long/Short |",
                     "|------------|--------|-------------|---------|-------|-------------|--------------|------------|"
@@ -132,10 +141,21 @@ public class NportTools
                         $"| {MarkdownText(p.RegistrantName) ?? "-"} | {MarkdownText(p.SeriesName) ?? "-"} | {p.ReportPeriodDate:yyyy-MM-dd} | {FormatAmount(p.Balance)} | {MarkdownText(FundCodes.Unit(p.Units))} | ${FormatAmount(p.ValueUsd)} | {FormatPercent(p.PercentValue)} | {MarkdownText(p.PayoffProfile) ?? "-"} |"
                 );
 
+                var pagingNote = McpOutput.PagedTruncationNote(
+                    positions.Count,
+                    totalCount,
+                    offset
+                );
+                if (pagingNote.Length > 0)
+                {
+                    result.AppendLine();
+                    result.AppendLine(pagingNote);
+                }
+
                 return result.ToString();
             },
             "GetFundsHoldingStock",
-            $"ticker: {ticker}"
+            $"ticker: {ticker}, registrantOrSeries: {registrantOrSeries}, offset: {offset}"
         );
     }
 

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryExtensionsResolveByTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryExtensionsResolveByTickerTests.cs
@@ -50,13 +50,15 @@ public class CommonStockRepositoryExtensionsResolveByTickerTests : IDisposable
     [Fact]
     public async Task ResolveByTicker_DottedClassShareFallsBackToStoredDashForm()
     {
-        _dbContext.Add(new CommonStock
-        {
-            Id = Guid.NewGuid(),
-            Ticker = "BRK-B",
-            Name = "Berkshire Hathaway Class B",
-            Cik = "0001067983",
-        });
+        _dbContext.Add(
+            new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = "BRK-B",
+                Name = "Berkshire Hathaway Class B",
+                Cik = "0001067983",
+            }
+        );
         await _dbContext.SaveChangesAsync();
 
         var (stock, error) = await _repository.ResolveByTicker("BRK.B");
@@ -69,8 +71,20 @@ public class CommonStockRepositoryExtensionsResolveByTickerTests : IDisposable
     public async Task ResolveByTicker_ExactDottedTickerWinsBeforeDashFallback()
     {
         _dbContext.AddRange(
-            new CommonStock { Id = Guid.NewGuid(), Ticker = "TEST.B", Name = "Exact", Cik = "1001" },
-            new CommonStock { Id = Guid.NewGuid(), Ticker = "TEST-B", Name = "Fallback", Cik = "1002" }
+            new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = "TEST.B",
+                Name = "Exact",
+                Cik = "1001",
+            },
+            new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = "TEST-B",
+                Name = "Fallback",
+                Cik = "1002",
+            }
         );
         await _dbContext.SaveChangesAsync();
 

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryExtensionsResolveByTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryExtensionsResolveByTickerTests.cs
@@ -48,6 +48,39 @@ public class CommonStockRepositoryExtensionsResolveByTickerTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveByTicker_DottedClassShareFallsBackToStoredDashForm()
+    {
+        _dbContext.Add(new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BRK-B",
+            Name = "Berkshire Hathaway Class B",
+            Cik = "0001067983",
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var (stock, error) = await _repository.ResolveByTicker("BRK.B");
+
+        stock!.Ticker.Should().Be("BRK-B");
+        error.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveByTicker_ExactDottedTickerWinsBeforeDashFallback()
+    {
+        _dbContext.AddRange(
+            new CommonStock { Id = Guid.NewGuid(), Ticker = "TEST.B", Name = "Exact", Cik = "1001" },
+            new CommonStock { Id = Guid.NewGuid(), Ticker = "TEST-B", Name = "Fallback", Cik = "1002" }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var (stock, error) = await _repository.ResolveByTicker("TEST.B");
+
+        stock!.Name.Should().Be("Exact");
+        error.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetByCikTolerant_UnpaddedInputResolvesPaddedPrimaryCik()
     {
         var stock = new CommonStock

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
@@ -254,6 +254,25 @@ public class CongressToolsTests : ParadeDbMcpTestBase
         result.Should().Contain("Bravo Lot");
         result.Should().NotContain("Charlie Lot");
         result.Should().NotContain("Delta Lot");
+
+        var secondPage = await Sut().GetCongressionalTrades(
+            "NVDA",
+            startDate: "2026-01-01",
+            endDate: "2026-04-30",
+            maxResults: 2,
+            offset: 2
+        );
+        var pastEnd = await Sut().GetCongressionalTrades(
+            "NVDA",
+            startDate: "2026-01-01",
+            endDate: "2026-04-30",
+            offset: 4
+        );
+
+        secondPage.Should().Contain("Charlie Lot").And.Contain("Delta Lot");
+        secondPage.Should().NotContain("Alpha Lot").And.NotContain("Bravo Lot");
+        secondPage.Should().Contain("Showing results 3-4 of 4 (the last page)");
+        pastEnd.Should().Contain("No results at offset 4 - only 4 trades match");
     }
 
     // ── GetMemberTrades ──────────────────────────────────────────────────
@@ -361,6 +380,31 @@ public class CongressToolsTests : ParadeDbMcpTestBase
         onPage1.Intersect(onPage2).Should().BeEmpty();
         onPage1.Concat(onPage2).Should().BeEquivalentTo(markers);
         page2.Should().Contain("Showing results 3-4 of 4 (the last page).");
+    }
+
+    [Fact]
+    public async Task GetMemberTrades_TickerFilterUsesResolvedStockIdentity()
+    {
+        var nvda = NvdaStock();
+        var apple = new CommonStock { Ticker = "AAPL", Name = "Apple Inc.", Cik = "0000320193" };
+        var pelosi = PelosiMember();
+        DbContext.Set<CommonStock>().AddRange(nvda, apple);
+        DbContext.Set<CongressMember>().Add(pelosi);
+        DbContext.Set<CongressionalTrade>().AddRange(
+            TradeFor(pelosi, nvda, new DateOnly(2026, 3, 15), assetName: "Nvidia Position"),
+            TradeFor(pelosi, apple, new DateOnly(2026, 3, 16), assetName: "Apple Position")
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetMemberTrades(
+            "Nancy Pelosi",
+            startDate: "2026-01-01",
+            endDate: "2026-04-30",
+            ticker: "NVDA"
+        );
+
+        result.Should().Contain("Nvidia Position").And.NotContain("Apple Position");
+        result.Should().Contain("in NVDA");
     }
 
     [Fact]
@@ -590,7 +634,9 @@ public class CongressToolsTests : ParadeDbMcpTestBase
                 maxResults: 2
             );
 
-        result.Should().Contain("Showing first 2 of 3 results - raise maxResults to see more.");
+        result.Should().Contain(
+            "Showing results 1-2 of 3 - raise maxResults (max 500) or pass offset=2 to continue."
+        );
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
@@ -255,19 +255,21 @@ public class CongressToolsTests : ParadeDbMcpTestBase
         result.Should().NotContain("Charlie Lot");
         result.Should().NotContain("Delta Lot");
 
-        var secondPage = await Sut().GetCongressionalTrades(
-            "NVDA",
-            startDate: "2026-01-01",
-            endDate: "2026-04-30",
-            maxResults: 2,
-            offset: 2
-        );
-        var pastEnd = await Sut().GetCongressionalTrades(
-            "NVDA",
-            startDate: "2026-01-01",
-            endDate: "2026-04-30",
-            offset: 4
-        );
+        var secondPage = await Sut()
+            .GetCongressionalTrades(
+                "NVDA",
+                startDate: "2026-01-01",
+                endDate: "2026-04-30",
+                maxResults: 2,
+                offset: 2
+            );
+        var pastEnd = await Sut()
+            .GetCongressionalTrades(
+                "NVDA",
+                startDate: "2026-01-01",
+                endDate: "2026-04-30",
+                offset: 4
+            );
 
         secondPage.Should().Contain("Charlie Lot").And.Contain("Delta Lot");
         secondPage.Should().NotContain("Alpha Lot").And.NotContain("Bravo Lot");
@@ -386,22 +388,30 @@ public class CongressToolsTests : ParadeDbMcpTestBase
     public async Task GetMemberTrades_TickerFilterUsesResolvedStockIdentity()
     {
         var nvda = NvdaStock();
-        var apple = new CommonStock { Ticker = "AAPL", Name = "Apple Inc.", Cik = "0000320193" };
+        var apple = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
         var pelosi = PelosiMember();
         DbContext.Set<CommonStock>().AddRange(nvda, apple);
         DbContext.Set<CongressMember>().Add(pelosi);
-        DbContext.Set<CongressionalTrade>().AddRange(
-            TradeFor(pelosi, nvda, new DateOnly(2026, 3, 15), assetName: "Nvidia Position"),
-            TradeFor(pelosi, apple, new DateOnly(2026, 3, 16), assetName: "Apple Position")
-        );
+        DbContext
+            .Set<CongressionalTrade>()
+            .AddRange(
+                TradeFor(pelosi, nvda, new DateOnly(2026, 3, 15), assetName: "Nvidia Position"),
+                TradeFor(pelosi, apple, new DateOnly(2026, 3, 16), assetName: "Apple Position")
+            );
         await DbContext.SaveChangesAsync();
 
-        var result = await Sut().GetMemberTrades(
-            "Nancy Pelosi",
-            startDate: "2026-01-01",
-            endDate: "2026-04-30",
-            ticker: "NVDA"
-        );
+        var result = await Sut()
+            .GetMemberTrades(
+                "Nancy Pelosi",
+                startDate: "2026-01-01",
+                endDate: "2026-04-30",
+                ticker: "NVDA"
+            );
 
         result.Should().Contain("Nvidia Position").And.NotContain("Apple Position");
         result.Should().Contain("in NVDA");
@@ -634,9 +644,11 @@ public class CongressToolsTests : ParadeDbMcpTestBase
                 maxResults: 2
             );
 
-        result.Should().Contain(
-            "Showing results 1-2 of 3 - raise maxResults (max 500) or pass offset=2 to continue."
-        );
+        result
+            .Should()
+            .Contain(
+                "Showing results 1-2 of 3 - raise maxResults (max 500) or pass offset=2 to continue."
+            );
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
@@ -196,17 +196,22 @@ public class Form144ProposedSalesToolTests : IDisposable
     public async Task GetForm144ProposedSales_OffsetPagesNewestFirst_AndRejectsPastEnd()
     {
         var stock = SeedStock();
-        _dbContext.Set<Form144Filing>().AddRange(
-            MakeFiling(stock.Id, "old", new DateOnly(2026, 1, 1), "OLD SELLER", 100),
-            MakeFiling(stock.Id, "middle", new DateOnly(2026, 2, 1), "MIDDLE SELLER", 100),
-            MakeFiling(stock.Id, "new", new DateOnly(2026, 3, 1), "NEW SELLER", 100)
-        );
+        _dbContext
+            .Set<Form144Filing>()
+            .AddRange(
+                MakeFiling(stock.Id, "old", new DateOnly(2026, 1, 1), "OLD SELLER", 100),
+                MakeFiling(stock.Id, "middle", new DateOnly(2026, 2, 1), "MIDDLE SELLER", 100),
+                MakeFiling(stock.Id, "new", new DateOnly(2026, 3, 1), "NEW SELLER", 100)
+            );
         await _dbContext.SaveChangesAsync();
 
         var page = await _tools.GetForm144ProposedSales("AAPL", maxResults: 1, offset: 1);
         var pastEnd = await _tools.GetForm144ProposedSales("AAPL", offset: 3);
 
-        page.Should().Contain("MIDDLE SELLER").And.NotContain("NEW SELLER").And.NotContain("OLD SELLER");
+        page.Should()
+            .Contain("MIDDLE SELLER")
+            .And.NotContain("NEW SELLER")
+            .And.NotContain("OLD SELLER");
         page.Should().Contain("Showing results 2-2 of 3");
         pastEnd.Should().Contain("No results at offset 3 - only 3 Form 144 notices match");
     }

--- a/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
@@ -150,8 +150,8 @@ public class Form144ProposedSalesToolTests : IDisposable
 
         var result = await _tools.GetForm144ProposedSales("AAPL", maxResults: 2);
 
-        result.Should().Contain("Showing 2 of 5 most recent notices");
-        result.Should().Contain("Showing first 2 of 5 results");
+        result.Should().Contain("Showing notices 1-2 of 5, newest first");
+        result.Should().Contain("Showing results 1-2 of 5");
     }
 
     [Fact]
@@ -165,7 +165,7 @@ public class Form144ProposedSalesToolTests : IDisposable
 
         var result = await _tools.GetForm144ProposedSales("AAPL");
 
-        result.Should().Contain("Showing 1 of 1 most recent notices");
+        result.Should().Contain("Showing notices 1-1 of 1, newest first");
         result.Should().NotContain("raise maxResults");
     }
 
@@ -189,7 +189,26 @@ public class Form144ProposedSalesToolTests : IDisposable
 
         result.Should().Contain("LATE SELLER");
         result.Should().NotContain("EARLY SELLER");
-        result.Should().Contain("Showing 1 of 1 most recent notices");
+        result.Should().Contain("Showing notices 1-1 of 1, newest first");
+    }
+
+    [Fact]
+    public async Task GetForm144ProposedSales_OffsetPagesNewestFirst_AndRejectsPastEnd()
+    {
+        var stock = SeedStock();
+        _dbContext.Set<Form144Filing>().AddRange(
+            MakeFiling(stock.Id, "old", new DateOnly(2026, 1, 1), "OLD SELLER", 100),
+            MakeFiling(stock.Id, "middle", new DateOnly(2026, 2, 1), "MIDDLE SELLER", 100),
+            MakeFiling(stock.Id, "new", new DateOnly(2026, 3, 1), "NEW SELLER", 100)
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var page = await _tools.GetForm144ProposedSales("AAPL", maxResults: 1, offset: 1);
+        var pastEnd = await _tools.GetForm144ProposedSales("AAPL", offset: 3);
+
+        page.Should().Contain("MIDDLE SELLER").And.NotContain("NEW SELLER").And.NotContain("OLD SELLER");
+        page.Should().Contain("Showing results 2-2 of 3");
+        pastEnd.Should().Contain("No results at offset 3 - only 3 Form 144 notices match");
     }
 
     [Fact]
@@ -201,6 +220,20 @@ public class Form144ProposedSalesToolTests : IDisposable
 
         result.Should().Contain("Unknown toDate 'June 2026'");
         result.Should().Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task GetForm144ProposedSales_InvertedDateRange_ReturnsExplicitError()
+    {
+        SeedStock();
+
+        var result = await _tools.GetForm144ProposedSales(
+            "AAPL",
+            fromDate: "2026-12-31",
+            toDate: "2026-01-01"
+        );
+
+        result.Should().Be("fromDate must be on or before toDate.");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
@@ -215,11 +215,13 @@ public class FormDExemptOfferingsToolTests : IDisposable
     public async Task GetFormDOfferings_OffsetPagesNewestFirst_AndRejectsPastEnd()
     {
         var stock = SeedStock();
-        _dbContext.Set<FormDFiling>().AddRange(
-            MakeFiling(stock.Id, "old", new DateOnly(2025, 1, 1), offeringAmount: 100_001),
-            MakeFiling(stock.Id, "middle", new DateOnly(2025, 2, 1), offeringAmount: 100_002),
-            MakeFiling(stock.Id, "new", new DateOnly(2025, 3, 1), offeringAmount: 100_003)
-        );
+        _dbContext
+            .Set<FormDFiling>()
+            .AddRange(
+                MakeFiling(stock.Id, "old", new DateOnly(2025, 1, 1), offeringAmount: 100_001),
+                MakeFiling(stock.Id, "middle", new DateOnly(2025, 2, 1), offeringAmount: 100_002),
+                MakeFiling(stock.Id, "new", new DateOnly(2025, 3, 1), offeringAmount: 100_003)
+            );
         await _dbContext.SaveChangesAsync();
 
         var page = await _tools.GetFormDOfferings("AAPL", maxResults: 1, offset: 1);

--- a/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
@@ -114,8 +114,8 @@ public class FormDExemptOfferingsToolTests : IDisposable
 
         var result = await _tools.GetFormDOfferings("AAPL", maxResults: 2);
 
-        result.Should().Contain("showing 2 most recent notices");
-        result.Should().Contain("Showing first 2 of 5 results");
+        result.Should().Contain("showing notices 1-2 of 5, newest first");
+        result.Should().Contain("Showing results 1-2 of 5");
     }
 
     [Fact]
@@ -195,6 +195,39 @@ public class FormDExemptOfferingsToolTests : IDisposable
 
         result.Should().Contain("Unknown fromDate '01/13/2025'");
         result.Should().Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task GetFormDOfferings_InvertedDateRange_ReturnsExplicitError()
+    {
+        SeedStock();
+
+        var result = await _tools.GetFormDOfferings(
+            "AAPL",
+            fromDate: "2025-12-31",
+            toDate: "2025-01-01"
+        );
+
+        result.Should().Be("fromDate must be on or before toDate.");
+    }
+
+    [Fact]
+    public async Task GetFormDOfferings_OffsetPagesNewestFirst_AndRejectsPastEnd()
+    {
+        var stock = SeedStock();
+        _dbContext.Set<FormDFiling>().AddRange(
+            MakeFiling(stock.Id, "old", new DateOnly(2025, 1, 1), offeringAmount: 100_001),
+            MakeFiling(stock.Id, "middle", new DateOnly(2025, 2, 1), offeringAmount: 100_002),
+            MakeFiling(stock.Id, "new", new DateOnly(2025, 3, 1), offeringAmount: 100_003)
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var page = await _tools.GetFormDOfferings("AAPL", maxResults: 1, offset: 1);
+        var pastEnd = await _tools.GetFormDOfferings("AAPL", offset: 3);
+
+        page.Should().Contain("100,002").And.NotContain("100,003").And.NotContain("100,001");
+        page.Should().Contain("Showing results 2-2 of 3");
+        pastEnd.Should().Contain("No results at offset 3 - only 3 Form D notices match");
     }
 
     private static FormDFiling MakeFiling(

--- a/tests/Equibles.IntegrationTests/Mcp/FundDirectoryToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FundDirectoryToolsTests.cs
@@ -165,8 +165,27 @@ public class FundDirectoryToolsTests : IDisposable
 
         var result = await _tools.GetFundProfile(series.Slug, maxResults: 2);
 
-        result.Should().Contain("showing the largest 2");
-        result.Should().Contain("Showing first 2 of 5 results");
+        result.Should().Contain("showing stored rows 1-2 by value");
+        result.Should().Contain("Showing results 1-2 of 5");
+    }
+
+    [Fact]
+    public async Task GetFundProfile_OffsetPagesByValue_AndRejectsPastEnd()
+    {
+        var series = SeedSeries("PAGED FUND", "S000020");
+        var filing = MakeFiling(series, "acc-page", new DateOnly(2026, 5, 15));
+        filing.Holdings.Add(MakeHolding("LOW CO", 1_000m));
+        filing.Holdings.Add(MakeHolding("MID CO", 2_000m));
+        filing.Holdings.Add(MakeHolding("HIGH CO", 3_000m));
+        _dbContext.Set<NportFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var page = await _tools.GetFundProfile(series.Slug, maxResults: 1, offset: 1);
+        var pastEnd = await _tools.GetFundProfile(series.Slug, offset: 3);
+
+        page.Should().Contain("MID CO").And.NotContain("HIGH CO").And.NotContain("LOW CO");
+        page.Should().Contain("Showing results 2-2 of 3");
+        pastEnd.Should().Contain("No results at offset 3 - only 3 stored holdings exist");
     }
 
     [Fact]
@@ -196,6 +215,22 @@ public class FundDirectoryToolsTests : IDisposable
 
         result.Should().Contain("No stored Form NPORT-P report is on record for ACME FUND");
         result.Should().Contain("dataset coverage result, not evidence that no SEC filing exists");
+    }
+
+    [Fact]
+    public async Task GetFundProfile_StoredReportWithoutHoldingRows_ExplainsEmptyStorage()
+    {
+        var series = SeedSeries("EMPTY FUND", "S000099", reportedHoldingCount: 12);
+        var filing = MakeFiling(series, "acc-empty", new DateOnly(2026, 5, 15));
+        filing.ReportedHoldingCount = 12;
+        _dbContext.Set<NportFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundProfile(series.Slug);
+
+        result.Should().Contain("12 holdings reported");
+        result.Should().Contain("no tracked-stock holding rows are stored");
+        result.Should().NotContain("rows 0-0");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/HoldingsToolsTests.cs
@@ -116,7 +116,7 @@ public class InstitutionalHoldingsToolsTests : ParadeDbMcpTestBase
         result.Should().Contain("BlackRock Inc");
         result.Should().Contain("10,000");
         result.Should().Contain("5,000");
-        result.Should().Contain("2 of 2 institutions");
+        result.Should().Contain("Showing rows 1-2 of 2 across 2 institutions");
     }
 
     [Fact]
@@ -210,10 +210,18 @@ public class InstitutionalHoldingsToolsTests : ParadeDbMcpTestBase
 
         var result = await Sut().GetTopHolders("AAPL", maxResults: 2);
 
-        result.Should().Contain("2 of 5 institutions");
+        result.Should().Contain("Showing rows 1-2 of 5 across 5 institutions");
         result.Should().Contain("Fund 1");
         result.Should().Contain("Fund 2");
         result.Should().NotContain("Fund 5");
+
+        var page = await Sut().GetTopHolders("AAPL", maxResults: 2, offset: 2);
+        var pastEnd = await Sut().GetTopHolders("AAPL", offset: 5);
+
+        page.Should().Contain("| 3 | Fund 3 |").And.Contain("| 4 | Fund 4 |");
+        page.Should().NotContain("| 1 | Fund 1 |");
+        page.Should().Contain("Showing results 3-4 of 5");
+        pastEnd.Should().Contain("No results at offset 5 - only 5 holding rows exist");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -277,7 +277,7 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
 
         var result = await Sut().GetInsiderTransactions("AAPL", maxResults: 3);
 
-        result.Should().Contain("Showing 3 most recent transactions");
+        result.Should().Contain("Showing transactions 1-3 of 5");
     }
 
     [Fact]
@@ -424,6 +424,40 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
     }
 
     // ══════════════════════════════════════════════════════════════════
+    [Fact]
+    public async Task GetInsiderTransactions_OffsetPagesNewestFirst_AndRejectsPastEnd()
+    {
+        var stock = CreateStock();
+        var owner = CreateOwner();
+        await SeedStock(stock);
+        await SeedOwner(owner);
+        await SeedTransaction(CreateTransaction(stock, owner, new DateOnly(2024, 1, 1), accessionNumber: "old"));
+        await SeedTransaction(CreateTransaction(stock, owner, new DateOnly(2024, 2, 1), accessionNumber: "middle"));
+        await SeedTransaction(CreateTransaction(stock, owner, new DateOnly(2024, 3, 1), accessionNumber: "new"));
+
+        var page = await Sut().GetInsiderTransactions("AAPL", maxResults: 1, offset: 1);
+        var pastEnd = await Sut().GetInsiderTransactions("AAPL", offset: 3);
+
+        page.Should().Contain("2024-02-01").And.NotContain("2024-03-01").And.NotContain("2024-01-01");
+        page.Should().Contain("Showing results 2-2 of 3");
+        pastEnd.Should().Contain("No results at offset 3 - only 3 insider transactions match");
+    }
+
+    [Fact]
+    public async Task GetInsiderTransactions_InvertedDateRange_ReturnsExplicitError()
+    {
+        var stock = CreateStock();
+        await SeedStock(stock);
+
+        var result = await Sut().GetInsiderTransactions(
+            "AAPL",
+            fromDate: "2024-12-31",
+            toDate: "2024-01-01"
+        );
+
+        result.Should().Be("fromDate must be on or before toDate.");
+    }
+
     // GetInsiderOwnership
     // ══════════════════════════════════════════════════════════════════
 

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -431,14 +431,23 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
         var owner = CreateOwner();
         await SeedStock(stock);
         await SeedOwner(owner);
-        await SeedTransaction(CreateTransaction(stock, owner, new DateOnly(2024, 1, 1), accessionNumber: "old"));
-        await SeedTransaction(CreateTransaction(stock, owner, new DateOnly(2024, 2, 1), accessionNumber: "middle"));
-        await SeedTransaction(CreateTransaction(stock, owner, new DateOnly(2024, 3, 1), accessionNumber: "new"));
+        await SeedTransaction(
+            CreateTransaction(stock, owner, new DateOnly(2024, 1, 1), accessionNumber: "old")
+        );
+        await SeedTransaction(
+            CreateTransaction(stock, owner, new DateOnly(2024, 2, 1), accessionNumber: "middle")
+        );
+        await SeedTransaction(
+            CreateTransaction(stock, owner, new DateOnly(2024, 3, 1), accessionNumber: "new")
+        );
 
         var page = await Sut().GetInsiderTransactions("AAPL", maxResults: 1, offset: 1);
         var pastEnd = await Sut().GetInsiderTransactions("AAPL", offset: 3);
 
-        page.Should().Contain("2024-02-01").And.NotContain("2024-03-01").And.NotContain("2024-01-01");
+        page.Should()
+            .Contain("2024-02-01")
+            .And.NotContain("2024-03-01")
+            .And.NotContain("2024-01-01");
         page.Should().Contain("Showing results 2-2 of 3");
         pastEnd.Should().Contain("No results at offset 3 - only 3 insider transactions match");
     }
@@ -449,11 +458,8 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
         var stock = CreateStock();
         await SeedStock(stock);
 
-        var result = await Sut().GetInsiderTransactions(
-            "AAPL",
-            fromDate: "2024-12-31",
-            toDate: "2024-01-01"
-        );
+        var result = await Sut()
+            .GetInsiderTransactions("AAPL", fromDate: "2024-12-31", toDate: "2024-01-01");
 
         result.Should().Be("fromDate must be on or before toDate.");
     }

--- a/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
@@ -163,6 +163,31 @@ public class NportFundsHoldingStockToolTests : IDisposable
         result.Should().Contain("dataset coverage result");
     }
 
+    [Fact]
+    public async Task GetFundsHoldingStock_OffsetPagesAfterValueRanking_AndRejectsPastEnd()
+    {
+        SeedStock("AAPL", HeldCusip);
+        var lowFund = SeedStock("LOWF", cusip: null, cik: "0000001001");
+        var highFund = SeedStock("HIGHF", cusip: null, cik: "0000001002");
+        var low = MakeFiling(lowFund.Id, "low", RecentFilingDate);
+        low.SeriesId = "SLOW";
+        low.SeriesName = "Low Value Fund";
+        low.Holdings.Add(MakeHolding(HeldCusip, 1_000m));
+        var high = MakeFiling(highFund.Id, "high", RecentFilingDate);
+        high.SeriesId = "SHIGH";
+        high.SeriesName = "High Value Fund";
+        high.Holdings.Add(MakeHolding(HeldCusip, 2_000m));
+        _dbContext.Set<NportFiling>().AddRange(low, high);
+        await _dbContext.SaveChangesAsync();
+
+        var page = await _tools.GetFundsHoldingStock("AAPL", maxResults: 1, offset: 1);
+        var pastEnd = await _tools.GetFundsHoldingStock("AAPL", offset: 2);
+
+        page.Should().Contain("Low Value Fund").And.NotContain("High Value Fund");
+        page.Should().Contain("Showing results 2-2 of 2 (the last page)");
+        pastEnd.Should().Contain("No results at offset 2 - only 2 current fund positions match");
+    }
+
     private CommonStock SeedStock(string ticker, string cusip, string cik = null)
     {
         var stock = new CommonStock

--- a/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/GovernmentContractsToolsShortenSurrogateTests.cs
@@ -98,6 +98,21 @@ public class GovernmentContractsToolsShortenSurrogateTests
                 Description = "Missile systems",
             }
         );
+        context.Add(
+            new GovernmentContract
+            {
+                CommonStockId = stock.Id,
+                AwardUniqueKey = "award-2",
+                AwardId = "NNH26C0002",
+                RecipientName = "Older Recipient LLC",
+                AwardType = GovernmentContractAwardType.DefinitiveContract,
+                AwardingAgency = "National Aeronautics and Space Administration",
+                Amount = 500_000m,
+                ActionDate = new DateOnly(2026, 5, 1),
+                EndDate = new DateOnly(2027, 5, 1),
+                Description = "Flight systems",
+            }
+        );
         await context.SaveChangesAsync();
         var tools = new GovernmentContractsTools(
             new GovernmentContractRepository(context),
@@ -122,6 +137,25 @@ public class GovernmentContractsToolsShortenSurrogateTests
                 "Recipient is the awarded entity",
                 "the market-wide ranking has no Recipient column"
             );
+
+        var secondPage = await tools.GetGovernmentContracts(
+            "RTX",
+            "2026-01-01",
+            "2026-12-31",
+            maxResults: 1,
+            sortBy: "date",
+            offset: 1
+        );
+        secondPage.Should().Contain("Older Recipient LLC");
+        secondPage.Should().Contain("Showing results 2-2 of 2");
+
+        var pastEnd = await tools.GetGovernmentContracts(
+            "RTX",
+            "2026-01-01",
+            "2026-12-31",
+            offset: 2
+        );
+        pastEnd.Should().Contain("No results at offset 2 - only 2 federal contract awards match");
     }
 
     private static bool HasUnpairedSurrogate(string value)

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsTransactionRenderingAndFilterTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsTransactionRenderingAndFilterTests.cs
@@ -247,7 +247,7 @@ public class InsiderTradingToolsTransactionRenderingAndFilterTests
 
         output.Should().Contain("Real Trader");
         output.Should().NotContain("Ghost Filer");
-        output.Should().Contain("Showing 1 most recent transactions");
+        output.Should().Contain("Showing transactions 1-1 of 1");
     }
 
     [Fact]
@@ -382,7 +382,11 @@ public class InsiderTradingToolsTransactionRenderingAndFilterTests
 
         var output = await Sut(db).GetInsiderTransactions("AAPL", maxResults: 2);
 
-        output.Should().Contain("Showing first 2 of 3 results - raise maxResults to see more.");
+        output
+            .Should()
+            .Contain(
+                "Showing results 1-2 of 3 - raise maxResults (max 500) or pass offset=2 to continue."
+            );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add safe offset paging to capped MCP list tools
- add authoritative Congress ticker filtering and shared deterministic ordering
- validate date windows and make paging/cap messages truthful
- harden ticker resolution and zero-row coverage states

## Verification
- `dotnet build Equibles.sln -c Release --no-restore`
- full integration assembly: 2,810 passed
- post-review affected suite: 42 passed
- independent review: no blocking or high-confidence findings