### PR TITLE
fix(mcp): qualify filtered empty states

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -520,7 +520,11 @@ public class InsiderTradingTools
 
                 var totalCount = await query.CountAsync();
                 if (totalCount == 0)
+                {
+                    if (fromDay.HasValue || toDay.HasValue)
+                        return $"No Form 144 proposed sales match the requested filing-date range for {stock.Ticker} (fromDate={fromDay?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "unbounded"}, toDate={toDay?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "unbounded"}).";
                     return $"No Form 144 proposed sales found for {stock.Ticker}.";
+                }
 
                 offset = McpLimit.ClampOffset(offset);
                 var filings = await query

--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -95,7 +95,11 @@ public class FormDTools
 
                 var totalCount = await query.CountAsync();
                 if (totalCount == 0)
+                {
+                    if (fromDay.HasValue || toDay.HasValue)
+                        return $"No Form D exempt offerings match the requested filing-date range for {ticker} (fromDate={fromDay?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "unbounded"}, toDate={toDay?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "unbounded"}).";
                     return $"No Form D exempt offerings found for {ticker}.";
+                }
 
                 offset = McpLimit.ClampOffset(offset);
                 var filings = await query

--- a/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
@@ -193,6 +193,26 @@ public class Form144ProposedSalesToolTests : IDisposable
     }
 
     [Fact]
+    public async Task GetForm144ProposedSales_DateRangeWithoutMatches_NamesTheAppliedRange()
+    {
+        var stock = SeedStock();
+        _dbContext
+            .Set<Form144Filing>()
+            .Add(MakeFiling(stock.Id, "old", new DateOnly(2026, 1, 10), "EARLY SELLER", 1000));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetForm144ProposedSales(
+            "AAPL",
+            fromDate: " 2026-03-01 ",
+            toDate: ""
+        );
+
+        result.Should().Contain("match the requested filing-date range");
+        result.Should().Contain("fromDate=2026-03-01, toDate=unbounded");
+        result.Should().NotBe("No Form 144 proposed sales found for AAPL.");
+    }
+
+    [Fact]
     public async Task GetForm144ProposedSales_OffsetPagesNewestFirst_AndRejectsPastEnd()
     {
         var stock = SeedStock();

--- a/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
@@ -187,6 +187,20 @@ public class FormDExemptOfferingsToolTests : IDisposable
     }
 
     [Fact]
+    public async Task GetFormDOfferings_DateRangeWithoutMatches_NamesTheAppliedRange()
+    {
+        var stock = SeedStock();
+        _dbContext.Set<FormDFiling>().Add(MakeFiling(stock.Id, "old", new DateOnly(2025, 1, 10)));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFormDOfferings("AAPL", fromDate: " 2025-03-01 ", toDate: "");
+
+        result.Should().Contain("match the requested filing-date range");
+        result.Should().Contain("fromDate=2025-03-01, toDate=unbounded");
+        result.Should().NotBe("No Form D exempt offerings found for AAPL.");
+    }
+
+    [Fact]
     public async Task GetFormDOfferings_MalformedDate_ReturnsAcceptedFormatError()
     {
         SeedStock();


### PR DESCRIPTION
## Problem

Date-filtered Form 144 and Form D queries could return an all-history empty message when rows existed outside the requested range.

## Fix

- Preserve the factual all-history empty state when no effective date bound is supplied.
- Name canonical effective bounds on filtered misses, including an unbounded side.
- Cover padded one-sided ranges for both tools.

## Verification

- Release solution build
- 32 focused integration tests
- CSharpier
- Independent audit-only rereview: no blocking or high-confidence findings