### PR TITLE
feat(sec): persist authoritative fund class tickers

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260903191028_PersistFundSeriesClassTickers.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260903191028_PersistFundSeriesClassTickers.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260903191028_PersistFundSeriesClassTickers")]
+    partial class PersistFundSeriesClassTickers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260903191028_PersistFundSeriesClassTickers.cs
+++ b/src/Equibles.Migrations/Migrations/20260903191028_PersistFundSeriesClassTickers.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersistFundSeriesClassTickers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<string>>(
+                name: "ClassTickers",
+                table: "FundSeries",
+                type: "text[]",
+                nullable: true);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "FundSeries"
+                SET "ClassTickers" = ARRAY[upper(replace("Ticker", '.', '-'))]
+                WHERE "Ticker" IS NOT NULL;
+                """
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FundSeries_ClassTickers_Gin",
+                table: "FundSeries",
+                column: "ClassTickers")
+                .Annotation("Npgsql:IndexMethod", "gin");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_FundSeries_ClassTickers_Gin",
+                table: "FundSeries");
+
+            migrationBuilder.DropColumn(
+                name: "ClassTickers",
+                table: "FundSeries");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/FundSeries.cs
+++ b/src/Equibles.Sec.Data/Models/FundSeries.cs
@@ -80,6 +80,16 @@ public class FundSeries
     [MaxLength(16)]
     public string Ticker { get; set; }
 
+    /// <summary>
+    /// Every exact SEC fund-class ticker assigned to this series, normalized to dash-listed form.
+    /// A multi-class series has no single <see cref="Ticker"/> but retains all class tickers here.
+    /// </summary>
+    public List<string> ClassTickers
+    {
+        get => field ?? [];
+        set;
+    } = [];
+
     public DateOnly LatestReportPeriodDate { get; set; }
 
     public DateOnly LatestFilingDate { get; set; }

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -58,7 +58,12 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<FormAdvAdviser>();
         builder.Entity<FormDFiling>();
         builder.Entity<FormDRelatedPerson>();
-        builder.Entity<FundSeries>();
+        builder.Entity<FundSeries>(b =>
+        {
+            b.HasIndex(e => e.ClassTickers)
+                .HasDatabaseName("IX_FundSeries_ClassTickers_Gin")
+                .HasMethod("gin");
+        });
         builder.Entity<NCenFiling>();
         builder.Entity<NCenServiceProvider>();
         builder.Entity<NportFiling>();

--- a/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
@@ -96,8 +96,7 @@ public class FundSeriesRefreshService
         if (!tickerDirectory.Available && rows.Count > 0)
         {
             var identityKeys = rows.Select(row => row.IdentityKey).ToList();
-            var seriesIds = rows
-                .Where(row => !string.IsNullOrEmpty(row.SeriesId))
+            var seriesIds = rows.Where(row => !string.IsNullOrEmpty(row.SeriesId))
                 .Select(row => row.SeriesId)
                 .Distinct()
                 .ToList();
@@ -120,11 +119,16 @@ public class FundSeriesRefreshService
                 .Where(row => !string.IsNullOrEmpty(row.SeriesId))
                 .GroupBy(row => row.SeriesId, StringComparer.OrdinalIgnoreCase)
                 .Where(group =>
-                    group.Select(row => TickerMetadataKey(row.Ticker, row.ClassTickers))
+                    group
+                        .Select(row => TickerMetadataKey(row.Ticker, row.ClassTickers))
                         .Distinct(StringComparer.Ordinal)
                         .Count() == 1
                 )
-                .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.First(),
+                    StringComparer.OrdinalIgnoreCase
+                );
             foreach (var row in rows)
             {
                 if (!string.IsNullOrEmpty(row.SeriesId))
@@ -299,19 +303,19 @@ public class FundSeriesRefreshService
         var unambiguous = normalized
             .GroupBy(t => t.Symbol, StringComparer.OrdinalIgnoreCase)
             .Where(group =>
-                group.Select(t => t.SeriesId)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .Count() == 1
+                group.Select(t => t.SeriesId).Distinct(StringComparer.OrdinalIgnoreCase).Count()
+                == 1
             )
             .SelectMany(group => group);
         return unambiguous
             .GroupBy(t => t.SeriesId, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 g => g.Key,
-                g => g.Select(t => t.Symbol)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .OrderBy(ticker => ticker, StringComparer.Ordinal)
-                    .ToList(),
+                g =>
+                    g.Select(t => t.Symbol)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .OrderBy(ticker => ticker, StringComparer.Ordinal)
+                        .ToList(),
                 StringComparer.OrdinalIgnoreCase
             );
     }

--- a/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FundSeriesRefreshService.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Integrations.Sec.Contracts;
@@ -84,13 +85,65 @@ public class FundSeriesRefreshService
             .ToListAsync(cancellationToken);
 
         var fundTypeByStock = await LoadFundTypesByStock(dbContext, cancellationToken);
-        var tickerBySeries = await LoadSeriesTickers(scope.ServiceProvider, cancellationToken);
+        var tickerDirectory = await LoadSeriesTickers(scope.ServiceProvider, cancellationToken);
 
         var computedAt = DateTime.UtcNow;
         var rows = aggregates
             .Where(a => a.CommonStockId != null || !string.IsNullOrEmpty(a.RegistrantCik))
-            .Select(a => BuildRow(a, fundTypeByStock, tickerBySeries, computedAt))
+            .Select(a => BuildRow(a, fundTypeByStock, tickerDirectory.TickersBySeries, computedAt))
             .ToList();
+
+        if (!tickerDirectory.Available && rows.Count > 0)
+        {
+            var identityKeys = rows.Select(row => row.IdentityKey).ToList();
+            var seriesIds = rows
+                .Where(row => !string.IsNullOrEmpty(row.SeriesId))
+                .Select(row => row.SeriesId)
+                .Distinct()
+                .ToList();
+            var existingTickerMetadata = await dbContext
+                .Set<FundSeries>()
+                .Where(row =>
+                    identityKeys.Contains(row.IdentityKey)
+                    || (!string.IsNullOrEmpty(row.SeriesId) && seriesIds.Contains(row.SeriesId))
+                )
+                .Select(row => new
+                {
+                    row.IdentityKey,
+                    row.SeriesId,
+                    row.Ticker,
+                    row.ClassTickers,
+                })
+                .ToListAsync(cancellationToken);
+            var metadataByIdentity = existingTickerMetadata.ToDictionary(row => row.IdentityKey);
+            var metadataBySeries = existingTickerMetadata
+                .Where(row => !string.IsNullOrEmpty(row.SeriesId))
+                .GroupBy(row => row.SeriesId, StringComparer.OrdinalIgnoreCase)
+                .Where(group =>
+                    group.Select(row => TickerMetadataKey(row.Ticker, row.ClassTickers))
+                        .Distinct(StringComparer.Ordinal)
+                        .Count() == 1
+                )
+                .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+            foreach (var row in rows)
+            {
+                if (!string.IsNullOrEmpty(row.SeriesId))
+                {
+                    if (metadataBySeries.TryGetValue(row.SeriesId, out var existingSeries))
+                    {
+                        row.Ticker = existingSeries.Ticker;
+                        row.ClassTickers = existingSeries.ClassTickers;
+                    }
+                    continue;
+                }
+
+                if (metadataByIdentity.TryGetValue(row.IdentityKey, out var existingIdentity))
+                {
+                    row.Ticker = existingIdentity.Ticker;
+                    row.ClassTickers = existingIdentity.ClassTickers;
+                }
+            }
+        }
 
         _logger.LogInformation("Rebuilding fund-series directory: {Count} series", rows.Count);
 
@@ -133,6 +186,7 @@ public class FundSeriesRefreshService
                             SeriesName = incoming.SeriesName,
                             RegistrantName = incoming.RegistrantName,
                             Ticker = incoming.Ticker,
+                            ClassTickers = incoming.ClassTickers,
                             LatestNportFilingId = incoming.LatestNportFilingId,
                             LatestReportPeriodDate = incoming.LatestReportPeriodDate,
                             LatestFilingDate = incoming.LatestFilingDate,
@@ -186,12 +240,10 @@ public class FundSeriesRefreshService
             );
     }
 
-    // Series → trading symbol from SEC's fund-class ticker directory, kept only where the series
-    // is unambiguous (exactly one distinct symbol across its share classes). ETFs — the funds a
-    // user looks up by ticker — have a single class, so they resolve; a multi-class mutual fund
-    // has no single ticker and honestly stays null. Best-effort: the directory being unreachable
-    // must never fail the rebuild, so a fetch error degrades to no enrichment.
-    private async Task<Dictionary<string, string>> LoadSeriesTickers(
+    // Series → every exact share-class symbol from SEC's fund-class ticker directory. Ticker keeps
+    // its historical single-symbol meaning; ClassTickers preserves multi-class ETF/mutual series.
+    // Best-effort: a directory fetch error degrades to no enrichment rather than failing rebuild.
+    private async Task<SeriesTickerDirectory> LoadSeriesTickers(
         IServiceProvider services,
         CancellationToken cancellationToken
     )
@@ -201,9 +253,24 @@ public class FundSeriesRefreshService
             var edgarClient = services.GetRequiredService<ISecEdgarClient>();
             var classTickers = await edgarClient.GetFundClassTickers();
             cancellationToken.ThrowIfCancellationRequested();
-            return BuildSeriesTickerMap(classTickers);
+            if (classTickers.Count == 0)
+            {
+                _logger.LogWarning(
+                    "Fund-class ticker directory was empty; preserving stored ticker metadata"
+                );
+                return new SeriesTickerDirectory([], false);
+            }
+            var tickerMap = BuildSeriesTickerMap(classTickers);
+            if (tickerMap.Count == 0)
+            {
+                _logger.LogWarning(
+                    "Fund-class ticker directory contained no unambiguous tickers; preserving stored ticker metadata"
+                );
+                return new SeriesTickerDirectory([], false);
+            }
+            return new SeriesTickerDirectory(tickerMap, true);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -213,26 +280,61 @@ public class FundSeriesRefreshService
                 ex,
                 "Fund-class ticker directory unavailable; rebuilding without ticker enrichment"
             );
-            return [];
+            return new SeriesTickerDirectory([], false);
         }
     }
 
-    internal static Dictionary<string, string> BuildSeriesTickerMap(
+    internal static Dictionary<string, List<string>> BuildSeriesTickerMap(
         List<FundClassTicker> classTickers
     )
     {
-        return classTickers
-            .GroupBy(t => t.SeriesId, StringComparer.OrdinalIgnoreCase)
-            .Where(g =>
-                g.Select(t => t.Symbol).Distinct(StringComparer.OrdinalIgnoreCase).Count() == 1
+        var normalized = classTickers
+            .Select(t => new
+            {
+                t.SeriesId,
+                Symbol = TickerNormalizer.NormalizeDashListed(t.Symbol),
+            })
+            .Where(t => t.Symbol != null && !string.IsNullOrWhiteSpace(t.SeriesId))
+            .ToList();
+        var unambiguous = normalized
+            .GroupBy(t => t.Symbol, StringComparer.OrdinalIgnoreCase)
+            .Where(group =>
+                group.Select(t => t.SeriesId)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Count() == 1
             )
-            .ToDictionary(g => g.Key, g => g.First().Symbol, StringComparer.OrdinalIgnoreCase);
+            .SelectMany(group => group);
+        return unambiguous
+            .GroupBy(t => t.SeriesId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(t => t.Symbol)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(ticker => ticker, StringComparer.Ordinal)
+                    .ToList(),
+                StringComparer.OrdinalIgnoreCase
+            );
+    }
+
+    private sealed record SeriesTickerDirectory(
+        Dictionary<string, List<string>> TickersBySeries,
+        bool Available
+    );
+
+    private static string TickerMetadataKey(string ticker, IEnumerable<string> classTickers)
+    {
+        var normalizedClasses = (classTickers ?? [])
+            .Select(TickerNormalizer.NormalizeDashListed)
+            .Where(value => value != null)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(value => value, StringComparer.Ordinal);
+        return $"{TickerNormalizer.NormalizeDashListed(ticker)}\0{string.Join('\0', normalizedClasses)}";
     }
 
     private static FundSeries BuildRow(
         FundSeriesAggregate a,
         Dictionary<Guid, string> fundTypeByStock,
-        Dictionary<string, string> tickerBySeries,
+        Dictionary<string, List<string>> tickersBySeries,
         DateTime computedAt
     )
     {
@@ -261,13 +363,18 @@ public class FundSeriesRefreshService
         // A series-bearing filing can share its issuer-feed stock with hundreds of sibling series,
         // so that stock's ticker is not series authority. SEC's fund-class directory is.
         string ticker = null;
+        List<string> classTickers = [];
         if (!string.IsNullOrEmpty(seriesId))
         {
-            tickerBySeries.TryGetValue(seriesId, out ticker);
+            tickersBySeries.TryGetValue(seriesId, out classTickers);
+            classTickers ??= [];
+            ticker = classTickers.Count == 1 ? classTickers[0] : null;
         }
         else if (isTracked)
         {
             ticker = a.Ticker;
+            var normalized = TickerNormalizer.NormalizeDashListed(a.Ticker);
+            classTickers = normalized == null ? [] : [normalized];
         }
 
         return new FundSeries
@@ -280,6 +387,7 @@ public class FundSeriesRefreshService
             SeriesName = a.SeriesName,
             RegistrantName = a.RegistrantName,
             Ticker = ticker,
+            ClassTickers = classTickers,
             LatestNportFilingId = a.LatestNportFilingId,
             LatestReportPeriodDate = a.LatestReportPeriodDate,
             LatestFilingDate = a.LatestFilingDate,

--- a/src/Equibles.Sec.Repositories/FundSeriesRepository.cs
+++ b/src/Equibles.Sec.Repositories/FundSeriesRepository.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
 
@@ -102,11 +103,33 @@ public class FundSeriesRepository : BaseRepository<FundSeries>
             empty
         );
     }
+
+    /// <summary>
+    /// Resolves only an exact stored series ticker or a verified SEC share-class ticker. This is
+    /// the listing-to-series boundary for ETF surfaces; unlike ResolveIdentifier it never accepts
+    /// a profile slug, series id, or descriptive search alias.
+    /// </summary>
+    public IQueryable<FundSeries> ResolveListedClassTicker(string ticker)
+    {
+        var normalized = TickerNormalizer.NormalizeDashListed(ticker);
+        if (normalized == null)
+            return GetAll().Where(_ => false);
+
+        var exactTicker = GetAll().Where(f => f.ClassTickers.Contains(normalized));
+        var uniqueExactTicker = exactTicker.Where(_ => exactTicker.Count() == 1);
+        var empty = GetAll().Where(_ => false);
+        return SearchTerms.WithExclusiveResolutionTiers(
+            uniqueExactTicker,
+            empty,
+            empty,
+            empty
+        );
+    }
 }
 
 internal static class FundSeriesSearchAliases
 {
-    private static readonly IReadOnlyDictionary<string, string> SeriesIds = new Dictionary<
+    private static readonly IReadOnlyDictionary<string, string> ClassTickerSeriesIds = new Dictionary<
         string,
         string
     >(StringComparer.OrdinalIgnoreCase)
@@ -115,12 +138,23 @@ internal static class FundSeriesSearchAliases
         // series, not every class ticker, so the directory row itself has no ticker.
         ["voo"] = "S000002839",
         ["vfiax"] = "S000002839",
-        ["vanguard 500"] = "S000002839",
         ["vti"] = "S000002848",
         ["vtsax"] = "S000002848",
+    };
+
+    private static readonly IReadOnlyDictionary<string, string> NameSeriesIds = new Dictionary<
+        string,
+        string
+    >(StringComparer.OrdinalIgnoreCase)
+    {
+        ["vanguard 500"] = "S000002839",
         ["vanguard total stock market"] = "S000002848",
     };
 
     public static string ResolveSeriesId(string query) =>
-        SeriesIds.GetValueOrDefault(SearchTerms.Normalize(query));
+        ResolveClassTickerSeriesId(query)
+        ?? NameSeriesIds.GetValueOrDefault(SearchTerms.Normalize(query));
+
+    public static string ResolveClassTickerSeriesId(string ticker) =>
+        ClassTickerSeriesIds.GetValueOrDefault(SearchTerms.Normalize(ticker));
 }

--- a/src/Equibles.Sec.Repositories/FundSeriesRepository.cs
+++ b/src/Equibles.Sec.Repositories/FundSeriesRepository.cs
@@ -118,29 +118,22 @@ public class FundSeriesRepository : BaseRepository<FundSeries>
         var exactTicker = GetAll().Where(f => f.ClassTickers.Contains(normalized));
         var uniqueExactTicker = exactTicker.Where(_ => exactTicker.Count() == 1);
         var empty = GetAll().Where(_ => false);
-        return SearchTerms.WithExclusiveResolutionTiers(
-            uniqueExactTicker,
-            empty,
-            empty,
-            empty
-        );
+        return SearchTerms.WithExclusiveResolutionTiers(uniqueExactTicker, empty, empty, empty);
     }
 }
 
 internal static class FundSeriesSearchAliases
 {
-    private static readonly IReadOnlyDictionary<string, string> ClassTickerSeriesIds = new Dictionary<
-        string,
-        string
-    >(StringComparer.OrdinalIgnoreCase)
-    {
-        // These share classes belong to the same SEC series. N-PORT identifies the
-        // series, not every class ticker, so the directory row itself has no ticker.
-        ["voo"] = "S000002839",
-        ["vfiax"] = "S000002839",
-        ["vti"] = "S000002848",
-        ["vtsax"] = "S000002848",
-    };
+    private static readonly IReadOnlyDictionary<string, string> ClassTickerSeriesIds =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // These share classes belong to the same SEC series. N-PORT identifies the
+            // series, not every class ticker, so the directory row itself has no ticker.
+            ["voo"] = "S000002839",
+            ["vfiax"] = "S000002839",
+            ["vti"] = "S000002848",
+            ["vtsax"] = "S000002848",
+        };
 
     private static readonly IReadOnlyDictionary<string, string> NameSeriesIds = new Dictionary<
         string,

--- a/tests/Equibles.IntegrationTests/Migrations/FundSeriesLatestNportFilingMigrationTests.cs
+++ b/tests/Equibles.IntegrationTests/Migrations/FundSeriesLatestNportFilingMigrationTests.cs
@@ -97,7 +97,9 @@ public class FundSeriesLatestNportFilingMigrationTests : ParadeDbMcpTestBase
             DbContext.ChangeTracker.Clear();
 
             var references = await DbContext
-                .Set<FundSeries>()
+                .Database.SqlQueryRaw<FundSeriesReference>(
+                    """SELECT "IdentityKey", "LatestNportFilingId" FROM "FundSeries";"""
+                )
                 .ToDictionaryAsync(series => series.IdentityKey, series => series.LatestNportFilingId);
             references["cross"].Should().Be(crossPopulationHigher.Id);
             references["tracked-idless"].Should().Be(trackedIdlessHigher.Id);
@@ -108,6 +110,13 @@ public class FundSeriesLatestNportFilingMigrationTests : ParadeDbMcpTestBase
         {
             await migrator.MigrateAsync();
         }
+    }
+
+    public class FundSeriesReference
+    {
+        public virtual string IdentityKey { get; set; }
+
+        public virtual Guid LatestNportFilingId { get; set; }
     }
 
     private static CommonStock Stock(string ticker) =>

--- a/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
@@ -239,6 +239,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
             .Should()
             .Equal($"cs:{trust.Id}:S000002277", $"cs:{trust.Id}:S000004310");
         rows.Select(s => s.Ticker).Should().Equal("IWM", "IVV");
+        rows.SelectMany(s => s.ClassTickers).Should().Equal("IWM", "IVV");
         rows.Select(s => s.Ticker).Should().NotContain(trust.Ticker);
         rows.Select(s => s.Slug).Should().OnlyHaveUniqueItems();
     }
@@ -522,6 +523,7 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
                 SeriesId = "S000002839",
                 SeriesName = "VANGUARD 500 INDEX FUND",
                 RegistrantName = "VANGUARD INDEX FUNDS",
+                ClassTickers = ["VOO", "VFIAX"],
             }
         );
         await db.SaveChangesAsync();
@@ -535,9 +537,94 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
             .ResolveIdentifier("VOO")
             .Select(f => f.SeriesName)
             .ToListAsync();
+        var listedAlias = await repository
+            .ResolveListedClassTicker("voo")
+            .Select(f => f.SeriesName)
+            .ToListAsync();
+        var slugIsNotAListedTicker = await repository
+            .ResolveListedClassTicker("vanguard-500-index-fund-s000002839")
+            .ToListAsync();
 
         exact.Should().ContainSingle().Which.Should().Be("ISHARES CORE S&P 500 ETF");
         alias.Should().ContainSingle().Which.Should().Be("VANGUARD 500 INDEX FUND");
+        listedAlias.Should().ContainSingle().Which.Should().Be("VANGUARD 500 INDEX FUND");
+        slugIsNotAListedTicker.Should().BeEmpty();
+
+        db.Add(new FundSeries
+        {
+            LatestNportFilingId = Guid.NewGuid(),
+            IdentityKey = "rc:9999999999:S000099999",
+            Slug = "conflicting-voo-series-s000099999",
+            RegistrantCik = "9999999999",
+            SeriesId = "S000099999",
+            SeriesName = "CONFLICTING SERIES",
+            RegistrantName = "CONFLICTING REGISTRANT",
+            ClassTickers = ["VOO"],
+        });
+        await db.SaveChangesAsync();
+
+        var ambiguous = await repository.ResolveListedClassTicker("VOO").ToListAsync();
+        ambiguous.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildSeriesTickerMap_RefusesSymbolsClaimedByMultipleSeries()
+    {
+        var map = FundSeriesRefreshService.BuildSeriesTickerMap([
+            new FundClassTicker { SeriesId = "S000000001", Symbol = "DUP" },
+            new FundClassTicker { SeriesId = "S000000002", Symbol = "DUP" },
+            new FundClassTicker { SeriesId = "S000000002", Symbol = "UNIQUE" },
+        ]);
+
+        map.Should().NotContainKey("S000000001");
+        map.Should().ContainKey("S000000002").WhoseValue.Should().Equal("UNIQUE");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RebuildAll_UnavailableClassTickerDirectory_PreservesStoredTickerMetadata(
+        bool returnsEmptyDirectory
+    )
+    {
+        await using var seed = FreshContext();
+        var trust = await SeedStock(seed, "VTI", "0000102909");
+        var filing = MakeFiling(
+            trust.Id,
+            null,
+            "0000102909-26-000001",
+            "S000002848",
+            "VANGUARD TOTAL STOCK MARKET INDEX FUND",
+            "VANGUARD INDEX FUNDS",
+            new DateOnly(2026, 3, 31),
+            netAssets: 2_000m,
+            totalAssets: 2_100m
+        );
+        seed.Add(filing);
+        seed.Add(new FundSeries
+        {
+            LatestNportFilingId = filing.Id,
+            IdentityKey = "rc:0000102909:S000002848",
+            Slug = "vanguard-total-stock-market-index-fund-s000002848",
+            RegistrantCik = "0000102909",
+            SeriesId = "S000002848",
+            Ticker = null,
+            ClassTickers = ["VTI", "VTSAX"],
+            LatestReportPeriodDate = filing.ReportPeriodDate,
+            LatestFilingDate = filing.FilingDate,
+        });
+        await seed.SaveChangesAsync();
+
+        await BuildService(returnsEmptyDirectory ? [] : null).RebuildAllAsync(
+            CancellationToken.None
+        );
+
+        await using var read = FreshContext();
+        var row = await read.Set<FundSeries>().SingleAsync();
+        row.IdentityKey.Should().Be($"cs:{trust.Id}:S000002848");
+        row.ClassTickers.Should().Equal("VTI", "VTSAX");
+        row.Ticker.Should().BeNull();
+        row.NetAssets.Should().Be(2_000m);
     }
 
     private static async Task<CommonStock> SeedStock(

--- a/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FundSeriesRefreshServiceTests.cs
@@ -550,17 +550,19 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
         listedAlias.Should().ContainSingle().Which.Should().Be("VANGUARD 500 INDEX FUND");
         slugIsNotAListedTicker.Should().BeEmpty();
 
-        db.Add(new FundSeries
-        {
-            LatestNportFilingId = Guid.NewGuid(),
-            IdentityKey = "rc:9999999999:S000099999",
-            Slug = "conflicting-voo-series-s000099999",
-            RegistrantCik = "9999999999",
-            SeriesId = "S000099999",
-            SeriesName = "CONFLICTING SERIES",
-            RegistrantName = "CONFLICTING REGISTRANT",
-            ClassTickers = ["VOO"],
-        });
+        db.Add(
+            new FundSeries
+            {
+                LatestNportFilingId = Guid.NewGuid(),
+                IdentityKey = "rc:9999999999:S000099999",
+                Slug = "conflicting-voo-series-s000099999",
+                RegistrantCik = "9999999999",
+                SeriesId = "S000099999",
+                SeriesName = "CONFLICTING SERIES",
+                RegistrantName = "CONFLICTING REGISTRANT",
+                ClassTickers = ["VOO"],
+            }
+        );
         await db.SaveChangesAsync();
 
         var ambiguous = await repository.ResolveListedClassTicker("VOO").ToListAsync();
@@ -601,23 +603,24 @@ public class FundSeriesRefreshServiceTests : IAsyncLifetime
             totalAssets: 2_100m
         );
         seed.Add(filing);
-        seed.Add(new FundSeries
-        {
-            LatestNportFilingId = filing.Id,
-            IdentityKey = "rc:0000102909:S000002848",
-            Slug = "vanguard-total-stock-market-index-fund-s000002848",
-            RegistrantCik = "0000102909",
-            SeriesId = "S000002848",
-            Ticker = null,
-            ClassTickers = ["VTI", "VTSAX"],
-            LatestReportPeriodDate = filing.ReportPeriodDate,
-            LatestFilingDate = filing.FilingDate,
-        });
+        seed.Add(
+            new FundSeries
+            {
+                LatestNportFilingId = filing.Id,
+                IdentityKey = "rc:0000102909:S000002848",
+                Slug = "vanguard-total-stock-market-index-fund-s000002848",
+                RegistrantCik = "0000102909",
+                SeriesId = "S000002848",
+                Ticker = null,
+                ClassTickers = ["VTI", "VTSAX"],
+                LatestReportPeriodDate = filing.ReportPeriodDate,
+                LatestFilingDate = filing.FilingDate,
+            }
+        );
         await seed.SaveChangesAsync();
 
-        await BuildService(returnsEmptyDirectory ? [] : null).RebuildAllAsync(
-            CancellationToken.None
-        );
+        await BuildService(returnsEmptyDirectory ? [] : null)
+            .RebuildAllAsync(CancellationToken.None);
 
         await using var read = FreshContext();
         var row = await read.Set<FundSeries>().SingleAsync();

--- a/tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceSeriesTickerMapTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FundSeriesRefreshServiceSeriesTickerMapTests.cs
@@ -3,11 +3,8 @@ using Equibles.Sec.HostedService.Services;
 
 namespace Equibles.UnitTests.Sec;
 
-// BuildSeriesTickerMap turns SEC's fund-class ticker directory into the series → symbol map that
-// fills FundSeries.Ticker for every series-bearing row (an ETF like ProShares Ultra Semiconductors
-// "USD" was unresolvable by ticker because NPORT carries no symbol). The rule under test: a series
-// maps ONLY when all its share classes agree on one symbol — a multi-class mutual fund has no single
-// ticker, and guessing one class's symbol would misattribute the whole series.
+// BuildSeriesTickerMap turns SEC's fund-class ticker directory into the series → class-symbol map.
+// Every unambiguous class alias is retained; a symbol claimed by more than one series is excluded.
 public class FundSeriesRefreshServiceSeriesTickerMapTests
 {
     private static FundClassTicker Row(string seriesId, string symbol, string classId = "C1") =>
@@ -24,18 +21,18 @@ public class FundSeriesRefreshServiceSeriesTickerMapTests
     {
         var map = FundSeriesRefreshService.BuildSeriesTickerMap([Row("S000014258", "USD")]);
 
-        map.Should().ContainKey("S000014258").WhoseValue.Should().Be("USD");
+        map.Should().ContainKey("S000014258").WhoseValue.Should().Equal("USD");
     }
 
     [Fact]
-    public void BuildSeriesTickerMap_MultiClassSeriesWithDifferentSymbols_IsExcluded()
+    public void BuildSeriesTickerMap_MultiClassSeriesWithDifferentSymbols_RetainsEveryAlias()
     {
         var map = FundSeriesRefreshService.BuildSeriesTickerMap([
             Row("S000001", "VFIAX", "C1"),
             Row("S000001", "VFFSX", "C2"),
         ]);
 
-        map.Should().BeEmpty("a multi-class fund has no single ticker — guessing misattributes it");
+        map.Should().ContainKey("S000001").WhoseValue.Should().Equal("VFFSX", "VFIAX");
     }
 
     [Fact]
@@ -46,7 +43,7 @@ public class FundSeriesRefreshServiceSeriesTickerMapTests
             Row("S000002", "SPY", "C2"),
         ]);
 
-        map.Should().ContainKey("S000002");
+        map.Should().ContainKey("S000002").WhoseValue.Should().Equal("SPY");
     }
 
     [Fact]
@@ -58,7 +55,21 @@ public class FundSeriesRefreshServiceSeriesTickerMapTests
             Row("S000001", "VFFSX", "C2"),
         ]);
 
-        map.Should().HaveCount(1);
-        map["S000014258"].Should().Be("USD");
+        map.Should().HaveCount(2);
+        map["S000014258"].Should().Equal("USD");
+        map["S000001"].Should().Equal("VFFSX", "VFIAX");
+    }
+
+    [Fact]
+    public void BuildSeriesTickerMap_SymbolClaimedByTwoSeries_IsExcludedFromBoth()
+    {
+        var map = FundSeriesRefreshService.BuildSeriesTickerMap([
+            Row("S000001", "SHARED"),
+            Row("S000002", "shared"),
+            Row("S000003", "UNIQUE"),
+        ]);
+
+        map.Should().ContainSingle();
+        map.Should().ContainKey("S000003").WhoseValue.Should().Equal("UNIQUE");
     }
 }


### PR DESCRIPTION
## Summary
- persist every authoritative SEC fund-class ticker on each FundSeries
- refuse class symbols claimed by multiple series and resolve exact aliases
- preserve ticker metadata when the SEC class directory is unavailable

## Validation
- Equibles.UnitTests: 4,758 passed
- FundSeriesRefreshServiceTests: 12 passed
- Release build consumed successfully by the commercial solution