### PR TITLE
fix(holdings): label reported quantities and values precisely

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -32,6 +32,10 @@ public class InstitutionalHoldingsTools
 {
     private static readonly TimeSpan MarketActivityCacheDuration = TimeSpan.FromMinutes(30);
 
+    private const string PublishedValueCaveat =
+        "_Published values normally use report-date closing prices, may fall back to filer values, "
+        + "and can be zero when unavailable._";
+
     private static readonly string[] ValidActivityBuckets =
     [
         "top-buys",
@@ -161,6 +165,7 @@ public class InstitutionalHoldingsTools
                         ReportDate = h.ReportDate,
                         ListedTicker = h.ListedTicker,
                         OptionType = h.OptionType,
+                        ShareType = h.ShareType,
                     })
                     .ToListAsync();
                 if (holdings.Count == 0)
@@ -267,6 +272,7 @@ public class InstitutionalHoldingsTools
                 ReportDate = h.ReportDate,
                 ListedTicker = h.ListedTicker,
                 OptionType = h.OptionType,
+                ShareType = h.ShareType,
             })
             .ToList();
         return RenderAdjustedTopHoldersTable(
@@ -320,8 +326,8 @@ public class InstitutionalHoldingsTools
                 // qualifies the type in place so single-class stocks pay no extra column.
                 var positionType =
                     h.ListedTicker == null
-                        ? PositionType(h.OptionType)
-                        : $"{PositionType(h.OptionType)} ({h.ListedTicker})";
+                        ? PositionType(h.OptionType, h.ShareType)
+                        : $"{PositionType(h.OptionType, h.ShareType)} ({h.ListedTicker})";
                 return $"| {offset + rank} | {h.InstitutionName} | "
                     + $"{positionType} | "
                     + $"{McpFormat.WholeNumber(h.Shares)} | "
@@ -335,7 +341,7 @@ public class InstitutionalHoldingsTools
             "_% of Inst. Total = the position's share of all institutional 13F shares in the stock, not of shares outstanding._"
         );
         result.AppendLine(
-            "_Type: Common = shares held outright. Put/Call = an option position reported at the "
+            "_Type: Common = shares held outright; Principal = a principal-denominated security. Put/Call = an option position reported at the "
                 + "underlying's notional value. A PUT IS A BEARISH POSITION, so a large put line is a "
                 + "holder betting against this stock, not accumulating it._"
         );
@@ -360,6 +366,7 @@ public class InstitutionalHoldingsTools
         public DateOnly ReportDate { get; set; }
         public string ListedTicker { get; set; }
         public OptionType? OptionType { get; set; }
+        public ShareType ShareType { get; set; }
     }
 
     [McpServerTool(
@@ -368,7 +375,7 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Get the historical trend of institutional ownership for a stock across multiple quarters. Shows how total institutional shares, published position value, and holder count changed. Values normally use report-date closing prices, may fall back to filer values, and can include zero for unavailable valuations. While the newest quarter's 13F filing window is open, that quarter is a provisional combined view (funds that have not filed yet carry their prior-quarter positions — flagged in the output). Use this to understand whether institutional interest is growing or declining."
+        "Get the historical trend of aggregate reported 13F exposure for a stock across multiple quarters. The legacy Total Shares field sums reported quantities across common-share rows, put/call notional-underlying rows, and any tracked principal-denominated rows, so it is not a pure share-ownership measure. Shows how total reported quantity, published position value, and filer count changed. Values normally use report-date closing prices, may fall back to filer values, and can include zero when unavailable. While the newest quarter's filing window is open, that quarter is a provisional combined view (funds that have not filed yet carry their prior-quarter positions — flagged in the output)."
     )]
     public Task<string> GetInstitutionalOwnershipHistory(
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
@@ -465,6 +472,10 @@ public class InstitutionalHoldingsTools
         result.AppendLine(
             "_Share Chg (QoQ) tracks the quarter-over-quarter change in total split-adjusted institutional shares._"
         );
+        result.AppendLine(
+            "_The legacy Total Shares column sums reported quantities across common-share rows, put/call notional-underlying rows, and any tracked principal-denominated rows; it is aggregate reported 13F exposure rather than pure share ownership._"
+        );
+        result.AppendLine(PublishedValueCaveat);
 
         return result.ToString();
     }
@@ -698,7 +709,7 @@ public class InstitutionalHoldingsTools
                 // Rank is the ABSOLUTE position in the value-ranked rows, so page two
                 // continues 21, 22, … instead of restarting at 1.
                 return $"| {offset + rank} | {listedTicker} | {h.CommonStock.Name} | "
-                    + $"{PositionType(h.OptionType)} | "
+                    + $"{PositionType(h.OptionType, h.ShareType)} | "
                     + $"{McpFormat.WholeNumber(shares)} | "
                     + $"{FormatMillions(h.Value)} | "
                     + $"{FormatPercent(pct)}% |";
@@ -711,7 +722,7 @@ public class InstitutionalHoldingsTools
         // Palantir, and every surface that omitted the distinction reported the opposite.
         result.AppendLine();
         result.AppendLine(
-            "_Type: Common = shares held outright. Put/Call = an option position, reported at the "
+            "_Type: Common = shares held outright; Principal = a principal-denominated security. Put/Call = an option position, reported at the "
                 + "notional value of the underlying shares, not the premium paid. A PUT IS A BEARISH "
                 + "POSITION — the filer profits if the stock falls. Option notional is included in the "
                 + "portfolio total and the percentages above, exactly as the filer reported it._"
@@ -734,12 +745,12 @@ public class InstitutionalHoldingsTools
     }
 
     // How a 13F line should be described to a reader: the security type, not the activity bucket.
-    private static string PositionType(OptionType? optionType) =>
+    private static string PositionType(OptionType? optionType, ShareType shareType) =>
         optionType switch
         {
             Equibles.Holdings.Data.Models.OptionType.Put => "Put",
             Equibles.Holdings.Data.Models.OptionType.Call => "Call",
-            _ => "Common",
+            _ => shareType == ShareType.Principal ? "Principal" : "Common",
         };
 
     [McpServerTool(
@@ -1809,6 +1820,7 @@ public class InstitutionalHoldingsTools
                 + $"${FormatMillions(slices.Sum(s => s.TotalValue))}M 13F value. "
                 + "_Percentages are of the 13F-reported (long U.S. equity) book only._"
         );
+        result.AppendLine(PublishedValueCaveat);
 
         if (holder.ConfidentialTreatmentRequested)
         {
@@ -1827,7 +1839,7 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Get an institution's 13F portfolio allocation for a given report quarter (defaults to the latest), grouped by fine-grained industry (default) or rolled up by sector via `groupBy`. Returns a markdown table sorted by % of portfolio descending, with stocks lacking a classification collapsed into a single 'Unclassified' row at the end. Use SearchInstitutions for an exact CIK; ambiguous partial names return candidates instead of selecting silently."
+        "Get an institution's 13F portfolio allocation for a given report quarter (defaults to the latest), grouped by fine-grained industry (default) or rolled up by sector via `groupBy`. Returns a markdown table sorted by % of portfolio descending, with stocks lacking a classification collapsed into a single 'Unclassified' row at the end. Published values normally use report-date closing prices, may fall back to filer values, and can be zero when unavailable. Use SearchInstitutions for an exact CIK; ambiguous partial names return candidates instead of selecting silently."
     )]
     public Task<string> GetInstitutionSectorAllocation(
         [Description(
@@ -2060,7 +2072,7 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Compare two institutions' 13F portfolios on their latest common report date. Returns Jaccard and dollar-weighted overlap, portfolio totals, and shared or unique positions. Resolve filer names with SearchInstitutions. For mutual-fund or ETF NPORT portfolios, use GetFundProfile."
+        "Compare two institutions' 13F portfolios on their latest common report date. Returns Jaccard and dollar-weighted overlap, portfolio totals, and shared or unique positions. Published values normally use report-date closing prices, may fall back to filer values, and can be zero when unavailable. Resolve filer names with SearchInstitutions. For mutual-fund or ETF NPORT portfolios, use GetFundProfile."
     )]
     public Task<string> CompareInstitutionPortfolios(
         [Description(
@@ -2217,6 +2229,7 @@ public class InstitutionalHoldingsTools
         result.AppendLine(
             "_$-weighted overlap = shared dollars (the smaller of the two funds' values per stock) as a share of union dollars (the larger per stock)._"
         );
+        result.AppendLine(PublishedValueCaveat);
         var truncation = McpOutput.TruncationNote(rendered.Count, overlap.Rows.Count);
         if (truncation.Length > 0)
             result.AppendLine(truncation);
@@ -2230,7 +2243,7 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Combine 2-25 institutions' 13F portfolios on their latest common report date. Ranks stocks by holder count, then combined value. Set minInstitutions to 2 or more for positions shared by multiple filers."
+        "Combine 2-25 institutions' 13F portfolios on their latest common report date. Ranks stocks by holder count, then combined value. Published values normally use report-date closing prices, may fall back to filer values, and can be zero when unavailable. Set minInstitutions to 2 or more for positions shared by multiple filers."
     )]
     public Task<string> GetInstitutionConsensusHoldings(
         [Description(
@@ -2384,6 +2397,9 @@ public class InstitutionalHoldingsTools
             (rank, x) =>
                 $"| {rank} | {x.Row.Ticker} | {x.Row.Name} | {x.HeldBy}/{holders.Count} | {McpFormat.Invariant(x.Row.CombinedValue / 1_000_000m, "N1")} |"
         );
+
+        result.AppendLine();
+        result.AppendLine(PublishedValueCaveat);
 
         var truncation = McpOutput.TruncationNote(
             rowsWithConsensus.Count,

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
@@ -44,9 +44,24 @@ public class InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTe
             Cik = "0001067983",
             Name = "Berkshire Hathaway Inc.",
         };
+        var principalHolder = new InstitutionalHolder
+        {
+            Cik = "0000000002",
+            Name = "Principal Reporter",
+        };
         DbContext.Add(stock);
         DbContext.Add(holder);
+        DbContext.Add(principalHolder);
         DbContext.Add(MakeHolding(stock, holder, new DateOnly(2024, 12, 31), shares: 1_234_567));
+        DbContext.Add(
+            MakeHolding(
+                stock,
+                principalHolder,
+                new DateOnly(2024, 12, 31),
+                shares: 2_000,
+                shareType: ShareType.Principal
+            )
+        );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
@@ -81,15 +96,20 @@ public class InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTe
         // Numeric cells must render with en-US separators on every host locale:
         // Total Shares (:N0) and Total Value $M (:N1). de-DE would produce
         // 1.234.567 and 123,5.
-        output.Should().Contain("| 1,234,567 |");
-        output.Should().Contain("| 123.5 |");
+        output.Should().Contain("| 1,236,567 |");
+        output.Should().Contain("| 123.7 |");
+        output.Should().Contain("put/call notional-underlying rows");
+        output.Should().Contain("principal-denominated rows");
+        output.Should().Contain("rather than pure share ownership");
+        output.Should().Contain("Published values normally use report-date closing prices");
     }
 
     private static InstitutionalHolding MakeHolding(
         CommonStock stock,
         InstitutionalHolder holder,
         DateOnly reportDate,
-        long shares
+        long shares,
+        ShareType shareType = ShareType.Shares
     ) =>
         new()
         {
@@ -99,7 +119,7 @@ public class InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTe
             ReportDate = reportDate,
             Shares = shares,
             Value = shares * 100,
-            ShareType = ShareType.Shares,
+            ShareType = shareType,
             InvestmentDiscretion = InvestmentDiscretion.Sole,
             AccessionNumber = $"acc-{reportDate:yyyyMMdd}",
         };

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvarianceTests.cs
@@ -66,5 +66,9 @@ public class InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvari
                 invariantOutput,
                 "MCP markdown output is consumed by LLMs trained on en-US conventions; the Combined ($M) :N1 cell follows CurrentCulture (de-DE swaps the thousand/decimal separators), forking the response by host locale — same bug class as the RenderOverlapTable, RenderInstitutionSummary and RenderSectorAllocationTable culture-invariance siblings"
             );
+        invariantOutput
+            .Should()
+            .Contain("Published values normally use report-date closing prices")
+            .And.Contain("can be zero when unavailable");
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderOverlapTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderOverlapTableCultureInvarianceTests.cs
@@ -87,5 +87,9 @@ public class InstitutionalHoldingsToolsRenderOverlapTableCultureInvarianceTests
                 invariantOutput,
                 "MCP markdown output is consumed by LLMs trained on en-US conventions; the :N0 / :F1 / :N1 and provider-less .ToString(\"N0\")/.ToString(\"F1\") cells follow CurrentCulture (de-DE swaps the thousand/decimal separators), forking the response by host locale — same bug class as the RenderInstitutionPortfolio, RenderTopHoldersTable, RenderInstitutionSummary and RenderSectorAllocationTable culture-invariance siblings"
             );
+        invariantOutput
+            .Should()
+            .Contain("Published values normally use report-date closing prices")
+            .And.Contain("can be zero when unavailable");
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvarianceTests.cs
@@ -62,5 +62,9 @@ public class InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvaria
                 invariantOutput,
                 "MCP markdown output is consumed by LLMs trained on en-US conventions; the :N0 / :N1 / :F1 row cells without an explicit IFormatProvider follow CurrentCulture (de-DE → 1.234 / 12.345,7 / 42,3), forking the response by host locale — same bug class as the RenderInstitutionPortfolio, RenderTopHoldersTable and RenderInstitutionSummary culture-invariance siblings"
             );
+        invariantOutput
+            .Should()
+            .Contain("Published values normally use report-date closing prices")
+            .And.Contain("can be zero when unavailable");
     }
 }

--- a/tests/Equibles.UnitTests/Mcp/InstitutionalHoldingsToolsPositionTypeTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InstitutionalHoldingsToolsPositionTypeTests.cs
@@ -6,14 +6,14 @@ namespace Equibles.UnitTests.Mcp;
 
 public class InstitutionalHoldingsToolsPositionTypeTests
 {
-    private static string Describe(OptionType? optionType)
+    private static string Describe(OptionType? optionType, ShareType shareType = ShareType.Shares)
     {
         var method = typeof(InstitutionalHoldingsTools).GetMethod(
             "PositionType",
             BindingFlags.NonPublic | BindingFlags.Static
         );
         method.Should().NotBeNull("the portfolio tables label each line through this helper");
-        return (string)method.Invoke(null, [optionType]);
+        return (string)method.Invoke(null, [optionType, shareType]);
     }
 
     [Fact]
@@ -40,5 +40,11 @@ public class InstitutionalHoldingsToolsPositionTypeTests
         // reads as missing data, and the whole point of the column is that every line states what
         // it is.
         Describe(null).Should().Be("Common");
+    }
+
+    [Fact]
+    public void PositionType_PrincipalRow_SaysPrincipal()
+    {
+        Describe(null, ShareType.Principal).Should().Be("Principal");
     }
 }


### PR DESCRIPTION
## Summary\n- disclose published-value provenance on sector, overlap, consensus, and ownership-history MCP outputs\n- label principal-denominated rows distinctly and clarify aggregate reported quantities\n- add regression coverage for principal rows and value caveats\n\n## Tests\n- dotnet csharpier check on changed files\n- focused unit tests: 7 passed\n- focused integration test: 1 passed\n\nCommercial portal/API branch depends on this OSS main change.