### PR TITLE
feat(sec): preserve filing artifacts

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260902210458_AddSecFilingArtifacts.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260902210458_AddSecFilingArtifacts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260902210458_AddSecFilingArtifacts")]
+    partial class AddSecFilingArtifacts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260902210458_AddSecFilingArtifacts.cs
+++ b/src/Equibles.Migrations/Migrations/20260902210458_AddSecFilingArtifacts.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSecFilingArtifacts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SecFilingArtifact",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DocumentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FileName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Type = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Sequence = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    SequenceNumber = table.Column<int>(type: "integer", nullable: true),
+                    Description = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    FilerCik = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    SourceUrl = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    IsPrimary = table.Column<bool>(type: "boolean", nullable: false),
+                    CaptureStatus = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Content = table.Column<string>(type: "text", nullable: true),
+                    ContentSha256 = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    ContentLength = table.Column<long>(type: "bigint", nullable: true),
+                    CapturedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SecFilingArtifact", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SecFilingArtifact_Document_DocumentId",
+                        column: x => x.DocumentId,
+                        principalTable: "Document",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SecFilingArtifact_DocumentId_FileName",
+                table: "SecFilingArtifact",
+                columns: new[] { "DocumentId", "FileName" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SecFilingArtifact_Type",
+                table: "SecFilingArtifact",
+                column: "Type");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SecFilingArtifact");
+        }
+    }
+}

--- a/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
@@ -156,6 +156,70 @@ public static class SecDocumentEnvelopeParser
             || content.Contains("<ix:", StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Enumerates the named files in a complete EDGAR SGML submission while preserving the
+    /// source-stated type, sequence, description, and document boundary. Unsafe or unnamed
+    /// filenames are refused because callers use the name to build an SEC artifact URL.
+    /// </summary>
+    public static IReadOnlyList<SecFilingArtifactDescriptor> EnumerateArtifacts(
+        string envelope,
+        string primaryDocumentFileName = null
+    )
+    {
+        var artifacts = new List<SecFilingArtifactDescriptor>();
+        foreach (var block in EnumerateDocumentBlocks(envelope))
+        {
+            if (!TryExtractSgmlTagValue(block, "FILENAME", out var fileName))
+                continue;
+            if (!IsSafeFilename(fileName))
+                continue;
+            if (!SecSgmlEnvelope.TryGetTagLine(block, "TYPE", out var type) || type.Length == 0)
+                continue;
+
+            TryExtractSgmlTagValue(block, "SEQUENCE", out var sequence);
+            var sequenceNumber = int.TryParse(sequence, out var parsedSequence)
+                ? parsedSequence
+                : (int?)null;
+            SecSgmlEnvelope.TryGetTagLine(block, "DESCRIPTION", out var description);
+            TryExtractTextBody(block, out var body);
+
+            artifacts.Add(
+                new SecFilingArtifactDescriptor(
+                    fileName,
+                    type,
+                    sequence,
+                    sequenceNumber,
+                    description,
+                    body,
+                    block,
+                    !string.IsNullOrEmpty(primaryDocumentFileName)
+                        && string.Equals(
+                            fileName,
+                            primaryDocumentFileName,
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                )
+            );
+        }
+
+        if (artifacts.Count > 0 && !artifacts.Exists(artifact => artifact.IsPrimary))
+        {
+            var first = artifacts[0];
+            artifacts[0] = new SecFilingArtifactDescriptor(
+                first.FileName,
+                first.Type,
+                first.Sequence,
+                first.SequenceNumber,
+                first.Description,
+                first.Body,
+                first.RawBlock,
+                isPrimary: true
+            );
+        }
+
+        return artifacts;
+    }
+
     // Walks the SGML envelope yielding each <DOCUMENT>...</DOCUMENT> block verbatim. Stops at
     // the first unterminated block, matching EDGAR's well-formed-or-nothing guarantee.
     private static IEnumerable<string> EnumerateDocumentBlocks(string envelope)

--- a/src/Equibles.Sec.BusinessLogic/SecFilingArtifactDescriptor.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecFilingArtifactDescriptor.cs
@@ -1,0 +1,35 @@
+namespace Equibles.Sec.BusinessLogic;
+
+/// <summary>Source-stated metadata and content for one named SGML document block.</summary>
+public sealed class SecFilingArtifactDescriptor
+{
+    public SecFilingArtifactDescriptor(
+        string fileName,
+        string type,
+        string sequence,
+        int? sequenceNumber,
+        string description,
+        string body,
+        string rawBlock,
+        bool isPrimary
+    )
+    {
+        FileName = fileName;
+        Type = type;
+        Sequence = sequence;
+        SequenceNumber = sequenceNumber;
+        Description = description;
+        Body = body;
+        RawBlock = rawBlock;
+        IsPrimary = isPrimary;
+    }
+
+    public string FileName { get; }
+    public string Type { get; }
+    public string Sequence { get; }
+    public int? SequenceNumber { get; }
+    public string Description { get; }
+    public string Body { get; }
+    public string RawBlock { get; }
+    public bool IsPrimary { get; }
+}

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -43,6 +43,12 @@ public class Document
     public virtual List<DocumentImage> Images { get; set; } = [];
 
     /// <summary>
+    /// Named files inside this filing's submission envelope. Unlike normalized filing content,
+    /// these rows preserve the boundary between the primary form and individual exhibits.
+    /// </summary>
+    public virtual List<SecFilingArtifact> Artifacts { get; set; } = [];
+
+    /// <summary>
     /// The file containing the document content.
     /// </summary>
     public Guid ContentId { get; set; }

--- a/src/Equibles.Sec.Data/Models/SecFilingArtifact.cs
+++ b/src/Equibles.Sec.Data/Models/SecFilingArtifact.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// One named artifact inside an EDGAR submission: the primary form, an exhibit, or another
+/// document block. The parent filing remains <see cref="Document"/>; this row preserves the
+/// per-file boundary and source metadata needed to cite a specific legal agreement.
+/// </summary>
+[Index(nameof(DocumentId), nameof(FileName), IsUnique = true)]
+[Index(nameof(Type))]
+public class SecFilingArtifact
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid DocumentId { get; set; }
+    public virtual Document Document { get; set; }
+
+    [Required]
+    [MaxLength(256)]
+    public string FileName { get; set; }
+
+    [Required]
+    [MaxLength(64)]
+    public string Type { get; set; }
+
+    [MaxLength(32)]
+    public string Sequence { get; set; }
+
+    /// <summary>
+    /// Parsed ordinal used only for display ordering. <see cref="Sequence"/> retains the exact
+    /// source value, including uncommon non-numeric values.
+    /// </summary>
+    public int? SequenceNumber { get; set; }
+
+    [MaxLength(512)]
+    public string Description { get; set; }
+
+    [MaxLength(20)]
+    public string FilerCik { get; set; }
+
+    [Required]
+    [MaxLength(512)]
+    public string SourceUrl { get; set; }
+
+    public bool IsPrimary { get; set; }
+
+    [Required]
+    public SecFilingArtifactCaptureStatus CaptureStatus { get; set; }
+
+    /// <summary>
+    /// Normalized Markdown for HTML/TXT artifacts. Binary artifacts keep this null and retain
+    /// their canonical SEC URL so a bounded parser can capture them later.
+    /// </summary>
+    public string Content { get; set; }
+
+    [MaxLength(64)]
+    public string ContentSha256 { get; set; }
+
+    public long? ContentLength { get; set; }
+
+    public DateTime CapturedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Sec.Data/Models/SecFilingArtifactCaptureStatus.cs
+++ b/src/Equibles.Sec.Data/Models/SecFilingArtifactCaptureStatus.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Sec.Data.Models;
+
+public enum SecFilingArtifactCaptureStatus
+{
+    [Display(Name = "Metadata only")]
+    MetadataOnly,
+
+    [Display(Name = "Text captured")]
+    TextCaptured,
+
+    [Display(Name = "Binary not parsed")]
+    BinaryNotParsed,
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -42,6 +42,15 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
+        builder.Entity<SecFilingArtifact>(b =>
+        {
+            b.Property(e => e.CaptureStatus).HasConversion<string>().HasMaxLength(32);
+            b.HasOne(e => e.Document)
+                .WithMany(d => d.Artifacts)
+                .HasForeignKey(e => e.DocumentId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
         builder.Entity<BackfillState>();
         builder.Entity<CompanyFilingSyncState>();
         builder.Entity<FailToDeliver>();

--- a/src/Equibles.Sec.Repositories/SecFilingArtifactRepository.cs
+++ b/src/Equibles.Sec.Repositories/SecFilingArtifactRepository.cs
@@ -1,0 +1,24 @@
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Repositories;
+
+public class SecFilingArtifactRepository : BaseRepository<SecFilingArtifact>
+{
+    public SecFilingArtifactRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<SecFilingArtifact> GetByDocument(Document document)
+    {
+        return Order(GetAll().Where(artifact => artifact.DocumentId == document.Id));
+    }
+
+    public static IOrderedQueryable<SecFilingArtifact> Order(
+        IQueryable<SecFilingArtifact> artifacts
+    ) =>
+        artifacts
+            .OrderBy(artifact => artifact.SequenceNumber == null)
+            .ThenBy(artifact => artifact.SequenceNumber)
+            .ThenBy(artifact => artifact.Sequence)
+            .ThenBy(artifact => artifact.FileName);
+}

--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserArtifactTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserArtifactTests.cs
@@ -1,0 +1,95 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserArtifactTests
+{
+    [Fact]
+    public void EnumerateArtifacts_MultipleDebtExhibits_PreservesIndividualMetadataAndBodies()
+    {
+        var envelope = """
+            <SEC-DOCUMENT>
+            <DOCUMENT>
+            <TYPE>8-K
+            <SEQUENCE>1
+            <FILENAME>issuer-8k.htm
+            <DESCRIPTION>Current report
+            <TEXT><html><body>Item 8.01</body></html></TEXT>
+            </DOCUMENT>
+            <DOCUMENT>
+            <TYPE>EX-4.1
+            <SEQUENCE>2
+            <FILENAME>indenture.htm
+            <DESCRIPTION>Supplemental Indenture
+            <TEXT><html><body>2.00% Notes due 2030</body></html></TEXT>
+            </DOCUMENT>
+            <DOCUMENT>
+            <TYPE>EX-10.1
+            <SEQUENCE>3
+            <FILENAME>credit-agreement.htm
+            <DESCRIPTION>Credit Agreement
+            <TEXT><html><body>Revolving Commitments</body></html></TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var artifacts = SecDocumentEnvelopeParser.EnumerateArtifacts(envelope, "issuer-8k.htm");
+
+        artifacts.Should().HaveCount(3);
+        artifacts[0].IsPrimary.Should().BeTrue();
+        artifacts[1].Type.Should().Be("EX-4.1");
+        artifacts[1].SequenceNumber.Should().Be(2);
+        artifacts[1].Description.Should().Be("Supplemental Indenture");
+        artifacts[1].Body.Should().Contain("2.00% Notes due 2030");
+        artifacts[2].FileName.Should().Be("credit-agreement.htm");
+    }
+
+    [Fact]
+    public void EnumerateArtifacts_MultiWordType_PreservesFullSourceValue()
+    {
+        var envelope = """
+            <DOCUMENT>
+            <TYPE>DEF 14A
+            <SEQUENCE>1
+            <FILENAME>proxy.htm
+            <TEXT>proxy statement</TEXT>
+            </DOCUMENT>
+            """;
+
+        var artifact = SecDocumentEnvelopeParser.EnumerateArtifacts(envelope).Single();
+
+        artifact.Type.Should().Be("DEF 14A");
+    }
+
+    [Fact]
+    public void EnumerateArtifacts_UnsafeFilename_RefusesArtifact()
+    {
+        var envelope = """
+            <DOCUMENT>
+            <TYPE>EX-10.1
+            <SEQUENCE>1
+            <FILENAME>%2e%2e%2fsecret.htm
+            <TEXT>secret</TEXT>
+            </DOCUMENT>
+            """;
+
+        SecDocumentEnvelopeParser.EnumerateArtifacts(envelope).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EnumerateArtifacts_UnknownPrimary_FallsBackToFirstNamedBlock()
+    {
+        var envelope = """
+            <DOCUMENT>
+            <TYPE>10-Q
+            <SEQUENCE>1
+            <FILENAME>issuer-10q.htm
+            <TEXT>quarterly report</TEXT>
+            </DOCUMENT>
+            """;
+
+        var artifact = SecDocumentEnvelopeParser.EnumerateArtifacts(envelope).Single();
+
+        artifact.IsPrimary.Should().BeTrue();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SecFilingArtifactRepositoryOrderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecFilingArtifactRepositoryOrderTests.cs
@@ -1,0 +1,36 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecFilingArtifactRepositoryOrderTests
+{
+    [Fact]
+    public void Order_NumericSequence_OrdersOneTwoTenBeforeUnknown()
+    {
+        var artifacts = new[]
+        {
+            Artifact("10", 10),
+            Artifact("unknown", null),
+            Artifact("2", 2),
+            Artifact("1", 1),
+        }.AsQueryable();
+
+        var ordered = SecFilingArtifactRepository.Order(artifacts).Select(x => x.Sequence);
+
+        ordered.Should().Equal("1", "2", "10", "unknown");
+    }
+
+    private static SecFilingArtifact Artifact(string sequence, int? sequenceNumber)
+    {
+        return new SecFilingArtifact
+        {
+            FileName = sequence + ".htm",
+            Type = "EX-4.1",
+            SourceUrl = "https://www.sec.gov/" + sequence,
+            Sequence = sequence,
+            SequenceNumber = sequenceNumber,
+            CaptureStatus = SecFilingArtifactCaptureStatus.MetadataOnly,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- preserve named SEC submission artifacts and exact source metadata
- enumerate SGML document blocks safely with numeric sequence ordering
- add the financial schema migration and parser regression coverage

## Verification
- dotnet build tests/Equibles.UnitTests/Equibles.UnitTests.csproj --no-restore
- dotnet vstest tests/Equibles.UnitTests/bin/Debug/net10.0/Equibles.UnitTests.dll --Tests:Equibles.UnitTests.Sec.SecDocumentEnvelopeParserArtifactTests,Equibles.UnitTests.Sec.SecFilingArtifactRepositoryOrderTests
- dotnet ef migrations has-pending-model-changes --project src/Equibles.Migrations --no-build
- git diff --check