### PR TITLE
fix(sec): reject any lower-priority Company Facts restatement

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactImportQualityFilter.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactImportQualityFilter.cs
@@ -11,6 +11,16 @@ namespace Equibles.Sec.FinancialFacts.HostedService.Services;
 /// the same actual period. Rejected natural keys are also deleted during a versioned replay so a
 /// bad value already in the store cannot remain selectable.
 /// </summary>
+/// <remarks>
+/// The lower-priority rule is keyed on the source RANK, not on a named form. It began as a
+/// DEF 14A rule, and the form that broke it was a PRE 14A: Company Facts states the form name
+/// verbatim, an unmapped name becomes <see cref="DocumentType.Other" />, and both land at the
+/// same lowest rank while only one was being rejected. RealReal's preliminary proxy restated
+/// five fiscal years of NetIncomeLoss with the sign flipped and a thousand-fold scale
+/// (FY2025: +41,799,000,000 against the 10-K's -41,799,000), which the scale rule cannot catch
+/// because it requires the candidate and the quarter sum to share a sign. Anything a periodic
+/// report already states for the exact same period adds nothing, so rank decides.
+/// </remarks>
 internal static class FinancialFactImportQualityFilter
 {
     private const int MinAnnualDays = 350;
@@ -21,6 +31,11 @@ internal static class FinancialFactImportQualityFilter
     private const decimal ScaleMatchTolerance = 0.05m;
     private const decimal MinimumScaledQuarterRatio = 0.1m;
     private const decimal MaximumScaledQuarterRatio = 10m;
+
+    // FinancialFactSourcePriority: periodic reports rank 0, 8-K/6-K rank 1, everything else
+    // (proxies, registration statements, prospectuses, and any form name Company Facts states
+    // that DocumentType does not map) ranks last.
+    private const int LowestSourceRank = 2;
 
     private static readonly decimal[] SuspectScaleFactors = [1_000m, 1_000_000m];
 
@@ -69,8 +84,12 @@ internal static class FinancialFactImportQualityFilter
             if (!period.Any(f => FinancialFactSourcePriority.Rank(f.Form) == 0))
                 continue;
 
-            foreach (var proxy in period.Where(f => f.Form == DocumentType.Def14A))
-                rejected.Add(proxy);
+            foreach (
+                var restatement in period.Where(f =>
+                    FinancialFactSourcePriority.Rank(f.Form) == LowestSourceRank
+                )
+            )
+                rejected.Add(restatement);
         }
 
         return new FilterResult(

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -35,7 +35,7 @@ public class FinancialFactsImportService
     // Bump whenever parsing, fiscal identity, or quality filtering changes existing rows. The
     // per-company checkpoint forces a full Company Facts replay without racing the old worker
     // during an additive migration rollout.
-    internal const int CurrentImporterVersion = 3;
+    internal const int CurrentImporterVersion = 4;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ISecEdgarClient _secEdgarClient;

--- a/tests/Equibles.UnitTests/Sec/FinancialFactImportQualityFilterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactImportQualityFilterTests.cs
@@ -129,6 +129,86 @@ public class FinancialFactImportQualityFilterTests
         result.Accepted.Should().ContainSingle().Which.Should().BeSameAs(tenK);
     }
 
+    // The RealReal shape (MCP feedback 4cbb4cd8): a PRELIMINARY proxy, whose form name
+    // DocumentType does not map, so it is stored as Other and shares the proxy's lowest
+    // source rank. It restated FY2025 net income with the sign flipped and a thousand-fold
+    // scale, which the scale rule cannot catch (it requires the candidate and the quarter
+    // sum to share a sign), and the derived-Q4 synthesis then picked it as the latest-filed
+    // annual and published a $41.76B TTM net income for a company that lost $41.8M.
+    [Fact]
+    public void Apply_UnmappedLowerPriorityFormSharesActualPeriodWithPeriodicFact_RejectsIt()
+    {
+        var tenK = Fact(
+            new DateOnly(2025, 1, 1),
+            new DateOnly(2025, 12, 31),
+            -41_799_000m,
+            DocumentType.TenK,
+            new DateOnly(2026, 2, 26),
+            "0001573221-26-000010"
+        );
+        var preliminaryProxy = Fact(
+            tenK.PeriodStart,
+            tenK.PeriodEnd,
+            41_799_000_000m,
+            DocumentType.Other,
+            new DateOnly(2026, 4, 15),
+            "0001573221-26-000026"
+        );
+
+        var result = FinancialFactImportQualityFilter.Apply([tenK, preliminaryProxy], ConceptIds);
+
+        result.Rejected.Should().ContainSingle().Which.Should().BeSameAs(preliminaryProxy);
+        result.Accepted.Should().ContainSingle().Which.Should().BeSameAs(tenK);
+    }
+
+    // An 8-K ranks ABOVE the proxy tier and states genuine interim figures, so it survives
+    // beside a periodic report — the rule rejects the lowest rank only.
+    [Fact]
+    public void Apply_CurrentReportSharesActualPeriodWithPeriodicFact_KeepsBoth()
+    {
+        var tenK = Fact(
+            new DateOnly(2025, 1, 1),
+            new DateOnly(2025, 12, 31),
+            1_000_000m,
+            DocumentType.TenK,
+            new DateOnly(2026, 2, 26),
+            "ten-k"
+        );
+        var eightK = Fact(
+            tenK.PeriodStart,
+            tenK.PeriodEnd,
+            1_000_000m,
+            DocumentType.EightK,
+            new DateOnly(2026, 1, 20),
+            "eight-k"
+        );
+
+        var result = FinancialFactImportQualityFilter.Apply([tenK, eightK], ConceptIds);
+
+        result.Rejected.Should().BeEmpty();
+        result.Accepted.Should().Equal(tenK, eightK);
+    }
+
+    // Nothing better exists for that period, so the only row stays selectable whatever its
+    // form — rejecting it would delete the company's only figure.
+    [Fact]
+    public void Apply_UnmappedLowerPriorityFormOnlyPeriod_KeepsAvailableFact()
+    {
+        var proxyOnly = Fact(
+            new DateOnly(2025, 1, 1),
+            new DateOnly(2025, 12, 31),
+            41_799_000_000m,
+            DocumentType.Other,
+            new DateOnly(2026, 4, 15),
+            "proxy-only"
+        );
+
+        var result = FinancialFactImportQualityFilter.Apply([proxyOnly], ConceptIds);
+
+        result.Rejected.Should().BeEmpty();
+        result.Accepted.Should().ContainSingle().Which.Should().BeSameAs(proxyOnly);
+    }
+
     [Fact]
     public void Apply_ProxyOnlyPeriod_KeepsAvailableFact()
     {


### PR DESCRIPTION
## Problem

`FinancialFactImportQualityFilter`'s proxy rule names one form:

```csharp
foreach (var proxy in period.Where(f => f.Form == DocumentType.Def14A))
    rejected.Add(proxy);
```

The form that broke it was a **PRE 14A**. Company Facts states the form name verbatim and `DocumentType.FromDisplayName(...) ?? DocumentType.Other` maps the unmapped name to `Other`, which shares the proxy's lowest source rank and was never rejected.

Observed on RealReal (REAL), five fiscal years, `NetIncomeLoss`:

| Source | Form stored | Filed | Value |
| --- | --- | --- | --- |
| 10-K | `TenK` | 2026-02-26 | -41,799,000 |
| PRE 14A | `Other` | 2026-04-15 | +41,799,000,000 |

Sign flipped and scaled a thousand-fold. `HasCorroboratedScaleError` cannot catch it: it returns false when the candidate and the quarter sum have different signs. The row stayed selectable and a downstream derived-Q4 synthesis picked it as the latest-filed annual.

## Change

The rule keys on the **rank**, not on a form name: when any rank-0 (periodic report) fact exists for the exact actual period, every rank-2 fact for that period is rejected. This strictly contains the old DEF 14A behaviour.

- Rank 1 (8-K / 6-K) is untouched, so genuine interim figures survive beside a periodic report.
- A period whose only row is lower-rank keeps that row, unchanged.
- No new `DocumentType` value: the point is that the rule must not depend on the form name being mapped at all.

`CurrentImporterVersion` 3 -> 4, so every company replays and `DeleteRejectedFacts` removes the stored rows.

## Tests

`dotnet test Equibles.sln --filter "Category!=Functional&Category!=Live"` — 4,748 unit + 2,813 integration, 3 new. One unrelated integration test (`AumSnapshotDrainWorkerTests.DrainOnce_LongRebuildRenewsClaimAndClearsDirtyAt`) flaked under parallel load and passes in isolation.

New cases: the REAL shape rejected, an 8-K kept beside a 10-K, a lower-rank-only period kept.