### PR TITLE
fix(holdings): pace quarterly bulk imports

### DIFF
--- a/src/Equibles.Core/Configuration/WorkerOptions.cs
+++ b/src/Equibles.Core/Configuration/WorkerOptions.cs
@@ -6,6 +6,13 @@ public class WorkerOptions
     public List<string> TickersToSync { get; set; } = [];
 
     /// <summary>
+    /// Pause after each quarterly 13F bulk-import write batch. The importer releases its database
+    /// scope before waiting, giving request traffic a bounded window between sustained replay
+    /// transactions. Realtime filing ingestion does not use this pause.
+    /// </summary>
+    public int HoldingsBulkBatchPauseMilliseconds { get; set; }
+
+    /// <summary>
     /// Caps how many listed series the corporate-action adjustment pass re-syncs per cycle, so the
     /// one-time universe backfill throttles against Yahoo's shared request limiter instead of
     /// re-pulling every series' full history at once. Series beyond the cap stay pending and are

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -28,6 +28,13 @@ public class HoldingsScraperWorker : BaseScraperWorker
     // production behaviour (the default is unchanged).
     protected virtual TimeSpan FailedDataSetCooldown => TimeSpan.FromMinutes(5);
 
+    // A bulk replay otherwise runs accession transactions back-to-back for hours. Clamp the
+    // operator value so a typo cannot turn the daily import into an unbounded sleep.
+    protected virtual TimeSpan BulkBatchPause =>
+        TimeSpan.FromMilliseconds(
+            Math.Clamp(_workerOptions.HoldingsBulkBatchPauseMilliseconds, 0, 1_000)
+        );
+
     private readonly WorkerOptions _workerOptions;
     private readonly IConfiguration _configuration;
     private readonly HoldingsRescanSignal _rescanSignal;
@@ -455,6 +462,7 @@ public class HoldingsScraperWorker : BaseScraperWorker
                 var result = await importService.ImportDataSet(
                     archive,
                     minReportDate,
+                    BulkBatchPause,
                     cancellationToken
                 );
 

--- a/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
+++ b/src/Equibles.Holdings.HostedService/Models/ImportContext.cs
@@ -17,6 +17,7 @@ public class ImportContext
     public TsvParser TsvParser { get; init; }
     public ZipArchive Archive { get; init; }
     public DateOnly MinReportDate { get; init; }
+    public TimeSpan BatchPause { get; init; }
 
     // Populated by phases
     public Dictionary<string, SubmissionRow> Submissions { get; set; }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsBatchPacer.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsBatchPacer.cs
@@ -1,0 +1,22 @@
+namespace Equibles.Holdings.HostedService.Services;
+
+internal static class HoldingsBatchPacer
+{
+    // The flush task owns and disposes its repository scope before it completes. Waiting only
+    // after that completion prevents throttling from holding a scarce database connection idle.
+    internal static async Task<T> Complete<T>(
+        Task<T> flushTask,
+        Func<T, bool> shouldPause,
+        TimeSpan pause,
+        CancellationToken cancellationToken
+    )
+    {
+        var result = await flushTask;
+        if (shouldPause(result) && pause > TimeSpan.Zero)
+        {
+            await Task.Delay(pause, cancellationToken);
+        }
+
+        return result;
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -55,9 +55,16 @@ public class HoldingsImportService
         _bus = bus;
     }
 
-    public async Task<ImportResult> ImportDataSet(
+    public virtual Task<ImportResult> ImportDataSet(
         ZipArchive archive,
         DateOnly minReportDate,
+        CancellationToken cancellationToken
+    ) => ImportDataSet(archive, minReportDate, TimeSpan.Zero, cancellationToken);
+
+    public virtual async Task<ImportResult> ImportDataSet(
+        ZipArchive archive,
+        DateOnly minReportDate,
+        TimeSpan batchPause,
         CancellationToken cancellationToken
     )
     {
@@ -66,6 +73,7 @@ public class HoldingsImportService
             TsvParser = new TsvParser(),
             Archive = archive,
             MinReportDate = minReportDate,
+            BatchPause = batchPause,
         };
 
         var parseResult = await ParseSubmissions(context, cancellationToken);
@@ -1681,10 +1689,14 @@ public class HoldingsImportService
             }
         }
 
-        var flushResult =
+        var flushResult = await HoldingsBatchPacer.Complete(
             holdingsMap.Count > 0
-                ? await FlushBatch(holdingsMap.Values.ToList(), cancellationToken)
-                : new HoldingsFlushResult(0, SkippedStaleParent: false);
+                ? FlushBatch(holdingsMap.Values.ToList(), cancellationToken)
+                : Task.FromResult(new HoldingsFlushResult(0, SkippedStaleParent: false)),
+            static result => result.Inserted > 0,
+            context.BatchPause,
+            cancellationToken
+        );
 
         return (flushResult.Inserted, duplicates, pending, flushResult.SkippedStaleParent);
     }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBulkBatchPacingTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBulkBatchPacingTests.cs
@@ -1,0 +1,160 @@
+using System.IO.Compression;
+using System.Reflection;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Holdings.HostedService;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Integrations.Sec.Contracts;
+using MassTransit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsBulkBatchPacingTests
+{
+    [Fact]
+    public async Task CompatibilityOverload_ForwardsZeroPause()
+    {
+        var importer = new RecordingHoldingsImportService();
+        using var archive = EmptyArchive();
+
+        await importer.ImportDataSet(archive, new DateOnly(2026, 1, 1), CancellationToken.None);
+
+        importer.ReceivedPause.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task QuarterlyWorker_ForwardsConfiguredPause()
+    {
+        var importer = new RecordingHoldingsImportService();
+        var secClient = Substitute.For<ISecEdgarClient>();
+        secClient.DownloadStream(Arg.Any<string>()).Returns(new MemoryStream(EmptyArchiveBytes()));
+        var dataSetClient = new HoldingsDataSetClient(
+            secClient,
+            Substitute.For<ILogger<HoldingsDataSetClient>>()
+        );
+        var provider = Substitute.For<IServiceProvider>();
+        provider.GetService(typeof(HoldingsDataSetClient)).Returns(dataSetClient);
+        provider.GetService(typeof(HoldingsImportService)).Returns(importer);
+        var scope = Substitute.For<IServiceScope>();
+        scope.ServiceProvider.Returns(provider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?> { ["Sec:ContactEmail"] = "test@example.com" }
+            )
+            .Build();
+        var worker = new HoldingsScraperWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            scopeFactory,
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions { HoldingsBulkBatchPauseMilliseconds = 250 }),
+            configuration,
+            new HoldingsRescanSignal()
+        );
+        var tryProcess = typeof(HoldingsScraperWorker).GetMethod(
+            "TryProcessDataSet",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        var result = await (Task<bool>)
+            tryProcess!.Invoke(
+                worker,
+                ["2026q1_form13f.zip", new DateOnly(2026, 1, 1), CancellationToken.None]
+            )!;
+
+        result.Should().BeTrue();
+        importer.ReceivedPause.Should().Be(TimeSpan.FromMilliseconds(250));
+    }
+
+    [Fact]
+    public async Task Complete_WaitsAfterFlushDisposesAndPropagatesCancellation()
+    {
+        var flushStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var releaseFlush = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var disposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
+
+        async Task<int> Flush()
+        {
+            using var scope = new DisposeAction(() => disposed.SetResult());
+            flushStarted.SetResult();
+            await releaseFlush.Task;
+            return 1;
+        }
+
+        var completion = HoldingsBatchPacer.Complete(
+            Flush(),
+            static inserted => inserted > 0,
+            TimeSpan.FromHours(1),
+            cancellation.Token
+        );
+        await flushStarted.Task;
+        completion.IsCompleted.Should().BeFalse();
+
+        releaseFlush.SetResult();
+        await disposed.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        completion.IsCompleted.Should().BeFalse("the cancellable pause follows scope disposal");
+
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => completion);
+    }
+
+    private static ZipArchive EmptyArchive() =>
+        new(new MemoryStream(EmptyArchiveBytes()), ZipArchiveMode.Read);
+
+    private static byte[] EmptyArchiveBytes()
+    {
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            archive.CreateEntry("EMPTY.tsv");
+        }
+
+        return buffer.ToArray();
+    }
+
+    private sealed class RecordingHoldingsImportService : HoldingsImportService
+    {
+        public RecordingHoldingsImportService()
+            : base(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<HoldingsImportService>>(),
+                Options.Create(new WorkerOptions()),
+                Substitute.For<IStockPriceProvider>(),
+                Substitute.For<IBus>()
+            ) { }
+
+        public TimeSpan? ReceivedPause { get; private set; }
+
+        public override Task<ImportResult> ImportDataSet(
+            ZipArchive archive,
+            DateOnly minReportDate,
+            TimeSpan batchPause,
+            CancellationToken cancellationToken
+        )
+        {
+            ReceivedPause = batchPause;
+            return Task.FromResult(new ImportResult(0, IsComplete: false));
+        }
+    }
+
+    private sealed class DisposeAction(Action dispose) : IDisposable
+    {
+        public void Dispose() => dispose();
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
@@ -188,6 +188,31 @@ public class HoldingsScraperWorkerTests
         sut.InvokeWorkerName().Should().Be("Holdings scraper");
     }
 
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(250, 250)]
+    [InlineData(5_000, 1_000)]
+    public void BulkBatchPause_ClampsTheConfiguredMilliseconds(
+        int configuredMilliseconds,
+        int expectedMilliseconds
+    )
+    {
+        var sut = new TestableHoldingsScraperWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(
+                new WorkerOptions { HoldingsBulkBatchPauseMilliseconds = configuredMilliseconds }
+            ),
+            new ConfigurationBuilder().Build()
+        );
+
+        sut.InvokeBulkBatchPause().Should().Be(TimeSpan.FromMilliseconds(expectedMilliseconds));
+    }
+
     private sealed class TestableHoldingsScraperWorker : HoldingsScraperWorker
     {
         public TestableHoldingsScraperWorker(
@@ -213,5 +238,7 @@ public class HoldingsScraperWorkerTests
         public ErrorSource InvokeErrorSource() => ErrorSource;
 
         public string InvokeWorkerName() => WorkerName;
+
+        public TimeSpan InvokeBulkBatchPause() => BulkBatchPause;
     }
 }


### PR DESCRIPTION
## Summary
- reduce database starvation during sustained quarterly 13F replays
- preserve realtime ingestion latency and the zero-delay OSS default

## Code changes
- add a bounded per-accession pause after the write scope is released
- forward the pause only from quarterly data-set processing
- cover forwarding, compatibility, scope ordering, cancellation, and clamping

## Testing
- dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj — 4,745 passed